### PR TITLE
feat: Windows native C support and PUID/PGID for Docker

### DIFF
--- a/docker-compose.qa.yml
+++ b/docker-compose.qa.yml
@@ -19,6 +19,8 @@
 #   SPELA_SCRAPER_DEV_PASS
 #   SPELA_SCRAPER_USER
 #   SPELA_SCRAPER_USER_PASS
+#   PUID                    — UID for the container process (default: 1000)
+#   PGID                    — GID for the container process (default: 1000)
 #   TURN_EXTERNAL_IP        — public IP if behind NAT (coturn auto-detects on most VPS)
 
 services:
@@ -37,6 +39,8 @@ services:
       - ${SPELA_GAMES_PATH:-${SPELA_BASE_PATH:-/docker/spela}/games}:/app/games:ro
       - ${SPELA_BIOS_PATH:-${SPELA_BASE_PATH:-/docker/spela}/bios}:/app/bios:ro
     environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
       - SPELA_PORT=8080
       - SPELA_JWT_SECRET=${SPELA_JWT_SECRET:?Set SPELA_JWT_SECRET in Portainer stack env}
       - SPELA_ENCRYPTION_KEY=${SPELA_ENCRYPTION_KEY:?Set SPELA_ENCRYPTION_KEY in Portainer stack env}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,8 @@
 #   SPELA_SCRAPER_DEV_PASS
 #   SPELA_SCRAPER_USER
 #   SPELA_SCRAPER_USER_PASS
+#   PUID                    — UID for the container process (default: 1000)
+#   PGID                    — GID for the container process (default: 1000)
 #   TURN_EXTERNAL_IP        — public IP if behind NAT (coturn auto-detects on most VPS)
 
 services:
@@ -37,6 +39,8 @@ services:
       - ${SPELA_GAMES_PATH:-${SPELA_BASE_PATH:-/docker/spela}/games}:/app/games:ro
       - ${SPELA_BIOS_PATH:-${SPELA_BASE_PATH:-/docker/spela}/bios}:/app/bios:ro
     environment:
+      - PUID=${PUID:-1000}
+      - PGID=${PGID:-1000}
       - SPELA_PORT=8080
       - SPELA_JWT_SECRET=${SPELA_JWT_SECRET:?Set SPELA_JWT_SECRET in .env}
       - SPELA_ENCRYPTION_KEY=${SPELA_ENCRYPTION_KEY:?Set SPELA_ENCRYPTION_KEY in .env}

--- a/player/native/src/gpu_renderer_vulkan.c
+++ b/player/native/src/gpu_renderer_vulkan.c
@@ -50,7 +50,7 @@
 #endif
 
 #include <vulkan/vulkan.h>
-#include <pthread.h>
+#include "sp_platform.h"
 
 #include "gpu_renderer.h"
 #include "gpu_shaders_spirv.h"
@@ -208,7 +208,7 @@ struct gpu_renderer {
     uint32_t hw_core_cmd_count;
     VkDescriptorPool hw_descriptor_pool;
     VkDescriptorSet hw_descriptor_sets[MAX_FRAMES_IN_FLIGHT];
-    pthread_mutex_t queue_mutex;
+    sp_mutex_t queue_mutex;
     bool queue_mutex_initialized;
 
     /* Actual surface dimensions (what the user sees, from SurfaceView callback).
@@ -368,9 +368,9 @@ void gpu_renderer_suspend_surface(gpu_renderer_t *r) {
      * hw_render_frame / gpu_renderer_render while we tear down. */
     r->active = false;
     /* Serialize with any in-flight queue submission from the render thread */
-    if (r->queue_mutex_initialized) pthread_mutex_lock(&r->queue_mutex);
+    if (r->queue_mutex_initialized) sp_mutex_lock(&r->queue_mutex);
     if (r->device) vkDeviceWaitIdle(r->device);
-    if (r->queue_mutex_initialized) pthread_mutex_unlock(&r->queue_mutex);
+    if (r->queue_mutex_initialized) sp_mutex_unlock(&r->queue_mutex);
     cleanup_swapchain(r);
     if (r->surface) {
         vkDestroySurfaceKHR(r->instance, r->surface, NULL);
@@ -425,7 +425,7 @@ void gpu_renderer_deinit_surface(gpu_renderer_t *r) {
         gpu_renderer_hw_vulkan_deinit(r);
     }
     if (r->queue_mutex_initialized) {
-        pthread_mutex_destroy(&r->queue_mutex);
+        sp_mutex_destroy(&r->queue_mutex);
         r->queue_mutex_initialized = false;
     }
 
@@ -845,7 +845,7 @@ static void hw_vulkan_lock_queue(void *handle) {
     (void)handle;
     gpu_renderer_t *r = g_hw_renderer;
     if (r && r->queue_mutex_initialized) {
-        pthread_mutex_lock(&r->queue_mutex);
+        sp_mutex_lock(&r->queue_mutex);
     }
 }
 
@@ -853,7 +853,7 @@ static void hw_vulkan_unlock_queue(void *handle) {
     (void)handle;
     gpu_renderer_t *r = g_hw_renderer;
     if (r && r->queue_mutex_initialized) {
-        pthread_mutex_unlock(&r->queue_mutex);
+        sp_mutex_unlock(&r->queue_mutex);
     }
 }
 
@@ -881,7 +881,7 @@ bool gpu_renderer_hw_vulkan_init(gpu_renderer_t *r) {
 
     /* Initialize queue mutex */
     if (!r->queue_mutex_initialized) {
-        if (pthread_mutex_init(&r->queue_mutex, NULL) != 0) {
+        if (sp_mutex_init(&r->queue_mutex) != 0) {
             VK_LOGE("Failed to init queue mutex");
             return false;
         }
@@ -1199,9 +1199,9 @@ static void gpu_renderer_hw_render_frame_offscreen(gpu_renderer_t *r, unsigned w
         .pSignalSemaphores = signal_sems,
     };
 
-    pthread_mutex_lock(&r->queue_mutex);
+    sp_mutex_lock(&r->queue_mutex);
     VkResult result = vkQueueSubmit(r->graphics_queue, 1, &submit_info, r->offscreen_fence);
-    pthread_mutex_unlock(&r->queue_mutex);
+    sp_mutex_unlock(&r->queue_mutex);
 
     if (result != VK_SUCCESS) {
         VK_LOGE("hw_render_frame_offscreen: vkQueueSubmit failed: %d", result);
@@ -1409,10 +1409,10 @@ void gpu_renderer_hw_render_frame(gpu_renderer_t *r, unsigned width, unsigned he
         .pSignalSemaphores = signal_sems,
     };
 
-    pthread_mutex_lock(&r->queue_mutex);
+    sp_mutex_lock(&r->queue_mutex);
     result = vkQueueSubmit(r->graphics_queue, 1, &submit_info,
                            r->in_flight_fences[r->current_frame]);
-    pthread_mutex_unlock(&r->queue_mutex);
+    sp_mutex_unlock(&r->queue_mutex);
 
     if (result != VK_SUCCESS) {
         VK_LOGE("hw_render_frame: vkQueueSubmit failed: %d", result);
@@ -1430,9 +1430,9 @@ void gpu_renderer_hw_render_frame(gpu_renderer_t *r, unsigned width, unsigned he
         .pImageIndices = &image_index,
     };
 
-    pthread_mutex_lock(&r->queue_mutex);
+    sp_mutex_lock(&r->queue_mutex);
     result = vkQueuePresentKHR(r->graphics_queue, &present_info);
-    pthread_mutex_unlock(&r->queue_mutex);
+    sp_mutex_unlock(&r->queue_mutex);
 
     if (result == VK_ERROR_OUT_OF_DATE_KHR) {
         recreate_swapchain(r);

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -16,12 +16,13 @@
 #include "hw_render_gl.h"
 
 #include <jni.h>
-#include <dlfcn.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifndef _WIN32
 #include <unistd.h>
 #include <sys/stat.h>
+#endif
 #include <errno.h>
 #ifdef __ANDROID__
 #include <android/native_window_jni.h>
@@ -40,7 +41,9 @@
 static FILE *g_bridge_log_file = NULL;
 static FILE *bridge_log_get(void) {
     if (!g_bridge_log_file) {
-        g_bridge_log_file = fopen("/tmp/spela_bridge.log", "w");
+        char log_path[512];
+        snprintf(log_path, sizeof(log_path), "%sspela_bridge.log", sp_get_temp_dir());
+        g_bridge_log_file = fopen(log_path, "w");
         if (g_bridge_log_file) setbuf(g_bridge_log_file, NULL);
     }
     return g_bridge_log_file ? g_bridge_log_file : stderr;
@@ -553,7 +556,7 @@ static bool environment_callback(unsigned cmd, void *data) {
 
 /* Resolve a symbol from the loaded core shared library */
 #define LOAD_SYM(sym) do { \
-    g_core.sym = (sym##_t)dlsym(g_core.handle, #sym); \
+    g_core.sym = (sym##_t)sp_dlsym(g_core.handle, #sym); \
     if (!g_core.sym) { \
         LOGE("Failed to load symbol: %s", #sym); \
         return -1; \
@@ -625,7 +628,7 @@ static void preload_vulkan_library(void) {
         LOGI("Set DYLD_FALLBACK_LIBRARY_PATH=%s", fallback);
 
         /* Pre-load MoltenVK with RTLD_GLOBAL so symbols are available */
-        void *h = dlopen(mvk_found, RTLD_NOW | RTLD_GLOBAL);
+        sp_lib_t h = sp_dlopen(mvk_found, RTLD_NOW | RTLD_GLOBAL);
         if (h) {
             LOGI("Pre-loaded MoltenVK: %s", mvk_found);
         }
@@ -649,14 +652,14 @@ static int core_load(const char *path) {
             g_core.retro_deinit();
             g_core.initialized = false;
         }
-        dlclose(g_core.handle);
+        sp_dlclose(g_core.handle);
         g_core.handle = NULL;
     }
 
     LOGI("Loading core: %s", path);
-    g_core.handle = dlopen(path, RTLD_LAZY);
+    g_core.handle = sp_dlopen(path, RTLD_LAZY);
     if (!g_core.handle) {
-        LOGE("dlopen failed: %s", dlerror());
+        LOGE("dlopen failed: %s", sp_dlerror());
         return -1;
     }
 
@@ -674,7 +677,7 @@ static int core_load(const char *path) {
          * Play! stores a static JavaVM* pointer via this method, which its
          * PS2VM worker thread needs for JNI AttachCurrentThread(). */
         typedef void (*SetJavaVM_fn)(JavaVM *);
-        SetJavaVM_fn set_jvm = (SetJavaVM_fn)dlsym(g_core.handle,
+        SetJavaVM_fn set_jvm = (SetJavaVM_fn)sp_dlsym(g_core.handle,
             "_ZN9Framework7CJavaVM9SetJavaVMEP7_JavaVM");
         if (set_jvm) {
             LOGI("Play! core detected, passing JavaVM to CJavaVM::SetJavaVM");
@@ -1040,7 +1043,7 @@ JNI_FUNC(void, nativeDeinit)(JNIEnv *env, jobject thiz) {
     input_deinit();
     audio_deinit();
 
-    /* Clear pointers into core's memory before dlclose */
+    /* Clear pointers into core's memory before sp_dlclose */
     g_core.hw_vk_negotiation = NULL;
     g_core.hw_render_enabled = false;
     memset(&g_core.hw_render_callback, 0, sizeof(g_core.hw_render_callback));
@@ -1057,10 +1060,10 @@ JNI_FUNC(void, nativeDeinit)(JNIEnv *env, jobject thiz) {
         if (g_gpu_renderer) {
             LOGI("Skipping dlclose for HW render core (background threads may still be running)");
         } else {
-            dlclose(g_core.handle);
+            sp_dlclose(g_core.handle);
         }
 #else
-        dlclose(g_core.handle);
+        sp_dlclose(g_core.handle);
 #endif
         g_core.handle = NULL;
     }

--- a/player/native/src/libretro_bridge.h
+++ b/player/native/src/libretro_bridge.h
@@ -7,6 +7,7 @@
 #define LIBRETRO_BRIDGE_H
 
 #include "libretro.h"
+#include "sp_platform.h"
 #include <stdbool.h>
 
 /* Forward declarations for subsystem modules */
@@ -52,7 +53,7 @@ void core_variables_clear(void);
 
 /* Core state */
 typedef struct {
-    void *handle;                           /* dlopen handle */
+    sp_lib_t handle;                        /* dlopen/LoadLibrary handle */
 
     /* Core API functions */
     retro_init_t                    retro_init;

--- a/player/native/src/sp_platform.h
+++ b/player/native/src/sp_platform.h
@@ -1,0 +1,141 @@
+/*
+ * Cross-platform wrappers for dynamic library loading, mutexes, and temp dirs.
+ * POSIX (Linux/macOS/Android) vs Win32.
+ *
+ * All functions are static inline to avoid ODR issues when included
+ * from multiple translation units.
+ */
+
+#ifndef SP_PLATFORM_H
+#define SP_PLATFORM_H
+
+#ifdef _WIN32
+
+/* ── Windows ─────────────────────────────────────────────────────── */
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+/* Dynamic library loading */
+typedef HMODULE sp_lib_t;
+
+static inline sp_lib_t sp_dlopen(const char *path, int flags) {
+    (void)flags;
+    return LoadLibraryA(path);
+}
+
+static inline void *sp_dlsym(sp_lib_t lib, const char *sym) {
+    return (void *)GetProcAddress(lib, sym);
+}
+
+static inline int sp_dlclose(sp_lib_t lib) {
+    return FreeLibrary(lib) ? 0 : -1;
+}
+
+static inline const char *sp_dlerror(void) {
+    static __declspec(thread) char buf[256];
+    DWORD err = GetLastError();
+    if (err == 0) return "(no error)";
+    FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+                   NULL, err, 0, buf, sizeof(buf), NULL);
+    return buf;
+}
+
+/* RTLD_* constants — unused on Windows but needed for source compat */
+#ifndef RTLD_LAZY
+#define RTLD_LAZY   0
+#endif
+#ifndef RTLD_NOW
+#define RTLD_NOW    0
+#endif
+#ifndef RTLD_GLOBAL
+#define RTLD_GLOBAL 0
+#endif
+
+/* Mutex */
+typedef CRITICAL_SECTION sp_mutex_t;
+
+static inline int sp_mutex_init(sp_mutex_t *m) {
+    InitializeCriticalSection(m);
+    return 0;
+}
+
+static inline void sp_mutex_lock(sp_mutex_t *m) {
+    EnterCriticalSection(m);
+}
+
+static inline void sp_mutex_unlock(sp_mutex_t *m) {
+    LeaveCriticalSection(m);
+}
+
+static inline void sp_mutex_destroy(sp_mutex_t *m) {
+    DeleteCriticalSection(m);
+}
+
+/* Temp directory (includes trailing path separator) */
+static inline const char *sp_get_temp_dir(void) {
+    static char buf[MAX_PATH];
+    if (buf[0] == '\0') {
+        DWORD len = GetTempPathA(MAX_PATH, buf);
+        /* GetTempPathA always includes trailing backslash, but guard anyway */
+        if (len > 0 && buf[len - 1] != '\\') {
+            buf[len] = '\\';
+            buf[len + 1] = '\0';
+        }
+    }
+    return buf;
+}
+
+#else
+
+/* ── POSIX (Linux / macOS / Android) ─────────────────────────────── */
+
+#include <dlfcn.h>
+#include <pthread.h>
+
+/* Dynamic library loading */
+typedef void *sp_lib_t;
+
+static inline sp_lib_t sp_dlopen(const char *path, int flags) {
+    return dlopen(path, flags);
+}
+
+static inline void *sp_dlsym(sp_lib_t lib, const char *sym) {
+    return dlsym(lib, sym);
+}
+
+static inline int sp_dlclose(sp_lib_t lib) {
+    return dlclose(lib);
+}
+
+static inline const char *sp_dlerror(void) {
+    return dlerror();
+}
+
+/* Mutex */
+typedef pthread_mutex_t sp_mutex_t;
+
+static inline int sp_mutex_init(sp_mutex_t *m) {
+    return pthread_mutex_init(m, NULL);
+}
+
+static inline void sp_mutex_lock(sp_mutex_t *m) {
+    pthread_mutex_lock(m);
+}
+
+static inline void sp_mutex_unlock(sp_mutex_t *m) {
+    pthread_mutex_unlock(m);
+}
+
+static inline void sp_mutex_destroy(sp_mutex_t *m) {
+    pthread_mutex_destroy(m);
+}
+
+/* Temp directory (includes trailing slash) */
+static inline const char *sp_get_temp_dir(void) {
+    return "/tmp/";
+}
+
+#endif /* _WIN32 */
+
+#endif /* SP_PLATFORM_H */

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,12 +1,41 @@
 #!/bin/sh
 set -e
 
+# ── Configure runtime user ─────────────────────────────────────────────
+# Set PUID/PGID to match the owner of your host directories.
+# Defaults to 1000:1000 (the built-in spela user).
+PUID=${PUID:-1000}
+PGID=${PGID:-1000}
+
+# Update the spela user/group to match the requested UID/GID.
+if [ "$(id -u spela)" != "$PUID" ] || [ "$(id -g spela)" != "$PGID" ]; then
+    echo "Setting spela user to uid=$PUID gid=$PGID"
+    sed -i "s/^spela:x:[0-9]*:[0-9]*/spela:x:${PUID}:${PGID}/" /etc/passwd
+    sed -i "s/^spela:x:[0-9]*/spela:x:${PGID}/" /etc/group
+fi
+
+# ── Fix ownership on bind-mounted directories ──────────────────────────
+# Docker creates host directories as root when they don't exist yet.
+# Ensure all data directories are owned by the spela user so the server
+# process can read and write to them.
+SPELA_DIRS="/app/data /app/saves /app/cores /app/images /app/bios"
+for dir in $SPELA_DIRS; do
+    if [ -d "$dir" ]; then
+        owner=$(stat -c '%u' "$dir" 2>/dev/null || stat -f '%u' "$dir" 2>/dev/null)
+        if [ "$owner" != "$PUID" ]; then
+            echo "Fixing ownership on $dir (was uid=$owner, setting to $PUID:$PGID)..."
+            chown -R "$PUID:$PGID" "$dir"
+        fi
+    fi
+done
+
+# ── Drop to spela user and run ─────────────────────────────────────────
 if [ "$SPELA_SEED" = "true" ]; then
     echo "Seeding database..."
-    ./spela-seed
+    su-exec spela ./spela-seed
 
     # Start the server in the background so we can trigger a game scan
-    ./spela-server &
+    su-exec spela ./spela-server &
     SERVER_PID=$!
 
     # Wait for the server to be ready
@@ -39,5 +68,5 @@ if [ "$SPELA_SEED" = "true" ]; then
     # Wait for server process (keeps container running)
     wait $SERVER_PID
 else
-    exec ./spela-server
+    exec su-exec spela ./spela-server
 fi


### PR DESCRIPTION
## Summary
- Add `sp_platform.h` with cross-platform wrappers for `dlfcn.h` (→ `LoadLibrary`/`GetProcAddress`), `pthread_mutex` (→ `CRITICAL_SECTION`), and temp directory paths, then replace all Unix-only API calls in `libretro_bridge.c` and `gpu_renderer_vulkan.c` with the portable wrappers — unblocks Windows MSI builds in CI
- Add `PUID`/`PGID` environment variable support to Docker compose files and entrypoint, with bind-mount ownership auto-fix and `su-exec` privilege dropping

## Test plan
- [ ] Verify `Desktop (windows-latest)` CI job compiles the native library successfully as part of `packageMsi`
- [ ] Verify macOS and Linux desktop builds still compile and pass tests (no behavioral change — POSIX wrappers are trivial passthroughs)
- [ ] Verify Android build still compiles
- [ ] Test Docker deployment with custom `PUID`/`PGID` values to confirm ownership fix works