### PR TITLE
fix: remove spinner from play button during sync

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -671,7 +671,7 @@ private fun GameInfoContent(
                     text = if (hasSaves) "Resume" else "Play",
                     onClick = { onPlay(gameId) },
                     enabled = !hasRequiredBiosMissing && !isSyncing,
-                    isLoading = isSyncing && syncState?.isTimedOut != true,
+                    isLoading = false,
                     modifier = Modifier
                         .shadow(10.dp, shadowShape, ambientColor = shadowColor, spotColor = shadowColor)
                         .semantics {


### PR DESCRIPTION
The play button was showing a spinner AND there was already a spinner in the status row below it — two spinners was too much. The button is now just disabled (grayed out) while the status row below handles the visual feedback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)