### PR TITLE
fix: gamepad navigation UI improvements

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
@@ -114,7 +114,7 @@ class NavigationViewModel(
                     current.copy(
                         currentScreen = sections[prevIndex],
                         backStack = emptyList(),
-                        isGoingBack = false,
+                        isGoingBack = true,
                     )
                 }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -121,7 +121,6 @@ import com.spela.player.presentation.viewmodel.SocialViewModel
 import com.spela.player.presentation.viewmodel.StatsViewModel
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.ui.components.SpSectionIndicator
-import kotlinx.coroutines.delay
 
 @Composable
 fun SpelaApp(
@@ -162,26 +161,8 @@ fun SpelaApp(
             ?: remember { mutableStateOf(emptyList<GamepadPortManager.PortAssignment>()) }
         val hasGamepad = gamepadAssignments.isNotEmpty()
 
-        // Auto-hide timer for section indicator
-        var sectionIndicatorVisible by remember { mutableStateOf(false) }
-
-        LaunchedEffect(hasGamepad) {
-            if (hasGamepad) {
-                sectionIndicatorVisible = true
-                delay(3000)
-                sectionIndicatorVisible = false
-            } else {
-                sectionIndicatorVisible = false
-            }
-        }
-
-        LaunchedEffect(navState.currentScreen, hasGamepad) {
-            if (hasGamepad) {
-                sectionIndicatorVisible = true
-                delay(3000)
-                sectionIndicatorVisible = false
-            }
-        }
+        // Section indicator is always visible when a gamepad is connected
+        val sectionIndicatorVisible = hasGamepad
 
         // Hidden indicator for E2E tests: exposes whether the libretro core is running.
         // Tests wait for "Core idle" instead of Thread.sleep after exiting games.

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
@@ -14,12 +14,14 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 
@@ -44,18 +46,33 @@ fun SpSectionIndicator(
                     shape = RoundedCornerShape(24.dp),
                 )
                 .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small),
-            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            BottomNavTab.entries.forEach { tab ->
-                val isActive = tab == activeTab
-                Icon(
-                    imageVector = tab.icon,
-                    contentDescription = if (isActive) "Section: ${tab.label}, active" else "Section: ${tab.label}",
-                    tint = if (isActive) SpColor.Primary else SpColor.OnBackgroundTertiary,
-                    modifier = Modifier.size(16.dp),
-                )
+            Text(
+                text = "L1",
+                color = SpColor.TextSecondary,
+                fontSize = 12.sp,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                BottomNavTab.entries.forEach { tab ->
+                    val isActive = tab == activeTab
+                    Icon(
+                        imageVector = tab.icon,
+                        contentDescription = if (isActive) "Section: ${tab.label}, active" else "Section: ${tab.label}",
+                        tint = if (isActive) SpColor.Primary else SpColor.OnBackgroundTertiary,
+                        modifier = Modifier.size(24.dp),
+                    )
+                }
             }
+            Text(
+                text = "R1",
+                color = SpColor.TextSecondary,
+                fontSize = 12.sp,
+            )
         }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
@@ -51,7 +51,7 @@ fun SpSectionIndicator(
         ) {
             Text(
                 text = "L1",
-                color = SpColor.TextSecondary,
+                color = SpColor.OnBackgroundSecondary,
                 fontSize = 12.sp,
             )
             Row(
@@ -70,7 +70,7 @@ fun SpSectionIndicator(
             }
             Text(
                 text = "R1",
-                color = SpColor.TextSecondary,
+                color = SpColor.OnBackgroundSecondary,
                 fontSize = 12.sp,
             )
         }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -272,6 +272,26 @@ class NavigationViewModelTest {
     }
 
     @Test
+    fun nextSectionSetsIsGoingBackFalse() = runTest(testDispatcher) {
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        vm.onIntent(NavigationIntent.NextSection)
+        assertFalse(vm.state.value.isGoingBack)
+    }
+
+    @Test
+    fun previousSectionSetsIsGoingBackTrue() = runTest(testDispatcher) {
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        vm.onIntent(NavigationIntent.PreviousSection)
+        assertTrue(vm.state.value.isGoingBack)
+    }
+
+    @Test
     fun nextSectionFromSubScreenMapsToCorrectTab() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()


### PR DESCRIPTION
## Summary
- Fix L1 (PreviousSection) slide animation going the wrong direction — now correctly slides in from the left
- Remove 3-second auto-hide timer on the section indicator — stays visible whenever a gamepad is connected
- Increase section indicator icon size from 16dp to 24dp for better visibility
- Add L1/R1 button labels flanking the icon row so users know which buttons cycle sections

## Test plan
- [x] Desktop tests pass (457 unit + 393 E2E, 0 new failures)
- [x] New unit tests verify `NextSection` sets `isGoingBack = false` and `PreviousSection` sets `isGoingBack = true`
- [ ] Manual: connect gamepad → indicator stays visible, shows "L1 [icons] R1", icons larger
- [ ] Manual: press L1 → screen slides in from left; press R1 → screen slides in from right