### PR TITLE
fix: cheat import reliability improvements

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/CheatsUiTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/CheatsUiTest.kt
@@ -108,6 +108,39 @@ class CheatsUiTest {
         assertTrue(harness.cheatRepo.cheats.first { it.id == "c1" }.enabled)
     }
 
+    // --- Load After Download ---
+
+    @Test
+    fun cheatsLoadedAfterDownloadingGame() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness)
+
+        // Cheats should already be loaded from initial loadGame → loadCheats
+        val stateBefore = harness.gameDetailViewModel.state.value
+        assertEquals(3, stateBefore.cheats.size, "cheats loaded on initial game load")
+
+        // Clear cheats in repo to simulate a scenario where initial load didn't have them,
+        // then re-add them so the post-download loadCheats can fetch them
+        harness.cheatRepo.cheats.clear()
+        // Force clear VM state to simulate no cheats loaded
+        harness.gameDetailViewModel.onIntent(GameDetailIntent.LoadCheats("1"))
+        advance(harness)
+        assertEquals(0, harness.gameDetailViewModel.state.value.cheats.size, "cheats cleared")
+
+        // Re-add cheats to repo so post-download loadCheats finds them
+        harness.cheatRepo.cheats.addAll(testCheats)
+
+        // Trigger download — the onSuccess callback should call loadCheats
+        harness.gameDetailViewModel.onIntent(GameDetailIntent.DownloadGame)
+        advanceFully(harness)
+
+        val stateAfter = harness.gameDetailViewModel.state.value
+        assertTrue(stateAfter.isGameCached, "game should be cached after download")
+        assertEquals(3, stateAfter.cheats.size, "cheats should be re-loaded after download")
+    }
+
     // --- Disable All ---
 
     @Test

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/CheatsUiTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/CheatsUiTest.kt
@@ -141,6 +141,7 @@ class CheatsUiTest {
         assertEquals(3, stateAfter.cheats.size, "cheats should be re-loaded after download")
     }
 
+
     // --- Disable All ---
 
     @Test

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -254,6 +254,7 @@ class GameDetailViewModel(
             downloadRepository.downloadGame(gameId, gameTitle).fold(
                 onSuccess = {
                     _state.update { it.copy(isGameCached = true, isDownloading = false) }
+                    currentGameId?.let { loadCheats(it) }
                 },
                 onFailure = { error ->
                     _state.update { it.copy(error = error.message, isDownloading = false) }

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/spela/server/internal/api"
 	"github.com/spela/server/internal/bios"
+	"github.com/spela/server/internal/cheats"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/scanner"
 	"github.com/spela/server/internal/scraper"
@@ -140,6 +141,9 @@ func main() {
 
 	// Auto-download missing BIOS files at startup (non-blocking)
 	bios.StartAutoDownload(store.BiosDir, database)
+
+	// Auto-import cheat codes on first boot (non-blocking)
+	cheats.StartAutoImport(database)
 
 	// Derive WebSocket origins: prefer explicit WS origins, fall back to CORS origins.
 	// This ensures WebSocket origin checking is not more permissive than CORS by default.

--- a/server/internal/cheats/importer.go
+++ b/server/internal/cheats/importer.go
@@ -199,6 +199,7 @@ func StartAutoImport(database *gorm.DB) {
 	}()
 }
 
+
 // ImportAllCheats imports cheat codes for all games that have a matching .cht file.
 func ImportAllCheats(database *gorm.DB, baseURL string) error {
 	// Load all games with their consoles

--- a/server/internal/cheats/importer.go
+++ b/server/internal/cheats/importer.go
@@ -115,6 +115,10 @@ func ParseChtContent(content string) ([]CheatEntry, error) {
 // ImportCheatsForGame fetches and imports cheat codes for a single game.
 // Returns nil if the game's console has no cheat folder or if the game has no .cht file.
 func ImportCheatsForGame(database *gorm.DB, game db.Game, console db.Console, baseURL string, httpClient *http.Client) error {
+	if game.VerificationStatus != "verified" {
+		return nil
+	}
+
 	folder, ok := systemFolders[console.FolderName]
 	if !ok {
 		return nil // No cheats for this console
@@ -171,6 +175,28 @@ func ImportCheatsForGame(database *gorm.DB, game db.Game, console db.Console, ba
 		slog.Info("imported cheats", "game", game.Title, "count", len(entries))
 	}
 	return nil
+}
+
+// StartAutoImport checks if cheats have already been imported and, if not,
+// spawns a goroutine that imports cheats for all verified games at startup.
+func StartAutoImport(database *gorm.DB) {
+	var count int64
+	database.Model(&db.CheatCode{}).Count(&count)
+	if count > 0 {
+		slog.Info("cheats already imported, skipping auto-import", "count", count)
+		return
+	}
+
+	go func() {
+		slog.Info("cheat auto-import starting")
+		if err := ImportAllCheats(database, DefaultBaseURL); err != nil {
+			slog.Warn("cheat auto-import failed", "error", err)
+		} else {
+			var imported int64
+			database.Model(&db.CheatCode{}).Count(&imported)
+			slog.Info("cheat auto-import complete", "imported", imported)
+		}
+	}()
 }
 
 // ImportAllCheats imports cheat codes for all games that have a matching .cht file.

--- a/server/internal/cheats/importer_test.go
+++ b/server/internal/cheats/importer_test.go
@@ -26,6 +26,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 	return database
 }
 
+
 func TestParseChtContent_basic(t *testing.T) {
 	content := `cheat0_desc = "Infinite Health"
 cheat0_code = "ABCD-1234"

--- a/server/internal/cheats/importer_test.go
+++ b/server/internal/cheats/importer_test.go
@@ -1,11 +1,30 @@
 package cheats
 
 import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
+	"github.com/spela/server/internal/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
 )
+
+func setupTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&db.Console{}, &db.Game{}, &db.CheatCode{}))
+	return database
+}
 
 func TestParseChtContent_basic(t *testing.T) {
 	content := `cheat0_desc = "Infinite Health"
@@ -55,4 +74,154 @@ func TestSystemFolders_knownConsoles(t *testing.T) {
 func TestSystemFolders_unknownConsole(t *testing.T) {
 	_, ok := systemFolders["nonexistent"]
 	assert.False(t, ok)
+}
+
+func TestImportCheatsForGame_SkipsUnverifiedGames(t *testing.T) {
+	database := setupTestDB(t)
+
+	var requestCount atomic.Int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	console := db.Console{Name: "SNES", Abbreviation: "snes", Extensions: ".sfc", FolderName: "snes"}
+	require.NoError(t, database.Create(&console).Error)
+
+	game := db.Game{
+		ConsoleID:          console.ID,
+		Title:              "Unverified Game",
+		FileName:           "Unverified Game.sfc",
+		FilePath:            "/games/snes/Unverified Game.sfc",
+		VerificationStatus: "unverified",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	err := ImportCheatsForGame(database, game, console, srv.URL, client)
+	require.NoError(t, err)
+
+	assert.Equal(t, int32(0), requestCount.Load(), "should make zero HTTP requests for unverified games")
+
+	var count int64
+	database.Model(&db.CheatCode{}).Count(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestImportCheatsForGame_ImportsVerifiedGames(t *testing.T) {
+	database := setupTestDB(t)
+
+	chtContent := `cheat0_desc = "Infinite Lives"
+cheat0_code = "7E0DB2:09"
+cheat1_desc = "Invincible"
+cheat1_code = "7E14A2:01"`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		expectedPath := fmt.Sprintf("/%s/%s.cht",
+			"Nintendo - Super Nintendo Entertainment System",
+			"Super Mario World (USA)")
+		if r.URL.Path == expectedPath {
+			w.WriteHeader(http.StatusOK)
+			w.Write([]byte(chtContent))
+		} else {
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer srv.Close()
+
+	console := db.Console{Name: "SNES", Abbreviation: "snes", Extensions: ".sfc", FolderName: "snes"}
+	require.NoError(t, database.Create(&console).Error)
+
+	game := db.Game{
+		ConsoleID:          console.ID,
+		Title:              "Super Mario World",
+		FileName:           "Super Mario World (USA).sfc",
+		FilePath:            "/games/snes/Super Mario World (USA).sfc",
+		VerificationStatus: "verified",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	err := ImportCheatsForGame(database, game, console, srv.URL, client)
+	require.NoError(t, err)
+
+	var cheats []db.CheatCode
+	require.NoError(t, database.Where("game_id = ?", game.ID).Find(&cheats).Error)
+	assert.Len(t, cheats, 2)
+}
+
+func TestStartAutoImport_SkipsWhenCheatsExist(t *testing.T) {
+	database := setupTestDB(t)
+
+	console := db.Console{Name: "SNES", Abbreviation: "snes", Extensions: ".sfc", FolderName: "snes"}
+	require.NoError(t, database.Create(&console).Error)
+
+	game := db.Game{
+		ConsoleID:          console.ID,
+		Title:              "Test Game",
+		FileName:           "Test Game.sfc",
+		FilePath:            "/games/snes/Test Game.sfc",
+		VerificationStatus: "verified",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	// Pre-populate a cheat so auto-import should skip
+	cheat := db.CheatCode{
+		GameID:      game.ID,
+		CheatIndex:  0,
+		Description: "Existing cheat",
+		Code:        "ABCD",
+	}
+	require.NoError(t, database.Create(&cheat).Error)
+
+	// StartAutoImport should return immediately without spawning import
+	StartAutoImport(database)
+
+	// Give a moment for any goroutine to start (it shouldn't)
+	time.Sleep(50 * time.Millisecond)
+
+	var count int64
+	database.Model(&db.CheatCode{}).Count(&count)
+	assert.Equal(t, int64(1), count, "should still have only the pre-existing cheat")
+}
+
+func TestStartAutoImport_RunsWhenNoCheats(t *testing.T) {
+	database := setupTestDB(t)
+
+	chtContent := `cheat0_desc = "Test Cheat"
+cheat0_code = "AAAA:01"`
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(chtContent))
+	}))
+	defer srv.Close()
+
+	console := db.Console{Name: "SNES", Abbreviation: "snes", Extensions: ".sfc", FolderName: "snes"}
+	require.NoError(t, database.Create(&console).Error)
+
+	game := db.Game{
+		ConsoleID:          console.ID,
+		Title:              "Test Game",
+		FileName:           "Test Game.sfc",
+		FilePath:            "/games/snes/Test Game.sfc",
+		VerificationStatus: "verified",
+		Console:            console,
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	// No cheats exist, so auto-import should run.
+	// We can't use StartAutoImport directly because it uses DefaultBaseURL.
+	// Instead, test the logic: count == 0 means import should happen.
+	var count int64
+	database.Model(&db.CheatCode{}).Count(&count)
+	assert.Equal(t, int64(0), count, "no cheats should exist before import")
+
+	// Directly call ImportAllCheats with the test server URL to verify it works
+	err := ImportAllCheats(database, srv.URL)
+	require.NoError(t, err)
+
+	database.Model(&db.CheatCode{}).Count(&count)
+	assert.Greater(t, count, int64(0), "cheats should be imported")
 }

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -566,8 +566,8 @@ type Core struct {
 // CheatCode represents a cheat code for a specific game.
 type CheatCode struct {
 	ID          uint   `gorm:"primarykey"`
-	GameID      uint   `gorm:"index;not null"`
-	CheatIndex  int    `gorm:"not null"`
+	GameID      uint   `gorm:"uniqueIndex:idx_game_cheat;not null"`
+	CheatIndex  int    `gorm:"uniqueIndex:idx_game_cheat;not null"`
 	Description string `gorm:"size:512;not null"`
 	Code        string `gorm:"size:1024;not null"`
 }


### PR DESCRIPTION
## Summary
- **Verified-only imports**: Skip cheat fetching for unverified games — their filenames won't match the libretro cheat database, wasting HTTP requests and risking wrong cheats
- **Auto-import on boot**: Cheats auto-populate on first server start (like BIOS files), removing the need for a manual admin trigger
- **Post-download fetch**: Player app re-fetches cheats after downloading a game, ensuring they're available for offline play
- **Unique index fix**: Adds the missing composite unique index on `(game_id, cheat_index)` that the upsert ON CONFLICT clause requires

## Test plan
- [x] Go unit tests: `TestImportCheatsForGame_SkipsUnverifiedGames`, `TestImportCheatsForGame_ImportsVerifiedGames`, `TestStartAutoImport_SkipsWhenCheatsExist`, `TestStartAutoImport_RunsWhenNoCheats`
- [x] Desktop E2E test: `cheatsLoadedAfterDownloadingGame` — verifies cheats populate after download
- [x] Full Go test suite passes (`go test ./...`)
- [x] Full desktop test suite passes (`desktopTest`)