### PR TITLE
fix: wire SessionDetailViewModel into App

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
@@ -20,6 +20,7 @@ import com.spela.player.data.remote.PresenceService
 import com.spela.player.presentation.navigation.NavigationEventBus
 import com.spela.player.presentation.viewmodel.NetplayLobbyViewModel
 import com.spela.player.presentation.viewmodel.SaveDataViewModel
+import com.spela.player.presentation.viewmodel.SessionDetailViewModel
 import com.spela.player.presentation.viewmodel.NetplayViewModel
 import com.spela.player.presentation.viewmodel.ChallengeDetailViewModel
 import com.spela.player.presentation.viewmodel.ChallengeListViewModel
@@ -58,6 +59,7 @@ fun App() {
     val presenceService: PresenceService = koinInject()
     val connectivityMonitor: ConnectivityMonitor = koinInject()
     val saveDataViewModel: SaveDataViewModel = koinInject()
+    val sessionDetailViewModel: SessionDetailViewModel = koinInject()
     val navigationEventBus: NavigationEventBus = koinInject()
     val gamepadPortManager: GamepadPortManager = koinInject()
 
@@ -85,6 +87,7 @@ fun App() {
         presenceService = presenceService,
         connectivityMonitor = connectivityMonitor,
         saveDataViewModel = saveDataViewModel,
+        sessionDetailViewModel = sessionDetailViewModel,
         navigationEventBus = navigationEventBus,
         gamepadPortManager = gamepadPortManager,
     )


### PR DESCRIPTION
## Summary
- `SessionDetailViewModel` was registered in Koin DI but never injected in `App.kt`
- It defaulted to `null`, so `SessionDetailScreen` rendered nothing
- Now properly injected via `koinInject()` and passed to `SpelaApp()`

## Test plan
- [x] APK built and deployed — session detail screen now renders
- [x] Desktop tests still pass (no test change needed — test harness already wired it correctly)