### PR TITLE
fix: DAT cache permission denied and 404 warnings in Docker

### DIFF
--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -27,7 +27,7 @@ if [ "$(id -u)" = "0" ]; then
 
     # Fix ownership on bind-mounted directories.
     # Docker creates host directories as root when they don't exist yet.
-    SPELA_DIRS="/app/data /app/saves /app/cores /app/images /app/bios"
+    SPELA_DIRS="/app/data /app/saves /app/cores /app/images /app/bios /app/dats"
     for dir in $SPELA_DIRS; do
         if [ -d "$dir" ]; then
             owner=$(stat -c '%u' "$dir" 2>/dev/null || stat -f '%u' "$dir" 2>/dev/null)

--- a/server/internal/scraper/datcache.go
+++ b/server/internal/scraper/datcache.go
@@ -12,13 +12,19 @@ import (
 )
 
 // DiscBasedSystems lists console abbreviations where CRC-based identification
-// is impractical (disc images are too large, and No-Intro DATs don't cover them).
+// is impractical — either disc images are too large, or No-Intro DATs don't
+// exist for the platform (arcade ROM sets, DOS, etc.).
 var DiscBasedSystems = map[string]bool{
-	"PSX": true,
-	"SAT": true,
-	"DC":  true,
-	"SCD": true,
-	"PS2": true,
+	"PSX":    true,
+	"SAT":    true,
+	"DC":     true,
+	"SCD":    true,
+	"PS2":    true,
+	"GC":     true, // disc-based
+	"PCFX":   true, // disc-based
+	"NEOGEO": true, // arcade ROM sets, no No-Intro DAT
+	"ARCADE": true, // MAME ROM sets, no No-Intro DAT
+	"DOS":    true, // no No-Intro DAT
 }
 
 const datBaseURL = "https://raw.githubusercontent.com/libretro/libretro-database/master/metadat/no-intro"


### PR DESCRIPTION
## Summary
- Add `/app/dats` to the entrypoint ownership fix so the `spela` user can write DAT cache files during refresh
- Add GameCube (`GC`) and PC-FX (`PCFX`) to `DiscBasedSystems` — they are disc-based and have no No-Intro DATs
- Add Neo Geo (`NEOGEO`), MAME (`ARCADE`), and `DOS` to `DiscBasedSystems` — no No-Intro DATs exist for these platforms

## Test plan
- [ ] Deploy Docker image to Portainer and verify no "permission denied" or 404 warnings in logs during DAT refresh
- [ ] Verify `go test ./internal/scraper/...` passes