### PR TITLE
fix: gamepad UI issues (status bar, focus wrap, ConsoleCard)

### DIFF
--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -3,6 +3,8 @@ package com.spela.player.android
 import android.content.pm.ActivityInfo
 import android.hardware.input.InputManager
 import android.os.Bundle
+import android.view.WindowInsets
+import android.view.WindowInsetsController
 import android.os.SystemClock
 import android.view.InputDevice
 import android.view.KeyEvent
@@ -94,6 +96,23 @@ class MainActivity : ComponentActivity() {
                 .map { it.orientationLock }
                 .distinctUntilChanged()
                 .collect { mode -> applyOrientationLock(mode) }
+        }
+
+        // Hide system bars during gameplay, restore when back in UI
+        lifecycleScope.launch {
+            navigationViewModel.state
+                .map { it.showInGameOverlay }
+                .distinctUntilChanged()
+                .collect { isInGame ->
+                    val controller = window.insetsController ?: return@collect
+                    if (isInGame) {
+                        controller.hide(WindowInsets.Type.systemBars())
+                        controller.systemBarsBehavior =
+                            WindowInsetsController.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+                    } else {
+                        controller.show(WindowInsets.Type.systemBars())
+                    }
+                }
         }
 
         setContent {

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
@@ -1,8 +1,10 @@
 package com.spela.player.desktop.e2e
 
+import androidx.compose.ui.input.key.Key
 import androidx.compose.ui.test.*
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.ui.gamepad.InputMode
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlin.test.Test
@@ -16,10 +18,6 @@ import kotlin.test.Test
  * and shows the section indicator. Tab bar interaction via D-pad is therefore
  * not possible — section cycling (L1/R1) is tested in SectionIndicatorTest
  * and SectionNavigationTest.
- *
- * Compose UI Test key injection requires a focused node as dispatch target,
- * so the GamepadHandler's Next-fallback (for "nothing focused" state) cannot be
- * tested here. That path is covered by manual device testing on the Ayn Thor.
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class GamepadNavigationTest {
@@ -58,5 +56,92 @@ class GamepadNavigationTest {
         onNodeWithText("Castlevania").assertIsDisplayed()
         onNodeWithText("Super Mario Bros.").assertIsDisplayed()
         onNodeWithText("Mega Man 2").assertIsDisplayed()
+    }
+
+    @Test
+    fun consoleCardsAreFocusableInGamepadMode() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        advance(harness)
+
+        // Enter gamepad mode and navigate to Consoles screen
+        // focusResetKey auto-focuses first focusable element
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.Consoles)
+        )
+        advance(harness)
+
+        // The first console card (NES) should have received focus automatically
+        val nesCard = onNodeWithContentDescription("Nintendo Entertainment System, 3 games")
+        nesCard.assertIsDisplayed()
+        nesCard.assertIsFocused()
+    }
+
+    @Test
+    fun focusDoesNotWrapOnDirectionLeftAtBoundary() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        advance(harness)
+
+        // Enter gamepad mode and navigate to Consoles
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.Consoles)
+        )
+        advance(harness)
+
+        val nesCard = onNodeWithContentDescription("Nintendo Entertainment System, 3 games")
+        nesCard.assertIsFocused()
+
+        // Press Left — nothing to the left, focus should stay on the same card
+        nesCard.performKeyInput { pressKey(Key.DirectionLeft) }
+        advanceQuick(harness)
+        nesCard.assertIsFocused()
+    }
+
+    @Test
+    fun focusDoesNotWrapOnDirectionUpAtBoundary() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        advance(harness)
+
+        // Enter gamepad mode and navigate to Consoles
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.Consoles)
+        )
+        advance(harness)
+
+        val nesCard = onNodeWithContentDescription("Nintendo Entertainment System, 3 games")
+        nesCard.assertIsFocused()
+
+        // Press Up — nothing above, focus should stay
+        nesCard.performKeyInput { pressKey(Key.DirectionUp) }
+        advanceQuick(harness)
+        nesCard.assertIsFocused()
+    }
+
+    @Test
+    fun focusMovesRightBetweenConsoleCards() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        advance(harness)
+
+        // Enter gamepad mode and navigate to Consoles
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.Consoles)
+        )
+        advance(harness)
+
+        val nesCard = onNodeWithContentDescription("Nintendo Entertainment System, 3 games")
+        val snesCard = onNodeWithContentDescription("Super Nintendo, 2 games")
+        nesCard.assertIsFocused()
+
+        // Press Right — focus should move to the SNES card
+        nesCard.performKeyInput { pressKey(Key.DirectionRight) }
+        advanceQuick(harness)
+        snesCard.assertIsFocused()
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
@@ -156,6 +157,7 @@ internal fun ConsoleCard(
                 indication = null,
                 onClick = onClick,
             )
+            .focusable(interactionSource = interactionSource)
             .semantics {
                 contentDescription = "${console.name}, ${console.gameCount} games$biosDesc"
                 role = Role.Button

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -79,26 +79,22 @@ fun GamepadHandler(
 
                 when (event.key) {
                     Key.DirectionUp -> {
-                        val moved = focusManager.moveFocus(FocusDirection.Up)
-                        if (!moved) focusManager.moveFocus(FocusDirection.Next)
+                        focusManager.moveFocus(FocusDirection.Up)
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionDown -> {
-                        val moved = focusManager.moveFocus(FocusDirection.Down)
-                        if (!moved) focusManager.moveFocus(FocusDirection.Next)
+                        focusManager.moveFocus(FocusDirection.Down)
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionLeft -> {
-                        val moved = focusManager.moveFocus(FocusDirection.Left)
-                        if (!moved) focusManager.moveFocus(FocusDirection.Next)
+                        focusManager.moveFocus(FocusDirection.Left)
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionRight -> {
-                        val moved = focusManager.moveFocus(FocusDirection.Right)
-                        if (!moved) focusManager.moveFocus(FocusDirection.Next)
+                        focusManager.moveFocus(FocusDirection.Right)
                         onGamepadInput?.invoke()
                         true
                     }


### PR DESCRIPTION
## Summary
- **Hide Android status bar during gameplay**: Observes `showInGameOverlay` state and hides system bars when in-game, restores them on exit. Transient bars available via swipe.
- **Fix D-pad focus wrapping at boundaries**: Removed `FocusDirection.Next` fallback when directional `moveFocus()` fails — focus now stays put instead of jumping to unrelated elements.
- **Make ConsoleCard focusable**: Added `.focusable(interactionSource)` so console cards on the Consoles screen are navigable with gamepad D-pad.

## Test plan
- [x] All 469 unit tests pass
- [x] All 420 desktop E2E tests pass (0 failures)
- [x] 4 new desktop E2E tests for gamepad navigation:
  - ConsoleCards receive focus in gamepad mode
  - Focus stays on Left at left boundary (no wrap)
  - Focus stays on Up at top boundary (no wrap)
  - Focus moves Right between adjacent ConsoleCards
- [ ] Manual: deploy to AYN Thor, launch game → status bar hidden, swipe shows transient bars
- [ ] Manual: exit game → status bar returns
- [ ] Manual: D-pad navigate Home/Consoles → focus stops at boundaries
- [ ] Manual: Consoles tab → console cards focusable and navigable with D-pad