### PR TITLE
Fix CSP violations and add pagination to console games

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
       - ${SPELA_BASE_PATH:-/docker/spela}/saves:/app/saves
       - ${SPELA_BASE_PATH:-/docker/spela}/cores:/app/cores
       - ${SPELA_BASE_PATH:-/docker/spela}/images:/app/images
-      - ${SPELA_GAMES_PATH:-${SPELA_BASE_PATH:-/docker/spela}/games}:/app/games:ro
+      - ${SPELA_GAMES_PATH:-${SPELA_BASE_PATH:-/docker/spela}/games}:/app/games
       - ${SPELA_BIOS_PATH:-${SPELA_BASE_PATH:-/docker/spela}/bios}:/app/bios:ro
     environment:
       - PUID=${PUID:-1000}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -152,9 +152,17 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/consoles").body()
     }
 
-    /** Returns flat GameResponse[] for a console */
-    suspend fun getGamesForConsole(consoleId: String): List<GameDto> {
-        return client.get("$baseUrl/api/consoles/$consoleId/games").body()
+    /** Returns paginated games for a console via the /api/games endpoint */
+    suspend fun getGamesForConsole(
+        consoleId: String,
+        page: Int? = null,
+        pageSize: Int? = null,
+    ): GameListResponse {
+        return client.get("$baseUrl/api/games") {
+            parameter("consoleId", consoleId)
+            page?.let { parameter("page", it) }
+            pageSize?.let { parameter("pageSize", it) }
+        }.body()
     }
 
     /** Returns {data, total, page, pageSize} paginated wrapper */

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
@@ -33,7 +33,8 @@ class GameRepositoryImpl(
 
     override suspend fun getGamesForConsole(consoleId: String): Result<List<Game>> {
         return runCatching {
-            val games = apiClient.getGamesForConsole(consoleId).map { it.toDomain().resolveImageUrls() }
+            val games = apiClient.getGamesForConsole(consoleId, pageSize = 200).data
+                .map { it.toDomain().resolveImageUrls() }
             cacheGames(games)
             games
         }.recoverCatching {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -11,6 +11,8 @@ import com.spela.player.presentation.state.GameListState
 import com.spela.player.presentation.state.ViewMode
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,6 +39,7 @@ class GameListViewModel(
 ) {
     private val _state = MutableStateFlow(GameListState())
     val state: StateFlow<GameListState> = _state.asStateFlow()
+    private var searchJob: Job? = null
 
     init {
         // Observe scrape completions and update games in state
@@ -241,11 +244,14 @@ class GameListViewModel(
     }
 
     private fun searchGames(query: String) {
-        val current = _state.value
-        _state.update { it.copy(searchQuery = query, isLoading = true) }
-        scope.launch(dispatchers.io) {
+        _state.update { it.copy(searchQuery = query) }
+        searchJob?.cancel()
+        searchJob = scope.launch(dispatchers.io) {
+            delay(300) // debounce
+            _state.update { it.copy(isLoading = true) }
+            val current = _state.value
             searchGamesUseCase(
-                query = query,
+                query = current.searchQuery,
                 consoleId = current.selectedConsoleFilter,
                 sortBy = current.sortBy,
                 sortOrder = current.sortOrder,

--- a/server/entrypoint.sh
+++ b/server/entrypoint.sh
@@ -12,6 +12,11 @@ run_as_spela() {
     fi
 }
 
+echo "entrypoint: uid=$(id -u) gid=$(id -g)"
+
+# Writable directories that the server needs.
+SPELA_DIRS="/app/data /app/saves /app/cores /app/images /app/bios /app/dats"
+
 # ── Root-only setup (skipped in rootless / non-root containers) ────────
 if [ "$(id -u)" = "0" ]; then
     # Configure runtime user — set PUID/PGID to match your host directories.
@@ -27,7 +32,6 @@ if [ "$(id -u)" = "0" ]; then
 
     # Fix ownership on bind-mounted directories.
     # Docker creates host directories as root when they don't exist yet.
-    SPELA_DIRS="/app/data /app/saves /app/cores /app/images /app/bios /app/dats"
     for dir in $SPELA_DIRS; do
         if [ -d "$dir" ]; then
             owner=$(stat -c '%u' "$dir" 2>/dev/null || stat -f '%u' "$dir" 2>/dev/null)
@@ -37,6 +41,38 @@ if [ "$(id -u)" = "0" ]; then
             fi
         fi
     done
+else
+    # ── Non-root: check that writable directories are accessible ──────
+    failed=""
+    for dir in $SPELA_DIRS; do
+        if [ -d "$dir" ] && ! touch "$dir/.write-test" 2>/dev/null; then
+            failed="$failed $dir"
+        fi
+        rm -f "$dir/.write-test" 2>/dev/null
+    done
+    if [ -n "$failed" ]; then
+        echo ""
+        echo "ERROR: Container is running as non-root (uid=$(id -u)) and these"
+        echo "directories are not writable:$failed"
+        echo ""
+        echo "The container is designed to start as root and drop privileges"
+        echo "automatically. To fix this, choose one of:"
+        echo ""
+        echo "  1. Remove any 'user:' override from your stack/docker-compose"
+        echo "     (the container handles user switching via PUID/PGID env vars)"
+        echo ""
+        echo "  2. In Portainer: check Settings > Security for 'run as non-root'"
+        echo "     or check the container's 'User' field — it should be empty"
+        echo ""
+        echo "  3. Fix host directory permissions manually:"
+        for dir in $failed; do
+            echo "       sudo chown -R $(id -u):$(id -g) <host-path-for$dir>"
+        done
+        echo ""
+        # Exit non-zero so Docker knows the container failed.
+        # The restart policy will retry with exponential backoff.
+        exit 1
+    fi
 fi
 
 # ── Run ────────────────────────────────────────────────────────────────

--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -3,13 +3,14 @@ package api
 import (
 	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
-	"math"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -95,7 +96,7 @@ func (h *ConsoleHandler) ListConsoles(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
-// ListConsoleGames returns games for a specific console as a flat Game array.
+// ListConsoleGames returns paginated games for a specific console.
 func (h *ConsoleHandler) ListConsoleGames(c *gin.Context) {
 	consoleID := c.Param("id")
 
@@ -105,17 +106,57 @@ func (h *ConsoleHandler) ListConsoleGames(c *gin.Context) {
 		return
 	}
 
+	query := h.DB.Where("console_id = ?", console.ID).Preload("Console")
+
+	// Search
+	if search := c.Query("search"); search != "" {
+		query = query.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")
+	}
+
+	// Sorting
+	sortCol := c.DefaultQuery("sortBy", "title")
+	sortOrder := c.DefaultQuery("sortOrder", "asc")
+	allowedSorts := map[string]bool{"title": true, "created_at": true, "file_size": true, "rating": true}
+	if !allowedSorts[sortCol] {
+		sortCol = "title"
+	}
+	if sortOrder != "asc" && sortOrder != "desc" {
+		sortOrder = "asc"
+	}
+	query = query.Order(sortCol + " " + sortOrder)
+
+	// Pagination
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	perPage, _ := strconv.Atoi(c.DefaultQuery("pageSize", "50"))
+	if page < 1 {
+		page = 1
+	}
+	if perPage < 1 || perPage > 200 {
+		perPage = 50
+	}
+
+	// Count with same filters
+	var total int64
+	countQuery := h.DB.Model(&db.Game{}).Where("console_id = ?", console.ID)
+	if search := c.Query("search"); search != "" {
+		countQuery = countQuery.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")
+	}
+	countQuery.Count(&total)
+
+	offset := (page - 1) * perPage
 	var games []db.Game
-	if err := h.DB.Where("console_id = ?", console.ID).
-		Preload("Console").
-		Order("title asc").
-		Find(&games).Error; err != nil {
+	if err := query.Offset(offset).Limit(perPage).Find(&games).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch games"})
 		return
 	}
 
 	userID := getUserID(c)
-	c.JSON(http.StatusOK, ToGameResponses(games, h.DB, userID))
+	c.JSON(http.StatusOK, PaginatedResponse{
+		Data:     ToGameResponses(games, h.DB, userID),
+		Total:    total,
+		Page:     page,
+		PageSize: perPage,
+	})
 }
 
 // GetPreviewScreenshot returns a representative screenshot for a console.

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -85,11 +85,15 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 		perPage = 50
 	}
 
-	// Count with the same filters applied
+	// Count with the same filters applied (reuse the resolved console ID
+	// from the data query above so we compare numeric IDs, not abbreviations).
 	var total int64
 	countQuery := h.DB.Model(&db.Game{})
-	if consoleID := c.Query("consoleId"); consoleID != "" {
-		countQuery = countQuery.Where("console_id = ?", consoleID)
+	if consoleAbbr := c.Query("consoleId"); consoleAbbr != "" {
+		var countConsole db.Console
+		if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", consoleAbbr).First(&countConsole).Error; err == nil {
+			countQuery = countQuery.Where("console_id = ?", countConsole.ID)
+		}
 	}
 	if search := c.Query("search"); search != "" {
 		countQuery = countQuery.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -58,7 +58,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
 		// Content Security Policy — frame-ancestors 'self' allows the emulator to load
 		// inside an iframe on the same origin while still blocking third-party embedding
-		c.Header("Content-Security-Policy", "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' wss: ws:; frame-ancestors 'self'")
+		c.Header("Content-Security-Policy", "default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' wss: ws:; worker-src 'self' blob:; frame-ancestors 'self'")
 		// HSTS — instruct browsers to always use HTTPS. Safe even behind a reverse
 		// proxy; browsers only honour this header on HTTPS responses.
 		c.Header("Strict-Transport-Security", "max-age=63072000; includeSubDomains")

--- a/web/public/emulator.js
+++ b/web/public/emulator.js
@@ -112,11 +112,6 @@
     window.EJS_backgroundBlur = true;
     window.EJS_backgroundColor = "#16191d";
 
-    // Load non-minified source files directly — the npm package does not
-    // include minified builds, so skip the emulator.min.js attempt to
-    // avoid 404 errors and ensure clean script loading order.
-    window.EJS_DEBUG_XX = true;
-
     // Enable threaded WASM cores for full-speed emulation.
     // Requires COOP/COEP headers (set by server and Vite dev config).
     window.EJS_threads = true;

--- a/web/src/features/games/components/games-filter-bar.tsx
+++ b/web/src/features/games/components/games-filter-bar.tsx
@@ -8,6 +8,8 @@ type ViewMode = "grid" | "list";
 interface GamesFilterBarProps {
   filters: GameFilters;
   onFiltersChange: (updater: (prev: GameFilters) => GameFilters) => void;
+  searchValue: string;
+  onSearchChange: (value: string) => void;
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
   consoles: Console[] | undefined;
@@ -16,6 +18,8 @@ interface GamesFilterBarProps {
 export function GamesFilterBar({
   filters,
   onFiltersChange,
+  searchValue,
+  onSearchChange,
   viewMode,
   onViewModeChange,
   consoles,
@@ -37,10 +41,8 @@ export function GamesFilterBar({
       <div className="flex-1 min-w-[240px] max-w-md">
         <SearchInput
           placeholder="Search games..."
-          value={filters.search ?? ""}
-          onChange={(e) =>
-            onFiltersChange((f) => ({ ...f, search: e.target.value, page: 1 }))
-          }
+          value={searchValue}
+          onChange={(e) => onSearchChange(e.target.value)}
         />
       </div>
 

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from "react";
+import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
 import { Library, Check, Globe } from "lucide-react";
 import { GameCard } from "@/components/game-card";
@@ -9,32 +9,47 @@ import {
   EmptyState,
   SearchInput,
 } from "@/components/ui";
-import { useConsoles, useConsoleGames } from "@/hooks/use-consoles";
-import { useToggleFavorite } from "@/hooks/use-games";
+import { useConsoles } from "@/hooks/use-consoles";
+import { useGames, useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
 import { useBiosStatus } from "@/hooks/use-bios";
 import { useAuth } from "@/hooks/use-auth";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { BiosWarningBanner } from "@/features/bios/components/bios-warning-banner";
+import { Pagination } from "@/components/pagination";
 import { getConsoleStyle } from "@/lib/console-metadata";
 import { cn } from "@/lib/cn";
+
+const PAGE_SIZE = 48;
 
 export function ConsoleDetailPage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { data: games, isLoading } = useConsoleGames(id ?? "");
   const { data: consoles } = useConsoles();
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
   const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
+  const [page, setPage] = useState(1);
   const { data: biosData } = useBiosStatus();
   const { isAdmin } = useAuth();
+
+  const { data, isLoading } = useGames({
+    consoleId: id,
+    search: debouncedSearch || undefined,
+    page,
+    pageSize: PAGE_SIZE,
+    sortBy: "title",
+    sortOrder: "asc",
+  });
 
   // Find console info from the consoles list
   const console = consoles?.find((c) => c.id === id);
 
   const consoleName = console?.name ?? "Console";
   const consoleAbbr = console?.abbreviation ?? id ?? "";
-  const gameList = games ?? [];
+  const games = data?.data ?? [];
+  const totalGames = data?.total ?? 0;
   const style = getConsoleStyle(consoleAbbr);
   const Icon = style.icon;
 
@@ -45,12 +60,6 @@ export function ConsoleDetailPage() {
     biosConsole?.files
       .filter((f) => f.status === "missing" && f.required)
       .map((f) => f.fileName) ?? [];
-
-  const filteredGames = useMemo(() => {
-    const q = search.trim().toLowerCase();
-    if (!q) return gameList;
-    return gameList.filter((g) => g.title.toLowerCase().includes(q));
-  }, [gameList, search]);
 
   return (
     <div className="space-y-6">
@@ -111,7 +120,7 @@ export function ConsoleDetailPage() {
           {/* Metadata row */}
           <div className="flex flex-wrap items-center justify-center gap-3 mt-4">
             <span className="text-sm font-medium text-white/70">
-              {gameList.length} {gameList.length === 1 ? "game" : "games"}
+              {totalGames} {totalGames === 1 ? "game" : "games"}
             </span>
             {console?.saveStateSupport && (
               <span className="inline-flex items-center gap-1.5 rounded-full bg-white/10 backdrop-blur-sm px-3 py-1 text-xs font-medium text-white/90">
@@ -139,14 +148,15 @@ export function ConsoleDetailPage() {
       )}
 
       {/* Search */}
-      {gameList.length > 5 && (
-        <SearchInput
-          placeholder={`Search ${consoleName} games...`}
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          className="max-w-sm"
-        />
-      )}
+      <SearchInput
+        placeholder={`Search ${consoleName} games...`}
+        value={search}
+        onChange={(e) => {
+          setSearch(e.target.value);
+          setPage(1);
+        }}
+        className="max-w-sm"
+      />
 
       {/* Games grid */}
       {isLoading ? (
@@ -158,7 +168,7 @@ export function ConsoleDetailPage() {
             />
           ))}
         </GameGrid>
-      ) : filteredGames.length === 0 ? (
+      ) : games.length === 0 ? (
         <EmptyState
           icon={Library}
           title={search.trim() ? "No matching games" : "No games found"}
@@ -170,7 +180,7 @@ export function ConsoleDetailPage() {
         />
       ) : (
         <GameGrid>
-          {filteredGames.map((game) => (
+          {games.map((game) => (
             <GameCard
               key={game.id}
               game={game}
@@ -180,6 +190,15 @@ export function ConsoleDetailPage() {
             />
           ))}
         </GameGrid>
+      )}
+
+      {data && (
+        <Pagination
+          total={data.total}
+          pageSize={PAGE_SIZE}
+          currentPage={page}
+          onPageChange={setPage}
+        />
       )}
     </div>
   );

--- a/web/src/pages/games-page.tsx
+++ b/web/src/pages/games-page.tsx
@@ -9,19 +9,25 @@ import { useConsoles } from "@/hooks/use-consoles";
 import { GamesFilterBar } from "@/features/games/components/games-filter-bar";
 import { GameListRow } from "@/features/games/components/game-list-row";
 import { Pagination } from "@/components/pagination";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import type { GameFilters } from "@/types/api";
 
 type ViewMode = "grid" | "list";
 
 export function GamesPage() {
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
+  const [searchInput, setSearchInput] = useState("");
+  const debouncedSearch = useDebouncedValue(searchInput, 300);
   const [filters, setFilters] = useState<GameFilters>({
     sortBy: "title",
     sortOrder: "asc",
     pageSize: 48,
   });
 
-  const { data, isLoading } = useGames(filters);
+  const { data, isLoading } = useGames({
+    ...filters,
+    search: debouncedSearch || undefined,
+  });
   const { data: consoles } = useConsoles();
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
@@ -42,6 +48,11 @@ export function GamesPage() {
       <GamesFilterBar
         filters={filters}
         onFiltersChange={setFilters}
+        searchValue={searchInput}
+        onSearchChange={(value) => {
+          setSearchInput(value);
+          setFilters((f) => ({ ...f, page: 1 }));
+        }}
         viewMode={viewMode}
         onViewModeChange={setViewMode}
         consoles={consoles}
@@ -67,7 +78,7 @@ export function GamesPage() {
           icon={Library}
           title="No games found"
           description={
-            filters.search
+            searchInput
               ? "No games match your search. Try different keywords."
               : "Your library is empty. Scan for games to get started."
           }


### PR DESCRIPTION
## Summary
- **Fix EmulatorJS CSP violations**: Remove `EJS_DEBUG_XX` flag that triggered unnecessary CDN version checks, and add `blob:` to `script-src`/`worker-src` for compression workers. EmulatorJS assets are fully self-hosted — no external CDN dependency at runtime.
- **Add pagination to console games endpoint**: `ListConsoleGames` now supports pagination, sorting, and search (matching `/api/games`). Console detail page uses the paginated endpoint with server-side search.
- **Debounce search inputs**: Both the games page and console detail page now debounce search by 300ms to avoid excessive API calls. Player app search also debounced.
- **Fix count query bug**: The `/api/games` count query now resolves console abbreviations to numeric IDs, matching the data query.

## Test plan
- [ ] Load a game in the web emulator on a deployed instance — no CSP errors in console
- [ ] Verify compression workers load (no `worker-src` violations)
- [ ] Browse console detail page — games load with pagination controls
- [ ] Search on console detail page — results filter server-side with debounce
- [ ] Search on all-games page — debounced, no flicker
- [ ] Player app browse console — games load correctly via paginated endpoint