### PR TITLE
fix: use git tag version in release artifact filenames

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
           ANDROID_KEYSTORE_PASSWORD: ${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
           ANDROID_KEY_ALIAS: ${{ secrets.ANDROID_KEY_ALIAS }}
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
-        run: ./gradlew :android:assembleRelease
+        run: ./gradlew :android:assembleRelease -PappVersion=${GITHUB_REF_NAME#v}
       - name: Upload APK
         uses: actions/upload-artifact@v4
         with:
@@ -196,7 +196,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Build package
         working-directory: player
-        run: ./gradlew ${{ matrix.format }}
+        run: ./gradlew ${{ matrix.format }} -PappVersion=${GITHUB_REF_NAME#v}
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
@@ -231,7 +231,7 @@ jobs:
             Linux-gradle-
       - name: Build distributable
         working-directory: player
-        run: ./gradlew createDistributable
+        run: ./gradlew createDistributable -PappVersion=${GITHUB_REF_NAME#v}
       - name: Build AppImage
         working-directory: player
         run: bash linux/build-appimage.sh --arch x86_64
@@ -277,7 +277,7 @@ jobs:
             Linux-gradle-
       - name: Build distributable
         working-directory: player
-        run: ./gradlew createDistributable
+        run: ./gradlew createDistributable -PappVersion=${GITHUB_REF_NAME#v}
       - name: Build Flatpak
         working-directory: player
         run: bash linux/flatpak/build-flatpak.sh
@@ -318,10 +318,10 @@ jobs:
             Linux-ARM64-gradle-
       - name: Build distributable
         working-directory: player
-        run: ./gradlew createDistributable
+        run: ./gradlew createDistributable -PappVersion=${GITHUB_REF_NAME#v}
       - name: Build DEB
         working-directory: player
-        run: ./gradlew packageDeb
+        run: ./gradlew packageDeb -PappVersion=${GITHUB_REF_NAME#v}
       - name: Build AppImage
         working-directory: player
         run: bash linux/build-appimage.sh --arch aarch64
@@ -358,13 +358,21 @@ jobs:
           merge-multiple: true
       - name: Collect release files
         run: |
+          VERSION="${GITHUB_REF_NAME#v}"
           mkdir -p release
           find artifacts -type f \( \
             -name "*.apk" -o -name "*.dmg" -o -name "*.deb" \
             -o -name "*.msi" -o -name "*.AppImage" -o -name "*.flatpak" \
           \) -exec cp {} release/ \;
+          cd release
+          [ -f android-release.apk ] && mv android-release.apk "spela-${VERSION}-android.apk"
+          [ -f app-release.apk ] && mv app-release.apk "spela-${VERSION}-android.apk"
+          for f in Spela-x86_64.AppImage Spela-aarch64.AppImage; do
+            [ -f "$f" ] && mv "$f" "${f/Spela-/Spela-${VERSION}-}"
+          done
+          [ -f spela.flatpak ] && mv spela.flatpak "spela-${VERSION}.flatpak"
           echo "Release artifacts:"
-          ls -lh release/
+          ls -lh .
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:

--- a/player/android/build.gradle.kts
+++ b/player/android/build.gradle.kts
@@ -42,7 +42,8 @@ android {
         minSdk = 24
         targetSdk = 34
         versionCode = 1
-        versionName = "1.0.0"
+        val appVersion = project.findProperty("appVersion")?.toString() ?: "0.0.0-dev"
+        versionName = appVersion
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         ndk {

--- a/player/android/build.gradle.kts
+++ b/player/android/build.gradle.kts
@@ -42,7 +42,7 @@ android {
         minSdk = 24
         targetSdk = 34
         versionCode = 1
-        val appVersion = project.findProperty("appVersion")?.toString() ?: "0.0.0-dev"
+        val appVersion = project.findProperty("appVersion")?.toString() ?: "1.0.0"
         versionName = appVersion
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/player/desktop/build.gradle.kts
+++ b/player/desktop/build.gradle.kts
@@ -132,7 +132,8 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Spela"
-            packageVersion = "1.0.0"
+            val appVersion = project.findProperty("appVersion")?.toString() ?: "0.0.0-dev"
+            packageVersion = appVersion
 
             macOS {
                 bundleID = "com.spela.player"

--- a/player/desktop/build.gradle.kts
+++ b/player/desktop/build.gradle.kts
@@ -132,7 +132,7 @@ compose.desktop {
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Spela"
-            val appVersion = project.findProperty("appVersion")?.toString() ?: "0.0.0-dev"
+            val appVersion = project.findProperty("appVersion")?.toString() ?: "1.0.0"
             packageVersion = appVersion
 
             macOS {


### PR DESCRIPTION
## Summary
- Replace hardcoded `1.0.0` version in desktop and Android Gradle configs with a `-PappVersion` property (falls back to `0.0.0-dev` for local builds)
- Pass `${GITHUB_REF_NAME#v}` as `-PappVersion` to all Gradle invocations in the release workflow
- Rename versionless artifacts (APK, AppImage, Flatpak) in the collect step so every release file includes the tag version

## Test plan
- [ ] Tag a new release (e.g. `v0.0.16`) and verify all artifact filenames on the GitHub release page include the correct version
- [ ] Verify local builds still work without passing `-PappVersion` (should use `0.0.0-dev`)