### PR TITLE
feat: native SINC resampler with NEON SIMD

### DIFF
--- a/player/native/CMakeLists.txt
+++ b/player/native/CMakeLists.txt
@@ -10,6 +10,7 @@ set(COMMON_SOURCES
     src/libretro_video.c
     src/libretro_input.c
     src/libretro_achievements.c
+    src/sinc_resampler.c
     rcheevos/src/rc_client_stub.c
 )
 
@@ -148,6 +149,7 @@ else()
                 ${JNI_LIBRARIES}
                 ${Vulkan_LIBRARIES}
                 dl
+                m
             )
         else()
             # Windows: Vulkan + opengl32 (for wglGetProcAddress)

--- a/player/native/src/libretro_audio.c
+++ b/player/native/src/libretro_audio.c
@@ -3,34 +3,66 @@
  *
  * Collects audio samples from the core and buffers them
  * for the Kotlin layer to read and output via platform audio APIs.
+ *
+ * Includes a native SINC resampler for high-quality sample rate conversion
+ * (e.g. 32029 Hz → 48000 Hz) with NEON SIMD on ARM64.
  */
 
 #include "libretro_bridge.h"
+#include "sinc_resampler.h"
 
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 
 /* Audio sample buffer. Stereo interleaved int16.
  * Sized for ~5 frames at 48kHz/60fps (~85ms). With audio-sync pacing
  * the buffer is drained every retro_run(), so this is ample headroom. */
 #define AUDIO_BUFFER_MAX_FRAMES 4096
 
+/* Resampled output buffer. At ratio ~1.5 (48000/32029), 4096 input frames
+ * produce ~6144 output frames. 8192 gives comfortable headroom. */
+#define RESAMPLED_BUFFER_MAX_FRAMES 8192
+
 static struct {
     int16_t  buffer[AUDIO_BUFFER_MAX_FRAMES * 2]; /* stereo */
     size_t   write_pos;  /* in frames */
     double   sample_rate;
     bool     initialized;
+
+    /* SINC resampler */
+    sinc_resampler_t *resampler;
+    int16_t  resampled_buffer[RESAMPLED_BUFFER_MAX_FRAMES * 2]; /* stereo */
+    size_t   resampled_frames;
 } audio_state = {0};
 
 void audio_init(double sample_rate) {
+    /* Destroy previous resampler if any */
+    if (audio_state.resampler) {
+        sinc_resampler_destroy(audio_state.resampler);
+    }
+
     memset(&audio_state, 0, sizeof(audio_state));
     audio_state.sample_rate = sample_rate;
     audio_state.initialized = true;
+
+    /* Create SINC resampler: stereo, 8 taps, 256 subphases */
+    audio_state.resampler = sinc_resampler_create(2, 8, 256);
+#if defined(__aarch64__)
+    printf("[SpelaAudio] SINC resampler created (8 taps, 256 subphases, NEON)\n");
+#else
+    printf("[SpelaAudio] SINC resampler created (8 taps, 256 subphases, scalar)\n");
+#endif
 }
 
 void audio_deinit(void) {
+    if (audio_state.resampler) {
+        sinc_resampler_destroy(audio_state.resampler);
+        audio_state.resampler = NULL;
+    }
     audio_state.initialized = false;
     audio_state.write_pos = 0;
+    audio_state.resampled_frames = 0;
 }
 
 /* Called by core for single stereo sample */
@@ -73,4 +105,41 @@ size_t audio_get_buffer_frames(void) {
 
 void audio_clear_buffer(void) {
     audio_state.write_pos = 0;
+}
+
+/* --- SINC resampler integration --- */
+
+size_t audio_resample(double ratio) {
+    if (!audio_state.resampler || audio_state.write_pos == 0) {
+        audio_state.resampled_frames = 0;
+        return 0;
+    }
+
+    size_t out_frames = sinc_resampler_process(
+        audio_state.resampler,
+        audio_state.buffer,
+        audio_state.write_pos,
+        audio_state.resampled_buffer,
+        RESAMPLED_BUFFER_MAX_FRAMES,
+        ratio
+    );
+
+    audio_state.resampled_frames = out_frames;
+    audio_state.write_pos = 0; /* consumed */
+    return out_frames;
+}
+
+const int16_t *audio_get_resampled_buffer(void) {
+    return audio_state.resampled_buffer;
+}
+
+size_t audio_get_resampled_frames(void) {
+    return audio_state.resampled_frames;
+}
+
+void audio_resampler_reset(void) {
+    if (audio_state.resampler) {
+        sinc_resampler_reset(audio_state.resampler);
+    }
+    audio_state.resampled_frames = 0;
 }

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -1179,6 +1179,22 @@ JNI_FUNC(jint, nativeFillAudioBuffer)(JNIEnv *env, jobject thiz, jshortArray out
     return (jint)copyLen;
 }
 
+JNI_FUNC(jint, nativeResampleAudio)(JNIEnv *env, jobject thiz,
+                                     jshortArray out, jdouble ratio) {
+    size_t frames = audio_resample(ratio);
+    if (frames == 0) return 0;
+    const int16_t *buf = audio_get_resampled_buffer();
+    jsize samples = (jsize)(frames * 2);
+    jsize arrayLen = (*env)->GetArrayLength(env, out);
+    jsize copyLen = samples < arrayLen ? samples : arrayLen;
+    (*env)->SetShortArrayRegion(env, out, 0, copyLen, buf);
+    return (jint)copyLen;
+}
+
+JNI_FUNC(void, nativeResetAudioResampler)(JNIEnv *env, jobject thiz) {
+    audio_resampler_reset();
+}
+
 JNI_FUNC(void, nativeSetInputButton)(JNIEnv *env, jobject thiz,
                                       jint port, jint id, jboolean pressed) {
     input_set_button((unsigned)port, (unsigned)id, pressed == JNI_TRUE);

--- a/player/native/src/libretro_bridge.h
+++ b/player/native/src/libretro_bridge.h
@@ -37,6 +37,10 @@ size_t audio_sample_batch_callback(const int16_t *data, size_t frames);
 const int16_t *audio_get_buffer(void);
 size_t audio_get_buffer_frames(void);
 void audio_clear_buffer(void);
+size_t audio_resample(double ratio);
+const int16_t *audio_get_resampled_buffer(void);
+size_t audio_get_resampled_frames(void);
+void audio_resampler_reset(void);
 
 /* Input subsystem (libretro_input.c) */
 void input_init(void);

--- a/player/native/src/sinc_resampler.c
+++ b/player/native/src/sinc_resampler.c
@@ -1,0 +1,316 @@
+/*
+ * Windowed SINC resampler — Kaiser-windowed sinc, polyphase implementation.
+ *
+ * Design matches RetroArch's audio resampler:
+ *   - Kaiser window (beta=5.0) for excellent stopband attenuation
+ *   - 8 taps, 256 subphases → 16 KB polyphase table (coefficients + deltas)
+ *   - Linear interpolation between adjacent phases for smooth transitions
+ *   - NEON SIMD on ARM64, scalar fallback elsewhere
+ *
+ * The resampler operates on stereo interleaved int16 samples. Internally
+ * it works in float32 for filter precision, converting at I/O boundaries.
+ */
+
+#include "sinc_resampler.h"
+
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+
+/* Portable 16-byte aligned allocation.
+ * aligned_alloc requires C11 and isn't available on older Android NDK targets. */
+static void *alloc_aligned(size_t alignment, size_t size) {
+    void *ptr = NULL;
+    if (posix_memalign(&ptr, alignment, size) != 0) return NULL;
+    return ptr;
+}
+
+/* NEON detection — restrict to AArch64 where vaddvq_f32 is available.
+ * ARMv7 NEON lacks horizontal sum intrinsics, so we use the scalar path. */
+#if defined(__aarch64__)
+#define SINC_USE_NEON 1
+#include <arm_neon.h>
+#else
+#define SINC_USE_NEON 0
+#endif
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+struct sinc_resampler {
+    int channels;
+    int taps;
+    int subphases;
+
+    /* Polyphase coefficient table: coeffs[subphase * taps + tap]
+     * and delta table for linear interpolation between phases. */
+    float *coeffs;      /* [subphases * taps] */
+    float *deltas;      /* [subphases * taps] */
+
+    /* Ring buffer of recent input samples (float, de-interleaved per channel).
+     * history_l[0..taps-1] and history_r[0..taps-1]. */
+    float *history_l;
+    float *history_r;
+    int hist_pos;       /* write cursor (next position to write) */
+
+    /* Fractional input position carried across calls. */
+    double frac_pos;
+};
+
+/* Modified Bessel function of the first kind, order 0 (I0).
+ * Used for the Kaiser window. Series expansion is sufficient
+ * for beta values up to ~20. */
+static double bessel_i0(double x) {
+    double sum = 1.0;
+    double term = 1.0;
+    double xh = x * 0.5;
+    for (int k = 1; k < 20; k++) {
+        term *= (xh / k) * (xh / k);
+        sum += term;
+        if (term < sum * 1e-12) break;
+    }
+    return sum;
+}
+
+/* Precompute polyphase coefficient table with Kaiser-windowed sinc. */
+static void compute_coefficients(sinc_resampler_t *r) {
+    const double beta = 5.0;
+    const double inv_i0_beta = 1.0 / bessel_i0(beta);
+    const int taps = r->taps;
+    const int subphases = r->subphases;
+    const double half_taps = taps * 0.5;
+
+    for (int phase = 0; phase < subphases; phase++) {
+        double frac = (double)phase / subphases;
+        double sum = 0.0;
+
+        /* Compute raw windowed sinc coefficients */
+        for (int t = 0; t < taps; t++) {
+            double n = t - half_taps + 1.0 + frac;
+            double sinc_val;
+            if (fabs(n) < 1e-9) {
+                sinc_val = 1.0;
+            } else {
+                sinc_val = sin(M_PI * n) / (M_PI * n);
+            }
+
+            /* Kaiser window */
+            double win_arg = (2.0 * (t + frac) / taps) - 1.0;
+            double win_val = bessel_i0(beta * sqrt(1.0 - win_arg * win_arg)) * inv_i0_beta;
+
+            double coeff = sinc_val * win_val;
+            r->coeffs[phase * taps + t] = (float)coeff;
+            sum += coeff;
+        }
+
+        /* Normalize so coefficients sum to 1.0 (unity gain) */
+        if (sum != 0.0) {
+            float inv_sum = (float)(1.0 / sum);
+            for (int t = 0; t < taps; t++) {
+                r->coeffs[phase * taps + t] *= inv_sum;
+            }
+        }
+    }
+
+    /* Compute delta table: delta[phase] = coeffs[phase+1] - coeffs[phase]
+     * for linear interpolation between adjacent phases.
+     * Last phase wraps to phase 0 (identical for normalized filters). */
+    for (int phase = 0; phase < subphases; phase++) {
+        int next_phase = (phase + 1) % subphases;
+        for (int t = 0; t < taps; t++) {
+            r->deltas[phase * taps + t] =
+                r->coeffs[next_phase * taps + t] - r->coeffs[phase * taps + t];
+        }
+    }
+}
+
+sinc_resampler_t *sinc_resampler_create(int channels, int taps, int subphases) {
+    sinc_resampler_t *r = (sinc_resampler_t *)calloc(1, sizeof(sinc_resampler_t));
+    if (!r) return NULL;
+
+    r->channels = channels;
+    r->taps = taps;
+    r->subphases = subphases;
+
+    /* Allocate coefficient tables (16-byte aligned for NEON) */
+    size_t table_size = (size_t)(subphases * taps) * sizeof(float);
+    r->coeffs = (float *)alloc_aligned(16, (table_size + 15) & ~(size_t)15);
+    r->deltas = (float *)alloc_aligned(16, (table_size + 15) & ~(size_t)15);
+
+    if (!r->coeffs || !r->deltas) {
+        sinc_resampler_destroy(r);
+        return NULL;
+    }
+
+    compute_coefficients(r);
+
+    /* Allocate history ring buffers (16-byte aligned) */
+    size_t hist_bytes = (size_t)taps * sizeof(float);
+    hist_bytes = (hist_bytes + 15) & ~(size_t)15;
+    r->history_l = (float *)alloc_aligned(16, hist_bytes);
+    r->history_r = (float *)alloc_aligned(16, hist_bytes);
+
+    if (!r->history_l || !r->history_r) {
+        sinc_resampler_destroy(r);
+        return NULL;
+    }
+
+    memset(r->history_l, 0, hist_bytes);
+    memset(r->history_r, 0, hist_bytes);
+    r->hist_pos = 0;
+    r->frac_pos = 0.0;
+
+    return r;
+}
+
+void sinc_resampler_destroy(sinc_resampler_t *r) {
+    if (!r) return;
+    free(r->coeffs);
+    free(r->deltas);
+    free(r->history_l);
+    free(r->history_r);
+    free(r);
+}
+
+void sinc_resampler_reset(sinc_resampler_t *r) {
+    if (!r) return;
+    size_t hist_bytes = (size_t)r->taps * sizeof(float);
+    memset(r->history_l, 0, hist_bytes);
+    memset(r->history_r, 0, hist_bytes);
+    r->hist_pos = 0;
+    r->frac_pos = 0.0;
+}
+
+/* Convolve history buffer with filter coefficients (with delta interpolation).
+ * Returns filtered sample for one channel. */
+static inline float convolve_scalar(const float *history, int hist_pos,
+                                    int taps, const float *coeffs,
+                                    const float *deltas, float delta_frac) {
+    float sum = 0.0f;
+    for (int t = 0; t < taps; t++) {
+        int idx = (hist_pos + t) % taps;
+        float c = coeffs[t] + deltas[t] * delta_frac;
+        sum += history[idx] * c;
+    }
+    return sum;
+}
+
+#if SINC_USE_NEON
+/* NEON-optimized convolution for 8 taps (2 iterations of 4). */
+static inline float convolve_neon(const float *history, int hist_pos,
+                                  int taps, const float *coeffs,
+                                  const float *deltas, float delta_frac) {
+    /* For 8-tap filter with aligned history, we can process 4 at a time.
+     * We need to handle the ring buffer wrap by extracting contiguous data. */
+    float aligned_hist[8] __attribute__((aligned(16)));
+    for (int t = 0; t < taps; t++) {
+        aligned_hist[t] = history[(hist_pos + t) % taps];
+    }
+
+    float32x4_t vfrac = vdupq_n_f32(delta_frac);
+    float32x4_t vsum = vdupq_n_f32(0.0f);
+
+    /* Process taps in groups of 4 */
+    for (int t = 0; t < taps; t += 4) {
+        float32x4_t vh = vld1q_f32(&aligned_hist[t]);
+        float32x4_t vc = vld1q_f32(&coeffs[t]);
+        float32x4_t vd = vld1q_f32(&deltas[t]);
+        /* c + delta * frac */
+        float32x4_t vcoeff = vmlaq_f32(vc, vd, vfrac);
+        vsum = vmlaq_f32(vsum, vh, vcoeff);
+    }
+
+    /* Horizontal sum */
+    return vaddvq_f32(vsum);
+}
+#endif
+
+/* Clamp float to int16 range */
+static inline short clamp_s16(float x) {
+    if (x > 32767.0f) return 32767;
+    if (x < -32768.0f) return -32768;
+    return (short)(x + (x < 0 ? -0.5f : 0.5f));
+}
+
+size_t sinc_resampler_process(sinc_resampler_t *r,
+                              const short *input, size_t input_frames,
+                              short *output, size_t max_output_frames,
+                              double ratio) {
+    if (!r || !input || !output || input_frames == 0 || ratio <= 0.0)
+        return 0;
+
+    const int taps = r->taps;
+    const int subphases = r->subphases;
+    const double input_step = 1.0 / ratio;
+    size_t out_count = 0;
+
+    /* Feed input samples into history and generate output */
+    size_t in_consumed = 0;
+    double pos = r->frac_pos;
+
+    while (out_count < max_output_frames) {
+        /* Feed input samples into history until we have enough for the current output position */
+        while (in_consumed <= (size_t)pos && in_consumed < input_frames) {
+            size_t idx = in_consumed * 2; /* stereo interleaved */
+            r->history_l[r->hist_pos] = (float)input[idx];
+            r->history_r[r->hist_pos] = (float)input[idx + 1];
+            r->hist_pos = (r->hist_pos + 1) % taps;
+            in_consumed++;
+        }
+
+        /* Check if we've consumed all input */
+        if (pos >= (double)input_frames) break;
+
+        /* Compute phase and delta fraction for sub-phase interpolation */
+        double int_pos;
+        double frac = modf(pos, &int_pos);
+        double phase_exact = frac * subphases;
+        int phase = (int)phase_exact;
+        float delta_frac = (float)(phase_exact - phase);
+        if (phase >= subphases) { phase = subphases - 1; delta_frac = 0.0f; }
+
+        const float *c = &r->coeffs[phase * taps];
+        const float *d = &r->deltas[phase * taps];
+
+        /* The history read position: we want to read the taps samples ending
+         * at the current input position. hist_pos points to where the NEXT
+         * sample will be written, so the oldest sample in the buffer is at
+         * hist_pos (it's a ring buffer of size taps). */
+        int read_pos = r->hist_pos; /* oldest sample */
+
+        float out_l, out_r;
+#if SINC_USE_NEON
+        if (taps == 8) {
+            out_l = convolve_neon(r->history_l, read_pos, taps, c, d, delta_frac);
+            out_r = convolve_neon(r->history_r, read_pos, taps, c, d, delta_frac);
+        } else {
+            out_l = convolve_scalar(r->history_l, read_pos, taps, c, d, delta_frac);
+            out_r = convolve_scalar(r->history_r, read_pos, taps, c, d, delta_frac);
+        }
+#else
+        out_l = convolve_scalar(r->history_l, read_pos, taps, c, d, delta_frac);
+        out_r = convolve_scalar(r->history_r, read_pos, taps, c, d, delta_frac);
+#endif
+
+        output[out_count * 2]     = clamp_s16(out_l);
+        output[out_count * 2 + 1] = clamp_s16(out_r);
+        out_count++;
+
+        pos += input_step;
+    }
+
+    /* Consume any remaining input into history */
+    while (in_consumed < input_frames) {
+        size_t idx = in_consumed * 2;
+        r->history_l[r->hist_pos] = (float)input[idx];
+        r->history_r[r->hist_pos] = (float)input[idx + 1];
+        r->hist_pos = (r->hist_pos + 1) % taps;
+        in_consumed++;
+    }
+
+    /* Carry fractional position to next call */
+    r->frac_pos = pos - (double)input_frames;
+
+    return out_count;
+}

--- a/player/native/src/sinc_resampler.h
+++ b/player/native/src/sinc_resampler.h
@@ -1,0 +1,43 @@
+/*
+ * Windowed SINC resampler with NEON SIMD optimization.
+ *
+ * Kaiser-windowed sinc filter (beta=5.0, 8 taps, 256 subphases) matching
+ * RetroArch's audio quality. NEON intrinsics on ARM64, scalar fallback
+ * on x86/armeabi-v7a.
+ *
+ * Usage:
+ *   sinc_resampler_t *r = sinc_resampler_create(2, 8, 256);
+ *   size_t out = sinc_resampler_process(r, in, in_frames, out, max_out, ratio);
+ *   sinc_resampler_destroy(r);
+ */
+
+#ifndef SINC_RESAMPLER_H
+#define SINC_RESAMPLER_H
+
+#include <stddef.h>
+
+typedef struct sinc_resampler sinc_resampler_t;
+
+/* Allocate resampler and precompute polyphase coefficient table.
+ * channels: 1 (mono) or 2 (stereo)
+ * taps:     filter length (must be even, typically 8)
+ * subphases: phase table resolution (typically 256) */
+sinc_resampler_t *sinc_resampler_create(int channels, int taps, int subphases);
+
+/* Free resampler and all internal buffers. */
+void sinc_resampler_destroy(sinc_resampler_t *r);
+
+/* Reset internal state (history buffer, fractional position).
+ * Call on seek or discontinuity. */
+void sinc_resampler_reset(sinc_resampler_t *r);
+
+/* Resample input_frames of interleaved int16 audio to output buffer.
+ * ratio = output_rate / input_rate (e.g. 48000/32029 ≈ 1.499).
+ * Returns number of output frames written.
+ * Carries fractional position across calls for seamless boundaries. */
+size_t sinc_resampler_process(sinc_resampler_t *r,
+                              const short *input, size_t input_frames,
+                              short *output, size_t max_output_frames,
+                              double ratio);
+
+#endif /* SINC_RESAMPLER_H */

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidAudioPlayer.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidAudioPlayer.kt
@@ -4,29 +4,25 @@ import android.media.AudioAttributes
 import android.media.AudioFormat
 import android.media.AudioTrack
 import android.util.Log
-import kotlin.math.floor
 
 /**
- * Android audio output modeled on RetroArch's audio pipeline:
+ * Android audio output with native SINC resampling:
  *
- *   core samples (32029 Hz) → linear interpolation resampler → AudioTrack (48000 Hz)
+ *   core samples (32029 Hz) → native SINC resampler (NEON on ARM64)
+ *   → AudioTrack (48000 Hz) with dynamic rate control
  *
- * The resampler converts from the core's native sample rate to a fixed 48000 Hz
- * output rate (matching most Android HAL native rates), with a dynamic ratio
- * adjustment of ±0.5% based on the AudioTrack buffer fill level.
+ * The native SINC resampler (Kaiser-windowed, 8 taps, 256 subphases) provides
+ * high-quality sample rate conversion matching RetroArch's audio quality.
  *
- * This dynamic rate control (identical to RetroArch's `audio_driver_flush`)
- * keeps the buffer hovering at ~50% full:
- * - Buffer emptier than target → ratio increases → more output samples → fills buffer
- * - Buffer fuller than target → ratio decreases → fewer output samples → drains buffer
- *
- * The ±0.5% pitch change is inaudible (<9 cents). Combined with blocking writes
- * as a safety backpressure mechanism, this eliminates both underruns (crackle)
- * and overruns (blocking stalls).
+ * Dynamic rate control (±0.5% pitch adjustment based on AudioTrack buffer fill)
+ * keeps the buffer at ~50% full, eliminating both underruns and overruns.
  *
  * The AudioTrack is opened lazily on the first [write] call.
  */
-class AndroidAudioPlayer(private val coreSampleRate: Int) {
+class AndroidAudioPlayer(
+    private val coreSampleRate: Int,
+    private val jni: LibretroJni,
+) {
 
     private var audioTrack: AudioTrack? = null
     private var initAttempted = false
@@ -37,20 +33,11 @@ class AndroidAudioPlayer(private val coreSampleRate: Int) {
     /** AudioTrack buffer capacity in stereo frames (at OUTPUT_RATE). */
     private var bufferCapacityFrames = 0
 
-    // --- Resampler state ---
-
     /** Base resampling ratio: OUTPUT_RATE / coreSampleRate (e.g. 48000/32029 ≈ 1.499). */
     private val baseRatio = OUTPUT_RATE.toDouble() / coreSampleRate
 
-    /** Fractional input position carried across write() calls for seamless resampling. */
-    private var resamplePos = 0.0
-
-    /** Last input sample from previous call, for cross-boundary interpolation. */
-    private var prevSampleL: Short = 0
-    private var prevSampleR: Short = 0
-
-    /** Reusable output buffer for resampled audio. */
-    private var outputBuffer = ShortArray(4096)
+    /** Reusable output buffer for resampled audio from native. */
+    private var outputBuffer = ShortArray(16384)
 
     companion object {
         private const val TAG = "AndroidAudioPlayer"
@@ -111,9 +98,6 @@ class AndroidAudioPlayer(private val coreSampleRate: Int) {
 
             audioTrack?.play()
             totalWrittenFrames = 0
-            resamplePos = 0.0
-            prevSampleL = 0
-            prevSampleR = 0
             Log.i(TAG, "AudioTrack opened at $OUTPUT_RATE Hz (buffer=$bufferSize bytes, " +
                 "~${bufferSize * 1000 / (OUTPUT_RATE * frameBytes)}ms, $bufferCapacityFrames frames)")
             return true
@@ -138,134 +122,41 @@ class AndroidAudioPlayer(private val coreSampleRate: Int) {
         }
         audioTrack = null
         initAttempted = false
-        resamplePos = 0.0
-        prevSampleL = 0
-        prevSampleR = 0
     }
 
     /**
-     * Accept audio samples from the core, resample to [OUTPUT_RATE] with
-     * dynamic rate control, and write to the AudioTrack.
+     * Calculate the dynamic resampling ratio based on AudioTrack buffer fill.
      *
-     * The dynamic ratio adjustment (RetroArch's formula) keeps the AudioTrack
-     * buffer at ~50% fill, compensating for clock drift between the system
-     * clock (which drives frame pacing) and the audio hardware clock.
-     *
-     * @param samples Stereo interleaved int16 samples at [coreSampleRate]
-     * @param count Number of valid shorts in the array
+     * The formula (RetroArch's audio_driver_flush) keeps the buffer at ~50% full:
+     * - Buffer emptier than target → ratio increases → more output → fills buffer
+     * - Buffer fuller than target → ratio decreases → fewer output → drains buffer
      */
-    fun write(samples: ShortArray, count: Int) {
-        if (count <= 0) return
-        if (!ensureStarted()) return
-        val track = audioTrack ?: return
-
-        val inputFrames = count / 2
-
-        // --- Dynamic rate control (RetroArch audio_driver_flush formula) ---
-        //
-        // avail     = free space in buffer
-        // half_size = target: half the buffer should be free
-        // direction = (avail - half_size) / half_size  ∈ [-1, +1]
-        // adjust    = 1.0 + 0.005 * direction
-        //
-        // When buffer is emptier than target: direction > 0 → adjust > 1 → more output → fills buffer
-        // When buffer is fuller than target:  direction < 0 → adjust < 1 → less output → drains buffer
+    fun calculateRatio(): Double {
+        val track = audioTrack ?: return baseRatio
         val played = track.playbackHeadPosition.toLong()
         val buffered = (totalWrittenFrames - played).coerceAtLeast(0)
         val halfSize = (bufferCapacityFrames / 2).coerceAtLeast(1)
         val avail = (bufferCapacityFrames - buffered).coerceAtLeast(0)
         val direction = (avail - halfSize).toDouble() / halfSize
         val adjust = 1.0 + RATE_CONTROL_DELTA * direction
-
-        // Resample: core rate → OUTPUT_RATE, incorporating dynamic adjustment
-        val ratio = baseRatio * adjust
-        val outFrames = resample(samples, inputFrames, ratio)
-
-        // Blocking write — acts as safety backpressure. When rate control keeps
-        // the buffer at ~50%, writes return immediately. Only blocks if the
-        // buffer is completely full (rare transient).
-        if (outFrames > 0) {
-            val written = track.write(outputBuffer, 0, outFrames * 2)
-            if (written > 0) {
-                totalWrittenFrames += written / 2
-            }
-        }
-
+        return baseRatio * adjust
     }
 
     /**
-     * Linear interpolation resampler. Converts [inputFrames] stereo frames at
-     * [coreSampleRate] to output at [OUTPUT_RATE] × adjust, using the given
-     * combined [ratio] (= OUTPUT_RATE / coreSampleRate × adjust).
+     * Resample buffered core audio via native SINC resampler and write to AudioTrack.
      *
-     * Maintains [resamplePos] across calls for seamless sample-accurate
-     * boundary handling. Saves the last input sample for cross-boundary
-     * interpolation.
-     *
-     * @return Number of output stereo frames written to [outputBuffer]
+     * @param ratio Dynamic resampling ratio from [calculateRatio]
      */
-    private fun resample(input: ShortArray, inputFrames: Int, ratio: Double): Int {
-        if (inputFrames <= 0 || ratio <= 0) return 0
+    fun write(ratio: Double) {
+        if (!ensureStarted()) return
+        val track = audioTrack ?: return
 
-        // Input samples consumed per output sample (< 1 for upsampling)
-        val inputStep = 1.0 / ratio
+        val sampleCount = jni.nativeResampleAudio(outputBuffer, ratio)
+        if (sampleCount <= 0) return
 
-        // Ensure output buffer is large enough
-        val maxOutput = ((inputFrames / inputStep) + 4).toInt()
-        if (outputBuffer.size < maxOutput * 2) {
-            outputBuffer = ShortArray(maxOutput * 2 + 64)
+        val written = track.write(outputBuffer, 0, sampleCount)
+        if (written > 0) {
+            totalWrittenFrames += written / 2
         }
-
-        var outCount = 0
-
-        while (resamplePos < inputFrames.toDouble()) {
-            val idx = floor(resamplePos).toInt()
-            val frac = resamplePos - idx
-
-            val s0L: Int
-            val s0R: Int
-            val s1L: Int
-            val s1R: Int
-
-            when {
-                idx < 0 -> {
-                    // Cross-boundary: interpolate between previous call's last
-                    // sample and this call's first sample
-                    s0L = prevSampleL.toInt()
-                    s0R = prevSampleR.toInt()
-                    s1L = input[0].toInt()
-                    s1R = input[1].toInt()
-                }
-                idx >= inputFrames - 1 -> {
-                    // At last sample — hold (next call will provide the neighbor)
-                    s0L = input[(inputFrames - 1) * 2].toInt()
-                    s0R = input[(inputFrames - 1) * 2 + 1].toInt()
-                    s1L = s0L
-                    s1R = s0R
-                }
-                else -> {
-                    s0L = input[idx * 2].toInt()
-                    s0R = input[idx * 2 + 1].toInt()
-                    s1L = input[(idx + 1) * 2].toInt()
-                    s1R = input[(idx + 1) * 2 + 1].toInt()
-                }
-            }
-
-            outputBuffer[outCount * 2] = ((1.0 - frac) * s0L + frac * s1L).toInt().toShort()
-            outputBuffer[outCount * 2 + 1] = ((1.0 - frac) * s0R + frac * s1R).toInt().toShort()
-            outCount++
-            resamplePos += inputStep
-        }
-
-        // Save last input sample for next call's cross-boundary interpolation
-        if (inputFrames > 0) {
-            prevSampleL = input[(inputFrames - 1) * 2]
-            prevSampleR = input[(inputFrames - 1) * 2 + 1]
-        }
-
-        // Carry fractional position to next call
-        resamplePos -= inputFrames
-
-        return outCount
     }
 }

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
@@ -76,7 +76,7 @@ class AndroidLibretroController(
     private val _frameBitmap = MutableStateFlow<Bitmap?>(null)
     val frameBitmap: StateFlow<Bitmap?> = _frameBitmap.asStateFlow()
 
-    /* Audio output — blocking writes provide audio-sync frame pacing */
+    /* Audio output — native SINC resampler with dynamic rate control */
     private var audioPlayer: AndroidAudioPlayer? = null
 
     /* Emulation-thread dispatch: some cores (Dolphin) require retro_serialize,
@@ -103,10 +103,6 @@ class AndroidLibretroController(
 
     /* Reusable byte buffer for video frame data from JNI (avoids NewByteArray per frame) */
     private var videoFrameBuffer = ByteArray(0)
-
-    /* Reusable short buffer for audio samples from JNI (avoids NewShortArray per frame) */
-    private var audioSampleBuffer = ShortArray(0)
-
 
     /* Handler for posting state updates to the main thread (avoids Compose multithreading crash) */
     private val mainHandler = Handler(Looper.getMainLooper())
@@ -303,8 +299,8 @@ class AndroidLibretroController(
             val sampleRate = jni.nativeGetSampleRate().toInt()
             Log.i(TAG, "Core sample rate: $sampleRate Hz")
             if (sampleRate > 0) {
-                audioPlayer = AndroidAudioPlayer(sampleRate)
-                Log.i(TAG, "AndroidAudioPlayer created at $sampleRate Hz")
+                audioPlayer = AndroidAudioPlayer(sampleRate, jni)
+                Log.i(TAG, "AndroidAudioPlayer created at $sampleRate Hz (native SINC resampler)")
             } else {
                 Log.w(TAG, "Core reported invalid sample rate: $sampleRate")
             }
@@ -350,8 +346,8 @@ class AndroidLibretroController(
                 updateVideoFrame()
             }
 
-            // Push audio (resampled to 48kHz with dynamic rate control,
-            // blocking write as safety backpressure).
+            // Push audio (resampled to 48kHz via native SINC resampler with
+            // dynamic rate control). Frame pacing via precisionSleep.
             if (!fastForward) {
                 pushAudio()
                 precisionSleep(frameStart + frameTimeNs)
@@ -635,30 +631,27 @@ class AndroidLibretroController(
     }
 
     /**
-     * Drain audio samples from the native layer and write to AudioTrack (non-blocking).
-     * Frame pacing is handled by precisionSleep on the system clock.
-     * The AudioTrack's large buffer (~80ms) absorbs timing jitter.
+     * Resample audio via native SINC resampler and write to AudioTrack.
+     * Rate control stays in Kotlin (reads AudioTrack.playbackHeadPosition).
      */
     private fun pushAudio() {
-        if (audioSampleBuffer.size < 4096) {
-            audioSampleBuffer = ShortArray(4096)
-        }
-
-        val count = jni.nativeFillAudioBuffer(audioSampleBuffer)
-        if (count > 0) {
-            audioPlayer?.write(audioSampleBuffer, count)
-        }
+        val player = audioPlayer ?: return
+        val ratio = player.calculateRatio()
+        player.write(ratio)
     }
 
+    /** Reusable buffer for discarding audio during fast-forward. */
+    private var discardBuffer = ShortArray(0)
+
     /**
-     * Drain audio samples from the native layer without writing to AudioTrack.
-     * Used during fast-forward to prevent the native audio buffer from growing unbounded.
+     * Discard audio samples during fast-forward.
+     * Clears the native buffer without resampling or writing to AudioTrack.
      */
     private fun pushAudioDiscard() {
-        if (audioSampleBuffer.size < 4096) {
-            audioSampleBuffer = ShortArray(4096)
+        if (discardBuffer.size < 4096) {
+            discardBuffer = ShortArray(4096)
         }
-        jni.nativeFillAudioBuffer(audioSampleBuffer)
+        jni.nativeFillAudioBuffer(discardBuffer)
     }
 
     /**

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
@@ -36,6 +36,8 @@ class LibretroJni {
     /* Audio */
     external fun nativeGetAudioBuffer(): ShortArray?
     external fun nativeFillAudioBuffer(out: ShortArray): Int
+    external fun nativeResampleAudio(out: ShortArray, ratio: Double): Int
+    external fun nativeResetAudioResampler()
 
     /* Input */
     external fun nativeSetInputButton(port: Int, id: Int, pressed: Boolean)

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/LibretroJni.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/LibretroJni.kt
@@ -35,6 +35,8 @@ class LibretroJni {
 
     /* Audio */
     external fun nativeGetAudioBuffer(): ShortArray?
+    external fun nativeResampleAudio(out: ShortArray, ratio: Double): Int
+    external fun nativeResetAudioResampler()
 
     /* Input */
     external fun nativeSetInputButton(port: Int, id: Int, pressed: Boolean)


### PR DESCRIPTION
## Summary

- Add native C windowed SINC resampler (Kaiser beta=5.0, 8 taps, 256 subphases) matching RetroArch's audio quality
- NEON SIMD inner loop on AArch64 (4 taps per vector iteration), scalar fallback on ARMv7/x86
- Replace Kotlin linear interpolation resampler with JNI call to native `nativeResampleAudio(out, ratio)`
- Dynamic rate control stays in Kotlin (reads `AudioTrack.playbackHeadPosition` for ±0.5% pitch adjustment)
- Desktop unaffected — JNI declarations added for symbol consistency but never called

## Test plan

- [x] Desktop tests pass (`./gradlew :shared:desktopTest` — all 413 tests)
- [x] Android build succeeds for arm64-v8a, armeabi-v7a, x86_64
- [x] Installed and tested on AYN Thor — clean audio confirmed
- [ ] Test SNES, Genesis, GameCube for audio quality (no crackles, no aliasing)
- [ ] Verify `adb logcat | grep SpelaAudio` shows "SINC resampler created (NEON)" on ARM64