### PR TITLE
fix: activity rating, online presence, netplay search, session duration

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
@@ -119,11 +119,24 @@ class PresenceService(
 
     /**
      * Stop sending play-time heartbeats.
+     * Sends a final API call to clear the game status on the server (best-effort).
      */
     fun stopHeartbeat() {
+        val gameId = currentGameId
         heartbeatJob?.cancel()
         heartbeatJob = null
         currentGameId = null
+
+        // Fire-and-forget: tell the server we stopped playing
+        if (gameId != null) {
+            scope.launch(dispatchers.io) {
+                try {
+                    apiClient.clearCurrentGame(gameId)
+                } catch (_: Exception) {
+                    // Best effort — the server will time out stale entries anyway
+                }
+            }
+        }
     }
 
     private fun handleFrame(text: String) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -663,6 +663,10 @@ class SpelaApiClient(
         }
     }
 
+    suspend fun clearCurrentGame(gameId: String) {
+        client.delete("$baseUrl/api/games/$gameId/play-time")
+    }
+
     /**
      * Returns the WebSocket URL for real-time events, with the auth token as a query param.
      * Converts http(s):// to ws(s)://.

--- a/server/internal/api/admin_handler.go
+++ b/server/internal/api/admin_handler.go
@@ -686,7 +686,7 @@ func (h *AdminHandler) GetGameCovers(c *gin.Context) {
 		return
 	}
 
-	var covers []CoverOption
+	covers := make([]CoverOption, 0)
 
 	if game.LibRetroCoverURL != "" {
 		covers = append(covers, CoverOption{Source: "libretro", URL: resolveImageURL(game.LibRetroCoverURL)})

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -641,6 +641,23 @@ func (h *GameHandler) UpdatePlayTime(c *gin.Context) {
 	})
 }
 
+// StopPlaying clears the user's current game status.
+// DELETE /api/games/:id/play-time
+func (h *GameHandler) StopPlaying(c *gin.Context) {
+	userID, _ := c.Get("userId")
+	uid, ok := userID.(uint)
+	if !ok {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	if h.Hub != nil {
+		h.Hub.SetUserGame(uid, 0)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "cleared"})
+}
+
 // DownloadDisc serves files for a specific disc in a multi-disc game.
 // For single-file disc formats (.iso, .chd), serves the file directly.
 // For multi-file disc formats (.cue+.bin), streams an uncompressed tar.

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -433,7 +433,7 @@ type ActivityEventResponse struct {
 	GameTitle   string    `json:"gameTitle"`
 	GameCoverURL string  `json:"gameCoverUrl,omitempty"`
 	ConsoleName string    `json:"consoleName,omitempty"`
-	Metadata    string    `json:"metadata,omitempty"`
+	Metadata    map[string]interface{} `json:"metadata,omitempty"`
 }
 
 // GameRatingResponse is the API response for a single game rating.

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -228,6 +228,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/games/:id/discs/:discNumber/download", downloadLimiter.RateLimit(), gameHandler.DownloadDisc)
 		api.POST("/games/:id/scrape-if-needed", gameHandler.ScrapeIfNeeded)
 		api.POST("/games/:id/play-time", gameHandler.UpdatePlayTime)
+		api.DELETE("/games/:id/play-time", gameHandler.StopPlaying)
 		api.GET("/games/:id/stats", gameHandler.GetGameStats)
 		api.GET("/games/:id/similar", discoveryHandler.GetSimilarGames)
 		api.GET("/games/:id/developer-games", discoveryHandler.GetDeveloperGames)

--- a/server/internal/api/social_handler.go
+++ b/server/internal/api/social_handler.go
@@ -264,6 +264,13 @@ func (h *SocialHandler) GetActivityFeed(c *gin.Context) {
 			consoleName = e.Game.Console.Name
 		}
 
+		var metadata map[string]interface{}
+		if e.Metadata != "" {
+			if err := json.Unmarshal([]byte(e.Metadata), &metadata); err != nil {
+				slog.Warn("failed to parse activity event metadata", "error", err, "eventId", e.ID)
+			}
+		}
+
 		result = append(result, ActivityEventResponse{
 			ID:           strconv.FormatUint(uint64(e.ID), 10),
 			EventType:    e.EventType,
@@ -275,7 +282,7 @@ func (h *SocialHandler) GetActivityFeed(c *gin.Context) {
 			GameTitle:    e.Game.Title,
 			GameCoverURL: coverURL,
 			ConsoleName:  consoleName,
-			Metadata:     e.Metadata,
+			Metadata:     metadata,
 		})
 	}
 
@@ -336,7 +343,7 @@ func CreateActivityEvent(database *gorm.DB, hub *ws.Hub, userID uint, eventType 
 		GameTitle:    game.Title,
 		GameCoverURL: coverURL,
 		ConsoleName:  consoleName,
-		Metadata:     metadataJSON,
+		Metadata:     metadata,
 	}
 
 	if hub != nil {

--- a/server/internal/api/social_handler_test.go
+++ b/server/internal/api/social_handler_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActivityFeed_RatingMetadataIsParsedObject(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	// Create a game
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Rated Game", FileName: "rated.nes", FilePath: "/tmp/rated.nes", FileSize: 100}
+	database.Create(&game)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	// Rate the game (which creates an activity event with metadata)
+	ratingBody, _ := json.Marshal(map[string]interface{}{"rating": 5})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/games/"+gameID+"/ratings", bytes.NewReader(ratingBody))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "rating request failed: %s", w.Body.String())
+
+	// Fetch the activity feed
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/social/activity", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var feedResp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &feedResp)
+	require.NoError(t, err)
+	data := feedResp["data"].([]interface{})
+
+	// Find the rated_game event
+	var ratedEvent map[string]interface{}
+	for _, item := range data {
+		event := item.(map[string]interface{})
+		if event["eventType"] == "rated_game" {
+			ratedEvent = event
+			break
+		}
+	}
+	require.NotNil(t, ratedEvent, "should have a rated_game activity event")
+
+	// The metadata must be a parsed JSON object, not a string
+	metadata, ok := ratedEvent["metadata"].(map[string]interface{})
+	require.True(t, ok, "metadata should be a JSON object, got %T: %v", ratedEvent["metadata"], ratedEvent["metadata"])
+
+	// Verify the rating value is correct
+	assert.Equal(t, float64(5), metadata["rating"], "metadata.rating should be 5")
+}
+
+func TestActivityFeed_EmptyMetadataOmitted(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	// Create a game and favorite it (creates event without metadata)
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Fav Game", FileName: "fav.nes", FilePath: "/tmp/fav.nes", FileSize: 100}
+	database.Create(&game)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/user/favorites/"+gameID, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Fetch activity feed
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/social/activity", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var feedResp map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &feedResp)
+	require.NoError(t, err)
+	data := feedResp["data"].([]interface{})
+
+	var favEvent map[string]interface{}
+	for _, item := range data {
+		event := item.(map[string]interface{})
+		if event["eventType"] == "favorited_game" {
+			favEvent = event
+			break
+		}
+	}
+	require.NotNil(t, favEvent, "should have a favorited_game activity event")
+
+	// Metadata should be nil/absent (omitempty) for events without metadata
+	assert.Nil(t, favEvent["metadata"], "metadata should be nil for events without metadata")
+}

--- a/server/internal/auth/auth.go
+++ b/server/internal/auth/auth.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	AccessTokenDuration  = 15 * time.Minute
-	RefreshTokenDuration = 7 * 24 * time.Hour
+	AccessTokenDuration  = 1 * time.Hour
+	RefreshTokenDuration = 90 * 24 * time.Hour
 )
 
 // Claims represents JWT claims.

--- a/server/internal/auth/auth_test.go
+++ b/server/internal/auth/auth_test.go
@@ -3,6 +3,7 @@ package auth
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,6 +73,11 @@ func TestValidateAccessToken_InvalidSecret(t *testing.T) {
 func TestValidateAccessToken_InvalidToken(t *testing.T) {
 	_, err := ValidateAccessToken("not.a.valid.token", "secret")
 	assert.Error(t, err)
+}
+
+func TestTokenDurations(t *testing.T) {
+	assert.Equal(t, 1*time.Hour, AccessTokenDuration, "access token should last 1 hour")
+	assert.Equal(t, 90*24*time.Hour, RefreshTokenDuration, "refresh token should last 90 days")
 }
 
 func TestGenerateRefreshToken(t *testing.T) {

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -26,6 +26,12 @@ type OnlineUser struct {
 	CurrentGame uint // 0 means not playing
 }
 
+// userGameEntry stores the game a user is playing and when the last heartbeat arrived.
+type userGameEntry struct {
+	GameID        uint
+	LastHeartbeat time.Time
+}
+
 // Hub manages WebSocket connections and broadcasts events.
 type Hub struct {
 	clients    map[*Client]bool
@@ -34,7 +40,8 @@ type Hub struct {
 	unregister chan *Client
 	mu         sync.Mutex
 	upgrader   websocket.Upgrader
-	userGames  map[uint]uint // userID -> gameID (0 = not playing)
+	userGames  map[uint]userGameEntry // userID -> game entry
+	nowFunc    func() time.Time       // for testing; defaults to time.Now
 }
 
 // Client represents a single WebSocket connection.
@@ -48,13 +55,21 @@ type Client struct {
 // NewHub creates a new WebSocket hub. allowedOrigins controls which
 // origins are accepted for WebSocket upgrades. An empty slice rejects all
 // cross-origin requests (secure default, consistent with CORS behaviour).
+// heartbeatTimeout is how long a user's game status persists without a heartbeat.
+// This is 3x the 30-second heartbeat interval, giving room for network jitter.
+const heartbeatTimeout = 90 * time.Second
+
+// heartbeatCleanupInterval is how often the hub checks for stale game entries.
+const heartbeatCleanupInterval = 30 * time.Second
+
 func NewHub(allowedOrigins []string) *Hub {
 	h := &Hub{
 		clients:    make(map[*Client]bool),
 		broadcast:  make(chan Event, 256),
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
-		userGames:  make(map[uint]uint),
+		userGames:  make(map[uint]userGameEntry),
+		nowFunc:    time.Now,
 	}
 	h.upgrader = websocket.Upgrader{
 		ReadBufferSize:  1024,
@@ -96,6 +111,8 @@ func checkOrigin(allowedOrigins []string) func(*http.Request) bool {
 
 // Run starts the hub event loop. Call this in a goroutine.
 func (h *Hub) Run() {
+	go h.cleanupStaleGames()
+
 	for {
 		select {
 		case client := <-h.register:
@@ -185,7 +202,10 @@ func (h *Hub) SetUserGame(userID, gameID uint) {
 	if gameID == 0 {
 		delete(h.userGames, userID)
 	} else {
-		h.userGames[userID] = gameID
+		h.userGames[userID] = userGameEntry{
+			GameID:        gameID,
+			LastHeartbeat: h.nowFunc(),
+		}
 	}
 }
 
@@ -193,7 +213,34 @@ func (h *Hub) SetUserGame(userID, gameID uint) {
 func (h *Hub) GetUserGame(userID uint) uint {
 	h.mu.Lock()
 	defer h.mu.Unlock()
-	return h.userGames[userID]
+	entry, ok := h.userGames[userID]
+	if !ok {
+		return 0
+	}
+	return entry.GameID
+}
+
+// cleanupStaleGames periodically removes game entries whose heartbeat has expired.
+func (h *Hub) cleanupStaleGames() {
+	ticker := time.NewTicker(heartbeatCleanupInterval)
+	defer ticker.Stop()
+	for range ticker.C {
+		h.expireStaleGames()
+	}
+}
+
+// expireStaleGames removes game entries that haven't received a heartbeat within
+// the timeout window. Separated from cleanupStaleGames for testability.
+func (h *Hub) expireStaleGames() {
+	now := h.nowFunc()
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for userID, entry := range h.userGames {
+		if now.Sub(entry.LastHeartbeat) > heartbeatTimeout {
+			slog.Info("clearing stale game status", "userId", userID, "gameId", entry.GameID)
+			delete(h.userGames, userID)
+		}
+	}
 }
 
 // maxConnectionsPerUser is the maximum number of concurrent WebSocket connections

--- a/server/internal/websocket/hub_test.go
+++ b/server/internal/websocket/hub_test.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -60,4 +61,116 @@ func TestCheckOrigin_InvalidOriginURL(t *testing.T) {
 	// Malformed Origin URL should be rejected gracefully.
 	check := checkOrigin(nil)
 	assert.False(t, check(makeRequest("://bad url", "server:8080")))
+}
+
+func TestSetUserGame_RecordsHeartbeat(t *testing.T) {
+	hub := NewHub(nil)
+	now := time.Now()
+	hub.nowFunc = func() time.Time { return now }
+
+	hub.SetUserGame(1, 42)
+
+	assert.Equal(t, uint(42), hub.GetUserGame(1))
+
+	hub.mu.Lock()
+	entry := hub.userGames[1]
+	hub.mu.Unlock()
+	assert.Equal(t, now, entry.LastHeartbeat)
+}
+
+func TestSetUserGame_ClearWithZero(t *testing.T) {
+	hub := NewHub(nil)
+
+	hub.SetUserGame(1, 42)
+	assert.Equal(t, uint(42), hub.GetUserGame(1))
+
+	hub.SetUserGame(1, 0)
+	assert.Equal(t, uint(0), hub.GetUserGame(1))
+}
+
+func TestExpireStaleGames_RemovesExpiredEntries(t *testing.T) {
+	hub := NewHub(nil)
+	now := time.Now()
+	hub.nowFunc = func() time.Time { return now }
+
+	// Set a game with a heartbeat 2 minutes ago (stale, > 90s)
+	hub.mu.Lock()
+	hub.userGames[1] = userGameEntry{
+		GameID:        42,
+		LastHeartbeat: now.Add(-2 * time.Minute),
+	}
+	hub.mu.Unlock()
+
+	hub.expireStaleGames()
+
+	assert.Equal(t, uint(0), hub.GetUserGame(1), "stale game entry should be removed")
+}
+
+func TestExpireStaleGames_KeepsFreshEntries(t *testing.T) {
+	hub := NewHub(nil)
+	now := time.Now()
+	hub.nowFunc = func() time.Time { return now }
+
+	// Set a game with a heartbeat 30s ago (fresh, < 90s)
+	hub.mu.Lock()
+	hub.userGames[1] = userGameEntry{
+		GameID:        42,
+		LastHeartbeat: now.Add(-30 * time.Second),
+	}
+	hub.mu.Unlock()
+
+	hub.expireStaleGames()
+
+	assert.Equal(t, uint(42), hub.GetUserGame(1), "fresh game entry should not be removed")
+}
+
+func TestExpireStaleGames_MixedEntries(t *testing.T) {
+	hub := NewHub(nil)
+	now := time.Now()
+	hub.nowFunc = func() time.Time { return now }
+
+	hub.mu.Lock()
+	// User 1: stale heartbeat (2 minutes ago)
+	hub.userGames[1] = userGameEntry{
+		GameID:        10,
+		LastHeartbeat: now.Add(-2 * time.Minute),
+	}
+	// User 2: fresh heartbeat (10 seconds ago)
+	hub.userGames[2] = userGameEntry{
+		GameID:        20,
+		LastHeartbeat: now.Add(-10 * time.Second),
+	}
+	// User 3: exactly at the boundary (91 seconds ago, should expire)
+	hub.userGames[3] = userGameEntry{
+		GameID:        30,
+		LastHeartbeat: now.Add(-91 * time.Second),
+	}
+	hub.mu.Unlock()
+
+	hub.expireStaleGames()
+
+	assert.Equal(t, uint(0), hub.GetUserGame(1), "user 1 stale entry should be removed")
+	assert.Equal(t, uint(20), hub.GetUserGame(2), "user 2 fresh entry should remain")
+	assert.Equal(t, uint(0), hub.GetUserGame(3), "user 3 boundary entry should be removed")
+}
+
+func TestExpireStaleGames_HeartbeatRefreshPreventsExpiry(t *testing.T) {
+	hub := NewHub(nil)
+	now := time.Now()
+	hub.nowFunc = func() time.Time { return now }
+
+	// Set initial game 2 minutes ago
+	hub.mu.Lock()
+	hub.userGames[1] = userGameEntry{
+		GameID:        42,
+		LastHeartbeat: now.Add(-2 * time.Minute),
+	}
+	hub.mu.Unlock()
+
+	// Simulate a heartbeat refresh via SetUserGame
+	hub.SetUserGame(1, 42)
+
+	hub.expireStaleGames()
+
+	assert.Equal(t, uint(42), hub.GetUserGame(1), "refreshed heartbeat should not be expired")
 }

--- a/web/src/features/netplay/components/__tests__/netplay-consoles.test.ts
+++ b/web/src/features/netplay/components/__tests__/netplay-consoles.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { NETPLAY_SUPPORTED_CONSOLES } from "../netplay-consoles";
+import type { Game } from "@/types/api";
+
+function makeGame(overrides: Partial<Game> & { consoleName: string }): Game {
+  const { consoleName, ...rest } = overrides;
+  return {
+    id: "test-id",
+    title: "Test Game",
+    consoleId: "test",
+    consoleName,
+    fileName: "test.rom",
+    fileSize: 1024,
+    discCount: 0,
+    screenshotUrls: [],
+    scrapeAttempts: 0,
+    coverAspectRatio: 1,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2024-01-01T00:00:00Z",
+    updatedAt: "2024-01-01T00:00:00Z",
+    ...rest,
+  };
+}
+
+function filterNetplayGames(games: Game[]): Game[] {
+  return games.filter((g) => NETPLAY_SUPPORTED_CONSOLES.includes(g.consoleName));
+}
+
+describe("NETPLAY_SUPPORTED_CONSOLES", () => {
+  it("includes all expected console names matching database values", () => {
+    expect(NETPLAY_SUPPORTED_CONSOLES).toEqual([
+      "Nintendo Entertainment System",
+      "Super Nintendo",
+      "Game Boy",
+      "Game Boy Color",
+      "Game Boy Advance",
+      "Sega Genesis",
+    ]);
+  });
+
+  it("does not include abbreviations or short names", () => {
+    expect(NETPLAY_SUPPORTED_CONSOLES).not.toContain("NES");
+    expect(NETPLAY_SUPPORTED_CONSOLES).not.toContain("SNES");
+    expect(NETPLAY_SUPPORTED_CONSOLES).not.toContain("Genesis");
+    expect(NETPLAY_SUPPORTED_CONSOLES).not.toContain("Mega Drive");
+    expect(NETPLAY_SUPPORTED_CONSOLES).not.toContain("GBA");
+    expect(NETPLAY_SUPPORTED_CONSOLES).not.toContain("GB");
+    expect(NETPLAY_SUPPORTED_CONSOLES).not.toContain("GBC");
+  });
+});
+
+describe("filterNetplayGames", () => {
+  it("keeps games on supported consoles", () => {
+    const games = [
+      makeGame({ id: "1", title: "Zelda", consoleName: "Nintendo Entertainment System" }),
+      makeGame({ id: "2", title: "Mario World", consoleName: "Super Nintendo" }),
+      makeGame({ id: "3", title: "Pokemon Red", consoleName: "Game Boy" }),
+      makeGame({ id: "4", title: "Pokemon Crystal", consoleName: "Game Boy Color" }),
+      makeGame({ id: "5", title: "Metroid Fusion", consoleName: "Game Boy Advance" }),
+      makeGame({ id: "6", title: "Sonic", consoleName: "Sega Genesis" }),
+    ];
+
+    const result = filterNetplayGames(games);
+    expect(result).toHaveLength(6);
+    expect(result.map((g) => g.id)).toEqual(["1", "2", "3", "4", "5", "6"]);
+  });
+
+  it("filters out games on unsupported consoles", () => {
+    const games = [
+      makeGame({ id: "1", title: "Crash", consoleName: "PlayStation" }),
+      makeGame({ id: "2", title: "Mario 64", consoleName: "Nintendo 64" }),
+      makeGame({ id: "3", title: "Pokemon DS", consoleName: "Nintendo DS" }),
+    ];
+
+    const result = filterNetplayGames(games);
+    expect(result).toHaveLength(0);
+  });
+
+  it("filters a mixed list correctly", () => {
+    const games = [
+      makeGame({ id: "1", title: "Mario World", consoleName: "Super Nintendo" }),
+      makeGame({ id: "2", title: "Crash", consoleName: "PlayStation" }),
+      makeGame({ id: "3", title: "Sonic", consoleName: "Sega Genesis" }),
+      makeGame({ id: "4", title: "Mario 64", consoleName: "Nintendo 64" }),
+    ];
+
+    const result = filterNetplayGames(games);
+    expect(result).toHaveLength(2);
+    expect(result.map((g) => g.title)).toEqual(["Mario World", "Sonic"]);
+  });
+
+  it("returns empty array for empty input", () => {
+    expect(filterNetplayGames([])).toEqual([]);
+  });
+});

--- a/web/src/features/netplay/components/__tests__/netplay-create-modal.test.tsx
+++ b/web/src/features/netplay/components/__tests__/netplay-create-modal.test.tsx
@@ -20,13 +20,13 @@ vi.mock("@/hooks/use-games", () => ({
         {
           id: "g1",
           title: "Super Mario World",
-          consoleName: "SNES",
+          consoleName: "Super Nintendo",
           coverUrl: "https://example.com/cover.png",
         },
         {
           id: "g2",
           title: "Sonic the Hedgehog",
-          consoleName: "Genesis",
+          consoleName: "Sega Genesis",
           coverUrl: null,
         },
         {
@@ -169,7 +169,7 @@ describe("NetplayCreateModal", () => {
 
     expect(
       screen.getByText(
-        "Netplay supports NES, SNES, Game Boy, Game Boy Color, Game Boy Advance, Genesis, and Mega Drive.",
+        "Netplay supports NES, SNES, Game Boy, Game Boy Color, Game Boy Advance, and Genesis.",
       ),
     ).toBeInTheDocument();
   });

--- a/web/src/features/netplay/components/netplay-consoles.ts
+++ b/web/src/features/netplay/components/netplay-consoles.ts
@@ -1,9 +1,8 @@
 export const NETPLAY_SUPPORTED_CONSOLES = [
-  "NES",
-  "SNES",
+  "Nintendo Entertainment System",
+  "Super Nintendo",
   "Game Boy",
   "Game Boy Color",
   "Game Boy Advance",
-  "Genesis",
-  "Mega Drive",
+  "Sega Genesis",
 ];

--- a/web/src/features/netplay/components/netplay-create-modal.tsx
+++ b/web/src/features/netplay/components/netplay-create-modal.tsx
@@ -68,10 +68,10 @@ export function NetplayCreateModal({
             onSelect={setSelectedGame}
             onClear={() => setSelectedGame(null)}
             filterFn={filterNetplayGames}
-            emptyMessage="No supported netplay games found. Supported consoles: NES, SNES, GB, GBC, GBA, Genesis, Mega Drive."
+            emptyMessage="No supported netplay games found. Supported consoles: NES, SNES, GB, GBC, GBA, Genesis."
           />
           <p className="text-xs text-surface-500">
-            Netplay supports NES, SNES, Game Boy, Game Boy Color, Game Boy Advance, Genesis, and Mega Drive.
+            Netplay supports NES, SNES, Game Boy, Game Boy Color, Game Boy Advance, and Genesis.
           </p>
         </div>
 

--- a/web/src/lib/api-client.test.ts
+++ b/web/src/lib/api-client.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { api } from "./api-client";
+
+function mockLocalStorage() {
+  const store: Record<string, string> = {};
+  return {
+    getItem: vi.fn((key: string) => store[key] ?? null),
+    setItem: vi.fn((key: string, value: string) => {
+      store[key] = value;
+    }),
+    removeItem: vi.fn((key: string) => {
+      delete store[key];
+    }),
+    clear: vi.fn(() => {
+      for (const key of Object.keys(store)) delete store[key];
+    }),
+    get length() {
+      return Object.keys(store).length;
+    },
+    key: vi.fn(() => null),
+  } satisfies Storage;
+}
+
+describe("api token refresh deduplication", () => {
+  let storage: ReturnType<typeof mockLocalStorage>;
+  const originalFetch = globalThis.fetch;
+  const originalLocation = window.location;
+
+  beforeEach(() => {
+    storage = mockLocalStorage();
+    Object.defineProperty(globalThis, "localStorage", {
+      value: storage,
+      writable: true,
+    });
+    // Prevent navigation on session expiry
+    Object.defineProperty(window, "location", {
+      value: { href: "" },
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    Object.defineProperty(window, "location", {
+      value: originalLocation,
+      writable: true,
+    });
+    vi.restoreAllMocks();
+  });
+
+  it("deduplicates concurrent refresh calls — only one refresh request is made", async () => {
+    // Set up an expired access token so requests get 401
+    storage.setItem("accessToken", "expired-token");
+    storage.setItem("refreshToken", "valid-refresh-token");
+
+    let refreshCallCount = 0;
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url.includes("/auth/refresh")) {
+        refreshCallCount++;
+        // Simulate async delay so concurrent callers overlap
+        await new Promise((r) => setTimeout(r, 10));
+        return new Response(
+          JSON.stringify({
+            accessToken: "new-access-token",
+            refreshToken: "new-refresh-token",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      // First call with expired token returns 401, retries succeed
+      const authHeader =
+        input instanceof Request
+          ? input.headers.get("Authorization")
+          : undefined;
+      const initHeaders = (
+        (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+          .calls as unknown[][]
+      )
+        .find((c) => c[0] === input)?.[1] as RequestInit | undefined;
+      const headerRecord = initHeaders?.headers as
+        | Record<string, string>
+        | undefined;
+      const bearer = headerRecord?.["Authorization"] ?? authHeader;
+
+      if (bearer === "Bearer expired-token") {
+        return new Response("Unauthorized", { status: 401 });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    // Fire 3 concurrent requests — all will get 401 and attempt refresh
+    const results = await Promise.all([
+      api.get("/test/1"),
+      api.get("/test/2"),
+      api.get("/test/3"),
+    ]);
+
+    expect(results).toHaveLength(3);
+    // The key assertion: only ONE refresh call was made despite 3 concurrent 401s
+    expect(refreshCallCount).toBe(1);
+  });
+
+  it("clears the refresh promise after failure so subsequent attempts can retry", async () => {
+    storage.setItem("accessToken", "expired-token");
+    storage.setItem("refreshToken", "bad-refresh-token");
+
+    let refreshCallCount = 0;
+
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url.includes("/auth/refresh")) {
+        refreshCallCount++;
+        return new Response("Forbidden", { status: 403 });
+      }
+
+      const initHeaders = (
+        (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+          .calls as unknown[][]
+      )
+        .find((c) => c[0] === input)?.[1] as RequestInit | undefined;
+      const headerRecord = initHeaders?.headers as
+        | Record<string, string>
+        | undefined;
+      const bearer = headerRecord?.["Authorization"];
+
+      if (bearer === "Bearer expired-token") {
+        return new Response("Unauthorized", { status: 401 });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    // First request fails refresh
+    await expect(api.get("/test")).rejects.toThrow("Session expired");
+    expect(refreshCallCount).toBe(1);
+
+    // Set up a new token and try again — should attempt a NEW refresh (not reuse old failed promise)
+    storage.setItem("accessToken", "expired-token-2");
+    storage.setItem("refreshToken", "new-refresh-token");
+
+    // Reconfigure fetch so second refresh succeeds
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === "string" ? input : input.toString();
+
+      if (url.includes("/auth/refresh")) {
+        refreshCallCount++;
+        return new Response(
+          JSON.stringify({
+            accessToken: "fresh-token",
+            refreshToken: "fresh-refresh",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      const initHeaders = (
+        (globalThis.fetch as ReturnType<typeof vi.fn>).mock
+          .calls as unknown[][]
+      )
+        .find((c) => c[0] === input)?.[1] as RequestInit | undefined;
+      const headerRecord = initHeaders?.headers as
+        | Record<string, string>
+        | undefined;
+      const bearer = headerRecord?.["Authorization"];
+
+      if (bearer === "Bearer expired-token-2") {
+        return new Response("Unauthorized", { status: 401 });
+      }
+
+      return new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const result = await api.get("/test");
+    expect(result).toEqual({ ok: true });
+    // Second refresh happened (total = 2)
+    expect(refreshCallCount).toBe(2);
+  });
+});

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -28,7 +28,22 @@ function clearTokens() {
   localStorage.removeItem("refreshToken");
 }
 
+let refreshPromise: Promise<string> | null = null;
+
 async function refreshAccessToken(): Promise<string> {
+  if (refreshPromise) {
+    return refreshPromise;
+  }
+
+  refreshPromise = doRefresh();
+  try {
+    return await refreshPromise;
+  } finally {
+    refreshPromise = null;
+  }
+}
+
+async function doRefresh(): Promise<string> {
   const refreshToken = getRefreshToken();
   if (!refreshToken) {
     throw new ApiError(401, "No refresh token");


### PR DESCRIPTION
## Summary

Fixes four user-reported issues:

- **Activity feed "rated 0/5"**: Parse metadata JSON string into object on server side before sending API response, so frontend receives `{rating: 5}` instead of `"{\"rating\":5}"`
- **"Online Now" incomplete**: Add heartbeat-based staleness detection (90s timeout) in WebSocket Hub, plus a `DELETE /api/games/:id/play-time` endpoint so the player app can immediately clear game status when stopping
- **Netplay search empty**: Update `NETPLAY_SUPPORTED_CONSOLES` to use full database console names (`"Nintendo Entertainment System"` instead of `"NES"`) so the client-side filter actually matches
- **Sessions too short**: Deduplicate concurrent token refresh calls with a shared promise to prevent token family revocation race condition; increase access token to 1h and refresh token to 90d

## Test plan

- [x] `go test ./...` — all server packages pass
- [x] `npx vitest run` — 66 files, 622 tests pass
- [ ] Verify activity feed shows correct rating in browser
- [ ] Verify "Online Now" updates correctly when starting/stopping a game
- [ ] Verify netplay game search returns results for supported consoles
- [ ] Verify web sessions persist for longer than 15 minutes