### PR TITLE
fix: resolve Flatpak and macOS release build failures

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,7 +172,7 @@ jobs:
       - name: Install macOS dependencies
         if: runner.os == 'macOS'
         run: |
-          brew install molten-vk sdl2
+          brew install molten-vk vulkan-headers vulkan-loader sdl2
           echo "VULKAN_SDK=$(brew --prefix)" >> "$GITHUB_ENV"
       - name: Install Vulkan SDK (Windows)
         if: runner.os == 'Windows'

--- a/player/linux/flatpak/com.spela.player.yml
+++ b/player/linux/flatpak/com.spela.player.yml
@@ -17,6 +17,7 @@ finish-args:
 modules:
   - name: SDL2
     buildsystem: cmake-ninja
+    builddir: true
     config-opts:
       - -DSDL_STATIC=OFF
       - -DSDL_TEST=OFF


### PR DESCRIPTION
## Summary
- Add `builddir: true` to Flatpak SDL2 module (SDL2 rejects in-tree builds)
- Install `vulkan-headers` and `vulkan-loader` on macOS so CMake finds Vulkan