### PR TITLE
fix: make native library build cross-platform for Windows CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -174,7 +174,7 @@ jobs:
         run: |
           brew install molten-vk vulkan-headers vulkan-loader sdl2
           echo "VULKAN_SDK=$(brew --prefix)" >> "$GITHUB_ENV"
-      - name: Install Vulkan SDK (Windows)
+      - name: Install Windows dependencies
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
@@ -183,6 +183,8 @@ jobs:
           Start-Process -FilePath .\vulkan_sdk.exe -ArgumentList "--accept-licenses --default-answer --confirm-command install" -Wait
           echo "VULKAN_SDK=C:\VulkanSDK\$ver" >> $env:GITHUB_ENV
           echo "C:\VulkanSDK\$ver\Bin" >> $env:GITHUB_PATH
+          choco install ninja cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
+          echo "C:\Program Files\CMake\bin" >> $env:GITHUB_PATH
       - name: Cache Gradle
         uses: actions/cache@v4
         with:

--- a/player/desktop/build.gradle.kts
+++ b/player/desktop/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 
 val nativeBuildDir = project.layout.buildDirectory.dir("native")
 
-val buildNativeLibrary by tasks.registering(Exec::class) {
+val buildNativeLibrary by tasks.registering {
     group = "native"
     description = "Build the spela-libretro native library for desktop"
 
@@ -22,31 +22,74 @@ val buildNativeLibrary by tasks.registering(Exec::class) {
     inputs.file(nativeSrc.resolve("CMakeLists.txt"))
     outputs.dir(nativeDir)
 
-    doFirst {
+    doLast {
         nativeDir.mkdirs()
-    }
 
-    workingDir = nativeDir
-    // Find cmake: system PATH, then Android SDK, then common Homebrew locations
-    commandLine("sh", "-c", """
-        CMAKE=${'$'}(command -v cmake 2>/dev/null)
-        if [ -z "${'$'}CMAKE" ]; then
-            for dir in "${'$'}HOME/Library/Android/sdk/cmake"/*/bin; do
-                if [ -x "${'$'}dir/cmake" ]; then CMAKE="${'$'}dir/cmake"; break; fi
-            done
-        fi
-        if [ -z "${'$'}CMAKE" ]; then
-            for dir in /opt/homebrew/bin /usr/local/bin; do
-                if [ -x "${'$'}dir/cmake" ]; then CMAKE="${'$'}dir/cmake"; break; fi
-            done
-        fi
-        if [ -z "${'$'}CMAKE" ]; then echo "ERROR: cmake not found" >&2; exit 1; fi
-        # Find JAVA_HOME for JNI headers
-        JHOME=${'$'}([ -n "${'$'}JAVA_HOME" ] && echo "${'$'}JAVA_HOME" || /usr/libexec/java_home 2>/dev/null || echo "")
-        echo "Using cmake: ${'$'}CMAKE"
-        echo "Using JAVA_HOME: ${'$'}JHOME"
-        "${'$'}CMAKE" -DJAVA_HOME="${'$'}JHOME" "${nativeSrc.absolutePath}" && make -j${'$'}(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)
-    """.trimIndent())
+        // Find cmake
+        val cmakePath = findCmake()
+            ?: error("cmake not found. Install CMake and ensure it is on PATH.")
+
+        val javaHome = System.getenv("JAVA_HOME")
+            ?: org.gradle.internal.jvm.Jvm.current().javaHome.absolutePath
+
+        logger.lifecycle("Using cmake: $cmakePath")
+        logger.lifecycle("Using JAVA_HOME: $javaHome")
+
+        // Configure
+        val configureArgs = mutableListOf(
+            cmakePath,
+            "-DJAVA_HOME=$javaHome",
+            nativeSrc.absolutePath,
+        )
+        // Use Ninja on Windows if available (avoids heavy Visual Studio generator)
+        if (org.gradle.internal.os.OperatingSystem.current().isWindows) {
+            if (findExecutable("ninja") != null) {
+                configureArgs.add(1, "-G")
+                configureArgs.add(2, "Ninja")
+            }
+        }
+
+        exec {
+            workingDir = nativeDir
+            commandLine(configureArgs)
+        }
+
+        // Build
+        exec {
+            workingDir = nativeDir
+            commandLine(cmakePath, "--build", ".", "--parallel")
+        }
+    }
+}
+
+fun findCmake(): String? {
+    findExecutable("cmake")?.let { return it }
+    // Fallback: Android SDK cmake
+    val androidHome = System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT")
+    if (androidHome != null) {
+        file("$androidHome/cmake").listFiles()?.flatMap { ver ->
+            listOf(File(ver, "bin/cmake"), File(ver, "bin/cmake.exe"))
+        }?.firstOrNull { it.canExecute() }?.let { return it.absolutePath }
+    }
+    // Fallback: common Homebrew locations
+    listOf("/opt/homebrew/bin/cmake", "/usr/local/bin/cmake")
+        .map { File(it) }
+        .firstOrNull { it.canExecute() }
+        ?.let { return it.absolutePath }
+    return null
+}
+
+fun findExecutable(name: String): String? {
+    val pathDirs = System.getenv("PATH")?.split(File.pathSeparator) ?: return null
+    val extensions = if (org.gradle.internal.os.OperatingSystem.current().isWindows)
+        listOf(".exe", ".cmd", ".bat", "") else listOf("")
+    for (dir in pathDirs) {
+        for (ext in extensions) {
+            val candidate = File(dir, "$name$ext")
+            if (candidate.canExecute()) return candidate.absolutePath
+        }
+    }
+    return null
 }
 
 kotlin {


### PR DESCRIPTION
## Summary
- Replace Unix-only `sh -c` shell script in `buildNativeLibrary` with Gradle-native `exec {}` calls
- Use `cmake --build . --parallel` instead of `make -j` (works on all platforms)
- Prefer Ninja generator on Windows (avoids heavy Visual Studio generator)
- Install cmake and ninja on Windows CI via chocolatey

## Context
Now that `gradlew.bat` exists (PR #6), the Windows build actually runs for the first time. The native library build task was a bash script with Unix-only commands (`make`, `sysctl`/`nproc`) and had quoting issues with Windows paths containing spaces (`C:\Program Files\...`).