### PR TITLE
fix: validate server URL before saving and fix invisible delete icon

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/AppLaunchAndConnectionTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/AppLaunchAndConnectionTest.kt
@@ -127,6 +127,75 @@ class AppLaunchAndConnectionTest {
     }
 
     @Test
+    fun addServerValidatesAndSavesOnSuccess() = runComposeUiTest {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // Form auto-opens when no servers exist — fill it in
+        onNodeWithText("Server Name").performTextInput("Test Server")
+        onNodeWithText("Server URL").performTextInput("http://localhost:8080")
+
+        // Click Add
+        onNodeWithText("Add").performClick()
+        advance(harness)
+
+        // Server should be added and form should close
+        onNodeWithText("Test Server").assertIsDisplayed()
+        onNodeWithText("Server Name").assertDoesNotExist()
+    }
+
+    @Test
+    fun addServerShowsErrorOnValidationFailure() = runComposeUiTest {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.serverRepo.validateServerResult = false
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // Form auto-opens — fill it in
+        onNodeWithText("Server Name").performTextInput("Bad Server")
+        onNodeWithText("Server URL").performTextInput("http://bad-url:9999")
+
+        // Click Add
+        onNodeWithText("Add").performClick()
+        advance(harness)
+
+        // Error should appear, form should stay open with entered values
+        onNodeWithText("Could not connect to server. Check the URL and try again.").assertIsDisplayed()
+        onNodeWithText("Server Name").assertIsDisplayed()
+        onNodeWithText("Server URL").assertIsDisplayed()
+    }
+
+    @Test
+    fun addServerRetryAfterFailure() = runComposeUiTest {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.serverRepo.validateServerResult = false
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // Fill form and try to add
+        onNodeWithText("Server Name").performTextInput("My Server")
+        onNodeWithText("Server URL").performTextInput("http://bad:9999")
+        onNodeWithText("Add").performClick()
+        advance(harness)
+
+        // Should show error
+        onNodeWithText("Could not connect to server. Check the URL and try again.").assertIsDisplayed()
+
+        // Fix the validation result and retry
+        harness.serverRepo.validateServerResult = true
+        onNodeWithText("Add").performClick()
+        advance(harness)
+
+        // Server should now be added and form closed
+        onNodeWithText("My Server").assertIsDisplayed()
+        onNodeWithText("Server Name").assertDoesNotExist()
+    }
+
+    @Test
     fun successfulLoginNavigatesToHomeScreen() = runComposeUiTest {
         val harness = SpelaTestHarness(StandardTestDispatcher())
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -111,6 +111,7 @@ class FakeServerRepository : ServerRepository {
     private val servers = mutableListOf<ServerConnection>()
     private var activeServerId: String? = null
     private val serversFlow = MutableStateFlow<List<ServerConnection>>(emptyList())
+    var validateServerResult: Boolean = true
 
     override fun observeServers(): Flow<List<ServerConnection>> = serversFlow
 
@@ -140,6 +141,8 @@ class FakeServerRepository : ServerRepository {
     override suspend fun setActiveServer(id: String) {
         activeServerId = id
     }
+
+    override suspend fun validateServer(url: String): Boolean = validateServerResult
 
     fun preAddServer(name: String, url: String, active: Boolean = false): ServerConnection {
         val server = ServerConnection(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ServerRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ServerRepositoryImpl.kt
@@ -3,6 +3,10 @@ package com.spela.player.data.repository
 import com.spela.player.data.local.SpelaDatabase
 import com.spela.player.domain.model.ServerConnection
 import com.spela.player.domain.repository.ServerRepository
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.request.get
+import io.ktor.http.isSuccess
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.uuid.ExperimentalUuidApi
@@ -10,6 +14,7 @@ import kotlin.uuid.Uuid
 
 class ServerRepositoryImpl(
     private val database: SpelaDatabase,
+    private val engineFactory: HttpClientEngineFactory<*>,
 ) : ServerRepository {
 
     private val queries = database.spelaDatabaseQueries
@@ -68,6 +73,17 @@ class ServerRepositoryImpl(
     override suspend fun setActiveServer(id: String) {
         queries.setActiveServer(id)
         refreshFromDb()
+    }
+
+    override suspend fun validateServer(url: String): Boolean {
+        return try {
+            val normalizedUrl = url.trimEnd('/')
+            val client = HttpClient(engineFactory)
+            val response = client.use { it.get("$normalizedUrl/api/health") }
+            response.status.isSuccess()
+        } catch (_: Exception) {
+            false
+        }
     }
 
     private fun refreshFromDb() {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -54,7 +54,7 @@ val commonModule = module {
     single<SaveDataRepository> { SaveDataRepositoryImpl(get(), get(), get(), get()) }
     single<CoreRepository> { CoreRepositoryImpl(get(), get(), get()) }
     single<DownloadRepository> { DownloadRepositoryImpl(get(), get(), get()) }
-    single<ServerRepository> { ServerRepositoryImpl(get()) }
+    single<ServerRepository> { ServerRepositoryImpl(get(), get()) }
     single<PreferencesRepository> { PreferencesRepositoryImpl(get(), get(), get(), get()) }
     single<KeyMappingRepository> { KeyMappingRepositoryImpl(get(), get(named("platformDefaultMapping"))) }
     single<AchievementsRepository> { AchievementsRepositoryImpl(get()) }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ServerRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ServerRepository.kt
@@ -10,4 +10,5 @@ interface ServerRepository {
     suspend fun addServer(name: String, url: String): ServerConnection
     suspend fun removeServer(id: String)
     suspend fun setActiveServer(id: String)
+    suspend fun validateServer(url: String): Boolean
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ServerConnectionScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ServerConnectionScreen.kt
@@ -182,12 +182,12 @@ fun ServerConnectionScreen(
                                     contentDescription = "Remove server",
                                     tint = SpColor.OnBackgroundTertiary,
                                     modifier = Modifier
-                                        .size(24.dp)
+                                        .size(36.dp)
                                         .clip(CircleShape)
                                         .clickable(onClick = {
                                             viewModel.onIntent(ServerConnectionIntent.RemoveServer(server.id))
                                         })
-                                        .padding(SpSpacing.Small),
+                                        .padding(6.dp),
                                 )
                             }
                         }
@@ -240,11 +240,14 @@ fun ServerConnectionScreen(
                                             text = "Cancel",
                                             onClick = { viewModel.onIntent(ServerConnectionIntent.ToggleAddServer) },
                                             style = SpButtonStyle.Ghost,
+                                            enabled = !state.isValidating,
                                         )
                                         Spacer(Modifier.width(SpSpacing.Small))
                                         SpButton(
                                             text = "Add",
                                             onClick = { viewModel.onIntent(ServerConnectionIntent.AddServer) },
+                                            enabled = !state.isValidating,
+                                            isLoading = state.isValidating,
                                         )
                                     }
                                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ServerConnectionViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ServerConnectionViewModel.kt
@@ -16,6 +16,7 @@ data class ServerConnectionState(
     val newServerUrl: String = "",
     val isAddingServer: Boolean = false,
     val isLoading: Boolean = false,
+    val isValidating: Boolean = false,
     val error: String? = null,
     val selectedServerId: String? = null,
 )
@@ -82,9 +83,19 @@ class ServerConnectionViewModel(
             return
         }
 
-        _state.update { it.copy(isLoading = true) }
+        _state.update { it.copy(isValidating = true, error = null) }
         scope.launch(dispatchers.io) {
             try {
+                val reachable = serverRepository.validateServer(current.newServerUrl)
+                if (!reachable) {
+                    _state.update {
+                        it.copy(
+                            isValidating = false,
+                            error = "Could not connect to server. Check the URL and try again.",
+                        )
+                    }
+                    return@launch
+                }
                 serverRepository.addServer(current.newServerName, current.newServerUrl)
                 val servers = serverRepository.getServers()
                 _state.update {
@@ -93,11 +104,11 @@ class ServerConnectionViewModel(
                         newServerName = "",
                         newServerUrl = "",
                         isAddingServer = false,
-                        isLoading = false,
+                        isValidating = false,
                     )
                 }
             } catch (e: Exception) {
-                _state.update { it.copy(error = e.message, isLoading = false) }
+                _state.update { it.copy(error = e.message, isValidating = false) }
             }
         }
     }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/ServerRepositoryImplTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/ServerRepositoryImplTest.kt
@@ -2,6 +2,14 @@ package com.spela.player.data.repository
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.spela.player.data.local.SpelaDatabase
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineConfig
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import kotlin.test.BeforeTest
@@ -16,6 +24,12 @@ class ServerRepositoryImplDbTest {
 
     private lateinit var database: SpelaDatabase
 
+    private val stubEngineFactory = object : HttpClientEngineFactory<HttpClientEngineConfig> {
+        override fun create(block: HttpClientEngineConfig.() -> Unit): HttpClientEngine {
+            return MockEngine { respond("{}", HttpStatusCode.OK, headersOf(HttpHeaders.ContentType, "application/json")) }
+        }
+    }
+
     @BeforeTest
     fun setup() {
         val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
@@ -24,7 +38,7 @@ class ServerRepositoryImplDbTest {
     }
 
     private fun createRepo(): ServerRepositoryImpl {
-        return ServerRepositoryImpl(database)
+        return ServerRepositoryImpl(database, stubEngineFactory)
     }
 
     @Test

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/RestoreSessionUseCaseTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/RestoreSessionUseCaseTest.kt
@@ -170,6 +170,7 @@ class RestoreSessionUseCaseTest {
             throw UnsupportedOperationException()
         override suspend fun removeServer(id: String) = throw UnsupportedOperationException()
         override suspend fun setActiveServer(id: String) = throw UnsupportedOperationException()
+        override suspend fun validateServer(url: String): Boolean = throw UnsupportedOperationException()
     }
 
     private class StubAuthRepository(

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -317,6 +317,7 @@ class NavigationViewModelTest {
             throw UnsupportedOperationException()
         override suspend fun removeServer(id: String) = throw UnsupportedOperationException()
         override suspend fun setActiveServer(id: String) = throw UnsupportedOperationException()
+        override suspend fun validateServer(url: String): Boolean = throw UnsupportedOperationException()
     }
 
     private class NoSessionAuthRepository : AuthRepository {


### PR DESCRIPTION
## Summary
- Validate server reachability (`GET /api/health`) before persisting a new server connection — on failure the form stays open with an error message so the user can correct the URL and retry
- Fix delete button icon on server cards — previous modifier left only 8dp for the icon (invisible), now 36dp container with 6dp padding = 24dp visible icon
- Add `isValidating` state with loading spinner on the Add button during validation

## Test plan
- [x] Desktop E2E: 3 new tests (validation success, failure with error shown, retry after failure)
- [x] All 469 unit tests + 413 desktop E2E tests pass (0 failures)
- [x] Android `assembleDebug` builds successfully
- [ ] Manual: add server with bad URL → error → fix URL → success → sign-in screen