### PR TITLE
feat: auto-download missing BIOS files on server boot

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/spela/server/internal/api"
+	"github.com/spela/server/internal/bios"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/scanner"
 	"github.com/spela/server/internal/scraper"
@@ -136,6 +137,9 @@ func main() {
 
 	// Start periodic expired refresh token cleanup (every hour)
 	api.StartTokenCleanup(database, 1*time.Hour)
+
+	// Auto-download missing BIOS files at startup (non-blocking)
+	bios.StartAutoDownload(store.BiosDir, database)
 
 	// Derive WebSocket origins: prefer explicit WS origins, fall back to CORS origins.
 	// This ensures WebSocket origin checking is not more permissive than CORS by default.

--- a/server/internal/api/admin_handler.go
+++ b/server/internal/api/admin_handler.go
@@ -228,6 +228,7 @@ var allowedSettingKeys = map[string]bool{
 	"registration_enabled": true,
 	"igdb_client_id":       true,
 	"igdb_client_secret":   true,
+	"bios_auto_download":   true,
 }
 
 // UpdateSettings updates server settings (admin only).

--- a/server/internal/api/bios_handler.go
+++ b/server/internal/api/bios_handler.go
@@ -4,15 +4,18 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"io"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/bios"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/storage"
+	ws "github.com/spela/server/internal/websocket"
 	"gorm.io/gorm"
 )
 
@@ -22,6 +25,10 @@ const maxBiosUploadSize = 16 << 20 // 16 MB
 type BiosHandler struct {
 	Storage *storage.Storage
 	DB      *gorm.DB
+	Hub     *ws.Hub
+
+	downloadMu  sync.Mutex
+	downloading bool
 }
 
 // BiosFileResponse represents an individual BIOS file in the response.
@@ -446,6 +453,65 @@ func (h *BiosHandler) DeleteBiosFile(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "file deleted"})
+}
+
+// TriggerDownload starts a background download of missing BIOS files (admin only).
+// Only one download can run at a time; concurrent requests are rejected.
+func (h *BiosHandler) TriggerDownload(c *gin.Context) {
+	h.downloadMu.Lock()
+	if h.downloading {
+		h.downloadMu.Unlock()
+		c.JSON(http.StatusConflict, gin.H{"error": "a BIOS download is already in progress"})
+		return
+	}
+	h.downloading = true
+	h.downloadMu.Unlock()
+
+	// Count missing files for the response
+	entries := bios.Downloadable()
+	missing := 0
+	for _, e := range entries {
+		path := filepath.Join(h.Storage.BiosDir, e.FileName)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			missing++
+		}
+	}
+
+	if h.Hub != nil {
+		h.Hub.Broadcast(ws.Event{Type: "bios_download_started", Payload: gin.H{"total": missing}})
+	}
+
+	go func() {
+		defer func() {
+			h.downloadMu.Lock()
+			h.downloading = false
+			h.downloadMu.Unlock()
+		}()
+
+		result := bios.DownloadMissing(h.Storage.BiosDir, bios.DefaultRepoBaseURL, func(p bios.DownloadProgress) {
+			if h.Hub != nil {
+				h.Hub.Broadcast(ws.Event{Type: "bios_download_progress", Payload: p})
+			}
+		})
+
+		slog.Info("BIOS manual download complete",
+			"downloaded", result.Downloaded,
+			"skipped", result.Skipped,
+			"failed", result.Failed,
+		)
+
+		if h.Hub != nil {
+			h.Hub.Broadcast(ws.Event{Type: "bios_download_complete", Payload: gin.H{
+				"downloaded": result.Downloaded,
+				"skipped":    result.Skipped,
+				"failed":     result.Failed,
+			}})
+		}
+	}()
+
+	adminID, _ := c.Get("userId")
+	slog.Info("audit: admin triggered BIOS download", "admin_id", adminID, "missing", missing)
+	c.JSON(http.StatusAccepted, gin.H{"message": "BIOS download started in background", "missing": missing})
 }
 
 // GetConsoleStatus returns the BIOS status string for a given console abbreviation.

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -158,7 +158,7 @@ func NewRouter(cfg Config) *gin.Engine {
 	relayHandler := &RelayHandler{DB: cfg.DB, Storage: cfg.Storage, Hub: cfg.Hub}
 	netplayHandler := &NetplayHandler{DB: cfg.DB, Hub: cfg.Hub, NetplayHub: cfg.NetplayHub}
 	raHandler := &RAHandler{DB: cfg.DB, RAClient: raClient, GameDir: cfg.GameDirs[0], EncryptionKey: encryptionKey}
-	biosHandler := &BiosHandler{Storage: cfg.Storage, DB: cfg.DB}
+	biosHandler := &BiosHandler{Storage: cfg.Storage, DB: cfg.DB, Hub: cfg.Hub}
 	gameKeyMappingHandler := &GameKeyMappingHandler{DB: cfg.DB}
 	saveDataHandler := &SaveDataHandler{DB: cfg.DB, Storage: cfg.Storage}
 	saveHandler := &SaveHandler{DB: cfg.DB, Storage: cfg.Storage}
@@ -430,6 +430,7 @@ func NewRouter(cfg Config) *gin.Engine {
 			admin.DELETE("/users/:id/rate-limit", adminHandler.ResetUserRateLimit)
 			admin.GET("/users/:id/devices", deviceHandler.AdminGetUserDevices)
 			admin.POST("/bios", biosHandler.UploadBiosFile)
+			admin.POST("/bios/download", biosHandler.TriggerDownload)
 			admin.DELETE("/bios/:filename", biosHandler.DeleteBiosFile)
 			admin.PUT("/games/:id/verification-tag", gameHandler.UpdateVerificationTag)
 

--- a/server/internal/bios/downloader.go
+++ b/server/internal/bios/downloader.go
@@ -1,0 +1,198 @@
+package bios
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// DefaultRepoBaseURL is the base URL for the retroarch_system BIOS repository.
+const DefaultRepoBaseURL = "https://raw.githubusercontent.com/Abdess/retroarch_system/master"
+
+// DownloadProgress reports the status of a single file download.
+type DownloadProgress struct {
+	FileName  string `json:"fileName"`
+	ConsoleID string `json:"consoleId"`
+	Status    string `json:"status"` // "downloaded", "skipped", "failed"
+	Error     string `json:"error,omitempty"`
+	Current   int    `json:"current"`
+	Total     int    `json:"total"`
+}
+
+// DownloadResult summarises a completed DownloadMissing run.
+type DownloadResult struct {
+	Downloaded int
+	Skipped    int
+	Failed     int
+	Errors     []string
+}
+
+// DownloadMissing downloads all BIOS files that are missing from biosDir.
+// Files already present on disk are skipped. Downloaded files are validated
+// against their registry MD5 (when available). The optional onProgress
+// callback is invoked after each file is processed.
+func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress)) DownloadResult {
+	entries := Downloadable()
+	result := DownloadResult{}
+	total := len(entries)
+
+	client := &http.Client{Timeout: 30 * time.Second}
+
+	for i, entry := range entries {
+		progress := DownloadProgress{
+			FileName:  entry.FileName,
+			ConsoleID: entry.ConsoleID,
+			Current:   i + 1,
+			Total:     total,
+		}
+
+		// Skip if already present
+		destPath := filepath.Join(biosDir, entry.FileName)
+		if _, err := os.Stat(destPath); err == nil {
+			progress.Status = "skipped"
+			result.Skipped++
+			if onProgress != nil {
+				onProgress(progress)
+			}
+			continue
+		}
+
+		// Build URL: {baseURL}/{RepoFolder(consoleID)}/{fileName}
+		folder := RepoFolder(entry.ConsoleID)
+		url := fmt.Sprintf("%s/%s/%s", baseURL, folder, entry.FileName)
+
+		resp, err := client.Get(url)
+		if err != nil {
+			progress.Status = "failed"
+			progress.Error = fmt.Sprintf("HTTP request failed: %v", err)
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			if onProgress != nil {
+				onProgress(progress)
+			}
+			continue
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			resp.Body.Close()
+			progress.Status = "failed"
+			progress.Error = fmt.Sprintf("HTTP %d", resp.StatusCode)
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			if onProgress != nil {
+				onProgress(progress)
+			}
+			continue
+		}
+
+		// Write to .tmp file first
+		tmpPath := destPath + ".tmp"
+		tmpFile, err := os.OpenFile(tmpPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0644)
+		if err != nil {
+			resp.Body.Close()
+			progress.Status = "failed"
+			progress.Error = fmt.Sprintf("creating temp file: %v", err)
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			if onProgress != nil {
+				onProgress(progress)
+			}
+			continue
+		}
+
+		hasher := md5.New()
+		writer := io.MultiWriter(tmpFile, hasher)
+		_, copyErr := io.Copy(writer, resp.Body)
+		resp.Body.Close()
+		tmpFile.Close()
+
+		if copyErr != nil {
+			os.Remove(tmpPath)
+			progress.Status = "failed"
+			progress.Error = fmt.Sprintf("downloading: %v", copyErr)
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			if onProgress != nil {
+				onProgress(progress)
+			}
+			continue
+		}
+
+		// Validate MD5 if the registry has a checksum
+		actualMD5 := hex.EncodeToString(hasher.Sum(nil))
+		if entry.MD5 != "" && actualMD5 != entry.MD5 {
+			os.Remove(tmpPath)
+			progress.Status = "failed"
+			progress.Error = fmt.Sprintf("MD5 mismatch: expected %s, got %s", entry.MD5, actualMD5)
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			if onProgress != nil {
+				onProgress(progress)
+			}
+			continue
+		}
+
+		// Rename to final path
+		if err := os.Rename(tmpPath, destPath); err != nil {
+			os.Remove(tmpPath)
+			progress.Status = "failed"
+			progress.Error = fmt.Sprintf("renaming temp file: %v", err)
+			result.Failed++
+			result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+			if onProgress != nil {
+				onProgress(progress)
+			}
+			continue
+		}
+
+		progress.Status = "downloaded"
+		result.Downloaded++
+		if onProgress != nil {
+			onProgress(progress)
+		}
+	}
+
+	return result
+}
+
+// StartAutoDownload checks the bios_auto_download setting and, if enabled,
+// spawns a goroutine that downloads missing BIOS files at startup.
+func StartAutoDownload(biosDir string, database *gorm.DB) {
+	// Read the setting; default to "true" if not set
+	var setting db.ServerSetting
+	enabled := true
+	if err := database.Where("key = ?", "bios_auto_download").First(&setting).Error; err == nil {
+		if setting.Value == "false" {
+			enabled = false
+		}
+	}
+
+	if !enabled {
+		slog.Info("BIOS auto-download disabled by server setting")
+		return
+	}
+
+	go func() {
+		slog.Info("BIOS auto-download starting")
+		result := DownloadMissing(biosDir, DefaultRepoBaseURL, nil)
+		slog.Info("BIOS auto-download complete",
+			"downloaded", result.Downloaded,
+			"skipped", result.Skipped,
+			"failed", result.Failed,
+		)
+		if len(result.Errors) > 0 {
+			for _, e := range result.Errors {
+				slog.Warn("BIOS download error", "detail", e)
+			}
+		}
+	}()
+}

--- a/server/internal/bios/downloader_test.go
+++ b/server/internal/bios/downloader_test.go
@@ -1,0 +1,181 @@
+package bios
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// md5hex returns the hex-encoded MD5 of the given data.
+func md5hex(data []byte) string {
+	h := md5.Sum(data)
+	return hex.EncodeToString(h[:])
+}
+
+func TestDownloadMissing_SuccessfulDownload(t *testing.T) {
+	biosDir := t.TempDir()
+	fileContent := []byte("fake bios content")
+	contentMD5 := md5hex(fileContent)
+
+	// Serve files that match registry entries for PSX
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(fileContent)
+	}))
+	defer server.Close()
+
+	// Temporarily override registry to a single entry with known MD5
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{ConsoleID: "psx", FileName: "test_bios.bin", Description: "Test BIOS", MD5: contentMD5, Required: true},
+	}
+	defer func() { registry = origRegistry }()
+
+	var progressCalls []DownloadProgress
+	result := DownloadMissing(biosDir, server.URL, func(p DownloadProgress) {
+		progressCalls = append(progressCalls, p)
+	})
+
+	assert.Equal(t, 1, result.Downloaded)
+	assert.Equal(t, 0, result.Skipped)
+	assert.Equal(t, 0, result.Failed)
+	assert.Empty(t, result.Errors)
+
+	// File should exist on disk
+	data, err := os.ReadFile(filepath.Join(biosDir, "test_bios.bin"))
+	require.NoError(t, err)
+	assert.Equal(t, fileContent, data)
+
+	// Progress callback should have been called
+	require.Len(t, progressCalls, 1)
+	assert.Equal(t, "downloaded", progressCalls[0].Status)
+	assert.Equal(t, "test_bios.bin", progressCalls[0].FileName)
+	assert.Equal(t, 1, progressCalls[0].Current)
+	assert.Equal(t, 1, progressCalls[0].Total)
+}
+
+func TestDownloadMissing_SkipsExistingFiles(t *testing.T) {
+	biosDir := t.TempDir()
+
+	// Pre-create the file
+	err := os.WriteFile(filepath.Join(biosDir, "existing.bin"), []byte("already here"), 0644)
+	require.NoError(t, err)
+
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{ConsoleID: "psx", FileName: "existing.bin", Description: "Existing BIOS", MD5: "abc", Required: true},
+	}
+	defer func() { registry = origRegistry }()
+
+	result := DownloadMissing(biosDir, "http://unused", nil)
+
+	assert.Equal(t, 0, result.Downloaded)
+	assert.Equal(t, 1, result.Skipped)
+	assert.Equal(t, 0, result.Failed)
+}
+
+func TestDownloadMissing_MD5Mismatch(t *testing.T) {
+	biosDir := t.TempDir()
+	fileContent := []byte("wrong content")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(fileContent)
+	}))
+	defer server.Close()
+
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{ConsoleID: "psx", FileName: "bad_md5.bin", Description: "Bad MD5", MD5: "0000000000000000000000000000dead", Required: true},
+	}
+	defer func() { registry = origRegistry }()
+
+	result := DownloadMissing(biosDir, server.URL, nil)
+
+	assert.Equal(t, 0, result.Downloaded)
+	assert.Equal(t, 0, result.Skipped)
+	assert.Equal(t, 1, result.Failed)
+	assert.Len(t, result.Errors, 1)
+	assert.Contains(t, result.Errors[0], "MD5 mismatch")
+
+	// Temp file should have been cleaned up, no file on disk
+	_, err := os.Stat(filepath.Join(biosDir, "bad_md5.bin"))
+	assert.True(t, os.IsNotExist(err))
+	_, err = os.Stat(filepath.Join(biosDir, "bad_md5.bin.tmp"))
+	assert.True(t, os.IsNotExist(err))
+}
+
+func TestDownloadMissing_ServerError(t *testing.T) {
+	biosDir := t.TempDir()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{ConsoleID: "gba", FileName: "missing_remote.bin", Description: "Not Found", MD5: "abc", Required: true},
+	}
+	defer func() { registry = origRegistry }()
+
+	result := DownloadMissing(biosDir, server.URL, nil)
+
+	assert.Equal(t, 0, result.Downloaded)
+	assert.Equal(t, 1, result.Failed)
+	assert.Contains(t, result.Errors[0], "HTTP 404")
+}
+
+func TestDownloadMissing_EmptyMD5Accepted(t *testing.T) {
+	biosDir := t.TempDir()
+	fileContent := []byte("sega cd bios")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(fileContent)
+	}))
+	defer server.Close()
+
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{ConsoleID: "scd", FileName: "bios_CD_U.bin", Description: "Sega CD BIOS", MD5: "", Required: true},
+	}
+	defer func() { registry = origRegistry }()
+
+	result := DownloadMissing(biosDir, server.URL, nil)
+
+	assert.Equal(t, 1, result.Downloaded)
+	assert.Equal(t, 0, result.Failed)
+
+	// File should exist
+	data, err := os.ReadFile(filepath.Join(biosDir, "bios_CD_U.bin"))
+	require.NoError(t, err)
+	assert.Equal(t, fileContent, data)
+}
+
+func TestDownloadMissing_NilProgressCallback(t *testing.T) {
+	biosDir := t.TempDir()
+
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{ConsoleID: "psx", FileName: "skip_me.bin", Description: "Skip", MD5: "", Required: false},
+	}
+	defer func() { registry = origRegistry }()
+
+	// Pre-create so it gets skipped
+	os.WriteFile(filepath.Join(biosDir, "skip_me.bin"), []byte("x"), 0644)
+
+	// Should not panic with nil callback
+	result := DownloadMissing(biosDir, "http://unused", nil)
+	assert.Equal(t, 1, result.Skipped)
+}

--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -51,6 +51,37 @@ var registry = []Entry{
 	{ConsoleID: "pce", FileName: "syscard3.pce", Description: "PC Engine CD System Card 3.0", MD5: "38179df8f4ac870017db21ebcbf53114", Required: true},
 }
 
+// repoFolders maps console IDs to their folder name in the
+// Abdess/retroarch_system GitHub repository.
+var repoFolders = map[string]string{
+	"psx": "Sony - PlayStation",
+	"sat": "Sega - Saturn",
+	"scd": "Sega - Mega CD - Sega CD",
+	"dc":  "Sega - Dreamcast",
+	"gba": "Nintendo - Game Boy Advance",
+	"nds": "Nintendo - Nintendo DS",
+	"pce": "NEC - PC Engine - TurboGrafx 16 - SuperGrafx",
+	// ps2 is not available in the repository
+}
+
+// RepoFolder returns the repository folder name for the given console ID,
+// or an empty string if the console has no downloadable BIOS files.
+func RepoFolder(consoleID string) string {
+	return repoFolders[consoleID]
+}
+
+// Downloadable returns all registry entries whose console has a known
+// repository folder, i.e. entries that can be auto-downloaded.
+func Downloadable() []Entry {
+	var out []Entry
+	for _, e := range registry {
+		if repoFolders[e.ConsoleID] != "" {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
 // All returns every entry in the registry.
 func All() []Entry {
 	out := make([]Entry, len(registry))

--- a/server/internal/bios/registry_test.go
+++ b/server/internal/bios/registry_test.go
@@ -81,6 +81,46 @@ func TestConsoleIDs(t *testing.T) {
 	}
 }
 
+func TestRepoFolder(t *testing.T) {
+	tests := []struct {
+		consoleID string
+		want      string
+	}{
+		{"psx", "Sony - PlayStation"},
+		{"sat", "Sega - Saturn"},
+		{"scd", "Sega - Mega CD - Sega CD"},
+		{"dc", "Sega - Dreamcast"},
+		{"gba", "Nintendo - Game Boy Advance"},
+		{"nds", "Nintendo - Nintendo DS"},
+		{"pce", "NEC - PC Engine - TurboGrafx 16 - SuperGrafx"},
+		{"ps2", ""},
+		{"unknown", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.consoleID, func(t *testing.T) {
+			assert.Equal(t, tt.want, RepoFolder(tt.consoleID))
+		})
+	}
+}
+
+func TestDownloadable(t *testing.T) {
+	entries := Downloadable()
+	assert.NotEmpty(t, entries)
+
+	// Every downloadable entry must have a repo folder mapping
+	for _, e := range entries {
+		assert.NotEmpty(t, RepoFolder(e.ConsoleID), "entry %s should have a repo folder", e.FileName)
+	}
+
+	// PS2 entries should NOT be in the downloadable list
+	for _, e := range entries {
+		assert.NotEqual(t, "ps2", e.ConsoleID, "ps2 entries should not be downloadable")
+	}
+
+	// Should be fewer than All() since PS2 is excluded
+	assert.Less(t, len(entries), len(All()))
+}
+
 func TestRegistryEntries_HaveRequiredFields(t *testing.T) {
 	for _, e := range All() {
 		assert.NotEmpty(t, e.ConsoleID, "ConsoleID must not be empty")

--- a/web/src/hooks/use-bios.ts
+++ b/web/src/hooks/use-bios.ts
@@ -46,6 +46,18 @@ export function useDeleteBiosFile() {
   });
 }
 
+export function useDownloadBios() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () =>
+      api.post<{ message: string; missing: number }>("/admin/bios/download"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["bios"] });
+    },
+  });
+}
+
 export function getBiosFileUrl(filename: string): string {
   return `/api/bios/${encodeURIComponent(filename)}`;
 }

--- a/web/src/pages/admin/bios-page.tsx
+++ b/web/src/pages/admin/bios-page.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from "react";
-import { Upload, Cpu } from "lucide-react";
+import { Upload, Cpu, Download } from "lucide-react";
 import {
   Button,
   Skeleton,
@@ -11,6 +11,7 @@ import {
   useBiosStatus,
   useUploadBiosFile,
   useDeleteBiosFile,
+  useDownloadBios,
 } from "@/hooks/use-bios";
 import { BiosConsoleCard } from "@/features/bios/components/bios-console-card";
 import {
@@ -35,6 +36,7 @@ export function AdminBiosPage() {
   const { data: biosData, isLoading } = useBiosStatus();
   const uploadBios = useUploadBiosFile();
   const deleteBios = useDeleteBiosFile();
+  const downloadBios = useDownloadBios();
   const { toast } = useToast();
 
   const [uploadResults, setUploadResults] = useState<UploadResult[]>([]);
@@ -131,6 +133,29 @@ export function AdminBiosPage() {
         <h1 className="text-3xl font-bold text-surface-100">BIOS Files</h1>
         <p className="mt-1 text-surface-400">
           Manage firmware and BIOS files required by emulation cores.
+        </p>
+      </div>
+
+      {/* Download missing BIOS */}
+      <div className="flex items-center gap-4">
+        <Button
+          onClick={() =>
+            downloadBios.mutate(undefined, {
+              onSuccess: () => toast("success", "BIOS download complete"),
+              onError: (err) =>
+                toast(
+                  "error",
+                  err instanceof Error ? err.message : "Download failed",
+                ),
+            })
+          }
+          loading={downloadBios.isPending}
+          icon={<Download className="h-4 w-4" />}
+        >
+          Download Missing BIOS
+        </Button>
+        <p className="text-xs text-surface-500">
+          PS2 BIOS must be uploaded manually
         </p>
       </div>
 

--- a/web/src/pages/admin/settings-page.tsx
+++ b/web/src/pages/admin/settings-page.tsx
@@ -28,6 +28,7 @@ export function AdminSettingsPage() {
   const [newDir, setNewDir] = useState("");
   const [allowRegistration, setAllowRegistration] = useState(true);
   const [scrapeOnScan, setScrapeOnScan] = useState(true);
+  const [biosAutoDownload, setBiosAutoDownload] = useState(true);
   const [igdbClientId, setIgdbClientId] = useState("");
   const [igdbClientSecret, setIgdbClientSecret] = useState("");
 
@@ -37,6 +38,7 @@ export function AdminSettingsPage() {
       setGameDirectories(dirs ? dirs.split(",") : []);
       setAllowRegistration(settings["registration_enabled"] !== "false");
       setScrapeOnScan(settings["scrapeOnScan"] !== "false");
+      setBiosAutoDownload(settings["bios_auto_download"] !== "false");
       setIgdbClientId(settings["igdb_client_id"] ?? "");
       setIgdbClientSecret(settings["igdb_client_secret"] ?? "");
     }
@@ -59,6 +61,7 @@ export function AdminSettingsPage() {
       gameDirectories: gameDirectories.join(","),
       registration_enabled: String(allowRegistration),
       scrapeOnScan: String(scrapeOnScan),
+      bios_auto_download: String(biosAutoDownload),
     };
     // Only send IGDB credentials when they're managed via the UI, not env vars
     if (!igdbEnvConfigured) {
@@ -167,6 +170,21 @@ export function AdminSettingsPage() {
               </p>
             </div>
             <Switch checked={scrapeOnScan} onChange={setScrapeOnScan} />
+          </div>
+
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-surface-200">
+                Auto-download BIOS on startup
+              </p>
+              <p className="text-xs text-surface-500">
+                Automatically download missing BIOS files when the server starts
+              </p>
+            </div>
+            <Switch
+              checked={biosAutoDownload}
+              onChange={setBiosAutoDownload}
+            />
           </div>
         </CardContent>
       </Card>


### PR DESCRIPTION
## Summary
- Auto-downloads missing BIOS/firmware files from a public GitHub repo (`Abdess/retroarch_system`) on server startup — covers PSX, Saturn, Sega CD, Dreamcast, GBA, NDS, and PC Engine (15 of 19 files)
- Adds `POST /api/admin/bios/download` endpoint for manual re-download with WebSocket progress events
- Adds "Download Missing BIOS" button on the admin BIOS page and "Auto-download BIOS on startup" toggle on the admin settings page
- PS2 BIOS (4 files) is not available in the repo and must still be uploaded manually

## Changes

### Server (Go)
| File | Change |
|------|--------|
| `server/internal/bios/registry.go` | `repoFolders` map, `RepoFolder()`, `Downloadable()` |
| `server/internal/bios/downloader.go` | **New** — `DownloadMissing()` with MD5 validation + `.tmp` atomic writes, `StartAutoDownload()` |
| `server/internal/bios/downloader_test.go` | **New** — 6 httptest-based tests (success, skip existing, MD5 mismatch, server error, empty MD5, nil callback) |
| `server/internal/bios/registry_test.go` | Added `TestRepoFolder` (9 cases) and `TestDownloadable` |
| `server/internal/api/bios_handler.go` | `TriggerDownload()` with mutex guard + WS events (`bios_download_started/progress/complete`) |
| `server/internal/api/admin_handler.go` | `bios_auto_download` in allowed settings |
| `server/internal/api/router.go` | `POST /bios/download` route, Hub wired to BiosHandler |
| `server/cmd/server/main.go` | `bios.StartAutoDownload()` call after storage init |

### Web (React/TypeScript)
| File | Change |
|------|--------|
| `web/src/hooks/use-bios.ts` | `useDownloadBios()` mutation hook |
| `web/src/pages/admin/bios-page.tsx` | "Download Missing BIOS" button with loading/toast |
| `web/src/pages/admin/settings-page.tsx` | "Auto-download BIOS on startup" toggle |

## Test plan
- [x] `go test ./...` — all packages pass (17 bios tests, full API suite)
- [x] `npx vitest run` — 66 test files, 627 tests pass
- [ ] Fresh boot → logs show "BIOS auto-download complete" with counts
- [ ] `/admin/bios` → console cards show "Ready" for downloaded consoles, PS2 shows "Missing"
- [ ] Disable setting → restart → no download logged
- [ ] Click "Download Missing BIOS" → cards update after completion