### PR TITLE
fix: clamshell close crashes GameCube and doesn't pause NES

### DIFF
--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -101,6 +101,21 @@ class MainActivity : ComponentActivity() {
         }
     }
 
+    override fun onPause() {
+        val state = emulationViewModel.state.value
+        if (state.isRunning && !state.isPaused) {
+            emulationViewModel.onIntent(EmulationIntent.LifecyclePause)
+        }
+        super.onPause()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        if (emulationViewModel.state.value.isLifecyclePaused) {
+            emulationViewModel.onIntent(EmulationIntent.LifecycleResume)
+        }
+    }
+
     override fun onDestroy() {
         val inputManager = getSystemService(INPUT_SERVICE) as InputManager
         inputManager.unregisterInputDeviceListener(inputDeviceListener)

--- a/player/native/src/gpu_renderer_vulkan.c
+++ b/player/native/src/gpu_renderer_vulkan.c
@@ -213,6 +213,8 @@ struct gpu_renderer {
     VkDescriptorSet hw_descriptor_sets[MAX_FRAMES_IN_FLIGHT];
     sp_mutex_t queue_mutex;
     bool queue_mutex_initialized;
+    sp_mutex_t surface_mutex;        /* serializes hw_render_frame with suspend_surface */
+    bool surface_mutex_initialized;
 
     /* Actual surface dimensions (what the user sees, from SurfaceView callback).
      * May differ from swapchain_extent when preTransform = IDENTITY and the
@@ -370,6 +372,10 @@ void gpu_renderer_suspend_surface(gpu_renderer_t *r) {
     /* Stop rendering FIRST so the core's render thread won't enter
      * hw_render_frame / gpu_renderer_render while we tear down. */
     r->active = false;
+    /* Acquire surface_mutex to wait for any in-flight hw_render_frame to finish
+     * before destroying swapchain resources. The render thread holds this mutex
+     * for its entire frame, so once we acquire it, no render is in progress. */
+    if (r->surface_mutex_initialized) sp_mutex_lock(&r->surface_mutex);
     /* Serialize with any in-flight queue submission from the render thread */
     if (r->queue_mutex_initialized) sp_mutex_lock(&r->queue_mutex);
     if (r->device) vkDeviceWaitIdle(r->device);
@@ -385,6 +391,7 @@ void gpu_renderer_suspend_surface(gpu_renderer_t *r) {
         r->native_window = NULL;
     }
 #endif
+    if (r->surface_mutex_initialized) sp_mutex_unlock(&r->surface_mutex);
     VK_LOGI("Surface suspended (swapchain+surface destroyed, device kept)");
 }
 
@@ -430,6 +437,10 @@ void gpu_renderer_deinit_surface(gpu_renderer_t *r) {
     if (r->queue_mutex_initialized) {
         sp_mutex_destroy(&r->queue_mutex);
         r->queue_mutex_initialized = false;
+    }
+    if (r->surface_mutex_initialized) {
+        sp_mutex_destroy(&r->surface_mutex);
+        r->surface_mutex_initialized = false;
     }
 
     if (r->offscreen_mode) {
@@ -890,6 +901,13 @@ bool gpu_renderer_hw_vulkan_init(gpu_renderer_t *r) {
         }
         r->queue_mutex_initialized = true;
     }
+    if (!r->surface_mutex_initialized) {
+        if (sp_mutex_init(&r->surface_mutex) != 0) {
+            VK_LOGE("Failed to init surface mutex");
+            return false;
+        }
+        r->surface_mutex_initialized = true;
+    }
 
     /* Create per-frame descriptor pool and sets for HW render */
     VkDescriptorPoolSize pool_size = {
@@ -1233,7 +1251,19 @@ void gpu_renderer_hw_render_frame(gpu_renderer_t *r, unsigned width, unsigned he
         gpu_renderer_hw_render_frame_offscreen(r, width, height);
         return;
     }
+
+    /* Hold surface_mutex for the entire frame to prevent suspend_surface from
+     * destroying the swapchain while we're using it (TOCTOU race). */
+    if (r->surface_mutex_initialized) sp_mutex_lock(&r->surface_mutex);
+    /* Double-check active after acquiring the lock — suspend_surface may have
+     * set it to false while we were waiting for the mutex. */
+    if (!r->active) {
+        if (r->surface_mutex_initialized) sp_mutex_unlock(&r->surface_mutex);
+        return;
+    }
+
     if (!r->hw_current_image.image_view) {
+        if (r->surface_mutex_initialized) sp_mutex_unlock(&r->surface_mutex);
         return;
     }
 
@@ -1245,9 +1275,11 @@ void gpu_renderer_hw_render_frame(gpu_renderer_t *r, unsigned width, unsigned he
                     VK_TRUE, (uint64_t)2000000000); /* 2s timeout */
     if (fence_result == VK_TIMEOUT) {
         VK_LOGE("hw_render_frame: WaitFence timeout on slot %u", r->current_frame);
+        if (r->surface_mutex_initialized) sp_mutex_unlock(&r->surface_mutex);
         return;
     } else if (fence_result != VK_SUCCESS) {
         VK_LOGE("hw_render_frame: WaitFence error=%d slot %u", fence_result, r->current_frame);
+        if (r->surface_mutex_initialized) sp_mutex_unlock(&r->surface_mutex);
         return;
     }
 
@@ -1258,12 +1290,15 @@ void gpu_renderer_hw_render_frame(gpu_renderer_t *r, unsigned width, unsigned he
 
     if (result == VK_ERROR_OUT_OF_DATE_KHR) {
         recreate_swapchain(r);
+        if (r->surface_mutex_initialized) sp_mutex_unlock(&r->surface_mutex);
         return;
     } else if (result == VK_TIMEOUT) {
         VK_LOGE("hw_render_frame: AcquireImage timeout");
+        if (r->surface_mutex_initialized) sp_mutex_unlock(&r->surface_mutex);
         return;
     } else if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
         VK_LOGE("hw_render_frame: vkAcquireNextImageKHR failed: %d", result);
+        if (r->surface_mutex_initialized) sp_mutex_unlock(&r->surface_mutex);
         return;
     }
 
@@ -1323,6 +1358,7 @@ void gpu_renderer_hw_render_frame(gpu_renderer_t *r, unsigned width, unsigned he
         VK_LOGE("hw_render_frame: pipeline[%d] is NULL, skipping frame", shader_idx);
         vkCmdEndRenderPass(cmd);
         vkEndCommandBuffer(cmd);
+        if (r->surface_mutex_initialized) sp_mutex_unlock(&r->surface_mutex);
         return;
     }
     vkCmdBindPipeline(cmd, VK_PIPELINE_BIND_POINT_GRAPHICS, r->pipelines[shader_idx]);
@@ -1419,6 +1455,7 @@ void gpu_renderer_hw_render_frame(gpu_renderer_t *r, unsigned width, unsigned he
 
     if (result != VK_SUCCESS) {
         VK_LOGE("hw_render_frame: vkQueueSubmit failed: %d", result);
+        if (r->surface_mutex_initialized) sp_mutex_unlock(&r->surface_mutex);
         return;
     }
 
@@ -1449,6 +1486,8 @@ void gpu_renderer_hw_render_frame(gpu_renderer_t *r, unsigned width, unsigned he
     r->hw_signal_semaphores[r->current_frame] = VK_NULL_HANDLE;
 
     r->current_frame = (r->current_frame + 1) % MAX_FRAMES_IN_FLIGHT;
+
+    if (r->surface_mutex_initialized) sp_mutex_unlock(&r->surface_mutex);
 }
 
 void gpu_renderer_hw_vulkan_deinit(gpu_renderer_t *r) {

--- a/player/native/src/libretro_video.c
+++ b/player/native/src/libretro_video.c
@@ -142,6 +142,11 @@ void video_refresh_callback(const void *data, unsigned width, unsigned height, s
             hw_gl_resize_fbo(g_core.hw_gl_ctx, width, height);
             return;
         }
+        /* HW frame but no active renderer — drop the frame. Falling through to
+         * the software path would dereference RETRO_HW_FRAME_BUFFER_VALID as a
+         * pointer, causing a SIGSEGV. This happens when the GPU surface is
+         * suspended (e.g. clamshell close) while the core is still running. */
+        return;
     }
 
     /*

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -28,6 +28,10 @@ sealed interface EmulationIntent {
     data object DismissStatus : EmulationIntent
     data object ClearExitRequest : EmulationIntent
 
+    // Lifecycle pause/resume (e.g. clamshell close on Android)
+    data object LifecyclePause : EmulationIntent
+    data object LifecycleResume : EmulationIntent
+
     data object ShowKeyMapping : EmulationIntent
     data object HideKeyMapping : EmulationIntent
     data object ShowGamepadConfig : EmulationIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -10,6 +10,8 @@ data class EmulationState(
     val consoleId: String = "",
     val isRunning: Boolean = false,
     val isPaused: Boolean = false,
+    /** True when paused by Android lifecycle (e.g. clamshell close). */
+    val isLifecyclePaused: Boolean = false,
     val isLoading: Boolean = false,
     val showOverlay: Boolean = false,
     val showPerformanceOverlay: Boolean = false,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -139,6 +139,9 @@ class EmulationViewModel(
             EmulationIntent.DismissStatus -> _state.update { it.copy(statusMessage = null) }
             EmulationIntent.ClearExitRequest -> _state.update { it.copy(requestExit = false) }
 
+            EmulationIntent.LifecyclePause -> lifecyclePause()
+            EmulationIntent.LifecycleResume -> lifecycleResume()
+
             EmulationIntent.ShowKeyMapping -> _state.update { it.copy(showKeyMapping = true, showOverlay = false, showGamepadConfig = false) }
             EmulationIntent.HideKeyMapping -> _state.update { it.copy(showKeyMapping = false, showOverlay = true) }
             EmulationIntent.ShowGamepadConfig -> _state.update { it.copy(showGamepadConfig = true, showOverlay = false) }
@@ -502,6 +505,24 @@ class EmulationViewModel(
         _state.update { it.copy(isPaused = false) }
     }
 
+    private fun lifecyclePause() {
+        val current = _state.value
+        if (current.isRunning && !current.isPaused) {
+            libretroController.pause()
+            _state.update { it.copy(isLifecyclePaused = true, isPaused = true) }
+        }
+    }
+
+    private fun lifecycleResume() {
+        val current = _state.value
+        if (current.isLifecyclePaused) {
+            _state.update { it.copy(isLifecyclePaused = false) }
+            // Only resume emulation if it wasn't user-paused before lifecycle pause
+            libretroController.resume()
+            _state.update { it.copy(isPaused = false) }
+        }
+    }
+
     private fun startSessionTimer() {
         sessionTimerJob?.cancel()
         sessionTimerJob = scope.launch(dispatchers.default) {
@@ -580,6 +601,7 @@ class EmulationViewModel(
                     it.copy(
                         isRunning = false,
                         isPaused = false,
+                        isLifecyclePaused = false,
                         fps = 0f,
                         frameTime = 0f,
                         isHardcoreMode = false,


### PR DESCRIPTION
## Summary

- **Fixes SIGSEGV on clamshell close** during Vulkan HW render games (GameCube/Dolphin): `video_refresh_callback` fell through to the software render path when the GPU was suspended, dereferencing `RETRO_HW_FRAME_BUFFER_VALID` as a real pointer
- **Fixes TOCTOU race** in `gpu_renderer_hw_render_frame`: adds `surface_mutex` to serialize the entire frame render with `suspend_surface`, preventing swapchain use-after-destroy
- **Adds lifecycle pause/resume**: `onPause`/`onResume` in `MainActivity` pause the emulation loop before surface destruction and auto-resume on reopen, preserving user pause state

## Test plan

- [x] Desktop tests pass (413 tests, 0 failures)
- [x] Android build succeeds
- [x] GameCube (Zelda Wind Waker): close clamshell → no crash, open → resumes
- [x] SNES: close clamshell → pauses, open → resumes