### PR TITLE
feat: input mode detection, focus recovery, and right stick scrolling

### DIFF
--- a/player/android/src/androidTest/java/com/spela/player/android/EstablishSessionTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/EstablishSessionTest.kt
@@ -21,10 +21,17 @@ class EstablishSessionTest {
         // Use ensureLoggedIn which handles any starting state
         composeTestRule.ensureLoggedIn()
 
-        // Verify we're on the Home screen
+        // Verify we're on the Home screen — check multiple indicators since the
+        // Home screen may show "Your library is empty" for users with no play history
         composeTestRule.waitUntil(timeoutMillis = 8000) {
             composeTestRule.onAllNodesWithText("Spela")
-                .fetchSemanticsNodes().isNotEmpty()
+                .fetchSemanticsNodes().isNotEmpty() ||
+                composeTestRule.onAllNodesWithText("Your library is empty", substring = true)
+                    .fetchSemanticsNodes().isNotEmpty() ||
+                composeTestRule.onAllNodesWithText("Top Rated", substring = true)
+                    .fetchSemanticsNodes().isNotEmpty() ||
+                composeTestRule.onAllNodesWithText("Continue Playing", substring = true)
+                    .fetchSemanticsNodes().isNotEmpty()
         }
     }
 }

--- a/player/android/src/androidTest/java/com/spela/player/android/NavigationTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/NavigationTest.kt
@@ -29,31 +29,35 @@ class NavigationTest {
         // Use compound matcher to avoid ambiguity with game cards that mention the console name
         rule.scrollToAndTapMatchingBoth("Nintendo Entertainment System", "games")
 
-        // Verify we're on console game list
-        rule.waitForText("Castlevania", timeout = 8_000)
+        // Verify we're on the console game list (title bar shows console name as text)
+        rule.waitForText("Nintendo Entertainment System", timeout = 8_000)
 
         // Navigate forward to Screen 3: Game detail
-        rule.scrollToAndTapText("Castlevania")
+        // Use a game from the "Top Rated" carousel (visible without scrolling)
+        // to avoid flaky scroll+click issues with LazyColumn off-screen nodes
+        rule.tapOn("Super Mario Bros. 3")
 
-        // Verify game detail screen
-        rule.waitUntil(timeoutMillis = 5_000) {
-            rule.onAllNodesWithText("Download", substring = true)
+        // Verify game detail screen — wait for action buttons unique to game detail
+        rule.waitUntil(timeoutMillis = 15_000) {
+            rule.onAllNodesWithContentDescription("Download Super Mario Bros. 3", substring = true)
                 .fetchSemanticsNodes().isNotEmpty() ||
-                rule.onAllNodesWithText("Play", substring = true)
+                rule.onAllNodesWithContentDescription("Play Super Mario Bros. 3", substring = true)
+                    .fetchSemanticsNodes().isNotEmpty() ||
+                rule.onAllNodesWithContentDescription("Resume Super Mario Bros. 3", substring = true)
                     .fetchSemanticsNodes().isNotEmpty()
         }
 
         // BACK #1: Game Detail -> Console game list
         rule.pressBack()
 
-        // Verify we're back on NES console game list
-        rule.waitForText("Castlevania")
+        // Verify we're back on NES console game list (title bar shows console name)
+        rule.waitForText("Nintendo Entertainment System", timeout = 8_000)
 
         // BACK #2: Console game list -> Consoles screen
         rule.pressBack()
 
         // Verify we're back on Consoles (console cards visible via contentDescription)
-        rule.waitForContentDescription("Nintendo Entertainment System", timeout = 5_000)
+        rule.waitForContentDescription("Nintendo Entertainment System", timeout = 8_000)
     }
 
     @Test
@@ -64,14 +68,17 @@ class NavigationTest {
         rule.tapOn("Consoles")
         rule.waitForContentDescription("Nintendo Entertainment System", timeout = 8_000)
         rule.scrollToAndTapMatchingBoth("Nintendo Entertainment System", "games")
-        rule.waitForText("Castlevania", timeout = 8_000)
+        rule.waitForText("Nintendo Entertainment System", timeout = 8_000)
         rule.scrollToAndTapText("Castlevania")
 
-        // Wait for game detail screen
-        rule.waitUntil(timeoutMillis = 3_000) {
-            rule.onAllNodesWithText("Download", substring = true)
+        // Wait for game detail screen — use contentDescription-based matchers that are
+        // unique to the game detail screen (not present on the console game list)
+        rule.waitUntil(timeoutMillis = 15_000) {
+            rule.onAllNodesWithContentDescription("Download Castlevania", substring = true)
                 .fetchSemanticsNodes().isNotEmpty() ||
-                rule.onAllNodesWithText("Play", substring = true)
+                rule.onAllNodesWithContentDescription("Play Castlevania", substring = true)
+                    .fetchSemanticsNodes().isNotEmpty() ||
+                rule.onAllNodesWithContentDescription("Resume Castlevania", substring = true)
                     .fetchSemanticsNodes().isNotEmpty()
         }
 

--- a/player/android/src/androidTest/java/com/spela/player/android/NavigationTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/NavigationTest.kt
@@ -21,12 +21,15 @@ class NavigationTest {
     fun backStackNavigation() {
         rule.startLoggedIn()
 
+        // Navigate to Consoles tab
+        rule.tapOn("Consoles")
+        rule.waitForText("Consoles", timeout = 8_000)
+
         // Navigate forward to Screen 2: NES console game list
         // Use compound matcher to avoid ambiguity with game cards that mention the console name
         rule.scrollToAndTapMatchingBoth("Nintendo Entertainment System", "games")
 
         // Verify we're on console game list
-        rule.waitForTextNotVisible("Spela", timeout = 8_000)
         rule.waitForText("Castlevania", timeout = 8_000)
 
         // Navigate forward to Screen 3: Game detail
@@ -46,18 +49,20 @@ class NavigationTest {
         // Verify we're back on NES console game list
         rule.waitForText("Castlevania")
 
-        // BACK #2: Console game list -> Home screen
+        // BACK #2: Console game list -> Consoles screen
         rule.pressBack()
 
-        // Verify we're back on Home
-        rule.waitForText("Nintendo Entertainment System", timeout = 5_000)
+        // Verify we're back on Consoles
+        rule.waitForText("Consoles", timeout = 5_000)
     }
 
     @Test
     fun autoScrapeMetadata() {
         rule.startLoggedIn()
 
-        // Navigate to NES > Castlevania
+        // Navigate to Consoles tab, then NES > Castlevania
+        rule.tapOn("Consoles")
+        rule.waitForText("Consoles", timeout = 8_000)
         rule.scrollToAndTapMatchingBoth("Nintendo Entertainment System", "games")
         rule.waitForText("Castlevania", timeout = 8_000)
         rule.scrollToAndTapText("Castlevania")

--- a/player/android/src/androidTest/java/com/spela/player/android/NavigationTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/NavigationTest.kt
@@ -21,9 +21,9 @@ class NavigationTest {
     fun backStackNavigation() {
         rule.startLoggedIn()
 
-        // Navigate to Consoles tab
+        // Navigate to Consoles tab and wait for console cards to load
         rule.tapOn("Consoles")
-        rule.waitForText("Consoles", timeout = 8_000)
+        rule.waitForContentDescription("Nintendo Entertainment System", timeout = 8_000)
 
         // Navigate forward to Screen 2: NES console game list
         // Use compound matcher to avoid ambiguity with game cards that mention the console name
@@ -52,8 +52,8 @@ class NavigationTest {
         // BACK #2: Console game list -> Consoles screen
         rule.pressBack()
 
-        // Verify we're back on Consoles
-        rule.waitForText("Consoles", timeout = 5_000)
+        // Verify we're back on Consoles (console cards visible via contentDescription)
+        rule.waitForContentDescription("Nintendo Entertainment System", timeout = 5_000)
     }
 
     @Test
@@ -62,7 +62,7 @@ class NavigationTest {
 
         // Navigate to Consoles tab, then NES > Castlevania
         rule.tapOn("Consoles")
-        rule.waitForText("Consoles", timeout = 8_000)
+        rule.waitForContentDescription("Nintendo Entertainment System", timeout = 8_000)
         rule.scrollToAndTapMatchingBoth("Nintendo Entertainment System", "games")
         rule.waitForText("Castlevania", timeout = 8_000)
         rule.scrollToAndTapText("Castlevania")

--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -544,9 +544,9 @@ private fun ComposeRule.doLogin(username: String, password: String) {
 // ── Navigation helpers ──
 
 fun ComposeRule.navigateToCastlevania() {
-    // Navigate to Consoles tab
+    // Navigate to Consoles tab and wait for console cards to appear
     tapOn("Consoles")
-    waitForText("Consoles", TIMEOUT_MEDIUM)
+    waitForContentDescription("Nintendo Entertainment System", TIMEOUT_MEDIUM)
 
     // Scroll to and tap the NES console card. We match on the card's content description
     // which contains both "Nintendo Entertainment System" and "games" — this distinguishes
@@ -565,7 +565,7 @@ fun ComposeRule.navigateToCastlevania() {
 
 fun ComposeRule.navigateToN64Game() {
     tapOn("Consoles")
-    waitForText("Consoles", TIMEOUT_MEDIUM)
+    waitForContentDescription("Nintendo 64", TIMEOUT_MEDIUM)
 
     scrollToAndTapMatchingBoth("Nintendo 64", "games")
 

--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -4,6 +4,7 @@ import android.view.KeyEvent
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasScrollToNodeAction
+import androidx.compose.ui.test.hasContentDescription
 import androidx.compose.ui.test.hasTestTag
 import androidx.compose.ui.test.hasText
 import androidx.compose.ui.test.onNodeWithTag
@@ -614,14 +615,15 @@ fun ComposeRule.tapNodeMatchingBoth(text1: String, text2: String) {
 }
 
 /**
- * Scroll through a LazyColumn until a node matching both text1 AND text2 (via hasText
- * substring matching, which covers both text content and content descriptions) is visible,
- * then tap it. This is like tapNodeMatchingBoth but with scroll-to-find support for
- * off-screen LazyColumn items.
+ * Scroll through a LazyColumn until a node matching both text1 AND text2 is visible,
+ * then tap it. Matches on both visible text and contentDescription (some elements
+ * like console cards use logos instead of text, with the name in contentDescription).
  */
 fun ComposeRule.scrollToAndTapMatchingBoth(text1: String, text2: String) {
     val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    val matcher = hasText(text1, substring = true) and hasText(text2, substring = true)
+    val textMatcher = hasText(text1, substring = true) and hasText(text2, substring = true)
+    val descMatcher = hasContentDescription(text1, substring = true) and hasContentDescription(text2, substring = true)
+    val matcher = textMatcher or descMatcher
     val maxSwipes = 10
     var found = false
 

--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -157,6 +157,22 @@ fun ComposeRule.assertNotVisible(label: String) {
     assert(!hasText && !hasDesc) { "Expected '$label' to NOT be visible, but it was found" }
 }
 
+/** Check if we're on the Home screen (works in both populated and empty states). */
+private fun ComposeRule.isOnHomeScreen(): Boolean {
+    return try {
+        onAllNodesWithText("Spela", substring = true)
+            .fetchSemanticsNodes().isNotEmpty() ||
+            onAllNodesWithText("Your library is empty", substring = true)
+                .fetchSemanticsNodes().isNotEmpty() ||
+            onAllNodesWithText("Top Rated", substring = true)
+                .fetchSemanticsNodes().isNotEmpty() ||
+            onAllNodesWithText("Continue Playing", substring = true)
+                .fetchSemanticsNodes().isNotEmpty()
+    } catch (_: IllegalStateException) {
+        false
+    }
+}
+
 /** Wait until label is visible in either text or content description. */
 fun ComposeRule.waitForVisible(label: String, timeout: Long = TIMEOUT_MEDIUM) {
     waitUntil(timeoutMillis = timeout) {
@@ -305,9 +321,7 @@ fun ComposeRule.restartApp() {
 private fun ComposeRule.navigateBackToHome() {
     for (i in 1..10) {
         try {
-            if (onAllNodesWithText("Spela", substring = true)
-                    .fetchSemanticsNodes().isNotEmpty()
-            ) return
+            if (isOnHomeScreen()) return
 
             // Don't press back on auth screens — it would exit the app
             if (onAllNodesWithText("Connect to your game server", substring = true)
@@ -381,8 +395,7 @@ fun ComposeRule.ensureLoggedIn(
     // Wait for any recognizable screen to load (extra long for fresh install / emulator).
     waitUntil(timeoutMillis = TIMEOUT_EXTRA_LONG) {
         try {
-            onAllNodesWithText("Spela", substring = true)
-                .fetchSemanticsNodes().isNotEmpty() ||
+            isOnHomeScreen() ||
                 onAllNodesWithText("Connect to your game server", substring = true)
                     .fetchSemanticsNodes().isNotEmpty() ||
                 onAllNodesWithText("Welcome Back", substring = true)
@@ -424,18 +437,28 @@ fun ComposeRule.ensureLoggedIn(
         return
     }
 
-    // Check if already on Home screen (look for the "Spela" title in the top bar)
-    val onHome = try {
-        onAllNodesWithText("Spela", substring = true)
-            .fetchSemanticsNodes().isNotEmpty()
-    } catch (_: IllegalStateException) { false }
-    if (onHome) return
+    // Check if already on Home screen. Home can show "Spela" (with games) or
+    // "Your library is empty" (fresh user with no play history).
+    if (isOnHomeScreen()) return
+
+    // Wait briefly for Home screen — the bottom nav renders before the page title,
+    // so checking once may miss it. This prevents navigateBackToHome from pressing
+    // back and accidentally exiting the app.
+    val arrivedHome = try {
+        waitUntil(timeoutMillis = TIMEOUT_MEDIUM) {
+            try { isOnHomeScreen() } catch (_: IllegalStateException) { false }
+        }
+        true
+    } catch (_: androidx.compose.ui.test.ComposeTimeoutException) { false }
+    if (arrivedHome) return
 
     // On some other logged-in screen (Settings, game detail, in-game, etc.)
     // Navigate back to Home first, then verify.
     // navigateBackToHome may need time if exiting a game (async core shutdown).
     navigateBackToHome()
-    waitForText("Spela", 30_000)
+    waitUntil(timeoutMillis = 30_000) {
+        try { isOnHomeScreen() } catch (_: IllegalStateException) { false }
+    }
 }
 
 /**
@@ -538,7 +561,9 @@ private fun ComposeRule.doLogin(username: String, password: String) {
     onNodeWithText("Sign In").performClick()
 
     // Verify home screen (extra long timeout for multi-class runs where server may be slow)
-    waitForText("Spela", TIMEOUT_EXTRA_LONG)
+    waitUntil(timeoutMillis = TIMEOUT_EXTRA_LONG) {
+        try { isOnHomeScreen() } catch (_: IllegalStateException) { false }
+    }
 }
 
 // ── Navigation helpers ──
@@ -553,10 +578,10 @@ fun ComposeRule.navigateToCastlevania() {
     // it from game cards that also mention the console name.
     scrollToAndTapMatchingBoth("Nintendo Entertainment System", "games")
 
-    // Wait for the console game list to load
-    waitForText("Castlevania", TIMEOUT_LONG)
+    // Wait for the console game list to load (title bar shows console name)
+    waitForText("Nintendo Entertainment System", TIMEOUT_LONG)
 
-    // Tap Castlevania in the game list
+    // Scroll to and tap Castlevania in the game list
     scrollToAndTapText("Castlevania")
 
     // Wait for game detail

--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -290,8 +290,6 @@ class MainActivity : ComponentActivity() {
         }
 
         // UI mode: convert analog stick to D-pad events for focus navigation
-        gamepadPortManager.setInputMode(InputMode.GAMEPAD)
-
         val x = event.getAxisValue(MotionEvent.AXIS_X)
         val y = event.getAxisValue(MotionEvent.AXIS_Y)
         val hatX = event.getAxisValue(MotionEvent.AXIS_HAT_X)
@@ -302,6 +300,15 @@ class MainActivity : ComponentActivity() {
         val nowRight = x > threshold || hatX > threshold
         val nowUp = y < -threshold || hatY < -threshold
         val nowDown = y > threshold || hatY > threshold
+
+        // Right stick scrolling: convert right analog stick Y-axis to scroll events
+        val rY = event.getAxisValue(MotionEvent.AXIS_RZ)
+
+        // Only switch to gamepad mode when there's actual meaningful input,
+        // not on zero-value motion events from stick drift
+        if (nowLeft || nowRight || nowUp || nowDown || Math.abs(rY) > 0.15f) {
+            gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        }
 
         if (nowLeft && !analogDpadLeft) dispatchDpadEvent(KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.ACTION_DOWN)
         if (!nowLeft && analogDpadLeft) dispatchDpadEvent(KeyEvent.KEYCODE_DPAD_LEFT, KeyEvent.ACTION_UP)
@@ -317,8 +324,6 @@ class MainActivity : ComponentActivity() {
         analogDpadUp = nowUp
         analogDpadDown = nowDown
 
-        // Right stick scrolling: convert right analog stick Y-axis to scroll events
-        val rY = event.getAxisValue(MotionEvent.AXIS_RZ)
         if (Math.abs(rY) > 0.15f) {
             val props = MotionEvent.PointerProperties().apply {
                 id = 0

--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -13,6 +13,7 @@ import androidx.lifecycle.lifecycleScope
 import com.spela.player.libretro.AndroidLibretroController
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.App
+import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.intent.EmulationIntent
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.NavigationViewModel
@@ -172,6 +173,7 @@ class MainActivity : ComponentActivity() {
         }
 
         // State 3: Not in game — UI mode: remap gamepad buttons for Compose navigation
+        gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         when (keyCode) {
             KeyEvent.KEYCODE_BUTTON_A -> {
                 val now = SystemClock.uptimeMillis()
@@ -288,6 +290,8 @@ class MainActivity : ComponentActivity() {
         }
 
         // UI mode: convert analog stick to D-pad events for focus navigation
+        gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+
         val x = event.getAxisValue(MotionEvent.AXIS_X)
         val y = event.getAxisValue(MotionEvent.AXIS_Y)
         val hatX = event.getAxisValue(MotionEvent.AXIS_HAT_X)
@@ -312,6 +316,25 @@ class MainActivity : ComponentActivity() {
         analogDpadRight = nowRight
         analogDpadUp = nowUp
         analogDpadDown = nowDown
+
+        // Right stick scrolling: convert right analog stick Y-axis to scroll events
+        val rY = event.getAxisValue(MotionEvent.AXIS_RZ)
+        if (Math.abs(rY) > 0.15f) {
+            val props = MotionEvent.PointerProperties().apply {
+                id = 0
+                toolType = MotionEvent.TOOL_TYPE_MOUSE
+            }
+            val coords = MotionEvent.PointerCoords().apply {
+                setAxisValue(MotionEvent.AXIS_VSCROLL, -rY * 2f)
+            }
+            val scrollEvent = MotionEvent.obtain(
+                event.downTime, event.eventTime, MotionEvent.ACTION_SCROLL,
+                1, arrayOf(props), arrayOf(coords),
+                0, 0, 1f, 1f, event.deviceId, 0, InputDevice.SOURCE_MOUSE, 0
+            )
+            super.dispatchGenericMotionEvent(scrollEvent)
+            scrollEvent.recycle()
+        }
 
         return true
     }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
@@ -1,6 +1,5 @@
 package com.spela.player.desktop.e2e
 
-import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.*
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.SpScreen
@@ -13,8 +12,13 @@ import kotlin.test.Test
  * Verifies component focusability and directional focus navigation
  * for gaming handheld support.
  *
- * Note: Compose UI Test key injection requires a focused node as dispatch target,
- * so the GamepadHandler's Enter-fallback (for "nothing focused" state) cannot be
+ * Note: D-pad input triggers gamepad mode which hides the bottom tab bar
+ * and shows the section indicator. Tab bar interaction via D-pad is therefore
+ * not possible — section cycling (L1/R1) is tested in SectionIndicatorTest
+ * and SectionNavigationTest.
+ *
+ * Compose UI Test key injection requires a focused node as dispatch target,
+ * so the GamepadHandler's Next-fallback (for "nothing focused" state) cannot be
  * tested here. That path is covered by manual device testing on the Ayn Thor.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
@@ -38,65 +42,6 @@ class GamepadNavigationTest {
         onNodeWithContentDescription("Home").performClick()
         advanceQuick(harness)
         onNodeWithContentDescription("Home").assertIsFocused()
-    }
-
-    @Test
-    fun dpadRightMovesFocusBetweenBottomNavTabs() = runComposeUiTest {
-        val harness = createLoggedInHarness()
-        setContent { harness.App() }
-        advance(harness)
-
-        // Establish focus on Home tab
-        onNodeWithContentDescription("Home").performClick()
-        advanceQuick(harness)
-        onNodeWithContentDescription("Home").assertIsFocused()
-
-        // D-pad Right → focus should move to Consoles tab
-        onNodeWithContentDescription("Home").performKeyInput {
-            pressKey(Key.DirectionRight)
-        }
-        advanceQuick(harness)
-        onNodeWithContentDescription("Consoles").assertIsFocused()
-    }
-
-    @Test
-    fun dpadLeftMovesFocusBackBetweenBottomNavTabs() = runComposeUiTest {
-        val harness = createLoggedInHarness()
-        setContent { harness.App() }
-        advance(harness)
-
-        // Focus on Consoles tab
-        onNodeWithContentDescription("Consoles").performClick()
-        advanceQuick(harness)
-        onNodeWithContentDescription("Consoles").assertIsFocused()
-
-        // D-pad Left → focus should move back to Home tab
-        onNodeWithContentDescription("Consoles").performKeyInput {
-            pressKey(Key.DirectionLeft)
-        }
-        advanceQuick(harness)
-        onNodeWithContentDescription("Home").assertIsFocused()
-    }
-
-    @Test
-    fun dpadDownFromBottomNavMovesFocusUp() = runComposeUiTest {
-        val harness = createLoggedInHarness()
-        setContent { harness.App() }
-        advance(harness)
-
-        // Focus on Home tab, then press Up to move focus into the content area
-        onNodeWithContentDescription("Home").performClick()
-        advanceQuick(harness)
-        onNodeWithContentDescription("Home").assertIsFocused()
-
-        // Press Up — should move focus away from bottom nav into screen content
-        onNodeWithContentDescription("Home").performKeyInput {
-            pressKey(Key.DirectionUp)
-        }
-        advanceQuick(harness)
-
-        // Home tab should no longer be focused (focus moved to content)
-        onNodeWithContentDescription("Home").assertIsNotFocused()
     }
 
     @Test

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InputModeTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InputModeTest.kt
@@ -1,0 +1,136 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.ui.gamepad.InputMode
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * E2E tests for input mode detection (TOUCH vs GAMEPAD).
+ *
+ * Verifies:
+ * - Default mode is touch → tab bar visible
+ * - Setting GAMEPAD mode → section indicator appears, tab bar hidden
+ * - Setting TOUCH mode → tab bar returns
+ * - Focus recovery: D-pad key press populates focus even from unfocused state
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class InputModeTest {
+
+    private fun createLoggedInHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.authRepo.preSetTokens()
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    @Test
+    fun defaultModeIsTouchWithTabBar() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // Default mode should be TOUCH
+        assertEquals(InputMode.TOUCH, harness.gamepadPortManager.inputMode.value)
+
+        // Tab bar should be visible
+        onNodeWithContentDescription("Home").assertExists()
+        onNodeWithContentDescription("Consoles").assertExists()
+        onNodeWithContentDescription("Settings").assertExists()
+
+        // Section indicator should not exist
+        onNodeWithContentDescription("Section indicator").assertDoesNotExist()
+    }
+
+    @Test
+    fun gamepadModeSwitchesToSectionIndicator() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // Switch to GAMEPAD mode
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        advanceQuick(harness)
+
+        // Section indicator should appear
+        onNodeWithContentDescription("Section indicator").assertExists()
+
+        // Tab bar should be hidden
+        onNodeWithContentDescription("Home").assertDoesNotExist()
+    }
+
+    @Test
+    fun touchModeRestoresTabBar() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // Switch to GAMEPAD mode
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        advanceQuick(harness)
+
+        // Verify gamepad mode
+        onNodeWithContentDescription("Section indicator").assertExists()
+        onNodeWithContentDescription("Home").assertDoesNotExist()
+
+        // Switch back to TOUCH mode (simulates touch on content)
+        harness.gamepadPortManager.setInputMode(InputMode.TOUCH)
+        advanceQuick(harness)
+
+        // Tab bar should return
+        onNodeWithContentDescription("Home").assertExists()
+        onNodeWithContentDescription("Consoles").assertExists()
+
+        // Section indicator should be gone
+        onNodeWithContentDescription("Section indicator").assertDoesNotExist()
+    }
+
+    @Test
+    fun inputModeTogglesRepeatedly() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // Cycle through modes multiple times
+        repeat(3) {
+            harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+            advanceQuick(harness)
+            onNodeWithContentDescription("Section indicator").assertExists()
+            onNodeWithContentDescription("Home").assertDoesNotExist()
+
+            harness.gamepadPortManager.setInputMode(InputMode.TOUCH)
+            advanceQuick(harness)
+            onNodeWithContentDescription("Home").assertExists()
+            onNodeWithContentDescription("Section indicator").assertDoesNotExist()
+        }
+    }
+
+    @Test
+    fun gamepadModePreservedAcrossScreens() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // Enter gamepad mode
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        advanceQuick(harness)
+        onNodeWithContentDescription("Section: Home, active").assertExists()
+
+        // Navigate to a different section
+        harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
+        advanceQuick(harness)
+
+        // Should still be in gamepad mode with the section indicator
+        onNodeWithContentDescription("Section indicator").assertExists()
+        onNodeWithContentDescription("Section: Consoles, active").assertExists()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionIndicatorTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionIndicatorTest.kt
@@ -117,7 +117,7 @@ class SectionIndicatorTest {
     }
 
     @Test
-    fun sectionCyclingShowsIndicator() = runComposeUiTest {
+    fun sectionCyclingUpdatesActiveSection() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
@@ -127,34 +127,12 @@ class SectionIndicatorTest {
         harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advance(harness)
 
-        // Wait for auto-hide (advance past the 3s window)
-        advance(harness)
-
         // Cycle to next section
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
         advanceQuick(harness)
 
-        // Indicator should reappear with new active section
+        // Indicator should show new active section
         onNodeWithContentDescription("Section indicator").assertExists()
         onNodeWithContentDescription("Section: Consoles, active").assertExists()
-    }
-
-    @Test
-    fun sectionIndicatorAutoHides() = runComposeUiTest {
-        val harness = createLoggedInHarness()
-
-        setContent { harness.App() }
-        advance(harness)
-
-        // Switch to gamepad mode — indicator appears
-        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
-        advanceQuick(harness)
-        onNodeWithContentDescription("Section indicator").assertExists()
-
-        // Advance past the 3s auto-hide window (advance = 4 iterations of 1s each)
-        advance(harness)
-
-        // Indicator should have auto-hidden
-        onNodeWithContentDescription("Section indicator").assertDoesNotExist()
     }
 }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionIndicatorTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionIndicatorTest.kt
@@ -3,13 +3,14 @@ package com.spela.player.desktop.e2e
 import androidx.compose.ui.test.*
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.ui.gamepad.InputMode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlin.test.Test
 
 /**
  * E2E tests for the floating section indicator that replaces the bottom tab bar
- * when a gamepad controller is connected.
+ * when the user is in gamepad input mode.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class SectionIndicatorTest {
@@ -38,17 +39,17 @@ class SectionIndicatorTest {
     }
 
     @Test
-    fun sectionIndicatorAppearsOnConnect() = runComposeUiTest {
+    fun sectionIndicatorAppearsOnGamepadInput() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        // Connect a gamepad
-        harness.gamepadPortManager.connectDevice(1, "Test Controller")
+        // Switch to gamepad input mode (simulates D-pad press)
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
 
-        // Section indicator should be visible (within 3s auto-hide window)
+        // Section indicator should be visible
         onNodeWithContentDescription("Section indicator").assertExists()
 
         // Bottom nav tabs should be gone
@@ -56,16 +57,38 @@ class SectionIndicatorTest {
     }
 
     @Test
-    fun sectionIndicatorDisappearsOnDisconnect() = runComposeUiTest {
+    fun gamepadConnectAloneDoesNotShowIndicator() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
-        // Connect then disconnect
+        // Just connecting a gamepad (without D-pad input) should NOT switch nav style
         harness.gamepadPortManager.connectDevice(1, "Test Controller")
         advanceQuick(harness)
-        harness.gamepadPortManager.disconnectDevice(1)
+
+        // Tab bar should still be visible (touch mode)
+        onNodeWithContentDescription("Home").assertExists()
+        onNodeWithContentDescription("Consoles").assertExists()
+
+        // Section indicator should not exist
+        onNodeWithContentDescription("Section indicator").assertDoesNotExist()
+    }
+
+    @Test
+    fun sectionIndicatorDisappearsOnTouchInput() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // Enter gamepad mode
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        advanceQuick(harness)
+        onNodeWithContentDescription("Section indicator").assertExists()
+
+        // Switch back to touch mode
+        harness.gamepadPortManager.setInputMode(InputMode.TOUCH)
         advanceQuick(harness)
 
         // Section indicator should be gone
@@ -83,8 +106,8 @@ class SectionIndicatorTest {
         setContent { harness.App() }
         advance(harness)
 
-        // Connect gamepad (we're on Home screen)
-        harness.gamepadPortManager.connectDevice(1, "Test Controller")
+        // Switch to gamepad mode (we're on Home screen)
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
 
         // Home should be the active section
@@ -100,8 +123,8 @@ class SectionIndicatorTest {
         setContent { harness.App() }
         advance(harness)
 
-        // Connect gamepad
-        harness.gamepadPortManager.connectDevice(1, "Test Controller")
+        // Switch to gamepad mode
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advance(harness)
 
         // Wait for auto-hide (advance past the 3s window)
@@ -123,8 +146,8 @@ class SectionIndicatorTest {
         setContent { harness.App() }
         advance(harness)
 
-        // Connect gamepad — indicator appears
-        harness.gamepadPortManager.connectDevice(1, "Test Controller")
+        // Switch to gamepad mode — indicator appears
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
         onNodeWithContentDescription("Section indicator").assertExists()
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
@@ -1,6 +1,7 @@
 package com.spela.player.libretro
 
 import com.spela.player.domain.repository.KeyMappingRepository
+import com.spela.player.presentation.ui.gamepad.InputMode
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -53,6 +54,14 @@ class GamepadPortManager(
     /** Observable list of current port assignments. */
     private val _assignments = MutableStateFlow<List<PortAssignment>>(emptyList())
     val assignments: StateFlow<List<PortAssignment>> = _assignments.asStateFlow()
+
+    /** Current input mode: TOUCH when touch input was last used, GAMEPAD when D-pad/buttons were. */
+    private val _inputMode = MutableStateFlow(InputMode.TOUCH)
+    val inputMode: StateFlow<InputMode> = _inputMode.asStateFlow()
+
+    fun setInputMode(mode: InputMode) {
+        _inputMode.value = mode
+    }
 
     /**
      * Assigns a device to the next available port.

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -97,7 +97,9 @@ import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.ui.gamepad.GamepadHandler
+import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.theme.SpelaTheme
+import androidx.compose.ui.input.pointer.PointerEventPass
 import com.spela.player.presentation.viewmodel.DownloadsViewModel
 import com.spela.player.presentation.viewmodel.EmulationViewModel
 import com.spela.player.presentation.viewmodel.GameDetailViewModel
@@ -156,13 +158,11 @@ fun SpelaApp(
     SpelaTheme(theme = currentTheme) {
         val navState by navigationViewModel.state.collectAsState()
 
-        // Gamepad connection state for section indicator
-        val gamepadAssignments by gamepadPortManager?.assignments?.collectAsState()
-            ?: remember { mutableStateOf(emptyList<GamepadPortManager.PortAssignment>()) }
-        val hasGamepad = gamepadAssignments.isNotEmpty()
-
-        // Section indicator is always visible when a gamepad is connected
-        val sectionIndicatorVisible = hasGamepad
+        // Input mode detection: TOUCH shows tab bar, GAMEPAD shows section indicator
+        val inputMode by gamepadPortManager?.inputMode?.collectAsState()
+            ?: remember { mutableStateOf(InputMode.TOUCH) }
+        val isGamepadMode = inputMode == InputMode.GAMEPAD
+        val sectionIndicatorVisible = isGamepadMode
 
         // Hidden indicator for E2E tests: exposes whether the libretro core is running.
         // Tests wait for "Core idle" instead of Thread.sleep after exiting games.
@@ -235,11 +235,23 @@ fun SpelaApp(
             onPreviousSection = if (isGamepadScreen) {
                 { navigationViewModel.onIntent(NavigationIntent.PreviousSection) }
             } else null,
+            onGamepadInput = { gamepadPortManager?.setInputMode(InputMode.GAMEPAD) },
+            focusResetKey = if (isGamepadMode) navState.currentScreen else null,
         ) {
         Box(
             modifier = Modifier
                 .fillMaxSize()
-                .background(SpColor.Background),
+                .background(SpColor.Background)
+                .pointerInput(Unit) {
+                    awaitPointerEventScope {
+                        while (true) {
+                            val event = awaitPointerEvent(PointerEventPass.Initial)
+                            if (event.changes.any { it.pressed }) {
+                                gamepadPortManager?.setInputMode(InputMode.TOUCH)
+                            }
+                        }
+                    }
+                },
         ) {
             Column(modifier = Modifier.fillMaxSize()) {
                 // Connection state
@@ -1015,9 +1027,9 @@ fun SpelaApp(
                     )
                 }
 
-                // Bottom navigation bar (hidden when gamepad connected)
+                // Bottom navigation bar (hidden when in gamepad mode)
                 val showNavArea = !navState.showInGameOverlay && shouldShowBottomNav(navState.currentScreen)
-                if (showNavArea && !hasGamepad) {
+                if (showNavArea && !isGamepadMode) {
                     SpBottomNavBar(
                         activeTab = activeTabForScreen(navState.currentScreen),
                         onTabSelected = { tab ->
@@ -1037,9 +1049,9 @@ fun SpelaApp(
                 } // else (not DatabaseError)
             }
 
-            // Section indicator overlay (shown when gamepad connected)
+            // Section indicator overlay (shown when in gamepad mode)
             val showNavArea = !navState.showInGameOverlay && shouldShowBottomNav(navState.currentScreen)
-            if (showNavArea && hasGamepad) {
+            if (showNavArea && isGamepadMode) {
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.TopCenter,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,6 +29,7 @@ import androidx.compose.ui.input.key.type
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.theme.SpColor
+import kotlinx.coroutines.delay
 
 /**
  * Wraps content with gamepad/keyboard navigation key handling.
@@ -39,6 +41,11 @@ import com.spela.player.presentation.ui.theme.SpColor
  * Platform-specific gamepad buttons (A, B) are handled at the platform layer:
  * - Android: MainActivity remaps BUTTON_A -> DPAD_CENTER, BUTTON_B -> BACK.
  * - Desktop: Arrow keys + Enter/Space + Escape cover all navigation needs.
+ *
+ * @param onGamepadInput Called on any handled D-pad/keyboard navigation input.
+ *   Used to signal that the user is using gamepad-style input (for input mode detection).
+ * @param focusResetKey When this value changes (e.g. on section switch), focus is
+ *   cleared and moved to the first focusable element after recomposition.
  */
 @Composable
 fun GamepadHandler(
@@ -46,9 +53,22 @@ fun GamepadHandler(
     onBack: (() -> Unit)? = null,
     onNextSection: (() -> Unit)? = null,
     onPreviousSection: (() -> Unit)? = null,
+    onGamepadInput: (() -> Unit)? = null,
+    focusResetKey: Any? = null,
     content: @Composable () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
+
+    // When focusResetKey changes (e.g. section switch in gamepad mode),
+    // clear focus and move to the first focusable element on the new page.
+    if (focusResetKey != null) {
+        LaunchedEffect(focusResetKey) {
+            // Wait for new content to compose
+            delay(100)
+            focusManager.clearFocus(force = true)
+            focusManager.moveFocus(FocusDirection.Next)
+        }
+    }
 
     Box(
         modifier = Modifier
@@ -60,22 +80,26 @@ fun GamepadHandler(
                 when (event.key) {
                     Key.DirectionUp -> {
                         val moved = focusManager.moveFocus(FocusDirection.Up)
-                        if (!moved) focusManager.moveFocus(FocusDirection.Enter)
+                        if (!moved) focusManager.moveFocus(FocusDirection.Next)
+                        onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionDown -> {
                         val moved = focusManager.moveFocus(FocusDirection.Down)
-                        if (!moved) focusManager.moveFocus(FocusDirection.Enter)
+                        if (!moved) focusManager.moveFocus(FocusDirection.Next)
+                        onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionLeft -> {
                         val moved = focusManager.moveFocus(FocusDirection.Left)
-                        if (!moved) focusManager.moveFocus(FocusDirection.Enter)
+                        if (!moved) focusManager.moveFocus(FocusDirection.Next)
+                        onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionRight -> {
                         val moved = focusManager.moveFocus(FocusDirection.Right)
-                        if (!moved) focusManager.moveFocus(FocusDirection.Enter)
+                        if (!moved) focusManager.moveFocus(FocusDirection.Next)
+                        onGamepadInput?.invoke()
                         true
                     }
                     Key.Escape -> {
@@ -83,19 +107,27 @@ fun GamepadHandler(
                         onBack != null
                     }
                     Key.RightBracket -> {
+                        focusManager.clearFocus(force = true)
                         onNextSection?.invoke()
+                        onGamepadInput?.invoke()
                         onNextSection != null
                     }
                     Key.LeftBracket -> {
+                        focusManager.clearFocus(force = true)
                         onPreviousSection?.invoke()
+                        onGamepadInput?.invoke()
                         onPreviousSection != null
                     }
                     Key.Tab -> {
                         if (event.isShiftPressed) {
+                            focusManager.clearFocus(force = true)
                             onPreviousSection?.invoke()
+                            onGamepadInput?.invoke()
                             onPreviousSection != null
                         } else {
+                            focusManager.clearFocus(force = true)
                             onNextSection?.invoke()
+                            onGamepadInput?.invoke()
                             onNextSection != null
                         }
                     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/InputMode.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/InputMode.kt
@@ -1,0 +1,3 @@
+package com.spela.player.presentation.ui.gamepad
+
+enum class InputMode { TOUCH, GAMEPAD }


### PR DESCRIPTION
## Summary

- **Input mode detection**: Nav style (tab bar vs section indicator) is now based on actual input mode (TOUCH vs GAMEPAD) instead of whether a gamepad is connected. Fixes the AYN Thor always hiding the tab bar since its built-in gamepad is always connected.
- **Focus recovery**: D-pad press now grabs the first focusable element when nothing is focused (uses `FocusDirection.Next` fallback instead of `FocusDirection.Enter`).
- **Section switch auto-focus**: Pressing L1/R1 to switch pages auto-focuses the first element on the new page in gamepad mode.
- **Right stick scrolling**: Right analog stick Y-axis scrolls content in Android UI mode.

## Test plan

- [x] Desktop E2E: 393 tests pass (0 failures)
- [x] New `InputModeTest` (5 tests): default touch mode, gamepad switch, touch restore, repeated toggling, mode preserved across screens
- [x] Updated `SectionIndicatorTest` (6 tests): tests use `setInputMode(GAMEPAD)` instead of `connectDevice()`
- [ ] On-device: D-pad navigates even when nothing is focused
- [ ] On-device: tab bar → bullet indicator on D-pad, back on touch
- [ ] On-device: right stick scrolls content
- [ ] On-device: L1/R1 section switch focuses first element on new page