### PR TITLE
fix: allow same-origin framing for emulator iframe

### DIFF
--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -52,12 +52,13 @@ func NewRouter(cfg Config) *gin.Engine {
 		c.Header("Cross-Origin-Embedder-Policy", "credentialless")
 		// Prevent MIME type sniffing
 		c.Header("X-Content-Type-Options", "nosniff")
-		// Prevent clickjacking
-		c.Header("X-Frame-Options", "DENY")
+		// Prevent clickjacking — allow same-origin framing for the emulator iframe
+		c.Header("X-Frame-Options", "SAMEORIGIN")
 		// Minimal referrer info to external sites
 		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
-		// Content Security Policy
-		c.Header("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' wss: ws:; frame-ancestors 'none'")
+		// Content Security Policy — frame-ancestors 'self' allows the emulator to load
+		// inside an iframe on the same origin while still blocking third-party embedding
+		c.Header("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' wss: ws:; frame-ancestors 'self'")
 		// HSTS — instruct browsers to always use HTTPS. Safe even behind a reverse
 		// proxy; browsers only honour this header on HTTPS responses.
 		c.Header("Strict-Transport-Security", "max-age=63072000; includeSubDomains")


### PR DESCRIPTION
## Summary

- Changed `frame-ancestors 'none'` → `frame-ancestors 'self'` in the global CSP header
- Changed `X-Frame-Options: DENY` → `SAMEORIGIN` to match

## Root Cause

The emulator runs inside an `<iframe src="/emulator.html">` in `play-page.tsx`. In single-container deployments (Go serving the frontend via `FrontendDir`), all responses — including `/emulator.html` — go through the security headers middleware. `frame-ancestors 'none'` blocked the iframe from loading, which cascaded into the `postMessage` failure (`target origin 'https://...' does not match recipient window origin 'null'`).

`frame-ancestors 'self'` still blocks third-party sites from embedding the app, while allowing the emulator to be framed on the same origin.

## Test plan

- [ ] Open a game and start the emulator — should load without CSP errors in the console
- [ ] Verify no `postMessage` origin mismatch errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)