### PR TITLE
fix: handle 0.x.y versions in release packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,12 +365,23 @@ jobs:
             -o -name "*.msi" -o -name "*.AppImage" -o -name "*.flatpak" \
           \) -exec cp {} release/ \;
           cd release
+          # Rename APK (no version in build output filename)
           [ -f android-release.apk ] && mv android-release.apk "spela-${VERSION}-android.apk"
           [ -f app-release.apk ] && mv app-release.apk "spela-${VERSION}-android.apk"
+          # Rename AppImage/Flatpak (no version in build output filename)
           for f in Spela-x86_64.AppImage Spela-aarch64.AppImage; do
             [ -f "$f" ] && mv "$f" "${f/Spela-/Spela-${VERSION}-}"
           done
           [ -f spela.flatpak ] && mv spela.flatpak "spela-${VERSION}.flatpak"
+          # Fix DMG/MSI/DEB filenames: packaging bumps 0.x.y → 1.x.y for macOS
+          # compatibility, so replace the bumped version with the real tag version
+          if [[ "$VERSION" == 0.* ]]; then
+            PKG_VERSION="1${VERSION#0}"
+            for f in *; do
+              new="${f//$PKG_VERSION/$VERSION}"
+              [ "$f" != "$new" ] && mv "$f" "$new"
+            done
+          fi
           echo "Release artifacts:"
           ls -lh .
       - name: Create Release

--- a/player/desktop/build.gradle.kts
+++ b/player/desktop/build.gradle.kts
@@ -133,7 +133,8 @@ compose.desktop {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Spela"
             val appVersion = project.findProperty("appVersion")?.toString() ?: "1.0.0"
-            packageVersion = appVersion
+            // macOS DMG requires MAJOR > 0; bump 0.x.y → 1.x.y for native packaging metadata
+            packageVersion = if (appVersion.startsWith("0.")) "1" + appVersion.substring(1) else appVersion
 
             macOS {
                 bundleID = "com.spela.player"


### PR DESCRIPTION
## Summary
- macOS DMG packaging requires MAJOR > 0, which rejects pre-1.0 versions like `0.0.16`
- Bump `0.x.y` → `1.x.y` for native packaging metadata in `desktop/build.gradle.kts`
- Rename DMG/MSI/DEB artifacts back to the real tag version in the release workflow collect step

Fixes the v0.0.16 release failure where all build jobs failed with: `Illegal version for 'Dmg': '0.0.16' is not a valid version`

## Test plan
- [ ] Verify CI passes (player unit tests configure `:desktop` project)
- [ ] Tag a new release and verify all artifact filenames use the correct `0.x.y` version