### PR TITLE
feat: 3DS/DS dual-screen split for secondary display

### DIFF
--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
@@ -55,6 +55,10 @@ class AndroidLibretroController(
     @Volatile
     private var netplayDisconnected = false
 
+    /** When true, skip GPU present and populate frameBitmap from CPU buffer instead. */
+    @Volatile
+    var dualScreenSplitActive = false
+
     /** Callback invoked on the emulation thread when the remote peer times out. */
     var onNetplayPeerTimeout: (() -> Unit)? = null
 
@@ -339,10 +343,16 @@ class AndroidLibretroController(
             jni.nativeRun()
 
             // GPU path: frame was already uploaded in video_refresh_callback,
-            // just trigger the render pass. Software path: read pixels via JNI.
-            if (jni.nativeGpuIsActive()) {
+            // just trigger the render pass. Skip when dual-screen split is active —
+            // the primary display uses EmulationSurface (Canvas) instead, which crops
+            // to the top screen from frameBitmap.
+            if (jni.nativeGpuIsActive() && !dualScreenSplitActive) {
                 jni.nativeGpuRender()
-            } else {
+            }
+            // Software path or dual-screen split: populate frameBitmap from CPU readback.
+            // For GLES HW render cores, hw_gl_read_pixels() in video_refresh_callback
+            // already populates the CPU buffer alongside the GPU upload.
+            if (dualScreenSplitActive || !jni.nativeGpuIsActive()) {
                 updateVideoFrame()
             }
 
@@ -469,9 +479,10 @@ class AndroidLibretroController(
             // 5. Run one emulation frame
             jni.nativeRun()
 
-            if (jni.nativeGpuIsActive()) {
+            if (jni.nativeGpuIsActive() && !dualScreenSplitActive) {
                 jni.nativeGpuRender()
-            } else {
+            }
+            if (dualScreenSplitActive || !jni.nativeGpuIsActive()) {
                 updateVideoFrame()
             }
             pushAudio()
@@ -562,6 +573,14 @@ class AndroidLibretroController(
 
         convertToPackedArgb(videoFrameBuffer, pixelCount, format, pixelBuffer)
 
+        // GLES HW render: the readback buffer from hw_gl_read_pixels() is bottom-up
+        // (OpenGL origin is bottom-left). The GPU renderer's shader handles this via
+        // flip_y, but when rendering via EmulationSurface (Canvas/Bitmap), we must
+        // flip the pixel data manually.
+        if (jni.nativeGpuIsActive()) {
+            flipVertically(pixelBuffer, width, height)
+        }
+
         // Reallocate double buffers if dimensions changed.
         // Don't recycle old bitmaps — Compose may still be drawing the previous
         // front bitmap via _frameBitmap. Let GC collect them instead.
@@ -627,6 +646,27 @@ class AndroidLibretroController(
                     out[i] = (0xFF shl 24) or (r shl 16) or (g shl 8) or b
                 }
             }
+        }
+    }
+
+    /** Temp row buffer for vertical flip, lazily allocated to match frame width. */
+    private var flipRowBuffer = IntArray(0)
+
+    /**
+     * Flips an IntArray of pixel data vertically (swaps top and bottom rows in-place).
+     * Used to convert from OpenGL bottom-left origin to top-left origin for Bitmap.
+     */
+    private fun flipVertically(pixels: IntArray, width: Int, height: Int) {
+        if (flipRowBuffer.size < width) {
+            flipRowBuffer = IntArray(width)
+        }
+        val halfHeight = height / 2
+        for (y in 0 until halfHeight) {
+            val topStart = y * width
+            val bottomStart = (height - 1 - y) * width
+            System.arraycopy(pixels, topStart, flipRowBuffer, 0, width)
+            System.arraycopy(pixels, bottomStart, pixels, topStart, width)
+            System.arraycopy(flipRowBuffer, 0, pixels, bottomStart, width)
         }
     }
 

--- a/player/shared/src/androidMain/kotlin/com/spela/player/platform/secondarydisplay/SecondaryDisplayPresentation.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/platform/secondarydisplay/SecondaryDisplayPresentation.kt
@@ -85,6 +85,12 @@ class SecondaryDisplayPresentation(
         return super.dispatchTouchEvent(ev)
     }
 
+    override fun onBackPressed() {
+        // Suppress back button (gamepad B mapped to KEYCODE_BACK) so it doesn't
+        // dismiss the secondary display during gameplay. The presentation is
+        // dismissed programmatically when the game stops.
+    }
+
     override fun dismiss() {
         if (lifecycleRegistry.currentState != Lifecycle.State.DESTROYED) {
             lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_DESTROY)

--- a/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformDsTouchScreen.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformDsTouchScreen.android.kt
@@ -40,6 +40,8 @@ actual fun PlatformDsTouchScreen(
     controller: LibretroController,
     splitY: Int,
     selectedShader: ShaderPreset,
+    bottomScreenWidth: Int,
+    bottomScreenOffsetX: Int,
     modifier: Modifier,
 ) {
     val androidController = controller as? AndroidLibretroController ?: return
@@ -62,11 +64,16 @@ actual fun PlatformDsTouchScreen(
                     awaitEachGesture {
                         val down = awaitFirstDown(requireUnconsumed = false)
                         val bmpHeight = bitmap?.height ?: 0
+                        val bmpWidth = bitmap?.width ?: 0
+                        val srcW = if (bottomScreenWidth > 0) bottomScreenWidth else bmpWidth
+                        val srcH = bmpHeight - splitY
                         // Map and send initial touch
                         sendPointerFromTouch(
                             controller, down.position.x, down.position.y,
-                            canvasSize, bitmap?.width ?: 0, bmpHeight - splitY,
+                            canvasSize, srcW, srcH,
+                            fullWidth = bmpWidth,
                             fullHeight = bmpHeight,
+                            bottomScreenOffsetX = bottomScreenOffsetX,
                             pressed = true,
                         )
                         down.consume()
@@ -79,8 +86,10 @@ actual fun PlatformDsTouchScreen(
                                 PointerEventType.Move -> {
                                     sendPointerFromTouch(
                                         controller, change.position.x, change.position.y,
-                                        canvasSize, bitmap?.width ?: 0, bmpHeight - splitY,
+                                        canvasSize, srcW, srcH,
+                                        fullWidth = bmpWidth,
                                         fullHeight = bmpHeight,
+                                        bottomScreenOffsetX = bottomScreenOffsetX,
                                         pressed = true,
                                     )
                                     change.consume()
@@ -99,7 +108,9 @@ actual fun PlatformDsTouchScreen(
             val bmp = bitmap ?: return@Canvas
             if (bmp.isRecycled || bmp.height <= splitY) return@Canvas
 
-            val srcWidth = bmp.width
+            // Horizontal crop for 3DS: bottom screen is narrower, padded with noise
+            val srcX = if (bottomScreenOffsetX > 0) bottomScreenOffsetX else 0
+            val srcWidth = if (bottomScreenWidth > 0) bottomScreenWidth else bmp.width
             val srcHeight = bmp.height - splitY
 
             val cWidth = size.width
@@ -117,7 +128,7 @@ actual fun PlatformDsTouchScreen(
 
             drawImage(
                 image = bmp.asImageBitmap(),
-                srcOffset = IntOffset(0, splitY),
+                srcOffset = IntOffset(srcX, splitY),
                 srcSize = srcSize,
                 dstOffset = dstOffset,
                 dstSize = dstSize,
@@ -138,9 +149,13 @@ actual fun PlatformDsTouchScreen(
  * For DS/3DS touch input, the core expects coordinates relative to the full viewport
  * (both screens stacked). The bottom screen occupies the lower portion of the viewport,
  * so Y is mapped to the bottom half only (0 to 0x7FFF), not the full range.
- * X uses the full range (-0x7FFF to 0x7FFF) as normal.
  *
+ * For 3DS, the bottom screen (320px) is narrower than the full framebuffer (400px),
+ * so X must be mapped to the sub-region within the full framebuffer width.
+ *
+ * @param fullWidth The full framebuffer width, used for horizontal offset mapping.
  * @param fullHeight The full framebuffer height (both screens), used to compute the split ratio.
+ * @param bottomScreenOffsetX Horizontal offset of the bottom screen within the framebuffer.
  */
 private fun sendPointerFromTouch(
     controller: LibretroController,
@@ -149,7 +164,9 @@ private fun sendPointerFromTouch(
     canvasSize: Size,
     srcWidth: Int,
     srcHeight: Int,
+    fullWidth: Int,
     fullHeight: Int,
+    bottomScreenOffsetX: Int,
     pressed: Boolean,
 ) {
     if (canvasSize.width <= 0 || canvasSize.height <= 0 || srcWidth <= 0 || srcHeight <= 0) return
@@ -165,8 +182,14 @@ private fun sendPointerFromTouch(
     val normalizedX = ((touchX - offsetX) / scaledWidth).coerceIn(0f, 1f)
     val normalizedY = ((touchY - offsetY) / scaledHeight).coerceIn(0f, 1f)
 
-    // X maps to full libretro pointer range: -0x7FFF to 0x7FFF
-    val pointerX = ((normalizedX * 2f - 1f) * 0x7FFF).toInt().coerceIn(-0x7FFF, 0x7FFF)
+    // X: map to the sub-region of the full framebuffer when bottom screen is narrower
+    val pointerX = if (bottomScreenOffsetX > 0 && fullWidth > 0) {
+        // Touch normalizedX maps to [offsetX .. offsetX + srcWidth] within the full framebuffer
+        val viewportX = (bottomScreenOffsetX.toFloat() + normalizedX * srcWidth) / fullWidth
+        ((viewportX * 2f - 1f) * 0x7FFF).toInt().coerceIn(-0x7FFF, 0x7FFF)
+    } else {
+        ((normalizedX * 2f - 1f) * 0x7FFF).toInt().coerceIn(-0x7FFF, 0x7FFF)
+    }
 
     // Y maps to the bottom portion of the full viewport.
     // The split ratio determines where the bottom screen starts in the full viewport.

--- a/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformEmulationSurface.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformEmulationSurface.android.kt
@@ -36,43 +36,36 @@ actual fun PlatformEmulationSurface(
 
     val isOverlayVisible = emulationState.showOverlay || emulationState.showKeyMapping || emulationState.showGamepadConfig
 
-    if (isDualScreenSplit) {
-        // Dual-screen DS/3DS: always use software surface (split rendering)
+    // Set flag so emulation loop populates frameBitmap via CPU readback
+    // (for both primary and secondary displays in dual-screen mode) and
+    // skips GPU present (primary uses EmulationSurface instead).
+    androidController.dualScreenSplitActive = isDualScreenSplit
+
+    // IMPORTANT: VulkanEmulationSurface must ALWAYS be at the same position in the
+    // composition tree. Putting it inside different if/else branches causes Compose
+    // to destroy and recreate it when the branch changes, triggering gpuDeinit()
+    // while the emulation thread is still running — a fatal race condition.
+    VulkanEmulationSurface(
+        controller = androidController,
+        selectedShader = selectedShader,
+        isHwRenderEnabled = hwRenderEnabled,
+        isOverlayVisible = isOverlayVisible,
+        modifier = modifier,
+    )
+
+    // Canvas-based rendering for primary display:
+    // - Software cores (DS/desmume): always used (GPU renderer not active)
+    // - Dual-screen split (DS or 3DS): crops to top screen via isDualScreenSplit.
+    //   For 3DS, the emulation loop skips nativeGpuRender() and populates
+    //   frameBitmap from CPU readback instead. The Y-flip is handled in
+    //   updateVideoFrame() so the Bitmap is in correct orientation.
+    if (!useVulkanSurface || isDualScreenSplit) {
         EmulationSurface(
             controller = androidController,
             selectedShader = selectedShader,
-            isDualScreenSplit = true,
-            splitY = emulationState.dualScreenSplitY,
+            isDualScreenSplit = isDualScreenSplit,
+            splitY = if (isDualScreenSplit) emulationState.dualScreenSplitY else 0,
             modifier = modifier,
         )
-    } else {
-        // Always include VulkanEmulationSurface in the tree so the SurfaceView
-        // is present from the first composition. Dynamically swapping it in later
-        // (when isHwRenderEnabled becomes true) causes the SurfaceView to never
-        // receive a surfaceCreated callback from the Android window manager.
-        //
-        // The SurfaceView starts transparent (TRANSLUCENT format). GPU rendering
-        // is deferred until isHwRenderEnabled becomes true. For software-only
-        // cores, the EmulationSurface Canvas renders beneath the transparent surface.
-        VulkanEmulationSurface(
-            controller = androidController,
-            selectedShader = selectedShader,
-            isHwRenderEnabled = hwRenderEnabled,
-            isOverlayVisible = isOverlayVisible,
-            modifier = modifier,
-        )
-
-        // Software fallback: render via Canvas when GPU renderer isn't active.
-        // Covers both non-HW cores (entire session) and the initial frames of
-        // HW cores before gpuInit completes.
-        if (!useVulkanSurface) {
-            EmulationSurface(
-                controller = androidController,
-                selectedShader = selectedShader,
-                isDualScreenSplit = false,
-                splitY = 0,
-                modifier = modifier,
-            )
-        }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -43,6 +43,11 @@ data class EmulationState(
     /** Y pixel offset where the framebuffer splits (e.g. 192 for DS top/bottom). */
     val dualScreenSplitY: Int = 0,
 
+    /** Width of the bottom screen in pixels (320 for 3DS, 256 for DS). */
+    val dualScreenBottomWidth: Int = 0,
+    /** X offset of the bottom screen within the framebuffer (40 for 3DS, 0 for DS). */
+    val dualScreenBottomOffsetX: Int = 0,
+
     /** Elapsed play session time in seconds, updated every second while running. */
     val sessionElapsedSeconds: Long = 0,
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformDsTouchScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformDsTouchScreen.kt
@@ -20,5 +20,7 @@ expect fun PlatformDsTouchScreen(
     controller: LibretroController,
     splitY: Int,
     selectedShader: ShaderPreset = ShaderPreset.NONE,
+    bottomScreenWidth: Int = 0,
+    bottomScreenOffsetX: Int = 0,
     modifier: Modifier = Modifier,
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
@@ -125,6 +125,8 @@ fun SecondaryScreenContent(
                     controller = controller,
                     splitY = state.dualScreenSplitY,
                     selectedShader = state.selectedShader,
+                    bottomScreenWidth = state.dualScreenBottomWidth,
+                    bottomScreenOffsetX = state.dualScreenBottomOffsetX,
                 )
             }
         } else {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -292,8 +292,25 @@ class EmulationViewModel(
                 "3ds" -> 240   // 400×240 top + 320×240 bottom = 400×480
                 else -> 0
             }
+            val bottomWidth = when (lc) {
+                "nds" -> 256   // Same width as top screen
+                "3ds" -> 320   // Narrower than top (400px)
+                else -> 0
+            }
+            val bottomOffsetX = when (lc) {
+                "nds" -> 0     // No padding
+                "3ds" -> 40    // (400 - 320) / 2 = 40px padding each side
+                else -> 0
+            }
             withContext(dispatchers.main) {
-                _state.update { it.copy(isDualScreenConsole = isDualScreen, dualScreenSplitY = splitY) }
+                _state.update {
+                    it.copy(
+                        isDualScreenConsole = isDualScreen,
+                        dualScreenSplitY = splitY,
+                        dualScreenBottomWidth = bottomWidth,
+                        dualScreenBottomOffsetX = bottomOffsetX,
+                    )
+                }
             }
 
             // Resolve shader using two-layer system
@@ -610,6 +627,8 @@ class EmulationViewModel(
                         secondaryDisplayActive = false,
                         isDualScreenConsole = false,
                         dualScreenSplitY = 0,
+                        dualScreenBottomWidth = 0,
+                        dualScreenBottomOffsetX = 0,
                         relayId = null,
                         turnToken = null,
                         netplaySessionId = null,

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformDsTouchScreen.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformDsTouchScreen.desktop.kt
@@ -10,6 +10,8 @@ actual fun PlatformDsTouchScreen(
     controller: LibretroController,
     splitY: Int,
     selectedShader: ShaderPreset,
+    bottomScreenWidth: Int,
+    bottomScreenOffsetX: Int,
     modifier: Modifier,
 ) {
     // No-op on desktop: secondary display is not supported.


### PR DESCRIPTION
## Summary
- Splits DS/3DS dual-screen framebuffer across primary (top screen) and secondary (bottom screen with touch) displays on devices like AYN Thor
- Flips GLES HW readback buffer vertically for correct orientation when rendering via Canvas instead of GPU shader
- Keeps VulkanEmulationSurface at stable composition position to prevent gpuDeinit() race condition
- Adds horizontal crop for 3DS bottom screen (320px centered in 400px buffer)
- Suppresses back button on secondary display to prevent gamepad B from dismissing it

## Test plan
- [x] Desktop tests pass (413 tests, 0 failures)
- [x] Deployed to AYN Thor — 3DS game shows top screen on primary, bottom screen on secondary
- [x] Touch input on secondary display works correctly for 3DS bottom screen
- [x] Gamepad B no longer dismisses secondary display
- [ ] Verify DS games still work with dual-screen split
- [ ] Verify single-screen games (non-DS/3DS) are unaffected