### PR TITLE
fix: auto-fix bind mount permissions on container startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,9 @@ RUN CGO_ENABLED=1 go build -o spela-seed ./cmd/seed
 # --- Stage 3: Runtime ---
 FROM alpine:3.20
 
-RUN apk add --no-cache sqlite-libs ca-certificates
+RUN apk add --no-cache sqlite-libs ca-certificates su-exec
 
 RUN adduser -D -h /app spela
-USER spela
 WORKDIR /app
 
 COPY --from=backend-builder /build/spela-server .

--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -19,6 +19,8 @@
 #   SPELA_SCRAPER_DEV_PASS
 #   SPELA_SCRAPER_USER
 #   SPELA_SCRAPER_USER_PASS
+#   PUID                    — UID for the container process (default: 1000)
+#   PGID                    — GID for the container process (default: 1000)
 #   TURN_EXTERNAL_IP        — public IP if behind NAT (coturn auto-detects on most VPS)
 
 services:
@@ -37,6 +39,8 @@ services:
       - ${SPELA_GAMES_PATH:-${SPELA_BASE_PATH:-/docker/spela}/games}:/app/games:ro
       - ${SPELA_BIOS_PATH:-${SPELA_BASE_PATH:-/docker/spela}/bios}:/app/bios:ro
     environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
       - SPELA_PORT=8080
       - SPELA_JWT_SECRET=${SPELA_JWT_SECRET:?Set SPELA_JWT_SECRET in Portainer stack env}
       - SPELA_ENCRYPTION_KEY=${SPELA_ENCRYPTION_KEY:?Set SPELA_ENCRYPTION_KEY in Portainer stack env}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@
 #   SPELA_SCRAPER_DEV_PASS
 #   SPELA_SCRAPER_USER
 #   SPELA_SCRAPER_USER_PASS
+#   PUID                    — UID for the container process (default: 1000)
+#   PGID                    — GID for the container process (default: 1000)
 #   TURN_EXTERNAL_IP        — public IP if behind NAT (coturn auto-detects on most VPS)
 
 services:
@@ -37,6 +39,8 @@ services:
       - ${SPELA_GAMES_PATH:-${SPELA_BASE_PATH:-/docker/spela}/games}:/app/games:ro
       - ${SPELA_BIOS_PATH:-${SPELA_BASE_PATH:-/docker/spela}/bios}:/app/bios:ro
     environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
       - SPELA_PORT=8080
       - SPELA_JWT_SECRET=${SPELA_JWT_SECRET:?Set SPELA_JWT_SECRET in .env}
       - SPELA_ENCRYPTION_KEY=${SPELA_ENCRYPTION_KEY:?Set SPELA_ENCRYPTION_KEY in .env}

--- a/server/README.md
+++ b/server/README.md
@@ -48,12 +48,12 @@ docker compose up -d
 | `SPELA_GAME_DIRS` | `./games` | Comma-separated ROM directories to scan |
 | `SPELA_SAVE_DIR` | `./saves` | Directory for save state files |
 | `SPELA_CORE_DIR` | `./cores` | Directory for libretro core binaries |
-| `SPELA_CORS_ORIGINS` | `*` | Comma-separated allowed CORS origins |
+| `SPELA_CORS_ORIGINS` | (none) | Comma-separated allowed CORS origins (same-origin only if unset) |
 | `SPELA_WS_ORIGINS` | (any) | Comma-separated allowed WebSocket origins |
 ### Security notes
 
 - `SPELA_JWT_SECRET` **must** be set in production. The server refuses to start in release mode (`GIN_MODE=release`) with the default secret.
-- When `SPELA_CORS_ORIGINS` is set to `*` (default), `AllowCredentials` is automatically disabled to comply with the CORS specification.
+- When `SPELA_CORS_ORIGINS` is set to `*`, `AllowCredentials` is automatically disabled to comply with the CORS specification.
 - Set `SPELA_WS_ORIGINS` to restrict WebSocket connections to specific origins.
 
 ## API Overview

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -88,9 +88,8 @@ func main() {
 		slog.Warn("SPELA_ENCRYPTION_KEY not set; deriving from JWT secret (set a separate key for production)")
 	}
 
-	// Warn if CORS origins are not configured
 	if len(corsOrigins) == 0 {
-		slog.Warn("SPELA_CORS_ORIGINS not set; cross-origin requests will be rejected")
+		slog.Info("CORS: same-origin only (set SPELA_CORS_ORIGINS to allow cross-origin requests)")
 	}
 
 	slog.Info("starting Spela server", "port", port, "gameDirs", gameDirs)

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,17 +1,30 @@
 #!/bin/sh
 set -e
 
+# ── Configure runtime user ─────────────────────────────────────────────
+# Set PUID/PGID to match the owner of your host directories.
+# Defaults to 1000:1000 (the built-in spela user).
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+# Update the spela user/group to match the requested UID/GID.
+if [ "$(id -u spela)" != "$PUID" ] || [ "$(id -g spela)" != "$PGID" ]; then
+    echo "Setting spela user to uid=$PUID gid=$PGID"
+    sed -i "s/^spela:x:[0-9]*:[0-9]*/spela:x:${PUID}:${PGID}/" /etc/passwd
+    sed -i "s/^spela:x:[0-9]*/spela:x:${PGID}/" /etc/group
+fi
+
 # ── Fix ownership on bind-mounted directories ──────────────────────────
 # Docker creates host directories as root when they don't exist yet.
-# Ensure all data directories are owned by the spela user (uid 1000)
-# so the server process can read and write to them.
+# Ensure all data directories are owned by the spela user so the server
+# process can read and write to them.
 SPELA_DIRS="/app/data /app/saves /app/cores /app/images /app/bios"
 for dir in $SPELA_DIRS; do
     if [ -d "$dir" ]; then
         owner=$(stat -c '%u' "$dir" 2>/dev/null || stat -f '%u' "$dir" 2>/dev/null)
-        if [ "$owner" != "$(id -u spela)" ]; then
-            echo "Fixing ownership on $dir (was uid=$owner, setting to spela)..."
-            chown -R spela:spela "$dir"
+        if [ "$owner" != "$PUID" ]; then
+            echo "Fixing ownership on $dir (was uid=$owner, setting to $PUID:$PGID)..."
+            chown -R "$PUID:$PGID" "$dir"
         fi
     fi
 done

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,12 +1,28 @@
 #!/bin/sh
 set -e
 
+# ── Fix ownership on bind-mounted directories ──────────────────────────
+# Docker creates host directories as root when they don't exist yet.
+# Ensure all data directories are owned by the spela user (uid 1000)
+# so the server process can read and write to them.
+SPELA_DIRS="/app/data /app/saves /app/cores /app/images /app/bios"
+for dir in $SPELA_DIRS; do
+    if [ -d "$dir" ]; then
+        owner=$(stat -c '%u' "$dir" 2>/dev/null || stat -f '%u' "$dir" 2>/dev/null)
+        if [ "$owner" != "$(id -u spela)" ]; then
+            echo "Fixing ownership on $dir (was uid=$owner, setting to spela)..."
+            chown -R spela:spela "$dir"
+        fi
+    fi
+done
+
+# ── Drop to spela user and run ─────────────────────────────────────────
 if [ "$SPELA_SEED" = "true" ]; then
     echo "Seeding database..."
-    ./spela-seed
+    su-exec spela ./spela-seed
 
     # Start the server in the background so we can trigger a game scan
-    ./spela-server &
+    su-exec spela ./spela-server &
     SERVER_PID=$!
 
     # Wait for the server to be ready
@@ -39,5 +55,5 @@ if [ "$SPELA_SEED" = "true" ]; then
     # Wait for server process (keeps container running)
     wait $SERVER_PID
 else
-    exec ./spela-server
+    exec su-exec spela ./spela-server
 fi


### PR DESCRIPTION
## Summary
- Entrypoint now starts as root, checks ownership of data directories (`/app/data`, `/app/saves`, `/app/cores`, `/app/images`, `/app/bios`), and chowns them to the `spela` user if needed before dropping privileges via `su-exec`
- Removes `USER spela` from Dockerfile — the entrypoint handles privilege dropping instead
- Downgrades CORS log from WARN to INFO since same-origin is the expected config

This fixes the common Portainer/Docker deployment issue where bind-mounted host directories are created as root, preventing the container from writing to them. Server admins no longer need to manually `chown` directories.

## Test plan
- [ ] Deploy with fresh bind mounts — container should auto-fix ownership and start successfully
- [ ] Verify logs show "Fixing ownership on /app/data..." on first start
- [ ] Verify subsequent restarts skip the chown (ownership already correct)
- [ ] Verify the server process runs as `spela` (uid 1000), not root