### PR TITLE
Fix EmulatorJS loading: restore debug flag, add unsafe-eval CSP

### DIFF
--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -58,7 +58,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		c.Header("Referrer-Policy", "strict-origin-when-cross-origin")
 		// Content Security Policy — frame-ancestors 'self' allows the emulator to load
 		// inside an iframe on the same origin while still blocking third-party embedding
-		c.Header("Content-Security-Policy", "default-src 'self'; script-src 'self' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' wss: ws:; worker-src 'self' blob:; frame-ancestors 'self'")
+		c.Header("Content-Security-Policy", "default-src 'self'; script-src 'self' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' https: data:; connect-src 'self' wss: ws:; worker-src 'self' blob:; frame-ancestors 'self'")
 		// HSTS — instruct browsers to always use HTTPS. Safe even behind a reverse
 		// proxy; browsers only honour this header on HTTPS responses.
 		c.Header("Strict-Transport-Security", "max-age=63072000; includeSubDomains")

--- a/web/public/emulator.js
+++ b/web/public/emulator.js
@@ -112,6 +112,12 @@
     window.EJS_backgroundBlur = true;
     window.EJS_backgroundColor = "#16191d";
 
+    // Skip loading emulator.min.js/css — the npm package has no minified
+    // builds, and the SPA fallback serves index.html (200 text/html) for
+    // missing files, which prevents the loader's onerror fallback from firing.
+    // This also triggers a CDN version check that is harmlessly blocked by CSP.
+    window.EJS_DEBUG_XX = true;
+
     // Enable threaded WASM cores for full-speed emulation.
     // Requires COOP/COEP headers (set by server and Vite dev config).
     window.EJS_threads = true;


### PR DESCRIPTION
## Summary
- **Restore `EJS_DEBUG_XX = true`** — the npm package has no minified builds, and the SPA fallback serves `index.html` (200 text/html) for missing `.min.js`/`.min.css` files. This prevents the loader's `onerror` fallback from firing, so the emulator never loads. The debug flag skips minified files entirely.
- **Add `'unsafe-eval'` to `script-src` CSP** — Emscripten WASM cores use `cwrap`/`eval()` internally, which is blocked without this directive.

Fixes three console errors on the deployed instance:
1. `Refused to execute script 'emulator.min.js'` (MIME type text/html)
2. `Refused to apply style 'emulator.min.css'` (MIME type text/html)
3. `Evaluating a string as JavaScript violates CSP: 'unsafe-eval' not allowed`

## Test plan
- [ ] Load a game in the web emulator — no CSP errors, emulator loads and runs
- [ ] Verify WASM cores initialize without eval CSP violations