### PR TITLE
fix: skip su-exec when container runs as non-root

### DIFF
--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -1,41 +1,51 @@
 #!/bin/sh
 set -e
 
-# ── Configure runtime user ─────────────────────────────────────────────
-# Set PUID/PGID to match the owner of your host directories.
-# Defaults to 1000:1000 (the built-in spela user).
-PUID=${PUID:-1000}
-PGID=${PGID:-1000}
+# Helper: run a command as the spela user when running as root,
+# or directly when already running as non-root (rootless Docker,
+# Portainer with --no-new-privileges, etc.).
+run_as_spela() {
+    if [ "$(id -u)" = "0" ]; then
+        su-exec spela "$@"
+    else
+        "$@"
+    fi
+}
 
-# Update the spela user/group to match the requested UID/GID.
-if [ "$(id -u spela)" != "$PUID" ] || [ "$(id -g spela)" != "$PGID" ]; then
-    echo "Setting spela user to uid=$PUID gid=$PGID"
-    sed -i "s/^spela:x:[0-9]*:[0-9]*/spela:x:${PUID}:${PGID}/" /etc/passwd
-    sed -i "s/^spela:x:[0-9]*/spela:x:${PGID}/" /etc/group
+# ── Root-only setup (skipped in rootless / non-root containers) ────────
+if [ "$(id -u)" = "0" ]; then
+    # Configure runtime user — set PUID/PGID to match your host directories.
+    PUID=${PUID:-1000}
+    PGID=${PGID:-1000}
+
+    # Update the spela user/group to match the requested UID/GID.
+    if [ "$(id -u spela)" != "$PUID" ] || [ "$(id -g spela)" != "$PGID" ]; then
+        echo "Setting spela user to uid=$PUID gid=$PGID"
+        sed -i "s/^spela:x:[0-9]*:[0-9]*/spela:x:${PUID}:${PGID}/" /etc/passwd
+        sed -i "s/^spela:x:[0-9]*/spela:x:${PGID}/" /etc/group
+    fi
+
+    # Fix ownership on bind-mounted directories.
+    # Docker creates host directories as root when they don't exist yet.
+    SPELA_DIRS="/app/data /app/saves /app/cores /app/images /app/bios"
+    for dir in $SPELA_DIRS; do
+        if [ -d "$dir" ]; then
+            owner=$(stat -c '%u' "$dir" 2>/dev/null || stat -f '%u' "$dir" 2>/dev/null)
+            if [ "$owner" != "$PUID" ]; then
+                echo "Fixing ownership on $dir (was uid=$owner, setting to $PUID:$PGID)..."
+                chown -R "$PUID:$PGID" "$dir"
+            fi
+        fi
+    done
 fi
 
-# ── Fix ownership on bind-mounted directories ──────────────────────────
-# Docker creates host directories as root when they don't exist yet.
-# Ensure all data directories are owned by the spela user so the server
-# process can read and write to them.
-SPELA_DIRS="/app/data /app/saves /app/cores /app/images /app/bios"
-for dir in $SPELA_DIRS; do
-    if [ -d "$dir" ]; then
-        owner=$(stat -c '%u' "$dir" 2>/dev/null || stat -f '%u' "$dir" 2>/dev/null)
-        if [ "$owner" != "$PUID" ]; then
-            echo "Fixing ownership on $dir (was uid=$owner, setting to $PUID:$PGID)..."
-            chown -R "$PUID:$PGID" "$dir"
-        fi
-    fi
-done
-
-# ── Drop to spela user and run ─────────────────────────────────────────
+# ── Run ────────────────────────────────────────────────────────────────
 if [ "$SPELA_SEED" = "true" ]; then
     echo "Seeding database..."
-    su-exec spela ./spela-seed
+    run_as_spela ./spela-seed
 
     # Start the server in the background so we can trigger a game scan
-    su-exec spela ./spela-server &
+    run_as_spela ./spela-server &
     SERVER_PID=$!
 
     # Wait for the server to be ready
@@ -68,5 +78,9 @@ if [ "$SPELA_SEED" = "true" ]; then
     # Wait for server process (keeps container running)
     wait $SERVER_PID
 else
-    exec su-exec spela ./spela-server
+    if [ "$(id -u)" = "0" ]; then
+        exec su-exec spela ./spela-server
+    else
+        exec ./spela-server
+    fi
 fi


### PR DESCRIPTION
## Summary
- Guard all `su-exec` calls and privilege operations (`sed /etc/passwd`, `chown`) behind `id -u == 0` check
- When running as non-root (rootless Docker, Portainer with `--no-new-privileges`), the entrypoint runs commands directly instead of via `su-exec`
- Fixes `su-exec: setgroups: Operation not permitted` on Portainer deployments

## Test plan
- [ ] Deploy to Portainer — container should start without `setgroups` errors
- [ ] Verify standard `docker compose up` still works (root → su-exec → spela)