### PR TITLE
fix: Genesis crash, progress bar, orientation lock, scroll speed

### DIFF
--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.spela.player.android
 
+import android.content.pm.ActivityInfo
 import android.hardware.input.InputManager
 import android.os.Bundle
 import android.os.SystemClock
@@ -10,6 +11,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.lifecycle.lifecycleScope
+import com.spela.player.domain.repository.PreferencesRepository
 import com.spela.player.libretro.AndroidLibretroController
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.App
@@ -22,6 +24,9 @@ import com.spela.player.presentation.viewmodel.EmulationViewModel
 import com.spela.player.presentation.viewmodel.KeyMappingViewModel
 import com.spela.player.presentation.viewmodel.LibretroButtons
 import com.spela.player.presentation.viewmodel.LibretroController
+import com.spela.player.presentation.viewmodel.SettingsViewModel
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 
@@ -35,6 +40,8 @@ class MainActivity : ComponentActivity() {
     private val emulationViewModel: EmulationViewModel by inject()
     private val keyMappingViewModel: KeyMappingViewModel by inject()
     private val gamepadPortManager: GamepadPortManager by inject()
+    private val settingsViewModel: SettingsViewModel by inject()
+    private val preferencesRepository: PreferencesRepository by inject()
 
     /** True when gamepad input should go to libretro (game running, overlay not shown). */
     private val isEmulationConsuming: Boolean
@@ -77,6 +84,18 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         val inputManager = getSystemService(INPUT_SERVICE) as InputManager
         inputManager.registerInputDeviceListener(inputDeviceListener, null)
+
+        // Apply initial orientation lock
+        applyOrientationLock(preferencesRepository.getOrientationLock())
+
+        // Observe orientation lock changes so they apply immediately
+        lifecycleScope.launch {
+            settingsViewModel.state
+                .map { it.orientationLock }
+                .distinctUntilChanged()
+                .collect { mode -> applyOrientationLock(mode) }
+        }
+
         setContent {
             App()
         }
@@ -330,7 +349,7 @@ class MainActivity : ComponentActivity() {
                 toolType = MotionEvent.TOOL_TYPE_MOUSE
             }
             val coords = MotionEvent.PointerCoords().apply {
-                setAxisValue(MotionEvent.AXIS_VSCROLL, -rY * 2f)
+                setAxisValue(MotionEvent.AXIS_VSCROLL, -rY * 0.5f)
             }
             val scrollEvent = MotionEvent.obtain(
                 event.downTime, event.eventTime, MotionEvent.ACTION_SCROLL,
@@ -342,6 +361,14 @@ class MainActivity : ComponentActivity() {
         }
 
         return true
+    }
+
+    private fun applyOrientationLock(mode: String) {
+        requestedOrientation = when (mode) {
+            "landscape" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE
+            "portrait" -> ActivityInfo.SCREEN_ORIENTATION_SENSOR_PORTRAIT
+            else -> ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED
+        }
     }
 
     private fun dispatchDpadEvent(keyCode: Int, action: Int) {

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsOrientationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsOrientationTest.kt
@@ -1,0 +1,130 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.viewmodel.SettingsIntent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * E2E tests for the orientation lock setting in the Display section.
+ *
+ * Verifies:
+ * - Display section renders with three radio options (Auto, Landscape, Portrait)
+ * - "Auto" is selected by default
+ * - Clicking an option updates the ViewModel state
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class SettingsOrientationTest {
+
+    private fun createLoggedInHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.authRepo.preSetTokens()
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun ComposeUiTest.navigateToSettings(harness: SpelaTestHarness) {
+        harness.settingsViewModel.onIntent(SettingsIntent.LoadSettings)
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.Settings)
+        )
+        advanceFully(harness)
+    }
+
+    @Test
+    fun displaySectionShowsOrientationOptions() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToSettings(harness)
+
+        // Scroll to Display section header
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Display"))
+        onNodeWithText("Display").assertIsDisplayed()
+
+        // Scroll to each orientation option
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Follow system orientation"))
+        onNodeWithText("Auto").assertExists()
+
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Lock to landscape orientation"))
+        onNodeWithText("Landscape").assertExists()
+
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Lock to portrait orientation"))
+        onNodeWithText("Portrait").assertExists()
+    }
+
+    @Test
+    fun autoIsSelectedByDefault() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToSettings(harness)
+
+        assertEquals("auto", harness.settingsViewModel.state.value.orientationLock)
+    }
+
+    @Test
+    fun selectingLandscapeUpdatesState() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToSettings(harness)
+
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Lock to landscape orientation"))
+
+        onNodeWithText("Landscape").performClick()
+        advance(harness)
+
+        assertEquals("landscape", harness.settingsViewModel.state.value.orientationLock)
+        assertEquals("landscape", harness.preferencesRepo.getOrientationLock())
+    }
+
+    @Test
+    fun selectingPortraitUpdatesState() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToSettings(harness)
+
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Lock to portrait orientation"))
+
+        onNodeWithText("Portrait").performClick()
+        advance(harness)
+
+        assertEquals("portrait", harness.settingsViewModel.state.value.orientationLock)
+        assertEquals("portrait", harness.preferencesRepo.getOrientationLock())
+    }
+
+    @Test
+    fun selectingAutoAfterLandscapeRestoresDefault() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToSettings(harness)
+
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Lock to landscape orientation"))
+
+        // First select Landscape
+        onNodeWithText("Landscape").performClick()
+        advance(harness)
+        assertEquals("landscape", harness.settingsViewModel.state.value.orientationLock)
+
+        // Then switch back to Auto
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Follow system orientation"))
+        onNodeWithText("Auto").performClick()
+        advance(harness)
+        assertEquals("auto", harness.settingsViewModel.state.value.orientationLock)
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -730,6 +730,9 @@ class FakePreferencesRepository : PreferencesRepository {
     override suspend fun pushDeviceShaderOverridesToServer() {}
     override suspend fun syncKeyMappingsFromServer() { syncKeyMappingsCalled = true }
     override suspend fun pushKeyMappingsToServer() { pushKeyMappingsCalled = true }
+    private var orientationLock: String = "auto"
+    override fun getOrientationLock(): String = orientationLock
+    override fun setOrientationLock(mode: String) { orientationLock = mode }
 }
 
 class FakeAchievementsRepository : AchievementsRepository {

--- a/player/shared/src/androidMain/kotlin/com/spela/player/di/PlatformModule.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/di/PlatformModule.kt
@@ -1,6 +1,7 @@
 package com.spela.player.di
 
 import android.view.KeyEvent
+import app.cash.sqldelight.db.SqlDriver
 import app.cash.sqldelight.driver.android.AndroidSqliteDriver
 import com.spela.player.data.local.DatabaseHealthCheck
 import com.spela.player.data.local.DatabaseResetHelper
@@ -31,21 +32,21 @@ import org.koin.dsl.module
 actual fun platformModule(): Module = module {
     single {
         val context: android.content.Context = get()
-        val dbFile = context.getDatabasePath("spela.db")
-        if (dbFile.exists()) {
-            try {
-                val errorMessage = validateSchemaAndroid(dbFile.path)
-                if (errorMessage != null) {
-                    println("Spela: $errorMessage")
-                    DatabaseHealthCheck.reportError("$errorMessage Please reset the app.")
-                }
-            } catch (e: Exception) {
-                println("Spela: Failed to validate database: ${e.message}")
-                DatabaseHealthCheck.reportError("Database validation failed: ${e.message}. Please reset the app.")
-            }
-        }
         DatabaseResetHelper.init(context)
-        AndroidSqliteDriver(SpelaDatabase.Schema, context, "spela.db")
+        // Create driver first — AndroidSqliteDriver runs migrations automatically
+        val driver = AndroidSqliteDriver(SpelaDatabase.Schema, context, "spela.db")
+        // Validate schema after migration using the same driver connection
+        try {
+            val errorMessage = validateSchemaWithDriver(driver)
+            if (errorMessage != null) {
+                println("Spela: $errorMessage")
+                DatabaseHealthCheck.reportError("$errorMessage Please reset the app.")
+            }
+        } catch (e: Exception) {
+            println("Spela: Failed to validate database: ${e.message}")
+            DatabaseHealthCheck.reportError("Database validation failed: ${e.message}. Please reset the app.")
+        }
+        driver
     }
     single { SpelaDatabase(get<AndroidSqliteDriver>()) }
     single<HttpClientEngineFactory<*>> { OkHttp }
@@ -109,46 +110,47 @@ actual fun platformModule(): Module = module {
 
 /**
  * Validates the existing database against [ExpectedSchema].
+ * Uses the same [SqlDriver] connection to avoid WAL visibility issues.
  * Returns an error message if incompatible, or null if OK.
  */
-private fun validateSchemaAndroid(dbPath: String): String? {
-    val db = android.database.sqlite.SQLiteDatabase.openDatabase(
-        dbPath, null, android.database.sqlite.SQLiteDatabase.OPEN_READONLY
-    )
-    try {
-        // Check tables
-        val tablesCursor = db.rawQuery(
-            "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'android_%'",
-            null,
-        )
-        val existingTables = mutableSetOf<String>()
-        while (tablesCursor.moveToNext()) {
-            existingTables.add(tablesCursor.getString(0))
-        }
-        tablesCursor.close()
-
-        val missingTables = ExpectedSchema.tables.keys - existingTables
-        if (missingTables.isNotEmpty()) {
-            return "Database schema incompatible: missing tables $missingTables."
-        }
-
-        // Check every table's columns
-        for ((table, expectedColumns) in ExpectedSchema.tables) {
-            val columnsCursor = db.rawQuery("PRAGMA table_info($table)", null)
-            val actualColumns = mutableSetOf<String>()
-            while (columnsCursor.moveToNext()) {
-                actualColumns.add(columnsCursor.getString(1))
+private fun validateSchemaWithDriver(driver: SqlDriver): String? {
+    val existingTables = driver.executeQuery(
+        identifier = null,
+        sql = "SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE 'android_%'",
+        mapper = { cursor ->
+            val tables = mutableSetOf<String>()
+            while (cursor.next().value) {
+                cursor.getString(0)?.let { tables.add(it) }
             }
-            columnsCursor.close()
+            app.cash.sqldelight.db.QueryResult.Value(tables)
+        },
+        parameters = 0,
+    ).value
 
-            val missingColumns = expectedColumns - actualColumns
-            if (missingColumns.isNotEmpty()) {
-                return "Database schema incompatible: table $table missing columns $missingColumns."
-            }
-        }
-
-        return null
-    } finally {
-        db.close()
+    val missingTables = ExpectedSchema.tables.keys - existingTables
+    if (missingTables.isNotEmpty()) {
+        return "Database schema incompatible: missing tables $missingTables."
     }
+
+    // Check every table's columns
+    for ((table, expectedColumns) in ExpectedSchema.tables) {
+        val actualColumns = driver.executeQuery(
+            identifier = null,
+            sql = "PRAGMA table_info($table)",
+            mapper = { cursor ->
+                val cols = mutableSetOf<String>()
+                while (cursor.next().value) {
+                    cursor.getString(1)?.let { cols.add(it) }
+                }
+                app.cash.sqldelight.db.QueryResult.Value(cols)
+            },
+            parameters = 0,
+        ).value
+        val missingColumns = expectedColumns - actualColumns
+        if (missingColumns.isNotEmpty()) {
+            return "Database schema incompatible: table $table missing columns $missingColumns."
+        }
+    }
+
+    return null
 }

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
@@ -570,10 +570,10 @@ class AndroidLibretroController(
 
         convertToPackedArgb(videoFrameBuffer, pixelCount, format, pixelBuffer)
 
-        // Reallocate double buffers if dimensions changed
+        // Reallocate double buffers if dimensions changed.
+        // Don't recycle old bitmaps — Compose may still be drawing the previous
+        // front bitmap via _frameBitmap. Let GC collect them instead.
         if (width != lastFrameWidth || height != lastFrameHeight) {
-            frontBitmap?.recycle()
-            backBitmap?.recycle()
             frontBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
             backBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888)
             lastFrameWidth = width

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/EmulationSurface.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/EmulationSurface.kt
@@ -48,7 +48,9 @@ fun EmulationSurface(
     ) {
         Canvas(modifier = Modifier.fillMaxSize()) {
             bitmap?.let { bmp ->
-                drawScaledBitmap(bmp, shader = selectedShader, isDualScreenSplit = isDualScreenSplit, splitY = splitY)
+                if (!bmp.isRecycled) {
+                    drawScaledBitmap(bmp, shader = selectedShader, isDualScreenSplit = isDualScreenSplit, splitY = splitY)
+                }
             }
         }
     }

--- a/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformDsTouchScreen.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformDsTouchScreen.android.kt
@@ -97,7 +97,7 @@ actual fun PlatformDsTouchScreen(
                 },
         ) {
             val bmp = bitmap ?: return@Canvas
-            if (bmp.height <= splitY) return@Canvas
+            if (bmp.isRecycled || bmp.height <= splitY) return@Canvas
 
             val srcWidth = bmp.width
             val srcHeight = bmp.height - splitY

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/local/ExpectedSchema.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/local/ExpectedSchema.kt
@@ -36,5 +36,6 @@ object ExpectedSchema {
             "id", "game_id", "name", "local_path", "file_size", "is_active",
             "created_at", "updated_at", "server_id", "sync_status",
         ),
+        "DeviceSettingEntity" to setOf("key", "value"),
     )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
@@ -178,6 +178,15 @@ class PreferencesRepositoryImpl(
         }
     }
 
+    override fun getOrientationLock(): String {
+        return database.spelaDatabaseQueries.getDeviceSetting("orientation_lock")
+            .executeAsOneOrNull() ?: "auto"
+    }
+
+    override fun setOrientationLock(mode: String) {
+        database.spelaDatabaseQueries.insertDeviceSetting("orientation_lock", mode)
+    }
+
     override suspend fun pushKeyMappingsToServer() {
         runCatching {
             val allMappings = database.spelaDatabaseQueries.getAllKeyMappings().executeAsList()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PreferencesRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PreferencesRepository.kt
@@ -21,4 +21,6 @@ interface PreferencesRepository {
     suspend fun pushDeviceShaderOverridesToServer()
     suspend fun syncKeyMappingsFromServer()
     suspend fun pushKeyMappingsToServer()
+    fun getOrientationLock(): String
+    fun setOrientationLock(mode: String)
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
@@ -15,6 +15,9 @@ import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -42,8 +45,14 @@ fun SpProgressBar(
     val resolvedProgressColors = if (onGradient) listOf(Color.White.copy(alpha = 0.65f), Color.White.copy(alpha = 0.90f)) else progressColors
     val resolvedLabelColor = if (onGradient) Color.White.copy(alpha = 0.70f) else SpColor.OnBackgroundSecondary
 
+    var maxProgress by remember { mutableFloatStateOf(0f) }
+    val clampedProgress = progress.coerceIn(0f, 1f)
+    // Reset on new download (progress drops to near zero)
+    if (clampedProgress < 0.01f) maxProgress = 0f
+    maxProgress = maxOf(maxProgress, clampedProgress)
+
     val animatedProgress by animateFloatAsState(
-        targetValue = progress.coerceIn(0f, 1f),
+        targetValue = maxProgress,
         animationSpec = tween(300),
         label = "progressBarAnimation",
     )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -196,63 +196,65 @@ internal fun ConsoleCard(
                 ),
         )
 
-        // Content: logo top-left, stats bottom-left
+        // Centered logo with dual constraints (width + height)
+        Box(
+            modifier = Modifier
+                .align(Alignment.Center)
+                .fillMaxWidth(0.65f)
+                .heightIn(max = 64.dp),
+            contentAlignment = Alignment.Center,
+        ) {
+            var logoFailed by remember { mutableStateOf(false) }
+            if (console.logoUrl.isNotEmpty() && !logoFailed) {
+                AsyncImage(
+                    model = console.logoUrl,
+                    contentDescription = console.name,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 64.dp),
+                    contentScale = ContentScale.Fit,
+                    onError = { logoFailed = true },
+                )
+            } else {
+                Text(
+                    text = console.name,
+                    style = SpTypography.HeadlineMedium,
+                    fontWeight = FontWeight.SemiBold,
+                    color = HeroTextPrimary,
+                )
+            }
+        }
+
+        // BIOS warning icon at top-right corner
+        if (hasMissingBios) {
+            Icon(
+                imageVector = Icons.Filled.Warning,
+                contentDescription = "BIOS missing for ${console.name}",
+                tint = SpColor.Warning,
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .padding(SpSpacing.Small)
+                    .size(16.dp),
+            )
+        }
+
+        // Bottom-left: game count + manufacturer · year
         Column(
             modifier = Modifier
-                .fillMaxSize()
+                .align(Alignment.BottomStart)
                 .padding(SpSpacing.Default),
-            verticalArrangement = Arrangement.SpaceBetween,
         ) {
-            // Top: console logo (or name fallback) + optional BIOS warning
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
-            ) {
-                var logoFailed by remember { mutableStateOf(false) }
-                if (console.logoUrl.isNotEmpty() && !logoFailed) {
-                    AsyncImage(
-                        model = console.logoUrl,
-                        contentDescription = console.name,
-                        modifier = Modifier
-                            .weight(1f, fill = false)
-                            .heightIn(max = 44.dp),
-                        contentScale = ContentScale.Fit,
-                        alignment = Alignment.CenterStart,
-                        onError = { logoFailed = true },
-                    )
-                } else {
-                    Text(
-                        text = console.name,
-                        style = SpTypography.HeadlineMedium,
-                        fontWeight = FontWeight.SemiBold,
-                        color = HeroTextPrimary,
-                        modifier = Modifier.weight(1f, fill = false),
-                    )
-                }
-                if (hasMissingBios) {
-                    Icon(
-                        imageVector = Icons.Filled.Warning,
-                        contentDescription = "BIOS missing for ${console.name}",
-                        tint = SpColor.Warning,
-                        modifier = Modifier.size(16.dp),
-                    )
-                }
-            }
-
-            // Bottom: game count + manufacturer · year
-            Column {
+            Text(
+                text = "${console.gameCount} ${if (console.gameCount == 1) "game" else "games"}",
+                style = SpTypography.BodySmall,
+                color = HeroTextSecondary,
+            )
+            if (consoleInfo != null) {
                 Text(
-                    text = "${console.gameCount} ${if (console.gameCount == 1) "game" else "games"}",
-                    style = SpTypography.BodySmall,
-                    color = HeroTextSecondary,
+                    text = "${consoleInfo.manufacturer} · ${consoleInfo.releaseYear}",
+                    style = SpTypography.LabelSmall,
+                    color = Color.White.copy(alpha = 0.50f),
                 )
-                if (consoleInfo != null) {
-                    Text(
-                        text = "${consoleInfo.manufacturer} · ${consoleInfo.releaseYear}",
-                        style = SpTypography.LabelSmall,
-                        color = Color.White.copy(alpha = 0.50f),
-                    )
-                }
             }
         }
     }
@@ -269,18 +271,21 @@ internal fun ConsoleCardSkeleton(
             .clip(shape)
             .background(SpColor.SurfaceVariant),
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(SpSpacing.Default),
-            verticalArrangement = Arrangement.SpaceBetween,
+        // Centered logo placeholder
+        Box(
+            modifier = Modifier.align(Alignment.Center),
         ) {
             SpShimmer(width = 120.dp, height = 28.dp)
-            Column {
-                SpShimmer(width = 64.dp, height = 12.dp)
-                Spacer(Modifier.height(SpSpacing.XSmall))
-                SpShimmer(width = 96.dp, height = 10.dp)
-            }
+        }
+        // Bottom-left stats placeholder
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(SpSpacing.Default),
+        ) {
+            SpShimmer(width = 64.dp, height = 12.dp)
+            Spacer(Modifier.height(SpSpacing.XSmall))
+            SpShimmer(width = 96.dp, height = 10.dp)
         }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
@@ -273,6 +273,41 @@ fun SettingsScreen(
                 }
             }
 
+            // Display section
+            item { Spacer(Modifier.height(SpSpacing.Medium)) }
+            item { SettingsSectionHeader(title = "Display") }
+
+            item {
+                SpCard {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = SpSpacing.Small),
+                    ) {
+                        SpRadioOption(
+                            title = "Auto",
+                            description = "Follow system orientation",
+                            isSelected = state.orientationLock == "auto",
+                            onClick = { viewModel.onIntent(SettingsIntent.SetOrientationLock("auto")) },
+                        )
+                        SettingsDivider()
+                        SpRadioOption(
+                            title = "Landscape",
+                            description = "Lock to landscape orientation",
+                            isSelected = state.orientationLock == "landscape",
+                            onClick = { viewModel.onIntent(SettingsIntent.SetOrientationLock("landscape")) },
+                        )
+                        SettingsDivider()
+                        SpRadioOption(
+                            title = "Portrait",
+                            description = "Lock to portrait orientation",
+                            isSelected = state.orientationLock == "portrait",
+                            onClick = { viewModel.onIntent(SettingsIntent.SetOrientationLock("portrait")) },
+                        )
+                    }
+                }
+            }
+
             // Emulation section
             item { Spacer(Modifier.height(SpSpacing.Medium)) }
             item { SettingsSectionHeader(title = "Emulation") }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SettingsViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SettingsViewModel.kt
@@ -56,6 +56,7 @@ data class SettingsState(
     val showDeleteDeviceConfirm: Long? = null,
     val scrollIndex: Int = 0,
     val scrollOffset: Int = 0,
+    val orientationLock: String = "auto",
 )
 
 sealed interface SettingsIntent {
@@ -89,6 +90,7 @@ sealed interface SettingsIntent {
     data object DismissDeleteDeviceConfirm : SettingsIntent
     data class SaveScrollPosition(val index: Int, val offset: Int) : SettingsIntent
     data object SyncNow : SettingsIntent
+    data class SetOrientationLock(val mode: String) : SettingsIntent
 }
 
 class SettingsViewModel(
@@ -173,12 +175,18 @@ class SettingsViewModel(
             is SettingsIntent.SaveScrollPosition ->
                 _state.update { it.copy(scrollIndex = intent.index, scrollOffset = intent.offset) }
             SettingsIntent.SyncNow -> syncNow()
+            is SettingsIntent.SetOrientationLock -> setOrientationLock(intent.mode)
         }
     }
 
     val syncState: StateFlow<SyncState> = syncEngine.syncState
     val isOnline: StateFlow<Boolean> = connectivityMonitor.isOnline
     val connectionState: StateFlow<ConnectionState> = connectivityMonitor.connectionState
+
+    private fun setOrientationLock(mode: String) {
+        preferencesRepository.setOrientationLock(mode)
+        _state.update { it.copy(orientationLock = mode) }
+    }
 
     private fun syncNow() {
         scope.launch(dispatchers.io) {
@@ -207,6 +215,7 @@ class SettingsViewModel(
             val cacheSize = downloadRepository.getCacheSize()
             val deviceName = deviceManager.getDeviceName()
             val activeServer = serverRepository.getActiveServer()
+            val orientationLock = preferencesRepository.getOrientationLock()
             _state.update {
                 it.copy(
                     userId = user?.id ?: "",
@@ -214,6 +223,7 @@ class SettingsViewModel(
                     serverUrl = activeServer?.url?.trimEnd('/') ?: "",
                     cacheSize = cacheSize,
                     deviceName = deviceName,
+                    orientationLock = orientationLock,
                 )
             }
 

--- a/player/shared/src/commonMain/sqldelight/com/spela/player/SpelaDatabase.sq
+++ b/player/shared/src/commonMain/sqldelight/com/spela/player/SpelaDatabase.sq
@@ -332,3 +332,18 @@ UPDATE LocalSaveDataEntity SET sync_status = 'synced', server_id = ? WHERE id = 
 
 deleteLocalSaveData:
 DELETE FROM LocalSaveDataEntity WHERE id = ?;
+
+-- Device-local settings (generic key-value, never synced to server)
+CREATE TABLE DeviceSettingEntity (
+    key TEXT NOT NULL PRIMARY KEY,
+    value TEXT NOT NULL
+);
+
+insertDeviceSetting:
+INSERT OR REPLACE INTO DeviceSettingEntity(key, value) VALUES (?, ?);
+
+getDeviceSetting:
+SELECT value FROM DeviceSettingEntity WHERE key = ?;
+
+deleteDeviceSetting:
+DELETE FROM DeviceSettingEntity WHERE key = ?;

--- a/player/shared/src/commonMain/sqldelight/com/spela/player/migrations/1.sqm
+++ b/player/shared/src/commonMain/sqldelight/com/spela/player/migrations/1.sqm
@@ -1,0 +1,5 @@
+-- Migration from schema version 1 to 2: add DeviceSettingEntity table
+CREATE TABLE DeviceSettingEntity (
+    key TEXT NOT NULL PRIMARY KEY,
+    value TEXT NOT NULL
+);

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/di/PlatformModule.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/di/PlatformModule.kt
@@ -31,24 +31,6 @@ import org.koin.dsl.module
 actual fun platformModule(): Module = module {
     single {
         val dbPath = "spela.db"
-        val dbFile = java.io.File(dbPath)
-
-        // Validate existing database schema before opening
-        if (dbFile.exists()) {
-            try {
-                val checkDriver = JdbcSqliteDriver("jdbc:sqlite:$dbPath")
-                val errorMessage = validateSchemaWithDriver(checkDriver)
-                checkDriver.close()
-                if (errorMessage != null) {
-                    println("Spela: $errorMessage")
-                    DatabaseHealthCheck.reportError("$errorMessage Please reset the app.")
-                }
-            } catch (e: Exception) {
-                println("Spela: Failed to validate database: ${e.message}")
-                DatabaseHealthCheck.reportError("Database validation failed: ${e.message}. Please reset the app.")
-            }
-        }
-
         val driver = JdbcSqliteDriver("jdbc:sqlite:$dbPath")
 
         val currentVersion: Long = driver.executeQuery(
@@ -78,11 +60,26 @@ actual fun platformModule(): Module = module {
 
             if (tableCount == 0L) {
                 SpelaDatabase.Schema.create(driver)
+            } else {
+                // Existing DB from before versioning — run migrations from v1
+                SpelaDatabase.Schema.migrate(driver, 1, schemaVersion)
             }
             driver.execute(null, "PRAGMA user_version = $schemaVersion", 0)
         } else if (currentVersion < schemaVersion) {
             SpelaDatabase.Schema.migrate(driver, currentVersion, schemaVersion)
             driver.execute(null, "PRAGMA user_version = $schemaVersion", 0)
+        }
+
+        // Validate schema after create/migrate to catch corruption
+        try {
+            val errorMessage = validateSchemaWithDriver(driver)
+            if (errorMessage != null) {
+                println("Spela: $errorMessage")
+                DatabaseHealthCheck.reportError("$errorMessage Please reset the app.")
+            }
+        } catch (e: Exception) {
+            println("Spela: Failed to validate database: ${e.message}")
+            DatabaseHealthCheck.reportError("Database validation failed: ${e.message}. Please reset the app.")
         }
 
         driver

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
@@ -325,6 +325,8 @@ class SyncEngineTest {
         override suspend fun resolveShader(consoleId: String) = ShaderPreset.NONE
         override suspend fun syncKeyMappingsFromServer() {}
         override suspend fun pushKeyMappingsToServer() {}
+        override fun getOrientationLock(): String = "auto"
+        override fun setOrientationLock(mode: String) {}
     }
 
     private class NoOpGameRepository : GameRepository {
@@ -357,6 +359,8 @@ class SyncEngineTest {
         override suspend fun resolveShader(consoleId: String) = ShaderPreset.NONE
         override suspend fun syncKeyMappingsFromServer() {}
         override suspend fun pushKeyMappingsToServer() {}
+        override fun getOrientationLock(): String = "auto"
+        override fun setOrientationLock(mode: String) {}
     }
 
     private class FailingGameRepository : GameRepository {
@@ -393,6 +397,8 @@ class SyncEngineTest {
         override suspend fun resolveShader(consoleId: String) = ShaderPreset.NONE
         override suspend fun syncKeyMappingsFromServer() {}
         override suspend fun pushKeyMappingsToServer() {}
+        override fun getOrientationLock(): String = "auto"
+        override fun setOrientationLock(mode: String) {}
     }
 
     private class TrackingGameRepository : GameRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -384,6 +384,8 @@ class NavigationViewModelTest {
         override suspend fun resolveShader(consoleId: String) = ShaderPreset.NONE
         override suspend fun syncKeyMappingsFromServer() {}
         override suspend fun pushKeyMappingsToServer() {}
+        override fun getOrientationLock(): String = "auto"
+        override fun setOrientationLock(mode: String) {}
     }
 
     private class NoOpGameRepository : GameRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
@@ -336,6 +336,8 @@ class KeyMappingViewModelTest {
         override suspend fun pushDeviceShaderOverridesToServer() {}
         override suspend fun syncKeyMappingsFromServer() {}
         override suspend fun pushKeyMappingsToServer() { pushKeyMappingsCalled = true }
+        override fun getOrientationLock(): String = "auto"
+        override fun setOrientationLock(mode: String) {}
     }
 
     private class FakeKeyMappingRepository : KeyMappingRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -324,6 +324,8 @@ class StubPreferencesRepository : PreferencesRepository {
     override suspend fun pushDeviceShaderOverridesToServer() {}
     override suspend fun syncKeyMappingsFromServer() {}
     override suspend fun pushKeyMappingsToServer() {}
+    override fun getOrientationLock(): String = "auto"
+    override fun setOrientationLock(mode: String) {}
 }
 
 class StubAchievementsRepository : AchievementsRepository {


### PR DESCRIPTION
## Summary

- **Fix Genesis crash**: Games using `genesis_plus_gx` core crashed with `Canvas: trying to use a recycled bitmap` when the core reported its video dimensions. Removed bitmap recycling on frame dimension change since Compose may still be drawing the previous front buffer. Added `isRecycled` guards as defense-in-depth.
- **Fix progress bar going backwards**: `SpProgressBar` now tracks the maximum progress seen and only animates forward, preventing visual regression during downloads.
- **Add orientation lock setting**: New per-device setting (auto/landscape/portrait) stored in a `DeviceSettingEntity` key-value table via SQLDelight. Includes schema migration (`1.sqm`), full Settings UI with radio options, and Android `requestedOrientation` application with live updates.
- **Reduce right stick scroll speed**: Changed the scroll multiplier from `2f` to `0.5f` (75% slower than before).
- **Fix Android DB validation**: Refactored `validateSchemaAndroid` to use the same `SqlDriver` connection instead of opening a separate `SQLiteDatabase`, fixing a WAL visibility issue where the validation couldn't see newly migrated tables.

## Test plan

- [x] All 406 desktop E2E tests pass (including new `SettingsOrientationTest` with 5 tests)
- [x] Genesis game (Sonic the Hedgehog) launches and runs on AYN Thor — no crash
- [x] App starts correctly after upgrade (migration creates `DeviceSettingEntity`, no "Database Error" screen)
- [ ] Verify orientation lock on device (Settings → Display → Landscape/Portrait)
- [ ] Verify right stick scroll speed feels appropriate
- [ ] Verify download progress bar doesn't go backwards