### PR TITLE
fix: pass IGDB credentials through docker-compose

### DIFF
--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -13,6 +13,8 @@
 #   SPELA_BASE_PATH         — host base path for all data (default: /docker/spela)
 #   SPELA_GAMES_PATH        — host path to ROM directory (default: $SPELA_BASE_PATH/games)
 #   SPELA_BIOS_PATH         — host path to BIOS directory (default: $SPELA_BASE_PATH/bios)
+#   SPELA_IGDB_CLIENT_ID    — IGDB / Twitch API credentials (game metadata)
+#   SPELA_IGDB_CLIENT_SECRET
 #   SPELA_SCRAPER_DEV_ID    — ScreenScraper dev credentials
 #   SPELA_SCRAPER_DEV_PASS
 #   SPELA_SCRAPER_USER
@@ -48,6 +50,8 @@ services:
       - SPELA_SCRAPER_DEV_PASS=${SPELA_SCRAPER_DEV_PASS:-}
       - SPELA_SCRAPER_USER=${SPELA_SCRAPER_USER:-}
       - SPELA_SCRAPER_USER_PASS=${SPELA_SCRAPER_USER_PASS:-}
+      - SPELA_IGDB_CLIENT_ID=${SPELA_IGDB_CLIENT_ID:-}
+      - SPELA_IGDB_CLIENT_SECRET=${SPELA_IGDB_CLIENT_SECRET:-}
       # TURN server credentials endpoint config
       - TURN_ENABLED=${TURN_ENABLED:-true}
       - TURN_HOST=${TURN_HOST:-}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@
 #   SPELA_BASE_PATH         — host base path for all data (default: /docker/spela)
 #   SPELA_GAMES_PATH        — host path to ROM directory (default: $SPELA_BASE_PATH/games)
 #   SPELA_BIOS_PATH         — host path to BIOS directory (default: $SPELA_BASE_PATH/bios)
+#   SPELA_IGDB_CLIENT_ID    — IGDB / Twitch API credentials (game metadata)
+#   SPELA_IGDB_CLIENT_SECRET
 #   SPELA_SCRAPER_DEV_ID    — ScreenScraper dev credentials
 #   SPELA_SCRAPER_DEV_PASS
 #   SPELA_SCRAPER_USER
@@ -48,6 +50,8 @@ services:
       - SPELA_SCRAPER_DEV_PASS=${SPELA_SCRAPER_DEV_PASS:-}
       - SPELA_SCRAPER_USER=${SPELA_SCRAPER_USER:-}
       - SPELA_SCRAPER_USER_PASS=${SPELA_SCRAPER_USER_PASS:-}
+      - SPELA_IGDB_CLIENT_ID=${SPELA_IGDB_CLIENT_ID:-}
+      - SPELA_IGDB_CLIENT_SECRET=${SPELA_IGDB_CLIENT_SECRET:-}
       # TURN server credentials endpoint config
       - TURN_ENABLED=${TURN_ENABLED:-true}
       - TURN_HOST=${TURN_HOST:-}

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -12,15 +12,79 @@ import (
 	"gorm.io/gorm/logger"
 )
 
+// checkDatabaseDirectory verifies that the database directory exists and is
+// writable, producing clear error messages for common deployment problems.
+func checkDatabaseDirectory(dir, dbPath string) error {
+	// Check if the directory exists.
+	info, err := os.Stat(dir)
+	if os.IsNotExist(err) {
+		// Try to create it.
+		if mkErr := os.MkdirAll(dir, 0700); mkErr != nil {
+			return fmt.Errorf("database directory %q does not exist and could not be created: %w\n"+
+				"  Hint: Create the directory on the host and ensure it is writable by the container user.\n"+
+				"  Example: sudo mkdir -p %s && sudo chown 1000:1000 %s", dir, mkErr, dir, dir)
+		}
+		slog.Info("created database directory", "path", dir)
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("cannot access database directory %q: %w", dir, err)
+	}
+
+	// Exists but is not a directory.
+	if !info.IsDir() {
+		return fmt.Errorf("database directory path %q exists but is not a directory (mode: %s)", dir, info.Mode())
+	}
+
+	// Check if we can write to the directory by creating a temp file.
+	testFile := filepath.Join(dir, ".spela-write-test")
+	f, err := os.Create(testFile)
+	if err != nil {
+		uid := os.Getuid()
+		gid := os.Getgid()
+		return fmt.Errorf("database directory %q exists but is not writable: %w\n"+
+			"  Directory permissions: %s\n"+
+			"  Container is running as uid=%d gid=%d\n"+
+			"  Hint: Fix permissions on the host with:\n"+
+			"    sudo chown %d:%d %s\n"+
+			"  Or more permissive:\n"+
+			"    sudo chmod 777 %s",
+			dir, err, info.Mode().Perm(), uid, gid, uid, gid, dir, dir)
+	}
+	f.Close()
+	os.Remove(testFile)
+
+	// If the database file already exists, check if it's readable/writable.
+	if dbInfo, err := os.Stat(dbPath); err == nil {
+		file, err := os.OpenFile(dbPath, os.O_RDWR, 0)
+		if err != nil {
+			uid := os.Getuid()
+			gid := os.Getgid()
+			return fmt.Errorf("database file %q exists but cannot be opened for read/write: %w\n"+
+				"  File permissions: %s\n"+
+				"  Container is running as uid=%d gid=%d\n"+
+				"  Hint: Fix permissions with:\n"+
+				"    sudo chown %d:%d %s",
+				dbPath, err, dbInfo.Mode().Perm(), uid, gid, uid, gid, dbPath)
+		}
+		file.Close()
+	}
+
+	return nil
+}
+
 // Initialize opens the SQLite database and runs auto-migrations.
 // The database file is restricted to owner-only access (0600) to prevent
 // other users on the system from reading tokens and password hashes.
 func Initialize(dbPath string) (*gorm.DB, error) {
-	// Ensure the parent directory exists so SQLite can create the file.
-	if dir := filepath.Dir(dbPath); dir != "." && dir != "" {
-		if err := os.MkdirAll(dir, 0700); err != nil {
-			return nil, fmt.Errorf("creating database directory %s: %w", dir, err)
-		}
+	dir := filepath.Dir(dbPath)
+	if dir == "" || dir == "." {
+		dir = "."
+	}
+
+	// Preflight checks: verify the database directory exists and is writable.
+	if err := checkDatabaseDirectory(dir, dbPath); err != nil {
+		return nil, err
 	}
 
 	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -16,6 +16,13 @@ import (
 // The database file is restricted to owner-only access (0600) to prevent
 // other users on the system from reading tokens and password hashes.
 func Initialize(dbPath string) (*gorm.DB, error) {
+	// Ensure the parent directory exists so SQLite can create the file.
+	if dir := filepath.Dir(dbPath); dir != "." && dir != "" {
+		if err := os.MkdirAll(dir, 0700); err != nil {
+			return nil, fmt.Errorf("creating database directory %s: %w", dir, err)
+		}
+	}
+
 	db, err := gorm.Open(sqlite.Open(dbPath), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Warn),
 	})


### PR DESCRIPTION
## Summary
- Add `SPELA_IGDB_CLIENT_ID` and `SPELA_IGDB_CLIENT_SECRET` environment variables to both `docker-compose.yml` and `docker-compose.qa.yml`
- Add IGDB credentials to the optional env vars documentation in compose file headers

Without this, IGDB game metadata scraping doesn't work in Docker deployments.