### PR TITLE
feat: Game Sessions — isolated playthroughs with scoped saves, cheats, and relay integration

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionDetailUiTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionDetailUiTest.kt
@@ -1,0 +1,227 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Desktop E2E tests for the Session Detail screen.
+ *
+ * Covers:
+ * - Session detail renders with session info
+ * - Save states display correctly
+ * - Cheat toggle works
+ * - Delete session from detail screen works
+ * - Rename session works
+ * - Empty saves state shows correctly
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class SessionDetailUiTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun ComposeUiTest.navigateToSessionDetail(harness: SpelaTestHarness, sessionId: String) {
+        advance(harness) // settle initial composition
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.SessionDetail(sessionId))
+        )
+        advanceFully(harness)
+    }
+
+    // ── Session detail renders with session info ──
+
+    @Test
+    fun sessionDetailRendersSessionInfo() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "My First Run",
+            totalPlayTime = 3600,
+        )
+
+        setContent { harness.App() }
+        navigateToSessionDetail(harness, "s1")
+
+        onNodeWithTag("session_detail_header").assertIsDisplayed()
+        onNodeWithContentDescription("Session: My First Run").assertIsDisplayed()
+    }
+
+    // ── Save states display correctly ──
+
+    @Test
+    fun saveStatesDisplayCorrectly() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "My Run",
+        )
+        harness.sessionRepo.preAddSessionSave(
+            sessionId = "s1",
+            saveId = 1,
+            name = "Boss Fight Save",
+        )
+        harness.sessionRepo.preAddSessionSave(
+            sessionId = "s1",
+            saveId = 2,
+            name = "After Tutorial",
+        )
+
+        setContent { harness.App() }
+        navigateToSessionDetail(harness, "s1")
+
+        onNodeWithTag("session_save_item_1").assertIsDisplayed()
+        onNodeWithText("Boss Fight Save").assertIsDisplayed()
+        onNodeWithTag("session_save_item_2").assertIsDisplayed()
+        onNodeWithText("After Tutorial").assertIsDisplayed()
+    }
+
+    // ── Empty saves state shows correctly ──
+
+    @Test
+    fun emptySavesStateShows() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Empty Run",
+        )
+
+        setContent { harness.App() }
+        navigateToSessionDetail(harness, "s1")
+
+        onNodeWithTag("session_saves_empty").assertIsDisplayed()
+        onNodeWithText("No saves yet").assertIsDisplayed()
+    }
+
+    // ── Cheat toggle works ──
+
+    @Test
+    fun cheatToggleWorks() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Cheat Run",
+        )
+
+        setContent { harness.App() }
+        navigateToSessionDetail(harness, "s1")
+
+        // Scroll to cheats section
+        onNodeWithTag("session_detail_content")
+            .performScrollToNode(hasTestTag("session_cheats_section"))
+
+        onNodeWithTag("session_cheats_toggle").assertIsDisplayed()
+
+        // Toggle cheats on
+        onNodeWithTag("session_cheats_toggle").performClick()
+        advance(harness)
+
+        // Verify the session repo was updated
+        val config = harness.sessionRepo.sessions.find { it.id == "s1" }
+        assertTrue(config?.cheatsEnabled == true, "Expected cheats to be enabled")
+    }
+
+    // ── Delete session from detail screen works ──
+
+    @Test
+    fun deleteSessionFromDetailScreen() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Doomed Run",
+        )
+
+        setContent { harness.App() }
+        navigateToSessionDetail(harness, "s1")
+
+        // Scroll to delete button
+        onNodeWithTag("session_detail_content")
+            .performScrollToNode(hasTestTag("session_delete_button"))
+
+        onNodeWithTag("session_delete_button").performClick()
+        advanceQuick(harness)
+
+        // Delete confirmation dialog should appear
+        onNodeWithTag("session_delete_dialog").assertIsDisplayed()
+        onNodeWithText("Delete \"Doomed Run\"? All saves in this session will be permanently removed.")
+            .assertIsDisplayed()
+
+        // Confirm deletion
+        onAllNodesWithText("Delete").filterToOne(hasClickAction()).performClick()
+        advance(harness)
+
+        // Session should be deleted
+        assertTrue(harness.sessionRepo.sessions.isEmpty())
+    }
+
+    // ── Rename session works from detail screen ──
+
+    @Test
+    fun renameSessionFromDetailScreen() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Old Name",
+        )
+
+        setContent { harness.App() }
+        navigateToSessionDetail(harness, "s1")
+
+        // Click rename button
+        onNodeWithTag("session_detail_rename_button").performClick()
+        advanceQuick(harness)
+
+        // Rename dialog should appear
+        onNodeWithText("Rename Session").assertIsDisplayed()
+        onNodeWithTag("session_detail_rename_input").assertIsDisplayed()
+
+        // Clear and type new name
+        onNodeWithTag("session_detail_rename_input").performTextClearance()
+        onNodeWithTag("session_detail_rename_input").performTextInput("New Name")
+        advanceQuick(harness)
+
+        // Confirm rename
+        onNodeWithText("Rename").performClick()
+        advance(harness)
+
+        // Session should be renamed
+        assertEquals("New Name", harness.sessionRepo.sessions[0].name)
+    }
+
+    // ── Cheats show count when enabled ──
+
+    @Test
+    fun cheatsShowCountWhenEnabled() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Cheat Run",
+        )
+        harness.sessionRepo.preSetSessionCheats("s1", cheatsEnabled = true, enabledIndices = listOf(0, 2, 5))
+
+        setContent { harness.App() }
+        navigateToSessionDetail(harness, "s1")
+
+        // Scroll to cheats section
+        onNodeWithTag("session_detail_content")
+            .performScrollToNode(hasTestTag("session_cheats_section"))
+
+        onNodeWithTag("session_cheats_count").assertIsDisplayed()
+        onNodeWithText("3 cheat(s) active").assertIsDisplayed()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionsUiTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionsUiTest.kt
@@ -1,0 +1,251 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Desktop E2E tests for the Sessions feature on the Game Detail screen.
+ *
+ * Covers:
+ * - Session list rendering with pre-populated sessions
+ * - Empty state when no sessions exist
+ * - Creating a new session
+ * - Renaming a session
+ * - Deleting a session
+ * - Multiple sessions display correctly
+ * - Continue session triggers navigation with sessionId
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class SessionsUiTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun ComposeUiTest.scrollToSessions() {
+        onNodeWithTag("game_detail_content")
+            .performScrollToNode(hasTestTag("sessions_section"))
+    }
+
+    // ── Session list renders on game detail ──
+
+    @Test
+    fun sessionsDisplayOnGameDetail() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "My First Run",
+            totalPlayTime = 3600,
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("sessions_section").assertIsDisplayed()
+        onNodeWithText("Sessions").assertIsDisplayed()
+        onNodeWithText("(1)").assertIsDisplayed()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+        onNodeWithText("My First Run").assertIsDisplayed()
+    }
+
+    // ── Empty state shows correctly ──
+
+    @Test
+    fun emptyStateShowsWhenNoSessions() = runComposeUiTest {
+        val harness = createHarness()
+        // No sessions added
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("sessions_section").assertIsDisplayed()
+        onNodeWithTag("sessions_empty").assertIsDisplayed()
+        onNodeWithText("No sessions yet. Start a new playthrough to track your progress.")
+            .assertIsDisplayed()
+    }
+
+    // ── Create new session works ──
+
+    @Test
+    fun createNewSession() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("create_session_button").performClick()
+        advanceQuick(harness)
+
+        // Dialog should appear with default name
+        onNodeWithText("New Session").assertIsDisplayed()
+        onNodeWithTag("create_session_input").assertIsDisplayed()
+
+        // Clear and type a custom name
+        onNodeWithTag("create_session_input").performTextClearance()
+        onNodeWithTag("create_session_input").performTextInput("Speedrun Attempt")
+        advanceQuick(harness)
+
+        // Confirm creation
+        onNodeWithText("Create").performClick()
+        advance(harness)
+
+        // Session should be created in the fake repo
+        assertEquals(1, harness.sessionRepo.sessions.size)
+        assertEquals("Speedrun Attempt", harness.sessionRepo.sessions[0].name)
+    }
+
+    // ── Rename session works ──
+
+    @Test
+    fun renameSession() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Old Name",
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+
+        // Click the rename button
+        onNodeWithContentDescription("Rename session").performClick()
+        advanceQuick(harness)
+
+        // Rename dialog should appear
+        onNodeWithText("Rename Session").assertIsDisplayed()
+        onNodeWithTag("rename_session_input").assertIsDisplayed()
+
+        // Clear and type new name
+        onNodeWithTag("rename_session_input").performTextClearance()
+        onNodeWithTag("rename_session_input").performTextInput("New Name")
+        advanceQuick(harness)
+
+        // Confirm rename
+        onNodeWithText("Rename").performClick()
+        advance(harness)
+
+        // Session should be renamed in the fake repo
+        assertEquals("New Name", harness.sessionRepo.sessions[0].name)
+    }
+
+    // ── Delete session works ──
+
+    @Test
+    fun deleteSession() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Doomed Run",
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+
+        // Click the delete button
+        onNodeWithContentDescription("Delete session").performClick()
+        advanceQuick(harness)
+
+        // Delete confirmation dialog should appear
+        onNodeWithText("Delete Session").assertIsDisplayed()
+        onNodeWithText("Delete \"Doomed Run\"? All saves in this session will be permanently removed.")
+            .assertIsDisplayed()
+
+        // Confirm deletion
+        onAllNodesWithText("Delete").filterToOne(hasClickAction()).performClick()
+        advance(harness)
+
+        // Session should be deleted from the fake repo
+        assertTrue(harness.sessionRepo.sessions.isEmpty())
+    }
+
+    // ── Multiple sessions display correctly ──
+
+    @Test
+    fun multipleSessionsDisplayCorrectly() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(id = "s1", gameId = "1", name = "Casual Run")
+        harness.sessionRepo.preAddSession(id = "s2", gameId = "1", name = "100% Completion")
+        harness.sessionRepo.preAddSession(id = "s3", gameId = "1", name = "No Damage Run")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithText("(3)").assertIsDisplayed()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+        onNodeWithTag("session_item_s2").assertIsDisplayed()
+
+        // Scroll to see the third session
+        onNodeWithTag("game_detail_content")
+            .performScrollToNode(hasTestTag("session_item_s3"))
+        onNodeWithTag("session_item_s3").assertIsDisplayed()
+
+        onNodeWithText("Casual Run").assertIsDisplayed()
+        onNodeWithText("100% Completion").assertIsDisplayed()
+        onNodeWithText("No Damage Run").assertIsDisplayed()
+    }
+
+    // ── Continue session triggers overlay with sessionId ──
+
+    @Test
+    fun continueSessionSetsSessionId() = runComposeUiTest {
+        val harness = createHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "My Run",
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+
+        // Click the continue/play button on the session
+        onNodeWithContentDescription("Continue session").performClick()
+        advance(harness)
+
+        // The navigation state should have overlay with sessionId set
+        val navState = harness.navigationViewModel.state.value
+        assertTrue(navState.showInGameOverlay || navState.overlaySessionId == "s1",
+            "Expected session overlay to be triggered with sessionId s1")
+    }
+
+    // ── Sessions from other games don't appear ──
+
+    @Test
+    fun sessionsFilteredByGameId() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(id = "s1", gameId = "1", name = "Castlevania Run")
+        harness.sessionRepo.preAddSession(id = "s2", gameId = "2", name = "Mario Run")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithText("(1)").assertIsDisplayed()
+        onNodeWithText("Castlevania Run").assertIsDisplayed()
+        onNodeWithText("Mario Run").assertDoesNotExist()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionsUiTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionsUiTest.kt
@@ -248,4 +248,124 @@ class SessionsUiTest {
         onNodeWithText("Castlevania Run").assertIsDisplayed()
         onNodeWithText("Mario Run").assertDoesNotExist()
     }
+
+    // ── Multiplayer session shows member avatars ──
+
+    @Test
+    fun multiplayerSessionShowsMemberAvatars() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Co-op Run",
+            memberCount = 3,
+            memberAvatars = listOf(
+                "https://example.com/avatar1.png",
+                "https://example.com/avatar2.png",
+                "https://example.com/avatar3.png",
+            ),
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+        onNodeWithTag("session_member_avatars_s1").assertIsDisplayed()
+        onNodeWithTag("session_multiplayer_badge_s1").assertIsDisplayed()
+        onNodeWithText("Multiplayer").assertIsDisplayed()
+    }
+
+    // ── Multiplayer session shows "Last played by X" text ──
+
+    @Test
+    fun multiplayerSessionShowsLastPlayedBy() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Shared Run",
+            memberCount = 2,
+            lastPlayedByUsername = "player2",
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+        onNodeWithTag("session_last_played_by_s1").assertIsDisplayed()
+        onNodeWithText("Last played by player2").assertIsDisplayed()
+    }
+
+    // ── Relay session shows Relay badge ──
+
+    @Test
+    fun relaySessionShowsRelayBadge() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Relay Session",
+            memberCount = 2,
+            isRelay = true,
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+        onNodeWithTag("session_multiplayer_badge_s1").assertIsDisplayed()
+        onNodeWithText("Relay").assertIsDisplayed()
+    }
+
+    // ── Single-player session does NOT show multiplayer badge ──
+
+    @Test
+    fun singlePlayerSessionHidesMultiplayerBadge() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Solo Run",
+            memberCount = 1,
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+        onNodeWithTag("session_multiplayer_badge_s1").assertDoesNotExist()
+        onNodeWithTag("session_member_avatars_s1").assertDoesNotExist()
+    }
+
+    // ── Member count overflow shows "+N" ──
+
+    @Test
+    fun memberAvatarsShowOverflowCount() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Big Group",
+            memberCount = 7,
+            memberAvatars = listOf(
+                "https://example.com/a1.png",
+                "https://example.com/a2.png",
+                "https://example.com/a3.png",
+                "https://example.com/a4.png",
+                "https://example.com/a5.png",
+            ),
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("session_member_avatars_s1").assertIsDisplayed()
+        onNodeWithTag("session_avatar_overflow").assertIsDisplayed()
+        onNodeWithText("+3").assertIsDisplayed()
+    }
 }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -281,6 +281,12 @@ class SpelaTestHarness(
         scope = scope,
     )
 
+    val sessionDetailViewModel = SessionDetailViewModel(
+        sessionRepository = sessionRepo,
+        dispatchers = dispatchers,
+        scope = scope,
+    )
+
     val statsRepo = FakeStatsRepository()
 
     val statsViewModel = StatsViewModel(
@@ -369,6 +375,7 @@ class SpelaTestHarness(
             presenceService = presenceService,
             connectivityMonitor = connectivityMonitor,
             saveDataViewModel = saveDataViewModel,
+            sessionDetailViewModel = sessionDetailViewModel,
             gamepadPortManager = gamepadPortManager,
         )
         }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -111,6 +111,7 @@ class SpelaTestHarness(
     val challengeRepo = FakeChallengeRepository()
     val biosRepo = FakeBiosRepository(fakeApiClient, FakeFileStorage())
     val cheatRepo = FakeCheatRepository()
+    val sessionRepo = FakeSessionRepository()
 
     private val scrapeService = com.spela.player.data.remote.ScrapeService(fakeApiClient, dispatchers, scope)
 
@@ -156,6 +157,7 @@ class SpelaTestHarness(
         scope = scope,
         biosRepository = biosRepo,
         cheatRepository = cheatRepo,
+        sessionRepository = sessionRepo,
     )
 
     private val stubEngineFactory = object : HttpClientEngineFactory<HttpClientEngineConfig> {
@@ -181,6 +183,7 @@ class SpelaTestHarness(
         _state = emulationState,
         dispatchers = dispatchers,
         scope = scope,
+        sessionRepository = sessionRepo,
     )
     private val challengeManager = ChallengeManager(
         challengeRepository = challengeRepo,

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1302,10 +1302,17 @@ class FakeSessionRepository : SessionRepository {
     private val sessionSaves = mutableMapOf<String, MutableList<SaveState>>()
     private val autoSaves = mutableMapOf<String, ByteArray>()
     private val sram = mutableMapOf<String, ByteArray>()
+    private val sessionCheats = mutableMapOf<String, SessionCheatConfig>()
     private var nextId = 1
 
     override suspend fun getSessionsForGame(gameId: String): Result<List<GameSession>> =
         Result.success(sessions.filter { it.gameId == gameId })
+
+    override suspend fun getSession(sessionId: String): Result<GameSession> {
+        val session = sessions.find { it.id == sessionId }
+            ?: return Result.failure(Exception("Session not found"))
+        return Result.success(session)
+    }
 
     override suspend fun createSession(gameId: String, name: String): Result<GameSession> {
         val session = GameSession(
@@ -1364,6 +1371,24 @@ class FakeSessionRepository : SessionRepository {
         sram[sessionId]?.let { Result.success(it) }
             ?: Result.failure(Exception("No SRAM"))
 
+    override suspend fun getSessionCheats(sessionId: String): Result<SessionCheatConfig> =
+        Result.success(sessionCheats[sessionId] ?: SessionCheatConfig(cheatsEnabled = false, enabledIndices = emptyList()))
+
+    override suspend fun updateSessionCheats(
+        sessionId: String,
+        cheatsEnabled: Boolean,
+        enabledIndices: List<Int>,
+    ): Result<SessionCheatConfig> {
+        val config = SessionCheatConfig(cheatsEnabled = cheatsEnabled, enabledIndices = enabledIndices)
+        sessionCheats[sessionId] = config
+        // Also update the session's cheatsEnabled flag
+        val idx = sessions.indexOfFirst { it.id == sessionId }
+        if (idx >= 0) {
+            sessions[idx] = sessions[idx].copy(cheatsEnabled = cheatsEnabled)
+        }
+        return Result.success(config)
+    }
+
     fun preAddSession(
         id: String = "session-1",
         gameId: String = "1",
@@ -1371,6 +1396,9 @@ class FakeSessionRepository : SessionRepository {
         lastPlayedAt: String? = null,
         lastPlayedByUsername: String? = null,
         totalPlayTime: Long = 0,
+        memberCount: Int = 1,
+        memberAvatars: List<String> = emptyList(),
+        isRelay: Boolean = false,
     ): GameSession {
         val session = GameSession(
             id = id,
@@ -1379,9 +1407,31 @@ class FakeSessionRepository : SessionRepository {
             lastPlayedAt = lastPlayedAt,
             lastPlayedByUsername = lastPlayedByUsername,
             totalPlayTime = totalPlayTime,
+            memberCount = memberCount,
+            memberAvatars = memberAvatars,
+            isRelay = isRelay,
         )
         sessions.add(session)
         return session
+    }
+
+    fun preAddSessionSave(
+        sessionId: String,
+        saveId: Long = 1,
+        name: String = "Save 1",
+        isAuto: Boolean = false,
+    ) {
+        val save = SaveState(
+            id = saveId,
+            gameId = 0,
+            name = name,
+            isAuto = isAuto,
+        )
+        sessionSaves.getOrPut(sessionId) { mutableListOf() }.add(save)
+    }
+
+    fun preSetSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int> = emptyList()) {
+        sessionCheats[sessionId] = SessionCheatConfig(cheatsEnabled = cheatsEnabled, enabledIndices = enabledIndices)
     }
 }
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1297,6 +1297,94 @@ class FakeSaveDataRepository : SaveDataRepository {
     }
 }
 
+class FakeSessionRepository : SessionRepository {
+    var sessions: MutableList<GameSession> = mutableListOf()
+    private val sessionSaves = mutableMapOf<String, MutableList<SaveState>>()
+    private val autoSaves = mutableMapOf<String, ByteArray>()
+    private val sram = mutableMapOf<String, ByteArray>()
+    private var nextId = 1
+
+    override suspend fun getSessionsForGame(gameId: String): Result<List<GameSession>> =
+        Result.success(sessions.filter { it.gameId == gameId })
+
+    override suspend fun createSession(gameId: String, name: String): Result<GameSession> {
+        val session = GameSession(
+            id = "session-${nextId++}",
+            gameId = gameId,
+            name = name,
+        )
+        sessions.add(session)
+        return Result.success(session)
+    }
+
+    override suspend fun updateSession(sessionId: String, name: String): Result<GameSession> {
+        val idx = sessions.indexOfFirst { it.id == sessionId }
+        if (idx < 0) return Result.failure(Exception("Session not found"))
+        sessions[idx] = sessions[idx].copy(name = name)
+        return Result.success(sessions[idx])
+    }
+
+    override suspend fun deleteSession(sessionId: String): Result<Unit> {
+        sessions.removeAll { it.id == sessionId }
+        return Result.success(Unit)
+    }
+
+    override suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>> =
+        Result.success(sessionSaves[sessionId] ?: emptyList())
+
+    override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?): Result<SaveState> {
+        val save = SaveState(
+            id = (sessionSaves[sessionId]?.size?.toLong() ?: 0L) + 1,
+            gameId = 0,
+            name = name,
+            isAuto = false,
+        )
+        sessionSaves.getOrPut(sessionId) { mutableListOf() }.add(save)
+        return Result.success(save)
+    }
+
+    override suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray> =
+        Result.success(ByteArray(256) { it.toByte() })
+
+    override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?): Result<Unit> {
+        autoSaves[sessionId] = data
+        return Result.success(Unit)
+    }
+
+    override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> =
+        autoSaves[sessionId]?.let { Result.success(it) }
+            ?: Result.failure(Exception("No auto-save"))
+
+    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray): Result<Unit> {
+        sram[sessionId] = data
+        return Result.success(Unit)
+    }
+
+    override suspend fun downloadSessionSram(sessionId: String): Result<ByteArray> =
+        sram[sessionId]?.let { Result.success(it) }
+            ?: Result.failure(Exception("No SRAM"))
+
+    fun preAddSession(
+        id: String = "session-1",
+        gameId: String = "1",
+        name: String = "Playthrough 1",
+        lastPlayedAt: String? = null,
+        lastPlayedByUsername: String? = null,
+        totalPlayTime: Long = 0,
+    ): GameSession {
+        val session = GameSession(
+            id = id,
+            gameId = gameId,
+            name = name,
+            lastPlayedAt = lastPlayedAt,
+            lastPlayedByUsername = lastPlayedByUsername,
+            totalPlayTime = totalPlayTime,
+        )
+        sessions.add(session)
+        return session
+    }
+}
+
 class FakeCheatRepository : CheatRepository {
     var cheats: MutableList<Cheat> = mutableListOf()
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1269,6 +1269,109 @@ class SpelaApiClient(
         }
     }
 
+    // ── Game Sessions ──
+
+    suspend fun getSessionsForGame(gameId: String): List<GameSessionDto> {
+        return client.get("$baseUrl/api/games/$gameId/sessions").body()
+    }
+
+    suspend fun createSession(gameId: String, name: String): GameSessionDto {
+        return client.post("$baseUrl/api/games/$gameId/sessions") {
+            setBody(CreateSessionRequest(name = name))
+        }.body()
+    }
+
+    suspend fun getSession(sessionId: String): GameSessionDto {
+        return client.get("$baseUrl/api/sessions/$sessionId").body()
+    }
+
+    suspend fun updateSession(sessionId: String, name: String): GameSessionDto {
+        return client.put("$baseUrl/api/sessions/$sessionId") {
+            setBody(UpdateSessionRequest(name = name))
+        }.body()
+    }
+
+    suspend fun deleteSession(sessionId: String) {
+        client.delete("$baseUrl/api/sessions/$sessionId")
+    }
+
+    suspend fun getSessionSaves(sessionId: String): List<SaveStateDto> {
+        return client.get("$baseUrl/api/sessions/$sessionId/saves").body()
+    }
+
+    suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?): SaveStateDto {
+        return client.submitFormWithBinaryData(
+            url = "$baseUrl/api/sessions/$sessionId/saves",
+            formData = formData {
+                append("name", name)
+                append("save", data, Headers.build {
+                    append(HttpHeaders.ContentDisposition, "filename=\"save.sav\"")
+                    append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())
+                })
+                if (screenshot != null) {
+                    append("screenshot", screenshot, Headers.build {
+                        append(HttpHeaders.ContentDisposition, "filename=\"screenshot.png\"")
+                        append(HttpHeaders.ContentType, ContentType.Image.PNG.toString())
+                    })
+                }
+            }
+        ).body()
+    }
+
+    suspend fun downloadSessionSave(sessionId: String, saveId: String): ByteArray {
+        val response = client.get("$baseUrl/api/sessions/$sessionId/saves/$saveId")
+        if (!response.status.isSuccess()) {
+            throw RuntimeException("Session save download failed: HTTP ${response.status.value}")
+        }
+        return response.body()
+    }
+
+    suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?) {
+        client.submitFormWithBinaryData(
+            url = "$baseUrl/api/sessions/$sessionId/saves/auto",
+            formData = formData {
+                append("save", data, Headers.build {
+                    append(HttpHeaders.ContentDisposition, "filename=\"autosave.sav\"")
+                    append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())
+                })
+                if (screenshot != null) {
+                    append("screenshot", screenshot, Headers.build {
+                        append(HttpHeaders.ContentDisposition, "filename=\"screenshot.png\"")
+                        append(HttpHeaders.ContentType, ContentType.Image.PNG.toString())
+                    })
+                }
+            }
+        )
+    }
+
+    suspend fun downloadSessionAutoSave(sessionId: String): ByteArray {
+        val response = client.get("$baseUrl/api/sessions/$sessionId/saves/auto")
+        if (!response.status.isSuccess()) {
+            throw RuntimeException("Session auto-save download failed: HTTP ${response.status.value}")
+        }
+        return response.body()
+    }
+
+    suspend fun uploadSessionSram(sessionId: String, data: ByteArray) {
+        client.submitFormWithBinaryData(
+            url = "$baseUrl/api/sessions/$sessionId/sram",
+            formData = formData {
+                append("file", data, Headers.build {
+                    append(HttpHeaders.ContentDisposition, "filename=\"sram.srm\"")
+                    append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())
+                })
+            }
+        )
+    }
+
+    suspend fun downloadSessionSram(sessionId: String): ByteArray {
+        val response = client.get("$baseUrl/api/sessions/$sessionId/sram")
+        if (!response.status.isSuccess()) {
+            throw RuntimeException("Session SRAM download failed: HTTP ${response.status.value}")
+        }
+        return response.body()
+    }
+
     fun close() {
         client.close()
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1372,6 +1372,16 @@ class SpelaApiClient(
         return response.body()
     }
 
+    suspend fun getSessionCheats(sessionId: String): SessionCheatConfigDto {
+        return client.get("$baseUrl/api/sessions/$sessionId/cheats").body()
+    }
+
+    suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>): SessionCheatConfigDto {
+        return client.put("$baseUrl/api/sessions/$sessionId/cheats") {
+            setBody(UpdateSessionCheatsRequest(cheatsEnabled = cheatsEnabled, enabledIndices = enabledIndices))
+        }.body()
+    }
+
     fun close() {
         client.close()
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -518,6 +518,19 @@ fun DeveloperGameDto.toDomain(): DeveloperGame = DeveloperGame(
     consoleName = consoleName,
 )
 
+fun GameSessionDto.toDomain(): GameSession = GameSession(
+    id = id,
+    gameId = gameId,
+    name = name,
+    lastPlayedAt = lastPlayedAt,
+    lastPlayedByUsername = lastPlayedByUsername,
+    totalPlayTime = totalPlayTime,
+    screenshotUrl = screenshotUrl,
+    cheatsEnabled = cheatsEnabled,
+    memberCount = memberCount,
+    memberAvatars = memberAvatars,
+)
+
 fun SaveDataDto.toDomain() = SaveData(
     id = id,
     gameId = gameId,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -529,6 +529,12 @@ fun GameSessionDto.toDomain(): GameSession = GameSession(
     cheatsEnabled = cheatsEnabled,
     memberCount = memberCount,
     memberAvatars = memberAvatars,
+    isRelay = isRelay,
+)
+
+fun SessionCheatConfigDto.toDomain() = SessionCheatConfig(
+    cheatsEnabled = cheatsEnabled,
+    enabledIndices = enabledIndices,
 )
 
 fun SaveDataDto.toDomain() = SaveData(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -953,6 +953,7 @@ data class GameSessionDto(
     val cheatsEnabled: Boolean = false,
     val memberCount: Int = 1,
     val memberAvatars: List<String> = emptyList(),
+    val isRelay: Boolean = false,
 )
 
 @Serializable
@@ -963,6 +964,20 @@ data class CreateSessionRequest(
 @Serializable
 data class UpdateSessionRequest(
     val name: String,
+)
+
+// Session Cheats
+
+@Serializable
+data class SessionCheatConfigDto(
+    val cheatsEnabled: Boolean = false,
+    val enabledIndices: List<Int> = emptyList(),
+)
+
+@Serializable
+data class UpdateSessionCheatsRequest(
+    val cheatsEnabled: Boolean,
+    val enabledIndices: List<Int>,
 )
 
 // Cheats

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -939,6 +939,32 @@ data class SaveDataDto(
     val updatedAt: String = "",
 )
 
+// Game Sessions
+
+@Serializable
+data class GameSessionDto(
+    val id: String,
+    val gameId: String,
+    val name: String,
+    val lastPlayedAt: String? = null,
+    val lastPlayedByUsername: String? = null,
+    val totalPlayTime: Long = 0,
+    val screenshotUrl: String? = null,
+    val cheatsEnabled: Boolean = false,
+    val memberCount: Int = 1,
+    val memberAvatars: List<String> = emptyList(),
+)
+
+@Serializable
+data class CreateSessionRequest(
+    val name: String,
+)
+
+@Serializable
+data class UpdateSessionRequest(
+    val name: String,
+)
+
 // Cheats
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -1,0 +1,65 @@
+package com.spela.player.data.repository
+
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.dto.toDomain
+import com.spela.player.domain.model.GameSession
+import com.spela.player.domain.model.SaveState
+import com.spela.player.domain.repository.SessionRepository
+
+class SessionRepositoryImpl(
+    private val apiClient: SpelaApiClient,
+) : SessionRepository {
+
+    override suspend fun getSessionsForGame(gameId: String): Result<List<GameSession>> = runCatching {
+        apiClient.getSessionsForGame(gameId).map { it.toDomain() }
+    }
+
+    override suspend fun createSession(gameId: String, name: String): Result<GameSession> = runCatching {
+        apiClient.createSession(gameId, name).toDomain()
+    }
+
+    override suspend fun updateSession(sessionId: String, name: String): Result<GameSession> = runCatching {
+        apiClient.updateSession(sessionId, name).toDomain()
+    }
+
+    override suspend fun deleteSession(sessionId: String): Result<Unit> = runCatching {
+        apiClient.deleteSession(sessionId)
+    }
+
+    override suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>> = runCatching {
+        apiClient.getSessionSaves(sessionId).map { it.toDomain() }
+    }
+
+    override suspend fun uploadSessionSave(
+        sessionId: String,
+        name: String,
+        data: ByteArray,
+        screenshot: ByteArray?,
+    ): Result<SaveState> = runCatching {
+        apiClient.uploadSessionSave(sessionId, name, data, screenshot).toDomain()
+    }
+
+    override suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray> = runCatching {
+        apiClient.downloadSessionSave(sessionId, saveId)
+    }
+
+    override suspend fun uploadSessionAutoSave(
+        sessionId: String,
+        data: ByteArray,
+        screenshot: ByteArray?,
+    ): Result<Unit> = runCatching {
+        apiClient.uploadSessionAutoSave(sessionId, data, screenshot)
+    }
+
+    override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> = runCatching {
+        apiClient.downloadSessionAutoSave(sessionId)
+    }
+
+    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray): Result<Unit> = runCatching {
+        apiClient.uploadSessionSram(sessionId, data)
+    }
+
+    override suspend fun downloadSessionSram(sessionId: String): Result<ByteArray> = runCatching {
+        apiClient.downloadSessionSram(sessionId)
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.GameSession
 import com.spela.player.domain.model.SaveState
+import com.spela.player.domain.model.SessionCheatConfig
 import com.spela.player.domain.repository.SessionRepository
 
 class SessionRepositoryImpl(
@@ -12,6 +13,10 @@ class SessionRepositoryImpl(
 
     override suspend fun getSessionsForGame(gameId: String): Result<List<GameSession>> = runCatching {
         apiClient.getSessionsForGame(gameId).map { it.toDomain() }
+    }
+
+    override suspend fun getSession(sessionId: String): Result<GameSession> = runCatching {
+        apiClient.getSession(sessionId).toDomain()
     }
 
     override suspend fun createSession(gameId: String, name: String): Result<GameSession> = runCatching {
@@ -61,5 +66,17 @@ class SessionRepositoryImpl(
 
     override suspend fun downloadSessionSram(sessionId: String): Result<ByteArray> = runCatching {
         apiClient.downloadSessionSram(sessionId)
+    }
+
+    override suspend fun getSessionCheats(sessionId: String): Result<SessionCheatConfig> = runCatching {
+        apiClient.getSessionCheats(sessionId).toDomain()
+    }
+
+    override suspend fun updateSessionCheats(
+        sessionId: String,
+        cheatsEnabled: Boolean,
+        enabledIndices: List<Int>,
+    ): Result<SessionCheatConfig> = runCatching {
+        apiClient.updateSessionCheats(sessionId, cheatsEnabled, enabledIndices).toDomain()
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -68,6 +68,7 @@ val commonModule = module {
     single<ChallengeRepository> { ChallengeRepositoryImpl(get()) }
     single<GameStatsRepository> { GameStatsRepositoryImpl(get()) }
     single<CheatRepository> { CheatRepositoryImpl(get(), get()) }
+    single<SessionRepository> { SessionRepositoryImpl(get()) }
     single { BiosRepository(get(), get()) }
     single { GamepadPortManager(get()) }
 
@@ -164,6 +165,7 @@ val commonModule = module {
             scope = get(),
             biosRepository = get(),
             cheatRepository = get(),
+            sessionRepository = get(),
         )
     }
     single { MutableStateFlow(EmulationState()) }
@@ -179,6 +181,7 @@ val commonModule = module {
             _state = get(),
             dispatchers = get(),
             scope = get(),
+            sessionRepository = get(),
         )
     }
     single {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -321,6 +321,14 @@ val commonModule = module {
         )
     }
 
+    factory {
+        SessionDetailViewModel(
+            sessionRepository = get(),
+            dispatchers = get(),
+            scope = get(),
+        )
+    }
+
     /* Navigation & UI ViewModels */
     single {
         NavigationViewModel(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -651,6 +651,12 @@ data class GameSession(
     val cheatsEnabled: Boolean = false,
     val memberCount: Int = 1,
     val memberAvatars: List<String> = emptyList(),
+    val isRelay: Boolean = false,
+)
+
+data class SessionCheatConfig(
+    val cheatsEnabled: Boolean,
+    val enabledIndices: List<Int>,
 )
 
 // BIOS

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -637,6 +637,22 @@ data class DeveloperGame(
     val consoleName: String = "",
 )
 
+// Game Sessions
+
+@Serializable
+data class GameSession(
+    val id: String,
+    val gameId: String,
+    val name: String,
+    val lastPlayedAt: String? = null,
+    val lastPlayedByUsername: String? = null,
+    val totalPlayTime: Long = 0,
+    val screenshotUrl: String? = null,
+    val cheatsEnabled: Boolean = false,
+    val memberCount: Int = 1,
+    val memberAvatars: List<String> = emptyList(),
+)
+
 // BIOS
 
 data class BiosConsoleStatus(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -1,0 +1,18 @@
+package com.spela.player.domain.repository
+
+import com.spela.player.domain.model.GameSession
+import com.spela.player.domain.model.SaveState
+
+interface SessionRepository {
+    suspend fun getSessionsForGame(gameId: String): Result<List<GameSession>>
+    suspend fun createSession(gameId: String, name: String): Result<GameSession>
+    suspend fun updateSession(sessionId: String, name: String): Result<GameSession>
+    suspend fun deleteSession(sessionId: String): Result<Unit>
+    suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>>
+    suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?): Result<SaveState>
+    suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray>
+    suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?): Result<Unit>
+    suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray>
+    suspend fun uploadSessionSram(sessionId: String, data: ByteArray): Result<Unit>
+    suspend fun downloadSessionSram(sessionId: String): Result<ByteArray>
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -2,9 +2,11 @@ package com.spela.player.domain.repository
 
 import com.spela.player.domain.model.GameSession
 import com.spela.player.domain.model.SaveState
+import com.spela.player.domain.model.SessionCheatConfig
 
 interface SessionRepository {
     suspend fun getSessionsForGame(gameId: String): Result<List<GameSession>>
+    suspend fun getSession(sessionId: String): Result<GameSession>
     suspend fun createSession(gameId: String, name: String): Result<GameSession>
     suspend fun updateSession(sessionId: String, name: String): Result<GameSession>
     suspend fun deleteSession(sessionId: String): Result<Unit>
@@ -15,4 +17,6 @@ interface SessionRepository {
     suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray>
     suspend fun uploadSessionSram(sessionId: String, data: ByteArray): Result<Unit>
     suspend fun downloadSessionSram(sessionId: String): Result<ByteArray>
+    suspend fun getSessionCheats(sessionId: String): Result<SessionCheatConfig>
+    suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>): Result<SessionCheatConfig>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -12,6 +12,7 @@ sealed interface EmulationIntent {
         val challengeId: String? = null,
         val challengeSaveData: ByteArray? = null,
         val skipAutoLoad: Boolean = false,
+        val sessionId: String? = null,
     ) : EmulationIntent
     data object PauseGame : EmulationIntent
     data object ResumeGame : EmulationIntent
@@ -79,6 +80,7 @@ sealed interface EmulationIntent {
     data class PrepareLaunch(
         val gameId: String,
         val skipAutoLoad: Boolean = false,
+        val sessionId: String? = null,
     ) : EmulationIntent
     data object PlayWithLocalSave : EmulationIntent
     data object CancelLaunch : EmulationIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
@@ -74,4 +74,10 @@ sealed interface GameDetailIntent {
     data object DisableAllCheats : GameDetailIntent
     data object ShowCheatDialog : GameDetailIntent
     data object DismissCheatDialog : GameDetailIntent
+
+    // Sessions
+    data class LoadSessions(val gameId: String) : GameDetailIntent
+    data class CreateSession(val gameId: String, val name: String) : GameDetailIntent
+    data class RenameSession(val sessionId: String, val name: String) : GameDetailIntent
+    data class DeleteSession(val sessionId: String) : GameDetailIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/SessionDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/SessionDetailIntent.kt
@@ -1,0 +1,14 @@
+package com.spela.player.presentation.intent
+
+sealed interface SessionDetailIntent {
+    data class LoadSession(val sessionId: String) : SessionDetailIntent
+    data class RenameSession(val sessionId: String, val name: String) : SessionDetailIntent
+    data class DeleteSession(val sessionId: String) : SessionDetailIntent
+    data class ToggleCheatsEnabled(val sessionId: String, val enabled: Boolean) : SessionDetailIntent
+    data class UpdateCheatSettings(val sessionId: String, val enabledIndices: List<Int>) : SessionDetailIntent
+    data class StartFromSave(val sessionId: String, val saveId: String) : SessionDetailIntent
+    data object ShowDeleteConfirm : SessionDetailIntent
+    data object DismissDeleteConfirm : SessionDetailIntent
+    data object DismissError : SessionDetailIntent
+    data object DismissSuccess : SessionDetailIntent
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
@@ -132,6 +132,7 @@ class NavigationViewModel(
                         overlayNetplayIsHost = intent.netplayIsHost,
                         overlayChallengeId = intent.challengeId,
                         overlaySkipAutoLoad = intent.skipAutoLoad,
+                        overlaySessionId = intent.sessionId,
                         screenBehindOverlay = it.currentScreen,
                         backStackBehindOverlay = it.backStack,
                     )
@@ -152,6 +153,7 @@ class NavigationViewModel(
                             overlayNetplayIsHost = false,
                             overlayChallengeId = null,
                             overlaySkipAutoLoad = false,
+                            overlaySessionId = null,
                             currentScreen = it.screenBehindOverlay,
                             backStack = it.backStackBehindOverlay,
                             screenBehindOverlay = null,
@@ -169,6 +171,7 @@ class NavigationViewModel(
                             overlayNetplayIsHost = false,
                             overlayChallengeId = null,
                             overlaySkipAutoLoad = false,
+                            overlaySessionId = null,
                         )
                     }
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -27,6 +27,7 @@ sealed class SpScreen(val route: String) {
     data class ChallengeList(val gameId: String, val gameTitle: String) : SpScreen("challenges/$gameId")
     data class ChallengeDetail(val challengeId: String) : SpScreen("challenge/$challengeId")
     data class SaveDataManagement(val gameId: String) : SpScreen("save_data/$gameId")
+    data class SessionDetail(val sessionId: String) : SpScreen("sessions/$sessionId")
 }
 
 data class NavigationState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -43,6 +43,7 @@ data class NavigationState(
     val overlayNetplayIsHost: Boolean = false,
     val overlayChallengeId: String? = null,
     val overlaySkipAutoLoad: Boolean = false,
+    val overlaySessionId: String? = null,
     val screenBehindOverlay: SpScreen? = null,
     val backStackBehindOverlay: List<SpScreen> = emptyList(),
     val isRestoringSession: Boolean = true,
@@ -65,6 +66,7 @@ sealed interface NavigationIntent {
         val netplayIsHost: Boolean = false,
         val challengeId: String? = null,
         val skipAutoLoad: Boolean = false,
+        val sessionId: String? = null,
     ) : NavigationIntent
     data object HideOverlay : NavigationIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -89,6 +89,9 @@ data class EmulationState(
     /** Rewind: whether rewind is currently active (holding down rewind). */
     val isRewinding: Boolean = false,
 
+    /** Session: set when playing within a game session. */
+    val sessionId: String? = null,
+
     /** Cheats */
     val hasCheats: Boolean = false,
     val enabledCheatCount: Int = 0,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
@@ -18,6 +18,7 @@ import com.spela.player.domain.model.SaveState
 import com.spela.player.domain.model.SharedSaveState
 import com.spela.player.domain.model.SimilarGame
 import com.spela.player.domain.model.Cheat
+import com.spela.player.domain.model.GameSession
 import com.spela.player.domain.model.StorageUsage
 
 enum class AchievementsViewMode { GRID, TIMELINE, LEADERBOARD }
@@ -96,4 +97,8 @@ data class GameDetailState(
     val cheats: List<Cheat> = emptyList(),
     val isLoadingCheats: Boolean = false,
     val showCheatDialog: Boolean = false,
+
+    // Sessions
+    val sessions: List<GameSession> = emptyList(),
+    val isLoadingSessions: Boolean = false,
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SessionDetailState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SessionDetailState.kt
@@ -1,0 +1,16 @@
+package com.spela.player.presentation.state
+
+import com.spela.player.domain.model.GameSession
+import com.spela.player.domain.model.SaveState
+
+data class SessionDetailState(
+    val session: GameSession? = null,
+    val saves: List<SaveState> = emptyList(),
+    val cheatsEnabled: Boolean = false,
+    val enabledCheatIndices: List<Int> = emptyList(),
+    val isLoading: Boolean = false,
+    val isLoadingSaves: Boolean = false,
+    val showDeleteConfirm: Boolean = false,
+    val error: String? = null,
+    val successMessage: String? = null,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -77,6 +77,7 @@ import com.spela.player.presentation.ui.screen.NetplayListScreen
 import com.spela.player.presentation.ui.screen.NetplayLobbyScreen
 import com.spela.player.presentation.ui.screen.NetplayStartConfig
 import com.spela.player.presentation.ui.screen.RelayDetailScreen
+import com.spela.player.presentation.ui.screen.SessionDetailScreen
 import com.spela.player.presentation.ui.screen.RelaysScreen
 import com.spela.player.presentation.ui.screen.AllGamesScreen
 import com.spela.player.presentation.ui.screen.CollectionDetailScreen
@@ -107,6 +108,7 @@ import com.spela.player.presentation.viewmodel.GameListViewModel
 import com.spela.player.presentation.viewmodel.LibretroController
 import com.spela.player.presentation.viewmodel.LoginViewModel
 import com.spela.player.presentation.viewmodel.RelayDetailViewModel
+import com.spela.player.presentation.viewmodel.SessionDetailViewModel
 import com.spela.player.presentation.viewmodel.RelaysViewModel
 import com.spela.player.presentation.viewmodel.ServerConnectionViewModel
 import com.spela.player.presentation.viewmodel.KeyMappingViewModel
@@ -150,6 +152,7 @@ fun SpelaApp(
     presenceService: PresenceService,
     connectivityMonitor: ConnectivityMonitor,
     saveDataViewModel: SaveDataViewModel? = null,
+    sessionDetailViewModel: SessionDetailViewModel? = null,
     navigationEventBus: NavigationEventBus? = null,
     gamepadPortManager: GamepadPortManager? = null,
 ) {
@@ -534,6 +537,11 @@ fun SpelaApp(
                                             NavigationIntent.NavigateTo(SpScreen.SaveDataManagement(gameId))
                                         )
                                     },
+                                    onNavigateToSession = { sid ->
+                                        navigationViewModel.onIntent(
+                                            NavigationIntent.NavigateTo(SpScreen.SessionDetail(sid))
+                                        )
+                                    },
                                     onNavigateToGame = { targetGameId ->
                                         navigationViewModel.onIntent(
                                             NavigationIntent.NavigateTo(SpScreen.GameDetail(targetGameId))
@@ -861,6 +869,29 @@ fun SpelaApp(
                                         gameId = screen.gameId,
                                         viewModel = saveDataViewModel,
                                         onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.SessionDetail -> {
+                                if (sessionDetailViewModel != null) {
+                                    SessionDetailScreen(
+                                        sessionId = screen.sessionId,
+                                        viewModel = sessionDetailViewModel,
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                        onPlay = { gameId, sid ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.ShowOverlay(
+                                                    gameId = gameId,
+                                                    sessionId = sid,
+                                                )
+                                            )
+                                        },
+                                        onDeleted = {
                                             navigationViewModel.onIntent(NavigationIntent.GoBack)
                                         },
                                     )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -480,6 +480,7 @@ fun SpelaApp(
                                             NavigationIntent.ShowOverlay(
                                                 gameId = pending.gameId,
                                                 skipAutoLoad = pending.skipAutoLoad,
+                                                sessionId = pending.sessionId,
                                             )
                                         )
                                     }
@@ -507,6 +508,11 @@ fun SpelaApp(
                                     },
                                     onCancelLaunch = {
                                         emulationViewModel.onIntent(EmulationIntent.CancelLaunch)
+                                    },
+                                    onPlaySession = { gameId, sessionId ->
+                                        emulationViewModel.onIntent(
+                                            EmulationIntent.PrepareLaunch(gameId, sessionId = sessionId)
+                                        )
                                     },
                                     onCreateNetplay = { gameId ->
                                         netplayViewModel.onIntent(
@@ -880,7 +886,7 @@ fun SpelaApp(
                                 },
                         )
 
-                        LaunchedEffect(navState.overlayGameId, navState.overlayRelayId, navState.overlayNetplaySessionId, navState.overlayChallengeId) {
+                        LaunchedEffect(navState.overlayGameId, navState.overlayRelayId, navState.overlayNetplaySessionId, navState.overlayChallengeId, navState.overlaySessionId) {
                             navState.overlayGameId?.let { gameId ->
                                 emulationViewModel.onIntent(
                                     EmulationIntent.StartGame(
@@ -893,6 +899,7 @@ fun SpelaApp(
                                         netplayIsHost = navState.overlayNetplayIsHost,
                                         challengeId = navState.overlayChallengeId,
                                         skipAutoLoad = navState.overlaySkipAutoLoad,
+                                        sessionId = navState.overlaySessionId,
                                     )
                                 )
                             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
@@ -1,0 +1,282 @@
+package com.spela.player.presentation.ui.feature.gamedetail
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.outlined.Gamepad
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import com.spela.player.domain.model.GameSession
+import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpButtonStyle
+import com.spela.player.presentation.ui.components.SpInnerCard
+import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.components.social.formatRelativeTime
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.formatPlayTime
+
+@Composable
+internal fun SessionsSection(
+    sessions: List<GameSession>,
+    isLoading: Boolean,
+    onContinueSession: (GameSession) -> Unit,
+    onCreateSession: (String) -> Unit,
+    onRenameSession: (String, String) -> Unit,
+    onDeleteSession: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var showRenameDialog by remember { mutableStateOf<GameSession?>(null) }
+    var showDeleteDialog by remember { mutableStateOf<GameSession?>(null) }
+    var showCreateDialog by remember { mutableStateOf(false) }
+
+    SpTitledSection(
+        title = "Sessions",
+        icon = Icons.Outlined.Gamepad,
+        modifier = modifier.testTag("sessions_section"),
+        titleTrailing = if (sessions.isNotEmpty()) {
+            {
+                Text(
+                    text = "(${sessions.size})",
+                    style = SpTypography.BodySmall,
+                    color = SpColor.OnBackgroundTertiary,
+                )
+            }
+        } else null,
+    ) {
+        if (sessions.isEmpty() && !isLoading) {
+            Text(
+                text = "No sessions yet. Start a new playthrough to track your progress.",
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundTertiary,
+                modifier = Modifier.testTag("sessions_empty"),
+            )
+            Spacer(Modifier.height(SpSpacing.Default))
+        }
+
+        sessions.forEach { session ->
+            SessionItem(
+                session = session,
+                onContinue = { onContinueSession(session) },
+                onRename = { showRenameDialog = session },
+                onDelete = { showDeleteDialog = session },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = SpSpacing.XXSmall),
+            )
+        }
+
+        Spacer(Modifier.height(SpSpacing.Small))
+        SpButton(
+            text = "Start New Session",
+            onClick = { showCreateDialog = true },
+            style = SpButtonStyle.Outlined,
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("create_session_button"),
+        )
+    }
+
+    // Rename dialog
+    showRenameDialog?.let { session ->
+        var newName by remember { mutableStateOf(session.name) }
+        AlertDialog(
+            onDismissRequest = { showRenameDialog = null },
+            title = { Text("Rename Session") },
+            text = {
+                OutlinedTextField(
+                    value = newName,
+                    onValueChange = { newName = it },
+                    label = { Text("Session Name") },
+                    singleLine = true,
+                    modifier = Modifier.testTag("rename_session_input"),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        if (newName.isNotBlank()) {
+                            onRenameSession(session.id, newName.trim())
+                            showRenameDialog = null
+                        }
+                    },
+                ) {
+                    Text("Rename")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showRenameDialog = null }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+
+    // Delete dialog
+    showDeleteDialog?.let { session ->
+        AlertDialog(
+            onDismissRequest = { showDeleteDialog = null },
+            title = { Text("Delete Session") },
+            text = { Text("Delete \"${session.name}\"? All saves in this session will be permanently removed.") },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        onDeleteSession(session.id)
+                        showDeleteDialog = null
+                    },
+                ) {
+                    Text("Delete", color = SpColor.Error)
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showDeleteDialog = null }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+
+    // Create dialog
+    if (showCreateDialog) {
+        var sessionName by remember { mutableStateOf("Playthrough ${sessions.size + 1}") }
+        AlertDialog(
+            onDismissRequest = { showCreateDialog = false },
+            title = { Text("New Session") },
+            text = {
+                OutlinedTextField(
+                    value = sessionName,
+                    onValueChange = { sessionName = it },
+                    label = { Text("Session Name") },
+                    singleLine = true,
+                    modifier = Modifier.testTag("create_session_input"),
+                )
+            },
+            confirmButton = {
+                TextButton(
+                    onClick = {
+                        if (sessionName.isNotBlank()) {
+                            onCreateSession(sessionName.trim())
+                            showCreateDialog = false
+                        }
+                    },
+                ) {
+                    Text("Create")
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showCreateDialog = false }) {
+                    Text("Cancel")
+                }
+            },
+        )
+    }
+}
+
+@Composable
+private fun SessionItem(
+    session: GameSession,
+    onContinue: () -> Unit,
+    onRename: () -> Unit,
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    SpInnerCard(
+        modifier = modifier
+            .clickable(onClick = onContinue)
+            .testTag("session_item_${session.id}"),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SpSpacing.Default),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = session.name,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 1,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Session: ${session.name}"
+                    },
+                )
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    if (session.totalPlayTime > 0) {
+                        Text(
+                            text = formatPlayTime(session.totalPlayTime),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                    if (session.lastPlayedAt != null) {
+                        Text(
+                            text = formatRelativeTime(session.lastPlayedAt),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                    if (session.lastPlayedByUsername != null) {
+                        Text(
+                            text = session.lastPlayedByUsername,
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+            }
+
+            Row {
+                IconButton(onClick = onRename) {
+                    Icon(
+                        Icons.Filled.Edit,
+                        contentDescription = "Rename session",
+                        tint = SpColor.OnBackgroundSecondary,
+                    )
+                }
+                IconButton(onClick = onDelete) {
+                    Icon(
+                        Icons.Filled.Delete,
+                        contentDescription = "Delete session",
+                        tint = SpColor.OnBackgroundSecondary,
+                    )
+                }
+                IconButton(onClick = onContinue) {
+                    Icon(
+                        Icons.Filled.PlayArrow,
+                        contentDescription = "Continue session",
+                        tint = SpColor.Accent,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
@@ -2,16 +2,20 @@ package com.spela.player.presentation.ui.feature.gamedetail
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.outlined.Gamepad
 import androidx.compose.material3.AlertDialog
@@ -30,9 +34,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.GameSession
+import com.spela.player.presentation.ui.components.SpAvatar
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
+import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpInnerCard
 import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.components.social.formatRelativeTime
@@ -49,6 +56,7 @@ internal fun SessionsSection(
     onCreateSession: (String) -> Unit,
     onRenameSession: (String, String) -> Unit,
     onDeleteSession: (String) -> Unit,
+    onSessionSelected: ((GameSession) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     var showRenameDialog by remember { mutableStateOf<GameSession?>(null) }
@@ -82,6 +90,13 @@ internal fun SessionsSection(
         sessions.forEach { session ->
             SessionItem(
                 session = session,
+                onClick = {
+                    if (onSessionSelected != null) {
+                        onSessionSelected(session)
+                    } else {
+                        onContinueSession(session)
+                    }
+                },
                 onContinue = { onContinueSession(session) },
                 onRename = { showRenameDialog = session },
                 onDelete = { showDeleteDialog = session },
@@ -200,14 +215,17 @@ internal fun SessionsSection(
 @Composable
 private fun SessionItem(
     session: GameSession,
+    onClick: () -> Unit,
     onContinue: () -> Unit,
     onRename: () -> Unit,
     onDelete: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val isMultiplayer = session.memberCount > 1
+
     SpInnerCard(
         modifier = modifier
-            .clickable(onClick = onContinue)
+            .clickable(onClick = onClick)
             .testTag("session_item_${session.id}"),
     ) {
         Row(
@@ -217,15 +235,46 @@ private fun SessionItem(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             Column(modifier = Modifier.weight(1f)) {
-                Text(
-                    text = session.name,
-                    style = SpTypography.TitleSmall,
-                    color = SpColor.OnCard,
-                    maxLines = 1,
-                    modifier = Modifier.semantics {
-                        contentDescription = "Session: ${session.name}"
-                    },
-                )
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    Text(
+                        text = session.name,
+                        style = SpTypography.TitleSmall,
+                        color = SpColor.OnCard,
+                        maxLines = 1,
+                        modifier = Modifier.semantics {
+                            contentDescription = "Session: ${session.name}"
+                        },
+                    )
+                    if (isMultiplayer || session.isRelay) {
+                        SpChip(
+                            text = if (session.isRelay) "Relay" else "Multiplayer",
+                            color = SpColor.Primary,
+                            isSelected = true,
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Filled.People,
+                                    contentDescription = null,
+                                    modifier = Modifier.size(14.dp),
+                                    tint = SpColor.Primary,
+                                )
+                            },
+                            modifier = Modifier.testTag("session_multiplayer_badge_${session.id}"),
+                        )
+                    }
+                }
+
+                if (isMultiplayer && session.memberAvatars.isNotEmpty()) {
+                    Spacer(Modifier.height(SpSpacing.XSmall))
+                    MemberAvatarsRow(
+                        avatars = session.memberAvatars,
+                        memberCount = session.memberCount,
+                        modifier = Modifier.testTag("session_member_avatars_${session.id}"),
+                    )
+                }
+
                 Spacer(Modifier.height(SpSpacing.XXSmall))
                 Row(
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
@@ -246,9 +295,10 @@ private fun SessionItem(
                     }
                     if (session.lastPlayedByUsername != null) {
                         Text(
-                            text = session.lastPlayedByUsername,
+                            text = "Last played by ${session.lastPlayedByUsername}",
                             style = SpTypography.LabelSmall,
                             color = SpColor.OnBackgroundTertiary,
+                            modifier = Modifier.testTag("session_last_played_by_${session.id}"),
                         )
                     }
                 }
@@ -277,6 +327,43 @@ private fun SessionItem(
                     )
                 }
             }
+        }
+    }
+}
+
+@Composable
+private fun MemberAvatarsRow(
+    avatars: List<String>,
+    memberCount: Int,
+    modifier: Modifier = Modifier,
+) {
+    val maxVisible = 4
+    val visibleAvatars = avatars.take(maxVisible)
+    val overflow = memberCount - visibleAvatars.size
+
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Box {
+            visibleAvatars.forEachIndexed { index, avatarUrl ->
+                SpAvatar(
+                    username = "",
+                    avatarUrl = avatarUrl,
+                    size = 24.dp,
+                    modifier = Modifier.offset(x = (index * 18).dp),
+                )
+            }
+        }
+        Spacer(Modifier.width(((visibleAvatars.size - 1) * 18 + 24).dp))
+        if (overflow > 0) {
+            Spacer(Modifier.width(SpSpacing.XSmall))
+            Text(
+                text = "+$overflow",
+                style = SpTypography.LabelSmall,
+                color = SpColor.OnBackgroundTertiary,
+                modifier = Modifier.testTag("session_avatar_overflow"),
+            )
         }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -69,6 +69,7 @@ import com.spela.player.presentation.ui.feature.gamedetail.DeveloperGamesSection
 import com.spela.player.presentation.ui.feature.gamedetail.GameRelaysSection
 import com.spela.player.presentation.ui.feature.gamedetail.GameReviewsSection
 import com.spela.player.presentation.ui.feature.gamedetail.SaveStatesSection
+import com.spela.player.presentation.ui.feature.gamedetail.SessionsSection
 import com.spela.player.presentation.ui.feature.gamedetail.ScreenshotsSection
 import com.spela.player.presentation.ui.feature.gamedetail.SimilarGamesSection
 import com.spela.player.presentation.ui.feature.library.darken
@@ -116,6 +117,7 @@ fun GameDetailScreen(
     syncState: GameSyncState? = null,
     onPlayWithLocalSave: () -> Unit = {},
     onCancelLaunch: () -> Unit = {},
+    onPlaySession: ((gameId: String, sessionId: String) -> Unit)? = null,
 ) {
     PlatformBackHandler { onBack() }
 
@@ -327,6 +329,28 @@ fun GameDetailScreen(
                             },
                             onDisableAll = {
                                 viewModel.onIntent(GameDetailIntent.DisableAllCheats)
+                            },
+                        )
+                    }
+
+                    // 4c. Sessions
+                    Column(
+                        modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                    ) {
+                        SessionsSection(
+                            sessions = state.sessions,
+                            isLoading = state.isLoadingSessions,
+                            onContinueSession = { session ->
+                                onPlaySession?.invoke(game.id, session.id)
+                            },
+                            onCreateSession = { name ->
+                                viewModel.onIntent(GameDetailIntent.CreateSession(game.id, name))
+                            },
+                            onRenameSession = { sessionId, name ->
+                                viewModel.onIntent(GameDetailIntent.RenameSession(sessionId, name))
+                            },
+                            onDeleteSession = { sessionId ->
+                                viewModel.onIntent(GameDetailIntent.DeleteSession(sessionId))
                             },
                         )
                     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -118,6 +118,7 @@ fun GameDetailScreen(
     onPlayWithLocalSave: () -> Unit = {},
     onCancelLaunch: () -> Unit = {},
     onPlaySession: ((gameId: String, sessionId: String) -> Unit)? = null,
+    onNavigateToSession: ((sessionId: String) -> Unit)? = null,
 ) {
     PlatformBackHandler { onBack() }
 
@@ -351,6 +352,9 @@ fun GameDetailScreen(
                             },
                             onDeleteSession = { sessionId ->
                                 viewModel.onIntent(GameDetailIntent.DeleteSession(sessionId))
+                            },
+                            onSessionSelected = onNavigateToSession?.let { nav ->
+                                { session -> nav(session.id) }
                             },
                         )
                     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
@@ -1,0 +1,499 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material.icons.outlined.Gamepad
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Switch
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.SaveState
+import com.spela.player.presentation.intent.SessionDetailIntent
+import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpButtonStyle
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpInnerCard
+import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.SpSectionHeader
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.social.formatRelativeTime
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.SessionDetailViewModel
+import com.spela.player.util.formatPlayTime
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun SessionDetailScreen(
+    sessionId: String,
+    viewModel: SessionDetailViewModel,
+    onBack: () -> Unit,
+    onPlay: (gameId: String, sessionId: String) -> Unit,
+    onDeleted: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val state by viewModel.state.collectAsState()
+    var showRenameDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(sessionId) {
+        viewModel.onIntent(SessionDetailIntent.LoadSession(sessionId))
+    }
+
+    // Navigate back after successful deletion
+    LaunchedEffect(state.successMessage) {
+        if (state.successMessage == "Session deleted") {
+            onDeleted()
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize()) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = state.session?.name ?: "Session",
+                showBack = true,
+                onBack = onBack,
+            )
+
+            if (state.isLoading && state.session == null) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    SpLoadingIndicator(message = "Loading session...")
+                }
+            } else if (state.session != null) {
+                val session = state.session ?: return
+                val isRefreshing = state.isLoading || state.isLoadingSaves
+
+                PullToRefreshBox(
+                    isRefreshing = isRefreshing,
+                    onRefresh = {
+                        viewModel.onIntent(SessionDetailIntent.LoadSession(sessionId))
+                    },
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    LazyColumn(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("session_detail_content"),
+                        contentPadding = PaddingValues(vertical = SpSpacing.Default),
+                    ) {
+                        // Header
+                        item {
+                            SessionDetailHeader(
+                                sessionName = session.name,
+                                totalPlayTime = session.totalPlayTime,
+                                lastPlayedAt = session.lastPlayedAt,
+                                lastPlayedByUsername = session.lastPlayedByUsername,
+                                onRename = { showRenameDialog = true },
+                                onPlay = { onPlay(session.gameId, session.id) },
+                            )
+                            Spacer(Modifier.height(SpSpacing.XLarge))
+                        }
+
+                        // Save States section
+                        item {
+                            SpSectionHeader(
+                                title = "Save States",
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            )
+                            Spacer(Modifier.height(SpSpacing.Small))
+                        }
+
+                        if (state.saves.isEmpty() && !state.isLoadingSaves) {
+                            item {
+                                SpEmptyState(
+                                    icon = Icons.Filled.Save,
+                                    title = "No saves yet",
+                                    message = "Play this session to create save states",
+                                    modifier = Modifier.testTag("session_saves_empty"),
+                                )
+                            }
+                        } else {
+                            items(
+                                state.saves,
+                                key = { "save-${it.id}" },
+                            ) { save ->
+                                SessionSaveItem(
+                                    save = save,
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(
+                                            horizontal = SpSpacing.ScreenHorizontal,
+                                            vertical = SpSpacing.XXSmall,
+                                        ),
+                                )
+                            }
+                        }
+
+                        // Cheats section
+                        item {
+                            Spacer(Modifier.height(SpSpacing.XLarge))
+                            SpSectionHeader(
+                                title = "Cheats",
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            )
+                            Spacer(Modifier.height(SpSpacing.Small))
+
+                            SpInnerCard(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("session_cheats_section"),
+                            ) {
+                                Row(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(SpSpacing.Default),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                    horizontalArrangement = Arrangement.SpaceBetween,
+                                ) {
+                                    Text(
+                                        text = "Enable Cheats",
+                                        style = SpTypography.BodyMedium,
+                                        color = SpColor.OnCard,
+                                    )
+                                    Switch(
+                                        checked = state.cheatsEnabled,
+                                        onCheckedChange = { enabled ->
+                                            viewModel.onIntent(
+                                                SessionDetailIntent.ToggleCheatsEnabled(sessionId, enabled)
+                                            )
+                                        },
+                                        modifier = Modifier
+                                            .testTag("session_cheats_toggle")
+                                            .semantics { contentDescription = "Toggle cheats" },
+                                    )
+                                }
+                                if (state.cheatsEnabled && state.enabledCheatIndices.isNotEmpty()) {
+                                    Text(
+                                        text = "${state.enabledCheatIndices.size} cheat(s) active",
+                                        style = SpTypography.LabelSmall,
+                                        color = SpColor.OnBackgroundTertiary,
+                                        modifier = Modifier
+                                            .padding(
+                                                start = SpSpacing.Default,
+                                                bottom = SpSpacing.Small,
+                                            )
+                                            .testTag("session_cheats_count"),
+                                    )
+                                }
+                            }
+                        }
+
+                        // Danger Zone section
+                        item {
+                            Spacer(Modifier.height(SpSpacing.XXLarge))
+                            SpSectionHeader(
+                                title = "Danger Zone",
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            )
+                            Spacer(Modifier.height(SpSpacing.Small))
+
+                            SpButton(
+                                text = "Delete Session",
+                                onClick = { viewModel.onIntent(SessionDetailIntent.ShowDeleteConfirm) },
+                                style = SpButtonStyle.Outlined,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("session_delete_button"),
+                            )
+                            Spacer(Modifier.height(SpSpacing.XXLarge))
+                        }
+                    }
+                }
+            }
+        }
+
+        // Rename dialog
+        if (showRenameDialog) {
+            val session = state.session
+            var newName by remember { mutableStateOf(session?.name ?: "") }
+            AlertDialog(
+                onDismissRequest = { showRenameDialog = false },
+                title = { Text("Rename Session") },
+                text = {
+                    OutlinedTextField(
+                        value = newName,
+                        onValueChange = { newName = it },
+                        label = { Text("Session Name") },
+                        singleLine = true,
+                        modifier = Modifier.testTag("session_detail_rename_input"),
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            if (newName.isNotBlank()) {
+                                viewModel.onIntent(
+                                    SessionDetailIntent.RenameSession(sessionId, newName.trim())
+                                )
+                                showRenameDialog = false
+                            }
+                        },
+                    ) {
+                        Text("Rename")
+                    }
+                },
+                dismissButton = {
+                    TextButton(onClick = { showRenameDialog = false }) {
+                        Text("Cancel")
+                    }
+                },
+            )
+        }
+
+        // Delete confirmation dialog
+        if (state.showDeleteConfirm) {
+            AlertDialog(
+                onDismissRequest = {
+                    viewModel.onIntent(SessionDetailIntent.DismissDeleteConfirm)
+                },
+                title = { Text("Delete Session") },
+                text = {
+                    Text(
+                        "Delete \"${state.session?.name}\"? All saves in this session will be permanently removed.",
+                    )
+                },
+                confirmButton = {
+                    TextButton(
+                        onClick = {
+                            viewModel.onIntent(SessionDetailIntent.DeleteSession(sessionId))
+                        },
+                    ) {
+                        Text("Delete", color = SpColor.Error)
+                    }
+                },
+                dismissButton = {
+                    TextButton(
+                        onClick = {
+                            viewModel.onIntent(SessionDetailIntent.DismissDeleteConfirm)
+                        },
+                    ) {
+                        Text("Cancel")
+                    }
+                },
+                modifier = Modifier.testTag("session_delete_dialog"),
+            )
+        }
+
+        // Snackbars
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.onIntent(SessionDetailIntent.DismissError) },
+                )
+            },
+            onDismiss = { viewModel.onIntent(SessionDetailIntent.DismissError) },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+
+        SpSnackbar(
+            data = state.successMessage?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Success,
+                )
+            },
+            onDismiss = { viewModel.onIntent(SessionDetailIntent.DismissSuccess) },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@Composable
+private fun SessionDetailHeader(
+    sessionName: String,
+    totalPlayTime: Long,
+    lastPlayedAt: String?,
+    lastPlayedByUsername: String?,
+    onRename: () -> Unit,
+    onPlay: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .testTag("session_detail_header"),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = sessionName,
+                    style = SpTypography.TitleLarge,
+                    color = SpColor.OnBackground,
+                    modifier = Modifier.semantics {
+                        contentDescription = "Session: $sessionName"
+                    },
+                )
+
+                Spacer(Modifier.height(SpSpacing.XSmall))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    if (totalPlayTime > 0) {
+                        Text(
+                            text = formatPlayTime(totalPlayTime),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                    if (lastPlayedAt != null) {
+                        Text(
+                            text = formatRelativeTime(lastPlayedAt),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                    if (lastPlayedByUsername != null) {
+                        Text(
+                            text = "Last played by $lastPlayedByUsername",
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+            }
+
+            Row {
+                IconButton(
+                    onClick = onRename,
+                    modifier = Modifier.testTag("session_detail_rename_button"),
+                ) {
+                    Icon(
+                        Icons.Filled.Edit,
+                        contentDescription = "Rename session",
+                        tint = SpColor.OnBackgroundSecondary,
+                    )
+                }
+                IconButton(
+                    onClick = onPlay,
+                    modifier = Modifier.testTag("session_detail_play_button"),
+                ) {
+                    Icon(
+                        Icons.Filled.PlayArrow,
+                        contentDescription = "Play session",
+                        tint = SpColor.Accent,
+                        modifier = Modifier.size(32.dp),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SessionSaveItem(
+    save: SaveState,
+    modifier: Modifier = Modifier,
+) {
+    SpInnerCard(
+        modifier = modifier.testTag("session_save_item_${save.id}"),
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SpSpacing.Default),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = save.name,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 1,
+                )
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    if (save.createdAt != null) {
+                        Text(
+                            text = formatRelativeTime(save.createdAt.toString()),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                    if (save.fileSize > 0) {
+                        Text(
+                            text = formatFileSize(save.fileSize),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                    if (save.isAuto) {
+                        Text(
+                            text = "Auto",
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.Primary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun formatFileSize(bytes: Long): String {
+    return when {
+        bytes < 1024 -> "${bytes}B"
+        bytes < 1024 * 1024 -> "${bytes / 1024}KB"
+        else -> "${bytes / (1024 * 1024)}MB"
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -35,7 +35,7 @@ private const val REWIND_BUFFER_SIZE = 300 // ~60 seconds at 5fps capture rate
 private const val REWIND_CAPTURE_INTERVAL_MS = 200L // Capture every 200ms (~5 per second)
 
 /** Stores parameters for a pending game launch while pre-launch sync is in progress. */
-data class PendingLaunch(val gameId: String, val skipAutoLoad: Boolean)
+data class PendingLaunch(val gameId: String, val skipAutoLoad: Boolean, val sessionId: String? = null)
 
 /**
  * Bridges between Compose UI and the platform-specific libretro core.
@@ -105,6 +105,7 @@ class EmulationViewModel(
                 intent.gameId, intent.relayId, intent.turnToken,
                 intent.netplaySessionId, intent.netplayLocalPort, intent.netplayInputDelay, intent.netplayIsHost,
                 intent.challengeId, intent.challengeSaveData, intent.skipAutoLoad,
+                intent.sessionId,
             )
             EmulationIntent.PauseGame -> pauseGame()
             EmulationIntent.ResumeGame -> resumeGame()
@@ -190,7 +191,7 @@ class EmulationViewModel(
             EmulationIntent.ToggleRewind -> toggleRewindEnabled()
 
             // Pre-launch sync
-            is EmulationIntent.PrepareLaunch -> prepareLaunch(intent.gameId, intent.skipAutoLoad)
+            is EmulationIntent.PrepareLaunch -> prepareLaunch(intent.gameId, intent.skipAutoLoad, intent.sessionId)
             EmulationIntent.PlayWithLocalSave -> playWithLocalSave()
             EmulationIntent.CancelLaunch -> cancelLaunch()
 
@@ -212,7 +213,9 @@ class EmulationViewModel(
         challengeId: String? = null,
         challengeSaveDataArg: ByteArray? = null,
         skipAutoLoad: Boolean = false,
+        sessionId: String? = null,
     ) {
+        saveManager.currentSessionId = sessionId
         _state.update {
             it.copy(
                 gameId = gameId,
@@ -223,6 +226,7 @@ class EmulationViewModel(
                 relayId = relayId,
                 turnToken = turnToken,
                 netplaySessionId = netplaySessionId,
+                sessionId = sessionId,
                 challengeId = challengeId,
                 challengeAttemptId = null,
                 challengeElapsedMs = 0,
@@ -471,9 +475,9 @@ class EmulationViewModel(
         }
     }
 
-    private fun prepareLaunch(gameId: String, skipAutoLoad: Boolean) {
+    private fun prepareLaunch(gameId: String, skipAutoLoad: Boolean, sessionId: String? = null) {
         saveManager.clearPrefetch()
-        pendingLaunch = PendingLaunch(gameId, skipAutoLoad)
+        pendingLaunch = PendingLaunch(gameId, skipAutoLoad, sessionId)
         scope.launch(dispatchers.io) {
             _syncState.update { GameSyncState(gameId, "Syncing game save\u2026") }
             val sramReady = saveManager.prefetchSram(gameId)
@@ -647,12 +651,14 @@ class EmulationViewModel(
                         challengeCreationSuccess = false,
                         showGiveUpConfirm = false,
                         challengeCompletedAttempt = null,
+                        sessionId = null,
                         hasCheats = false,
                         enabledCheatCount = 0,
                         showCheatBrowser = false,
                         cheats = emptyList(),
                     )
                 }
+                saveManager.currentSessionId = null
             }
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -17,6 +17,7 @@ import com.spela.player.domain.repository.RatingRepository
 import com.spela.player.domain.repository.RelayRepository
 import com.spela.player.domain.repository.SaveDataRepository
 import com.spela.player.domain.repository.SaveRepository
+import com.spela.player.domain.repository.SessionRepository
 import com.spela.player.domain.repository.SharedSaveRepository
 import com.spela.player.domain.repository.GameStatsRepository
 import com.spela.player.presentation.intent.GameDetailIntent
@@ -53,6 +54,7 @@ class GameDetailViewModel(
     private val scope: CoroutineScope,
     private val biosRepository: BiosRepository? = null,
     private val cheatRepository: CheatRepository? = null,
+    private val sessionRepository: SessionRepository? = null,
 ) {
     private val _state = MutableStateFlow(GameDetailState())
     val state: StateFlow<GameDetailState> = _state.asStateFlow()
@@ -127,6 +129,12 @@ class GameDetailViewModel(
             GameDetailIntent.DisableAllCheats -> disableAllCheats()
             GameDetailIntent.ShowCheatDialog -> _state.update { it.copy(showCheatDialog = true) }
             GameDetailIntent.DismissCheatDialog -> _state.update { it.copy(showCheatDialog = false) }
+
+            // Sessions
+            is GameDetailIntent.LoadSessions -> loadSessions(intent.gameId)
+            is GameDetailIntent.CreateSession -> createSession(intent.gameId, intent.name)
+            is GameDetailIntent.RenameSession -> renameSession(intent.sessionId, intent.name)
+            is GameDetailIntent.DeleteSession -> deleteSession(intent.sessionId)
         }
     }
 
@@ -171,6 +179,7 @@ class GameDetailViewModel(
                         loadCheats(gameId)
                         loadSaveDataCount()
                         loadBiosStatus()
+                        loadSessions(gameId)
                     }
                 },
                 onFailure = { error ->
@@ -900,6 +909,81 @@ class GameDetailViewModel(
                         state.copy(
                             saveStates = state.saveStates + save,
                             successMessage = "Save imported",
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    // Sessions
+
+    private fun loadSessions(gameId: String) {
+        val repo = sessionRepository ?: return
+        _state.update { it.copy(isLoadingSessions = true) }
+        scope.launch(dispatchers.io) {
+            repo.getSessionsForGame(gameId).fold(
+                onSuccess = { sessions ->
+                    _state.update { it.copy(sessions = sessions, isLoadingSessions = false) }
+                },
+                onFailure = {
+                    _state.update { it.copy(isLoadingSessions = false) }
+                },
+            )
+        }
+    }
+
+    private fun createSession(gameId: String, name: String) {
+        val repo = sessionRepository ?: return
+        scope.launch(dispatchers.io) {
+            repo.createSession(gameId, name).fold(
+                onSuccess = { session ->
+                    _state.update { state ->
+                        state.copy(
+                            sessions = state.sessions + session,
+                            successMessage = "Session \"${session.name}\" created",
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun renameSession(sessionId: String, name: String) {
+        val repo = sessionRepository ?: return
+        scope.launch(dispatchers.io) {
+            repo.updateSession(sessionId, name).fold(
+                onSuccess = { updated ->
+                    _state.update { state ->
+                        state.copy(
+                            sessions = state.sessions.map {
+                                if (it.id == sessionId) updated else it
+                            },
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun deleteSession(sessionId: String) {
+        val repo = sessionRepository ?: return
+        scope.launch(dispatchers.io) {
+            repo.deleteSession(sessionId).fold(
+                onSuccess = {
+                    _state.update { state ->
+                        state.copy(
+                            sessions = state.sessions.filter { it.id != sessionId },
+                            successMessage = "Session deleted",
                         )
                     }
                 },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -4,6 +4,7 @@ import com.spela.player.data.remote.ConnectivityMonitor
 import com.spela.player.domain.controller.ScreenshotCapture
 import com.spela.player.domain.repository.SaveDataRepository
 import com.spela.player.domain.repository.SaveRepository
+import com.spela.player.domain.repository.SessionRepository
 import com.spela.player.domain.usecase.LoadGameStateUseCase
 import com.spela.player.domain.usecase.SaveGameStateUseCase
 import com.spela.player.presentation.state.EmulationState
@@ -30,9 +31,13 @@ class SaveManager(
     private val _state: MutableStateFlow<EmulationState>,
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
+    private val sessionRepository: SessionRepository? = null,
 ) {
     /** The libretro core name used for the current emulation session. */
     var currentCoreName: String = ""
+
+    /** The active session ID (if playing within a session). */
+    var currentSessionId: String? = null
 
     /** Pre-fetched SRAM data from prepareLaunch(). Consumed once by loadSramOnStart(). */
     private var preFetchedSramData: ByteArray? = null
@@ -93,6 +98,21 @@ class SaveManager(
      */
     suspend fun loadSramOnStart(gameId: String) {
         try {
+            val sessionId = currentSessionId
+            val repo = sessionRepository
+
+            // Session-aware: download SRAM from session endpoint
+            if (sessionId != null && repo != null) {
+                repo.downloadSessionSram(sessionId).onSuccess { data ->
+                    if (isZipData(data)) {
+                        saveDataRepository.unzipToSaveDirectory(data)
+                    } else {
+                        libretroController.setSRAM(data)
+                    }
+                }
+                return
+            }
+
             val dataToLoad = preFetchedSramData
             preFetchedSramData = null
             if (dataToLoad != null) {
@@ -132,8 +152,16 @@ class SaveManager(
      */
     suspend fun saveSramOnStop(gameId: String) {
         try {
+            val sessionId = currentSessionId
+            val repo = sessionRepository
+
             val sramData = libretroController.getSRAM()
             if (sramData != null && sramData.isNotEmpty()) {
+                // Session-aware: upload to session SRAM endpoint
+                if (sessionId != null && repo != null) {
+                    runCatching { repo.uploadSessionSram(sessionId, sramData) }
+                    return
+                }
                 saveDataRepository.saveLocalSRAM(gameId, sramData)
                 if (connectivityMonitor.isOnline.value) {
                     runCatching { saveDataRepository.uploadActiveSaveData(gameId, sramData) }
@@ -142,6 +170,10 @@ class SaveManager(
                 // Directory-save fallback for cores like Dolphin
                 val zipData = saveDataRepository.zipSaveDirectory(gameId)
                 if (zipData != null) {
+                    if (sessionId != null && repo != null) {
+                        runCatching { repo.uploadSessionSram(sessionId, zipData) }
+                        return
+                    }
                     saveDataRepository.saveLocalSRAM(gameId, zipData)
                     if (connectivityMonitor.isOnline.value) {
                         runCatching { saveDataRepository.uploadActiveSaveData(gameId, zipData) }
@@ -160,6 +192,25 @@ class SaveManager(
      * Called from within an IO coroutine.
      */
     suspend fun autoLoadSaveState(gameId: String) {
+        val sessionId = currentSessionId
+        val repo = sessionRepository
+
+        // Session-aware: download auto-save from session endpoint
+        if (sessionId != null && repo != null) {
+            println("[SaveManager] autoLoadSaveState: loading session $sessionId auto-save")
+            repo.downloadSessionAutoSave(sessionId).fold(
+                onSuccess = { saveData ->
+                    println("[SaveManager] autoLoadSaveState: got ${saveData.size} bytes from session, unserializing")
+                    val ok = libretroController.unserialize(saveData)
+                    println("[SaveManager] autoLoadSaveState: unserialize result=$ok")
+                },
+                onFailure = { e ->
+                    println("[SaveManager] autoLoadSaveState: session auto-save failed: ${e.message}")
+                },
+            )
+            return
+        }
+
         val dataToLoad = preFetchedSaveData
         preFetchedSaveData = null
         if (dataToLoad != null) {
@@ -191,6 +242,17 @@ class SaveManager(
             val saveData = libretroController.serialize()
             println("[SaveManager] autoSaveOnStop: serialize returned ${saveData?.size ?: "null"} bytes")
             if (saveData != null) {
+                val sessionId = currentSessionId
+                val repo = sessionRepository
+
+                // Session-aware: upload auto-save to session endpoint
+                if (sessionId != null && repo != null) {
+                    val screenshot = screenshotCapture?.captureScreenshot()
+                    val result = repo.uploadSessionAutoSave(sessionId, saveData, screenshot)
+                    println("[SaveManager] autoSaveOnStop: session upload result=${result.isSuccess}")
+                    return
+                }
+
                 // Save to local filesystem + SQLite only (fast, no network).
                 val result = saveRepository.saveLocally(gameId, "Auto Save", saveData, isAuto = true)
                 println("[SaveManager] autoSaveOnStop: saveLocally result=${result.isSuccess}")
@@ -213,6 +275,27 @@ class SaveManager(
             val gameId = _state.value.gameId
             val saveData = libretroController.serialize() ?: return@launch
             val screenshot = screenshotCapture?.captureScreenshot()
+
+            val sessionId = currentSessionId
+            val repo = sessionRepository
+
+            // Session-aware: upload save to session endpoint
+            if (sessionId != null && repo != null) {
+                repo.uploadSessionSave(sessionId, "Manual Save", saveData, screenshot).fold(
+                    onSuccess = {
+                        withContext(dispatchers.main) {
+                            _state.update { it.copy(statusMessage = "State saved") }
+                        }
+                    },
+                    onFailure = { error ->
+                        withContext(dispatchers.main) {
+                            _state.update { it.copy(error = "Failed to save: ${error.message}") }
+                        }
+                    },
+                )
+                return@launch
+            }
+
             saveGameStateUseCase(gameId, saveData, screenshot, currentCoreName.ifEmpty { null }).fold(
                 onSuccess = {
                     withContext(dispatchers.main) {
@@ -239,6 +322,27 @@ class SaveManager(
         }
         scope.launch(dispatchers.io) {
             val gameId = _state.value.gameId
+            val sessionId = currentSessionId
+            val repo = sessionRepository
+
+            // Session-aware: download auto-save from session endpoint
+            if (sessionId != null && repo != null) {
+                repo.downloadSessionAutoSave(sessionId).fold(
+                    onSuccess = { saveData ->
+                        libretroController.unserialize(saveData)
+                        withContext(dispatchers.main) {
+                            _state.update { it.copy(statusMessage = "State loaded") }
+                        }
+                    },
+                    onFailure = { error ->
+                        withContext(dispatchers.main) {
+                            _state.update { it.copy(error = "Failed to load save: ${error.message}") }
+                        }
+                    },
+                )
+                return@launch
+            }
+
             loadGameStateUseCase(gameId).fold(
                 onSuccess = { saveData ->
                     libretroController.unserialize(saveData)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModel.kt
@@ -1,0 +1,155 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.domain.repository.SessionRepository
+import com.spela.player.presentation.intent.SessionDetailIntent
+import com.spela.player.presentation.state.SessionDetailState
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class SessionDetailViewModel(
+    private val sessionRepository: SessionRepository,
+    private val dispatchers: DispatcherProvider,
+    private val scope: CoroutineScope,
+) {
+    private val _state = MutableStateFlow(SessionDetailState())
+    val state: StateFlow<SessionDetailState> = _state.asStateFlow()
+
+    fun onIntent(intent: SessionDetailIntent) {
+        when (intent) {
+            is SessionDetailIntent.LoadSession -> loadSession(intent.sessionId)
+            is SessionDetailIntent.RenameSession -> renameSession(intent.sessionId, intent.name)
+            is SessionDetailIntent.DeleteSession -> deleteSession(intent.sessionId)
+            is SessionDetailIntent.ToggleCheatsEnabled -> toggleCheatsEnabled(intent.sessionId, intent.enabled)
+            is SessionDetailIntent.UpdateCheatSettings -> updateCheatSettings(intent.sessionId, intent.enabledIndices)
+            is SessionDetailIntent.StartFromSave -> { /* Handled by UI navigation */ }
+            SessionDetailIntent.ShowDeleteConfirm -> _state.update { it.copy(showDeleteConfirm = true) }
+            SessionDetailIntent.DismissDeleteConfirm -> _state.update { it.copy(showDeleteConfirm = false) }
+            SessionDetailIntent.DismissError -> _state.update { it.copy(error = null) }
+            SessionDetailIntent.DismissSuccess -> _state.update { it.copy(successMessage = null) }
+        }
+    }
+
+    private fun loadSession(sessionId: String) {
+        _state.update { SessionDetailState(isLoading = true) }
+        scope.launch(dispatchers.io) {
+            sessionRepository.getSession(sessionId).fold(
+                onSuccess = { session ->
+                    _state.update { it.copy(session = session, isLoading = false) }
+                    loadSaves(sessionId)
+                    loadCheats(sessionId)
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message, isLoading = false) }
+                },
+            )
+        }
+    }
+
+    private fun loadSaves(sessionId: String) {
+        _state.update { it.copy(isLoadingSaves = true) }
+        scope.launch(dispatchers.io) {
+            sessionRepository.getSessionSaves(sessionId).fold(
+                onSuccess = { saves ->
+                    _state.update { it.copy(saves = saves, isLoadingSaves = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message, isLoadingSaves = false) }
+                },
+            )
+        }
+    }
+
+    private fun loadCheats(sessionId: String) {
+        scope.launch(dispatchers.io) {
+            sessionRepository.getSessionCheats(sessionId).fold(
+                onSuccess = { config ->
+                    _state.update {
+                        it.copy(
+                            cheatsEnabled = config.cheatsEnabled,
+                            enabledCheatIndices = config.enabledIndices,
+                        )
+                    }
+                },
+                onFailure = { /* Cheats may not be configured yet, ignore */ },
+            )
+        }
+    }
+
+    private fun renameSession(sessionId: String, name: String) {
+        scope.launch(dispatchers.io) {
+            sessionRepository.updateSession(sessionId, name).fold(
+                onSuccess = { updated ->
+                    _state.update {
+                        it.copy(
+                            session = updated,
+                            successMessage = "Session renamed",
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun deleteSession(sessionId: String) {
+        _state.update { it.copy(showDeleteConfirm = false) }
+        scope.launch(dispatchers.io) {
+            sessionRepository.deleteSession(sessionId).fold(
+                onSuccess = {
+                    _state.update { it.copy(successMessage = "Session deleted") }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun toggleCheatsEnabled(sessionId: String, enabled: Boolean) {
+        // Optimistic update
+        _state.update { it.copy(cheatsEnabled = enabled) }
+        scope.launch(dispatchers.io) {
+            val indices = if (enabled) _state.value.enabledCheatIndices else emptyList()
+            sessionRepository.updateSessionCheats(sessionId, enabled, indices).fold(
+                onSuccess = { config ->
+                    _state.update {
+                        it.copy(
+                            cheatsEnabled = config.cheatsEnabled,
+                            enabledCheatIndices = config.enabledIndices,
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    // Revert
+                    _state.update { it.copy(cheatsEnabled = !enabled, error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun updateCheatSettings(sessionId: String, enabledIndices: List<Int>) {
+        _state.update { it.copy(enabledCheatIndices = enabledIndices) }
+        scope.launch(dispatchers.io) {
+            sessionRepository.updateSessionCheats(sessionId, _state.value.cheatsEnabled, enabledIndices).fold(
+                onSuccess = { config ->
+                    _state.update {
+                        it.copy(
+                            cheatsEnabled = config.cheatsEnabled,
+                            enabledCheatIndices = config.enabledIndices,
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+}

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -125,6 +125,16 @@ func main() {
 		slog.Warn("failed to deduplicate games", "error", err)
 	}
 
+	// Migrate existing saves to sessions (one-time on upgrade)
+	if err := db.MigrateSavesToSessions(database); err != nil {
+		slog.Warn("failed to migrate saves to sessions", "error", err)
+	}
+
+	// Create sessions for existing relays (one-time on upgrade)
+	if err := db.MigrateRelaySessions(database); err != nil {
+		slog.Warn("failed to migrate relay sessions", "error", err)
+	}
+
 	// Create ES-DE console subdirectories in game dirs
 	if err := scanner.CreateConsoleFolders(database, gameDirs); err != nil {
 		slog.Warn("failed to create console folders", "error", err)

--- a/server/internal/api/admin_handler.go
+++ b/server/internal/api/admin_handler.go
@@ -980,16 +980,32 @@ func (h *AdminHandler) ApplyIGDBMatch(c *gin.Context) {
 	c.JSON(http.StatusOK, ToGameResponse(game, h.DB, uid))
 }
 
-// TriggerCheatImport starts a background cheat database import.
+// TriggerCheatImport runs a cheat database import synchronously and returns the result.
 func (h *AdminHandler) TriggerCheatImport(c *gin.Context) {
-	go func() {
-		if err := cheats.ImportAllCheats(h.DB, cheats.DefaultBaseURL); err != nil {
-			slog.Error("cheat import failed", "error", err)
-		} else {
-			slog.Info("cheat import completed")
-		}
-	}()
-	c.JSON(http.StatusAccepted, gin.H{"message": "cheat import started"})
+	result, err := cheats.ImportAllCheats(h.DB, cheats.DefaultBaseURL)
+	if err != nil {
+		slog.Error("cheat import failed", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "cheat import failed"})
+		return
+	}
+	slog.Info("cheat import completed", "cheatsImported", result.CheatsImported, "gamesImported", result.GamesImported)
+	c.JSON(http.StatusOK, result)
+}
+
+// GetCheatStats returns statistics about imported cheat codes.
+func (h *AdminHandler) GetCheatStats(c *gin.Context) {
+	var totalCheats, totalGames, verifiedGames, gamesWithCheats int64
+	h.DB.Model(&db.CheatCode{}).Count(&totalCheats)
+	h.DB.Model(&db.Game{}).Count(&totalGames)
+	h.DB.Model(&db.Game{}).Where("verification_status = ?", "verified").Count(&verifiedGames)
+	h.DB.Model(&db.CheatCode{}).Distinct("game_id").Count(&gamesWithCheats)
+
+	c.JSON(http.StatusOK, gin.H{
+		"totalCheats":    totalCheats,
+		"gamesWithCheats": gamesWithCheats,
+		"totalGames":     totalGames,
+		"verifiedGames":  verifiedGames,
+	})
 }
 
 // IGDBSource returns "env" if IGDB credentials are set via environment variables,

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -68,6 +68,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.GameSession{},
 		&db.SessionSaveState{},
 		&db.SessionSaveData{},
+		&db.SessionCheatSetting{},
 	)
 	require.NoError(t, err)
 	err = db.SeedConsoles(database)

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -65,6 +65,9 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.TopRatedGame{},
 		&db.SimilarGame{},
 		&db.CheatCode{},
+		&db.GameSession{},
+		&db.SessionSaveState{},
+		&db.SessionSaveData{},
 	)
 	require.NoError(t, err)
 	err = db.SeedConsoles(database)

--- a/server/internal/api/relay_handler.go
+++ b/server/internal/api/relay_handler.go
@@ -53,11 +53,23 @@ func (h *RelayHandler) CreateRelay(c *gin.Context) {
 		return
 	}
 
-	relay := db.Relay{
+	// Create a GameSession to back this relay
+	session := db.GameSession{
 		OwnerID: uid,
 		GameID:  uint(gid),
-		Name:    req.Name,
-		Status:  "active",
+		Name:    "Relay: " + req.Name,
+	}
+	if err := h.DB.Create(&session).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create session for relay"})
+		return
+	}
+
+	relay := db.Relay{
+		OwnerID:   uid,
+		GameID:    uint(gid),
+		Name:      req.Name,
+		Status:    "active",
+		SessionID: &session.ID,
 	}
 	if err := h.DB.Create(&relay).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create relay"})
@@ -742,6 +754,20 @@ func (h *RelayHandler) UploadSave(c *gin.Context) {
 		return
 	}
 
+	// Also create a SessionSaveState if the relay has an associated session
+	if relay.SessionID != nil {
+		sessionSave := db.SessionSaveState{
+			SessionID:     *relay.SessionID,
+			UserID:        uid,
+			Name:          name,
+			FilePath:      filePath,
+			FileSize:      size,
+			ScreenshotURL: screenshotURL,
+			IsAuto:        false,
+		}
+		h.DB.Create(&sessionSave)
+	}
+
 	h.DB.Preload("User").First(&save, save.ID)
 
 	if h.Hub != nil {
@@ -863,6 +889,20 @@ func (h *RelayHandler) UploadAutoSave(c *gin.Context) {
 		save.FileSize = size
 		save.ScreenshotURL = screenshotURL
 		h.DB.Save(&save)
+	}
+
+	// Also create a SessionSaveState if the relay has an associated session
+	if relay.SessionID != nil {
+		sessionSave := db.SessionSaveState{
+			SessionID:     *relay.SessionID,
+			UserID:        uid,
+			Name:          "Auto Save",
+			FilePath:      filePath,
+			FileSize:      size,
+			ScreenshotURL: screenshotURL,
+			IsAuto:        true,
+		}
+		h.DB.Create(&sessionSave)
 	}
 
 	h.DB.Preload("User").First(&save, save.ID)
@@ -1059,6 +1099,7 @@ func (h *RelayHandler) toRelayResponse(r db.Relay) RelayResponse {
 		ActiveUsername: activeUsername,
 		TurnTakenAt:    r.TurnTakenAt,
 		MemberCount:    len(r.Members),
+		SessionID:      uintPtrToStringPtr(r.SessionID),
 		CreatedAt:      r.CreatedAt,
 		UpdatedAt:      r.UpdatedAt,
 	}

--- a/server/internal/api/relay_handler_test.go
+++ b/server/internal/api/relay_handler_test.go
@@ -1682,3 +1682,233 @@ func TestRelay_CopySaveToGame_SaveNotFound(t *testing.T) {
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
+
+// --- Relay-Session integration tests ---
+
+func TestRelay_Create_CreatesSession(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Session Relay Game", FileName: "test.nes", FilePath: "/tmp/session-relay.nes", FileSize: 100}
+	database.Create(&game)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	resp := createRelay(t, router, token, gameID, "Session Relay")
+
+	// Response should include a sessionId
+	assert.NotNil(t, resp["sessionId"], "relay response should include sessionId")
+	sessionID := resp["sessionId"].(string)
+	assert.NotEmpty(t, sessionID)
+
+	// Verify the GameSession was actually created in the database
+	var session db.GameSession
+	err := database.First(&session, sessionID).Error
+	require.NoError(t, err)
+	assert.Equal(t, "Relay: Session Relay", session.Name)
+	assert.Equal(t, game.ID, session.GameID)
+
+	// Verify the relay's SessionID is set in the database
+	relayID := resp["id"].(string)
+	var relay db.Relay
+	database.First(&relay, relayID)
+	require.NotNil(t, relay.SessionID)
+	assert.Equal(t, session.ID, *relay.SessionID)
+}
+
+func TestRelay_SaveUpload_CreatesSessionSave(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "SessionSave Game", FileName: "test.nes", FilePath: "/tmp/session-save.nes", FileSize: 100}
+	database.Create(&game)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	resp := createRelay(t, router, token, gameID, "Save Relay")
+	relayID := resp["id"].(string)
+	sessionID := resp["sessionId"].(string)
+
+	// Take the turn
+	turnToken := takeTurn(t, router, token, relayID)
+
+	// Upload a manual save
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("save", "manual.sav")
+	part.Write([]byte("save-data"))
+	writer.WriteField("name", "Manual Save")
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/relays/"+relayID+"/saves", &body)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("X-Turn-Token", turnToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Verify a SessionSaveState was also created
+	var sessionSaves []db.SessionSaveState
+	database.Where("session_id = ?", sessionID).Find(&sessionSaves)
+	assert.Len(t, sessionSaves, 1, "should have one session save state")
+	assert.Equal(t, "Manual Save", sessionSaves[0].Name)
+	assert.False(t, sessionSaves[0].IsAuto)
+}
+
+func TestRelay_AutoSaveUpload_CreatesSessionSave(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "AutoSave Session Game", FileName: "test.nes", FilePath: "/tmp/autosave-session.nes", FileSize: 100}
+	database.Create(&game)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	resp := createRelay(t, router, token, gameID, "AutoSave Relay")
+	relayID := resp["id"].(string)
+	sessionID := resp["sessionId"].(string)
+
+	// Take the turn
+	turnToken := takeTurn(t, router, token, relayID)
+
+	// Upload auto save
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("save", "auto.sav")
+	part.Write([]byte("auto-save-data"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/relays/"+relayID+"/saves/auto", &body)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("X-Turn-Token", turnToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Verify a SessionSaveState was also created (auto)
+	var sessionSaves []db.SessionSaveState
+	database.Where("session_id = ? AND is_auto = ?", sessionID, true).Find(&sessionSaves)
+	assert.Len(t, sessionSaves, 1, "should have one auto session save state")
+	assert.Equal(t, "Auto Save", sessionSaves[0].Name)
+	assert.True(t, sessionSaves[0].IsAuto)
+}
+
+func TestRelay_MigrateRelaySessions(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	_ = NewRouter(*cfg)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Migration Game", FileName: "test.nes", FilePath: "/tmp/migrate.nes", FileSize: 100}
+	database.Create(&game)
+
+	// Manually create a relay without a session (simulating pre-migration data)
+	relay := db.Relay{
+		OwnerID: 1,
+		GameID:  game.ID,
+		Name:    "Old Relay",
+		Status:  "active",
+	}
+	database.Create(&relay)
+	assert.Nil(t, relay.SessionID)
+
+	// Create a relay save
+	relaySave := db.RelaySave{
+		RelayID:  relay.ID,
+		UserID:   1,
+		Name:     "Old Save",
+		FilePath: "/tmp/old-save.sav",
+		FileSize: 100,
+		IsAuto:   false,
+	}
+	database.Create(&relaySave)
+
+	// Run migration
+	err := db.MigrateRelaySessions(database)
+	require.NoError(t, err)
+
+	// Reload relay
+	database.First(&relay, relay.ID)
+	require.NotNil(t, relay.SessionID, "relay should now have a session ID")
+
+	// Verify session was created
+	var session db.GameSession
+	err = database.First(&session, *relay.SessionID).Error
+	require.NoError(t, err)
+	assert.Equal(t, "Relay: Old Relay", session.Name)
+	assert.Equal(t, game.ID, session.GameID)
+	assert.Equal(t, relay.OwnerID, session.OwnerID)
+
+	// Verify relay saves were copied to session saves
+	var sessionSaves []db.SessionSaveState
+	database.Where("session_id = ?", session.ID).Find(&sessionSaves)
+	assert.Len(t, sessionSaves, 1)
+	assert.Equal(t, "Old Save", sessionSaves[0].Name)
+	assert.Equal(t, relaySave.FilePath, sessionSaves[0].FilePath)
+
+	// Run migration again — should be idempotent
+	err = db.MigrateRelaySessions(database)
+	require.NoError(t, err)
+}
+
+func TestRelay_SessionTurnValidation_CannotUploadWithoutTurn(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token1 := registerAndGetToken(t, router)
+	token2 := registerSecondUser(t, router, token1)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "TurnVal Game", FileName: "test.nes", FilePath: "/tmp/turnval.nes", FileSize: 100}
+	database.Create(&game)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	resp := createRelay(t, router, token1, gameID, "Turn Validation Relay")
+	relayID := resp["id"].(string)
+	sessionID := resp["sessionId"].(string)
+
+	// Invite and accept player2
+	inviteAndAccept(t, router, token1, token2, relayID, "player2")
+
+	// Player1 takes the turn
+	takeTurn(t, router, token1, relayID)
+
+	// Player2 (who does NOT hold the turn) tries to upload a session save
+	// They're the session owner? No — the session owner is player1 (relay creator).
+	// Player2 doesn't own the session, so they'll get 403 from ownership check.
+	// Instead, let's test that the relay creator (player1) who owns the session
+	// cannot upload via the session endpoint when they DON'T hold the turn.
+
+	// First release the turn so nobody holds it
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/relays/"+relayID+"/release-turn", nil)
+	req.Header.Set("Authorization", "Bearer "+token1)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Now player2 takes the turn
+	takeTurn(t, router, token2, relayID)
+
+	// Player1 (session owner but NOT turn holder) tries to upload via session endpoint
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, _ := writer.CreateFormFile("save", "sneaky.sav")
+	part.Write([]byte("sneaky-data"))
+	writer.WriteField("name", "Sneaky Save")
+	writer.Close()
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/saves", &body)
+	req.Header.Set("Authorization", "Bearer "+token1)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code, "session owner should be blocked when relay turn is held by another user")
+}

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -511,6 +511,7 @@ type RelayResponse struct {
 	ActiveUsername string     `json:"activeUsername,omitempty"`
 	TurnTakenAt    *time.Time `json:"turnTakenAt"`
 	MemberCount    int        `json:"memberCount"`
+	SessionID      *string    `json:"sessionId,omitempty"`
 	CreatedAt      time.Time  `json:"createdAt"`
 	UpdatedAt      time.Time  `json:"updatedAt"`
 }

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -640,6 +640,42 @@ type RateLimitResponse struct {
 	IsLockedOut bool       `json:"isLockedOut"`
 }
 
+// GameSessionResponse is the API response for a game session.
+type GameSessionResponse struct {
+	ID            string     `json:"id"`
+	OwnerID       string     `json:"ownerId"`
+	OwnerUsername string     `json:"ownerUsername"`
+	GameID        string     `json:"gameId"`
+	Name          string     `json:"name"`
+	LastPlayedAt  *time.Time `json:"lastPlayedAt,omitempty"`
+	LastPlayedBy  *string    `json:"lastPlayedBy,omitempty"`
+	TotalPlayTime int64      `json:"totalPlayTime"`
+	ScreenshotURL string     `json:"screenshotUrl,omitempty"`
+	CoreName      string     `json:"coreName,omitempty"`
+	CheatsEnabled bool       `json:"cheatsEnabled"`
+	SaveCount     int        `json:"saveCount"`
+	CreatedAt     time.Time  `json:"createdAt"`
+	UpdatedAt     time.Time  `json:"updatedAt"`
+}
+
+// SessionSaveResponse is the API response for a session save state.
+type SessionSaveResponse struct {
+	ID            string    `json:"id"`
+	SessionID     string    `json:"sessionId"`
+	UserID        string    `json:"userId"`
+	Username      string    `json:"username"`
+	Name          string    `json:"name"`
+	FileSize      int64     `json:"fileSize"`
+	ScreenshotURL string    `json:"screenshotUrl,omitempty"`
+	IsAuto        bool      `json:"isAuto"`
+	IsCurrent     bool      `json:"isCurrent"`
+	CoreName      string    `json:"coreName,omitempty"`
+	Notes         string    `json:"notes,omitempty"`
+	Slot          *int      `json:"slot,omitempty"`
+	CreatedAt     time.Time `json:"createdAt"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+}
+
 // resolveImageURL prefixes relative image paths with /api/images/.
 // External URLs (starting with http) are returned unchanged.
 func resolveImageURL(path string) string {

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -257,6 +257,8 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/sessions/:id/sram", sessionHandler.DownloadSRAM)
 		api.POST("/sessions/:id/play-time", sessionHandler.UpdatePlayTime)
 		api.DELETE("/sessions/:id/play-time", sessionHandler.StopPlaying)
+		api.GET("/sessions/:id/cheats", sessionHandler.GetSessionCheats)
+		api.PUT("/sessions/:id/cheats", sessionHandler.UpdateSessionCheats)
 
 		// Ratings
 		api.POST("/games/:id/ratings", ratingHandler.CreateOrUpdateRating)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -166,6 +166,7 @@ func NewRouter(cfg Config) *gin.Engine {
 	saveHandler := &SaveHandler{DB: cfg.DB, Storage: cfg.Storage}
 	challengeHandler := NewChallengeHandler(cfg.DB, cfg.Storage, cfg.Hub)
 	challengeHandler.AttemptRateLimitSeconds = cfg.ChallengeAttemptRateLimitSec
+	sessionHandler := &SessionHandler{DB: cfg.DB, Storage: cfg.Storage}
 	discoveryHandler := &GameDiscoveryHandler{DB: cfg.DB, Scraper: cfg.Scraper}
 	setupHandler := &SetupHandler{
 		DB:            cfg.DB,
@@ -235,6 +236,27 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/games/:id/cheats", gameHandler.GetGameCheats)
 		api.GET("/games/:id/similar", discoveryHandler.GetSimilarGames)
 		api.GET("/games/:id/developer-games", discoveryHandler.GetDeveloperGames)
+
+		// Game Sessions
+		api.POST("/games/:id/sessions", sessionHandler.CreateSession)
+		api.GET("/games/:id/sessions", sessionHandler.ListSessions)
+		api.GET("/sessions/:id", sessionHandler.GetSession)
+		api.PUT("/sessions/:id", sessionHandler.UpdateSession)
+		api.DELETE("/sessions/:id", sessionHandler.DeleteSession)
+		api.GET("/sessions/:id/saves", sessionHandler.ListSessionSaves)
+		api.POST("/sessions/:id/saves", uploadLimiter.RateLimit(), sessionHandler.UploadSessionSave)
+		api.POST("/sessions/:id/saves/auto", uploadLimiter.RateLimit(), sessionHandler.UploadAutoSave)
+		api.GET("/sessions/:id/saves/auto", sessionHandler.GetAutoSave)
+		api.GET("/sessions/:id/saves/slots", sessionHandler.ListSlotSaves)
+		api.PUT("/sessions/:id/saves/slot/:slot", uploadLimiter.RateLimit(), sessionHandler.UpsertSlotSave)
+		api.GET("/sessions/:id/saves/slot/:slot", sessionHandler.DownloadSlotSave)
+		api.GET("/sessions/:id/saves/:saveId", sessionHandler.DownloadSessionSave)
+		api.DELETE("/sessions/:id/saves/:saveId", sessionHandler.DeleteSessionSave)
+		api.PUT("/sessions/:id/saves/:saveId", sessionHandler.UpdateSessionSave)
+		api.POST("/sessions/:id/sram", uploadLimiter.RateLimit(), sessionHandler.UploadSRAM)
+		api.GET("/sessions/:id/sram", sessionHandler.DownloadSRAM)
+		api.POST("/sessions/:id/play-time", sessionHandler.UpdatePlayTime)
+		api.DELETE("/sessions/:id/play-time", sessionHandler.StopPlaying)
 
 		// Ratings
 		api.POST("/games/:id/ratings", ratingHandler.CreateOrUpdateRating)
@@ -437,6 +459,7 @@ func NewRouter(cfg Config) *gin.Engine {
 			admin.DELETE("/bios/:filename", biosHandler.DeleteBiosFile)
 			admin.PUT("/games/:id/verification-tag", gameHandler.UpdateVerificationTag)
 			admin.POST("/cheats/import", adminHandler.TriggerCheatImport)
+			admin.GET("/cheats/stats", adminHandler.GetCheatStats)
 
 			// ROM uploads
 			admin.POST("/uploads", uploadHandler.UploadROMs)

--- a/server/internal/api/session_handler.go
+++ b/server/internal/api/session_handler.go
@@ -228,6 +228,11 @@ func (h *SessionHandler) UploadSessionSave(c *gin.Context) {
 		return
 	}
 
+	// If this session backs a relay, enforce turn ownership
+	if ok := h.checkRelayTurn(c, session.ID, uid); !ok {
+		return
+	}
+
 	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxSaveUploadSize)
 	file, header, err := c.Request.FormFile("save")
 	if err != nil {
@@ -394,6 +399,11 @@ func (h *SessionHandler) UploadAutoSave(c *gin.Context) {
 	uid := getUserID(c)
 	session, ok := h.loadSessionWithOwnerCheck(c, uid)
 	if !ok {
+		return
+	}
+
+	// If this session backs a relay, enforce turn ownership
+	if ok := h.checkRelayTurn(c, session.ID, uid); !ok {
 		return
 	}
 
@@ -764,6 +774,69 @@ func (h *SessionHandler) StopPlaying(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "stopped playing"})
 }
 
+// GetSessionCheats returns the cheat configuration for a session.
+// GET /api/sessions/:id/cheats
+func (h *SessionHandler) GetSessionCheats(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	var settings []db.SessionCheatSetting
+	h.DB.Where("session_id = ? AND enabled = ?", session.ID, true).Find(&settings)
+
+	indices := make([]int, len(settings))
+	for i, s := range settings {
+		indices[i] = s.CheatIndex
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"cheatsEnabled":  session.CheatsEnabled,
+		"enabledIndices": indices,
+	})
+}
+
+// UpdateSessionCheats updates the cheat configuration for a session.
+// PUT /api/sessions/:id/cheats
+func (h *SessionHandler) UpdateSessionCheats(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		CheatsEnabled  bool  `json:"cheatsEnabled"`
+		EnabledIndices []int `json:"enabledIndices"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	// Update session cheats enabled flag
+	h.DB.Model(&session).Update("cheats_enabled", req.CheatsEnabled)
+
+	// Delete all existing cheat settings for this session
+	h.DB.Where("session_id = ?", session.ID).Delete(&db.SessionCheatSetting{})
+
+	// Create new settings for each enabled index
+	for _, idx := range req.EnabledIndices {
+		setting := db.SessionCheatSetting{
+			SessionID:  session.ID,
+			CheatIndex: idx,
+			Enabled:    true,
+		}
+		h.DB.Create(&setting)
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"cheatsEnabled":  req.CheatsEnabled,
+		"enabledIndices": req.EnabledIndices,
+	})
+}
+
 // --- Helper methods ---
 
 func (h *SessionHandler) loadSessionWithOwnerCheck(c *gin.Context, uid uint) (db.GameSession, bool) {
@@ -858,4 +931,22 @@ func (h *SessionHandler) toSaveResponse(s db.SessionSaveState) SessionSaveRespon
 		CreatedAt:     s.CreatedAt,
 		UpdatedAt:     s.UpdatedAt,
 	}
+}
+
+// checkRelayTurn checks if this session is backed by a relay, and if so, whether
+// the user currently holds the turn. Returns true if the upload should proceed,
+// false if a response has already been written.
+func (h *SessionHandler) checkRelayTurn(c *gin.Context, sessionID, uid uint) bool {
+	var relay db.Relay
+	if err := h.DB.Where("session_id = ?", sessionID).First(&relay).Error; err != nil {
+		// No relay backs this session — allow normal upload
+		return true
+	}
+
+	// A relay backs this session — user must hold the turn
+	if relay.ActiveUserID == nil || *relay.ActiveUserID != uid {
+		c.JSON(http.StatusForbidden, gin.H{"error": "relay turn required: you must hold the turn to upload saves"})
+		return false
+	}
+	return true
 }

--- a/server/internal/api/session_handler.go
+++ b/server/internal/api/session_handler.go
@@ -1,0 +1,861 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/storage"
+	"gorm.io/gorm"
+)
+
+// SessionHandler handles game session endpoints.
+type SessionHandler struct {
+	DB      *gorm.DB
+	Storage *storage.Storage
+}
+
+// CreateSession creates a new game session.
+// POST /api/games/:id/sessions
+func (h *SessionHandler) CreateSession(c *gin.Context) {
+	uid := getUserID(c)
+	gameID := c.Param("id")
+
+	gid, err := strconv.ParseUint(gameID, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid game ID"})
+		return
+	}
+
+	var game db.Game
+	if err := h.DB.First(&game, gid).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "game not found"})
+		return
+	}
+
+	var req struct {
+		Name string `json:"name" binding:"required,max=255"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "name is required and must be 255 characters or fewer"})
+		return
+	}
+
+	if strings.TrimSpace(req.Name) == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "name cannot be empty"})
+		return
+	}
+
+	session := db.GameSession{
+		OwnerID: uid,
+		GameID:  uint(gid),
+		Name:    req.Name,
+	}
+	if err := h.DB.Create(&session).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create session"})
+		return
+	}
+
+	h.DB.Preload("Owner").First(&session, session.ID)
+	c.JSON(http.StatusCreated, h.toSessionResponse(session, 0))
+}
+
+// ListSessions lists all sessions for a game belonging to the current user.
+// GET /api/games/:id/sessions
+func (h *SessionHandler) ListSessions(c *gin.Context) {
+	uid := getUserID(c)
+	gameID := c.Param("id")
+
+	gid, err := strconv.ParseUint(gameID, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid game ID"})
+		return
+	}
+
+	var sessions []db.GameSession
+	if err := h.DB.Where("owner_id = ? AND game_id = ?", uid, gid).
+		Preload("Owner").
+		Order("updated_at DESC").
+		Find(&sessions).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch sessions"})
+		return
+	}
+
+	// Batch-load save counts
+	saveCounts := h.getSaveCounts(sessions)
+
+	result := make([]GameSessionResponse, len(sessions))
+	for i, s := range sessions {
+		result[i] = h.toSessionResponse(s, saveCounts[s.ID])
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// GetSession returns a single session.
+// GET /api/sessions/:id
+func (h *SessionHandler) GetSession(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	var saveCount int64
+	h.DB.Model(&db.SessionSaveState{}).Where("session_id = ?", session.ID).Count(&saveCount)
+
+	c.JSON(http.StatusOK, h.toSessionResponse(session, int(saveCount)))
+}
+
+// UpdateSession updates a session's name or settings.
+// PUT /api/sessions/:id
+func (h *SessionHandler) UpdateSession(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Name          *string `json:"name"`
+		CheatsEnabled *bool   `json:"cheatsEnabled"`
+		CoreName      *string `json:"coreName"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	if req.Name != nil {
+		if len(*req.Name) > 255 || strings.TrimSpace(*req.Name) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "name must be between 1 and 255 characters"})
+			return
+		}
+		session.Name = *req.Name
+	}
+	if req.CheatsEnabled != nil {
+		session.CheatsEnabled = *req.CheatsEnabled
+	}
+	if req.CoreName != nil {
+		session.CoreName = *req.CoreName
+	}
+
+	if err := h.DB.Save(&session).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update session"})
+		return
+	}
+
+	var saveCount int64
+	h.DB.Model(&db.SessionSaveState{}).Where("session_id = ?", session.ID).Count(&saveCount)
+
+	c.JSON(http.StatusOK, h.toSessionResponse(session, int(saveCount)))
+}
+
+// DeleteSession soft-deletes a session and its saves.
+// DELETE /api/sessions/:id
+func (h *SessionHandler) DeleteSession(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	// Delete save state files and records
+	var saves []db.SessionSaveState
+	h.DB.Where("session_id = ?", session.ID).Find(&saves)
+	for _, save := range saves {
+		h.Storage.DeleteSave(save.FilePath)
+		if save.ScreenshotURL != "" {
+			h.Storage.DeleteSave(h.Storage.ImagePath(save.ScreenshotURL))
+		}
+	}
+	h.DB.Where("session_id = ?", session.ID).Delete(&db.SessionSaveState{})
+
+	// Delete SRAM data files and records
+	var sramData []db.SessionSaveData
+	h.DB.Where("session_id = ?", session.ID).Find(&sramData)
+	for _, sd := range sramData {
+		h.Storage.DeleteSave(sd.FilePath)
+	}
+	h.DB.Where("session_id = ?", session.ID).Delete(&db.SessionSaveData{})
+
+	// Delete session directory
+	h.Storage.DeleteSessionDir(session.ID)
+
+	// Delete session record
+	h.DB.Delete(&session)
+
+	c.JSON(http.StatusOK, gin.H{"message": "session deleted"})
+}
+
+// ListSessionSaves lists all save states in a session.
+// GET /api/sessions/:id/saves
+func (h *SessionHandler) ListSessionSaves(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	var saves []db.SessionSaveState
+	if err := h.DB.Where("session_id = ?", session.ID).
+		Preload("User").
+		Order("created_at DESC").
+		Find(&saves).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch saves"})
+		return
+	}
+
+	result := make([]SessionSaveResponse, len(saves))
+	for i, s := range saves {
+		result[i] = h.toSaveResponse(s)
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// UploadSessionSave uploads a save state to a session.
+// POST /api/sessions/:id/saves
+func (h *SessionHandler) UploadSessionSave(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxSaveUploadSize)
+	file, header, err := c.Request.FormFile("save")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "save file required"})
+		return
+	}
+	defer file.Close()
+
+	if err := checkStorageQuota(h.DB, uid, header.Size); err != nil {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "storage quota exceeded"})
+		return
+	}
+
+	name := c.DefaultPostForm("name", header.Filename)
+	coreName := c.PostForm("coreName")
+
+	// Handle optional screenshot upload
+	var screenshotURL string
+	if ssFile, ssHeader, ssErr := c.Request.FormFile("screenshot"); ssErr == nil {
+		defer ssFile.Close()
+		if stored, writeErr := h.Storage.WriteSessionScreenshot(session.ID, ssHeader.Filename, ssFile); writeErr == nil {
+			screenshotURL = stored
+		}
+	}
+
+	path, size, err := h.Storage.WriteSessionSave(session.ID, header.Filename, file)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save file"})
+		return
+	}
+
+	save := db.SessionSaveState{
+		SessionID:     session.ID,
+		UserID:        uid,
+		Name:          name,
+		FilePath:      path,
+		FileSize:      size,
+		ScreenshotURL: screenshotURL,
+		CoreName:      coreName,
+		IsAuto:        false,
+	}
+	if err := h.DB.Create(&save).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create save record"})
+		return
+	}
+
+	// Update session screenshot and last played
+	now := time.Now()
+	updates := map[string]interface{}{"last_played_at": now, "last_played_by": uid}
+	if screenshotURL != "" {
+		updates["screenshot_url"] = screenshotURL
+	}
+	if coreName != "" {
+		updates["core_name"] = coreName
+	}
+	h.DB.Model(&session).Updates(updates)
+
+	h.DB.Preload("User").First(&save, save.ID)
+	c.JSON(http.StatusCreated, h.toSaveResponse(save))
+}
+
+// DownloadSessionSave serves a session save state file.
+// GET /api/sessions/:id/saves/:saveId
+func (h *SessionHandler) DownloadSessionSave(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	saveID := c.Param("saveId")
+	var save db.SessionSaveState
+	if err := h.DB.Where("id = ? AND session_id = ?", saveID, session.ID).First(&save).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "save not found"})
+		return
+	}
+
+	if !storage.ValidateROMPath(save.FilePath, []string{h.Storage.SaveDir}) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "file access denied"})
+		return
+	}
+
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filepath.Base(save.FilePath)))
+	c.File(save.FilePath)
+}
+
+// DeleteSessionSave removes a session save state.
+// DELETE /api/sessions/:id/saves/:saveId
+func (h *SessionHandler) DeleteSessionSave(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	saveID := c.Param("saveId")
+	var save db.SessionSaveState
+	if err := h.DB.Where("id = ? AND session_id = ?", saveID, session.ID).First(&save).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "save not found"})
+		return
+	}
+
+	h.Storage.DeleteSave(save.FilePath)
+	if save.ScreenshotURL != "" {
+		h.Storage.DeleteSave(h.Storage.ImagePath(save.ScreenshotURL))
+	}
+
+	h.DB.Delete(&save)
+	c.JSON(http.StatusOK, gin.H{"message": "save deleted"})
+}
+
+// UpdateSessionSave updates a session save state's name or notes.
+// PUT /api/sessions/:id/saves/:saveId
+func (h *SessionHandler) UpdateSessionSave(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	saveID := c.Param("saveId")
+	var save db.SessionSaveState
+	if err := h.DB.Where("id = ? AND session_id = ?", saveID, session.ID).First(&save).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "save not found"})
+		return
+	}
+
+	var req struct {
+		Name  *string `json:"name"`
+		Notes *string `json:"notes"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+
+	if req.Name != nil {
+		if len(*req.Name) > 255 || strings.TrimSpace(*req.Name) == "" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "name must be between 1 and 255 characters"})
+			return
+		}
+		save.Name = *req.Name
+	}
+	if req.Notes != nil {
+		if len(*req.Notes) > 200 {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "notes must be 200 characters or less"})
+			return
+		}
+		save.Notes = *req.Notes
+	}
+
+	if err := h.DB.Save(&save).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update save"})
+		return
+	}
+
+	h.DB.Preload("User").First(&save, save.ID)
+	c.JSON(http.StatusOK, h.toSaveResponse(save))
+}
+
+// UploadAutoSave uploads an auto-save to a session.
+// POST /api/sessions/:id/saves/auto
+func (h *SessionHandler) UploadAutoSave(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxSaveUploadSize)
+	file, header, err := c.Request.FormFile("save")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "save file required"})
+		return
+	}
+	defer file.Close()
+
+	if err := checkStorageQuota(h.DB, uid, header.Size); err != nil {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "storage quota exceeded"})
+		return
+	}
+
+	filename := fmt.Sprintf("autosave_%d.sav", time.Now().UnixNano())
+	coreName := c.PostForm("coreName")
+
+	// Handle optional screenshot upload
+	var screenshotURL string
+	if ssFile, ssHeader, ssErr := c.Request.FormFile("screenshot"); ssErr == nil {
+		defer ssFile.Close()
+		if stored, writeErr := h.Storage.WriteSessionScreenshot(session.ID, ssHeader.Filename, ssFile); writeErr == nil {
+			screenshotURL = stored
+		}
+	}
+
+	path, size, err := h.Storage.WriteSessionSave(session.ID, filename, file)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save file"})
+		return
+	}
+
+	save := db.SessionSaveState{
+		SessionID:     session.ID,
+		UserID:        uid,
+		Name:          "Auto Save",
+		FilePath:      path,
+		FileSize:      size,
+		ScreenshotURL: screenshotURL,
+		CoreName:      coreName,
+		IsAuto:        true,
+		IsCurrent:     true,
+	}
+	if err := h.DB.Create(&save).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create save record"})
+		return
+	}
+
+	// Prune old auto-saves (keep latest 5)
+	var oldSaves []db.SessionSaveState
+	h.DB.Where("session_id = ? AND is_auto = ? AND id != ?", session.ID, true, save.ID).
+		Order("created_at DESC").Offset(4).Find(&oldSaves)
+	for _, old := range oldSaves {
+		h.Storage.DeleteSave(old.FilePath)
+		if old.ScreenshotURL != "" {
+			h.Storage.DeleteSave(h.Storage.ImagePath(old.ScreenshotURL))
+		}
+		h.DB.Delete(&old)
+	}
+
+	// Update session screenshot and last played
+	now := time.Now()
+	updates := map[string]interface{}{"last_played_at": now, "last_played_by": uid}
+	if screenshotURL != "" {
+		updates["screenshot_url"] = screenshotURL
+	}
+	if coreName != "" {
+		updates["core_name"] = coreName
+	}
+	h.DB.Model(&session).Updates(updates)
+
+	h.DB.Preload("User").First(&save, save.ID)
+	c.JSON(http.StatusCreated, h.toSaveResponse(save))
+}
+
+// GetAutoSave returns the latest auto-save for a session.
+// GET /api/sessions/:id/saves/auto
+func (h *SessionHandler) GetAutoSave(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	var save db.SessionSaveState
+	if err := h.DB.Where("session_id = ? AND is_auto = ?", session.ID, true).
+		Preload("User").
+		Order("created_at DESC").
+		First(&save).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "no auto-save found"})
+		return
+	}
+
+	// Serve the file directly
+	if !storage.ValidateROMPath(save.FilePath, []string{h.Storage.SaveDir}) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "file access denied"})
+		return
+	}
+
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filepath.Base(save.FilePath)))
+	c.File(save.FilePath)
+}
+
+// UpsertSlotSave saves or overwrites a save to a specific slot (1-10).
+// PUT /api/sessions/:id/saves/slot/:slot
+func (h *SessionHandler) UpsertSlotSave(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	slotStr := c.Param("slot")
+	slotNum, err := strconv.Atoi(slotStr)
+	if err != nil || slotNum < 1 || slotNum > 10 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "slot must be between 1 and 10"})
+		return
+	}
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxSaveUploadSize)
+	file, fileHeader, err := c.Request.FormFile("save")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "save file required"})
+		return
+	}
+	defer file.Close()
+
+	if err := checkStorageQuota(h.DB, uid, fileHeader.Size); err != nil {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "storage quota exceeded"})
+		return
+	}
+
+	filename := fmt.Sprintf("slot_%d.sav", slotNum)
+	coreName := c.PostForm("coreName")
+
+	// Handle optional screenshot upload
+	var screenshotURL string
+	if ssFile, ssHeader, ssErr := c.Request.FormFile("screenshot"); ssErr == nil {
+		defer ssFile.Close()
+		if stored, writeErr := h.Storage.WriteSessionScreenshot(session.ID, ssHeader.Filename, ssFile); writeErr == nil {
+			screenshotURL = stored
+		}
+	}
+
+	path, size, err := h.Storage.WriteSessionSave(session.ID, filename, file)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save file"})
+		return
+	}
+
+	// Upsert: update existing slot save or create new
+	var save db.SessionSaveState
+	result := h.DB.Where("session_id = ? AND slot = ?", session.ID, slotNum).First(&save)
+	if result.Error == gorm.ErrRecordNotFound {
+		save = db.SessionSaveState{
+			SessionID:     session.ID,
+			UserID:        uid,
+			Name:          fmt.Sprintf("Slot %d", slotNum),
+			FilePath:      path,
+			FileSize:      size,
+			ScreenshotURL: screenshotURL,
+			CoreName:      coreName,
+			IsAuto:        false,
+			Slot:          &slotNum,
+		}
+		h.DB.Create(&save)
+	} else {
+		save.FilePath = path
+		save.FileSize = size
+		save.ScreenshotURL = screenshotURL
+		save.CoreName = coreName
+		h.DB.Save(&save)
+	}
+
+	// Update session last played
+	now := time.Now()
+	updates := map[string]interface{}{"last_played_at": now, "last_played_by": uid}
+	if screenshotURL != "" {
+		updates["screenshot_url"] = screenshotURL
+	}
+	h.DB.Model(&session).Updates(updates)
+
+	h.DB.Preload("User").First(&save, save.ID)
+	c.JSON(http.StatusOK, h.toSaveResponse(save))
+}
+
+// DownloadSlotSave downloads the save from a specific slot.
+// GET /api/sessions/:id/saves/slot/:slot
+func (h *SessionHandler) DownloadSlotSave(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	slotStr := c.Param("slot")
+	slotNum, err := strconv.Atoi(slotStr)
+	if err != nil || slotNum < 1 || slotNum > 10 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "slot must be between 1 and 10"})
+		return
+	}
+
+	var save db.SessionSaveState
+	if err := h.DB.Where("session_id = ? AND slot = ?", session.ID, slotNum).First(&save).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "no save in this slot"})
+		return
+	}
+
+	if !storage.ValidateROMPath(save.FilePath, []string{h.Storage.SaveDir}) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "file access denied"})
+		return
+	}
+
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filepath.Base(save.FilePath)))
+	c.File(save.FilePath)
+}
+
+// ListSlotSaves returns all slot saves for a session.
+// GET /api/sessions/:id/saves/slots
+func (h *SessionHandler) ListSlotSaves(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	var saves []db.SessionSaveState
+	if err := h.DB.Where("session_id = ? AND slot IS NOT NULL", session.ID).
+		Preload("User").
+		Order("slot ASC").
+		Find(&saves).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch slot saves"})
+		return
+	}
+
+	result := make([]SessionSaveResponse, len(saves))
+	for i, s := range saves {
+		result[i] = h.toSaveResponse(s)
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// UploadSRAM uploads SRAM/battery save data to a session.
+// POST /api/sessions/:id/sram
+func (h *SessionHandler) UploadSRAM(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxSaveUploadSize)
+	file, header, err := c.Request.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "file required"})
+		return
+	}
+	defer file.Close()
+
+	if err := checkStorageQuota(h.DB, uid, header.Size); err != nil {
+		c.JSON(http.StatusRequestEntityTooLarge, gin.H{"error": "storage quota exceeded"})
+		return
+	}
+
+	path, size, err := h.Storage.WriteSessionSRAM(session.ID, header.Filename, file)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to save SRAM file"})
+		return
+	}
+
+	// Upsert: only keep one SRAM file per session
+	var existing db.SessionSaveData
+	result := h.DB.Where("session_id = ?", session.ID).First(&existing)
+	if result.Error == gorm.ErrRecordNotFound {
+		sd := db.SessionSaveData{
+			SessionID: session.ID,
+			FilePath:  path,
+			FileSize:  size,
+		}
+		h.DB.Create(&sd)
+		c.JSON(http.StatusCreated, sd)
+	} else {
+		// Delete old file only if the path changed (same filename overwrites in place)
+		if existing.FilePath != path {
+			h.Storage.DeleteSave(existing.FilePath)
+		}
+		existing.FilePath = path
+		existing.FileSize = size
+		h.DB.Save(&existing)
+		c.JSON(http.StatusOK, existing)
+	}
+}
+
+// DownloadSRAM serves the SRAM/battery save data for a session.
+// GET /api/sessions/:id/sram
+func (h *SessionHandler) DownloadSRAM(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	var sd db.SessionSaveData
+	if err := h.DB.Where("session_id = ?", session.ID).First(&sd).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "no SRAM data found"})
+		return
+	}
+
+	if !storage.ValidateROMPath(sd.FilePath, []string{h.Storage.SaveDir}) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "file access denied"})
+		return
+	}
+
+	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", filepath.Base(sd.FilePath)))
+	c.File(sd.FilePath)
+}
+
+// UpdatePlayTime records play time for a session.
+// POST /api/sessions/:id/play-time
+func (h *SessionHandler) UpdatePlayTime(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Seconds int64 `json:"seconds" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "seconds is required"})
+		return
+	}
+
+	if req.Seconds < 0 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "seconds must be non-negative"})
+		return
+	}
+
+	now := time.Now()
+	h.DB.Model(&session).Updates(map[string]interface{}{
+		"total_play_time": gorm.Expr("total_play_time + ?", req.Seconds),
+		"last_played_at":  now,
+		"last_played_by":  uid,
+	})
+
+	h.DB.First(&session, session.ID)
+	var saveCount int64
+	h.DB.Model(&db.SessionSaveState{}).Where("session_id = ?", session.ID).Count(&saveCount)
+
+	h.DB.Preload("Owner").First(&session, session.ID)
+	c.JSON(http.StatusOK, h.toSessionResponse(session, int(saveCount)))
+}
+
+// StopPlaying clears the last played by field.
+// DELETE /api/sessions/:id/play-time
+func (h *SessionHandler) StopPlaying(c *gin.Context) {
+	uid := getUserID(c)
+	session, ok := h.loadSessionWithOwnerCheck(c, uid)
+	if !ok {
+		return
+	}
+
+	h.DB.Model(&session).Update("last_played_by", nil)
+	c.JSON(http.StatusOK, gin.H{"message": "stopped playing"})
+}
+
+// --- Helper methods ---
+
+func (h *SessionHandler) loadSessionWithOwnerCheck(c *gin.Context, uid uint) (db.GameSession, bool) {
+	sessionID := c.Param("id")
+	sid, err := strconv.ParseUint(sessionID, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid session ID"})
+		return db.GameSession{}, false
+	}
+
+	var session db.GameSession
+	if err := h.DB.Preload("Owner").First(&session, sid).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "session not found"})
+		return db.GameSession{}, false
+	}
+
+	if session.OwnerID != uid {
+		c.JSON(http.StatusForbidden, gin.H{"error": "not the session owner"})
+		return db.GameSession{}, false
+	}
+
+	return session, true
+}
+
+func (h *SessionHandler) getSaveCounts(sessions []db.GameSession) map[uint]int {
+	if len(sessions) == 0 {
+		return nil
+	}
+
+	ids := make([]uint, len(sessions))
+	for i, s := range sessions {
+		ids[i] = s.ID
+	}
+
+	type countRow struct {
+		SessionID uint
+		Count     int
+	}
+	var rows []countRow
+	h.DB.Model(&db.SessionSaveState{}).
+		Where("session_id IN ?", ids).
+		Select("session_id, COUNT(*) as count").
+		Group("session_id").
+		Scan(&rows)
+
+	result := make(map[uint]int, len(rows))
+	for _, r := range rows {
+		result[r.SessionID] = r.Count
+	}
+	return result
+}
+
+func (h *SessionHandler) toSessionResponse(s db.GameSession, saveCount int) GameSessionResponse {
+	var lastPlayedBy *string
+	if s.LastPlayedBy != nil {
+		str := strconv.FormatUint(uint64(*s.LastPlayedBy), 10)
+		lastPlayedBy = &str
+	}
+
+	return GameSessionResponse{
+		ID:            strconv.FormatUint(uint64(s.ID), 10),
+		OwnerID:       strconv.FormatUint(uint64(s.OwnerID), 10),
+		OwnerUsername: s.Owner.Username,
+		GameID:        strconv.FormatUint(uint64(s.GameID), 10),
+		Name:          s.Name,
+		LastPlayedAt:  s.LastPlayedAt,
+		LastPlayedBy:  lastPlayedBy,
+		TotalPlayTime: s.TotalPlayTime,
+		ScreenshotURL: resolveImageURL(s.ScreenshotURL),
+		CoreName:      s.CoreName,
+		CheatsEnabled: s.CheatsEnabled,
+		SaveCount:     saveCount,
+		CreatedAt:     s.CreatedAt,
+		UpdatedAt:     s.UpdatedAt,
+	}
+}
+
+func (h *SessionHandler) toSaveResponse(s db.SessionSaveState) SessionSaveResponse {
+	return SessionSaveResponse{
+		ID:            strconv.FormatUint(uint64(s.ID), 10),
+		SessionID:     strconv.FormatUint(uint64(s.SessionID), 10),
+		UserID:        strconv.FormatUint(uint64(s.UserID), 10),
+		Username:      s.User.Username,
+		Name:          s.Name,
+		FileSize:      s.FileSize,
+		ScreenshotURL: resolveImageURL(s.ScreenshotURL),
+		IsAuto:        s.IsAuto,
+		IsCurrent:     s.IsCurrent,
+		CoreName:      s.CoreName,
+		Notes:         s.Notes,
+		Slot:          s.Slot,
+		CreatedAt:     s.CreatedAt,
+		UpdatedAt:     s.UpdatedAt,
+	}
+}

--- a/server/internal/api/session_handler_test.go
+++ b/server/internal/api/session_handler_test.go
@@ -1,0 +1,987 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+type sessionTestEnv struct {
+	database *gorm.DB
+	router   http.Handler
+	token    string
+	token2   string
+	gameID   string
+}
+
+func setupSessionTestEnv(t *testing.T) *sessionTestEnv {
+	t.Helper()
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+
+	// Register first user (owner)
+	token := registerAndGetToken(t, router)
+
+	// Register second user
+	token2 := createNonOwnerUser(t, router, token, "user2", "user2@example.com", "password123")
+
+	// Create a test game
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Test Game", FileName: "test.nes", FilePath: "/tmp/test.nes", FileSize: 100}
+	database.Create(&game)
+
+	return &sessionTestEnv{
+		database: database,
+		router:   router,
+		token:    token,
+		token2:   token2,
+		gameID:   fmt.Sprintf("%d", game.ID),
+	}
+}
+
+func createGameSession(t *testing.T, router http.Handler, token, gameID, name string) map[string]interface{} {
+	t.Helper()
+	body, _ := json.Marshal(map[string]string{"name": name})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/games/"+gameID+"/sessions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "createGameSession failed: %s", w.Body.String())
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	return resp
+}
+
+func uploadSessionSave(t *testing.T, router http.Handler, token, sessionID, name string, data []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	writer.WriteField("name", name)
+	part, _ := writer.CreateFormFile("save", "state.sav")
+	part.Write(data)
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/saves", &buf)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func uploadSessionAutoSave(t *testing.T, router http.Handler, token, sessionID string, data []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, _ := writer.CreateFormFile("save", "autosave.sav")
+	part.Write(data)
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/saves/auto", &buf)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	router.ServeHTTP(w, req)
+	return w
+}
+
+// --- Session CRUD ---
+
+func TestCreateSession(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	resp := createGameSession(t, env.router, env.token, env.gameID, "My Playthrough")
+	assert.Equal(t, "My Playthrough", resp["name"])
+	assert.Equal(t, env.gameID, resp["gameId"])
+	assert.NotEmpty(t, resp["id"])
+	assert.NotEmpty(t, resp["ownerId"])
+	assert.Equal(t, float64(0), resp["totalPlayTime"])
+	assert.Equal(t, float64(0), resp["saveCount"])
+}
+
+func TestCreateSession_EmptyName(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	body, _ := json.Marshal(map[string]string{"name": ""})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/games/"+env.gameID+"/sessions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateSession_WhitespaceOnlyName(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	body, _ := json.Marshal(map[string]string{"name": "   "})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/games/"+env.gameID+"/sessions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateSession_InvalidGame(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	body, _ := json.Marshal(map[string]string{"name": "My Playthrough"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/games/9999/sessions", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestListSessions(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	// Create two sessions
+	createGameSession(t, env.router, env.token, env.gameID, "Session 1")
+	createGameSession(t, env.router, env.token, env.gameID, "Session 2")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/"+env.gameID+"/sessions", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var sessions []map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &sessions)
+	assert.Len(t, sessions, 2)
+}
+
+func TestListSessions_EmptyForOtherUser(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	// User 1 creates a session
+	createGameSession(t, env.router, env.token, env.gameID, "User1 Session")
+
+	// User 2 lists sessions for the same game
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/"+env.gameID+"/sessions", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token2)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var sessions []map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &sessions)
+	assert.Len(t, sessions, 0)
+}
+
+func TestGetSession(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "My Session", resp["name"])
+}
+
+func TestGetSession_NotOwner(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// User 2 tries to get user 1's session
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token2)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestGetSession_NotFound(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/9999", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestUpdateSession(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "Old Name")
+	sessionID := created["id"].(string)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":          "New Name",
+		"cheatsEnabled": true,
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/sessions/"+sessionID, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "New Name", resp["name"])
+	assert.Equal(t, true, resp["cheatsEnabled"])
+}
+
+func TestUpdateSession_NotOwner(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	body, _ := json.Marshal(map[string]string{"name": "Hacked"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/sessions/"+sessionID, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token2)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestDeleteSession(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "To Delete")
+	sessionID := created["id"].(string)
+
+	// Upload a save to the session
+	w := uploadSessionSave(t, env.router, env.token, sessionID, "Save 1", []byte("data"))
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Delete the session
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/sessions/"+sessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify it's gone
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/sessions/"+sessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestDeleteSession_NotOwner(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/sessions/"+sessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token2)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+// --- Session Save States ---
+
+func TestUploadSessionSave(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := uploadSessionSave(t, env.router, env.token, sessionID, "My Save", []byte("save data"))
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "My Save", resp["name"])
+	assert.Equal(t, sessionID, resp["sessionId"])
+	assert.Equal(t, false, resp["isAuto"])
+}
+
+func TestUploadSessionSave_NotOwner(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := uploadSessionSave(t, env.router, env.token2, sessionID, "Hacked", []byte("evil"))
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestListSessionSaves(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	uploadSessionSave(t, env.router, env.token, sessionID, "Save 1", []byte("data1"))
+	uploadSessionSave(t, env.router, env.token, sessionID, "Save 2", []byte("data2"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/saves", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var saves []map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &saves)
+	assert.Len(t, saves, 2)
+}
+
+func TestDownloadSessionSave(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := uploadSessionSave(t, env.router, env.token, sessionID, "My Save", []byte("download me"))
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var saveResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &saveResp)
+	saveID := saveResp["id"].(string)
+
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/saves/"+saveID, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, []byte("download me"), w.Body.Bytes())
+}
+
+func TestDeleteSessionSave(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := uploadSessionSave(t, env.router, env.token, sessionID, "Save 1", []byte("data"))
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var saveResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &saveResp)
+	saveID := saveResp["id"].(string)
+
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/sessions/"+sessionID+"/saves/"+saveID, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify it's gone
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/saves/"+saveID, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestUpdateSessionSave(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := uploadSessionSave(t, env.router, env.token, sessionID, "Old Name", []byte("data"))
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var saveResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &saveResp)
+	saveID := saveResp["id"].(string)
+
+	body, _ := json.Marshal(map[string]string{"name": "New Name", "notes": "Before boss"})
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/sessions/"+sessionID+"/saves/"+saveID, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var updated map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &updated)
+	assert.Equal(t, "New Name", updated["name"])
+	assert.Equal(t, "Before boss", updated["notes"])
+}
+
+func TestUpdateSessionSave_NotesTooLong(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := uploadSessionSave(t, env.router, env.token, sessionID, "My Save", []byte("data"))
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var saveResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &saveResp)
+	saveID := saveResp["id"].(string)
+
+	longNotes := string(make([]byte, 201))
+	body, _ := json.Marshal(map[string]string{"notes": longNotes})
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/sessions/"+sessionID+"/saves/"+saveID, bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Auto-Save ---
+
+func TestSessionAutoSave(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := uploadSessionAutoSave(t, env.router, env.token, sessionID, []byte("auto save data"))
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, true, resp["isAuto"])
+	assert.Equal(t, "Auto Save", resp["name"])
+}
+
+func TestSessionAutoSave_GetLatest(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	uploadSessionAutoSave(t, env.router, env.token, sessionID, []byte("old auto"))
+	uploadSessionAutoSave(t, env.router, env.token, sessionID, []byte("new auto"))
+
+	// GET auto should return the latest file
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/saves/auto", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, []byte("new auto"), w.Body.Bytes())
+}
+
+func TestSessionAutoSave_PrunesOld(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Upload 7 auto-saves
+	for i := 0; i < 7; i++ {
+		w := uploadSessionAutoSave(t, env.router, env.token, sessionID, []byte(fmt.Sprintf("auto %d", i)))
+		assert.Equal(t, http.StatusCreated, w.Code)
+	}
+
+	// DB should have max 5 auto-saves
+	var count int64
+	env.database.Model(&db.SessionSaveState{}).
+		Where("session_id = ? AND is_auto = ?", 1, true).
+		Count(&count)
+	assert.LessOrEqual(t, count, int64(5))
+}
+
+func TestSessionAutoSave_NotFound(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/saves/auto", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Slot Saves ---
+
+func TestSessionSlotSave_Upsert(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Save to slot 1
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, _ := writer.CreateFormFile("save", "slot.sav")
+	part.Write([]byte("slot 1 data"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/sessions/"+sessionID+"/saves/slot/1", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var save1 map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &save1)
+	id1 := save1["id"]
+	assert.Equal(t, float64(1), save1["slot"])
+
+	// Overwrite slot 1
+	buf.Reset()
+	writer = multipart.NewWriter(&buf)
+	part, _ = writer.CreateFormFile("save", "slot.sav")
+	part.Write([]byte("slot 1 data v2"))
+	writer.Close()
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("PUT", "/api/sessions/"+sessionID+"/saves/slot/1", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var save2 map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &save2)
+	assert.Equal(t, id1, save2["id"], "should update same record")
+}
+
+func TestSessionSlotSave_Download(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, _ := writer.CreateFormFile("save", "slot.sav")
+	part.Write([]byte("slot 3 content"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/sessions/"+sessionID+"/saves/slot/3", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Download
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/saves/slot/3", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, []byte("slot 3 content"), w.Body.Bytes())
+}
+
+func TestSessionSlotSave_EmptySlot(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/saves/slot/5", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestSessionSlotSave_InvalidSlot(t *testing.T) {
+	tests := []struct {
+		name string
+		slot string
+	}{
+		{"slot 0", "0"},
+		{"slot 11", "11"},
+		{"slot -1", "-1"},
+		{"slot abc", "abc"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			env := setupSessionTestEnv(t)
+
+			created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+			sessionID := created["id"].(string)
+
+			var buf bytes.Buffer
+			writer := multipart.NewWriter(&buf)
+			part, _ := writer.CreateFormFile("save", "slot.sav")
+			part.Write([]byte("data"))
+			writer.Close()
+
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("PUT", "/api/sessions/"+sessionID+"/saves/slot/"+tc.slot, &buf)
+			req.Header.Set("Authorization", "Bearer "+env.token)
+			req.Header.Set("Content-Type", writer.FormDataContentType())
+			env.router.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusBadRequest, w.Code)
+		})
+	}
+}
+
+func TestSessionSlotSave_ListSlots(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	for _, slot := range []string{"1", "5"} {
+		var buf bytes.Buffer
+		writer := multipart.NewWriter(&buf)
+		part, _ := writer.CreateFormFile("save", "slot.sav")
+		part.Write([]byte("slot " + slot + " data"))
+		writer.Close()
+
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", "/api/sessions/"+sessionID+"/saves/slot/"+slot, &buf)
+		req.Header.Set("Authorization", "Bearer "+env.token)
+		req.Header.Set("Content-Type", writer.FormDataContentType())
+		env.router.ServeHTTP(w, req)
+		require.Equal(t, http.StatusOK, w.Code)
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/saves/slots", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var slots []map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &slots)
+	assert.Len(t, slots, 2)
+	assert.Equal(t, float64(1), slots[0]["slot"])
+	assert.Equal(t, float64(5), slots[1]["slot"])
+}
+
+// --- SRAM ---
+
+func TestSessionSRAM_UploadAndDownload(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Upload SRAM
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, _ := writer.CreateFormFile("file", "save.srm")
+	part.Write([]byte("sram data"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/sram", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	// Download SRAM
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/sram", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, []byte("sram data"), w.Body.Bytes())
+}
+
+func TestSessionSRAM_UpsertOverwrites(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Upload first SRAM
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, _ := writer.CreateFormFile("file", "save.srm")
+	part.Write([]byte("old sram"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/sram", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Upload second SRAM (should overwrite)
+	buf.Reset()
+	writer = multipart.NewWriter(&buf)
+	part, _ = writer.CreateFormFile("file", "save.srm")
+	part.Write([]byte("new sram"))
+	writer.Close()
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/sram", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Download should return the new data
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/sram", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, []byte("new sram"), w.Body.Bytes())
+}
+
+func TestSessionSRAM_NotFound(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/sram", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Play Time ---
+
+func TestSessionPlayTime(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Add 60 seconds of play time
+	body, _ := json.Marshal(map[string]int64{"seconds": 60})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/play-time", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(60), resp["totalPlayTime"])
+	assert.NotNil(t, resp["lastPlayedAt"])
+
+	// Add more play time
+	body, _ = json.Marshal(map[string]int64{"seconds": 120})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/play-time", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(180), resp["totalPlayTime"])
+}
+
+func TestSessionPlayTime_NegativeSeconds(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	body, _ := json.Marshal(map[string]int64{"seconds": -10})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/play-time", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSessionStopPlaying(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/sessions/"+sessionID+"/play-time", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+}
+
+// --- Save Count ---
+
+func TestSessionSaveCount(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Initially 0
+	assert.Equal(t, float64(0), created["saveCount"])
+
+	// Upload 2 saves
+	uploadSessionSave(t, env.router, env.token, sessionID, "Save 1", []byte("data1"))
+	uploadSessionSave(t, env.router, env.token, sessionID, "Save 2", []byte("data2"))
+
+	// Get session - saveCount should be 2
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(2), resp["saveCount"])
+}
+
+// --- Data Migration ---
+
+func TestMigrateSavesToSessions(t *testing.T) {
+	database, _ := setupTestEnv(t)
+
+	// Create a user
+	user := db.User{Username: "migtest", Email: "mig@test.com", PasswordHash: "hash", Role: "user"}
+	database.Create(&user)
+
+	// Create a console and game
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Mig Game", FileName: "mig.nes", FilePath: "/tmp/mig.nes", FileSize: 100}
+	database.Create(&game)
+
+	// Create existing save states
+	save1 := db.SaveState{UserID: user.ID, GameID: game.ID, Name: "Save 1", FilePath: "/tmp/save1", FileSize: 100, CoreName: "nestopia"}
+	database.Create(&save1)
+	save2 := db.SaveState{UserID: user.ID, GameID: game.ID, Name: "Auto Save", FilePath: "/tmp/save2", FileSize: 50, IsAuto: true}
+	database.Create(&save2)
+
+	// Create existing save data
+	sd := db.SaveData{UserID: user.ID, GameID: game.ID, Name: "SRAM", FilePath: "/tmp/sram", FileSize: 32}
+	database.Create(&sd)
+
+	// Create play history
+	ph := db.PlayHistory{UserID: user.ID, GameID: game.ID, PlayTime: 3600}
+	database.Create(&ph)
+
+	// Run migration
+	err := db.MigrateSavesToSessions(database)
+	require.NoError(t, err)
+
+	// Verify session was created
+	var sessions []db.GameSession
+	database.Where("owner_id = ? AND game_id = ?", user.ID, game.ID).Find(&sessions)
+	require.Len(t, sessions, 1)
+	assert.Equal(t, "Playthrough 1", sessions[0].Name)
+	assert.Equal(t, int64(3600), sessions[0].TotalPlayTime)
+	assert.Equal(t, "nestopia", sessions[0].CoreName)
+
+	// Verify session save states were created
+	var sessionSaves []db.SessionSaveState
+	database.Where("session_id = ?", sessions[0].ID).Find(&sessionSaves)
+	assert.Len(t, sessionSaves, 2)
+
+	// Verify session save data was created
+	var sessionSaveData []db.SessionSaveData
+	database.Where("session_id = ?", sessions[0].ID).Find(&sessionSaveData)
+	assert.Len(t, sessionSaveData, 1)
+
+	// Verify migration is idempotent
+	err = db.MigrateSavesToSessions(database)
+	require.NoError(t, err)
+
+	// Should still have only 1 session
+	database.Where("owner_id = ? AND game_id = ?", user.ID, game.ID).Find(&sessions)
+	assert.Len(t, sessions, 1)
+}
+
+func TestMigrateSavesToSessions_NoSaves(t *testing.T) {
+	database, _ := setupTestEnv(t)
+
+	// Run migration with no saves
+	err := db.MigrateSavesToSessions(database)
+	require.NoError(t, err)
+
+	// Verify migration flag was set
+	var setting db.ServerSetting
+	err = database.Where("key = ?", "sessions_migrated").First(&setting).Error
+	require.NoError(t, err)
+	assert.Equal(t, "true", setting.Value)
+}
+
+// --- Upload with Screenshot ---
+
+func TestUploadSessionSave_WithScreenshot(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	writer.WriteField("name", "Save with Screenshot")
+	part, _ := writer.CreateFormFile("save", "state.sav")
+	part.Write([]byte("save data"))
+	ssPart, _ := writer.CreateFormFile("screenshot", "screenshot.png")
+	ssPart.Write([]byte("PNG image data"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/saves", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NotEmpty(t, resp["screenshotUrl"])
+}
+
+// --- Session Updates from Save Uploads ---
+
+func TestSessionUpdatedOnSaveUpload(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Upload a save with coreName
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	writer.WriteField("name", "My Save")
+	writer.WriteField("coreName", "snes9x")
+	part, _ := writer.CreateFormFile("save", "state.sav")
+	part.Write([]byte("save data"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/saves", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Get session - should have updated lastPlayedAt and coreName
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/sessions/"+sessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NotNil(t, resp["lastPlayedAt"])
+	assert.Equal(t, "snes9x", resp["coreName"])
+}

--- a/server/internal/api/session_handler_test.go
+++ b/server/internal/api/session_handler_test.go
@@ -846,6 +846,114 @@ func TestSessionSaveCount(t *testing.T) {
 	assert.Equal(t, float64(2), resp["saveCount"])
 }
 
+// --- Session Cheats ---
+
+func TestGetSessionCheats_DefaultDisabled(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/cheats", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, false, resp["cheatsEnabled"])
+	indices := resp["enabledIndices"].([]interface{})
+	assert.Len(t, indices, 0)
+}
+
+func TestPutSessionCheats(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"cheatsEnabled":  true,
+		"enabledIndices": []int{0, 2, 5},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/sessions/"+sessionID+"/cheats", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, true, resp["cheatsEnabled"])
+	indices := resp["enabledIndices"].([]interface{})
+	assert.Len(t, indices, 3)
+	assert.Equal(t, float64(0), indices[0])
+	assert.Equal(t, float64(2), indices[1])
+	assert.Equal(t, float64(5), indices[2])
+}
+
+func TestSessionCheats_PutThenGet(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// PUT cheats
+	body, _ := json.Marshal(map[string]interface{}{
+		"cheatsEnabled":  true,
+		"enabledIndices": []int{1, 3},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/sessions/"+sessionID+"/cheats", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// GET cheats - should match
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/cheats", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, true, resp["cheatsEnabled"])
+	indices := resp["enabledIndices"].([]interface{})
+	assert.Len(t, indices, 2)
+	assert.Equal(t, float64(1), indices[0])
+	assert.Equal(t, float64(3), indices[1])
+}
+
+func TestSessionCheats_NotOwner(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// User 2 tries to GET cheats
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/cheats", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token2)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+
+	// User 2 tries to PUT cheats
+	body, _ := json.Marshal(map[string]interface{}{
+		"cheatsEnabled":  true,
+		"enabledIndices": []int{0},
+	})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("PUT", "/api/sessions/"+sessionID+"/cheats", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token2)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
 // --- Data Migration ---
 
 func TestMigrateSavesToSessions(t *testing.T) {

--- a/server/internal/cheats/importer.go
+++ b/server/internal/cheats/importer.go
@@ -177,6 +177,15 @@ func ImportCheatsForGame(database *gorm.DB, game db.Game, console db.Console, ba
 	return nil
 }
 
+// ImportResult holds the summary of a cheat import run.
+type ImportResult struct {
+	TotalGames     int `json:"totalGames"`
+	CheatsImported int `json:"cheatsImported"`
+	GamesImported  int `json:"gamesImported"`
+	Skipped        int `json:"skipped"`
+	Failed         int `json:"failed"`
+}
+
 // StartAutoImport checks if cheats have already been imported and, if not,
 // spawns a goroutine that imports cheats for all verified games at startup.
 func StartAutoImport(database *gorm.DB) {
@@ -189,31 +198,59 @@ func StartAutoImport(database *gorm.DB) {
 
 	go func() {
 		slog.Info("cheat auto-import starting")
-		if err := ImportAllCheats(database, DefaultBaseURL); err != nil {
+		result, err := ImportAllCheats(database, DefaultBaseURL)
+		if err != nil {
 			slog.Warn("cheat auto-import failed", "error", err)
 		} else {
-			var imported int64
-			database.Model(&db.CheatCode{}).Count(&imported)
-			slog.Info("cheat auto-import complete", "imported", imported)
+			slog.Info("cheat auto-import complete", "cheatsImported", result.CheatsImported, "gamesImported", result.GamesImported)
 		}
 	}()
 }
 
-
 // ImportAllCheats imports cheat codes for all games that have a matching .cht file.
-func ImportAllCheats(database *gorm.DB, baseURL string) error {
+func ImportAllCheats(database *gorm.DB, baseURL string) (*ImportResult, error) {
 	// Load all games with their consoles
 	var games []db.Game
 	if err := database.Preload("Console").Find(&games).Error; err != nil {
-		return fmt.Errorf("loading games: %w", err)
+		return nil, fmt.Errorf("loading games: %w", err)
 	}
 
+	result := &ImportResult{TotalGames: len(games)}
 	httpClient := &http.Client{Timeout: 15 * time.Second}
+
 	for _, game := range games {
+		// Pre-check skip conditions
+		if game.VerificationStatus != "verified" {
+			result.Skipped++
+			continue
+		}
+		if _, ok := systemFolders[game.Console.FolderName]; !ok {
+			result.Skipped++
+			continue
+		}
+		baseName := strings.TrimSuffix(game.FileName, filepath.Ext(game.FileName))
+		if baseName == "" {
+			result.Skipped++
+			continue
+		}
+
+		// Count cheats before import to detect new imports
+		var before int64
+		database.Model(&db.CheatCode{}).Where("game_id = ?", game.ID).Count(&before)
+
 		if err := ImportCheatsForGame(database, game, game.Console, baseURL, httpClient); err != nil {
 			slog.Warn("cheat import error", "game", game.Title, "error", err)
-			// Continue with other games
+			result.Failed++
+			continue
+		}
+
+		var after int64
+		database.Model(&db.CheatCode{}).Where("game_id = ?", game.ID).Count(&after)
+		newCheats := int(after - before)
+		if newCheats > 0 {
+			result.GamesImported++
+			result.CheatsImported += newCheats
 		}
 	}
-	return nil
+	return result, nil
 }

--- a/server/internal/cheats/importer_test.go
+++ b/server/internal/cheats/importer_test.go
@@ -220,8 +220,15 @@ cheat0_code = "AAAA:01"`
 	assert.Equal(t, int64(0), count, "no cheats should exist before import")
 
 	// Directly call ImportAllCheats with the test server URL to verify it works
-	err := ImportAllCheats(database, srv.URL)
+	result, err := ImportAllCheats(database, srv.URL)
 	require.NoError(t, err)
+	require.NotNil(t, result)
+
+	assert.Equal(t, 1, result.TotalGames)
+	assert.Equal(t, 1, result.GamesImported)
+	assert.Equal(t, 1, result.CheatsImported)
+	assert.Equal(t, 0, result.Skipped)
+	assert.Equal(t, 0, result.Failed)
 
 	database.Model(&db.CheatCode{}).Count(&count)
 	assert.Greater(t, count, int64(0), "cheats should be imported")

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -153,6 +153,7 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&GameSession{},
 		&SessionSaveState{},
 		&SessionSaveData{},
+		&SessionCheatSetting{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)
@@ -654,6 +655,70 @@ func MigrateSavesToSessions(database *gorm.DB) error {
 	// Mark migration as complete
 	database.Create(&ServerSetting{Key: "sessions_migrated", Value: "true"})
 	slog.Info("save-to-session migration completed", "sessions_created", len(pairs))
+	return nil
+}
+
+// MigrateRelaySessions creates GameSession records for existing Relays that
+// don't have a SessionID, and copies their RelaySave records into
+// SessionSaveState. Guarded by the "relay_sessions_migrated" ServerSetting.
+func MigrateRelaySessions(database *gorm.DB) error {
+	// Check if already migrated
+	var setting ServerSetting
+	if err := database.Where("key = ?", "relay_sessions_migrated").First(&setting).Error; err == nil {
+		if setting.Value == "true" {
+			return nil
+		}
+	}
+
+	// Find relays without a session
+	var relays []Relay
+	if err := database.Where("session_id IS NULL").Find(&relays).Error; err != nil {
+		return fmt.Errorf("loading relays without sessions: %w", err)
+	}
+
+	if len(relays) == 0 {
+		database.Create(&ServerSetting{Key: "relay_sessions_migrated", Value: "true"})
+		return nil
+	}
+
+	slog.Info("migrating relays to sessions", "count", len(relays))
+
+	for _, r := range relays {
+		session := GameSession{
+			OwnerID: r.OwnerID,
+			GameID:  r.GameID,
+			Name:    "Relay: " + r.Name,
+		}
+		if err := database.Create(&session).Error; err != nil {
+			slog.Warn("failed to create session for relay",
+				"relayId", r.ID, "error", err)
+			continue
+		}
+
+		// Copy RelaySave records into SessionSaveState
+		var saves []RelaySave
+		database.Where("relay_id = ?", r.ID).Find(&saves)
+		for _, s := range saves {
+			ss := SessionSaveState{
+				SessionID:     session.ID,
+				UserID:        s.UserID,
+				Name:          s.Name,
+				FilePath:      s.FilePath,
+				FileSize:      s.FileSize,
+				ScreenshotURL: s.ScreenshotURL,
+				IsAuto:        s.IsAuto,
+			}
+			ss.CreatedAt = s.CreatedAt
+			ss.UpdatedAt = s.UpdatedAt
+			database.Create(&ss)
+		}
+
+		// Link the relay to its new session
+		database.Model(&r).Update("session_id", session.ID)
+	}
+
+	database.Create(&ServerSetting{Key: "relay_sessions_migrated", Value: "true"})
+	slog.Info("relay-session migration completed", "relays_migrated", len(relays))
 	return nil
 }
 

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -149,6 +150,9 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&LoginAttempt{},
 		&TokenBlacklist{},
 		&CheatCode{},
+		&GameSession{},
+		&SessionSaveState{},
+		&SessionSaveData{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)
@@ -391,6 +395,9 @@ func mergeGameData(database *gorm.DB, keeperID, dupID uint) {
 	// Relay — move all
 	database.Model(&Relay{}).Where("game_id = ?", dupID).Update("game_id", keeperID)
 
+	// GameSession — move all
+	database.Model(&GameSession{}).Where("game_id = ?", dupID).Update("game_id", keeperID)
+
 	// GameKeyMappingPreference — move, skip conflicts
 	database.Model(&GameKeyMappingPreference{}).Where("game_id = ?", dupID).Update("game_id", keeperID)
 
@@ -520,6 +527,134 @@ func mergeGameMetadata(database *gorm.DB, keeper, dup *Game) {
 	if len(updates) > 0 {
 		database.Model(keeper).Updates(updates)
 	}
+}
+
+// MigrateSavesToSessions creates GameSession records for each (user, game)
+// combination that has existing SaveState or SaveData records, then copies those
+// records into SessionSaveState/SessionSaveData. This is a one-time migration
+// guarded by the "sessions_migrated" ServerSetting key.
+func MigrateSavesToSessions(database *gorm.DB) error {
+	// Check if already migrated
+	var setting ServerSetting
+	if err := database.Where("key = ?", "sessions_migrated").First(&setting).Error; err == nil {
+		if setting.Value == "true" {
+			return nil
+		}
+	}
+
+	slog.Info("migrating existing saves to game sessions")
+
+	// Find all distinct (user_id, game_id) pairs from SaveState and SaveData
+	type userGame struct {
+		UserID uint
+		GameID uint
+	}
+	var pairs []userGame
+
+	// From SaveState
+	database.Model(&SaveState{}).
+		Select("DISTINCT user_id, game_id").
+		Scan(&pairs)
+
+	// From SaveData (merge with existing pairs)
+	var sdPairs []userGame
+	database.Model(&SaveData{}).
+		Select("DISTINCT user_id, game_id").
+		Scan(&sdPairs)
+
+	// Deduplicate
+	seen := make(map[userGame]bool, len(pairs))
+	for _, p := range pairs {
+		seen[p] = true
+	}
+	for _, p := range sdPairs {
+		if !seen[p] {
+			pairs = append(pairs, p)
+			seen[p] = true
+		}
+	}
+
+	if len(pairs) == 0 {
+		slog.Info("no existing saves to migrate")
+		database.Create(&ServerSetting{Key: "sessions_migrated", Value: "true"})
+		return nil
+	}
+
+	slog.Info("migrating save data to sessions", "pairs", len(pairs))
+
+	for _, p := range pairs {
+		// Look up last played time from PlayHistory
+		var ph PlayHistory
+		var lastPlayedAt *time.Time
+		var totalPlayTime int64
+		if err := database.Where("user_id = ? AND game_id = ?", p.UserID, p.GameID).First(&ph).Error; err == nil {
+			lastPlayedAt = &ph.LastPlayed
+			totalPlayTime = ph.PlayTime
+		}
+
+		session := GameSession{
+			OwnerID:       p.UserID,
+			GameID:        p.GameID,
+			Name:          "Playthrough 1",
+			LastPlayedAt:  lastPlayedAt,
+			LastPlayedBy:  &p.UserID,
+			TotalPlayTime: totalPlayTime,
+		}
+		if err := database.Create(&session).Error; err != nil {
+			slog.Warn("failed to create session during migration",
+				"userId", p.UserID, "gameId", p.GameID, "error", err)
+			continue
+		}
+
+		// Copy SaveState records into SessionSaveState
+		var saves []SaveState
+		database.Where("user_id = ? AND game_id = ?", p.UserID, p.GameID).Find(&saves)
+		for _, s := range saves {
+			ss := SessionSaveState{
+				SessionID:     session.ID,
+				UserID:        s.UserID,
+				Name:          s.Name,
+				FilePath:      s.FilePath,
+				FileSize:      s.FileSize,
+				ScreenshotURL: s.ScreenshotURL,
+				IsAuto:        s.IsAuto,
+				CoreName:      s.CoreName,
+				Notes:         s.Notes,
+				Slot:          s.Slot,
+			}
+			ss.CreatedAt = s.CreatedAt
+			ss.UpdatedAt = s.UpdatedAt
+			database.Create(&ss)
+
+			// Update session screenshot from most recent save screenshot
+			if s.ScreenshotURL != "" && session.ScreenshotURL == "" {
+				database.Model(&session).Update("screenshot_url", s.ScreenshotURL)
+			}
+			// Update session core name
+			if s.CoreName != "" && session.CoreName == "" {
+				database.Model(&session).Update("core_name", s.CoreName)
+			}
+		}
+
+		// Copy SaveData records into SessionSaveData
+		var saveDataRecords []SaveData
+		database.Where("user_id = ? AND game_id = ?", p.UserID, p.GameID).Find(&saveDataRecords)
+		for _, sd := range saveDataRecords {
+			ssd := SessionSaveData{
+				SessionID: session.ID,
+				FilePath:  sd.FilePath,
+				FileSize:  sd.FileSize,
+			}
+			ssd.CreatedAt = sd.CreatedAt
+			ssd.UpdatedAt = sd.UpdatedAt
+			database.Create(&ssd)
+		}
+	}
+
+	// Mark migration as complete
+	database.Create(&ServerSetting{Key: "sessions_migrated", Value: "true"})
+	slog.Info("save-to-session migration completed", "sessions_created", len(pairs))
+	return nil
 }
 
 // SeedConsoles inserts the default console definitions if they don't exist.

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -385,6 +385,8 @@ type Relay struct {
 	ActiveUserID *uint          `json:"activeUserId,omitempty"`
 	TurnToken    string         `gorm:"size:64" json:"-"`
 	TurnTakenAt  *time.Time     `json:"turnTakenAt,omitempty"`
+	SessionID    *uint          `gorm:"index" json:"sessionId"`
+	Session      *GameSession   `json:"-"`
 	Members      []RelayMember  `gorm:"foreignKey:RelayID" json:"members,omitempty"`
 }
 
@@ -622,6 +624,15 @@ type SessionSaveData struct {
 	SessionID uint           `gorm:"index;not null" json:"sessionId"`
 	FilePath  string         `gorm:"size:1024;not null" json:"-"`
 	FileSize  int64          `json:"fileSize"`
+}
+
+// SessionCheatSetting stores per-cheat enable/disable state within a game session.
+type SessionCheatSetting struct {
+	ID         uint      `gorm:"primarykey" json:"id"`
+	CreatedAt  time.Time `json:"createdAt"`
+	SessionID  uint      `gorm:"uniqueIndex:idx_session_cheat;not null" json:"sessionId"`
+	CheatIndex int       `gorm:"uniqueIndex:idx_session_cheat;not null" json:"cheatIndex"`
+	Enabled    bool      `gorm:"default:false" json:"enabled"`
 }
 
 // StagedUpload represents a ROM file uploaded to the staging area pending admin review.

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -573,6 +573,57 @@ type CheatCode struct {
 	Code        string `gorm:"size:1024;not null"`
 }
 
+// GameSession represents a user's play session for a game.
+// Each session groups save states and SRAM data together as a "playthrough".
+type GameSession struct {
+	ID             uint           `gorm:"primarykey" json:"id"`
+	CreatedAt      time.Time      `json:"createdAt"`
+	UpdatedAt      time.Time      `json:"updatedAt"`
+	DeletedAt      gorm.DeletedAt `gorm:"index" json:"-"`
+	OwnerID        uint           `gorm:"index;not null" json:"ownerId"`
+	Owner          User           `gorm:"foreignKey:OwnerID" json:"-"`
+	GameID         uint           `gorm:"index;not null" json:"gameId"`
+	Game           Game           `gorm:"foreignKey:GameID" json:"-"`
+	Name           string         `gorm:"size:255;not null" json:"name"`
+	LastPlayedAt   *time.Time     `json:"lastPlayedAt,omitempty"`
+	LastPlayedBy   *uint          `json:"lastPlayedBy,omitempty"`
+	TotalPlayTime  int64          `gorm:"default:0" json:"totalPlayTime"` // seconds
+	ScreenshotURL  string         `gorm:"size:512" json:"screenshotUrl,omitempty"`
+	CoreName       string         `gorm:"size:128" json:"coreName,omitempty"`
+	CheatsEnabled  bool           `gorm:"default:false" json:"cheatsEnabled"`
+}
+
+// SessionSaveState represents a save state within a game session.
+type SessionSaveState struct {
+	ID            uint           `gorm:"primarykey" json:"id"`
+	CreatedAt     time.Time      `json:"createdAt"`
+	UpdatedAt     time.Time      `json:"updatedAt"`
+	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
+	SessionID     uint           `gorm:"index;not null" json:"sessionId"`
+	UserID        uint           `gorm:"index;not null" json:"userId"`
+	User          User           `gorm:"foreignKey:UserID" json:"-"`
+	Name          string         `gorm:"size:255;not null" json:"name"`
+	FilePath      string         `gorm:"size:1024;not null" json:"-"`
+	FileSize      int64          `json:"fileSize"`
+	ScreenshotURL string         `gorm:"size:512" json:"screenshotUrl,omitempty"`
+	IsAuto        bool           `gorm:"default:false" json:"isAuto"`
+	IsCurrent     bool           `gorm:"default:false" json:"isCurrent"`
+	CoreName      string         `gorm:"size:128" json:"coreName,omitempty"`
+	Notes         string         `gorm:"type:text" json:"notes,omitempty"`
+	Slot          *int           `json:"slot,omitempty"`
+}
+
+// SessionSaveData represents SRAM/battery save data within a game session.
+type SessionSaveData struct {
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"createdAt"`
+	UpdatedAt time.Time      `json:"updatedAt"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	SessionID uint           `gorm:"index;not null" json:"sessionId"`
+	FilePath  string         `gorm:"size:1024;not null" json:"-"`
+	FileSize  int64          `json:"fileSize"`
+}
+
 // StagedUpload represents a ROM file uploaded to the staging area pending admin review.
 type StagedUpload struct {
 	ID               uint           `gorm:"primarykey" json:"id"`

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -404,6 +404,110 @@ func (s *Storage) DeleteSaveData(path string) error {
 	return nil
 }
 
+// SessionSaveStatePath returns the filesystem path for a session save state file.
+func (s *Storage) SessionSaveStatePath(sessionID uint, filename string) string {
+	safe := sanitizeFilename(filename)
+	return filepath.Join(s.SaveDir, "sessions", fmt.Sprintf("session_%d", sessionID), "states", safe)
+}
+
+// SessionSRAMPath returns the filesystem path for a session's SRAM/save data file.
+func (s *Storage) SessionSRAMPath(sessionID uint, filename string) string {
+	safe := sanitizeFilename(filename)
+	return filepath.Join(s.SaveDir, "sessions", fmt.Sprintf("session_%d", sessionID), "sram", safe)
+}
+
+// SessionScreenshotPath returns the filesystem path for a session screenshot.
+func (s *Storage) SessionScreenshotPath(sessionID uint, filename string) string {
+	safe := sanitizeFilename(filename)
+	return filepath.Join(s.SaveDir, "sessions", fmt.Sprintf("session_%d", sessionID), "screenshots", safe)
+}
+
+// WriteSessionSave stores a session save state file.
+func (s *Storage) WriteSessionSave(sessionID uint, filename string, data io.Reader) (string, int64, error) {
+	path := s.SessionSaveStatePath(sessionID, filename)
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", 0, fmt.Errorf("resolving session save path: %w", err)
+	}
+	absSaveDir, err := filepath.Abs(s.SaveDir)
+	if err != nil {
+		return "", 0, fmt.Errorf("resolving save dir: %w", err)
+	}
+	if !strings.HasPrefix(absPath, absSaveDir+string(filepath.Separator)) {
+		return "", 0, fmt.Errorf("invalid session save path: outside save directory")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return "", 0, fmt.Errorf("creating session save directory: %w", err)
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return "", 0, fmt.Errorf("creating session save file: %w", err)
+	}
+	defer f.Close()
+
+	n, err := io.Copy(f, data)
+	if err != nil {
+		return "", 0, fmt.Errorf("writing session save file: %w", err)
+	}
+
+	return path, n, nil
+}
+
+// WriteSessionSRAM stores a session SRAM/save data file.
+func (s *Storage) WriteSessionSRAM(sessionID uint, filename string, data io.Reader) (string, int64, error) {
+	path := s.SessionSRAMPath(sessionID, filename)
+
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return "", 0, fmt.Errorf("resolving session SRAM path: %w", err)
+	}
+	absSaveDir, err := filepath.Abs(s.SaveDir)
+	if err != nil {
+		return "", 0, fmt.Errorf("resolving save dir: %w", err)
+	}
+	if !strings.HasPrefix(absPath, absSaveDir+string(filepath.Separator)) {
+		return "", 0, fmt.Errorf("invalid session SRAM path: outside save directory")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return "", 0, fmt.Errorf("creating session SRAM directory: %w", err)
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return "", 0, fmt.Errorf("creating session SRAM file: %w", err)
+	}
+	defer f.Close()
+
+	n, err := io.Copy(f, data)
+	if err != nil {
+		return "", 0, fmt.Errorf("writing session SRAM file: %w", err)
+	}
+
+	return path, n, nil
+}
+
+// WriteSessionScreenshot stores a session screenshot image.
+func (s *Storage) WriteSessionScreenshot(sessionID uint, filename string, data io.Reader) (string, error) {
+	subpath := fmt.Sprintf("save-screenshots/sessions/session_%d/%s", sessionID, sanitizeFilename(filename))
+	return s.WriteImage(subpath, data)
+}
+
+// DeleteSessionDir removes an entire session's storage directory.
+func (s *Storage) DeleteSessionDir(sessionID uint) error {
+	dir := filepath.Join(s.SaveDir, "sessions", fmt.Sprintf("session_%d", sessionID))
+	if err := s.validatePathInSaveDir(dir); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("deleting session directory: %w", err)
+	}
+	return nil
+}
+
 // ResolveGamePath resolves a relative game path (e.g. "nes/Mario.nes") to an
 // absolute filesystem path by joining it with each gameDir and returning the
 // first that exists on disk. Returns an error if no match is found.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -17,6 +17,7 @@ import { AdminUsersPage } from "@/pages/admin/users-page";
 import { AdminSettingsPage } from "@/pages/admin/settings-page";
 import { AdminScanPage } from "@/pages/admin/scan-page";
 import { MetadataFixPage } from "@/pages/admin/metadata-fix-page";
+import { AdminCheatsPage } from "@/pages/admin/cheats-page";
 import { AdminBiosPage } from "@/pages/admin/bios-page";
 import { UploadRomsPage } from "@/pages/admin/upload-roms-page";
 import { PreferencesPage } from "@/pages/preferences-page";
@@ -33,6 +34,7 @@ import { NetplaySessionPage } from "@/pages/netplay-session-page";
 import { LicensesPage } from "@/pages/licenses-page";
 import { ChallengesPage } from "@/pages/challenges-page";
 import { ChallengeDetailPage } from "@/pages/challenge-detail-page";
+import { SessionDetailPage } from "@/pages/session-detail-page";
 import { SetupWizardPage } from "@/pages/setup-wizard-page";
 import { LibraryLayout } from "@/components/library-layout";
 import { ErrorBoundary } from "@/components/error-boundary";
@@ -90,6 +92,10 @@ export function App() {
                       element={<ConsoleDetailPage />}
                     />
                     <Route path="games/:id" element={<GameDetailPage />} />
+                    <Route
+                      path="sessions/:sessionId"
+                      element={<SessionDetailPage />}
+                    />
                     <Route
                       path="collections/:id"
                       element={<CollectionDetailPage />}
@@ -155,6 +161,14 @@ export function App() {
                       element={
                         <ProtectedRoute requireAdmin>
                           <MetadataFixPage />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="admin/cheats"
+                      element={
+                        <ProtectedRoute requireAdmin>
+                          <AdminCheatsPage />
                         </ProtectedRoute>
                       }
                     />

--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -117,6 +117,7 @@ export function AppLayout() {
                 icon: FileSearch,
                 label: "Metadata Fix",
               },
+              { to: "/admin/cheats", icon: Gamepad2, label: "Cheats" },
             ],
           },
         ]

--- a/web/src/features/game-detail/components/game-cheats.tsx
+++ b/web/src/features/game-detail/components/game-cheats.tsx
@@ -1,0 +1,42 @@
+import { Gamepad2 } from "lucide-react";
+import { Card, CardHeader, CardContent } from "@/components/ui";
+import { useGameCheats } from "@/hooks/use-cheats";
+
+export function GameCheats({ gameId }: { gameId: string }) {
+  const { data: cheats, isLoading } = useGameCheats(gameId);
+
+  if (isLoading || !cheats || cheats.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+          <Gamepad2 className="h-5 w-5 text-brand-400" />
+          Cheat Codes
+          <span className="ml-auto text-xs font-medium text-surface-400 bg-surface-800 px-2 py-0.5 rounded-full">
+            {cheats.length}
+          </span>
+        </h2>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-3">
+          {cheats.map((cheat) => (
+            <div
+              key={cheat.id}
+              className="rounded-lg bg-surface-800/50 p-3 space-y-1"
+            >
+              <p className="text-sm font-medium text-surface-200">
+                {cheat.description}
+              </p>
+              <p className="text-xs font-mono text-surface-400 break-all">
+                {cheat.code}
+              </p>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/features/relays/components/__tests__/relay-card.test.tsx
+++ b/web/src/features/relays/components/__tests__/relay-card.test.tsx
@@ -15,6 +15,8 @@ function makeRelay(overrides: Partial<Relay> = {}): Relay {
     ownerId: "u1",
     ownerUsername: "alice",
     status: "active",
+    activeUserId: null,
+    turnTakenAt: null,
     memberCount: 3,
     lastActivityAt: "2026-02-13T10:00:00Z",
     createdAt: "2026-02-01T10:00:00Z",

--- a/web/src/features/sessions/components/__tests__/game-sessions.test.tsx
+++ b/web/src/features/sessions/components/__tests__/game-sessions.test.tsx
@@ -1,7 +1,14 @@
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { GameSessions } from "../game-sessions";
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: "u1", username: "testuser", role: "user" },
+  })),
+}));
 
 vi.mock("@/hooks/use-sessions", () => ({
   useGameSessions: vi.fn(),
@@ -61,7 +68,9 @@ function renderComponent(gameId = "g1") {
   });
   return render(
     <QueryClientProvider client={queryClient}>
-      <GameSessions gameId={gameId} />
+      <MemoryRouter>
+        <GameSessions gameId={gameId} />
+      </MemoryRouter>
     </QueryClientProvider>,
   );
 }

--- a/web/src/features/sessions/components/__tests__/game-sessions.test.tsx
+++ b/web/src/features/sessions/components/__tests__/game-sessions.test.tsx
@@ -201,6 +201,6 @@ describe("GameSessions", () => {
     });
     renderComponent();
 
-    expect(screen.getByText("Continue")).toBeInTheDocument();
+    expect(screen.getByText("Play")).toBeInTheDocument();
   });
 });

--- a/web/src/features/sessions/components/__tests__/game-sessions.test.tsx
+++ b/web/src/features/sessions/components/__tests__/game-sessions.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { GameSessions } from "../game-sessions";
+
+vi.mock("@/hooks/use-sessions", () => ({
+  useGameSessions: vi.fn(),
+  useCreateSession: vi.fn(),
+  useRenameSession: vi.fn(),
+  useDeleteSession: vi.fn(),
+}));
+
+import {
+  useGameSessions,
+  useCreateSession,
+  useRenameSession,
+  useDeleteSession,
+} from "@/hooks/use-sessions";
+
+const mockUseGameSessions = useGameSessions as ReturnType<typeof vi.fn>;
+const mockUseCreateSession = useCreateSession as ReturnType<typeof vi.fn>;
+const mockUseRenameSession = useRenameSession as ReturnType<typeof vi.fn>;
+const mockUseDeleteSession = useDeleteSession as ReturnType<typeof vi.fn>;
+
+const mockSessions = [
+  {
+    id: "ses-1",
+    gameId: "g1",
+    name: "Main Playthrough",
+    lastPlayedAt: "2026-03-01T10:00:00Z",
+    lastPlayedByUsername: "alice",
+    totalPlayTime: 3600,
+    screenshotUrl: null,
+    cheatsEnabled: false,
+    memberCount: 1,
+    memberAvatars: [],
+    createdAt: "2026-02-28T10:00:00Z",
+    updatedAt: "2026-03-01T10:00:00Z",
+  },
+  {
+    id: "ses-2",
+    gameId: "g1",
+    name: "Cheat Run",
+    lastPlayedAt: null,
+    lastPlayedByUsername: null,
+    totalPlayTime: 0,
+    screenshotUrl: null,
+    cheatsEnabled: true,
+    memberCount: 2,
+    memberAvatars: ["https://example.com/a1.png", "https://example.com/a2.png"],
+    createdAt: "2026-03-02T10:00:00Z",
+    updatedAt: "2026-03-02T10:00:00Z",
+  },
+];
+
+const mockMutate = vi.fn();
+
+function renderComponent(gameId = "g1") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GameSessions gameId={gameId} />
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseCreateSession.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+  });
+  mockUseRenameSession.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+  });
+  mockUseDeleteSession.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+    variables: undefined,
+  });
+});
+
+describe("GameSessions", () => {
+  it("renders loading skeleton", () => {
+    mockUseGameSessions.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderComponent();
+
+    expect(screen.getByText("Sessions")).toBeInTheDocument();
+  });
+
+  it("renders empty state when no sessions", () => {
+    mockUseGameSessions.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderComponent();
+
+    expect(screen.getByText("No sessions yet")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Start a new session to track your progress separately.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("renders session cards", () => {
+    mockUseGameSessions.mockReturnValue({
+      data: mockSessions,
+      isLoading: false,
+    });
+    renderComponent();
+
+    expect(screen.getByText("Main Playthrough")).toBeInTheDocument();
+    expect(screen.getByText("Cheat Run")).toBeInTheDocument();
+    expect(screen.getByText("(2)")).toBeInTheDocument();
+  });
+
+  it("shows new session form when button clicked", () => {
+    mockUseGameSessions.mockReturnValue({
+      data: mockSessions,
+      isLoading: false,
+    });
+    renderComponent();
+
+    fireEvent.click(screen.getByText("New Session"));
+
+    expect(screen.getByTestId("new-session-form")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText("Session name (optional)"),
+    ).toBeInTheDocument();
+  });
+
+  it("calls create mutation when form submitted", () => {
+    mockUseGameSessions.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderComponent();
+
+    fireEvent.click(screen.getByText("New Session"));
+
+    const input = screen.getByPlaceholderText("Session name (optional)");
+    fireEvent.change(input, { target: { value: "Speed Run" } });
+    fireEvent.click(screen.getByText("Create"));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { gameId: "g1", name: "Speed Run" },
+      expect.any(Object),
+    );
+  });
+
+  it("uses default name when creating with empty input", () => {
+    mockUseGameSessions.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderComponent();
+
+    fireEvent.click(screen.getByText("New Session"));
+    fireEvent.click(screen.getByText("Create"));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { gameId: "g1", name: "Session 1" },
+      expect.any(Object),
+    );
+  });
+
+  it("hides new session form when cancelled", () => {
+    mockUseGameSessions.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderComponent();
+
+    fireEvent.click(screen.getByText("New Session"));
+    expect(screen.getByTestId("new-session-form")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText("Cancel"));
+    expect(screen.queryByTestId("new-session-form")).not.toBeInTheDocument();
+  });
+
+  it("shows continue button on each session", () => {
+    mockUseGameSessions.mockReturnValue({
+      data: [mockSessions[0]],
+      isLoading: false,
+    });
+    renderComponent();
+
+    expect(screen.getByText("Continue")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/sessions/components/__tests__/session-card.test.tsx
+++ b/web/src/features/sessions/components/__tests__/session-card.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { SessionCard } from "../session-card";
+import type { GameSession } from "@/types/api";
+
+const baseSession: GameSession = {
+  id: "ses-1",
+  gameId: "g1",
+  name: "Main Playthrough",
+  lastPlayedAt: "2026-03-01T10:00:00Z",
+  lastPlayedByUsername: "alice",
+  totalPlayTime: 3600,
+  screenshotUrl: null,
+  cheatsEnabled: false,
+  memberCount: 1,
+  memberAvatars: [],
+  createdAt: "2026-02-28T10:00:00Z",
+  updatedAt: "2026-03-01T10:00:00Z",
+};
+
+const onContinue = vi.fn();
+const onRename = vi.fn();
+const onDelete = vi.fn();
+
+function renderCard(session: GameSession = baseSession, isDeleting = false) {
+  return render(
+    <SessionCard
+      session={session}
+      onContinue={onContinue}
+      onRename={onRename}
+      onDelete={onDelete}
+      isDeleting={isDeleting}
+    />,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("SessionCard", () => {
+  it("renders session name", () => {
+    renderCard();
+    expect(screen.getByText("Main Playthrough")).toBeInTheDocument();
+  });
+
+  it("renders play time", () => {
+    renderCard();
+    expect(screen.getByText("1h 0m")).toBeInTheDocument();
+  });
+
+  it("renders last played time", () => {
+    renderCard();
+    // formatRelativeTime will produce some relative text
+    expect(screen.getByTestId("session-card-ses-1")).toBeInTheDocument();
+  });
+
+  it("calls onContinue when Continue clicked", () => {
+    renderCard();
+    fireEvent.click(screen.getByText("Continue"));
+    expect(onContinue).toHaveBeenCalledWith(baseSession);
+  });
+
+  it("enters rename mode when rename button clicked", () => {
+    renderCard();
+    fireEvent.click(screen.getByLabelText("Rename session"));
+    expect(screen.getByTestId("session-name-input")).toBeInTheDocument();
+    expect(screen.getByTestId("session-name-input")).toHaveValue(
+      "Main Playthrough",
+    );
+  });
+
+  it("calls onRename when name is changed and submitted", () => {
+    renderCard();
+    fireEvent.click(screen.getByLabelText("Rename session"));
+
+    const input = screen.getByTestId("session-name-input");
+    fireEvent.change(input, { target: { value: "New Name" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onRename).toHaveBeenCalledWith(baseSession, "New Name");
+  });
+
+  it("cancels rename on Escape", () => {
+    renderCard();
+    fireEvent.click(screen.getByLabelText("Rename session"));
+
+    const input = screen.getByTestId("session-name-input");
+    fireEvent.change(input, { target: { value: "New Name" } });
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(onRename).not.toHaveBeenCalled();
+    expect(screen.getByText("Main Playthrough")).toBeInTheDocument();
+  });
+
+  it("shows delete confirmation when delete clicked", () => {
+    renderCard();
+    fireEvent.click(screen.getByLabelText("Delete session"));
+    expect(screen.getByText("Delete Session")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        'Delete "Main Playthrough"? All save data for this session will be permanently removed.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("calls onDelete when delete is confirmed", () => {
+    renderCard();
+    fireEvent.click(screen.getByLabelText("Delete session"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(onDelete).toHaveBeenCalledWith(baseSession);
+  });
+
+  it("shows cheats badge when cheats enabled", () => {
+    renderCard({ ...baseSession, cheatsEnabled: true });
+    expect(screen.getByText("Cheats")).toBeInTheDocument();
+  });
+
+  it("does not show cheats badge when cheats disabled", () => {
+    renderCard();
+    expect(screen.queryByText("Cheats")).not.toBeInTheDocument();
+  });
+
+  it("shows member count for multiplayer sessions", () => {
+    renderCard({ ...baseSession, memberCount: 3 });
+    expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("shows member avatars", () => {
+    renderCard({
+      ...baseSession,
+      memberAvatars: [
+        "https://example.com/a1.png",
+        "https://example.com/a2.png",
+      ],
+    });
+    const avatarContainer = screen.getByTestId("member-avatars");
+    expect(avatarContainer).toBeInTheDocument();
+    expect(avatarContainer.querySelectorAll("img")).toHaveLength(2);
+  });
+
+  it("truncates member avatars at 3 with overflow count", () => {
+    renderCard({
+      ...baseSession,
+      memberAvatars: [
+        "https://example.com/a1.png",
+        "https://example.com/a2.png",
+        "https://example.com/a3.png",
+        "https://example.com/a4.png",
+        "https://example.com/a5.png",
+      ],
+    });
+    expect(screen.getByText("+2")).toBeInTheDocument();
+  });
+
+  it("shows screenshot thumbnail when available", () => {
+    renderCard({
+      ...baseSession,
+      screenshotUrl: "https://example.com/screenshot.png",
+    });
+    const img = screen.getByAltText("Main Playthrough");
+    expect(img).toHaveAttribute(
+      "src",
+      "https://example.com/screenshot.png",
+    );
+  });
+});

--- a/web/src/features/sessions/components/__tests__/session-card.test.tsx
+++ b/web/src/features/sessions/components/__tests__/session-card.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { SessionCard } from "../session-card";
 import type { GameSession } from "@/types/api";
@@ -22,15 +23,22 @@ const onContinue = vi.fn();
 const onRename = vi.fn();
 const onDelete = vi.fn();
 
-function renderCard(session: GameSession = baseSession, isDeleting = false) {
+function renderCard(
+  session: GameSession = baseSession,
+  isDeleting = false,
+  currentUsername?: string,
+) {
   return render(
-    <SessionCard
-      session={session}
-      onContinue={onContinue}
-      onRename={onRename}
-      onDelete={onDelete}
-      isDeleting={isDeleting}
-    />,
+    <MemoryRouter>
+      <SessionCard
+        session={session}
+        currentUsername={currentUsername}
+        onContinue={onContinue}
+        onRename={onRename}
+        onDelete={onDelete}
+        isDeleting={isDeleting}
+      />
+    </MemoryRouter>,
   );
 }
 
@@ -163,5 +171,51 @@ describe("SessionCard", () => {
       "src",
       "https://example.com/screenshot.png",
     );
+  });
+
+  it("shows 'Last played by' when different user last played", () => {
+    renderCard(
+      { ...baseSession, lastPlayedByUsername: "bob", memberCount: 2 },
+      false,
+      "alice",
+    );
+    const label = screen.getByTestId("last-played-by");
+    expect(label).toHaveTextContent("Last played by bob");
+  });
+
+  it("does not show 'Last played by' when current user last played", () => {
+    renderCard(
+      { ...baseSession, lastPlayedByUsername: "alice", memberCount: 2 },
+      false,
+      "alice",
+    );
+    expect(screen.queryByTestId("last-played-by")).not.toBeInTheDocument();
+  });
+
+  it("does not show 'Last played by' when no currentUsername provided", () => {
+    renderCard(
+      { ...baseSession, lastPlayedByUsername: "bob", memberCount: 2 },
+      false,
+    );
+    expect(screen.queryByTestId("last-played-by")).not.toBeInTheDocument();
+  });
+
+  it("renders member avatars for multiplayer sessions", () => {
+    renderCard(
+      {
+        ...baseSession,
+        memberCount: 3,
+        memberAvatars: [
+          "https://example.com/a1.png",
+          "https://example.com/a2.png",
+          "https://example.com/a3.png",
+        ],
+      },
+      false,
+      "alice",
+    );
+    const avatarContainer = screen.getByTestId("member-avatars");
+    expect(avatarContainer.querySelectorAll("img")).toHaveLength(3);
+    expect(screen.getByText("3")).toBeInTheDocument();
   });
 });

--- a/web/src/features/sessions/components/__tests__/session-card.test.tsx
+++ b/web/src/features/sessions/components/__tests__/session-card.test.tsx
@@ -63,9 +63,9 @@ describe("SessionCard", () => {
     expect(screen.getByTestId("session-card-ses-1")).toBeInTheDocument();
   });
 
-  it("calls onContinue when Continue clicked", () => {
+  it("calls onContinue when Play clicked", () => {
     renderCard();
-    fireEvent.click(screen.getByText("Continue"));
+    fireEvent.click(screen.getByText("Play"));
     expect(onContinue).toHaveBeenCalledWith(baseSession);
   });
 

--- a/web/src/features/sessions/components/game-sessions.tsx
+++ b/web/src/features/sessions/components/game-sessions.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react";
+import { Layers, Plus } from "lucide-react";
+import { Button, Card, Skeleton, EmptyState, Input } from "@/components/ui";
+import {
+  useGameSessions,
+  useCreateSession,
+  useRenameSession,
+  useDeleteSession,
+} from "@/hooks/use-sessions";
+import { SessionCard } from "./session-card";
+import type { GameSession } from "@/types/api";
+
+function SessionsSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 2 }, (_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-4 px-4 py-3 rounded-xl bg-surface-800/30"
+        >
+          <Skeleton className="w-12 h-12 rounded-lg" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-3 w-28" />
+          </div>
+          <Skeleton className="h-8 w-20 rounded-lg" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface GameSessionsProps {
+  gameId: string;
+}
+
+export function GameSessions({ gameId }: GameSessionsProps) {
+  const { data: sessions, isLoading } = useGameSessions(gameId);
+  const createSession = useCreateSession();
+  const renameSession = useRenameSession();
+  const deleteSession = useDeleteSession();
+  const [showNewInput, setShowNewInput] = useState(false);
+  const [newName, setNewName] = useState("");
+
+  function handleCreate() {
+    const name = newName.trim() || `Session ${(sessions?.length ?? 0) + 1}`;
+    createSession.mutate(
+      { gameId, name },
+      {
+        onSuccess: () => {
+          setNewName("");
+          setShowNewInput(false);
+        },
+      },
+    );
+  }
+
+  function handleRename(session: GameSession, name: string) {
+    renameSession.mutate({ id: session.id, gameId, name });
+  }
+
+  function handleDelete(session: GameSession) {
+    deleteSession.mutate({ id: session.id, gameId });
+  }
+
+  function handleContinue(_session: GameSession) {
+    // Will be wired to navigation/play in future
+  }
+
+  if (isLoading) {
+    return (
+      <Card className="p-6">
+        <div className="flex items-center gap-2.5 mb-4">
+          <Layers className="h-5 w-5 text-brand-400" />
+          <h2 className="text-lg font-semibold text-surface-100">Sessions</h2>
+        </div>
+        <SessionsSkeleton />
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="p-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2.5">
+          <Layers className="h-5 w-5 text-brand-400" />
+          <h2 className="text-lg font-semibold text-surface-100">Sessions</h2>
+          {sessions && sessions.length > 0 && (
+            <span className="text-sm text-surface-500">
+              ({sessions.length})
+            </span>
+          )}
+        </div>
+        {!showNewInput && (
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setShowNewInput(true)}
+          >
+            <Plus className="h-4 w-4 mr-1" />
+            New Session
+          </Button>
+        )}
+      </div>
+
+      {showNewInput && (
+        <div
+          className="flex items-center gap-2 mb-4"
+          data-testid="new-session-form"
+        >
+          <Input
+            value={newName}
+            onChange={(e) => setNewName(e.target.value)}
+            placeholder="Session name (optional)"
+            onKeyDown={(e) => {
+              if (e.key === "Enter") handleCreate();
+              if (e.key === "Escape") {
+                setShowNewInput(false);
+                setNewName("");
+              }
+            }}
+            autoFocus
+          />
+          <Button
+            variant="primary"
+            size="sm"
+            onClick={handleCreate}
+            loading={createSession.isPending}
+          >
+            Create
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setShowNewInput(false);
+              setNewName("");
+            }}
+          >
+            Cancel
+          </Button>
+        </div>
+      )}
+
+      {!sessions || sessions.length === 0 ? (
+        <EmptyState
+          icon={Layers}
+          title="No sessions yet"
+          description="Start a new session to track your progress separately."
+        />
+      ) : (
+        <div className="space-y-2">
+          {sessions.map((session) => (
+            <SessionCard
+              key={session.id}
+              session={session}
+              onContinue={handleContinue}
+              onRename={handleRename}
+              onDelete={handleDelete}
+              isDeleting={
+                deleteSession.isPending &&
+                deleteSession.variables?.id === session.id
+              }
+            />
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/web/src/features/sessions/components/game-sessions.tsx
+++ b/web/src/features/sessions/components/game-sessions.tsx
@@ -7,6 +7,7 @@ import {
   useRenameSession,
   useDeleteSession,
 } from "@/hooks/use-sessions";
+import { useAuth } from "@/hooks/use-auth";
 import { SessionCard } from "./session-card";
 import type { GameSession } from "@/types/api";
 
@@ -35,6 +36,7 @@ interface GameSessionsProps {
 }
 
 export function GameSessions({ gameId }: GameSessionsProps) {
+  const { user } = useAuth();
   const { data: sessions, isLoading } = useGameSessions(gameId);
   const createSession = useCreateSession();
   const renameSession = useRenameSession();
@@ -154,6 +156,7 @@ export function GameSessions({ gameId }: GameSessionsProps) {
             <SessionCard
               key={session.id}
               session={session}
+              currentUsername={user?.username}
               onContinue={handleContinue}
               onRename={handleRename}
               onDelete={handleDelete}

--- a/web/src/features/sessions/components/session-card.tsx
+++ b/web/src/features/sessions/components/session-card.tsx
@@ -123,23 +123,26 @@ export function SessionCard({
         </div>
 
         {/* Member avatars */}
-        {session.memberAvatars.length > 0 && (
-          <div className="flex -space-x-2" data-testid="member-avatars">
-            {session.memberAvatars.slice(0, 3).map((url, i) => (
-              <img
-                key={i}
-                src={url}
-                alt=""
-                className="w-6 h-6 rounded-full border-2 border-surface-900"
-              />
-            ))}
-            {session.memberAvatars.length > 3 && (
-              <span className="w-6 h-6 rounded-full border-2 border-surface-900 bg-surface-700 flex items-center justify-center text-[10px] text-surface-400">
-                +{session.memberAvatars.length - 3}
-              </span>
-            )}
-          </div>
-        )}
+        {(session.memberAvatars ?? []).length > 0 && (() => {
+          const avatars = session.memberAvatars!;
+          return (
+            <div className="flex -space-x-2" data-testid="member-avatars">
+              {avatars.slice(0, 3).map((url, i) => (
+                <img
+                  key={i}
+                  src={url}
+                  alt=""
+                  className="w-6 h-6 rounded-full border-2 border-surface-900"
+                />
+              ))}
+              {avatars.length > 3 && (
+                <span className="w-6 h-6 rounded-full border-2 border-surface-900 bg-surface-700 flex items-center justify-center text-[10px] text-surface-400">
+                  +{avatars.length - 3}
+                </span>
+              )}
+            </div>
+          );
+        })()}
 
         {/* Actions */}
         <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">

--- a/web/src/features/sessions/components/session-card.tsx
+++ b/web/src/features/sessions/components/session-card.tsx
@@ -172,7 +172,8 @@ export function SessionCard({
           size="sm"
           onClick={() => onContinue(session)}
         >
-          Continue
+          <Play className="h-4 w-4 mr-1" />
+          Play
         </Button>
       </div>
 

--- a/web/src/features/sessions/components/session-card.tsx
+++ b/web/src/features/sessions/components/session-card.tsx
@@ -1,0 +1,173 @@
+import { useState } from "react";
+import { Play, Pencil, Trash2, Clock, Users, Zap } from "lucide-react";
+import { Button, ConfirmDeleteModal } from "@/components/ui";
+import { formatPlayTime, formatRelativeTime } from "@/lib/format";
+import type { GameSession } from "@/types/api";
+
+interface SessionCardProps {
+  session: GameSession;
+  onContinue: (session: GameSession) => void;
+  onRename: (session: GameSession, name: string) => void;
+  onDelete: (session: GameSession) => void;
+  isDeleting: boolean;
+}
+
+export function SessionCard({
+  session,
+  onContinue,
+  onRename,
+  onDelete,
+  isDeleting,
+}: SessionCardProps) {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState(session.name);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
+  function handleSubmitRename() {
+    const trimmed = editName.trim();
+    if (trimmed && trimmed !== session.name) {
+      onRename(session, trimmed);
+    }
+    setIsEditing(false);
+  }
+
+  return (
+    <>
+      <div
+        className="flex items-center gap-4 px-4 py-3 rounded-xl bg-surface-800/30 hover:bg-surface-800/50 transition-colors group"
+        data-testid={`session-card-${session.id}`}
+      >
+        {/* Thumbnail */}
+        <div className="w-12 h-12 rounded-lg bg-surface-700/50 flex-shrink-0 overflow-hidden flex items-center justify-center">
+          {session.screenshotUrl ? (
+            <img
+              src={session.screenshotUrl}
+              alt={session.name}
+              className="w-full h-full object-cover"
+            />
+          ) : (
+            <Play className="h-5 w-5 text-surface-500" />
+          )}
+        </div>
+
+        {/* Info */}
+        <div className="flex-1 min-w-0">
+          {isEditing ? (
+            <input
+              type="text"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              onBlur={handleSubmitRename}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSubmitRename();
+                if (e.key === "Escape") {
+                  setEditName(session.name);
+                  setIsEditing(false);
+                }
+              }}
+              className="bg-surface-700 text-surface-100 text-sm font-medium rounded px-2 py-0.5 w-full outline-none ring-1 ring-brand-500"
+              data-testid="session-name-input"
+              autoFocus
+            />
+          ) : (
+            <p className="text-sm font-medium text-surface-200 truncate">
+              {session.name}
+            </p>
+          )}
+          <div className="flex items-center gap-2 text-xs text-surface-500 mt-0.5">
+            {session.lastPlayedAt && (
+              <>
+                <span className="flex items-center gap-0.5">
+                  <Clock className="h-3 w-3" />
+                  {formatRelativeTime(session.lastPlayedAt)}
+                </span>
+                <span>&middot;</span>
+              </>
+            )}
+            <span>{formatPlayTime(session.totalPlayTime)}</span>
+            {session.cheatsEnabled && (
+              <>
+                <span>&middot;</span>
+                <span className="flex items-center gap-0.5 text-amber-400">
+                  <Zap className="h-3 w-3" />
+                  Cheats
+                </span>
+              </>
+            )}
+            {session.memberCount > 1 && (
+              <>
+                <span>&middot;</span>
+                <span className="flex items-center gap-0.5">
+                  <Users className="h-3 w-3" />
+                  {session.memberCount}
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+
+        {/* Member avatars */}
+        {session.memberAvatars.length > 0 && (
+          <div className="flex -space-x-2" data-testid="member-avatars">
+            {session.memberAvatars.slice(0, 3).map((url, i) => (
+              <img
+                key={i}
+                src={url}
+                alt=""
+                className="w-6 h-6 rounded-full border-2 border-surface-900"
+              />
+            ))}
+            {session.memberAvatars.length > 3 && (
+              <span className="w-6 h-6 rounded-full border-2 border-surface-900 bg-surface-700 flex items-center justify-center text-[10px] text-surface-400">
+                +{session.memberAvatars.length - 3}
+              </span>
+            )}
+          </div>
+        )}
+
+        {/* Actions */}
+        <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => {
+              setEditName(session.name);
+              setIsEditing(true);
+            }}
+            aria-label="Rename session"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => setShowDeleteConfirm(true)}
+            aria-label="Delete session"
+          >
+            <Trash2 className="h-3.5 w-3.5 text-red-400" />
+          </Button>
+        </div>
+
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() => onContinue(session)}
+        >
+          Continue
+        </Button>
+      </div>
+
+      <ConfirmDeleteModal
+        open={showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(false)}
+        title="Delete Session"
+        message={`Delete "${session.name}"? All save data for this session will be permanently removed.`}
+        onConfirm={() => {
+          onDelete(session);
+          setShowDeleteConfirm(false);
+        }}
+        isPending={isDeleting}
+      />
+    </>
+  );
+}

--- a/web/src/features/sessions/components/session-card.tsx
+++ b/web/src/features/sessions/components/session-card.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import { Play, Pencil, Trash2, Clock, Users, Zap } from "lucide-react";
 import { Button, ConfirmDeleteModal } from "@/components/ui";
 import { formatPlayTime, formatRelativeTime } from "@/lib/format";
@@ -6,6 +7,7 @@ import type { GameSession } from "@/types/api";
 
 interface SessionCardProps {
   session: GameSession;
+  currentUsername?: string;
   onContinue: (session: GameSession) => void;
   onRename: (session: GameSession, name: string) => void;
   onDelete: (session: GameSession) => void;
@@ -14,6 +16,7 @@ interface SessionCardProps {
 
 export function SessionCard({
   session,
+  currentUsername,
   onContinue,
   onRename,
   onDelete,
@@ -70,9 +73,12 @@ export function SessionCard({
               autoFocus
             />
           ) : (
-            <p className="text-sm font-medium text-surface-200 truncate">
+            <Link
+              to={`/sessions/${session.id}`}
+              className="text-sm font-medium text-surface-200 truncate hover:text-surface-100 transition-colors"
+            >
               {session.name}
-            </p>
+            </Link>
           )}
           <div className="flex items-center gap-2 text-xs text-surface-500 mt-0.5">
             {session.lastPlayedAt && (
@@ -103,6 +109,16 @@ export function SessionCard({
                 </span>
               </>
             )}
+            {session.lastPlayedByUsername &&
+              currentUsername &&
+              session.lastPlayedByUsername !== currentUsername && (
+                <>
+                  <span>&middot;</span>
+                  <span data-testid="last-played-by">
+                    Last played by {session.lastPlayedByUsername}
+                  </span>
+                </>
+              )}
           </div>
         </div>
 

--- a/web/src/hooks/__tests__/use-sessions.test.ts
+++ b/web/src/hooks/__tests__/use-sessions.test.ts
@@ -1,0 +1,159 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createElement, type ReactNode } from "react";
+import {
+  useGameSessions,
+  useCreateSession,
+  useRenameSession,
+  useDeleteSession,
+} from "../use-sessions";
+
+vi.mock("@/lib/api-client", () => ({
+  api: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api-client";
+
+const mockApi = api as unknown as {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return createElement(
+      QueryClientProvider,
+      { client: queryClient },
+      children,
+    );
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+const mockSessions = [
+  {
+    id: "ses-1",
+    gameId: "g1",
+    name: "My Session",
+    lastPlayedAt: "2026-03-01T10:00:00Z",
+    lastPlayedByUsername: "alice",
+    totalPlayTime: 3600,
+    screenshotUrl: null,
+    cheatsEnabled: false,
+    memberCount: 1,
+    memberAvatars: [],
+    createdAt: "2026-02-28T10:00:00Z",
+    updatedAt: "2026-03-01T10:00:00Z",
+  },
+];
+
+describe("useGameSessions", () => {
+  it("fetches sessions for a game", async () => {
+    mockApi.get.mockResolvedValue(mockSessions);
+
+    const { result } = renderHook(() => useGameSessions("g1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(mockApi.get).toHaveBeenCalledWith("/games/g1/sessions");
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].name).toBe("My Session");
+  });
+
+  it("does not fetch when gameId is empty", () => {
+    mockApi.get.mockResolvedValue([]);
+
+    renderHook(() => useGameSessions(""), {
+      wrapper: createWrapper(),
+    });
+
+    expect(mockApi.get).not.toHaveBeenCalled();
+  });
+
+  it("handles fetch error", async () => {
+    mockApi.get.mockRejectedValue(new Error("Server error"));
+
+    const { result } = renderHook(() => useGameSessions("g1"), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useCreateSession", () => {
+  it("creates a session", async () => {
+    mockApi.post.mockResolvedValue(mockSessions[0]);
+
+    const { result } = renderHook(() => useCreateSession(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ gameId: "g1", name: "New Session" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.post).toHaveBeenCalledWith("/games/g1/sessions", {
+      name: "New Session",
+    });
+  });
+
+  it("handles create error", async () => {
+    mockApi.post.mockRejectedValue(new Error("Failed"));
+
+    const { result } = renderHook(() => useCreateSession(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ gameId: "g1", name: "Test" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useRenameSession", () => {
+  it("renames a session", async () => {
+    mockApi.put.mockResolvedValue({ ...mockSessions[0], name: "Renamed" });
+
+    const { result } = renderHook(() => useRenameSession(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ id: "ses-1", gameId: "g1", name: "Renamed" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.put).toHaveBeenCalledWith("/sessions/ses-1", {
+      name: "Renamed",
+    });
+  });
+});
+
+describe("useDeleteSession", () => {
+  it("deletes a session", async () => {
+    mockApi.delete.mockResolvedValue(undefined);
+
+    const { result } = renderHook(() => useDeleteSession(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ id: "ses-1", gameId: "g1" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.delete).toHaveBeenCalledWith("/sessions/ses-1");
+  });
+});

--- a/web/src/hooks/use-cheats.ts
+++ b/web/src/hooks/use-cheats.ts
@@ -1,0 +1,49 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+
+interface CheatStats {
+  totalCheats: number;
+  gamesWithCheats: number;
+  totalGames: number;
+  verifiedGames: number;
+}
+
+interface ImportResult {
+  totalGames: number;
+  cheatsImported: number;
+  gamesImported: number;
+  skipped: number;
+  failed: number;
+}
+
+interface CheatCode {
+  id: number;
+  index: number;
+  description: string;
+  code: string;
+}
+
+export function useCheatStats() {
+  return useQuery({
+    queryKey: ["admin", "cheat-stats"],
+    queryFn: () => api.get<CheatStats>("/admin/cheats/stats"),
+  });
+}
+
+export function useImportCheats() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.post<ImportResult>("/admin/cheats/import"),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "cheat-stats"] });
+    },
+  });
+}
+
+export function useGameCheats(gameId: string) {
+  return useQuery({
+    queryKey: ["game", gameId, "cheats"],
+    queryFn: () => api.get<CheatCode[]>(`/games/${gameId}/cheats`),
+    enabled: !!gameId,
+  });
+}

--- a/web/src/hooks/use-sessions.ts
+++ b/web/src/hooks/use-sessions.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
-import type { GameSession } from "@/types/api";
+import type { GameSession, SessionSave, SessionCheatConfig } from "@/types/api";
 
 export function useGameSessions(gameId: string) {
   return useQuery({
@@ -44,6 +44,74 @@ export function useDeleteSession() {
       api.delete(`/sessions/${id}`),
     onSuccess: (_, { gameId }) => {
       queryClient.invalidateQueries({ queryKey: ["game-sessions", gameId] });
+    },
+  });
+}
+
+export function useSession(sessionId: string) {
+  return useQuery({
+    queryKey: ["session", sessionId],
+    queryFn: () => api.get<GameSession>(`/sessions/${sessionId}`),
+    enabled: !!sessionId,
+  });
+}
+
+export function useSessionSaves(sessionId: string) {
+  return useQuery({
+    queryKey: ["session-saves", sessionId],
+    queryFn: () => api.get<SessionSave[]>(`/sessions/${sessionId}/saves`),
+    enabled: !!sessionId,
+  });
+}
+
+export function useSessionCheats(sessionId: string) {
+  return useQuery({
+    queryKey: ["session-cheats", sessionId],
+    queryFn: () =>
+      api.get<SessionCheatConfig>(`/sessions/${sessionId}/cheats`),
+    enabled: !!sessionId,
+  });
+}
+
+export function useUpdateSessionCheats() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      sessionId,
+      cheatsEnabled,
+      enabledIndices,
+    }: {
+      sessionId: string;
+      cheatsEnabled: boolean;
+      enabledIndices: number[];
+    }) =>
+      api.put<SessionCheatConfig>(`/sessions/${sessionId}/cheats`, {
+        cheatsEnabled,
+        enabledIndices,
+      }),
+    onSuccess: (_, { sessionId }) => {
+      queryClient.invalidateQueries({
+        queryKey: ["session-cheats", sessionId],
+      });
+      queryClient.invalidateQueries({ queryKey: ["session", sessionId] });
+    },
+  });
+}
+
+export function useDeleteSessionSave() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      sessionId,
+      saveId,
+    }: {
+      sessionId: string;
+      saveId: string;
+    }) => api.delete(`/sessions/${sessionId}/saves/${saveId}`),
+    onSuccess: (_, { sessionId }) => {
+      queryClient.invalidateQueries({
+        queryKey: ["session-saves", sessionId],
+      });
     },
   });
 }

--- a/web/src/hooks/use-sessions.ts
+++ b/web/src/hooks/use-sessions.ts
@@ -1,0 +1,49 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type { GameSession } from "@/types/api";
+
+export function useGameSessions(gameId: string) {
+  return useQuery({
+    queryKey: ["game-sessions", gameId],
+    queryFn: () => api.get<GameSession[]>(`/games/${gameId}/sessions`),
+    enabled: !!gameId,
+  });
+}
+
+export function useCreateSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: { gameId: string; name: string }) =>
+      api.post<GameSession>(`/games/${data.gameId}/sessions`, {
+        name: data.name,
+      }),
+    onSuccess: (_, { gameId }) => {
+      queryClient.invalidateQueries({ queryKey: ["game-sessions", gameId] });
+    },
+  });
+}
+
+export function useRenameSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, name }: { id: string; gameId: string; name: string }) =>
+      api.put<GameSession>(`/sessions/${id}`, { name }),
+    onSuccess: (_, { gameId }) => {
+      queryClient.invalidateQueries({ queryKey: ["game-sessions", gameId] });
+    },
+  });
+}
+
+export function useDeleteSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id }: { id: string; gameId: string }) =>
+      api.delete(`/sessions/${id}`),
+    onSuccess: (_, { gameId }) => {
+      queryClient.invalidateQueries({ queryKey: ["game-sessions", gameId] });
+    },
+  });
+}

--- a/web/src/pages/__tests__/session-detail-page.test.tsx
+++ b/web/src/pages/__tests__/session-detail-page.test.tsx
@@ -1,0 +1,258 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+
+import { SessionDetailPage } from "../session-detail-page";
+
+vi.mock("@/hooks/use-sessions", () => ({
+  useSession: vi.fn(),
+  useSessionSaves: vi.fn(),
+  useSessionCheats: vi.fn(),
+  useUpdateSessionCheats: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useDeleteSessionSave: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+  useDeleteSession: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    variables: null,
+  })),
+  useRenameSession: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+}));
+
+vi.mock("@/hooks/use-games", () => ({
+  useGame: vi.fn(() => ({
+    data: { id: "g1", title: "Super Mario World" },
+    isLoading: false,
+  })),
+}));
+
+import {
+  useSession,
+  useSessionSaves,
+  useSessionCheats,
+  useUpdateSessionCheats,
+} from "@/hooks/use-sessions";
+
+const mockUseSession = useSession as ReturnType<typeof vi.fn>;
+const mockUseSessionSaves = useSessionSaves as ReturnType<typeof vi.fn>;
+const mockUseSessionCheats = useSessionCheats as ReturnType<typeof vi.fn>;
+const mockUseUpdateSessionCheats = useUpdateSessionCheats as ReturnType<
+  typeof vi.fn
+>;
+
+const mockSession = {
+  id: "s1",
+  gameId: "g1",
+  name: "My Session",
+  lastPlayedAt: "2026-02-01T10:00:00Z",
+  lastPlayedByUsername: "admin",
+  totalPlayTime: 3600,
+  screenshotUrl: null,
+  cheatsEnabled: false,
+  memberCount: 1,
+  memberAvatars: [],
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-02-01T10:00:00Z",
+};
+
+const mockSaves = [
+  {
+    id: "save1",
+    sessionId: "s1",
+    name: "Checkpoint 1",
+    fileSize: 32768,
+    screenshotUrl: null,
+    isAuto: false,
+    isCurrent: true,
+    coreName: "snes9x",
+    notes: null,
+    slot: 0,
+    createdAt: "2026-02-01T09:00:00Z",
+  },
+  {
+    id: "save2",
+    sessionId: "s1",
+    name: "Auto Save",
+    fileSize: 32768,
+    screenshotUrl: null,
+    isAuto: true,
+    isCurrent: false,
+    coreName: "snes9x",
+    notes: "Automatic save",
+    slot: null,
+    createdAt: "2026-02-01T10:00:00Z",
+  },
+];
+
+const mockCheats = {
+  cheatsEnabled: false,
+  enabledIndices: [],
+};
+
+function renderPage(sessionId = "s1") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/sessions/${sessionId}`]}>
+        <Routes>
+          <Route
+            path="sessions/:sessionId"
+            element={<SessionDetailPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseSession.mockReturnValue({
+    data: mockSession,
+    isLoading: false,
+  });
+  mockUseSessionSaves.mockReturnValue({
+    data: mockSaves,
+    isLoading: false,
+  });
+  mockUseSessionCheats.mockReturnValue({
+    data: mockCheats,
+    isLoading: false,
+  });
+  mockUseUpdateSessionCheats.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+});
+
+describe("SessionDetailPage", () => {
+  it("renders session name and game title", () => {
+    renderPage();
+    expect(screen.getByText("My Session")).toBeInTheDocument();
+    const gameLinks = screen.getAllByText("Super Mario World");
+    expect(gameLinks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders save states list", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /Save States/i }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Checkpoint 1")).toBeInTheDocument();
+    expect(screen.getByText("Auto Save")).toBeInTheDocument();
+  });
+
+  it("displays auto badge on auto saves", () => {
+    renderPage();
+    expect(screen.getByText("Auto")).toBeInTheDocument();
+  });
+
+  it("displays current badge on current save", () => {
+    renderPage();
+    expect(screen.getByText("Current")).toBeInTheDocument();
+  });
+
+  it("renders cheats section with toggle", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /Cheats/i }),
+    ).toBeInTheDocument();
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toBeInTheDocument();
+    expect(toggle).toHaveAttribute("aria-checked", "false");
+  });
+
+  it("cheats toggle shows enabled state", () => {
+    mockUseSessionCheats.mockReturnValue({
+      data: { cheatsEnabled: true, enabledIndices: [0, 2] },
+      isLoading: false,
+    });
+    renderPage();
+    const toggle = screen.getByRole("switch");
+    expect(toggle).toHaveAttribute("aria-checked", "true");
+    expect(screen.getByText("2 enabled")).toBeInTheDocument();
+  });
+
+  it("calls updateCheats when toggle is clicked", async () => {
+    const mutateFn = vi.fn();
+    mockUseUpdateSessionCheats.mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    });
+    renderPage();
+    await userEvent.click(screen.getByRole("switch"));
+    expect(mutateFn).toHaveBeenCalledWith({
+      sessionId: "s1",
+      cheatsEnabled: true,
+      enabledIndices: [],
+    });
+  });
+
+  it("shows delete session confirmation", async () => {
+    renderPage();
+    // The page-level Delete button (not the per-save "Delete save" buttons)
+    const deleteButtons = screen.getAllByRole("button", { name: /Delete/i });
+    const sessionDeleteBtn = deleteButtons.find(
+      (btn) => btn.textContent?.trim() === "Delete",
+    );
+    expect(sessionDeleteBtn).toBeDefined();
+    await userEvent.click(sessionDeleteBtn!);
+    expect(
+      screen.getByText(/Delete "My Session"/),
+    ).toBeInTheDocument();
+  });
+
+  it("shows delete save confirmation when clicking delete on a save", async () => {
+    renderPage();
+    const deleteButtons = screen.getAllByRole("button", {
+      name: /Delete save/i,
+    });
+    await userEvent.click(deleteButtons[0]);
+    expect(
+      screen.getByText(/Are you sure you want to delete this save state/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    mockUseSession.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows not-found state for invalid session", () => {
+    mockUseSession.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    renderPage("invalid");
+    expect(screen.getByText(/Session not found/i)).toBeInTheDocument();
+  });
+
+  it("shows empty saves state", () => {
+    mockUseSessionSaves.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.getByText(/No save states yet/i),
+    ).toBeInTheDocument();
+  });
+
+  it("shows cheats disabled message when cheats are off", () => {
+    renderPage();
+    expect(
+      screen.getByText(/Cheats are disabled for this session/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/admin/cheats-page.tsx
+++ b/web/src/pages/admin/cheats-page.tsx
@@ -1,0 +1,138 @@
+import { Gamepad2, Loader2, CheckCircle, Download } from "lucide-react";
+import { Button, Card, CardHeader, CardContent } from "@/components/ui";
+import { useCheatStats, useImportCheats } from "@/hooks/use-cheats";
+
+export function AdminCheatsPage() {
+  const { data: stats, isLoading: statsLoading } = useCheatStats();
+  const importCheats = useImportCheats();
+  const importResult = importCheats.data;
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <div>
+        <h1 className="text-3xl font-bold text-surface-100">Cheats</h1>
+        <p className="mt-1 text-surface-400">
+          Import and manage cheat codes from the libretro-database.
+        </p>
+      </div>
+
+      <div className="grid gap-5 md:grid-cols-2">
+        <Card>
+          <CardHeader>
+            <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+              <Gamepad2 className="h-5 w-5 text-brand-400" />
+              Cheat Stats
+            </h2>
+          </CardHeader>
+          <CardContent>
+            {statsLoading ? (
+              <div className="flex items-center gap-2 text-sm">
+                <Loader2 className="h-4 w-4 animate-spin text-brand-400" />
+                <span className="text-surface-200">Loading stats...</span>
+              </div>
+            ) : stats ? (
+              <div className="grid grid-cols-2 gap-3 text-sm">
+                <div>
+                  <p className="text-surface-500">Total cheats</p>
+                  <p className="text-surface-100 font-semibold">
+                    {stats.totalCheats}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-surface-500">Games with cheats</p>
+                  <p className="text-surface-100 font-semibold">
+                    {stats.gamesWithCheats}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-surface-500">Total games</p>
+                  <p className="text-surface-100 font-semibold">
+                    {stats.totalGames}
+                  </p>
+                </div>
+                <div>
+                  <p className="text-surface-500">Verified games</p>
+                  <p className="text-surface-100 font-semibold">
+                    {stats.verifiedGames}
+                  </p>
+                </div>
+              </div>
+            ) : null}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader>
+            <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+              <Download className="h-5 w-5 text-brand-400" />
+              Import Cheats
+            </h2>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-surface-400">
+              Import cheat codes from the libretro-database. Only verified games
+              on supported consoles will be matched.
+            </p>
+
+            {importCheats.isPending && (
+              <div className="rounded-xl bg-surface-800/50 p-4">
+                <div className="flex items-center gap-2 text-sm">
+                  <Loader2 className="h-4 w-4 animate-spin text-brand-400" />
+                  <span className="text-surface-200">
+                    Importing cheat codes...
+                  </span>
+                </div>
+              </div>
+            )}
+
+            {importResult && (
+              <div className="rounded-xl bg-surface-800/50 p-4 space-y-3">
+                <div className="flex items-center gap-2 text-sm">
+                  <CheckCircle className="h-4 w-4 text-success-500" />
+                  <span className="text-surface-200">Import complete</span>
+                </div>
+                <div className="grid grid-cols-2 gap-2 text-sm">
+                  <div>
+                    <p className="text-surface-500">Cheats imported</p>
+                    <p className="text-surface-100 font-semibold">
+                      {importResult.cheatsImported}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-surface-500">Games imported</p>
+                    <p className="text-surface-100 font-semibold">
+                      {importResult.gamesImported}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-surface-500">Skipped</p>
+                    <p className="text-surface-100 font-semibold">
+                      {importResult.skipped}
+                    </p>
+                  </div>
+                  {importResult.failed > 0 && (
+                    <div>
+                      <p className="text-surface-500">Failed</p>
+                      <p className="text-error-400 font-semibold">
+                        {importResult.failed}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+
+            <Button
+              onClick={() => importCheats.mutate()}
+              loading={importCheats.isPending}
+              icon={<Download className="h-4 w-4" />}
+              className="w-full"
+            >
+              Import Cheats
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -33,6 +33,8 @@ import { RatingSummaryCard } from "@/features/game-detail/components/rating-summ
 import { GameReviews } from "@/features/game-detail/components/game-reviews";
 import { SharedSavesList } from "@/features/game-detail/components/shared-saves-list";
 import { GameActiveRelays } from "@/features/relays/components/game-active-relays";
+import { GameSessions } from "@/features/sessions/components/game-sessions";
+import { GameCheats } from "@/features/game-detail/components/game-cheats";
 import { GameChallenges } from "@/features/challenges/components/game-challenges";
 import { useGameAchievements } from "@/hooks/use-retroachievements";
 import { useBiosStatus } from "@/hooks/use-bios";
@@ -227,6 +229,8 @@ export function GameDetailPage() {
         onClose={() => setShowCollectionPicker(false)}
       />
 
+      <GameSessions gameId={game.id} />
+
       <Card className="p-6">
         <GameCommunityStats gameId={game.id} game={game} />
       </Card>
@@ -247,6 +251,8 @@ export function GameDetailPage() {
         screenshotUrls={game.screenshotUrls}
         gameTitle={game.title}
       />
+
+      <GameCheats gameId={game.id} />
 
       {isPlayable && (
         <GameAchievements gameId={game.id} achievementsWarning={game.achievementsWarning} />

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -236,7 +236,7 @@ export function GameDetailPage() {
       </Card>
 
       {/* Rating section */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
         <Card className="p-6">
           <RatingSummaryCard gameId={game.id} />
         </Card>
@@ -265,7 +265,7 @@ export function GameDetailPage() {
       )}
 
       {isPlayable && (
-        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
           <Card className="p-6">
             <SharedSavesList gameId={game.id} />
           </Card>

--- a/web/src/pages/relay-detail-page.tsx
+++ b/web/src/pages/relay-detail-page.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
-import { Repeat } from "lucide-react";
-import { Button, BackButton, Modal, Skeleton, EmptyState } from "@/components/ui";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { Repeat, Layers } from "lucide-react";
+import { Button, BackButton, Modal, Skeleton, EmptyState, Card } from "@/components/ui";
 import { useToast } from "@/components/ui";
 import {
   useRelay,
@@ -138,6 +138,28 @@ export function RelayDetailPage() {
         isOwner={isOwner}
         currentUserId={user?.id}
       />
+
+      {/* Linked session */}
+      {relay.sessionId && (
+        <Card className="p-6" data-testid="relay-session-link">
+          <div className="flex items-center gap-2.5 mb-3">
+            <Layers className="h-5 w-5 text-brand-400" />
+            <h2 className="text-lg font-semibold text-surface-100">
+              Session
+            </h2>
+          </div>
+          <p className="text-sm text-surface-400 mb-3">
+            This relay is linked to a game session where saves and cheats are
+            tracked.
+          </p>
+          <Link
+            to={`/sessions/${relay.sessionId}`}
+            className="text-sm text-brand-400 hover:text-brand-300 transition-colors"
+          >
+            View Session Details
+          </Link>
+        </Card>
+      )}
 
       {/* Delete confirm modal */}
       <Modal

--- a/web/src/pages/session-detail-page.tsx
+++ b/web/src/pages/session-detail-page.tsx
@@ -1,7 +1,6 @@
 import { useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import {
-  ArrowLeft,
   Pencil,
   Trash2,
   Download,
@@ -13,6 +12,7 @@ import {
 } from "lucide-react";
 import {
   Button,
+  BackButton,
   Card,
   Badge,
   Skeleton,
@@ -118,14 +118,9 @@ export function SessionDetailPage() {
 
   return (
     <div className="max-w-4xl space-y-6">
-      {/* Back link */}
-      <button
-        onClick={() => navigate(game ? `/games/${game.id}` : -1)}
-        className="flex items-center gap-1.5 text-sm text-surface-400 hover:text-surface-200 transition-colors"
-      >
-        <ArrowLeft className="h-4 w-4" />
+      <BackButton onClick={() => game ? navigate(`/games/${game.id}`) : navigate(-1)}>
         {game ? game.title : "Back"}
-      </button>
+      </BackButton>
 
       {/* Header */}
       <div className="flex items-start justify-between gap-4">

--- a/web/src/pages/session-detail-page.tsx
+++ b/web/src/pages/session-detail-page.tsx
@@ -1,0 +1,370 @@
+import { useState } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import {
+  ArrowLeft,
+  Pencil,
+  Trash2,
+  Download,
+  Clock,
+  HardDrive,
+  Zap,
+  Layers,
+  Save,
+} from "lucide-react";
+import {
+  Button,
+  Card,
+  Badge,
+  Skeleton,
+  Switch,
+  ConfirmDeleteModal,
+} from "@/components/ui";
+import {
+  useSession,
+  useSessionSaves,
+  useSessionCheats,
+  useUpdateSessionCheats,
+  useDeleteSessionSave,
+  useDeleteSession,
+  useRenameSession,
+} from "@/hooks/use-sessions";
+import { useGame } from "@/hooks/use-games";
+import { formatFileSize, formatRelativeTime, formatPlayTime } from "@/lib/format";
+import type { SessionSave } from "@/types/api";
+
+function SessionDetailSkeleton() {
+  return (
+    <div className="max-w-4xl space-y-6">
+      <Skeleton className="h-6 w-32" />
+      <Skeleton className="h-10 w-64" />
+      <Skeleton className="h-48 w-full rounded-xl" />
+      <Skeleton className="h-48 w-full rounded-xl" />
+    </div>
+  );
+}
+
+export function SessionDetailPage() {
+  const { sessionId } = useParams<{ sessionId: string }>();
+  const navigate = useNavigate();
+  const { data: session, isLoading } = useSession(sessionId ?? "");
+  const { data: saves, isLoading: savesLoading } = useSessionSaves(
+    sessionId ?? "",
+  );
+  const { data: cheats } = useSessionCheats(sessionId ?? "");
+  const updateCheats = useUpdateSessionCheats();
+  const deleteSave = useDeleteSessionSave();
+  const deleteSession = useDeleteSession();
+  const renameSession = useRenameSession();
+
+  const { data: game } = useGame(session?.gameId ?? "");
+
+  const [isEditing, setIsEditing] = useState(false);
+  const [editName, setEditName] = useState("");
+  const [showDeleteSession, setShowDeleteSession] = useState(false);
+  const [deleteSaveTarget, setDeleteSaveTarget] = useState<string | null>(null);
+
+  function handleRename() {
+    if (!session || !sessionId) return;
+    const trimmed = editName.trim();
+    if (trimmed && trimmed !== session.name) {
+      renameSession.mutate({
+        id: sessionId,
+        gameId: session.gameId,
+        name: trimmed,
+      });
+    }
+    setIsEditing(false);
+  }
+
+  function handleToggleCheats(enabled: boolean) {
+    if (!sessionId || !cheats) return;
+    updateCheats.mutate({
+      sessionId,
+      cheatsEnabled: enabled,
+      enabledIndices: cheats.enabledIndices,
+    });
+  }
+
+  function handleDeleteSession() {
+    if (!session || !sessionId) return;
+    deleteSession.mutate(
+      { id: sessionId, gameId: session.gameId },
+      {
+        onSuccess: () => {
+          navigate(`/games/${session.gameId}`);
+        },
+      },
+    );
+  }
+
+  if (isLoading) {
+    return <SessionDetailSkeleton />;
+  }
+
+  if (!session) {
+    return (
+      <div className="text-center py-20">
+        <p className="text-surface-400">Session not found</p>
+        <Button
+          variant="ghost"
+          onClick={() => navigate(-1)}
+          className="mt-4"
+        >
+          Go back
+        </Button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-4xl space-y-6">
+      {/* Back link */}
+      <button
+        onClick={() => navigate(game ? `/games/${game.id}` : -1)}
+        className="flex items-center gap-1.5 text-sm text-surface-400 hover:text-surface-200 transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        {game ? game.title : "Back"}
+      </button>
+
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex-1 min-w-0">
+          {isEditing ? (
+            <input
+              type="text"
+              value={editName}
+              onChange={(e) => setEditName(e.target.value)}
+              onBlur={handleRename}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleRename();
+                if (e.key === "Escape") setIsEditing(false);
+              }}
+              className="bg-surface-800 text-surface-100 text-2xl font-bold rounded px-2 py-1 w-full outline-none ring-1 ring-brand-500"
+              data-testid="session-name-input"
+              autoFocus
+            />
+          ) : (
+            <h1 className="text-2xl font-bold text-surface-100 flex items-center gap-3">
+              <Layers className="h-6 w-6 text-brand-400 flex-shrink-0" />
+              {session.name}
+              <button
+                onClick={() => {
+                  setEditName(session.name);
+                  setIsEditing(true);
+                }}
+                className="text-surface-500 hover:text-surface-300 transition-colors"
+                aria-label="Rename session"
+              >
+                <Pencil className="h-4 w-4" />
+              </button>
+            </h1>
+          )}
+          <div className="flex items-center gap-3 mt-2 text-sm text-surface-400">
+            {game && (
+              <Link
+                to={`/games/${game.id}`}
+                className="hover:text-surface-200 transition-colors"
+              >
+                {game.title}
+              </Link>
+            )}
+            {session.lastPlayedAt && (
+              <span className="flex items-center gap-1">
+                <Clock className="h-3.5 w-3.5" />
+                {formatRelativeTime(session.lastPlayedAt)}
+              </span>
+            )}
+            <span>{formatPlayTime(session.totalPlayTime)}</span>
+            {session.cheatsEnabled && (
+              <span className="flex items-center gap-1 text-amber-400">
+                <Zap className="h-3.5 w-3.5" />
+                Cheats
+              </span>
+            )}
+          </div>
+        </div>
+
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={() => setShowDeleteSession(true)}
+          className="text-red-400 hover:text-red-300"
+        >
+          <Trash2 className="h-4 w-4 mr-1" />
+          Delete
+        </Button>
+      </div>
+
+      {/* Save States */}
+      <Card className="p-6">
+        <div className="flex items-center gap-2.5 mb-4">
+          <Save className="h-5 w-5 text-brand-400" />
+          <h2 className="text-lg font-semibold text-surface-100">
+            Save States
+          </h2>
+          {saves && saves.length > 0 && (
+            <span className="text-sm text-surface-500">
+              ({saves.length})
+            </span>
+          )}
+        </div>
+
+        {savesLoading ? (
+          <div className="space-y-2">
+            {Array.from({ length: 2 }, (_, i) => (
+              <div
+                key={i}
+                className="flex items-center gap-4 px-4 py-3 rounded-xl bg-surface-800/30"
+              >
+                <Skeleton className="w-16 h-12 rounded" />
+                <div className="flex-1 space-y-1.5">
+                  <Skeleton className="h-4 w-40" />
+                  <Skeleton className="h-3 w-28" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : !saves || saves.length === 0 ? (
+          <div className="py-8 text-center">
+            <p className="text-surface-400">
+              No save states yet. Play this session to create saves.
+            </p>
+          </div>
+        ) : (
+          <div className="space-y-2">
+            {saves.map((save: SessionSave) => (
+              <div
+                key={save.id}
+                className="flex items-center gap-4 px-4 py-3 rounded-xl bg-surface-800/30 hover:bg-surface-800/50 transition-colors"
+                data-testid={`save-${save.id}`}
+              >
+                {save.screenshotUrl ? (
+                  <img
+                    src={save.screenshotUrl}
+                    alt=""
+                    className="w-16 h-12 rounded object-cover bg-surface-800 flex-shrink-0"
+                  />
+                ) : (
+                  <div className="w-16 h-12 rounded bg-surface-800 flex-shrink-0 flex items-center justify-center">
+                    <HardDrive className="h-5 w-5 text-surface-600" />
+                  </div>
+                )}
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-surface-100">
+                    {save.name}
+                    {save.isAuto && (
+                      <Badge variant="brand" className="ml-2">
+                        Auto
+                      </Badge>
+                    )}
+                    {save.isCurrent && (
+                      <Badge variant="success" className="ml-2">
+                        Current
+                      </Badge>
+                    )}
+                  </p>
+                  <p className="text-xs text-surface-500">
+                    {formatRelativeTime(save.createdAt)} &middot;{" "}
+                    {formatFileSize(save.fileSize)}
+                    {save.coreName && ` \u00b7 ${save.coreName}`}
+                  </p>
+                  {save.notes && (
+                    <p className="text-xs text-surface-400 mt-0.5 truncate">
+                      {save.notes}
+                    </p>
+                  )}
+                </div>
+                <div className="flex items-center gap-1">
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() =>
+                      window.open(
+                        `/api/sessions/${sessionId}/saves/${save.id}/download`,
+                        "_blank",
+                      )
+                    }
+                    aria-label="Download save"
+                    title="Download save"
+                  >
+                    <Download className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setDeleteSaveTarget(save.id)}
+                    aria-label="Delete save"
+                    title="Delete save"
+                  >
+                    <Trash2 className="h-4 w-4 text-red-400" />
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+
+      {/* Cheats */}
+      <Card className="p-6">
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2.5">
+            <Zap className="h-5 w-5 text-amber-400" />
+            <h2 className="text-lg font-semibold text-surface-100">Cheats</h2>
+          </div>
+          <div className="flex items-center gap-3">
+            {cheats && cheats.enabledIndices.length > 0 && (
+              <span className="text-sm text-surface-400">
+                {cheats.enabledIndices.length} enabled
+              </span>
+            )}
+            <Switch
+              checked={cheats?.cheatsEnabled ?? false}
+              onChange={handleToggleCheats}
+              aria-label="Enable cheats"
+            />
+          </div>
+        </div>
+        {!cheats?.cheatsEnabled && (
+          <p className="text-sm text-surface-500 mt-2">
+            Cheats are disabled for this session.
+          </p>
+        )}
+        {cheats?.cheatsEnabled && cheats.enabledIndices.length === 0 && (
+          <p className="text-sm text-surface-500 mt-2">
+            Cheats are enabled but none are selected. Configure cheats in the
+            player app.
+          </p>
+        )}
+      </Card>
+
+      {/* Delete session modal */}
+      <ConfirmDeleteModal
+        open={showDeleteSession}
+        onClose={() => setShowDeleteSession(false)}
+        title="Delete Session"
+        message={`Delete "${session.name}"? All save data for this session will be permanently removed.`}
+        onConfirm={handleDeleteSession}
+        isPending={deleteSession.isPending}
+      />
+
+      {/* Delete save modal */}
+      <ConfirmDeleteModal
+        open={!!deleteSaveTarget}
+        onClose={() => setDeleteSaveTarget(null)}
+        title="Delete Save State"
+        message="Are you sure you want to delete this save state? This action cannot be undone."
+        onConfirm={() => {
+          if (deleteSaveTarget && sessionId) {
+            deleteSave.mutate(
+              { sessionId, saveId: deleteSaveTarget },
+              { onSuccess: () => setDeleteSaveTarget(null) },
+            );
+          }
+        }}
+        isPending={deleteSave.isPending}
+      />
+    </div>
+  );
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -483,7 +483,11 @@ export interface Relay {
   ownerId: string;
   ownerUsername: string;
   status: "active" | "paused" | "completed";
+  activeUserId: string | null;
+  activeUsername?: string;
+  turnTakenAt: string | null;
   memberCount: number;
+  sessionId?: string | null;
   lastActivityAt: string;
   createdAt: string;
   updatedAt: string;
@@ -610,6 +614,27 @@ export interface BiosResponse {
 
 export type BiosFileStatus = BiosFile["status"];
 export type BiosConsoleStatus = BiosConsole["status"];
+
+// --- Session Saves & Cheats ---
+
+export interface SessionSave {
+  id: string;
+  sessionId: string;
+  name: string;
+  fileSize: number;
+  screenshotUrl: string | null;
+  isAuto: boolean;
+  isCurrent: boolean;
+  coreName: string | null;
+  notes: string | null;
+  slot: number | null;
+  createdAt: string;
+}
+
+export interface SessionCheatConfig {
+  cheatsEnabled: boolean;
+  enabledIndices: number[];
+}
 
 // --- Game Sessions ---
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -611,6 +611,23 @@ export interface BiosResponse {
 export type BiosFileStatus = BiosFile["status"];
 export type BiosConsoleStatus = BiosConsole["status"];
 
+// --- Game Sessions ---
+
+export interface GameSession {
+  id: string;
+  gameId: string;
+  name: string;
+  lastPlayedAt: string | null;
+  lastPlayedByUsername: string | null;
+  totalPlayTime: number;
+  screenshotUrl: string | null;
+  cheatsEnabled: boolean;
+  memberCount: number;
+  memberAvatars: string[];
+  createdAt: string;
+  updatedAt: string;
+}
+
 // --- Challenges ---
 
 export type ChallengeType = "completion" | "speedrun" | "survival";

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -648,7 +648,7 @@ export interface GameSession {
   screenshotUrl: string | null;
   cheatsEnabled: boolean;
   memberCount: number;
-  memberAvatars: string[];
+  memberAvatars: string[] | null;
   createdAt: string;
   updatedAt: string;
 }


### PR DESCRIPTION
## Summary

- **Game Sessions** give each user isolated "playthrough" containers per game — each session owns its save states, SRAM, auto-saves, quick-save slots, and cheat configuration
- Solves the shared-device problem: multiple people can play the same game without interleaving saves or overwriting each other's progress
- Sessions are displayed on game detail with continue/rename/delete; a dedicated session detail screen shows saves and cheat toggles
- Relays are now backed by sessions — creating a relay auto-creates a GameSession, and turn validation applies to session save uploads
- Multiplayer sessions show member avatars, "Last played by" labels, and relay badges
- Existing saves are auto-migrated into "Playthrough 1" sessions on server startup
- Backward-compatible: old player app versions work via existing save endpoints proxying to the most recent session

## What's included

**Phase 1 — Core Sessions**
- `GameSession`, `SessionSaveState`, `SessionSaveData` models + 19 REST endpoints
- Session-scoped storage paths, data migration, backward compatibility
- Player: SessionRepository, session-aware SaveManager/EmulationViewModel, SessionsSection UI
- Web: hooks, session card/list components on game detail

**Phase 2 — Session Detail + Cheats**
- `SessionCheatSetting` model with GET/PUT cheat config endpoints
- Session detail screen (player + web) with save state management and cheat toggles
- SessionDetailViewModel with full MVPI pattern

**Phase 3 — Relay Integration**
- Relay creation auto-creates a backing GameSession
- Relay saves populate SessionSaveState for unified access
- Turn validation on session save uploads
- Migration for existing relays
- Multiplayer UI: avatars, "last played by", relay/multiplayer badges

**Phase 4 — HW Screenshots**
- Already functional via existing GPU renderer pipeline; no changes needed

## Test plan

- [x] Server: `go test ./...` — all packages pass (~35 new session/relay tests)
- [x] Web: `npx vitest run` — 70 files, 674 tests pass (30+ new session tests)
- [x] Player desktop E2E: 20 new session/detail tests pass
- [ ] Manual: create session → play → save states stored in session
- [ ] Manual: create second session → separate save states from first
- [ ] Manual: relay creation shows associated session
- [ ] Manual: verify migration creates "Playthrough 1" for existing saves