### PR TITLE
fix: use bash shell for Windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,12 +365,23 @@ jobs:
             -o -name "*.msi" -o -name "*.AppImage" -o -name "*.flatpak" \
           \) -exec cp {} release/ \;
           cd release
+          # Rename APK (no version in build output filename)
           [ -f android-release.apk ] && mv android-release.apk "spela-${VERSION}-android.apk"
           [ -f app-release.apk ] && mv app-release.apk "spela-${VERSION}-android.apk"
+          # Rename AppImage/Flatpak (no version in build output filename)
           for f in Spela-x86_64.AppImage Spela-aarch64.AppImage; do
             [ -f "$f" ] && mv "$f" "${f/Spela-/Spela-${VERSION}-}"
           done
           [ -f spela.flatpak ] && mv spela.flatpak "spela-${VERSION}.flatpak"
+          # Fix DMG/MSI/DEB filenames: packaging bumps 0.x.y → 1.x.y for macOS
+          # compatibility, so replace the bumped version with the real tag version
+          if [[ "$VERSION" == 0.* ]]; then
+            PKG_VERSION="1${VERSION#0}"
+            for f in *; do
+              new="${f//$PKG_VERSION/$VERSION}"
+              [ "$f" != "$new" ] && mv "$f" "$new"
+            done
+          fi
           echo "Release artifacts:"
           ls -lh .
       - name: Create Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -196,6 +196,7 @@ jobs:
             ${{ runner.os }}-gradle-
       - name: Build package
         working-directory: player
+        shell: bash
         run: ./gradlew ${{ matrix.format }} -PappVersion=${GITHUB_REF_NAME#v}
       - name: Upload artifact
         uses: actions/upload-artifact@v4

--- a/player/desktop/build.gradle.kts
+++ b/player/desktop/build.gradle.kts
@@ -133,7 +133,8 @@ compose.desktop {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Spela"
             val appVersion = project.findProperty("appVersion")?.toString() ?: "1.0.0"
-            packageVersion = appVersion
+            // macOS DMG requires MAJOR > 0; bump 0.x.y → 1.x.y for native packaging metadata
+            packageVersion = if (appVersion.startsWith("0.")) "1" + appVersion.substring(1) else appVersion
 
             macOS {
                 bundleID = "com.spela.player"


### PR DESCRIPTION
## Summary
- The `${GITHUB_REF_NAME#v}` bash parameter expansion doesn't work in PowerShell (default shell on Windows runners), causing the Gradle command to be malformed
- Add `shell: bash` to the desktop matrix build step so it works on all platforms

Fixes the Windows build failure in v0.0.17 release workflow.

## Test plan
- [ ] Tag a release and verify the Windows MSI build succeeds