### PR TITLE
refactor: make session selection explicit in play routing

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionsUiTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionsUiTest.kt
@@ -319,6 +319,56 @@ class SessionsUiTest {
         onNodeWithText("Relay").assertIsDisplayed()
     }
 
+    // ── First session shows "Current" badge ──
+
+    @Test
+    fun firstSessionShowsCurrentBadge() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(id = "s1", gameId = "1", name = "Main Run")
+        harness.sessionRepo.preAddSession(id = "s2", gameId = "1", name = "Side Run")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        // First session should have the "Current" badge
+        onNode(hasTestTag("session_current_badge"), useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("Current").assertIsDisplayed()
+    }
+
+    // ── Only the first session shows "Current" badge ──
+
+    @Test
+    fun onlyFirstSessionShowsCurrentBadge() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(id = "s1", gameId = "1", name = "First Run")
+        harness.sessionRepo.preAddSession(id = "s2", gameId = "1", name = "Second Run")
+        harness.sessionRepo.preAddSession(id = "s3", gameId = "1", name = "Third Run")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        // There should be exactly one "Current" badge in the tree
+        onAllNodes(hasTestTag("session_current_badge"), useUnmergedTree = true)
+            .assertCountEquals(1)
+    }
+
+    // ── Single session shows "Current" badge ──
+
+    @Test
+    fun singleSessionShowsCurrentBadge() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(id = "s1", gameId = "1", name = "Solo Run")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNode(hasTestTag("session_current_badge"), useUnmergedTree = true).assertIsDisplayed()
+        onNodeWithText("Current").assertIsDisplayed()
+    }
+
     // ── Single-player session does NOT show multiplayer badge ──
 
     @Test

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
@@ -86,9 +86,10 @@ internal fun SessionsSection(
             Spacer(Modifier.height(SpSpacing.Default))
         }
 
-        sessions.forEach { session ->
+        sessions.forEachIndexed { index, session ->
             SessionItem(
                 session = session,
+                isCurrent = index == 0,
                 onClick = {
                     if (onSessionSelected != null) {
                         onSessionSelected(session)
@@ -214,6 +215,7 @@ internal fun SessionsSection(
 @Composable
 private fun SessionItem(
     session: GameSession,
+    isCurrent: Boolean,
     onClick: () -> Unit,
     onContinue: () -> Unit,
     onRename: () -> Unit,
@@ -247,6 +249,14 @@ private fun SessionItem(
                             contentDescription = "Session: ${session.name}"
                         },
                     )
+                    if (isCurrent) {
+                        SpChip(
+                            text = "Current",
+                            color = SpColor.Primary,
+                            isSelected = true,
+                            modifier = Modifier.testTag("session_current_badge"),
+                        )
+                    }
                     if (isMultiplayer || session.isRelay) {
                         SpChip(
                             text = if (session.isRelay) "Relay" else "Multiplayer",

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -63,7 +63,7 @@ export function App() {
 
                   {/* Emulator route (protected, no sidebar) */}
                   <Route
-                    path="games/:id/play"
+                    path="games/:id/play/:sessionId"
                     element={
                       <ProtectedRoute>
                         <PlayPage />

--- a/web/src/features/game-detail/components/shared-saves-list.tsx
+++ b/web/src/features/game-detail/components/shared-saves-list.tsx
@@ -116,7 +116,7 @@ export function SharedSavesList({ gameId }: SharedSavesListProps) {
                         {
                           onSuccess: (session) => {
                             navigate(
-                              `/games/${gameId}/play?sessionId=${session.id}`,
+                              `/games/${gameId}/play/${session.id}`,
                             );
                           },
                           onError: () => {

--- a/web/src/features/sessions/components/__tests__/game-sessions.test.tsx
+++ b/web/src/features/sessions/components/__tests__/game-sessions.test.tsx
@@ -4,6 +4,12 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { GameSessions } from "../game-sessions";
 
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => mockNavigate };
+});
+
 vi.mock("@/hooks/use-auth", () => ({
   useAuth: vi.fn(() => ({
     user: { id: "u1", username: "testuser", role: "user" },
@@ -202,5 +208,28 @@ describe("GameSessions", () => {
     renderComponent();
 
     expect(screen.getByText("Play")).toBeInTheDocument();
+  });
+
+  it("navigates to play route with session ID when Play clicked", () => {
+    mockUseGameSessions.mockReturnValue({
+      data: [mockSessions[0]],
+      isLoading: false,
+    });
+    renderComponent();
+
+    fireEvent.click(screen.getByText("Play"));
+
+    expect(mockNavigate).toHaveBeenCalledWith("/games/g1/play/ses-1");
+  });
+
+  it("shows Current badge on first session only", () => {
+    mockUseGameSessions.mockReturnValue({
+      data: mockSessions,
+      isLoading: false,
+    });
+    renderComponent();
+
+    const currentBadges = screen.getAllByText("Current");
+    expect(currentBadges).toHaveLength(1);
   });
 });

--- a/web/src/features/sessions/components/__tests__/session-card.test.tsx
+++ b/web/src/features/sessions/components/__tests__/session-card.test.tsx
@@ -27,12 +27,14 @@ function renderCard(
   session: GameSession = baseSession,
   isDeleting = false,
   currentUsername?: string,
+  isCurrent?: boolean,
 ) {
   return render(
     <MemoryRouter>
       <SessionCard
         session={session}
         currentUsername={currentUsername}
+        isCurrent={isCurrent}
         onContinue={onContinue}
         onRename={onRename}
         onDelete={onDelete}
@@ -216,5 +218,20 @@ describe("SessionCard", () => {
     const avatarContainer = screen.getByTestId("member-avatars");
     expect(avatarContainer.querySelectorAll("img")).toHaveLength(3);
     expect(screen.getByText("3")).toBeInTheDocument();
+  });
+
+  it("shows Current badge when isCurrent is true", () => {
+    renderCard(baseSession, false, undefined, true);
+    expect(screen.getByText("Current")).toBeInTheDocument();
+  });
+
+  it("does not show Current badge when isCurrent is false", () => {
+    renderCard(baseSession, false, undefined, false);
+    expect(screen.queryByText("Current")).not.toBeInTheDocument();
+  });
+
+  it("does not show Current badge when isCurrent is undefined", () => {
+    renderCard();
+    expect(screen.queryByText("Current")).not.toBeInTheDocument();
   });
 });

--- a/web/src/features/sessions/components/game-sessions.tsx
+++ b/web/src/features/sessions/components/game-sessions.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { useNavigate } from "react-router-dom";
 import { Layers, Plus } from "lucide-react";
 import { Button, Card, Skeleton, EmptyState, Input } from "@/components/ui";
 import {
@@ -36,6 +37,7 @@ interface GameSessionsProps {
 }
 
 export function GameSessions({ gameId }: GameSessionsProps) {
+  const navigate = useNavigate();
   const { user } = useAuth();
   const { data: sessions, isLoading } = useGameSessions(gameId);
   const createSession = useCreateSession();
@@ -65,8 +67,8 @@ export function GameSessions({ gameId }: GameSessionsProps) {
     deleteSession.mutate({ id: session.id, gameId });
   }
 
-  function handleContinue(_session: GameSession) {
-    // Will be wired to navigation/play in future
+  function handleContinue(session: GameSession) {
+    navigate(`/games/${gameId}/play/${session.id}`);
   }
 
   if (isLoading) {
@@ -152,11 +154,12 @@ export function GameSessions({ gameId }: GameSessionsProps) {
         />
       ) : (
         <div className="space-y-2">
-          {sessions.map((session) => (
+          {sessions.map((session, index) => (
             <SessionCard
               key={session.id}
               session={session}
               currentUsername={user?.username}
+              isCurrent={index === 0}
               onContinue={handleContinue}
               onRename={handleRename}
               onDelete={handleDelete}

--- a/web/src/features/sessions/components/session-card.tsx
+++ b/web/src/features/sessions/components/session-card.tsx
@@ -8,6 +8,7 @@ import type { GameSession } from "@/types/api";
 interface SessionCardProps {
   session: GameSession;
   currentUsername?: string;
+  isCurrent?: boolean;
   onContinue: (session: GameSession) => void;
   onRename: (session: GameSession, name: string) => void;
   onDelete: (session: GameSession) => void;
@@ -17,6 +18,7 @@ interface SessionCardProps {
 export function SessionCard({
   session,
   currentUsername,
+  isCurrent,
   onContinue,
   onRename,
   onDelete,
@@ -73,12 +75,19 @@ export function SessionCard({
               autoFocus
             />
           ) : (
-            <Link
-              to={`/sessions/${session.id}`}
-              className="text-sm font-medium text-surface-200 truncate hover:text-surface-100 transition-colors"
-            >
-              {session.name}
-            </Link>
+            <span className="flex items-center gap-1.5">
+              <Link
+                to={`/sessions/${session.id}`}
+                className="text-sm font-medium text-surface-200 truncate hover:text-surface-100 transition-colors"
+              >
+                {session.name}
+              </Link>
+              {isCurrent && (
+                <span className="text-xs px-1.5 py-0.5 rounded-full bg-brand-500/20 text-brand-400">
+                  Current
+                </span>
+              )}
+            </span>
           )}
           <div className="flex items-center gap-2 text-xs text-surface-500 mt-0.5">
             {session.lastPlayedAt && (

--- a/web/src/hooks/use-sessions.ts
+++ b/web/src/hooks/use-sessions.ts
@@ -1,5 +1,4 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api-client";
 import type { GameSession, SessionSave, SessionCheatConfig } from "@/types/api";
 
@@ -117,49 +116,3 @@ export function useDeleteSessionSave() {
   });
 }
 
-/**
- * Returns a session ID for the given game, auto-creating a default session if none exists.
- * If `explicitSessionId` is provided, uses that directly.
- */
-export function useDefaultSession(
-  gameId: string | undefined,
-  explicitSessionId?: string,
-) {
-  const { data: sessions } = useGameSessions(gameId ?? "");
-  const [sessionId, setSessionId] = useState<string | undefined>(
-    explicitSessionId,
-  );
-  const creatingRef = useRef(false);
-
-  useEffect(() => {
-    if (explicitSessionId) {
-      setSessionId(explicitSessionId);
-      return;
-    }
-
-    if (!gameId || !sessions || creatingRef.current) return;
-
-    if (sessions.length > 0) {
-      // Use the most recently updated session
-      setSessionId(sessions[0].id);
-    } else {
-      // Auto-create a default session
-      creatingRef.current = true;
-      api
-        .post<GameSession>(`/games/${gameId}/sessions`, {
-          name: "Default",
-        })
-        .then((session) => {
-          setSessionId(session.id);
-        })
-        .catch(() => {
-          // If creation fails, saves won't work but the game can still be played
-        })
-        .finally(() => {
-          creatingRef.current = false;
-        });
-    }
-  }, [gameId, sessions, explicitSessionId]);
-
-  return sessionId;
-}

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -32,6 +32,7 @@ import { GameReviews } from "@/features/game-detail/components/game-reviews";
 import { SharedSavesList } from "@/features/game-detail/components/shared-saves-list";
 import { GameActiveRelays } from "@/features/relays/components/game-active-relays";
 import { GameSessions } from "@/features/sessions/components/game-sessions";
+import { useGameSessions } from "@/hooks/use-sessions";
 import { GameCheats } from "@/features/game-detail/components/game-cheats";
 import { GameChallenges } from "@/features/challenges/components/game-challenges";
 import { useGameAchievements } from "@/hooks/use-retroachievements";
@@ -113,6 +114,7 @@ export function GameDetailPage() {
     currentUser?.role === "admin" || currentUser?.role === "owner";
 
   const { data: biosData } = useBiosStatus();
+  const { data: sessions } = useGameSessions(id ?? "");
   const { data: gameAchievements } = useGameAchievements(id);
   const consoleInfo = consoles?.find((c) => c.id === game?.consoleId);
   const canPlayInBrowser = !!consoleInfo?.emulatorJsCore;
@@ -193,7 +195,7 @@ export function GameDetailPage() {
         isScraping={scrapeGame.isPending}
         hasAchievements={hasAchievements}
         biosMissing={showBiosWarning}
-        onPlay={() => navigate(`/games/${game.id}/play`)}
+        onPlay={() => navigate(`/games/${game.id}/play/${sessions && sessions.length > 0 ? sessions[0].id : "new"}`)}
         onScrape={() => scrapeGame.mutate(game.id)}
         onToggleFavorite={() =>
           toggleFavorite.mutate({ gameId: game.id, isFavorite })

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import { useState, useEffect, useRef, useCallback } from "react";
 import { AlertTriangle } from "lucide-react";
 import { Button, Skeleton } from "@/components/ui";
@@ -11,23 +11,38 @@ import { useEmulatorIframe } from "@/hooks/use-emulator-iframe";
 import { useEmulatorSaves } from "@/hooks/use-emulator-saves";
 import { useDiscManager } from "@/hooks/use-disc-manager";
 import { usePlaySession } from "@/hooks/use-play-session";
-import { useDefaultSession } from "@/hooks/use-sessions";
 import { useFullscreen } from "@/hooks/use-fullscreen";
 import { useToast } from "@/components/ui";
 import { useGamepadConnected } from "@/hooks/use-gamepad";
+import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
 import { toEmulatorJsShader } from "@/lib/shader-mapping";
 import { PlayToolbar } from "@/features/play/components/play-toolbar";
 import { EmulatorOverlay } from "@/features/play/components/emulator-overlay";
 import type { EmulatorPreferences } from "@/lib/emulator-protocol";
+import type { GameSession } from "@/types/api";
 
 export function PlayPage() {
-  const { id } = useParams<{ id: string }>();
+  const { id, sessionId: sessionIdParam } = useParams<{ id: string; sessionId: string }>();
   const navigate = useNavigate();
-  const [searchParams] = useSearchParams();
-  const isFreshStart = searchParams.get("fresh") === "true";
-  const explicitSessionId = searchParams.get("sessionId") ?? undefined;
+  const queryClient = useQueryClient();
   const { toast } = useToast();
+
+  const isFreshStart = sessionIdParam === "new";
+  const [createdSessionId, setCreatedSessionId] = useState<string | undefined>();
+  const sessionId = sessionIdParam === "new" ? createdSessionId : sessionIdParam;
+
+  // Auto-create session when sessionId is "new"
+  const creatingRef = useRef(false);
+  useEffect(() => {
+    if (sessionIdParam !== "new" || creatingRef.current || createdSessionId) return;
+    creatingRef.current = true;
+    api
+      .post<GameSession>(`/games/${id}/sessions`, { name: "Default" })
+      .then((session) => setCreatedSessionId(session.id))
+      .catch(() => {})
+      .finally(() => { creatingRef.current = false; });
+  }, [sessionIdParam, id, createdSessionId]);
 
   const { data: game, isLoading: gameLoading } = useGame(id ?? "");
   const { data: preferences } = useUserPreferences();
@@ -35,7 +50,6 @@ export function PlayPage() {
   const { data: biosFiles } = useBiosFiles();
   const { data: biosData } = useBiosStatus();
   const { isAdmin } = useAuth();
-  const sessionId = useDefaultSession(id, explicitSessionId);
 
   const biosConsole = biosData?.consoles.find(
     (c) => c.consoleId === game?.consoleId,
@@ -268,6 +282,7 @@ export function PlayPage() {
         ),
       ]);
     }
+    queryClient.invalidateQueries({ queryKey: ["game-sessions"] });
     navigate(-1);
   }
 

--- a/web/src/pages/relay-detail-page.tsx
+++ b/web/src/pages/relay-detail-page.tsx
@@ -86,7 +86,8 @@ export function RelayDetailPage() {
   }
 
   function handlePlay() {
-    navigate(`/games/${relay!.gameId}/play?relayId=${relay!.id}`);
+    const sid = relay!.sessionId ?? "new";
+    navigate(`/games/${relay!.gameId}/play/${sid}?relayId=${relay!.id}`);
   }
 
   function handleDelete() {


### PR DESCRIPTION
## Summary

- Play route changed from `/games/:id/play` to `/games/:id/play/:sessionId` — no implicit session selection
- `useDefaultSession` hook removed — client explicitly picks session or passes "new"
- Session card Play buttons and game detail Resume button now navigate with explicit session IDs
- "Current" badge shown on the first (most recently played) session in both web and player app
- Sessions refetched after exiting play so the order stays up to date

## Test plan

- [ ] Web: `cd web && npx vitest run` (673 tests)
- [ ] Desktop: `player/run-desktop-tests.sh`
- [ ] Manual: game detail with multiple sessions shows "Current" on first one
- [ ] Manual: Resume navigates to `/games/:id/play/:sessionId` with correct session
- [ ] Manual: "New Session" + Play navigates to `/games/:id/play/new`