### PR TITLE
fix: chown writable directories in Dockerfile for non-root containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,7 @@ COPY --from=backend-builder /build/entrypoint.sh .
 RUN mkdir -p /app/data /app/games /app/saves /app/cores /app/images /app/dats /app/frontend
 COPY --from=backend-builder /build/dats/ /app/dats/
 COPY --from=frontend-builder /app/web/dist/ /app/frontend/
+RUN chown -R spela:spela /app/data /app/saves /app/cores /app/images /app/dats
 
 ENV SPELA_PORT=8080
 ENV SPELA_DB_PATH=/app/data/spela.db


### PR DESCRIPTION
## Summary
- The entrypoint ownership fix only runs when the container starts as root. In rootless Docker or Portainer with non-root user, `/app/dats` and other data directories stay root-owned, causing permission denied on every DAT refresh
- Add `RUN chown -R spela:spela` for writable directories at Docker build time so they work regardless of how the container is started

## Test plan
- [ ] Deploy to Portainer and verify no "permission denied" warnings in logs
- [ ] DAT refresh should complete with `refreshed=26 failures=0`