### PR TITLE
fix: improve IGDB ranking with suffix tier and metadata quality

### DIFF
--- a/server/internal/scraper/igdb_ranking.go
+++ b/server/internal/scraper/igdb_ranking.go
@@ -11,6 +11,17 @@ import (
 // bestIGDBMatch picks the IGDB search result whose name is most similar to the
 // query (the cleaned filename). It reuses normalizeName and jaroWinkler from
 // namematch.go with tiered scoring logic.
+//
+// Scoring tiers (highest to lowest):
+//
+//	exact  = 1.0           (always wins, no metadata penalty)
+//	suffix = 0.91–0.96     (query at end of name: "Disney's Aladdin" for "Aladdin")
+//	prefix = 0.90–0.95     (query at start of name: "Aladdin 2000" for "Aladdin")
+//	contains = 0.80–0.85   (query somewhere inside name)
+//	fuzzy  = Jaro-Winkler  (fallback)
+//
+// Non-exact matches are further adjusted by metadataQuality, which penalises
+// games with missing release dates, companies, cover art, or screenshots.
 func bestIGDBMatch(query string, games []igdb.Game) igdb.Game {
 	if len(games) == 1 {
 		slog.Info("IGDB match: single result", "query", query, "match", games[0].Name, "igdbId", games[0].ID)
@@ -31,6 +42,14 @@ func bestIGDBMatch(query string, games []igdb.Game) igdb.Game {
 		case n == normalizedQuery:
 			score = 1.0
 			tier = "exact"
+		case strings.HasSuffix(n, normalizedQuery) || strings.HasSuffix(normalizedQuery, n):
+			shorter := len(normalizedQuery)
+			longer := len(n)
+			if shorter > longer {
+				shorter, longer = longer, shorter
+			}
+			score = 0.91 + 0.05*float64(shorter)/float64(longer)
+			tier = "suffix"
 		case strings.HasPrefix(n, normalizedQuery) || strings.HasPrefix(normalizedQuery, n):
 			shorter := len(normalizedQuery)
 			longer := len(n)
@@ -52,7 +71,15 @@ func bestIGDBMatch(query string, games []igdb.Game) igdb.Game {
 			tier = "fuzzy"
 		}
 
-		slog.Debug("IGDB match candidate", "query", normalizedQuery, "candidate", g.Name, "normalized", n, "tier", tier, "score", fmt.Sprintf("%.4f", score), "igdbId", g.ID)
+		// Apply metadata quality as a secondary signal for non-exact matches.
+		// Exact matches always score 1.0 regardless of metadata completeness.
+		if tier != "exact" {
+			mq := metadataQuality(g)
+			score *= mq
+			slog.Debug("IGDB match candidate", "query", normalizedQuery, "candidate", g.Name, "normalized", n, "tier", tier, "nameScore", fmt.Sprintf("%.4f", score/mq), "metadataQuality", fmt.Sprintf("%.4f", mq), "finalScore", fmt.Sprintf("%.4f", score), "igdbId", g.ID)
+		} else {
+			slog.Debug("IGDB match candidate", "query", normalizedQuery, "candidate", g.Name, "normalized", n, "tier", tier, "score", fmt.Sprintf("%.4f", score), "igdbId", g.ID)
+		}
 
 		if isBetterIGDBMatch(score, g, bestScore, games[bestIdx]) {
 			bestScore = score
@@ -62,6 +89,26 @@ func bestIGDBMatch(query string, games []igdb.Game) igdb.Game {
 
 	slog.Info("IGDB match selected", "query", query, "match", games[bestIdx].Name, "score", fmt.Sprintf("%.4f", bestScore), "igdbId", games[bestIdx].ID)
 	return games[bestIdx]
+}
+
+// metadataQuality returns a multiplier (0.0–1.0) reflecting how well-documented
+// a game is in IGDB. Games with missing metadata are penalised, as sparse entries
+// are more likely to be bootlegs, unreleased games, or duplicates.
+func metadataQuality(g igdb.Game) float64 {
+	q := 1.0
+	if g.FirstReleaseDate == 0 {
+		q *= 0.92
+	}
+	if len(g.InvolvedCompanies) == 0 {
+		q *= 0.95
+	}
+	if g.Cover == nil {
+		q *= 0.95
+	}
+	if len(g.Screenshots) == 0 {
+		q *= 0.95
+	}
+	return q
 }
 
 // isBetterIGDBMatch returns true if candidate (with candidateScore) is a better

--- a/server/internal/scraper/igdb_ranking_test.go
+++ b/server/internal/scraper/igdb_ranking_test.go
@@ -34,13 +34,13 @@ func TestBestIGDBMatch_Ranking(t *testing.T) {
 			wantName: "Super Mario Bros.",
 		},
 		{
-			name:  "Zelda prefix matches Zelda II over Legend of Zelda contains",
+			name:  "Zelda suffix match beats prefix match",
 			query: "Zelda",
 			games: []igdb.Game{
 				{ID: 1, Name: "The Legend of Zelda"},
 				{ID: 2, Name: "Zelda II: The Adventure of Link"},
 			},
-			wantName: "Zelda II: The Adventure of Link",
+			wantName: "The Legend of Zelda",
 		},
 		{
 			name:  "single result returns it",
@@ -133,6 +133,145 @@ func TestBestIGDBMatch_EarlierReleasePreferred(t *testing.T) {
 		{ID: 2, Name: "Doom", FirstReleaseDate: 755222400},  // 1993
 	})
 	assert.Equal(t, 2, got.ID)
+}
+
+func TestBestIGDBMatch_Aladdin_PicksRealGame(t *testing.T) {
+	// Regression test: IGDB text search for "Aladdin" on SNES returns both
+	// "Aladdin 2000" (unlicensed bootleg, prefix match) and "Disney's Aladdin"
+	// (real Capcom game, suffix match). The suffix tier + metadata quality
+	// penalties must prefer the real game.
+	got := bestIGDBMatch("Aladdin", []igdb.Game{
+		{
+			ID:               247332,
+			Name:             "Aladdin 2000",
+			FirstReleaseDate: 0, // no release date
+			InvolvedCompanies: []igdb.InvolvedCompany{
+				{Company: igdb.Company{ID: 1, Name: "Unknown"}},
+			},
+			Screenshots: []igdb.Image{{ID: 1, ImageID: "s1"}},
+			Genres:      []igdb.Genre{{ID: 1, Name: "Platform"}},
+			// no cover
+		},
+		{
+			ID:               2473,
+			Name:             "Disney's Aladdin",
+			FirstReleaseDate: 754272000, // 1993-11-21
+			InvolvedCompanies: []igdb.InvolvedCompany{
+				{Company: igdb.Company{ID: 1, Name: "Capcom"}, Developer: true},
+				{Company: igdb.Company{ID: 2, Name: "Capcom"}, Publisher: true},
+				{Company: igdb.Company{ID: 3, Name: "The Walt Disney Company"}},
+			},
+			Cover:       &igdb.Image{ID: 1, ImageID: "c1"},
+			Screenshots: []igdb.Image{{ID: 1, ImageID: "s1"}, {ID: 2, ImageID: "s2"}, {ID: 3, ImageID: "s3"}},
+			Genres:      []igdb.Genre{{ID: 1, Name: "Platform"}, {ID: 2, Name: "Adventure"}, {ID: 3, Name: "Arcade"}},
+		},
+	})
+	assert.Equal(t, "Disney's Aladdin", got.Name)
+	assert.Equal(t, 2473, got.ID)
+}
+
+func TestBestIGDBMatch_SuffixBeatsPrefixForQualifiedNames(t *testing.T) {
+	// Games with possessive qualifiers (e.g. "Tom Clancy's Splinter Cell")
+	// should rank higher via suffix match than prefix matches.
+	tests := []struct {
+		name     string
+		query    string
+		games    []igdb.Game
+		wantName string
+	}{
+		{
+			name:  "Tom Clancys Splinter Cell suffix over Splinter Cell Blacklist prefix",
+			query: "Splinter Cell",
+			games: []igdb.Game{
+				{ID: 1, Name: "Splinter Cell: Blacklist", FirstReleaseDate: 100, Cover: &igdb.Image{ID: 1, ImageID: "c1"}},
+				{ID: 2, Name: "Tom Clancy's Splinter Cell", FirstReleaseDate: 100, Cover: &igdb.Image{ID: 1, ImageID: "c2"}},
+			},
+			wantName: "Tom Clancy's Splinter Cell",
+		},
+		{
+			name:  "Disneys Aladdin suffix over Aladdin 2000 prefix",
+			query: "Aladdin",
+			games: []igdb.Game{
+				{ID: 1, Name: "Aladdin 2000", FirstReleaseDate: 100, Cover: &igdb.Image{ID: 1, ImageID: "c1"}},
+				{ID: 2, Name: "Disney's Aladdin", FirstReleaseDate: 100, Cover: &igdb.Image{ID: 1, ImageID: "c2"}},
+			},
+			wantName: "Disney's Aladdin",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := bestIGDBMatch(tt.query, tt.games)
+			assert.Equal(t, tt.wantName, got.Name)
+		})
+	}
+}
+
+func TestMetadataQuality(t *testing.T) {
+	tests := []struct {
+		name string
+		game igdb.Game
+		want float64
+	}{
+		{
+			name: "full metadata scores 1.0",
+			game: igdb.Game{
+				FirstReleaseDate:  100,
+				InvolvedCompanies: []igdb.InvolvedCompany{{Company: igdb.Company{ID: 1}}},
+				Cover:             &igdb.Image{ID: 1, ImageID: "c1"},
+				Screenshots:       []igdb.Image{{ID: 1, ImageID: "s1"}},
+			},
+			want: 1.0,
+		},
+		{
+			name: "missing release date",
+			game: igdb.Game{
+				FirstReleaseDate:  0,
+				InvolvedCompanies: []igdb.InvolvedCompany{{Company: igdb.Company{ID: 1}}},
+				Cover:             &igdb.Image{ID: 1, ImageID: "c1"},
+				Screenshots:       []igdb.Image{{ID: 1, ImageID: "s1"}},
+			},
+			want: 0.92,
+		},
+		{
+			name: "missing everything",
+			game: igdb.Game{},
+			want: 0.92 * 0.95 * 0.95 * 0.95,
+		},
+		{
+			name: "only missing cover",
+			game: igdb.Game{
+				FirstReleaseDate:  100,
+				InvolvedCompanies: []igdb.InvolvedCompany{{Company: igdb.Company{ID: 1}}},
+				Screenshots:       []igdb.Image{{ID: 1, ImageID: "s1"}},
+			},
+			want: 0.95,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := metadataQuality(tt.game)
+			assert.InDelta(t, tt.want, got, 0.0001)
+		})
+	}
+}
+
+func TestBestIGDBMatch_MetadataPenaltyBreaksTie(t *testing.T) {
+	// Two prefix matches with same length ratio — metadata quality decides.
+	// "Game A" has no metadata, "Game B" is well-documented.
+	got := bestIGDBMatch("Battle", []igdb.Game{
+		{ID: 1, Name: "Battle Zone"}, // prefix match, no metadata → penalised
+		{
+			ID:                2,
+			Name:              "Battle Toads",
+			FirstReleaseDate:  100,
+			InvolvedCompanies: []igdb.InvolvedCompany{{Company: igdb.Company{ID: 1}}},
+			Cover:             &igdb.Image{ID: 1, ImageID: "c1"},
+			Screenshots:       []igdb.Image{{ID: 1, ImageID: "s1"}},
+		}, // prefix match, full metadata → no penalty
+	})
+	assert.Equal(t, "Battle Toads", got.Name)
 }
 
 func TestIsBetterIGDBMatch(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds a **suffix match tier** (0.91–0.96) scored slightly above prefix (0.90–0.95) to correctly rank games with possessive qualifiers like "Disney's Aladdin" and "Tom Clancy's Splinter Cell"
- Applies **metadata quality penalties** (release date, companies, cover, screenshots) as multipliers on non-exact matches, demoting bootlegs and undocumented entries
- Fixes scraping "Aladdin" on SNES returning the unlicensed bootleg "Aladdin 2000" instead of the real Capcom game

## Test plan
- [x] Aladdin regression test: confirms "Disney's Aladdin" ranks above "Aladdin 2000"
- [x] Suffix beats prefix tests: "Tom Clancy's Splinter Cell" and "Disney's Aladdin" patterns
- [x] Metadata quality unit tests: full metadata, missing release date, missing everything, missing cover
- [x] Metadata penalty tiebreaker test: well-documented game wins over sparse entry at same tier
- [x] Updated Zelda test: suffix match ("The Legend of Zelda") now correctly beats prefix ("Zelda II")
- [x] All existing tests pass (no regressions)
- [x] Full `go test ./...` passes