### PR TITLE
fix: correct include order so vulkan types are defined for libretro_bridge.h

### DIFF
--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -7,9 +7,10 @@
  * Reference: RetroArch's core_ctl.c and runloop.c
  */
 
-#include "libretro_bridge.h"  /* includes sp_platform.h → windows.h on Win32 */
-
+#include "sp_platform.h"      /* must precede vulkan.h on Win32 (provides windows.h) */
 #include <vulkan/vulkan.h>
+
+#include "libretro_bridge.h"
 #include "libretro_achievements.h"
 #include "gpu_renderer.h"
 


### PR DESCRIPTION
## Summary
Fix the include order regression from #15: `libretro_bridge.h` was moved before `vulkan.h`, but it forward-declares `retro_hw_render_context_negotiation_interface_vulkan` which needs the full Vulkan type definition at callsites.

Fix: `sp_platform.h` (→ `windows.h`) → `vulkan.h` → `libretro_bridge.h` — satisfies both Win32 types and Vulkan struct definitions.

This broke all platform builds (Android, macOS, Linux, Windows) in v0.0.12.

## Test plan
- [ ] All platform release builds pass