### PR TITLE
fix: link opengl32 on Windows for wglGetProcAddress

### DIFF
--- a/player/native/CMakeLists.txt
+++ b/player/native/CMakeLists.txt
@@ -150,10 +150,11 @@ else()
                 dl
             )
         else()
-            # Windows: Vulkan (GL loaded at runtime via LoadLibrary)
+            # Windows: Vulkan + opengl32 (for wglGetProcAddress)
             target_link_libraries(spela-libretro
                 ${JNI_LIBRARIES}
                 ${Vulkan_LIBRARIES}
+                opengl32
             )
         endif()
     endif()


### PR DESCRIPTION
## Summary
Link `opengl32` on Windows to resolve `undefined reference to wglGetProcAddress` linker error. The `hw_render_gl_desktop.c` has one direct call to `wglGetProcAddress` (line 730) outside the function-pointer pattern used elsewhere.

## Test plan
- [ ] Windows MSI build links successfully