### PR TITLE
feat: play from community save

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1118,6 +1118,16 @@ class FakeSessionRepository : SessionRepository {
         return Result.success(session)
     }
 
+    override suspend fun createSessionFromSharedSave(gameId: String, saveId: String): Result<GameSession> {
+        val session = GameSession(
+            id = "session-${nextId++}",
+            gameId = gameId,
+            name = "From shared save $saveId",
+        )
+        sessions.add(session)
+        return Result.success(session)
+    }
+
     override suspend fun updateSession(sessionId: String, name: String): Result<GameSession> {
         val idx = sessions.indexOfFirst { it.id == sessionId }
         if (idx < 0) return Result.failure(Exception("Session not found"))

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1041,6 +1041,10 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/games/$gameId/sessions").body()
     }
 
+    suspend fun createSessionFromSharedSave(gameId: String, saveId: String): GameSessionDto {
+        return client.post("$baseUrl/api/games/$gameId/sessions/from-shared-save/$saveId").body()
+    }
+
     suspend fun createSession(gameId: String, name: String): GameSessionDto {
         return client.post("$baseUrl/api/games/$gameId/sessions") {
             setBody(CreateSessionRequest(name = name))

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -23,6 +23,10 @@ class SessionRepositoryImpl(
         apiClient.createSession(gameId, name).toDomain()
     }
 
+    override suspend fun createSessionFromSharedSave(gameId: String, saveId: String): Result<GameSession> = runCatching {
+        apiClient.createSessionFromSharedSave(gameId, saveId).toDomain()
+    }
+
     override suspend fun updateSession(sessionId: String, name: String): Result<GameSession> = runCatching {
         apiClient.updateSession(sessionId, name).toDomain()
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -8,6 +8,7 @@ interface SessionRepository {
     suspend fun getSessionsForGame(gameId: String): Result<List<GameSession>>
     suspend fun getSession(sessionId: String): Result<GameSession>
     suspend fun createSession(gameId: String, name: String): Result<GameSession>
+    suspend fun createSessionFromSharedSave(gameId: String, saveId: String): Result<GameSession>
     suspend fun updateSession(sessionId: String, name: String): Result<GameSession>
     suspend fun deleteSession(sessionId: String): Result<Unit>
     suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>>

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
@@ -15,6 +15,7 @@ sealed interface GameDetailIntent {
     data class ShareSave(val saveId: String, val name: String, val description: String) : GameDetailIntent
     data class DownloadSharedSave(val saveId: String) : GameDetailIntent
     data class DeleteSharedSave(val saveId: String) : GameDetailIntent
+    data class PlayFromSharedSave(val saveId: String) : GameDetailIntent
     // Add to Collection
     data object ShowAddToCollectionDialog : GameDetailIntent
     data object DismissAddToCollectionDialog : GameDetailIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
@@ -78,4 +78,6 @@ data class GameDetailState(
     // Sessions
     val sessions: List<GameSession> = emptyList(),
     val isLoadingSessions: Boolean = false,
+    val isPlayingFromSharedSave: Boolean = false,
+    val playFromSharedSaveSessionId: String? = null,
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/social/SharedSaveItem.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/social/SharedSaveItem.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Download
+import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
@@ -33,6 +34,7 @@ fun SharedSaveItem(
     sharedSave: SharedSaveState,
     onDownload: () -> Unit,
     onDelete: (() -> Unit)?,
+    onPlay: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val description = "${sharedSave.name} by ${sharedSave.username}"
@@ -95,6 +97,18 @@ fun SharedSaveItem(
                         text = formatBytes(sharedSave.fileSize),
                         style = SpTypography.LabelSmall,
                         color = SpColor.OnBackgroundTertiary,
+                    )
+                }
+            }
+
+            // Play button
+            if (onPlay != null) {
+                IconButton(onClick = onPlay) {
+                    Icon(
+                        imageVector = Icons.Filled.PlayArrow,
+                        contentDescription = "Play from ${sharedSave.name}",
+                        tint = SpColor.Primary,
+                        modifier = Modifier.size(24.dp),
                     )
                 }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameDetailSections.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameDetailSections.kt
@@ -112,6 +112,7 @@ fun CommunitySharesSection(
     sharedSaves: List<SharedSaveState>,
     onDownload: (String) -> Unit,
     onDelete: (String) -> Unit,
+    onPlayFromSave: ((String) -> Unit)? = null,
 ) {
     SpTitledSection(title = "Community Saves", icon = Icons.Outlined.Share) {
         if (sharedSaves.isEmpty()) {
@@ -126,6 +127,7 @@ fun CommunitySharesSection(
                     sharedSave = save,
                     onDownload = { onDownload(save.id) },
                     onDelete = { onDelete(save.id) },
+                    onPlay = onPlayFromSave?.let { { it(save.id) } },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(vertical = SpSpacing.XSmall),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -126,6 +126,12 @@ fun GameDetailScreen(
         viewModel.onIntent(GameDetailIntent.LoadGame(gameId))
     }
 
+    // Navigate to play when a session is created from a shared save
+    LaunchedEffect(state.playFromSharedSaveSessionId) {
+        val sessionId = state.playFromSharedSaveSessionId ?: return@LaunchedEffect
+        onPlaySession?.invoke(gameId, sessionId)
+    }
+
     if (state.isLoading && state.gameDetail == null) {
         GameDetailSkeleton(onBack = onBack)
         return
@@ -352,6 +358,9 @@ fun GameDetailScreen(
                             onDelete = { saveId ->
                                 viewModel.onIntent(GameDetailIntent.DeleteSharedSave(saveId))
                             },
+                            onPlayFromSave = if (onPlaySession != null) { saveId ->
+                                viewModel.onIntent(GameDetailIntent.PlayFromSharedSave(saveId))
+                            } else null,
                         )
                     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -77,6 +77,7 @@ class GameDetailViewModel(
             is GameDetailIntent.ShareSave -> shareSave(intent.saveId, intent.name, intent.description)
             is GameDetailIntent.DownloadSharedSave -> downloadSharedSave(intent.saveId)
             is GameDetailIntent.DeleteSharedSave -> deleteSharedSave(intent.saveId)
+            is GameDetailIntent.PlayFromSharedSave -> playFromSharedSave(intent.saveId)
             GameDetailIntent.ShowAddToCollectionDialog -> showAddToCollectionDialog()
             GameDetailIntent.DismissAddToCollectionDialog -> _state.update {
                 it.copy(showAddToCollectionDialog = false)
@@ -388,6 +389,33 @@ class GameDetailViewModel(
                 },
                 onFailure = { error ->
                     _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun playFromSharedSave(saveId: String) {
+        val gameId = currentGameId ?: return
+        val repo = sessionRepository ?: return
+        _state.update { it.copy(isPlayingFromSharedSave = true) }
+        scope.launch(dispatchers.io) {
+            repo.createSessionFromSharedSave(gameId, saveId).fold(
+                onSuccess = { session ->
+                    _state.update { state ->
+                        state.copy(
+                            sessions = state.sessions + session,
+                            isPlayingFromSharedSave = false,
+                            playFromSharedSaveSessionId = session.id,
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update {
+                        it.copy(
+                            error = error.message,
+                            isPlayingFromSharedSave = false,
+                        )
+                    }
                 },
             )
         }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -1,0 +1,314 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import com.spela.player.domain.model.*
+import com.spela.player.domain.repository.*
+import com.spela.player.domain.usecase.AddGameToCollectionUseCase
+import com.spela.player.domain.usecase.CreateCollectionUseCase
+import com.spela.player.domain.usecase.GetGameDetailUseCase
+import com.spela.player.domain.usecase.GetMyCollectionsUseCase
+import com.spela.player.domain.usecase.ToggleFavoriteUseCase
+import com.spela.player.domain.usecase.GetGameStatsUseCase
+import com.spela.player.domain.usecase.TogglePlayLaterUseCase
+import com.spela.player.presentation.intent.GameDetailIntent
+import com.spela.player.test.NoOpMockEngineFactory
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.*
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class GameDetailPlayFromSharedSaveTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testDispatchers = object : DispatcherProvider {
+        override val main: CoroutineDispatcher = testDispatcher
+        override val io: CoroutineDispatcher = testDispatcher
+        override val default: CoroutineDispatcher = testDispatcher
+    }
+
+    private lateinit var fakeSessionRepo: FakePlayFromSharedSaveSessionRepository
+    private lateinit var fakeSharedSaveRepo: FakePlayFromSharedSaveSharedSaveRepository
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        fakeSessionRepo = FakePlayFromSharedSaveSessionRepository()
+        fakeSharedSaveRepo = FakePlayFromSharedSaveSharedSaveRepository()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): GameDetailViewModel {
+        val scope = CoroutineScope(testDispatcher)
+        val apiClient = SpelaApiClient(NoOpMockEngineFactory, TokenManager())
+        val testGameRepo = PlayFromSharedSaveTestGameRepository()
+        return GameDetailViewModel(
+            getGameDetailUseCase = GetGameDetailUseCase(testGameRepo),
+            toggleFavoriteUseCase = ToggleFavoriteUseCase(testGameRepo),
+            togglePlayLaterUseCase = TogglePlayLaterUseCase(testGameRepo),
+            downloadRepository = PlayFromSharedSaveTestDownloadRepository(),
+            ratingRepository = PlayFromSharedSaveTestRatingRepository(),
+            sharedSaveRepository = fakeSharedSaveRepo,
+            getMyCollectionsUseCase = GetMyCollectionsUseCase(PlayFromSharedSaveTestCollectionRepository()),
+            addGameToCollectionUseCase = AddGameToCollectionUseCase(PlayFromSharedSaveTestCollectionRepository()),
+            createCollectionUseCase = CreateCollectionUseCase(PlayFromSharedSaveTestCollectionRepository()),
+            getGameStatsUseCase = GetGameStatsUseCase(PlayFromSharedSaveTestGameStatsRepository()),
+            gameStatsRepository = PlayFromSharedSaveTestGameStatsRepository(),
+            challengeRepository = PlayFromSharedSaveTestChallengeRepository(),
+            relayRepository = PlayFromSharedSaveTestRelayRepository(),
+            gameRepository = testGameRepo,
+            apiClient = apiClient,
+            dispatchers = testDispatchers,
+            scope = scope,
+            sessionRepository = fakeSessionRepo,
+        )
+    }
+
+    @Test
+    fun playFromSharedSaveCreatesSessionAndSetsNavigationId() = runTest(testDispatcher) {
+        fakeSharedSaveRepo.saves = listOf(
+            SharedSaveState("s1", "u1", "Alice", null, "1", "Boss Fight", "Before final boss", 1024, 5, ""),
+        )
+        val vm = createViewModel()
+        vm.onIntent(GameDetailIntent.LoadGame("1"))
+        advanceUntilIdle()
+
+        vm.onIntent(GameDetailIntent.PlayFromSharedSave("s1"))
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertFalse(state.isPlayingFromSharedSave)
+        assertNotNull(state.playFromSharedSaveSessionId)
+        assertEquals("session-1", state.playFromSharedSaveSessionId)
+        assertTrue(state.sessions.any { it.id == "session-1" })
+    }
+
+    @Test
+    fun playFromSharedSaveShowsLoadingState() = runTest(testDispatcher) {
+        fakeSharedSaveRepo.saves = listOf(
+            SharedSaveState("s1", "u1", "Alice", null, "1", "Boss Fight", "desc", 1024, 0, ""),
+        )
+        val vm = createViewModel()
+        vm.onIntent(GameDetailIntent.LoadGame("1"))
+        advanceUntilIdle()
+
+        assertFalse(vm.state.value.isPlayingFromSharedSave)
+        assertNull(vm.state.value.playFromSharedSaveSessionId)
+    }
+
+    @Test
+    fun playFromSharedSaveShowsErrorOnFailure() = runTest(testDispatcher) {
+        fakeSessionRepo.shouldFailCreateFromSharedSave = true
+        fakeSharedSaveRepo.saves = listOf(
+            SharedSaveState("s1", "u1", "Alice", null, "1", "Boss Fight", "desc", 1024, 0, ""),
+        )
+        val vm = createViewModel()
+        vm.onIntent(GameDetailIntent.LoadGame("1"))
+        advanceUntilIdle()
+
+        vm.onIntent(GameDetailIntent.PlayFromSharedSave("s1"))
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertFalse(state.isPlayingFromSharedSave)
+        assertNull(state.playFromSharedSaveSessionId)
+        assertNotNull(state.error)
+        assertTrue(state.error.orEmpty().contains("Failed to create session"))
+    }
+
+    @Test
+    fun playFromSharedSaveAddsSessionToList() = runTest(testDispatcher) {
+        fakeSharedSaveRepo.saves = listOf(
+            SharedSaveState("s1", "u1", "Alice", null, "1", "Save A", "desc", 512, 0, ""),
+            SharedSaveState("s2", "u2", "Bob", null, "1", "Save B", "desc", 1024, 3, ""),
+        )
+        val vm = createViewModel()
+        vm.onIntent(GameDetailIntent.LoadGame("1"))
+        advanceUntilIdle()
+
+        val sessionsBefore = vm.state.value.sessions.size
+
+        vm.onIntent(GameDetailIntent.PlayFromSharedSave("s2"))
+        advanceUntilIdle()
+
+        assertEquals(sessionsBefore + 1, vm.state.value.sessions.size)
+        val newSession = vm.state.value.sessions.find { it.id == "session-1" }
+        assertNotNull(newSession)
+        assertEquals("1", newSession.gameId)
+    }
+}
+
+private class FakePlayFromSharedSaveSessionRepository : SessionRepository {
+    var shouldFailCreateFromSharedSave = false
+    private var nextId = 1
+
+    override suspend fun getSessionsForGame(gameId: String) = Result.success(emptyList<GameSession>())
+    override suspend fun getSession(sessionId: String) = Result.failure<GameSession>(Exception("stub"))
+    override suspend fun createSession(gameId: String, name: String) = Result.failure<GameSession>(Exception("stub"))
+    override suspend fun createSessionFromSharedSave(gameId: String, saveId: String): Result<GameSession> {
+        if (shouldFailCreateFromSharedSave) return Result.failure(Exception("Failed to create session from shared save"))
+        val session = GameSession(
+            id = "session-${nextId++}",
+            gameId = gameId,
+            name = "From shared save $saveId",
+        )
+        return Result.success(session)
+    }
+    override suspend fun updateSession(sessionId: String, name: String) = Result.failure<GameSession>(Exception("stub"))
+    override suspend fun deleteSession(sessionId: String) = Result.success(Unit)
+    override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
+    override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?) =
+        Result.success(SaveState(id = 1, gameId = 1, name = name))
+    override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
+    override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?) = Result.success(Unit)
+    override suspend fun downloadSessionAutoSave(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))
+    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray) = Result.success(Unit)
+    override suspend fun downloadSessionSram(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))
+    override suspend fun getSessionCheats(sessionId: String) = Result.success(SessionCheatConfig(false, emptyList()))
+    override suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>) =
+        Result.success(SessionCheatConfig(cheatsEnabled, enabledIndices))
+}
+
+private class FakePlayFromSharedSaveSharedSaveRepository : SharedSaveRepository {
+    var saves = emptyList<SharedSaveState>()
+
+    override suspend fun getSharedSaves(gameId: String, page: Int, pageSize: Int) = Result.success(saves)
+    override suspend fun shareSave(gameId: String, name: String, description: String, saveData: ByteArray) =
+        Result.success(SharedSaveState("new-1", "1", "user", null, gameId, name, description, saveData.size.toLong(), 0, ""))
+    override suspend fun downloadSharedSave(gameId: String, saveId: String) = Result.success(ByteArray(256))
+    override suspend fun deleteSharedSave(gameId: String, saveId: String) = Result.success(Unit)
+}
+
+private class PlayFromSharedSaveTestGameRepository : GameRepository {
+    private val game = Game(
+        id = "1",
+        title = "Test Game",
+        consoleId = "nes",
+        consoleName = "NES",
+        scrapeAttempts = 1,
+    )
+
+    override suspend fun getConsoles() = Result.success(emptyList<Console>())
+    override suspend fun getGamesForConsole(consoleId: String) = Result.success(emptyList<Game>())
+    override suspend fun getAllGames() = Result.success(emptyList<Game>())
+    override suspend fun searchGames(query: String, consoleId: String?, sortBy: String?, sortOrder: String?) = Result.success(emptyList<Game>())
+    override suspend fun getGameDetail(gameId: String) = Result.success(GameDetail(game))
+    override suspend fun getRecentGames() = Result.success(emptyList<Game>())
+    override suspend fun getFavoriteGames() = Result.success(emptyList<Game>())
+    override suspend fun addFavorite(gameId: String) = Result.success(Unit)
+    override suspend fun removeFavorite(gameId: String) = Result.success(Unit)
+    override suspend fun getPlayLaterGames() = Result.success(emptyList<Game>())
+    override suspend fun addToPlayLater(gameId: String) = Result.success(Unit)
+    override suspend fun removeFromPlayLater(gameId: String) = Result.success(Unit)
+    override suspend fun getTopRatedGames(consoleId: String) = Result.success(emptyList<TopRatedGame>())
+    override suspend fun getTopRatedGamesGlobal() = Result.success(emptyList<TopRatedGame>())
+    override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
+    override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
+}
+
+private class PlayFromSharedSaveTestRatingRepository : RatingRepository {
+    override suspend fun rateGame(gameId: String, rating: Int, review: String) =
+        Result.success(GameRating("1", "1", "user", null, gameId, rating, review, ""))
+    override suspend fun getGameRatings(gameId: String, page: Int, pageSize: Int) = Result.success(emptyList<GameRating>())
+    override suspend fun getRatingSummary(gameId: String) = Result.success(RatingSummary(0.0, 0, emptyMap()))
+    override suspend fun getMyRating(gameId: String) = Result.success<GameRating?>(null)
+    override suspend fun deleteRating(gameId: String) = Result.success(Unit)
+}
+
+private class PlayFromSharedSaveTestDownloadRepository : DownloadRepository {
+    override fun observeDownloads() = MutableStateFlow(emptyList<DownloadProgress>())
+    override fun observeDownload(gameId: String) = MutableStateFlow(DownloadProgress(gameId, state = DownloadState.IDLE))
+    override fun observeDownloadedGames(): Flow<List<DownloadedGame>> = MutableStateFlow(emptyList())
+    override suspend fun downloadGame(gameId: String, gameTitle: String) = Result.success("/fake")
+    override suspend fun cancelDownload(gameId: String) {}
+    override suspend fun getLocalGamePath(gameId: String): String? = null
+    override suspend fun isGameCached(gameId: String) = false
+    override suspend fun deleteLocalGame(gameId: String) {}
+    override suspend fun getCacheSize() = 0L
+    override suspend fun clearCache() {}
+}
+
+private class PlayFromSharedSaveTestCollectionRepository : CollectionRepository {
+    override suspend fun getMyCollections(page: Int, pageSize: Int) = Result.success(emptyList<GameCollection>())
+    override suspend fun getPublicCollections(page: Int, pageSize: Int) = Result.success(emptyList<GameCollection>())
+    override suspend fun getCollection(id: String) = Result.failure<GameCollectionDetail>(Exception("not found"))
+    override suspend fun createCollection(name: String, description: String?, isPublic: Boolean) =
+        Result.success(GameCollection("1", "1", "user", name = name, description = description, isPublic = isPublic))
+    override suspend fun updateCollection(id: String, name: String?, description: String?, isPublic: Boolean?) =
+        Result.success(GameCollection(id, "1", "user", name = name ?: "", description = description, isPublic = isPublic ?: false))
+    override suspend fun deleteCollection(id: String) = Result.success(Unit)
+    override suspend fun addGameToCollection(collectionId: String, gameId: String) = Result.success(Unit)
+    override suspend fun removeGameFromCollection(collectionId: String, gameId: String) = Result.success(Unit)
+}
+
+private class PlayFromSharedSaveTestGameStatsRepository : GameStatsRepository {
+    override suspend fun getGameStats(gameId: String) = Result.success(GameStats(0, 0L, 0L, emptyList()))
+    override suspend fun getGameAchievements(gameId: String) = Result.success(emptyList<GameAchievement>())
+    override suspend fun getAchievementProgress(gameId: String) = Result.success(emptyList<AchievementProgress>())
+    override suspend fun getAchievementTimeline(gameId: String) = Result.success(
+        AchievementTimelineData(null, "", 0L, emptyList(), 0, 0, 0, 0)
+    )
+    override suspend fun getAchievementLeaderboard(gameId: String) = Result.success(emptyList<AchievementPlayerRanking>())
+    override suspend fun getUserStats() = Result.success(UserStats(0L, 0L, 0, 0, null, 0L, null))
+    override suspend fun getRecentAchievements() = Result.success(emptyList<RecentAchievement>())
+}
+
+private class PlayFromSharedSaveTestRelayRepository : RelayRepository {
+    override suspend fun getMyRelays(page: Int, pageSize: Int) = Result.success(emptyList<Relay>())
+    override suspend fun getRelay(relayId: String) = Result.failure<RelayDetail>(Exception("stub"))
+    override suspend fun getRelayInvitations() = Result.success(emptyList<RelayInvitation>())
+    override suspend fun getPendingInvitationCount() = Result.success(0)
+    override suspend fun createRelay(name: String, gameId: String, description: String) = Result.failure<RelayDetail>(Exception("stub"))
+    override suspend fun deleteRelay(relayId: String) = Result.success(Unit)
+    override suspend fun inviteUser(relayId: String, username: String) = Result.success(Unit)
+    override suspend fun acceptInvitation(invitationId: String) = Result.success(Unit)
+    override suspend fun rejectInvitation(invitationId: String) = Result.success(Unit)
+    override suspend fun leaveRelay(relayId: String) = Result.success(Unit)
+    override suspend fun removeMember(relayId: String, userId: String) = Result.success(Unit)
+    override suspend fun getGameRelays(gameId: String) = Result.success(emptyList<Relay>())
+    override suspend fun getRelaySaves(relayId: String) = Result.success(emptyList<RelaySave>())
+    override suspend fun deleteRelaySave(relayId: String, saveId: Long) = Result.success(Unit)
+    override suspend fun takeTurn(relayId: String) = Result.success("stub-token")
+    override suspend fun releaseTurn(relayId: String) = Result.success(Unit)
+    override suspend fun heartbeat(relayId: String) = Result.success(Unit)
+    override suspend fun uploadRelaySave(relayId: String, name: String, turnToken: String, data: ByteArray) =
+        Result.success(RelaySave(id = 1, relayId = relayId, name = name))
+    override suspend fun downloadRelaySave(relayId: String, saveId: Long) = Result.success(byteArrayOf())
+    override suspend fun downloadRelayAutoSave(relayId: String) = Result.success(byteArrayOf())
+    override suspend fun uploadRelayAutoSave(relayId: String, turnToken: String, data: ByteArray) =
+        Result.success(RelaySave(id = 1, relayId = relayId, name = "Auto Save", isAuto = true))
+    override suspend fun copyRelaySaveToGame(relayId: String, saveId: Long) = Result.success(Unit)
+}
+
+private class PlayFromSharedSaveTestChallengeRepository : ChallengeRepository {
+    override suspend fun getChallenges(gameId: String?, consoleId: String?, difficulty: String?, sort: String?, page: Int) =
+        Result.success(emptyList<Challenge>())
+    override suspend fun getGameChallenges(gameId: String, page: Int) = Result.success(emptyList<Challenge>())
+    override suspend fun getMyChallenges(page: Int) = Result.success(emptyList<Challenge>())
+    override suspend fun getChallengeDetail(challengeId: String) = Result.failure<Challenge>(Exception("stub"))
+    override suspend fun getLeaderboard(challengeId: String, page: Int) = Result.success(emptyList<ChallengeLeaderboardEntry>())
+    override suspend fun createChallenge(gameId: String, name: String, description: String, type: String, difficulty: String, coreName: String, saveData: ByteArray, screenshotData: ByteArray?) =
+        Result.failure<Challenge>(Exception("stub"))
+    override suspend fun downloadChallengeSave(challengeId: String) = Result.success(byteArrayOf())
+    override suspend fun startAttempt(challengeId: String) =
+        Result.success(ChallengeAttempt("1", challengeId, "1", "test", null, "in_progress", "", null, 0, false))
+    override suspend fun completeAttempt(challengeId: String, attemptId: String) =
+        Result.success(ChallengeAttempt(attemptId, challengeId, "1", "test", null, "completed", "", "", 1000, false))
+    override suspend fun abandonAttempt(challengeId: String, attemptId: String) = Result.success(Unit)
+    override suspend fun getMyAttempts(challengeId: String) = Result.success(emptyList<ChallengeAttempt>())
+    override suspend fun deleteChallenge(challengeId: String) = Result.success(Unit)
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -366,6 +366,8 @@ class StubSessionRepository : SessionRepository {
         downloadSessionSramCallCount++
         return downloadSessionSramResult
     }
+    override suspend fun createSessionFromSharedSave(gameId: String, saveId: String) =
+        Result.success(GameSession(id = "shared-session-1", gameId = gameId, name = "From shared save $saveId"))
     override suspend fun getSessionCheats(sessionId: String) = Result.success(SessionCheatConfig(false, emptyList()))
     override suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>) = Result.success(SessionCheatConfig(cheatsEnabled, enabledIndices))
 }

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -237,6 +237,7 @@ func NewRouter(cfg Config) *gin.Engine {
 
 		// Game Sessions
 		api.POST("/games/:id/sessions", sessionHandler.CreateSession)
+		api.POST("/games/:id/sessions/from-shared-save/:saveId", sessionHandler.CreateFromSharedSave)
 		api.GET("/games/:id/sessions", sessionHandler.ListSessions)
 		api.GET("/sessions/:id", sessionHandler.GetSession)
 		api.PUT("/sessions/:id", sessionHandler.UpdateSession)

--- a/server/internal/api/session_handler.go
+++ b/server/internal/api/session_handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -63,6 +64,90 @@ func (h *SessionHandler) CreateSession(c *gin.Context) {
 
 	h.DB.Preload("Owner").First(&session, session.ID)
 	c.JSON(http.StatusCreated, h.toSessionResponse(session, 0))
+}
+
+// CreateFromSharedSave creates a new game session from a community shared save.
+// POST /api/games/:id/sessions/from-shared-save/:saveId
+func (h *SessionHandler) CreateFromSharedSave(c *gin.Context) {
+	uid := getUserID(c)
+	gameID := c.Param("id")
+	saveID := c.Param("saveId")
+
+	gid, err := strconv.ParseUint(gameID, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid game ID"})
+		return
+	}
+
+	sid, err := strconv.ParseUint(saveID, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid save ID"})
+		return
+	}
+
+	var game db.Game
+	if err := h.DB.First(&game, gid).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "game not found"})
+		return
+	}
+
+	var sharedSave db.SharedSaveState
+	if err := h.DB.First(&sharedSave, sid).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "shared save not found"})
+		return
+	}
+
+	if sharedSave.GameID != uint(gid) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "shared save does not belong to this game"})
+		return
+	}
+
+	// Create session
+	session := db.GameSession{
+		OwnerID: uid,
+		GameID:  uint(gid),
+		Name:    fmt.Sprintf("From: %s", sharedSave.Name),
+	}
+	if err := h.DB.Create(&session).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create session"})
+		return
+	}
+
+	// Copy the shared save file to the new session
+	srcFile, err := os.Open(sharedSave.FilePath)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read shared save file"})
+		return
+	}
+	defer srcFile.Close()
+
+	filename := filepath.Base(sharedSave.FilePath)
+	path, size, err := h.Storage.WriteSessionSave(session.ID, filename, srcFile)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to copy save file"})
+		return
+	}
+
+	// Create session save state record
+	save := db.SessionSaveState{
+		SessionID:     session.ID,
+		UserID:        uid,
+		Name:          sharedSave.Name,
+		FilePath:      path,
+		FileSize:      size,
+		ScreenshotURL: sharedSave.ScreenshotURL,
+		IsAuto:        false,
+	}
+	if err := h.DB.Create(&save).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create save record"})
+		return
+	}
+
+	// Increment download count on the shared save
+	h.DB.Model(&sharedSave).UpdateColumn("download_count", gorm.Expr("download_count + ?", 1))
+
+	h.DB.Preload("Owner").First(&session, session.ID)
+	c.JSON(http.StatusCreated, h.toSessionResponse(session, 1))
 }
 
 // ListSessions lists all sessions for a game belonging to the current user.

--- a/server/internal/api/session_handler_test.go
+++ b/server/internal/api/session_handler_test.go
@@ -7,6 +7,8 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spela/server/internal/db"
@@ -981,6 +983,135 @@ func TestUploadSessionSave_WithScreenshot(t *testing.T) {
 	var resp map[string]interface{}
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.NotEmpty(t, resp["screenshotUrl"])
+}
+
+// --- Create From Shared Save ---
+
+func createSharedSaveOnDisk(t *testing.T, database *gorm.DB, storage string, gameID uint, userID uint, name string, data []byte) db.SharedSaveState {
+	t.Helper()
+	shared := db.SharedSaveState{
+		UserID: userID,
+		GameID: gameID,
+		Name:   name,
+	}
+	require.NoError(t, database.Create(&shared).Error)
+
+	// Write the file to the save dir so the handler can read it
+	dir := filepath.Join(storage, "shared_saves", fmt.Sprintf("game_%d", gameID))
+	require.NoError(t, os.MkdirAll(dir, 0700))
+	filePath := filepath.Join(dir, fmt.Sprintf("save_%d.sav", shared.ID))
+	require.NoError(t, os.WriteFile(filePath, data, 0600))
+
+	shared.FilePath = filePath
+	shared.FileSize = int64(len(data))
+	require.NoError(t, database.Save(&shared).Error)
+
+	return shared
+}
+
+func TestCreateFromSharedSave_Success(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	var user db.User
+	database.First(&user)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Test Game", FileName: "test.nes", FilePath: "/tmp/test.nes", FileSize: 100}
+	database.Create(&game)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	shared := createSharedSaveOnDisk(t, database, cfg.Storage.SaveDir, game.ID, user.ID, "Boss Fight Save", []byte("shared save data"))
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/games/%s/sessions/from-shared-save/%d", gameID, shared.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "From: Boss Fight Save", resp["name"])
+	assert.Equal(t, gameID, resp["gameId"])
+	assert.Equal(t, float64(1), resp["saveCount"])
+	assert.NotEmpty(t, resp["id"])
+
+	// Verify download count was incremented
+	var updatedShared db.SharedSaveState
+	database.First(&updatedShared, shared.ID)
+	assert.Equal(t, 1, updatedShared.DownloadCount)
+}
+
+func TestCreateFromSharedSave_InvalidGameID(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/games/abc/sessions/from-shared-save/1", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateFromSharedSave_InvalidSaveID(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/games/"+env.gameID+"/sessions/from-shared-save/abc", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateFromSharedSave_GameNotFound(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/games/9999/sessions/from-shared-save/1", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCreateFromSharedSave_SaveNotFound(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/games/"+env.gameID+"/sessions/from-shared-save/9999", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCreateFromSharedSave_SaveBelongsToDifferentGame(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	var user db.User
+	database.First(&user)
+
+	var console db.Console
+	database.First(&console)
+	game1 := db.Game{ConsoleID: console.ID, Title: "Game 1", FileName: "game1.nes", FilePath: "/tmp/game1.nes", FileSize: 100}
+	database.Create(&game1)
+	game2 := db.Game{ConsoleID: console.ID, Title: "Game 2", FileName: "game2.nes", FilePath: "/tmp/game2.nes", FileSize: 100}
+	database.Create(&game2)
+
+	// Create shared save for game2
+	shared := createSharedSaveOnDisk(t, database, cfg.Storage.SaveDir, game2.ID, user.ID, "Wrong Game Save", []byte("data"))
+
+	// Try to create session from shared save using game1's ID
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", fmt.Sprintf("/api/games/%d/sessions/from-shared-save/%d", game1.ID, shared.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "shared save does not belong to this game", resp["error"])
 }
 
 // --- Session Updates from Save Uploads ---

--- a/web/src/features/game-detail/components/shared-saves-list.tsx
+++ b/web/src/features/game-detail/components/shared-saves-list.tsx
@@ -1,10 +1,16 @@
 import { useState } from "react";
-import { Share2, Download, Trash2 } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Share2, Download, Trash2, Play, Loader2 } from "lucide-react";
 import { Button, Skeleton, EmptyState, ConfirmDeleteModal } from "@/components/ui";
+import { useToast } from "@/components/ui";
 import { PlayerAvatar } from "@/components/player-avatar";
 import { formatFileSize, formatRelativeTime } from "@/lib/format";
 import { useAuth } from "@/hooks/use-auth";
-import { useSharedSaves, useDeleteSharedSave } from "@/hooks/use-shared-saves";
+import {
+  useSharedSaves,
+  useDeleteSharedSave,
+  useCreateSessionFromSharedSave,
+} from "@/hooks/use-shared-saves";
 
 function SharedSavesSkeleton() {
   return (
@@ -35,6 +41,9 @@ export function SharedSavesList({ gameId }: SharedSavesListProps) {
   const pageSize = 10;
   const { data, isLoading } = useSharedSaves(gameId, page, pageSize);
   const deleteSharedSave = useDeleteSharedSave();
+  const createSession = useCreateSessionFromSharedSave();
+  const navigate = useNavigate();
+  const { toast } = useToast();
   const { user } = useAuth();
   const isAdmin = user?.role === "admin" || user?.role === "owner";
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
@@ -100,6 +109,36 @@ export function SharedSavesList({ gameId }: SharedSavesListProps) {
                 </span>
 
                 <div className="flex items-center gap-1">
+                  <button
+                    onClick={() => {
+                      createSession.mutate(
+                        { gameId, saveId: save.id },
+                        {
+                          onSuccess: (session) => {
+                            navigate(
+                              `/games/${gameId}/play?sessionId=${session.id}`,
+                            );
+                          },
+                          onError: () => {
+                            toast(
+                              "error",
+                              "Failed to create session from save",
+                            );
+                          },
+                        },
+                      );
+                    }}
+                    disabled={createSession.isPending}
+                    className="p-2 rounded-lg text-brand-400 hover:text-brand-300 hover:bg-brand-500/10 transition-colors disabled:opacity-50"
+                    title="Play from this save"
+                    aria-label="Play from this save"
+                  >
+                    {createSession.isPending ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Play className="h-4 w-4" />
+                    )}
+                  </button>
                   <a
                     href={`/api/games/${gameId}/shared-saves/${save.id}/download`}
                     download

--- a/web/src/hooks/__tests__/use-shared-saves.test.ts
+++ b/web/src/hooks/__tests__/use-shared-saves.test.ts
@@ -2,11 +2,16 @@ import { renderHook, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement, type ReactNode } from "react";
-import { useSharedSaves, useDeleteSharedSave } from "../use-shared-saves";
+import {
+  useSharedSaves,
+  useDeleteSharedSave,
+  useCreateSessionFromSharedSave,
+} from "../use-shared-saves";
 
 vi.mock("@/lib/api-client", () => ({
   api: {
     get: vi.fn(),
+    post: vi.fn(),
     upload: vi.fn(),
     delete: vi.fn(),
     getAccessToken: vi.fn(() => "test-token"),
@@ -17,6 +22,7 @@ import { api } from "@/lib/api-client";
 
 const mockApi = api as unknown as {
   get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
   upload: ReturnType<typeof vi.fn>;
   delete: ReturnType<typeof vi.fn>;
   getAccessToken: ReturnType<typeof vi.fn>;
@@ -134,5 +140,51 @@ describe("useDeleteSharedSave", () => {
     result.current.mutate({ gameId: "g1", saveId: "ss1" });
 
     await waitFor(() => expect(result.current.isError).toBe(true));
+  });
+});
+
+describe("useCreateSessionFromSharedSave", () => {
+  const mockSession = {
+    id: "ses-new",
+    gameId: "g1",
+    name: "From shared save",
+    lastPlayedAt: "2026-03-06T10:00:00Z",
+    lastPlayedByUsername: "alice",
+    totalPlayTime: 0,
+    screenshotUrl: null,
+    cheatsEnabled: false,
+    memberCount: 1,
+    memberAvatars: [],
+    createdAt: "2026-03-06T10:00:00Z",
+    updatedAt: "2026-03-06T10:00:00Z",
+  };
+
+  it("creates a session from a shared save", async () => {
+    mockApi.post.mockResolvedValue(mockSession);
+
+    const { result } = renderHook(() => useCreateSessionFromSharedSave(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ gameId: "g1", saveId: "ss1" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.post).toHaveBeenCalledWith(
+      "/games/g1/sessions/from-shared-save/ss1",
+    );
+    expect(result.current.data).toEqual(mockSession);
+  });
+
+  it("handles error when creating session from shared save", async () => {
+    mockApi.post.mockRejectedValue(new Error("Save not found"));
+
+    const { result } = renderHook(() => useCreateSessionFromSharedSave(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ gameId: "g1", saveId: "bad-id" });
+
+    await waitFor(() => expect(result.current.isError).toBe(true));
+    expect(result.current.error).toBeInstanceOf(Error);
   });
 });

--- a/web/src/hooks/use-shared-saves.ts
+++ b/web/src/hooks/use-shared-saves.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
-import type { SharedSavesResponse } from "@/types/api";
+import type { SharedSavesResponse, GameSession } from "@/types/api";
 
 export function useSharedSaves(
   gameId: string,
@@ -14,6 +14,21 @@ export function useSharedSaves(
         `/games/${gameId}/shared-saves?page=${page}&pageSize=${pageSize}`,
       ),
     enabled: !!gameId,
+  });
+}
+
+export function useCreateSessionFromSharedSave() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ gameId, saveId }: { gameId: string; saveId: string }) =>
+      api.post<GameSession>(
+        `/games/${gameId}/sessions/from-shared-save/${saveId}`,
+      ),
+    onSuccess: (_, { gameId }) => {
+      queryClient.invalidateQueries({ queryKey: ["game-sessions", gameId] });
+      queryClient.invalidateQueries({ queryKey: ["shared-saves", gameId] });
+    },
   });
 }
 

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -152,6 +152,7 @@ export type ApiPostPath = WithQuery<
   | `/games/${string}/scrape-if-needed`
   | `/games/${string}/play-time`
   | `/games/${string}/sessions`
+  | `/games/${string}/sessions/from-shared-save/${string}`
   | `/games/${string}/shared-saves`
   | `/games/${string}/ratings`
 


### PR DESCRIPTION
## Summary

- Add `POST /api/games/:id/sessions/from-shared-save/:saveId` backend endpoint that atomically creates a session and copies a community save into it
- Add "Play" button on community save items in both web and player app — one click to start playing from any shared save
- Full test coverage: 6 Go tests, 2 web hook tests, 4 desktop E2E tests

## Test plan

- [ ] Backend: `cd server && go test ./internal/api/ -run TestCreateFromSharedSave -v`
- [ ] Web: `cd web && npx vitest run`
- [ ] Desktop: `player/run-desktop-tests.sh`
- [ ] Manual: open game detail → community saves → click Play → verify session created and game launches