### PR TITLE
feat: allow admins to fix invalid IGDB scrape matches

### DIFF
--- a/server/internal/api/admin_handler.go
+++ b/server/internal/api/admin_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"sync"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/auth"
@@ -685,6 +686,110 @@ func igdbCredentials(database *gorm.DB) (clientID, clientSecret string) {
 		sm[s.Key] = s.Value
 	}
 	return sm["igdb_client_id"], sm["igdb_client_secret"]
+}
+
+// IGDBSearchResult represents a single IGDB game candidate for admin match correction.
+type IGDBSearchResult struct {
+	IGDBID      int    `json:"igdbId"`
+	Name        string `json:"name"`
+	CoverURL    string `json:"coverUrl,omitempty"`
+	ReleaseYear int    `json:"releaseYear,omitempty"`
+	Developer   string `json:"developer,omitempty"`
+	Summary     string `json:"summary,omitempty"`
+}
+
+// SearchIGDB searches IGDB for game candidates scoped to the game's platform.
+// GET /api/admin/games/:id/igdb-search?q=query
+func (h *AdminHandler) SearchIGDB(c *gin.Context) {
+	id := c.Param("id")
+	var game db.Game
+	if err := h.DB.Preload("Console").First(&game, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "game not found"})
+		return
+	}
+
+	query := c.Query("q")
+	if query == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "query parameter 'q' is required"})
+		return
+	}
+
+	h.tryConfigureIGDB()
+	if h.Scraper.IGDBClient == nil || !h.Scraper.IGDBClient.IsConfigured() {
+		c.JSON(http.StatusServiceUnavailable, gin.H{"error": "IGDB is not configured"})
+		return
+	}
+
+	platformID, ok := igdb.AbbreviationToIGDBPlatform[game.Console.Abbreviation]
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "no IGDB platform mapping for this console"})
+		return
+	}
+
+	games, err := h.Scraper.IGDBClient.SearchGame(query, platformID)
+	if err != nil {
+		slog.Warn("IGDB search failed", "query", query, "error", err)
+		c.JSON(http.StatusBadGateway, gin.H{"error": "IGDB search failed"})
+		return
+	}
+
+	results := make([]IGDBSearchResult, 0, len(games))
+	for _, g := range games {
+		result := IGDBSearchResult{
+			IGDBID:  g.ID,
+			Name:    g.Name,
+			Summary: g.Summary,
+		}
+		if g.Cover != nil && g.Cover.ImageID != "" {
+			result.CoverURL = igdb.ImageURL(g.Cover.ImageID, "cover_big")
+		}
+		if g.FirstReleaseDate > 0 {
+			result.ReleaseYear = time.Unix(g.FirstReleaseDate, 0).Year()
+		}
+		for _, ic := range g.InvolvedCompanies {
+			if ic.Developer {
+				result.Developer = ic.Company.Name
+				break
+			}
+		}
+		results = append(results, result)
+	}
+
+	c.JSON(http.StatusOK, results)
+}
+
+// ApplyIGDBMatch re-scrapes a game using a specific admin-chosen IGDB game ID.
+// POST /api/admin/games/:id/igdb-match with body { "igdbId": 1234 }
+func (h *AdminHandler) ApplyIGDBMatch(c *gin.Context) {
+	id := c.Param("id")
+	var game db.Game
+	if err := h.DB.Preload("Console").First(&game, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "game not found"})
+		return
+	}
+
+	var req struct {
+		IGDBID int `json:"igdbId" binding:"required,min=1"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		slog.Debug("request binding failed", "error", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": "igdbId is required and must be a positive integer"})
+		return
+	}
+
+	h.tryConfigureIGDB()
+
+	if err := h.Scraper.ScrapeGameWithIGDBMatch(&game, req.IGDBID); err != nil {
+		slog.Warn("IGDB match failed", "game", game.Title, "igdbId", req.IGDBID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to apply IGDB match"})
+		return
+	}
+
+	// Reload with all associations for the response
+	h.DB.Preload("Console").Preload("Discs").Preload("Screenshots").First(&game, game.ID)
+	userID, _ := c.Get("userId")
+	uid, _ := userID.(uint)
+	c.JSON(http.StatusOK, ToGameResponse(game, h.DB, uid))
 }
 
 // IGDBSource returns "env" if IGDB credentials are set via environment variables,

--- a/server/internal/api/admin_igdb_match_test.go
+++ b/server/internal/api/admin_igdb_match_test.go
@@ -1,0 +1,332 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/auth"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/igdb"
+	"github.com/spela/server/internal/scraper"
+	"github.com/spela/server/internal/storage"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+const igdbMatchTestSecret = "igdb-match-test-secret"
+
+func setupIGDBMatchTestEnv(t *testing.T, tokenServerURL, igdbServerURL string) (*gorm.DB, *gin.Engine, *scraper.Scraper) {
+	t.Helper()
+
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(
+		&db.User{}, &db.Console{}, &db.Game{}, &db.GameScreenshot{},
+		&db.GameDisc{}, &db.Favorite{}, &db.PlayHistory{}, &db.ServerSetting{},
+		&db.GameRating{}, &db.PlayLaterItem{},
+	))
+
+	if tokenServerURL != "" {
+		origURL := igdb.TwitchTokenURLForTest()
+		igdb.SetTwitchTokenURLForTest(tokenServerURL)
+		t.Cleanup(func() { igdb.SetTwitchTokenURLForTest(origURL) })
+	}
+	if igdbServerURL != "" {
+		origBase := igdb.IGDBAPIBaseForTest()
+		igdb.SetIGDBAPIBaseForTest(igdbServerURL + "/v4")
+		t.Cleanup(func() { igdb.SetIGDBAPIBaseForTest(origBase) })
+	}
+
+	tmpDir := t.TempDir()
+	store, err := storage.NewStorage(tmpDir+"/saves", tmpDir+"/cores", tmpDir+"/images", tmpDir+"/bios")
+	require.NoError(t, err)
+
+	hub := ws.NewHub(nil)
+	go hub.Run()
+
+	s := scraper.NewScraper(database, store, t.TempDir(), []string{tmpDir})
+	if tokenServerURL != "" && igdbServerURL != "" {
+		igdbClient := igdb.NewClient("test-id", "test-secret")
+		igdbClient.HTTPClient = &http.Client{Timeout: 5 * time.Second}
+		s.IGDBClient = igdbClient
+	}
+
+	adminHandler := &AdminHandler{DB: database, Scraper: s, Hub: hub, Storage: store}
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+	api := router.Group("/api")
+	api.Use(AuthMiddleware(igdbMatchTestSecret, database))
+	{
+		admin := api.Group("/admin")
+		admin.Use(AdminMiddleware())
+		{
+			admin.GET("/games/:id/igdb-search", adminHandler.SearchIGDB)
+			admin.POST("/games/:id/igdb-match", adminHandler.ApplyIGDBMatch)
+		}
+	}
+
+	return database, router, s
+}
+
+func createIGDBMatchTestUser(t *testing.T, database *gorm.DB) string {
+	t.Helper()
+	user := db.User{
+		Username:     "match-admin",
+		Email:        "match-admin@test.com",
+		PasswordHash: "unused",
+		Role:         "admin",
+	}
+	require.NoError(t, database.Create(&user).Error)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, igdbMatchTestSecret)
+	require.NoError(t, err)
+	return token
+}
+
+func TestSearchIGDB_Success(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]igdb.Game{
+			{
+				ID:      999,
+				Name:    "Disney's Aladdin",
+				Summary: "A platformer based on the Disney film",
+				Cover:   &igdb.Image{ID: 1, ImageID: "co5555"},
+				InvolvedCompanies: []igdb.InvolvedCompany{
+					{Company: igdb.Company{ID: 1, Name: "Capcom"}, Developer: true},
+				},
+				FirstReleaseDate: 753926400,
+			},
+			{
+				ID:   888,
+				Name: "Aladdin 2000",
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	database, router, _ := setupIGDBMatchTestEnv(t, tokenServer.URL, igdbServer.URL)
+	token := createIGDBMatchTestUser(t, database)
+
+	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{ConsoleID: console.ID, Title: "Aladdin", FileName: "Aladdin.sfc"}
+	require.NoError(t, database.Create(&game).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-search?q=Aladdin", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var results []IGDBSearchResult
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &results))
+	require.Len(t, results, 2)
+
+	assert.Equal(t, 999, results[0].IGDBID)
+	assert.Equal(t, "Disney's Aladdin", results[0].Name)
+	assert.NotEmpty(t, results[0].CoverURL)
+	assert.Equal(t, 1993, results[0].ReleaseYear)
+	assert.Equal(t, "Capcom", results[0].Developer)
+	assert.Equal(t, "A platformer based on the Disney film", results[0].Summary)
+
+	assert.Equal(t, 888, results[1].IGDBID)
+	assert.Equal(t, "Aladdin 2000", results[1].Name)
+	assert.Empty(t, results[1].CoverURL)
+	assert.Equal(t, 0, results[1].ReleaseYear)
+}
+
+func TestSearchIGDB_MissingQuery(t *testing.T) {
+	database, router, _ := setupIGDBMatchTestEnv(t, "", "")
+	token := createIGDBMatchTestUser(t, database)
+
+	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{ConsoleID: console.ID, Title: "Test", FileName: "Test.sfc"}
+	require.NoError(t, database.Create(&game).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-search", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSearchIGDB_GameNotFound(t *testing.T) {
+	database, router, _ := setupIGDBMatchTestEnv(t, "", "")
+	token := createIGDBMatchTestUser(t, database)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/games/99999/igdb-search?q=test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestSearchIGDB_IGDBNotConfigured(t *testing.T) {
+	database, router, _ := setupIGDBMatchTestEnv(t, "", "")
+	token := createIGDBMatchTestUser(t, database)
+
+	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{ConsoleID: console.ID, Title: "Test", FileName: "Test.sfc"}
+	require.NoError(t, database.Create(&game).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-search?q=test", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+}
+
+func TestApplyIGDBMatch_Success(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]igdb.Game{
+			{
+				ID:      999,
+				Name:    "Disney's Aladdin",
+				Summary: "The correct Aladdin game",
+				Genres:  []igdb.Genre{{ID: 8, Name: "Platform"}},
+				InvolvedCompanies: []igdb.InvolvedCompany{
+					{Company: igdb.Company{ID: 1, Name: "Capcom"}, Developer: true},
+				},
+				FirstReleaseDate: 753926400,
+				AggregatedRating: 82.0,
+				GameModes: []igdb.GameMode{
+					{ID: 1, Name: "Single player"},
+				},
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	database, router, _ := setupIGDBMatchTestEnv(t, tokenServer.URL, igdbServer.URL)
+	token := createIGDBMatchTestUser(t, database)
+
+	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
+	require.NoError(t, database.Create(&console).Error)
+
+	game := db.Game{
+		ConsoleID:      console.ID,
+		Title:          "Aladdin 2000",
+		FileName:       "Aladdin.sfc",
+		ScraperID:      "igdb:555",
+		ScrapeAttempts: 1,
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	body, _ := json.Marshal(map[string]int{"igdbId": 999})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-match", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "Disney's Aladdin", resp["title"])
+	assert.Equal(t, "The correct Aladdin game", resp["description"])
+	assert.Equal(t, "igdb:999", resp["scraperId"])
+}
+
+func TestApplyIGDBMatch_GameNotFound(t *testing.T) {
+	database, router, _ := setupIGDBMatchTestEnv(t, "", "")
+	token := createIGDBMatchTestUser(t, database)
+
+	body, _ := json.Marshal(map[string]int{"igdbId": 999})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/admin/games/99999/igdb-match", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestApplyIGDBMatch_MissingIGDBID(t *testing.T) {
+	database, router, _ := setupIGDBMatchTestEnv(t, "", "")
+	token := createIGDBMatchTestUser(t, database)
+
+	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{ConsoleID: console.ID, Title: "Test", FileName: "Test.sfc"}
+	require.NoError(t, database.Create(&game).Error)
+
+	body, _ := json.Marshal(map[string]string{})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-match", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestApplyIGDBMatch_IGDBNotFound(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Return empty results — game not found on IGDB
+		json.NewEncoder(w).Encode([]igdb.Game{})
+	}))
+	defer igdbServer.Close()
+
+	database, router, _ := setupIGDBMatchTestEnv(t, tokenServer.URL, igdbServer.URL)
+	token := createIGDBMatchTestUser(t, database)
+
+	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{ConsoleID: console.ID, Title: "Test", FileName: "Test.sfc"}
+	require.NoError(t, database.Create(&game).Error)
+
+	body, _ := json.Marshal(map[string]int{"igdbId": 99999})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-match", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusInternalServerError, w.Code)
+}

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -546,6 +546,11 @@ func (h *GameHandler) ScrapeIfNeeded(c *gin.Context) {
 			slog.Warn("auto-scrape failed", "game", g.Title, "error", err)
 			return
 		}
+		// Reload with Screenshots so the WebSocket broadcast includes them.
+		if err := h.DB.Preload("Console").Preload("Screenshots").First(&g, id).Error; err != nil {
+			slog.Warn("auto-scrape: failed to reload game after scrape", "id", id, "error", err)
+			return
+		}
 		h.Hub.Broadcast(ws.Event{
 			Type:    "game_scraped",
 			Payload: ToGameResponse(g, h.DB, 0),

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -418,6 +418,8 @@ func NewRouter(cfg Config) *gin.Engine {
 			admin.GET("/games/:id/covers", adminHandler.GetGameCovers)
 			admin.PUT("/games/:id/covers", adminHandler.SetGameCover)
 			admin.GET("/metadata-matches", adminHandler.MetadataMatches)
+			admin.GET("/games/:id/igdb-search", adminHandler.SearchIGDB)
+			admin.POST("/games/:id/igdb-match", adminHandler.ApplyIGDBMatch)
 			admin.POST("/igdb/test", igdbHandler.TestIGDB)
 			admin.GET("/igdb/status", igdbHandler.GetIGDBStatus)
 			admin.GET("/stats", adminHandler.GetStats)

--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -346,6 +346,64 @@ func (c *Client) SearchGameExact(name string, platformID int) ([]Game, error) {
 	return games, nil
 }
 
+// GetGameByID fetches a single game from IGDB by its ID.
+// Returns the full game data with the same fields as SearchGame.
+// Returns nil if the game is not found.
+func (c *Client) GetGameByID(igdbID int) (*Game, error) {
+	if err := c.authenticate(); err != nil {
+		return nil, fmt.Errorf("IGDB authentication: %w", err)
+	}
+
+	// Wait for rate limiter
+	<-c.rateLimiter
+
+	query := fmt.Sprintf(
+		`fields name,summary,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,game_modes.name; where id = %d; limit 1;`,
+		igdbID,
+	)
+
+	slog.Info("IGDB get game by ID request", "igdbID", igdbID, "query", query)
+
+	c.mu.Lock()
+	token := c.token.AccessToken
+	c.mu.Unlock()
+
+	req, err := http.NewRequest("POST", igdbAPIBase+"/games", strings.NewReader(query))
+	if err != nil {
+		return nil, fmt.Errorf("creating IGDB request: %w", err)
+	}
+	req.Header.Set("Client-ID", c.ClientID)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling IGDB API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading IGDB response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var games []Game
+	if err := json.Unmarshal(body, &games); err != nil {
+		return nil, fmt.Errorf("decoding IGDB response: %w", err)
+	}
+
+	if len(games) == 0 {
+		slog.Info("IGDB get game by ID: not found", "igdbID", igdbID)
+		return nil, nil
+	}
+
+	slog.Info("IGDB get game by ID response", "igdbID", igdbID, "name", games[0].Name)
+	return &games[0], nil
+}
+
 // TopGame represents an IGDB top-rated game result.
 type TopGame struct {
 	ID               int    `json:"id"`

--- a/server/internal/igdb/client_test.go
+++ b/server/internal/igdb/client_test.go
@@ -613,6 +613,158 @@ func TestGetSimilarGames_APIError(t *testing.T) {
 	assert.Contains(t, err.Error(), "500")
 }
 
+func TestGetGameByID_Success(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/v4/games", r.URL.Path)
+		assert.Equal(t, "myid", r.Header.Get("Client-ID"))
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		json.NewEncoder(w).Encode([]Game{
+			{
+				ID:      1234,
+				Name:    "Disney's Aladdin",
+				Summary: "A platformer based on the Disney film",
+				Cover:   &Image{ID: 1, ImageID: "co5555"},
+				Screenshots: []Image{
+					{ID: 2, ImageID: "sc6666"},
+				},
+				Genres: []Genre{
+					{ID: 8, Name: "Platform"},
+				},
+				InvolvedCompanies: []InvolvedCompany{
+					{Company: Company{ID: 1, Name: "Capcom"}, Developer: true, Publisher: false},
+					{Company: Company{ID: 2, Name: "Nintendo"}, Developer: false, Publisher: true},
+				},
+				FirstReleaseDate: 753926400,
+				AggregatedRating: 78.0,
+				GameModes: []GameMode{
+					{ID: 1, Name: "Single player"},
+				},
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	game, err := c.GetGameByID(1234)
+	require.NoError(t, err)
+	require.NotNil(t, game)
+
+	assert.Equal(t, 1234, game.ID)
+	assert.Equal(t, "Disney's Aladdin", game.Name)
+	assert.Equal(t, "A platformer based on the Disney film", game.Summary)
+	assert.NotNil(t, game.Cover)
+	assert.Equal(t, "co5555", game.Cover.ImageID)
+	assert.Len(t, game.Screenshots, 1)
+	assert.Equal(t, "sc6666", game.Screenshots[0].ImageID)
+	assert.Len(t, game.Genres, 1)
+	assert.Equal(t, "Platform", game.Genres[0].Name)
+	assert.Len(t, game.InvolvedCompanies, 2)
+	assert.True(t, game.InvolvedCompanies[0].Developer)
+	assert.Equal(t, "Capcom", game.InvolvedCompanies[0].Company.Name)
+	assert.Equal(t, int64(753926400), game.FirstReleaseDate)
+	assert.InDelta(t, 78.0, game.AggregatedRating, 0.01)
+	assert.Len(t, game.GameModes, 1)
+}
+
+func TestGetGameByID_NotFound(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]Game{})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	game, err := c.GetGameByID(99999)
+	require.NoError(t, err)
+	assert.Nil(t, game)
+}
+
+func TestGetGameByID_APIError(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	_, err := c.GetGameByID(1234)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
 func TestPlatformMapping(t *testing.T) {
 	// Verify key platform mappings exist
 	assert.Equal(t, 18, AbbreviationToIGDBPlatform["NES"])

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -361,13 +361,25 @@ func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string
 	// Pick the result whose name best matches the search name
 	match := bestIGDBMatch(searchName, games)
 
+	// When CRC-verified, only overwrite the title if the IGDB name is an exact match
+	// (e.g. don't replace "Aladdin" with "Aladdin 2000" from a fuzzy IGDB result).
+	forceTitle := !crcVerified || normalizeName(match.Name) == normalizeName(searchName)
+
+	s.applyIGDBMatch(game, console, match, gameIDStr, forceTitle)
+
+	slog.Info("IGDB match found", "game", searchName, "matched", match.Name, "igdbId", match.ID)
+	return nil
+}
+
+// applyIGDBMatch populates a game's metadata and downloads images from a specific
+// IGDB game result. If forceTitle is true, the game title is always overwritten
+// with the IGDB name; otherwise it is left unchanged.
+func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.Game, gameIDStr string, forceTitle bool) {
 	// Set scraper ID
 	game.ScraperID = fmt.Sprintf("igdb:%d", match.ID)
 
 	// Populate metadata — don't overwrite existing non-empty fields with empty values.
-	// When CRC-verified, only overwrite the title if the IGDB name is an exact match
-	// (e.g. don't replace "Aladdin" with "Aladdin 2000" from a fuzzy IGDB result).
-	if match.Name != "" && (!crcVerified || normalizeName(match.Name) == normalizeName(searchName)) {
+	if match.Name != "" && forceTitle {
 		game.Title = match.Name
 	}
 	if match.Summary != "" {
@@ -432,8 +444,118 @@ func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string
 			s.DB.Create(&db.GameScreenshot{GameID: game.ID, URL: path, Position: i})
 		}
 	}
+}
 
-	slog.Info("IGDB match found", "game", searchName, "matched", match.Name, "igdbId", match.ID)
+// ScrapeGameWithIGDBMatch re-scrapes a game using a specific IGDB game ID
+// chosen by an admin, bypassing the automatic search and ranking.
+// It clears stale metadata, fetches the IGDB game by ID, applies its metadata
+// and images, re-fetches LibRetro thumbnails, and persists the result.
+func (s *Scraper) ScrapeGameWithIGDBMatch(game *db.Game, igdbID int) error {
+	// Load console if not preloaded
+	var console db.Console
+	if game.Console.ID != 0 {
+		console = game.Console
+	} else {
+		if err := s.DB.First(&console, game.ConsoleID).Error; err != nil {
+			return fmt.Errorf("loading console for game: %w", err)
+		}
+	}
+
+	if s.IGDBClient == nil || !s.IGDBClient.IsConfigured() {
+		return fmt.Errorf("IGDB client is not configured")
+	}
+
+	// Fetch the specific IGDB game
+	igdbGame, err := s.IGDBClient.GetGameByID(igdbID)
+	if err != nil {
+		return fmt.Errorf("fetching IGDB game %d: %w", igdbID, err)
+	}
+	if igdbGame == nil {
+		return fmt.Errorf("IGDB game %d not found", igdbID)
+	}
+
+	// Clear stale IGDB metadata for re-scrape. Preserve LibRetro cover and
+	// manual cover choice handling (same logic as ScrapeGame).
+	manualOverride := game.CoverManuallySet
+	prevCoverSource := ""
+	if manualOverride {
+		switch game.CoverURL {
+		case game.LibRetroCoverURL:
+			prevCoverSource = "libretro"
+		case game.IGDBCoverURL:
+			prevCoverSource = "igdb"
+		}
+	}
+	game.CoverURL = ""
+	game.ScreenshotURL = ""
+	game.IGDBCoverURL = ""
+	// Clear IGDB-sourced metadata so the new match fully replaces it
+	game.Description = ""
+	game.Developer = ""
+	game.Publisher = ""
+	game.Genre = ""
+	game.Rating = 0
+	game.Players = 0
+	game.ReleaseDate = ""
+	// Delete old IGDB screenshots
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameScreenshot{})
+
+	gameIDStr := strconv.FormatUint(uint64(game.ID), 10)
+
+	// Apply the admin-selected IGDB match (always overwrite title)
+	s.applyIGDBMatch(game, console, *igdbGame, gameIDStr, true)
+
+	// Re-fetch LibRetro thumbnails (filename-based, independent of IGDB match)
+	gameName := gameNameFromFileName(game.FileName)
+	libRetroSystem, hasLibRetro := AbbreviationToLibRetro[console.Abbreviation]
+	if hasLibRetro {
+		boxartSubpath := fmt.Sprintf("%s/%s/boxart-libretro.png", console.Abbreviation, gameIDStr)
+		if path := s.downloadLibRetroImage(libRetroSystem, gameName, "Named_Boxarts", boxartSubpath); path != "" {
+			game.LibRetroCoverURL = path
+		}
+
+		var screenshotCount int64
+		s.DB.Model(&db.GameScreenshot{}).Where("game_id = ?", game.ID).Count(&screenshotCount)
+		if screenshotCount == 0 {
+			snapSubpath := fmt.Sprintf("%s/%s/screenshot.png", console.Abbreviation, gameIDStr)
+			if path := s.downloadLibRetroImage(libRetroSystem, gameName, "Named_Snaps", snapSubpath); path != "" {
+				s.DB.Create(&db.GameScreenshot{GameID: game.ID, URL: path, Position: 0})
+			}
+		}
+	}
+
+	// Set active cover: restore admin's manual choice if still available,
+	// otherwise prefer LibRetro box art, fall back to IGDB.
+	if manualOverride {
+		switch prevCoverSource {
+		case "libretro":
+			if game.LibRetroCoverURL != "" {
+				game.CoverURL = game.LibRetroCoverURL
+			}
+		case "igdb":
+			if game.IGDBCoverURL != "" {
+				game.CoverURL = game.IGDBCoverURL
+			}
+		}
+	}
+	if game.CoverURL == "" {
+		if game.LibRetroCoverURL != "" {
+			game.CoverURL = game.LibRetroCoverURL
+		} else if game.IGDBCoverURL != "" {
+			game.CoverURL = game.IGDBCoverURL
+		}
+		if manualOverride {
+			game.CoverManuallySet = false
+		}
+	}
+
+	game.ScrapeAttempts++
+
+	if err := s.DB.Save(game).Error; err != nil {
+		return fmt.Errorf("saving scraped metadata: %w", err)
+	}
+
+	slog.Info("re-scraped with manual IGDB match", "game", game.Title, "igdbId", igdbID, "scraperId", game.ScraperID)
 	return nil
 }
 

--- a/server/internal/scraper/scraper_igdb_test.go
+++ b/server/internal/scraper/scraper_igdb_test.go
@@ -667,6 +667,211 @@ func TestScrapeAll_ForceScrapesAll(t *testing.T) {
 	assert.Equal(t, 2, successes)
 }
 
+func TestScrapeGameWithIGDBMatch_Success(t *testing.T) {
+	// Set up IGDB mock that responds to GetGameByID
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]igdb.Game{
+			{
+				ID:      999,
+				Name:    "Disney's Aladdin",
+				Summary: "The correct Aladdin game",
+				Cover:   &igdb.Image{ID: 1, ImageID: "co7777"},
+				Screenshots: []igdb.Image{
+					{ID: 2, ImageID: "sc8888"},
+				},
+				Genres: []igdb.Genre{
+					{ID: 8, Name: "Platform"},
+				},
+				InvolvedCompanies: []igdb.InvolvedCompany{
+					{Company: igdb.Company{ID: 1, Name: "Capcom"}, Developer: true},
+					{Company: igdb.Company{ID: 2, Name: "Nintendo"}, Publisher: true},
+				},
+				FirstReleaseDate: 753926400,
+				AggregatedRating: 82.0,
+				GameModes: []igdb.GameMode{
+					{ID: 1, Name: "Single player"},
+				},
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	imageServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "image/jpeg")
+		w.Write([]byte("fake-image-data"))
+	}))
+	defer imageServer.Close()
+
+	origTokenURL := igdb.TwitchTokenURLForTest()
+	origAPIBase := igdb.IGDBAPIBaseForTest()
+	origImageBase := igdb.ImageBaseForTest()
+	igdb.SetTwitchTokenURLForTest(tokenServer.URL)
+	igdb.SetIGDBAPIBaseForTest(igdbServer.URL + "/v4")
+	igdb.SetImageBaseForTest(imageServer.URL)
+	defer func() {
+		igdb.SetTwitchTokenURLForTest(origTokenURL)
+		igdb.SetIGDBAPIBaseForTest(origAPIBase)
+		igdb.SetImageBaseForTest(origImageBase)
+	}()
+
+	database := setupTestDB(t)
+	store := setupTestStorage(t)
+
+	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
+	require.NoError(t, database.Create(&console).Error)
+
+	// Create a game that was previously scraped with the wrong IGDB match
+	game := db.Game{
+		ConsoleID:      console.ID,
+		Console:        console,
+		Title:          "Aladdin 2000",
+		FileName:       "Aladdin (USA).sfc",
+		Description:    "Wrong description from bootleg",
+		Developer:      "Bootleg Corp",
+		Publisher:      "Bootleg Corp",
+		Genre:          "Action",
+		Rating:         10.0,
+		Players:        1,
+		ReleaseDate:    "2000-01-01",
+		ScraperID:      "igdb:555",
+		ScrapeAttempts: 1,
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	// Add an old screenshot that should be cleared
+	database.Create(&db.GameScreenshot{GameID: game.ID, URL: "/old/screenshot.jpg", Position: 0})
+
+	igdbClient := igdb.NewClient("test-id", "test-secret")
+	igdbClient.HTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+	s := &Scraper{
+		DB:         database,
+		Storage:    store,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		IGDBClient: igdbClient,
+		DATCache:   NewDATCache(t.TempDir(), &http.Client{Timeout: 5 * time.Second}),
+		cache:      &nameCache{entries: make(map[string][]nameEntry)},
+	}
+
+	err := s.ScrapeGameWithIGDBMatch(&game, 999)
+	require.NoError(t, err)
+
+	// Verify all metadata was replaced with the correct IGDB match
+	assert.Equal(t, "Disney's Aladdin", game.Title)
+	assert.Equal(t, "The correct Aladdin game", game.Description)
+	assert.Equal(t, "Capcom", game.Developer)
+	assert.Equal(t, "Nintendo", game.Publisher)
+	assert.Equal(t, "Platform", game.Genre)
+	assert.Equal(t, "1993-11-22", game.ReleaseDate)
+	assert.InDelta(t, 82.0, game.Rating, 0.01)
+	assert.Equal(t, 1, game.Players)
+	assert.Equal(t, "igdb:999", game.ScraperID)
+	assert.Equal(t, 2, game.ScrapeAttempts)
+
+	// Verify cover was downloaded
+	assert.NotEmpty(t, game.IGDBCoverURL)
+
+	// Verify new screenshots replaced old ones
+	var screenshots []db.GameScreenshot
+	database.Where("game_id = ?", game.ID).Find(&screenshots)
+	assert.Len(t, screenshots, 1)
+	assert.NotEqual(t, "/old/screenshot.jpg", screenshots[0].URL)
+}
+
+func TestScrapeGameWithIGDBMatch_NotFound(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]igdb.Game{})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := igdb.TwitchTokenURLForTest()
+	origAPIBase := igdb.IGDBAPIBaseForTest()
+	igdb.SetTwitchTokenURLForTest(tokenServer.URL)
+	igdb.SetIGDBAPIBaseForTest(igdbServer.URL + "/v4")
+	defer func() {
+		igdb.SetTwitchTokenURLForTest(origTokenURL)
+		igdb.SetIGDBAPIBaseForTest(origAPIBase)
+	}()
+
+	database := setupTestDB(t)
+	store := setupTestStorage(t)
+
+	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
+	require.NoError(t, database.Create(&console).Error)
+
+	game := db.Game{
+		ConsoleID: console.ID,
+		Console:   console,
+		Title:     "Test Game",
+		FileName:  "Test.sfc",
+		ScraperID: "igdb:555",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	igdbClient := igdb.NewClient("test-id", "test-secret")
+	igdbClient.HTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+	s := &Scraper{
+		DB:         database,
+		Storage:    store,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		IGDBClient: igdbClient,
+		DATCache:   NewDATCache(t.TempDir(), &http.Client{Timeout: 5 * time.Second}),
+		cache:      &nameCache{entries: make(map[string][]nameEntry)},
+	}
+
+	err := s.ScrapeGameWithIGDBMatch(&game, 99999)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not found")
+}
+
+func TestScrapeGameWithIGDBMatch_NoIGDBClient(t *testing.T) {
+	database := setupTestDB(t)
+	store := setupTestStorage(t)
+
+	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
+	require.NoError(t, database.Create(&console).Error)
+
+	game := db.Game{
+		ConsoleID: console.ID,
+		Console:   console,
+		Title:     "Test Game",
+		FileName:  "Test.sfc",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	s := &Scraper{
+		DB:         database,
+		Storage:    store,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		IGDBClient: nil,
+		DATCache:   NewDATCache(t.TempDir(), &http.Client{Timeout: 5 * time.Second}),
+		cache:      &nameCache{entries: make(map[string][]nameEntry)},
+	}
+
+	err := s.ScrapeGameWithIGDBMatch(&game, 999)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "not configured")
+}
+
 func TestScrapeGame_RescrapesClearsStaleImages(t *testing.T) {
 	database := setupTestDB(t)
 	store := setupTestStorage(t)

--- a/web/src/features/game-detail/components/__tests__/scrape-match-modal.test.tsx
+++ b/web/src/features/game-detail/components/__tests__/scrape-match-modal.test.tsx
@@ -1,0 +1,375 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ScrapeMatchModal } from "../scrape-match-modal";
+
+const mockMutate = vi.fn();
+const mockToast = vi.fn();
+
+vi.mock("@/hooks/use-admin", () => ({
+  useIgdbSearch: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  })),
+  useApplyIgdbMatch: vi.fn(() => ({
+    mutate: mockMutate,
+    isPending: false,
+  })),
+  useIgdbStatus: vi.fn(() => ({
+    data: { configured: true, status: "connected", source: "database" },
+  })),
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual("@/components/ui");
+  return {
+    ...actual,
+    useToast: vi.fn(() => ({ toast: mockToast })),
+  };
+});
+
+import { useIgdbSearch, useApplyIgdbMatch, useIgdbStatus } from "@/hooks/use-admin";
+
+const mockUseIgdbSearch = useIgdbSearch as ReturnType<typeof vi.fn>;
+const mockUseApplyIgdbMatch = useApplyIgdbMatch as ReturnType<typeof vi.fn>;
+const mockUseIgdbStatus = useIgdbStatus as ReturnType<typeof vi.fn>;
+
+const mockSearchResults = [
+  {
+    igdbId: 1234,
+    name: "Super Mario Bros.",
+    coverUrl: "https://images.igdb.com/cover.jpg",
+    releaseYear: 1985,
+    developer: "Nintendo",
+    summary: "A classic platformer",
+  },
+  {
+    igdbId: 5678,
+    name: "Super Mario Bros. 2",
+    coverUrl: "https://images.igdb.com/cover2.jpg",
+    releaseYear: 1988,
+    developer: "Nintendo",
+    summary: "The sequel",
+  },
+];
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  mockUseIgdbSearch.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+  });
+  mockUseApplyIgdbMatch.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+  });
+  mockUseIgdbStatus.mockReturnValue({
+    data: { configured: true, status: "connected", source: "database" },
+  });
+});
+
+const defaultProps = {
+  gameId: "game-1",
+  currentTitle: "Super Mario Bros",
+  open: true,
+  onClose: vi.fn(),
+};
+
+describe("ScrapeMatchModal", () => {
+  it("renders modal with title when open", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Fix Scrape Match" }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} open={false} />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.queryByRole("dialog", { name: "Fix Scrape Match" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("pre-fills search input with current game title", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    const input = screen.getByPlaceholderText("Search IGDB...");
+    expect(input).toHaveValue("Super Mario Bros");
+  });
+
+  it("displays search results", () => {
+    mockUseIgdbSearch.mockReturnValue({
+      data: mockSearchResults,
+      isLoading: false,
+      isError: false,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Super Mario Bros.")).toBeInTheDocument();
+    expect(screen.getByText("Super Mario Bros. 2")).toBeInTheDocument();
+    expect(screen.getByText("1985")).toBeInTheDocument();
+    expect(screen.getByText("1988")).toBeInTheDocument();
+  });
+
+  it("displays developer and summary for results", () => {
+    mockUseIgdbSearch.mockReturnValue({
+      data: mockSearchResults,
+      isLoading: false,
+      isError: false,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(screen.getAllByText("Nintendo")).toHaveLength(2);
+    expect(screen.getByText("A classic platformer")).toBeInTheDocument();
+    expect(screen.getByText("The sequel")).toBeInTheDocument();
+  });
+
+  it("shows loading skeletons when searching", () => {
+    mockUseIgdbSearch.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      isError: false,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    const resultsContainer = screen.getByTestId("igdb-search-results");
+    expect(resultsContainer).toBeInTheDocument();
+    // Skeleton renders 5 placeholder rows
+    expect(
+      resultsContainer.querySelectorAll("[class*='animate-pulse']").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("shows error message when search fails", () => {
+    mockUseIgdbSearch.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.getByText("Failed to search IGDB. Please try again."),
+    ).toBeInTheDocument();
+  });
+
+  it("shows empty state when no results found", () => {
+    mockUseIgdbSearch.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.getByText("No results found on IGDB"),
+    ).toBeInTheDocument();
+  });
+
+  it("highlights current match with badge", () => {
+    mockUseIgdbSearch.mockReturnValue({
+      data: mockSearchResults,
+      isLoading: false,
+      isError: false,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal
+          {...defaultProps}
+          currentScraperId="igdb:1234"
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Current")).toBeInTheDocument();
+    // The current match button should be disabled
+    const currentMatchBtn = screen.getByTestId("igdb-result-1234");
+    expect(currentMatchBtn).toBeDisabled();
+  });
+
+  it("calls applyMatch.mutate when a result is selected", async () => {
+    mockUseIgdbSearch.mockReturnValue({
+      data: mockSearchResults,
+      isLoading: false,
+      isError: false,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    await userEvent.click(screen.getByTestId("igdb-result-1234"));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { gameId: "game-1", igdbId: 1234 },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+  });
+
+  it("disables result buttons while applying match", () => {
+    mockUseIgdbSearch.mockReturnValue({
+      data: mockSearchResults,
+      isLoading: false,
+      isError: false,
+    });
+    mockUseApplyIgdbMatch.mockReturnValue({
+      mutate: mockMutate,
+      isPending: true,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByTestId("igdb-result-1234")).toBeDisabled();
+    expect(screen.getByTestId("igdb-result-5678")).toBeDisabled();
+  });
+
+  it("shows IGDB not configured warning when status is not connected", () => {
+    mockUseIgdbStatus.mockReturnValue({
+      data: { configured: false, status: "not_configured", source: "none" },
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.getByText(/IGDB is not configured/),
+    ).toBeInTheDocument();
+  });
+
+  it("does not show warning when IGDB is connected", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.queryByText(/IGDB is not configured/),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows result cover images", () => {
+    mockUseIgdbSearch.mockReturnValue({
+      data: mockSearchResults,
+      isLoading: false,
+      isError: false,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    const images = screen.getAllByRole("img");
+    expect(images).toHaveLength(2);
+    expect(images[0]).toHaveAttribute(
+      "src",
+      "https://images.igdb.com/cover.jpg",
+    );
+  });
+
+  it("shows fallback initial when result has no cover", () => {
+    mockUseIgdbSearch.mockReturnValue({
+      data: [
+        {
+          igdbId: 999,
+          name: "Zelda",
+          releaseYear: 1986,
+        },
+      ],
+      isLoading: false,
+      isError: false,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ScrapeMatchModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Z")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -13,6 +13,7 @@ import {
   Clock,
   FolderPlus,
   ImageIcon,
+  Search,
 } from "lucide-react";
 import { Button, Badge, SplitButton, ActionsMenu } from "@/components/ui";
 import { VerificationBadge } from "./verification-badge";
@@ -45,6 +46,7 @@ interface GameHeroProps {
   onToggleFavorite: () => void;
   onTogglePlayLater: () => void;
   onAddToCollection?: () => void;
+  onFixMatch?: () => void;
 }
 
 export function GameHero({
@@ -65,6 +67,7 @@ export function GameHero({
   onToggleFavorite,
   onTogglePlayLater,
   onAddToCollection,
+  onFixMatch,
 }: GameHeroProps) {
   const [showCoverModal, setShowCoverModal] = useState(false);
   const consoleName = game.consoleName ?? "";
@@ -111,6 +114,15 @@ export function GameHero({
             label: "Add to Collection",
             icon: <FolderPlus className="h-4 w-4" />,
             onClick: onAddToCollection,
+          },
+        ]
+      : []),
+    ...(onFixMatch
+      ? [
+          {
+            label: "Fix Match",
+            icon: <Search className="h-4 w-4" />,
+            onClick: onFixMatch,
           },
         ]
       : []),

--- a/web/src/features/game-detail/components/scrape-match-modal.tsx
+++ b/web/src/features/game-detail/components/scrape-match-modal.tsx
@@ -1,0 +1,245 @@
+import { useState, useEffect, useRef } from "react";
+import { Search, Check, AlertTriangle } from "lucide-react";
+import { Modal, SearchInput, Badge, Skeleton, useToast } from "@/components/ui";
+import { useIgdbSearch, useApplyIgdbMatch, useIgdbStatus } from "@/hooks/use-admin";
+import { cn } from "@/lib/cn";
+import type { IgdbSearchResult } from "@/types/api";
+
+interface ScrapeMatchModalProps {
+  gameId: string;
+  currentTitle: string;
+  currentScraperId?: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ScrapeMatchModal({
+  gameId,
+  currentTitle,
+  currentScraperId,
+  open,
+  onClose,
+}: ScrapeMatchModalProps) {
+  const [searchInput, setSearchInput] = useState(currentTitle);
+  const [debouncedQuery, setDebouncedQuery] = useState(currentTitle);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { toast } = useToast();
+
+  const { data: igdbStatus } = useIgdbStatus();
+  const { data: results, isLoading, isError } = useIgdbSearch(gameId, debouncedQuery);
+  const applyMatch = useApplyIgdbMatch();
+
+  // Reset search when modal opens with a new game
+  useEffect(() => {
+    if (open) {
+      setSearchInput(currentTitle);
+      setDebouncedQuery(currentTitle);
+    }
+  }, [open, currentTitle]);
+
+  // Debounce search input
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setDebouncedQuery(searchInput);
+    }, 400);
+    return () => clearTimeout(timer);
+  }, [searchInput]);
+
+  // Focus input when modal opens
+  useEffect(() => {
+    if (open) {
+      // Small delay to allow modal animation
+      const timer = setTimeout(() => inputRef.current?.focus(), 100);
+      return () => clearTimeout(timer);
+    }
+  }, [open]);
+
+  function handleSelect(result: IgdbSearchResult) {
+    if (applyMatch.isPending) return;
+    applyMatch.mutate(
+      { gameId, igdbId: result.igdbId },
+      {
+        onSuccess: () => {
+          toast("success", `Matched to "${result.name}"`);
+          onClose();
+        },
+        onError: () => {
+          toast("error", "Failed to apply match");
+        },
+      },
+    );
+  }
+
+  const currentIgdbId = currentScraperId?.replace("igdb:", "") ?? null;
+
+  const igdbNotConfigured =
+    igdbStatus && igdbStatus.status !== "connected";
+
+  return (
+    <Modal open={open} onClose={onClose} title="Fix Scrape Match" size="lg">
+      <div className="space-y-4">
+        <SearchInput
+          ref={inputRef}
+          value={searchInput}
+          onChange={(e) => setSearchInput(e.currentTarget.value)}
+          placeholder="Search IGDB..."
+          data-testid="igdb-search-input"
+        />
+
+        {igdbNotConfigured ? (
+          <div className="flex items-center gap-3 rounded-xl bg-warning-500/10 border border-warning-500/20 px-4 py-3">
+            <AlertTriangle className="h-5 w-5 text-warning-500 flex-shrink-0" />
+            <p className="text-sm text-surface-300">
+              IGDB is not configured. Set up credentials in Admin Settings to
+              search for games.
+            </p>
+          </div>
+        ) : (
+          <div
+            className="max-h-96 overflow-y-auto -mx-6 px-6 space-y-1"
+            data-testid="igdb-search-results"
+          >
+            {isLoading && debouncedQuery.length >= 2 && (
+              <SearchResultsSkeleton />
+            )}
+
+            {isError && (
+              <p className="py-8 text-sm text-danger-400 text-center">
+                Failed to search IGDB. Please try again.
+              </p>
+            )}
+
+            {!isLoading && !isError && results && results.length === 0 && (
+              <div className="flex flex-col items-center py-8">
+                <Search className="h-8 w-8 text-surface-600 mb-2" />
+                <p className="text-sm text-surface-400">
+                  No results found on IGDB
+                </p>
+              </div>
+            )}
+
+            {!isLoading &&
+              results?.map((result) => (
+                <IgdbResultItem
+                  key={result.igdbId}
+                  result={result}
+                  isCurrentMatch={
+                    currentIgdbId != null &&
+                    String(result.igdbId) === currentIgdbId
+                  }
+                  isApplying={applyMatch.isPending}
+                  onSelect={() => handleSelect(result)}
+                />
+              ))}
+
+            {debouncedQuery.length < 2 && !isLoading && (
+              <p className="py-8 text-sm text-surface-500 text-center">
+                Type at least 2 characters to search
+              </p>
+            )}
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+function IgdbResultItem({
+  result,
+  isCurrentMatch,
+  isApplying,
+  onSelect,
+}: {
+  result: IgdbSearchResult;
+  isCurrentMatch: boolean;
+  isApplying: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      onClick={onSelect}
+      disabled={isApplying || isCurrentMatch}
+      data-testid={`igdb-result-${result.igdbId}`}
+      className={cn(
+        "w-full flex items-start gap-3 rounded-xl px-3 py-3 text-left transition-colors",
+        isCurrentMatch
+          ? "bg-brand-500/10 border border-brand-500/30 cursor-default"
+          : "hover:bg-surface-800 cursor-pointer border border-transparent",
+        isApplying && !isCurrentMatch && "opacity-50 cursor-not-allowed",
+      )}
+    >
+      {/* Cover thumbnail */}
+      <div className="w-12 flex-shrink-0 rounded-lg overflow-hidden bg-surface-800">
+        {result.coverUrl ? (
+          <img
+            src={result.coverUrl}
+            alt={result.name}
+            className="w-full"
+            style={{ aspectRatio: 3 / 4 }}
+            loading="lazy"
+          />
+        ) : (
+          <div
+            className="w-full bg-surface-800 flex items-center justify-center"
+            style={{ aspectRatio: 3 / 4 }}
+          >
+            <span className="text-lg font-bold text-surface-700">
+              {result.name.charAt(0)}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="flex-1 min-w-0 space-y-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium text-surface-100 truncate">
+            {result.name}
+          </span>
+          {isCurrentMatch && (
+            <Badge variant="brand" className="flex-shrink-0">
+              <Check className="h-3 w-3 mr-0.5" />
+              Current
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-2 text-xs text-surface-400">
+          {result.releaseYear && <span>{result.releaseYear}</span>}
+          {result.developer && (
+            <>
+              {result.releaseYear && (
+                <span className="text-surface-600">&middot;</span>
+              )}
+              <span className="truncate">{result.developer}</span>
+            </>
+          )}
+        </div>
+        {result.summary && (
+          <p className="text-xs text-surface-500 line-clamp-2">
+            {result.summary}
+          </p>
+        )}
+      </div>
+    </button>
+  );
+}
+
+function SearchResultsSkeleton() {
+  return (
+    <>
+      {Array.from({ length: 5 }, (_, i) => (
+        <div key={i} className="flex items-start gap-3 px-3 py-3">
+          <Skeleton
+            className="w-12 flex-shrink-0 rounded-lg"
+            style={{ aspectRatio: 3 / 4 }}
+          />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-3/5" />
+            <Skeleton className="h-3 w-2/5" />
+            <Skeleton className="h-3 w-full" />
+          </div>
+        </div>
+      ))}
+    </>
+  );
+}

--- a/web/src/hooks/__tests__/use-igdb-match.test.ts
+++ b/web/src/hooks/__tests__/use-igdb-match.test.ts
@@ -1,0 +1,154 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import { useIgdbSearch, useApplyIgdbMatch } from "../use-admin";
+
+vi.mock("@/lib/api-client", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api-client";
+
+const mockApi = api as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const mockSearchResults = [
+  {
+    igdbId: 1234,
+    name: "Super Mario Bros.",
+    coverUrl: "https://images.igdb.com/cover.jpg",
+    releaseYear: 1985,
+    developer: "Nintendo",
+    summary: "A classic platformer",
+  },
+  {
+    igdbId: 5678,
+    name: "Super Mario Bros. 2",
+    coverUrl: "https://images.igdb.com/cover2.jpg",
+    releaseYear: 1988,
+    developer: "Nintendo",
+    summary: "The sequel",
+  },
+];
+
+describe("useIgdbSearch", () => {
+  it("fetches IGDB search results for a game", async () => {
+    mockApi.get.mockResolvedValue(mockSearchResults);
+
+    const { result } = renderHook(
+      () => useIgdbSearch("game-1", "Super Mario"),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockApi.get).toHaveBeenCalledWith(
+      "/admin/games/game-1/igdb-search?q=Super%20Mario",
+    );
+    expect(result.current.data).toHaveLength(2);
+    expect(result.current.data?.[0].igdbId).toBe(1234);
+    expect(result.current.data?.[0].name).toBe("Super Mario Bros.");
+  });
+
+  it("does not fetch when query is less than 2 characters", () => {
+    const { result } = renderHook(() => useIgdbSearch("game-1", "S"), {
+      wrapper: createWrapper(),
+    });
+
+    expect(result.current.isFetching).toBe(false);
+    expect(mockApi.get).not.toHaveBeenCalled();
+  });
+
+  it("fetches when query is exactly 2 characters", async () => {
+    mockApi.get.mockResolvedValue([]);
+
+    const { result } = renderHook(() => useIgdbSearch("game-1", "SM"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockApi.get).toHaveBeenCalledWith(
+      "/admin/games/game-1/igdb-search?q=SM",
+    );
+  });
+
+  it("encodes special characters in query", async () => {
+    mockApi.get.mockResolvedValue([]);
+
+    const { result } = renderHook(
+      () => useIgdbSearch("game-1", "Crash & Burn"),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockApi.get).toHaveBeenCalledWith(
+      "/admin/games/game-1/igdb-search?q=Crash%20%26%20Burn",
+    );
+  });
+
+  it("handles fetch error", async () => {
+    mockApi.get.mockRejectedValue(new Error("Network error"));
+
+    const { result } = renderHook(
+      () => useIgdbSearch("game-1", "Super Mario"),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useApplyIgdbMatch", () => {
+  it("posts IGDB match and succeeds", async () => {
+    mockApi.post.mockResolvedValue({ id: "game-1", title: "Super Mario Bros." });
+
+    const { result } = renderHook(() => useApplyIgdbMatch(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ gameId: "game-1", igdbId: 1234 });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.post).toHaveBeenCalledWith(
+      "/admin/games/game-1/igdb-match",
+      { igdbId: 1234 },
+    );
+  });
+
+  it("handles mutation error", async () => {
+    mockApi.post.mockRejectedValue(new Error("Server error"));
+
+    const { result } = renderHook(() => useApplyIgdbMatch(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ gameId: "game-1", igdbId: 9999 });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -1,6 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
-import type { User, ServerSettingsMap, MetadataMatchesResponse } from "@/types/api";
+import type {
+  User,
+  ServerSettingsMap,
+  MetadataMatchesResponse,
+  IgdbSearchResult,
+} from "@/types/api";
 
 export function useAdminUsers() {
   return useQuery({
@@ -252,6 +257,40 @@ export function useUpdateGameMetadata() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["games"] });
       queryClient.invalidateQueries({ queryKey: ["game"] });
+      queryClient.invalidateQueries({
+        queryKey: ["admin", "metadata-matches"],
+      });
+    },
+  });
+}
+
+export function useIgdbSearch(gameId: string, query: string) {
+  return useQuery({
+    queryKey: ["admin", "igdb-search", gameId, query],
+    queryFn: () =>
+      api.get<IgdbSearchResult[]>(
+        `/admin/games/${gameId}/igdb-search?q=${encodeURIComponent(query)}`,
+      ),
+    enabled: query.length >= 2,
+  });
+}
+
+export function useApplyIgdbMatch() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({
+      gameId,
+      igdbId,
+    }: {
+      gameId: string;
+      igdbId: number;
+    }) => {
+      await api.post(`/admin/games/${gameId}/igdb-match`, { igdbId });
+    },
+    onSuccess: (_data, { gameId }) => {
+      queryClient.invalidateQueries({ queryKey: ["game", gameId] });
+      queryClient.invalidateQueries({ queryKey: ["games"] });
       queryClient.invalidateQueries({
         queryKey: ["admin", "metadata-matches"],
       });

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -37,6 +37,7 @@ import { GameChallenges } from "@/features/challenges/components/game-challenges
 import { useGameAchievements } from "@/hooks/use-retroachievements";
 import { useBiosStatus } from "@/hooks/use-bios";
 import { BiosWarningBanner } from "@/features/bios/components/bios-warning-banner";
+import { ScrapeMatchModal } from "@/features/game-detail/components/scrape-match-modal";
 import type { Collection } from "@/types/api";
 
 function CollectionPickerModal({
@@ -117,6 +118,7 @@ export function GameDetailPage() {
   const canPlayInBrowser = !!consoleInfo?.emulatorJsCore;
   const hasAchievements = (gameAchievements?.achievements?.length ?? 0) > 0;
   const [showCollectionPicker, setShowCollectionPicker] = useState(false);
+  const [showScrapeMatch, setShowScrapeMatch] = useState(false);
 
   useEffect(() => {
     if (game && game.scrapeAttempts === 0) {
@@ -191,6 +193,19 @@ export function GameDetailPage() {
           togglePlayLater.mutate({ gameId: game.id, isInPlayLater })
         }
         onAddToCollection={() => setShowCollectionPicker(true)}
+        onFixMatch={
+          isAdmin && game.scrapeAttempts > 0
+            ? () => setShowScrapeMatch(true)
+            : undefined
+        }
+      />
+
+      <ScrapeMatchModal
+        gameId={game.id}
+        currentTitle={game.title}
+        currentScraperId={game.scraperId}
+        open={showScrapeMatch}
+        onClose={() => setShowScrapeMatch(false)}
       />
 
       <CollectionPickerModal

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -119,6 +119,15 @@ export interface MetadataMatchesResponse {
   incomplete: Game[];
 }
 
+export interface IgdbSearchResult {
+  igdbId: number;
+  name: string;
+  coverUrl?: string;
+  releaseYear?: number;
+  developer?: string;
+  summary?: string;
+}
+
 export interface Device {
   id: number;
   userId: number;


### PR DESCRIPTION
## Summary
- Adds a **"Fix Match"** option to the game detail page actions menu (admin-only) that lets admins search IGDB manually and select the correct game when the automatic scraper picked the wrong match
- New backend endpoints: `GET /admin/games/:id/igdb-search` (proxy search scoped to platform) and `POST /admin/games/:id/igdb-match` (re-scrape with specific IGDB ID)
- Refactors scraper to extract `applyIGDBMatch()` for reuse between auto-scrape and manual match flows
- Includes the screenshot WebSocket broadcast fix (preload `Screenshots` relation before broadcast)

## Test plan
- [x] IGDB client: GetGameByID success, not found, API error (3 tests)
- [x] Scraper: ScrapeGameWithIGDBMatch success, not found, no client (3 tests)
- [x] Admin endpoints: search success/errors, match success/errors (8 tests)
- [x] Frontend hooks: search fetching, min chars, encoding, errors, match mutation (7 tests)
- [x] ScrapeMatchModal: rendering, search, results, loading, errors, current match, selection (15 tests)
- [x] Full Go test suite passes (all packages)
- [x] Full web unit test suite passes (64 files, 614 tests)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)