### PR TITLE
fix: resolve Windows native build errors

### DIFF
--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -987,7 +987,7 @@ JNI_FUNC(void, nativeUnloadGame)(JNIEnv *env, jobject thiz) {
          * pipelines. context_destroy signals them to stop but doesn't join them.
          * Wait for the device to go idle, then give threads time to exit. */
         gpu_renderer_wait_idle(g_gpu_renderer);
-        usleep(200000); /* 200ms grace period for background thread shutdown */
+        sp_sleep_ms(200); /* 200ms grace period for background thread shutdown */
         gpu_renderer_hw_vulkan_deinit(g_gpu_renderer);
         g_core.hw_render_enabled = false;
         LOGI("Vulkan HW render context destroyed");
@@ -1020,7 +1020,7 @@ JNI_FUNC(void, nativeDeinit)(JNIEnv *env, jobject thiz) {
                 g_core.hw_render_callback.context_destroy();
             }
             gpu_renderer_wait_idle(g_gpu_renderer);
-            usleep(200000); /* 200ms grace for Granite background threads */
+            sp_sleep_ms(200); /* 200ms grace for Granite background threads */
             gpu_renderer_hw_vulkan_deinit(g_gpu_renderer);
             g_core.hw_render_enabled = false;
         }
@@ -1462,7 +1462,7 @@ JNI_FUNC(void, nativeGpuDeinit)(JNIEnv *env, jobject thiz) {
             /* Granite's DefaultDispatch threads may still be compiling pipelines.
              * Wait for device idle + grace period before destroying resources. */
             gpu_renderer_wait_idle(g_gpu_renderer);
-            usleep(200000); /* 200ms grace for Granite background threads */
+            sp_sleep_ms(200); /* 200ms grace for Granite background threads */
             gpu_renderer_hw_vulkan_deinit(g_gpu_renderer);
             LOGI("Vulkan HW render context destroyed (surface deinit)");
         }

--- a/player/native/src/libretro_video.c
+++ b/player/native/src/libretro_video.c
@@ -23,9 +23,7 @@
 #include "libretro_bridge.h"
 #include "gpu_renderer.h"
 
-#if defined(__APPLE__) || defined(__ANDROID__)
 #include "hw_render_gl.h"
-#endif
 #ifdef __APPLE__
 #include <OpenGL/gl3.h>
 #endif

--- a/player/native/src/sp_platform.h
+++ b/player/native/src/sp_platform.h
@@ -33,7 +33,7 @@ static inline int sp_dlclose(sp_lib_t lib) {
 }
 
 static inline const char *sp_dlerror(void) {
-    static __declspec(thread) char buf[256];
+    static char buf[256];
     DWORD err = GetLastError();
     if (err == 0) return "(no error)";
     FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
@@ -72,6 +72,11 @@ static inline void sp_mutex_destroy(sp_mutex_t *m) {
     DeleteCriticalSection(m);
 }
 
+/* Sleep */
+static inline void sp_sleep_ms(unsigned ms) {
+    Sleep(ms);
+}
+
 /* Temp directory (includes trailing path separator) */
 static inline const char *sp_get_temp_dir(void) {
     static char buf[MAX_PATH];
@@ -92,6 +97,7 @@ static inline const char *sp_get_temp_dir(void) {
 
 #include <dlfcn.h>
 #include <pthread.h>
+#include <unistd.h>
 
 /* Dynamic library loading */
 typedef void *sp_lib_t;
@@ -129,6 +135,11 @@ static inline void sp_mutex_unlock(sp_mutex_t *m) {
 
 static inline void sp_mutex_destroy(sp_mutex_t *m) {
     pthread_mutex_destroy(m);
+}
+
+/* Sleep */
+static inline void sp_sleep_ms(unsigned ms) {
+    usleep(ms * 1000u);
 }
 
 /* Temp directory (includes trailing slash) */


### PR DESCRIPTION
## Summary
Fixes three compilation errors found in the v0.0.9/v0.0.10 Windows release CI:

- **`__declspec(thread)` warning**: MinGW/GCC ignores `__declspec(thread)` — removed thread-local qualifier from `sp_dlerror` buffer (all callsites are single-threaded)
- **`usleep` undefined**: Added `sp_sleep_ms()` wrapper to `sp_platform.h` (`Sleep()` on Windows, `usleep()` on POSIX) and replaced all `usleep(200000)` calls
- **`hw_gl_read_pixels`/`hw_gl_resize_fbo` implicit declarations**: `hw_render_gl.h` was guarded by `#if defined(__APPLE__) || defined(__ANDROID__)` but the functions are called on all desktop platforms — removed the guard

## Test plan
- [ ] Verify `Desktop (windows-latest)` CI job compiles successfully
- [ ] Verify macOS and Linux desktop builds still pass