### PR TITLE
feat: require admin approval for new registrations

### DIFF
--- a/server/internal/api/admin_handler.go
+++ b/server/internal/api/admin_handler.go
@@ -111,10 +111,11 @@ func (h *AdminHandler) UpdateUser(c *gin.Context) {
 	}
 
 	var req struct {
-		Role     string `json:"role"`
-		Email    string `json:"email"`
-		Password string `json:"password"`
-		Disabled *bool  `json:"disabled"`
+		Role            string `json:"role"`
+		Email           string `json:"email"`
+		Password        string `json:"password"`
+		Disabled        *bool  `json:"disabled"`
+		PendingApproval *bool  `json:"pendingApproval"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
@@ -171,9 +172,12 @@ func (h *AdminHandler) UpdateUser(c *gin.Context) {
 		}
 		user.Disabled = *req.Disabled
 	}
+	if req.PendingApproval != nil {
+		user.PendingApproval = *req.PendingApproval
+	}
 
 	// Invalidate all existing tokens if security-sensitive fields changed
-	if req.Role != "" || req.Password != "" || req.Disabled != nil {
+	if req.Role != "" || req.Password != "" || req.Disabled != nil || req.PendingApproval != nil {
 		user.TokenVersion++
 	}
 
@@ -183,7 +187,8 @@ func (h *AdminHandler) UpdateUser(c *gin.Context) {
 	}
 
 	slog.Info("audit: admin updated user", "admin_id", currentUserID, "target_user", user.Username,
-		"changed_role", req.Role != "", "changed_password", req.Password != "", "changed_disabled", req.Disabled != nil)
+		"changed_role", req.Role != "", "changed_password", req.Password != "",
+		"changed_disabled", req.Disabled != nil, "changed_pending_approval", req.PendingApproval != nil)
 
 	c.JSON(http.StatusOK, ToUserResponse(user))
 }

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -411,23 +411,10 @@ func TestAdminEndpoint_NonAdmin(t *testing.T) {
 	router := NewRouter(*cfg)
 
 	// Register first user as admin
-	registerAndGetToken(t, router)
+	ownerToken := registerAndGetToken(t, router)
 
 	// Register second user (will be regular user)
-	body, _ := json.Marshal(map[string]string{
-		"username": "regularuser",
-		"email":    "regular@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	userToken := regResp["accessToken"].(string)
+	userToken := createNonOwnerUser(t, router, ownerToken, "regularuser", "regular@example.com", "password123")
 
 	// Verify user is not admin
 	var user db.User
@@ -435,8 +422,8 @@ func TestAdminEndpoint_NonAdmin(t *testing.T) {
 	assert.Equal(t, "user", user.Role)
 
 	// Try admin endpoint
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/api/admin/users", nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/users", nil)
 	req.Header.Set("Authorization", "Bearer "+userToken)
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusForbidden, w.Code)
@@ -1120,26 +1107,16 @@ func TestGetPublicProfile_EmptyStats(t *testing.T) {
 	token := registerAndGetToken(t, router)
 
 	// Register a second user with no activity
-	body, _ := json.Marshal(map[string]string{
-		"username": "emptyuser",
-		"email":    "empty@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
+	createNonOwnerUser(t, router, token, "emptyuser", "empty@example.com", "password123")
 
-	var database *gorm.DB
-	database = cfg.DB
+	database := cfg.DB
 	var user db.User
 	database.Where("username = ?", "emptyuser").First(&user)
 	userID := fmt.Sprintf("%d", user.ID)
 
 	// Get public profile of empty user
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/api/users/"+userID+"/profile", nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/"+userID+"/profile", nil)
 	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -1986,20 +1963,7 @@ func TestDeleteSharedSave_NotOwner(t *testing.T) {
 	saveID := createResp["id"].(string)
 
 	// Register a second user
-	body, _ := json.Marshal(map[string]string{
-		"username": "otheruser",
-		"email":    "other@example.com",
-		"password": "password123",
-	})
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	otherToken := regResp["accessToken"].(string)
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
 
 	// Try to delete as other user - should fail
 	w = httptest.NewRecorder()
@@ -2065,16 +2029,7 @@ func TestSearchUsers(t *testing.T) {
 
 	// Register additional users
 	for _, name := range []string{"alice", "alex", "bob", "charlie"} {
-		body, _ := json.Marshal(map[string]string{
-			"username": name,
-			"email":    name + "@example.com",
-			"password": "password123",
-		})
-		w := httptest.NewRecorder()
-		req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-		req.Header.Set("Content-Type", "application/json")
-		router.ServeHTTP(w, req)
-		require.Equal(t, http.StatusCreated, w.Code)
+		createNonOwnerUser(t, router, token, name, name+"@example.com", "password123")
 	}
 
 	t.Run("returns matching users by prefix", func(t *testing.T) {
@@ -2149,20 +2104,7 @@ func TestGetPendingInviteCount(t *testing.T) {
 	token := registerAndGetToken(t, router)
 
 	// Register a second user
-	body, _ := json.Marshal(map[string]string{
-		"username": "invitee",
-		"email":    "invitee@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	inviteeToken := regResp["accessToken"].(string)
+	inviteeToken := createNonOwnerUser(t, router, token, "invitee", "invitee@example.com", "password123")
 
 	t.Run("returns zero when no invites", func(t *testing.T) {
 		w := httptest.NewRecorder()
@@ -2252,23 +2194,10 @@ func TestUpdateVerificationTag_NonAdmin_Forbidden(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	// Register first user as owner
-	registerAndGetToken(t, router)
+	ownerToken := registerAndGetToken(t, router)
 
 	// Register second user (regular user)
-	body, _ := json.Marshal(map[string]string{
-		"username": "regularuser",
-		"email":    "regular@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	userToken := regResp["accessToken"].(string)
+	userToken := createNonOwnerUser(t, router, ownerToken, "regularuser", "regular@example.com", "password123")
 
 	// Create a test game
 	var console db.Console
@@ -2276,9 +2205,9 @@ func TestUpdateVerificationTag_NonAdmin_Forbidden(t *testing.T) {
 	game := db.Game{ConsoleID: console.ID, Title: "Test Game", FileName: "test.nes", FilePath: "/tmp/test.nes", FileSize: 100}
 	database.Create(&game)
 
-	body, _ = json.Marshal(map[string]string{"tag": "Hacked"})
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("PUT", fmt.Sprintf("/api/admin/games/%d/verification-tag", game.ID), bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]string{"tag": "Hacked"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", fmt.Sprintf("/api/admin/games/%d/verification-tag", game.ID), bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+userToken)
 	router.ServeHTTP(w, req)
@@ -2353,23 +2282,10 @@ func TestScrapeStatus_NonAdmin(t *testing.T) {
 	router := NewRouter(*cfg)
 
 	// Register first user as admin (owner)
-	registerAndGetToken(t, router)
+	ownerToken := registerAndGetToken(t, router)
 
 	// Register second user (will be regular user)
-	body, _ := json.Marshal(map[string]string{
-		"username": "regularuser2",
-		"email":    "regular2@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	userToken := regResp["accessToken"].(string)
+	userToken := createNonOwnerUser(t, router, ownerToken, "regularuser2", "regular2@example.com", "password123")
 
 	// Verify user is not admin
 	var user db.User
@@ -2377,8 +2293,8 @@ func TestScrapeStatus_NonAdmin(t *testing.T) {
 	assert.Equal(t, "user", user.Role)
 
 	// Non-admin should be rejected
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", "/api/admin/scrape/status", nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/scrape/status", nil)
 	req.Header.Set("Authorization", "Bearer "+userToken)
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusForbidden, w.Code)

--- a/server/internal/api/auth_handler.go
+++ b/server/internal/api/auth_handler.go
@@ -173,6 +173,11 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
+	if user.PendingApproval {
+		c.JSON(http.StatusForbidden, gin.H{"error": "account pending approval"})
+		return
+	}
+
 	if user.Disabled {
 		c.JSON(http.StatusForbidden, gin.H{"error": "account is disabled"})
 		return
@@ -258,11 +263,15 @@ func (h *AuthHandler) Register(c *gin.Context) {
 			role = db.RoleOwner
 		}
 
+		// Non-owner registrations are pending admin approval
+		pendingApproval := role != db.RoleOwner
+
 		user = db.User{
-			Username:     req.Username,
-			Email:        req.Email,
-			PasswordHash: hash,
-			Role:         role,
+			Username:        req.Username,
+			Email:           req.Email,
+			PasswordHash:    hash,
+			Role:            role,
+			PendingApproval: pendingApproval,
 		}
 
 		return tx.Create(&user).Error
@@ -272,6 +281,16 @@ func (h *AuthHandler) Register(c *gin.Context) {
 			return
 		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create user"})
+		return
+	}
+
+	// Non-owner registrations require admin approval before the account is active.
+	// Return 202 Accepted without tokens — the user cannot log in until approved.
+	if user.PendingApproval {
+		c.JSON(http.StatusAccepted, gin.H{
+			"pending": true,
+			"message": "Your account is pending admin approval.",
+		})
 		return
 	}
 

--- a/server/internal/api/auth_handler.go
+++ b/server/internal/api/auth_handler.go
@@ -144,13 +144,13 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	var req loginRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		apiError(c, http.StatusBadRequest, "invalid request body", "Please check your input and try again.")
 		return
 	}
 
 	// Check account lockout before proceeding
 	if h.isLockedOut(req.Username) {
-		c.JSON(http.StatusTooManyRequests, gin.H{"error": "account temporarily locked due to too many failed login attempts"})
+		apiError(c, http.StatusTooManyRequests, "account locked", "Your account has been temporarily locked due to too many failed login attempts. Please try again later.")
 		return
 	}
 
@@ -163,23 +163,23 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		// "wrong password" (slow bcrypt) by measuring response time.
 		auth.CheckPassword(req.Password, dummyBcryptHash)
 		h.recordFailedLogin(req.Username)
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+		apiError(c, http.StatusUnauthorized, "invalid credentials", "Invalid username or password.")
 		return
 	}
 
 	if !auth.CheckPassword(req.Password, user.PasswordHash) {
 		h.recordFailedLogin(req.Username)
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid credentials"})
+		apiError(c, http.StatusUnauthorized, "invalid credentials", "Invalid username or password.")
 		return
 	}
 
 	if user.PendingApproval {
-		c.JSON(http.StatusForbidden, gin.H{"error": "account pending approval"})
+		apiError(c, http.StatusForbidden, "account pending approval", "Your account is awaiting admin approval. Please try again once an admin has approved it.")
 		return
 	}
 
 	if user.Disabled {
-		c.JSON(http.StatusForbidden, gin.H{"error": "account is disabled"})
+		apiError(c, http.StatusForbidden, "account is disabled", "Your account has been disabled. Please contact an administrator.")
 		return
 	}
 
@@ -188,13 +188,13 @@ func (h *AuthHandler) Login(c *gin.Context) {
 
 	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, h.JWTSecret, user.TokenVersion)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate token"})
+		apiError(c, http.StatusInternalServerError, "failed to generate token", "Sign in failed. Please try again.")
 		return
 	}
 
 	refreshToken, err := auth.GenerateRefreshToken()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate refresh token"})
+		apiError(c, http.StatusInternalServerError, "failed to generate refresh token", "Sign in failed. Please try again.")
 		return
 	}
 
@@ -220,13 +220,13 @@ func (h *AuthHandler) Register(c *gin.Context) {
 	var req registerRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		apiError(c, http.StatusBadRequest, "invalid request body", "Please check your input and try again.")
 		return
 	}
 
 	hash, err := auth.HashPassword(req.Password)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to hash password"})
+		apiError(c, http.StatusInternalServerError, "failed to hash password", "Registration failed. Please try again.")
 		return
 	}
 
@@ -240,7 +240,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 		var count int64
 		tx.Model(&db.User{}).Where("username = ? OR email = ?", req.Username, req.Email).Count(&count)
 		if count > 0 {
-			c.JSON(http.StatusConflict, gin.H{"error": "username or email already exists"})
+			apiError(c, http.StatusConflict, "username or email already exists", "That username or email is already taken.")
 			return fmt.Errorf("duplicate")
 		}
 
@@ -251,7 +251,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 			var setting db.ServerSetting
 			if err := tx.Where("key = ?", "registration_enabled").First(&setting).Error; err == nil {
 				if setting.Value == "false" {
-					c.JSON(http.StatusForbidden, gin.H{"error": "registration is disabled"})
+					apiError(c, http.StatusForbidden, "registration is disabled", "Registration is currently disabled. Please contact an administrator.")
 					return fmt.Errorf("disabled")
 				}
 			}
@@ -280,7 +280,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 		if c.Writer.Written() {
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create user"})
+		apiError(c, http.StatusInternalServerError, "failed to create user", "Registration failed. Please try again.")
 		return
 	}
 
@@ -296,13 +296,13 @@ func (h *AuthHandler) Register(c *gin.Context) {
 
 	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, h.JWTSecret)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate token"})
+		apiError(c, http.StatusInternalServerError, "failed to generate token", "Account created but sign-in failed. Please sign in manually.")
 		return
 	}
 
 	refreshToken, err := auth.GenerateRefreshToken()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate refresh token"})
+		apiError(c, http.StatusInternalServerError, "failed to generate refresh token", "Account created but sign-in failed. Please sign in manually.")
 		return
 	}
 
@@ -328,7 +328,7 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 	var req refreshRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		apiError(c, http.StatusBadRequest, "invalid request body", "Please check your input and try again.")
 		return
 	}
 
@@ -347,7 +347,7 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 			h.DB.Where("token_family = ? AND user_id = ?", consumed.TokenFamily, consumed.UserID).
 				Delete(&db.RefreshToken{})
 		}
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid refresh token"})
+		apiError(c, http.StatusUnauthorized, "invalid refresh token", "Your session has expired. Please sign in again.")
 		return
 	}
 
@@ -357,38 +357,38 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 		slog.Warn("consumed refresh token presented", "user_id", rt.UserID, "family", rt.TokenFamily)
 		h.DB.Where("token_family = ? AND user_id = ?", rt.TokenFamily, rt.UserID).
 			Delete(&db.RefreshToken{})
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid refresh token"})
+		apiError(c, http.StatusUnauthorized, "invalid refresh token", "Your session has expired. Please sign in again.")
 		return
 	}
 
 	if time.Now().After(rt.ExpiresAt) {
 		h.DB.Delete(&rt)
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "refresh token expired"})
+		apiError(c, http.StatusUnauthorized, "refresh token expired", "Your session has expired. Please sign in again.")
 		return
 	}
 
 	var user db.User
 	if err := h.DB.First(&user, rt.UserID).Error; err != nil {
-		c.JSON(http.StatusUnauthorized, gin.H{"error": "user not found"})
+		apiError(c, http.StatusUnauthorized, "user not found", "Your account could not be found. Please sign in again.")
 		return
 	}
 
 	if user.Disabled {
 		h.DB.Where("token_family = ? AND user_id = ?", rt.TokenFamily, rt.UserID).
 			Delete(&db.RefreshToken{})
-		c.JSON(http.StatusForbidden, gin.H{"error": "account is disabled"})
+		apiError(c, http.StatusForbidden, "account is disabled", "Your account has been disabled. Please contact an administrator.")
 		return
 	}
 
 	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, h.JWTSecret, user.TokenVersion)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate token"})
+		apiError(c, http.StatusInternalServerError, "failed to generate token", "Session refresh failed. Please sign in again.")
 		return
 	}
 
 	newRefreshToken, err := auth.GenerateRefreshToken()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate refresh token"})
+		apiError(c, http.StatusInternalServerError, "failed to generate refresh token", "Session refresh failed. Please sign in again.")
 		return
 	}
 
@@ -412,7 +412,7 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 		}
 		return tx.Create(&newRT).Error
 	}); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to rotate token"})
+		apiError(c, http.StatusInternalServerError, "failed to rotate token", "Session refresh failed. Please sign in again.")
 		return
 	}
 
@@ -522,13 +522,13 @@ func (h *AuthHandler) Setup(c *gin.Context) {
 	var req registerRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
-		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		apiError(c, http.StatusBadRequest, "invalid request body", "Please check your input and try again.")
 		return
 	}
 
 	hash, err := auth.HashPassword(req.Password)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to hash password"})
+		apiError(c, http.StatusInternalServerError, "failed to hash password", "Setup failed. Please try again.")
 		return
 	}
 
@@ -537,7 +537,7 @@ func (h *AuthHandler) Setup(c *gin.Context) {
 		var userCount int64
 		tx.Model(&db.User{}).Count(&userCount)
 		if userCount > 0 {
-			c.JSON(http.StatusForbidden, gin.H{"error": "setup already completed"})
+			apiError(c, http.StatusForbidden, "setup already completed", "Setup has already been completed.")
 			return fmt.Errorf("setup already completed")
 		}
 
@@ -552,19 +552,19 @@ func (h *AuthHandler) Setup(c *gin.Context) {
 		if c.Writer.Written() {
 			return
 		}
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create user"})
+		apiError(c, http.StatusInternalServerError, "failed to create user", "Setup failed. Please try again.")
 		return
 	}
 
 	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, h.JWTSecret)
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate token"})
+		apiError(c, http.StatusInternalServerError, "failed to generate token", "Setup failed. Please try again.")
 		return
 	}
 
 	refreshToken, err := auth.GenerateRefreshToken()
 	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate refresh token"})
+		apiError(c, http.StatusInternalServerError, "failed to generate refresh token", "Setup failed. Please try again.")
 		return
 	}
 

--- a/server/internal/api/challenge_handler_test.go
+++ b/server/internal/api/challenge_handler_test.go
@@ -65,20 +65,7 @@ func setupChallengeTestWithRateLimit(t *testing.T, rateLimitSec int) *challengeT
 	require.NoError(t, err)
 
 	// Create user 2
-	w = httptest.NewRecorder()
-	body, _ = json.Marshal(map[string]string{
-		"username": "challenger2",
-		"email":    "challenger2@test.com",
-		"password": "password123",
-	})
-	req = httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code, "register user2: %s", w.Body.String())
-
-	var reg2 map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &reg2)
-	token2 := reg2["accessToken"].(string)
+	token2 := createNonOwnerUser(t, router, token1, "challenger2", "challenger2@test.com", "password123")
 
 	claims2, err := auth.ValidateAccessToken(token2, testJWTSecret)
 	require.NoError(t, err)

--- a/server/internal/api/collection_handler_test.go
+++ b/server/internal/api/collection_handler_test.go
@@ -264,20 +264,7 @@ func TestGetCollection_PrivateNotAccessibleByOthers(t *testing.T) {
 	colID := createResp["id"].(string)
 
 	// Register a second user
-	body, _ = json.Marshal(map[string]string{
-		"username": "otheruser",
-		"email":    "other@example.com",
-		"password": "password123",
-	})
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	otherToken := regResp["accessToken"].(string)
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
 
 	// Other user tries to access private collection
 	w = httptest.NewRecorder()
@@ -306,20 +293,7 @@ func TestGetCollection_PublicAccessibleByOthers(t *testing.T) {
 	colID := createResp["id"].(string)
 
 	// Register a second user
-	body, _ = json.Marshal(map[string]string{
-		"username": "otheruser",
-		"email":    "other@example.com",
-		"password": "password123",
-	})
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	otherToken := regResp["accessToken"].(string)
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
 
 	// Other user can access public collection
 	w = httptest.NewRecorder()
@@ -390,20 +364,7 @@ func TestUpdateCollection_NotOwner(t *testing.T) {
 	colID := createResp["id"].(string)
 
 	// Register a second user
-	body, _ = json.Marshal(map[string]string{
-		"username": "otheruser",
-		"email":    "other@example.com",
-		"password": "password123",
-	})
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	otherToken := regResp["accessToken"].(string)
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
 
 	// Other user tries to update
 	body, _ = json.Marshal(map[string]interface{}{"name": "Hacked Name"})
@@ -485,20 +446,7 @@ func TestDeleteCollection_NotOwner(t *testing.T) {
 	colID := createResp["id"].(string)
 
 	// Register second user
-	body, _ = json.Marshal(map[string]string{
-		"username": "otheruser",
-		"email":    "other@example.com",
-		"password": "password123",
-	})
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	otherToken := regResp["accessToken"].(string)
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
 
 	// Other user tries to delete
 	w = httptest.NewRecorder()
@@ -635,20 +583,7 @@ func TestAddGame_NotOwner(t *testing.T) {
 	colID := createResp["id"].(string)
 
 	// Register second user
-	body, _ = json.Marshal(map[string]string{
-		"username": "otheruser",
-		"email":    "other@example.com",
-		"password": "password123",
-	})
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	otherToken := regResp["accessToken"].(string)
+	otherToken := createNonOwnerUser(t, router, token, "otheruser", "other@example.com", "password123")
 
 	// Other user tries to add game
 	body, _ = json.Marshal(map[string]interface{}{"gameId": game.ID})

--- a/server/internal/api/device_handler_test.go
+++ b/server/internal/api/device_handler_test.go
@@ -501,30 +501,17 @@ func TestAdminGetUserDevices_NonAdmin(t *testing.T) {
 	router := NewRouter(*cfg)
 
 	// Register first user (becomes owner)
-	registerAndGetToken(t, router)
+	ownerToken := registerAndGetToken(t, router)
 
 	// Register second user (regular user)
-	body, _ := json.Marshal(map[string]string{
-		"username": "regular",
-		"email":    "regular@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	userToken := regResp["accessToken"].(string)
+	userToken := createNonOwnerUser(t, router, ownerToken, "regular", "regular@example.com", "password123")
 
 	var adminUser db.User
 	database.Where("username = ?", "apitest").First(&adminUser)
 
 	// Regular user tries admin endpoint
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("GET", fmt.Sprintf("/api/admin/users/%d/devices", adminUser.ID), nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/admin/users/%d/devices", adminUser.ID), nil)
 	req.Header.Set("Authorization", "Bearer "+userToken)
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusForbidden, w.Code)

--- a/server/internal/api/errors.go
+++ b/server/internal/api/errors.go
@@ -1,0 +1,14 @@
+package api
+
+import "github.com/gin-gonic/gin"
+
+// apiError sends a JSON error response with a technical message (for logging)
+// and a separate user-facing message.
+func apiError(c *gin.Context, status int, technical, userMessage string) {
+	c.JSON(status, gin.H{"error": technical, "message": userMessage})
+}
+
+// abortWithError aborts the middleware chain and sends a dual-field error response.
+func abortWithError(c *gin.Context, status int, technical, userMessage string) {
+	c.AbortWithStatusJSON(status, gin.H{"error": technical, "message": userMessage})
+}

--- a/server/internal/api/game_keymapping_handler_test.go
+++ b/server/internal/api/game_keymapping_handler_test.go
@@ -276,19 +276,7 @@ func TestGameKeyMapping_IsolatedPerUser(t *testing.T) {
 	token1 := registerAndGetToken(t, router)
 
 	// Register second user
-	body, _ := json.Marshal(map[string]string{
-		"username": "user2",
-		"email":    "user2@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	token2 := regResp["accessToken"].(string)
+	token2 := createNonOwnerUser(t, router, token1, "user2", "user2@example.com", "password123")
 
 	// Create a game
 	game := db.Game{ConsoleID: 1, Title: "Test Game", FileName: "test.nes", FilePath: "/roms/test.nes"}
@@ -296,9 +284,9 @@ func TestGameKeyMapping_IsolatedPerUser(t *testing.T) {
 
 	// User 1 creates a mapping
 	mapping1 := map[string]string{"0": "96", "1": "97"}
-	body, _ = json.Marshal(map[string]interface{}{"customMapping": mapping1})
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("PUT", fmt.Sprintf("/api/user/games/%d/keymapping", game.ID), bytes.NewReader(body))
+	body, _ := json.Marshal(map[string]interface{}{"customMapping": mapping1})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", fmt.Sprintf("/api/user/games/%d/keymapping", game.ID), bytes.NewReader(body))
 	req.Header.Set("Authorization", "Bearer "+token1)
 	req.Header.Set("Content-Type", "application/json")
 	router.ServeHTTP(w, req)

--- a/server/internal/api/middleware.go
+++ b/server/internal/api/middleware.go
@@ -37,36 +37,36 @@ func AuthMiddleware(jwtSecret string, database *gorm.DB) gin.HandlerFunc {
 		}
 
 		if token == "" {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing authorization"})
+			abortWithError(c, http.StatusUnauthorized, "missing authorization", "Please sign in to continue.")
 			return
 		}
 
 		claims, err := auth.ValidateAccessToken(token, jwtSecret)
 		if err != nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid or expired token"})
+			abortWithError(c, http.StatusUnauthorized, "invalid or expired token", "Your session has expired. Please sign in again.")
 			return
 		}
 
 		// Reject revoked (logged-out) access tokens
 		if IsTokenBlacklisted(database, token) {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "token has been revoked"})
+			abortWithError(c, http.StatusUnauthorized, "token has been revoked", "Your session has ended. Please sign in again.")
 			return
 		}
 
 		// Reject disabled users even if their access token is still valid
 		var user db.User
 		if err := database.Select("id", "disabled", "token_version").First(&user, claims.UserID).Error; err != nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "user not found"})
+			abortWithError(c, http.StatusUnauthorized, "user not found", "Your account could not be found. Please sign in again.")
 			return
 		}
 		if user.Disabled {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "account is disabled"})
+			abortWithError(c, http.StatusForbidden, "account is disabled", "Your account has been disabled. Please contact an administrator.")
 			return
 		}
 
 		// Reject tokens minted before a role/password/disabled change
 		if claims.TokenVersion != user.TokenVersion {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "token has been invalidated"})
+			abortWithError(c, http.StatusUnauthorized, "token has been invalidated", "Your session is no longer valid. Please sign in again.")
 			return
 		}
 
@@ -82,7 +82,7 @@ func AdminMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		role, _ := c.Get("role")
 		if role != "admin" && role != "owner" {
-			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "admin access required"})
+			abortWithError(c, http.StatusForbidden, "admin access required", "You don't have permission to access this resource.")
 			return
 		}
 		c.Next()
@@ -165,7 +165,7 @@ func (rl *RateLimiter) RateLimit() gin.HandlerFunc {
 		rl.mu.Unlock()
 
 		if !e.limiter.Allow() {
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "rate limit exceeded"})
+			abortWithError(c, http.StatusTooManyRequests, "rate limit exceeded", "Too many requests. Please slow down and try again.")
 			return
 		}
 		c.Next()
@@ -197,7 +197,7 @@ func (rl *RateLimiter) UserRateLimit() gin.HandlerFunc {
 		rl.mu.Unlock()
 
 		if !e.limiter.Allow() {
-			c.AbortWithStatusJSON(http.StatusTooManyRequests, gin.H{"error": "rate limit exceeded"})
+			abortWithError(c, http.StatusTooManyRequests, "rate limit exceeded", "Too many requests. Please slow down and try again.")
 			return
 		}
 		c.Next()

--- a/server/internal/api/netplay_test.go
+++ b/server/internal/api/netplay_test.go
@@ -13,23 +13,11 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// registerUserAndGetToken registers a user and returns the access token.
-func registerUserAndGetToken(t *testing.T, router http.Handler, username, email string) string {
+// registerUserAndGetToken registers a non-owner user via the admin endpoint and returns the access token.
+// ownerToken must be a valid admin/owner token.
+func registerUserAndGetToken(t *testing.T, router http.Handler, ownerToken, username, email string) string {
 	t.Helper()
-	body, _ := json.Marshal(map[string]string{
-		"username": username,
-		"email":    email,
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var resp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &resp)
-	return resp["accessToken"].(string)
+	return createNonOwnerUser(t, router, ownerToken, username, email, "password123")
 }
 
 // netplayTestCtx holds shared state for netplay tests.
@@ -52,8 +40,11 @@ func setupNetplayCtx(t *testing.T) netplayTestCtx {
 	database.Create(&game)
 
 	router := NewRouter(*cfg)
-	hostToken := registerUserAndGetToken(t, router, "host", "host@test.com")
-	clientToken := registerUserAndGetToken(t, router, "client", "client@test.com")
+	// Register owner first (regular register, gets owner role)
+	ownerToken := registerAndGetToken(t, router)
+	// Create host and client as non-owner users via admin endpoint
+	hostToken := registerUserAndGetToken(t, router, ownerToken, "host", "host@test.com")
+	clientToken := registerUserAndGetToken(t, router, ownerToken, "client", "client@test.com")
 
 	return netplayTestCtx{
 		router:      router,
@@ -143,7 +134,7 @@ func TestNetplay_CreateSession_UnsupportedConsole(t *testing.T) {
 	database.Create(&game)
 
 	router := NewRouter(*cfg)
-	token := registerUserAndGetToken(t, router, "psxhost", "psxhost@test.com")
+	token := registerAndGetToken(t, router)
 
 	body, _ := json.Marshal(map[string]interface{}{"gameId": "1"})
 	w := httptest.NewRecorder()
@@ -259,9 +250,10 @@ func TestNetplay_JoinFullSession(t *testing.T) {
 	database.Create(&game)
 
 	router := NewRouter(*cfg)
-	hostToken := registerUserAndGetToken(t, router, "fullhost", "fh@t.com")
-	p2Token := registerUserAndGetToken(t, router, "fullp2", "fp2@t.com")
-	p3Token := registerUserAndGetToken(t, router, "fullp3", "fp3@t.com")
+	ownerToken := registerAndGetToken(t, router)
+	hostToken := registerUserAndGetToken(t, router, ownerToken, "fullhost", "fh@t.com")
+	p2Token := registerUserAndGetToken(t, router, ownerToken, "fullp2", "fp2@t.com")
+	p3Token := registerUserAndGetToken(t, router, ownerToken, "fullp3", "fp3@t.com")
 
 	// Create
 	body, _ := json.Marshal(map[string]interface{}{"gameId": "1"})

--- a/server/internal/api/play_later_handler_test.go
+++ b/server/internal/api/play_later_handler_test.go
@@ -503,20 +503,7 @@ func TestPlayLater_PerUserIsolation(t *testing.T) {
 	token1 := registerAndGetToken(t, router)
 
 	// Register second user
-	body, _ := json.Marshal(map[string]string{
-		"username": "otheruser",
-		"email":    "other@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var regResp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &regResp)
-	token2 := regResp["accessToken"].(string)
+	token2 := createNonOwnerUser(t, router, token1, "otheruser", "other@example.com", "password123")
 
 	var console db.Console
 	database.First(&console)
@@ -525,8 +512,8 @@ func TestPlayLater_PerUserIsolation(t *testing.T) {
 	gameID := fmt.Sprintf("%d", game.ID)
 
 	// User 1 adds game to play later
-	w = httptest.NewRecorder()
-	req = httptest.NewRequest("POST", "/api/user/play-later/"+gameID, nil)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/user/play-later/"+gameID, nil)
 	req.Header.Set("Authorization", "Bearer "+token1)
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusCreated, w.Code)

--- a/server/internal/api/relay_handler_test.go
+++ b/server/internal/api/relay_handler_test.go
@@ -18,41 +18,15 @@ import (
 // --- Helper functions ---
 
 // registerSecondUser registers a second user and returns their access token.
-func registerSecondUser(t *testing.T, router http.Handler) string {
+func registerSecondUser(t *testing.T, router http.Handler, ownerToken string) string {
 	t.Helper()
-	body, _ := json.Marshal(map[string]string{
-		"username": "player2",
-		"email":    "player2@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var resp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &resp)
-	return resp["accessToken"].(string)
+	return createNonOwnerUser(t, router, ownerToken, "player2", "player2@example.com", "password123")
 }
 
 // registerNamedUser registers a user with the given username and returns their access token.
-func registerNamedUser(t *testing.T, router http.Handler, username string) string {
+func registerNamedUser(t *testing.T, router http.Handler, ownerToken, username string) string {
 	t.Helper()
-	body, _ := json.Marshal(map[string]string{
-		"username": username,
-		"email":    username + "@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var resp map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &resp)
-	return resp["accessToken"].(string)
+	return createNonOwnerUser(t, router, ownerToken, username, username+"@example.com", "password123")
 }
 
 // createRelay creates a relay via API and returns the response map.
@@ -202,7 +176,7 @@ func TestRelay_List_OnlyMyRelays(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -271,7 +245,7 @@ func TestRelay_GetDetail_NonMemberForbidden(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -325,7 +299,7 @@ func TestRelay_Update_MemberCannotUpdate(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -404,7 +378,7 @@ func TestRelay_Delete_MemberCannotDelete(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -430,7 +404,7 @@ func TestRelay_InviteUser(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	_ = registerSecondUser(t, router)
+	_ = registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -460,7 +434,7 @@ func TestRelay_InviteUser_AlreadyMember(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -487,7 +461,7 @@ func TestRelay_InviteUser_AlreadyInvited(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	_ = registerSecondUser(t, router)
+	_ = registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -543,7 +517,7 @@ func TestRelay_AcceptInvite(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -573,8 +547,8 @@ func TestRelay_AcceptInvite_WrongUser(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	_ = registerSecondUser(t, router)
-	token3 := registerNamedUser(t, router, "player3")
+	_ = registerSecondUser(t, router, token1)
+	token3 := registerNamedUser(t, router, token1, "player3")
 
 	var console db.Console
 	database.First(&console)
@@ -610,7 +584,7 @@ func TestRelay_DeclineInvite(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -663,7 +637,7 @@ func TestRelay_LeaveRelay_MemberCanLeave(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -720,7 +694,7 @@ func TestRelay_RemoveMember_OwnerCanRemove(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -761,7 +735,7 @@ func TestRelay_RemoveMember_MemberCannotRemoveOthers(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -819,7 +793,7 @@ func TestRelay_TakeTurn_Conflict(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -847,7 +821,7 @@ func TestRelay_TakeTurn_StaleTurnExpired(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -920,7 +894,7 @@ func TestRelay_ReleaseTurn_NonHolderFails(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -978,7 +952,7 @@ func TestRelay_Heartbeat_NonHolderFails(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -1152,7 +1126,7 @@ func TestRelay_DownloadSave_MemberCanDownload(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -1286,7 +1260,7 @@ func TestRelay_DeleteSave_OwnerOnly(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -1351,7 +1325,7 @@ func TestRelay_Saves_NonMemberCannotAccess(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -1420,7 +1394,7 @@ func TestRelay_LeaveRelay_ReleasesTurn(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -1472,7 +1446,7 @@ func TestRelay_ReInviteAfterDecline(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -1535,7 +1509,7 @@ func TestRelay_RemoveMember_ReleasesTurn(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)
@@ -1646,7 +1620,7 @@ func TestRelay_CopySaveToGame_NotMember(t *testing.T) {
 	database, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)
 	token1 := registerAndGetToken(t, router)
-	token2 := registerSecondUser(t, router)
+	token2 := registerSecondUser(t, router, token1)
 
 	var console db.Console
 	database.First(&console)

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -320,27 +320,29 @@ func ToGameResponses(games []db.Game, database *gorm.DB, userID uint) []GameResp
 
 // UserResponse is the API response for a user, with string ID for consistency.
 type UserResponse struct {
-	ID        string    `json:"id"`
-	Username  string    `json:"username"`
-	Email     string    `json:"email"`
-	Role      string    `json:"role"`
-	AvatarURL string    `json:"avatarUrl,omitempty"`
-	Disabled  bool      `json:"disabled"`
-	CreatedAt time.Time `json:"createdAt"`
-	UpdatedAt time.Time `json:"updatedAt"`
+	ID              string    `json:"id"`
+	Username        string    `json:"username"`
+	Email           string    `json:"email"`
+	Role            string    `json:"role"`
+	AvatarURL       string    `json:"avatarUrl,omitempty"`
+	Disabled        bool      `json:"disabled"`
+	PendingApproval bool      `json:"pendingApproval"`
+	CreatedAt       time.Time `json:"createdAt"`
+	UpdatedAt       time.Time `json:"updatedAt"`
 }
 
 // ToUserResponse converts a db.User to its API response.
 func ToUserResponse(u db.User) UserResponse {
 	return UserResponse{
-		ID:        strconv.FormatUint(uint64(u.ID), 10),
-		Username:  u.Username,
-		Email:     u.Email,
-		Role:      u.Role,
-		AvatarURL: u.AvatarURL,
-		Disabled:  u.Disabled,
-		CreatedAt: u.CreatedAt,
-		UpdatedAt: u.UpdatedAt,
+		ID:              strconv.FormatUint(uint64(u.ID), 10),
+		Username:        u.Username,
+		Email:           u.Email,
+		Role:            u.Role,
+		AvatarURL:       u.AvatarURL,
+		Disabled:        u.Disabled,
+		PendingApproval: u.PendingApproval,
+		CreatedAt:       u.CreatedAt,
+		UpdatedAt:       u.UpdatedAt,
 	}
 }
 

--- a/server/internal/api/save_data_handler_test.go
+++ b/server/internal/api/save_data_handler_test.go
@@ -32,20 +32,7 @@ func setupSaveDataTestEnv(t *testing.T) *saveDataTestEnv {
 	token := registerAndGetToken(t, router)
 
 	// Register second user
-	body, _ := json.Marshal(map[string]string{
-		"username": "user2",
-		"email":    "user2@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var reg2 map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &reg2)
-	token2 := reg2["accessToken"].(string)
+	token2 := createNonOwnerUser(t, router, token, "user2", "user2@example.com", "password123")
 
 	// Create a test game
 	var console db.Console

--- a/server/internal/api/save_handler_test.go
+++ b/server/internal/api/save_handler_test.go
@@ -32,20 +32,7 @@ func setupSaveTestEnv(t *testing.T) *saveTestEnv {
 	token := registerAndGetToken(t, router)
 
 	// Register second user
-	body, _ := json.Marshal(map[string]string{
-		"username": "user2",
-		"email":    "user2@example.com",
-		"password": "password123",
-	})
-	w := httptest.NewRecorder()
-	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
-	req.Header.Set("Content-Type", "application/json")
-	router.ServeHTTP(w, req)
-	require.Equal(t, http.StatusCreated, w.Code)
-
-	var reg2 map[string]interface{}
-	json.Unmarshal(w.Body.Bytes(), &reg2)
-	token2 := reg2["accessToken"].(string)
+	token2 := createNonOwnerUser(t, router, token, "user2", "user2@example.com", "password123")
 
 	// Create a test game
 	var console db.Console

--- a/server/internal/api/test_user_helpers_test.go
+++ b/server/internal/api/test_user_helpers_test.go
@@ -1,0 +1,43 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// createNonOwnerUser creates a user via the admin endpoint (which bypasses pending approval)
+// and returns their access token by logging in. ownerToken must be a valid admin/owner token.
+func createNonOwnerUser(t *testing.T, router http.Handler, ownerToken, username, email, password string) string {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{
+		"username": username,
+		"email":    email,
+		"password": password,
+		"role":     "user",
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/admin/users", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "createNonOwnerUser: admin create failed: %s", w.Body.String())
+
+	loginBody, _ := json.Marshal(map[string]string{
+		"username": username,
+		"password": password,
+	})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/auth/login", bytes.NewReader(loginBody))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "createNonOwnerUser: login failed: %s", w.Body.String())
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	return resp["accessToken"].(string)
+}

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -31,6 +31,7 @@ type User struct {
 	AvatarURL    string         `gorm:"size:512" json:"avatarUrl,omitempty"`
 	TokenVersion        int            `gorm:"default:0" json:"-"`
 	Disabled            bool           `gorm:"default:false" json:"disabled"`
+	PendingApproval     bool           `gorm:"default:false" json:"pendingApproval"`
 	ShowPerfOverlay     bool           `gorm:"default:false" json:"showPerformanceOverlay"`
 	AutoSaveEnabled     bool           `gorm:"default:true" json:"autoSaveEnabled"`
 	AutoLoadSaveEnabled bool           `gorm:"default:true" json:"autoLoadSaveEnabled"`

--- a/web/e2e/admin-settings.spec.ts
+++ b/web/e2e/admin-settings.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "./fixtures";
+
+test.describe("Admin Settings — Allow Registration", () => {
+  test("disabling Allow Registration persists after page reload", async ({
+    page,
+  }) => {
+    await page.goto("/admin/settings");
+    await expect(page.getByText("Allow Registration")).toBeVisible();
+
+    // Find the Allow Registration switch (first switch in the General card)
+    const registrationToggle = page
+      .locator("div")
+      .filter({ hasText: /^Allow Registration/ })
+      .getByRole("switch")
+      .first();
+
+    // Ensure it starts enabled
+    await expect(registrationToggle).toHaveAttribute("aria-checked", "true");
+
+    // Disable it
+    await registrationToggle.click();
+    await expect(registrationToggle).toHaveAttribute("aria-checked", "false");
+
+    // Save
+    await page.getByRole("button", { name: /save settings/i }).click();
+    await expect(page.getByText("Settings saved")).toBeVisible();
+
+    // Reload and re-check
+    await page.goto("/admin/settings");
+    await expect(page.getByText("Allow Registration")).toBeVisible();
+
+    const toggleAfterReload = page
+      .locator("div")
+      .filter({ hasText: /^Allow Registration/ })
+      .getByRole("switch")
+      .first();
+    await expect(toggleAfterReload).toHaveAttribute("aria-checked", "false");
+
+    // Re-enable for clean state
+    await toggleAfterReload.click();
+    await page.getByRole("button", { name: /save settings/i }).click();
+    await expect(page.getByText("Settings saved")).toBeVisible();
+  });
+
+  test("registration endpoint returns 403 when registration is disabled", async ({
+    page,
+  }) => {
+    await page.goto("/admin/settings");
+    // Disable registration via API (direct fetch as admin)
+    const response = await page.evaluate(async () => {
+      const token = localStorage.getItem("accessToken");
+      const res = await fetch("/api/admin/settings", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ registration_enabled: "false" }),
+      });
+      return res.ok;
+    });
+    expect(response).toBe(true);
+
+    // Try to register a new user — should be forbidden
+    const regResult = await page.evaluate(async () => {
+      const res = await fetch("/api/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: "blockeduser",
+          email: "blockeduser@test.com",
+          password: "password123",
+        }),
+      });
+      return { status: res.status };
+    });
+    expect(regResult.status).toBe(403);
+
+    // Re-enable registration
+    await page.evaluate(async () => {
+      const token = localStorage.getItem("accessToken");
+      await fetch("/api/admin/settings", {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ registration_enabled: "true" }),
+      });
+    });
+  });
+});

--- a/web/e2e/registration-approval.spec.ts
+++ b/web/e2e/registration-approval.spec.ts
@@ -65,7 +65,7 @@ test.describe("Registration Approval Flow", () => {
     // Should see "pending approval" error, NOT navigate to "/"
     await expect(page).not.toHaveURL("/", { timeout: 5_000 });
     await expect(
-      page.getByText(/pending.*approval|account.*pending/i),
+      page.getByText(/pending.*approval|account.*pending|awaiting.*approval/i),
     ).toBeVisible({ timeout: 5_000 });
   });
 

--- a/web/e2e/registration-approval.spec.ts
+++ b/web/e2e/registration-approval.spec.ts
@@ -1,0 +1,141 @@
+import { test, expect } from "@playwright/test";
+
+/**
+ * E2E tests for the registration approval workflow.
+ * New accounts require admin approval before they can log in.
+ *
+ * These tests run without the default auth storage state so that
+ * we can test the unauthenticated registration flow directly.
+ */
+
+// Each test run uses a unique suffix to avoid username conflicts across runs
+const suffix = Date.now();
+
+test.describe("Registration Approval Flow", () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test("registration shows pending approval message instead of logging in", async ({
+    page,
+  }) => {
+    const username = `pendinguser${suffix}`;
+
+    await page.goto("/register");
+    await page.getByLabel("Username").fill(username);
+    await page.getByLabel("Email").fill(`${username}@test.com`);
+    await page.getByLabel("Password", { exact: true }).fill("password123");
+    await page.getByLabel("Confirm Password", { exact: true }).fill("password123");
+    await page.getByRole("button", { name: /create account/i }).click();
+
+    // Should NOT navigate to "/" — should show a pending message
+    await expect(page).not.toHaveURL("/", { timeout: 5_000 });
+    await expect(
+      page.getByText(/pending.*approval|waiting.*admin|admin.*approve/i).first(),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("pending user cannot log in", async ({ page }) => {
+    const username = `pendinglogin${suffix}`;
+
+    // Register via API (bypass the UI to avoid waiting for the UI message test)
+    await page.goto("/");
+    const regStatus = await page.evaluate(
+      async ([user, suffix]) => {
+        const res = await fetch("/api/auth/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            username: `${user}${suffix}`,
+            email: `${user}${suffix}@test.com`,
+            password: "password123",
+          }),
+        });
+        return res.status;
+      },
+      [username, ""] as [string, string],
+    );
+    // Should return 202 (pending), not 201 (auto-login)
+    expect(regStatus).toBe(202);
+
+    // Try to log in as the pending user
+    await page.goto("/login");
+    await page.getByLabel("Username").fill(username);
+    await page.getByLabel("Password").fill("password123");
+    await page.getByRole("button", { name: /sign in/i }).click();
+
+    // Should see "pending approval" error, NOT navigate to "/"
+    await expect(page).not.toHaveURL("/", { timeout: 5_000 });
+    await expect(
+      page.getByText(/pending.*approval|account.*pending/i),
+    ).toBeVisible({ timeout: 5_000 });
+  });
+
+  test("admin can approve a pending user and the user can then log in", async ({
+    browser,
+  }) => {
+    const username = `approvaltest${suffix}`;
+
+    // Step 1: Register a new user (unauthenticated context)
+    const userCtx = await browser.newContext({
+      storageState: { cookies: [], origins: [] },
+      baseURL: "http://localhost:5173",
+    });
+    const userPage = await userCtx.newPage();
+
+    // Navigate first so the page has a URL context for relative fetch calls
+    await userPage.goto("/login");
+
+    const regStatus = await userPage.evaluate(
+      async (uname: string) => {
+        const res = await fetch("/api/auth/register", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            username: uname,
+            email: `${uname}@test.com`,
+            password: "password123",
+          }),
+        });
+        return res.status;
+      },
+      username,
+    );
+    expect(regStatus).toBe(202);
+
+    // Step 2: Log in as admin and approve the user
+    const adminCtx = await browser.newContext();
+    const adminPage = await adminCtx.newPage();
+
+    await adminPage.goto("/login");
+    await adminPage.getByLabel("Username").fill("admin");
+    await adminPage.getByLabel("Password").fill("admin123");
+    await adminPage.getByRole("button", { name: /sign in/i }).click();
+    await expect(adminPage).toHaveURL("/", { timeout: 15_000 });
+
+    await adminPage.goto("/admin/users");
+    await expect(adminPage.getByText("User Management")).toBeVisible();
+
+    // Find the pending user row — it should have a "pending" badge
+    const userRow = adminPage.locator("tr").filter({ hasText: username });
+    await expect(userRow).toBeVisible();
+    await expect(userRow.getByText(/pending/i)).toBeVisible();
+
+    // Click "Approve" for this user
+    await userRow.getByRole("button", { name: /approve/i }).click();
+
+    // Wait for the row to update — "pending" badge should be gone
+    await expect(userRow.getByText(/pending/i)).not.toBeVisible({
+      timeout: 5_000,
+    });
+
+    await adminCtx.close();
+
+    // Step 3: Now the user should be able to log in
+    await userPage.goto("/login");
+    await userPage.getByLabel("Username").fill(username);
+    await userPage.getByLabel("Password").fill("password123");
+    await userPage.getByRole("button", { name: /sign in/i }).click();
+    await expect(userPage).toHaveURL("/", { timeout: 10_000 });
+
+    await userCtx.close();
+  });
+});

--- a/web/src/features/admin/components/user-table.tsx
+++ b/web/src/features/admin/components/user-table.tsx
@@ -1,4 +1,4 @@
-import { Shield, ShieldCheck, Crown, Trash2, UserX } from "lucide-react";
+import { Shield, ShieldCheck, Crown, Trash2, UserX, Clock } from "lucide-react";
 import {
   Button,
   Badge,
@@ -18,6 +18,7 @@ interface UserTableProps {
   onEdit: (user: User) => void;
   onDelete: (user: User) => void;
   onViewDevices: (user: User) => void;
+  onApprove: (user: User) => void;
 }
 
 function getRoleBadge(role: string) {
@@ -53,6 +54,7 @@ export function UserTable({
   onEdit,
   onDelete,
   onViewDevices,
+  onApprove,
 }: UserTableProps) {
   const isOwnerOrSelf = (user: User) =>
     user.role === "owner" || user.id === currentUser?.id;
@@ -127,7 +129,12 @@ export function UserTable({
                   </td>
                   <td className="px-5 py-3">{getRoleBadge(user.role)}</td>
                   <td className="px-5 py-3">
-                    {user.disabled ? (
+                    {user.pendingApproval ? (
+                      <Badge variant="warning">
+                        <Clock className="h-3 w-3 mr-1" />
+                        pending
+                      </Badge>
+                    ) : user.disabled ? (
                       <Badge variant="danger">
                         <UserX className="h-3 w-3 mr-1" />
                         disabled
@@ -141,6 +148,15 @@ export function UserTable({
                   </td>
                   <td className="px-5 py-3 text-right">
                     <div className="flex items-center justify-end gap-1">
+                      {user.pendingApproval && (
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          onClick={() => onApprove(user)}
+                        >
+                          Approve
+                        </Button>
+                      )}
                       <Button
                         variant="ghost"
                         size="sm"

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -23,6 +23,7 @@ export function useUpdateUser() {
         email?: string;
         password?: string;
         disabled?: boolean;
+        pendingApproval?: boolean;
       };
     }) => {
       await api.put(`/admin/users/${id}`, data);

--- a/web/src/hooks/use-auth.tsx
+++ b/web/src/hooks/use-auth.tsx
@@ -21,7 +21,7 @@ interface AuthContextValue {
     username: string,
     email: string,
     password: string,
-  ) => Promise<void>;
+  ) => Promise<{ pending: boolean }>;
   setup: (username: string, email: string, password: string) => Promise<void>;
   logout: () => void;
 }
@@ -83,14 +83,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const register = useCallback(
-    async (username: string, email: string, password: string) => {
-      const data = await api.post<AuthTokens>("/auth/register", {
-        username,
-        email,
-        password,
-      });
-      api.setTokens(data.accessToken, data.refreshToken);
-      setUser(data.user);
+    async (
+      username: string,
+      email: string,
+      password: string,
+    ): Promise<{ pending: boolean }> => {
+      const data = await api.post<
+        AuthTokens | { pending: true; message: string }
+      >("/auth/register", { username, email, password });
+      if ("pending" in data && data.pending) {
+        return { pending: true };
+      }
+      const tokens = data as AuthTokens;
+      api.setTokens(tokens.accessToken, tokens.refreshToken);
+      setUser(tokens.user);
+      return { pending: false };
     },
     [],
   );

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -83,7 +83,8 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
     const body = await res.text();
     let message: string;
     try {
-      message = JSON.parse(body).error ?? body;
+      const parsed = JSON.parse(body);
+      message = parsed.message ?? parsed.error ?? body;
     } catch {
       message = body;
     }

--- a/web/src/pages/admin/settings-page.test.tsx
+++ b/web/src/pages/admin/settings-page.test.tsx
@@ -7,7 +7,7 @@ import { AdminSettingsPage } from "./settings-page";
 
 const mockSettings = {
   gameDirectories: "/games",
-  allowRegistration: "true",
+  registration_enabled: "true",
   scrapeOnScan: "true",
   igdb_client_id: "test-client-id",
   igdb_client_secret: "test-client-secret",
@@ -15,7 +15,7 @@ const mockSettings = {
 
 const mockSettingsEmpty = {
   gameDirectories: "/games",
-  allowRegistration: "true",
+  registration_enabled: "true",
   scrapeOnScan: "true",
   igdb_client_id: "",
   igdb_client_secret: "",

--- a/web/src/pages/admin/settings-page.tsx
+++ b/web/src/pages/admin/settings-page.tsx
@@ -35,7 +35,7 @@ export function AdminSettingsPage() {
     if (settings) {
       const dirs = settings["gameDirectories"] ?? "";
       setGameDirectories(dirs ? dirs.split(",") : []);
-      setAllowRegistration(settings["allowRegistration"] !== "false");
+      setAllowRegistration(settings["registration_enabled"] !== "false");
       setScrapeOnScan(settings["scrapeOnScan"] !== "false");
       setIgdbClientId(settings["igdb_client_id"] ?? "");
       setIgdbClientSecret(settings["igdb_client_secret"] ?? "");
@@ -57,7 +57,7 @@ export function AdminSettingsPage() {
   function handleSave() {
     const payload: Record<string, string> = {
       gameDirectories: gameDirectories.join(","),
-      allowRegistration: String(allowRegistration),
+      registration_enabled: String(allowRegistration),
       scrapeOnScan: String(scrapeOnScan),
     };
     // Only send IGDB credentials when they're managed via the UI, not env vars

--- a/web/src/pages/admin/users-page.tsx
+++ b/web/src/pages/admin/users-page.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { Plus } from "lucide-react";
 import { Button } from "@/components/ui";
-import { useAdminUsers, useAdminStats } from "@/hooks/use-admin";
+import { useAdminUsers, useAdminStats, useUpdateUser } from "@/hooks/use-admin";
 import { useAuth } from "@/hooks/use-auth";
 import { UserStatsGrid } from "@/features/admin/components/user-stats-grid";
 import { UserTable } from "@/features/admin/components/user-table";
@@ -15,11 +15,16 @@ export function AdminUsersPage() {
   const { data: users, isLoading } = useAdminUsers();
   const { data: stats } = useAdminStats();
   const { user: currentUser } = useAuth();
+  const { mutate: updateUser } = useUpdateUser();
 
   const [editingUser, setEditingUser] = useState<User | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<User | null>(null);
   const [devicesUser, setDevicesUser] = useState<User | null>(null);
   const [showCreate, setShowCreate] = useState(false);
+
+  function handleApprove(user: User) {
+    updateUser({ id: user.id, data: { pendingApproval: false } });
+  }
 
   return (
     <div className="space-y-6">
@@ -47,6 +52,7 @@ export function AdminUsersPage() {
         onEdit={setEditingUser}
         onDelete={setDeleteTarget}
         onViewDevices={setDevicesUser}
+        onApprove={handleApprove}
       />
 
       <EditUserModal

--- a/web/src/pages/register-page.tsx
+++ b/web/src/pages/register-page.tsx
@@ -12,10 +12,35 @@ export function RegisterPage() {
   const [confirmPassword, setConfirmPassword] = useState("");
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
+  const [pendingApproval, setPendingApproval] = useState(false);
   const { register, needsSetup } = useAuth();
   const navigate = useNavigate();
 
   if (needsSetup) return <Navigate to="/setup" replace />;
+
+  if (pendingApproval) {
+    return (
+      <AuthFormLayout
+        title="Account pending approval"
+        subtitle="Your registration was received"
+        footer={
+          <p className="text-center text-sm text-surface-400">
+            <Link
+              to="/login"
+              className="text-brand-400 hover:text-brand-300 font-medium transition-colors"
+            >
+              Back to sign in
+            </Link>
+          </p>
+        }
+      >
+        <p className="text-sm text-surface-300 text-center">
+          An admin needs to approve your account before you can sign in. You
+          will be able to log in once your account has been activated.
+        </p>
+      </AuthFormLayout>
+    );
+  }
 
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
@@ -29,8 +54,12 @@ export function RegisterPage() {
 
     setLoading(true);
     try {
-      await register(username, email, password);
-      navigate("/");
+      const result = await register(username, email, password);
+      if (result.pending) {
+        setPendingApproval(true);
+      } else {
+        navigate("/");
+      }
     } catch (err) {
       setError(
         err instanceof Error && err.message

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -4,6 +4,7 @@ export interface User {
   email: string;
   role: "owner" | "admin" | "user";
   disabled: boolean;
+  pendingApproval: boolean;
   avatarUrl?: string;
   createdAt: string;
   updatedAt: string;


### PR DESCRIPTION
## Summary

- New user registrations no longer auto-activate — accounts are set to `pending_approval` until an admin approves them
- Fixed bug where the \"Allow Registration\" admin setting did not persist after page reload (frontend was sending `allowRegistration` but the backend key is `registration_enabled`)
- Error responses in auth and middleware now carry both a machine-readable `error` field and a user-friendly `message` field

## Changes

**Backend**
- `User` model: new `PendingApproval bool` field (auto-migrated)
- `POST /api/auth/register`: returns HTTP 202 with `{pending: true}` for non-owner accounts instead of tokens
- `POST /api/auth/login`: returns 403 for accounts with `pending_approval = true`
- `PUT /api/admin/users/:id`: accepts `pendingApproval` to approve users
- New `apiError` / `abortWithError` helpers in `errors.go` for dual-field error responses
- All auth handler and middleware errors updated to include both `error` (technical) and `message` (user-facing)

**Frontend**
- Admin settings page: fixed `allowRegistration` → `registration_enabled` key
- Registration page: shows pending approval screen instead of navigating on 202
- Admin users page: pending badge + Approve button per user row
- `api-client.ts`: prefers `message` over `error` when parsing error responses (backward compatible)

## Test plan

- [ ] Register a new account → should see "pending approval" screen, not be logged in
- [ ] Pending user tries to log in → should see user-friendly error message
- [ ] Admin approves user from `/admin/users` → user can now log in
- [ ] Disable "Allow Registration" in admin settings → save → reload → toggle stays disabled
- [ ] `POST /api/auth/register` returns 403 when registration is disabled
- [ ] `go test ./...` passes
- [ ] Playwright E2E: `registration-approval.spec.ts` and `admin-settings.spec.ts` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)