### PR TITLE
fix: Windows build — use sp_dlsym for cheat symbols

### DIFF
--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -710,8 +710,8 @@ static int core_load(const char *path) {
     LOAD_SYM(retro_get_memory_size);
 
     /* Cheat functions are optional — not all cores implement them. */
-    g_core.retro_cheat_reset = (retro_cheat_reset_t)sp_lib_sym(g_core.handle, "retro_cheat_reset");
-    g_core.retro_cheat_set   = (retro_cheat_set_t)sp_lib_sym(g_core.handle, "retro_cheat_set");
+    g_core.retro_cheat_reset = (retro_cheat_reset_t)sp_dlsym(g_core.handle, "retro_cheat_reset");
+    g_core.retro_cheat_set   = (retro_cheat_set_t)sp_dlsym(g_core.handle, "retro_cheat_set");
 
     /* Get system info BEFORE registering callbacks — the environment callback
      * may query the core name (e.g. GET_PREFERRED_HW_RENDER uses it to choose


### PR DESCRIPTION
## Summary
- Fixes `sp_lib_sym` → `sp_dlsym` in cheat function loading (line 713-714 of libretro_bridge.c)
- `sp_lib_sym` is undefined; all other symbol loads use `sp_dlsym`
- This broke the Windows desktop release build in v0.0.32

## Test plan
- [x] Grep confirms no remaining `sp_lib_sym` references
- [ ] Windows release build should now compile