### PR TITLE
fix: filter artifact download in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -354,6 +354,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: artifacts
+          pattern: spela-*
+          merge-multiple: true
       - name: Collect release files
         run: |
           mkdir -p release


### PR DESCRIPTION
## Summary
- The `Create GitHub Release` job downloads ALL workflow artifacts including Docker build metadata artifacts that aren't valid zips, causing the step to fail
- Added `pattern: spela-*` filter to `actions/download-artifact@v4` to only download actual build outputs (APK, DMG, DEB, MSI, AppImage, Flatpak)
- Added `merge-multiple: true` to flatten artifacts into a single directory

## Test plan
- [ ] Merge and tag a new release (v0.0.15) to verify the full release pipeline completes