### PR TITLE
fix: include windows.h before vulkan.h for Win32 types

### DIFF
--- a/player/native/src/gpu_renderer_vulkan.c
+++ b/player/native/src/gpu_renderer_vulkan.c
@@ -43,14 +43,17 @@
  *   - All Vulkan commands are single-threaded (emulation thread owns the context)
  */
 
+#include "sp_platform.h"
+
 #ifdef __ANDROID__
 #define VK_USE_PLATFORM_ANDROID_KHR
 #elif defined(__APPLE__)
 #define VK_USE_PLATFORM_METAL_EXT
+#elif defined(_WIN32)
+#define VK_USE_PLATFORM_WIN32_KHR
 #endif
 
 #include <vulkan/vulkan.h>
-#include "sp_platform.h"
 
 #include "gpu_renderer.h"
 #include "gpu_shaders_spirv.h"

--- a/player/native/src/gpu_renderer_vulkan_desktop.c
+++ b/player/native/src/gpu_renderer_vulkan_desktop.c
@@ -15,14 +15,18 @@
 /* Only compile on non-Android, non-Apple desktop */
 #if !defined(__ANDROID__) && !defined(__APPLE__)
 
+#ifdef _WIN32
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#define VK_USE_PLATFORM_WIN32_KHR
+#endif
+
 #include <vulkan/vulkan.h>
 #include <stdio.h>
 #include <stdlib.h>
 
 #ifdef _WIN32
-#define VK_USE_PLATFORM_WIN32_KHR
 #include <vulkan/vulkan_win32.h>
-#include <windows.h>
 #elif defined(__linux__)
 
 /* X11 — always available */

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -7,9 +7,9 @@
  * Reference: RetroArch's core_ctl.c and runloop.c
  */
 
-#include <vulkan/vulkan.h>
+#include "libretro_bridge.h"  /* includes sp_platform.h → windows.h on Win32 */
 
-#include "libretro_bridge.h"
+#include <vulkan/vulkan.h>
 #include "libretro_achievements.h"
 #include "gpu_renderer.h"
 


### PR DESCRIPTION
## Summary
- Reorder includes so `sp_platform.h` (→ `windows.h`) comes before `<vulkan/vulkan.h>` in `gpu_renderer_vulkan.c`, `gpu_renderer_vulkan_desktop.c`, and `libretro_bridge.c`
- Add `VK_USE_PLATFORM_WIN32_KHR` define before the Vulkan include
- Fixes `unknown type name 'HANDLE'/'DWORD'/'HINSTANCE'` errors from `vulkan_win32.h` on Windows CI

## Test plan
- [ ] Verify `Desktop (windows-latest)` CI job compiles successfully
- [ ] Verify macOS/Linux/Android builds still pass (include reorder is harmless on POSIX)