### PR TITLE
feat: add session duplication

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionsUiTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionsUiTest.kt
@@ -413,6 +413,35 @@ class SessionsUiTest {
         onNode(hasTestTag("session_member_avatars_s1"), useUnmergedTree = true).assertDoesNotExist()
     }
 
+    // ── Duplicate session creates a copy ──
+
+    @Test
+    fun duplicateSessionCreatesACopy() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "My Playthrough",
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+        onNodeWithText("(1)").assertIsDisplayed()
+
+        // Click the duplicate button
+        onNodeWithContentDescription("Duplicate session").performClick()
+        advance(harness)
+
+        // A new session should appear in the list
+        assertEquals(2, harness.sessionRepo.sessions.size)
+        assertEquals("My Playthrough (Copy)", harness.sessionRepo.sessions[1].name)
+        onNodeWithText("(2)").assertIsDisplayed()
+        onNodeWithText("My Playthrough (Copy)").assertIsDisplayed()
+    }
+
     // ── Member count overflow shows "+N" ──
 
     @Test

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1193,6 +1193,17 @@ class FakeSessionRepository : SessionRepository {
         return Result.success(config)
     }
 
+    override suspend fun duplicateSession(sessionId: String, name: String?): Result<GameSession> {
+        val original = sessions.find { it.id == sessionId }
+            ?: return Result.failure(Exception("Session not found"))
+        val newSession = original.copy(
+            id = "session-${nextId++}",
+            name = name ?: (original.name + " (Copy)"),
+        )
+        sessions.add(newSession)
+        return Result.success(newSession)
+    }
+
     fun preAddSession(
         id: String = "session-1",
         gameId: String = "1",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1065,6 +1065,14 @@ class SpelaApiClient(
         client.delete("$baseUrl/api/sessions/$sessionId")
     }
 
+    suspend fun duplicateSession(sessionId: String, name: String? = null): GameSessionDto {
+        return client.post("$baseUrl/api/sessions/$sessionId/duplicate") {
+            if (name != null) {
+                setBody(mapOf("name" to name))
+            }
+        }.body()
+    }
+
     suspend fun getSessionSaves(sessionId: String): List<SaveStateDto> {
         return client.get("$baseUrl/api/sessions/$sessionId/saves").body()
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -83,4 +83,8 @@ class SessionRepositoryImpl(
     ): Result<SessionCheatConfig> = runCatching {
         apiClient.updateSessionCheats(sessionId, cheatsEnabled, enabledIndices).toDomain()
     }
+
+    override suspend fun duplicateSession(sessionId: String, name: String?): Result<GameSession> = runCatching {
+        apiClient.duplicateSession(sessionId, name).toDomain()
+    }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -20,4 +20,5 @@ interface SessionRepository {
     suspend fun downloadSessionSram(sessionId: String): Result<ByteArray>
     suspend fun getSessionCheats(sessionId: String): Result<SessionCheatConfig>
     suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>): Result<SessionCheatConfig>
+    suspend fun duplicateSession(sessionId: String, name: String? = null): Result<GameSession>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
@@ -53,4 +53,5 @@ sealed interface GameDetailIntent {
     data class CreateSession(val gameId: String, val name: String) : GameDetailIntent
     data class RenameSession(val sessionId: String, val name: String) : GameDetailIntent
     data class DeleteSession(val sessionId: String) : GameDetailIntent
+    data class DuplicateSession(val sessionId: String) : GameDetailIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.People
@@ -55,6 +56,7 @@ internal fun SessionsSection(
     onCreateSession: (String) -> Unit,
     onRenameSession: (String, String) -> Unit,
     onDeleteSession: (String) -> Unit,
+    onDuplicateSession: (String) -> Unit,
     onSessionSelected: ((GameSession) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
@@ -100,6 +102,7 @@ internal fun SessionsSection(
                 onContinue = { onContinueSession(session) },
                 onRename = { showRenameDialog = session },
                 onDelete = { showDeleteDialog = session },
+                onDuplicate = { onDuplicateSession(session.id) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(vertical = SpSpacing.XXSmall),
@@ -220,6 +223,7 @@ private fun SessionItem(
     onContinue: () -> Unit,
     onRename: () -> Unit,
     onDelete: () -> Unit,
+    onDuplicate: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val isMultiplayer = session.memberCount > 1
@@ -302,6 +306,13 @@ private fun SessionItem(
             }
 
             Row {
+                IconButton(onClick = onDuplicate) {
+                    Icon(
+                        Icons.Filled.ContentCopy,
+                        contentDescription = "Duplicate session",
+                        tint = SpColor.OnBackgroundSecondary,
+                    )
+                }
                 IconButton(onClick = onRename) {
                     Icon(
                         Icons.Filled.Edit,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -241,6 +241,9 @@ fun GameDetailScreen(
                         onDeleteSession = { sessionId ->
                             viewModel.onIntent(GameDetailIntent.DeleteSession(sessionId))
                         },
+                        onDuplicateSession = { sessionId ->
+                            viewModel.onIntent(GameDetailIntent.DuplicateSession(sessionId))
+                        },
                         onSessionSelected = onNavigateToSession?.let { nav ->
                             { session -> nav(session.id) }
                         },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -109,6 +109,7 @@ class GameDetailViewModel(
             is GameDetailIntent.CreateSession -> createSession(intent.gameId, intent.name)
             is GameDetailIntent.RenameSession -> renameSession(intent.sessionId, intent.name)
             is GameDetailIntent.DeleteSession -> deleteSession(intent.sessionId)
+            is GameDetailIntent.DuplicateSession -> duplicateSession(intent.sessionId)
         }
     }
 
@@ -783,6 +784,25 @@ class GameDetailViewModel(
                         state.copy(
                             sessions = state.sessions.filter { it.id != sessionId },
                             successMessage = "Session deleted",
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun duplicateSession(sessionId: String) {
+        val repo = sessionRepository ?: return
+        scope.launch(dispatchers.io) {
+            repo.duplicateSession(sessionId).fold(
+                onSuccess = { newSession ->
+                    _state.update { state ->
+                        state.copy(
+                            sessions = state.sessions + newSession,
+                            successMessage = "Session duplicated as \"${newSession.name}\"",
                         )
                     }
                 },

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -181,6 +181,7 @@ private class FakePlayFromSharedSaveSessionRepository : SessionRepository {
     override suspend fun getSessionCheats(sessionId: String) = Result.success(SessionCheatConfig(false, emptyList()))
     override suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>) =
         Result.success(SessionCheatConfig(cheatsEnabled, enabledIndices))
+    override suspend fun duplicateSession(sessionId: String, name: String?) = Result.failure<GameSession>(Exception("stub"))
 }
 
 private class FakePlayFromSharedSaveSharedSaveRepository : SharedSaveRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -370,6 +370,7 @@ class StubSessionRepository : SessionRepository {
         Result.success(GameSession(id = "shared-session-1", gameId = gameId, name = "From shared save $saveId"))
     override suspend fun getSessionCheats(sessionId: String) = Result.success(SessionCheatConfig(false, emptyList()))
     override suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>) = Result.success(SessionCheatConfig(cheatsEnabled, enabledIndices))
+    override suspend fun duplicateSession(sessionId: String, name: String?) = Result.failure<GameSession>(Exception("stub"))
 }
 
 class StubChallengeRepository : ChallengeRepository {

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -258,6 +258,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.DELETE("/sessions/:id/play-time", sessionHandler.StopPlaying)
 		api.GET("/sessions/:id/cheats", sessionHandler.GetSessionCheats)
 		api.PUT("/sessions/:id/cheats", sessionHandler.UpdateSessionCheats)
+		api.POST("/sessions/:id/duplicate", sessionHandler.DuplicateSession)
 
 		// Ratings
 		api.POST("/games/:id/ratings", ratingHandler.CreateOrUpdateRating)

--- a/server/internal/api/session_handler.go
+++ b/server/internal/api/session_handler.go
@@ -344,6 +344,134 @@ func (h *SessionHandler) DeleteSession(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "session deleted"})
 }
 
+// DuplicateSession creates a copy of a session including saves, SRAM, and cheats.
+// POST /api/sessions/:id/duplicate
+func (h *SessionHandler) DuplicateSession(c *gin.Context) {
+	uid := getUserID(c)
+	sessionID := c.Param("id")
+	sid, err := strconv.ParseUint(sessionID, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid session ID"})
+		return
+	}
+
+	var session db.GameSession
+	if err := h.DB.Preload("Owner").First(&session, sid).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "session not found"})
+		return
+	}
+
+	// Access check: owner OR member of shared session that backs this session
+	if session.OwnerID != uid {
+		var count int64
+		h.DB.Model(&db.SharedSessionMember{}).
+			Joins("JOIN shared_sessions ON shared_sessions.id = shared_session_members.shared_session_id").
+			Where("shared_sessions.session_id = ? AND shared_session_members.user_id = ?", session.ID, uid).
+			Count(&count)
+		if count == 0 {
+			c.JSON(http.StatusForbidden, gin.H{"error": "not the session owner or a shared session member"})
+			return
+		}
+	}
+
+	var req struct {
+		Name string `json:"name"`
+	}
+	_ = c.ShouldBindJSON(&req)
+	if strings.TrimSpace(req.Name) == "" {
+		req.Name = session.Name + " (Copy)"
+	}
+	if len(req.Name) > 255 {
+		req.Name = req.Name[:255]
+	}
+
+	// Create new session owned by requesting user
+	newSession := db.GameSession{
+		OwnerID:       uid,
+		GameID:        session.GameID,
+		Name:          req.Name,
+		CoreName:      session.CoreName,
+		CheatsEnabled: session.CheatsEnabled,
+	}
+	if err := h.DB.Create(&newSession).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create session"})
+		return
+	}
+
+	// Copy save states
+	var saves []db.SessionSaveState
+	h.DB.Where("session_id = ?", session.ID).Find(&saves)
+	for _, save := range saves {
+		newPath := h.Storage.SessionSaveStatePath(newSession.ID, filepath.Base(save.FilePath))
+		if _, copyErr := h.Storage.CopyFile(save.FilePath, newPath); copyErr != nil {
+			continue // skip files that fail to copy
+		}
+		var screenshotURL string
+		if save.ScreenshotURL != "" {
+			dstSubpath := h.Storage.SessionScreenshotSubpath(newSession.ID, filepath.Base(save.ScreenshotURL))
+			if _, cpErr := h.Storage.CopyImageFile(save.ScreenshotURL, dstSubpath); cpErr == nil {
+				screenshotURL = dstSubpath
+			}
+		}
+		slot := save.Slot
+		newSave := db.SessionSaveState{
+			SessionID:     newSession.ID,
+			UserID:        uid,
+			Name:          save.Name,
+			FilePath:      newPath,
+			FileSize:      save.FileSize,
+			ScreenshotURL: screenshotURL,
+			IsAuto:        save.IsAuto,
+			CoreName:      save.CoreName,
+			Notes:         save.Notes,
+			Slot:          slot,
+		}
+		h.DB.Create(&newSave)
+	}
+
+	// Copy SRAM
+	var sram db.SessionSaveData
+	if err := h.DB.Where("session_id = ?", session.ID).First(&sram).Error; err == nil {
+		newSramPath := h.Storage.SessionSRAMPath(newSession.ID, filepath.Base(sram.FilePath))
+		if size, copyErr := h.Storage.CopyFile(sram.FilePath, newSramPath); copyErr == nil {
+			newSram := db.SessionSaveData{
+				SessionID: newSession.ID,
+				FilePath:  newSramPath,
+				FileSize:  size,
+			}
+			h.DB.Create(&newSram)
+		}
+	}
+
+	// Copy cheat settings
+	var cheats []db.SessionCheatSetting
+	h.DB.Where("session_id = ?", session.ID).Find(&cheats)
+	for _, cheat := range cheats {
+		newCheat := db.SessionCheatSetting{
+			SessionID:  newSession.ID,
+			CheatIndex: cheat.CheatIndex,
+			Enabled:    cheat.Enabled,
+		}
+		h.DB.Create(&newCheat)
+	}
+
+	// Copy session screenshot
+	if session.ScreenshotURL != "" {
+		dstSubpath := h.Storage.SessionScreenshotSubpath(newSession.ID, filepath.Base(session.ScreenshotURL))
+		if _, cpErr := h.Storage.CopyImageFile(session.ScreenshotURL, dstSubpath); cpErr == nil {
+			h.DB.Model(&newSession).Update("screenshot_url", dstSubpath)
+		}
+	}
+
+	h.DB.Preload("Owner").First(&newSession, newSession.ID)
+	var saveCount int64
+	h.DB.Model(&db.SessionSaveState{}).Where("session_id = ?", newSession.ID).Count(&saveCount)
+
+	resp := h.toSessionResponse(newSession, int(saveCount))
+	h.enrichWithSharedSessionData(&resp, newSession.ID)
+	c.JSON(http.StatusCreated, resp)
+}
+
 // ListSessionSaves lists all save states in a session.
 // GET /api/sessions/:id/saves
 func (h *SessionHandler) ListSessionSaves(c *gin.Context) {

--- a/server/internal/api/session_handler_test.go
+++ b/server/internal/api/session_handler_test.go
@@ -1150,3 +1150,214 @@ func TestSessionUpdatedOnSaveUpload(t *testing.T) {
 	assert.NotNil(t, resp["lastPlayedAt"])
 	assert.Equal(t, "snes9x", resp["coreName"])
 }
+
+// --- Duplicate Session ---
+
+func duplicateSession(t *testing.T, router http.Handler, token, sessionID string, body []byte) *httptest.ResponseRecorder {
+	t.Helper()
+	w := httptest.NewRecorder()
+	var req *http.Request
+	if body != nil {
+		req = httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/duplicate", bytes.NewReader(body))
+		req.Header.Set("Content-Type", "application/json")
+	} else {
+		req = httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/duplicate", nil)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	return w
+}
+
+func TestDuplicateSession_Basic(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Playthrough")
+	sessionID := created["id"].(string)
+
+	w := duplicateSession(t, env.router, env.token, sessionID, nil)
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "My Playthrough (Copy)", resp["name"])
+	assert.Equal(t, env.gameID, resp["gameId"])
+	assert.NotEqual(t, sessionID, resp["id"])
+}
+
+func TestDuplicateSession_CustomName(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "Original")
+	sessionID := created["id"].(string)
+
+	body, _ := json.Marshal(map[string]string{"name": "My Custom Copy"})
+	w := duplicateSession(t, env.router, env.token, sessionID, body)
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "My Custom Copy", resp["name"])
+}
+
+func TestDuplicateSession_CopiesSaves(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Upload saves to original session
+	w := uploadSessionSave(t, env.router, env.token, sessionID, "Save 1", []byte("save1"))
+	require.Equal(t, http.StatusCreated, w.Code)
+	w = uploadSessionSave(t, env.router, env.token, sessionID, "Save 2", []byte("save2"))
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Duplicate
+	w = duplicateSession(t, env.router, env.token, sessionID, nil)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(2), resp["saveCount"])
+
+	// List saves in the new session
+	newSessionID := resp["id"].(string)
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+newSessionID+"/saves", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var saves []map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &saves)
+	assert.Len(t, saves, 2)
+}
+
+func TestDuplicateSession_CopiesSRAM(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Upload SRAM
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	part, _ := writer.CreateFormFile("file", "save.srm")
+	part.Write([]byte("sram data content"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/sram", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Duplicate
+	w = duplicateSession(t, env.router, env.token, sessionID, nil)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	newSessionID := resp["id"].(string)
+
+	// Download SRAM from new session
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/sessions/"+newSessionID+"/sram", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, []byte("sram data content"), w.Body.Bytes())
+}
+
+func TestDuplicateSession_CopiesCheats(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Set cheats on original
+	body, _ := json.Marshal(map[string]interface{}{
+		"cheatsEnabled":  true,
+		"enabledIndices": []int{0, 2},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/sessions/"+sessionID+"/cheats", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", "application/json")
+	env.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Duplicate
+	w = duplicateSession(t, env.router, env.token, sessionID, nil)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, true, resp["cheatsEnabled"])
+	newSessionID := resp["id"].(string)
+
+	// Get cheats from new session
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/sessions/"+newSessionID+"/cheats", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var cheats map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &cheats)
+	assert.Equal(t, true, cheats["cheatsEnabled"])
+	indices := cheats["enabledIndices"].([]interface{})
+	assert.Len(t, indices, 2)
+	assert.Equal(t, float64(0), indices[0])
+	assert.Equal(t, float64(2), indices[1])
+}
+
+func TestDuplicateSession_NotOwner(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// User 2 tries to duplicate user 1's session
+	w := duplicateSession(t, env.router, env.token2, sessionID, nil)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestDuplicateSession_NotFound(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	w := duplicateSession(t, env.router, env.token, "9999", nil)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestDuplicateSession_SharedSessionMember(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+
+	token1 := registerAndGetToken(t, router)
+	token2 := createNonOwnerUser(t, router, token1, "user2", "user2@example.com", "password123")
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Test Game", FileName: "test.nes", FilePath: "/tmp/test.nes", FileSize: 100}
+	database.Create(&game)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	// User 1 creates a shared session (this auto-creates a backing game session)
+	shared := createSharedSession(t, router, token1, gameID, "Coop Run")
+	sharedSessionID := shared["id"].(string)
+
+	// Invite and accept user 2
+	inviteAndAcceptSharedSession(t, router, token1, token2, sharedSessionID, "user2")
+
+	// Find the backing session ID
+	backingSessionID := shared["sessionId"].(string)
+
+	// User 2 (member) duplicates the backing session
+	w := duplicateSession(t, router, token2, backingSessionID, nil)
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Contains(t, resp["name"], "(Copy)")
+}

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -497,6 +497,64 @@ func (s *Storage) WriteSessionScreenshot(sessionID uint, filename string, data i
 	return s.WriteImage(subpath, data)
 }
 
+// CopyFile copies a file from src to dst, creating parent directories as needed.
+// Returns the number of bytes copied.
+func (s *Storage) CopyFile(src, dst string) (int64, error) {
+	if err := s.validatePathInSaveDir(src); err != nil {
+		return 0, fmt.Errorf("source path invalid: %w", err)
+	}
+	return s.copyFileRaw(src, dst)
+}
+
+// CopyImageFile copies an image file from srcSubpath to dstSubpath (both relative to ImageDir).
+// Returns the number of bytes copied.
+func (s *Storage) CopyImageFile(srcSubpath, dstSubpath string) (int64, error) {
+	src := filepath.Join(s.ImageDir, srcSubpath)
+	dst := filepath.Join(s.ImageDir, dstSubpath)
+
+	absImageDir, err := filepath.Abs(s.ImageDir)
+	if err != nil {
+		return 0, fmt.Errorf("resolving image dir: %w", err)
+	}
+	for _, p := range []string{src, dst} {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return 0, fmt.Errorf("resolving path: %w", err)
+		}
+		if !strings.HasPrefix(abs, absImageDir+string(filepath.Separator)) {
+			return 0, fmt.Errorf("path outside image directory")
+		}
+	}
+
+	return s.copyFileRaw(src, dst)
+}
+
+// SessionScreenshotSubpath returns the subpath for a session screenshot without writing anything.
+func (s *Storage) SessionScreenshotSubpath(sessionID uint, filename string) string {
+	return fmt.Sprintf("save-screenshots/sessions/session_%d/%s", sessionID, sanitizeFilename(filename))
+}
+
+func (s *Storage) copyFileRaw(src, dst string) (int64, error) {
+	if err := os.MkdirAll(filepath.Dir(dst), 0700); err != nil {
+		return 0, fmt.Errorf("creating destination directory: %w", err)
+	}
+	in, err := os.Open(src)
+	if err != nil {
+		return 0, fmt.Errorf("opening source file: %w", err)
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return 0, fmt.Errorf("creating destination file: %w", err)
+	}
+	defer out.Close()
+	n, err := io.Copy(out, in)
+	if err != nil {
+		return 0, fmt.Errorf("copying file: %w", err)
+	}
+	return n, nil
+}
+
 // DeleteSessionDir removes an entire session's storage directory.
 func (s *Storage) DeleteSessionDir(sessionID uint) error {
 	dir := filepath.Join(s.SaveDir, "sessions", fmt.Sprintf("session_%d", sessionID))

--- a/web/src/features/sessions/components/__tests__/game-sessions.test.tsx
+++ b/web/src/features/sessions/components/__tests__/game-sessions.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/hooks/use-sessions", () => ({
   useCreateSession: vi.fn(),
   useRenameSession: vi.fn(),
   useDeleteSession: vi.fn(),
+  useDuplicateSession: vi.fn(),
 }));
 
 import {
@@ -28,12 +29,14 @@ import {
   useCreateSession,
   useRenameSession,
   useDeleteSession,
+  useDuplicateSession,
 } from "@/hooks/use-sessions";
 
 const mockUseGameSessions = useGameSessions as ReturnType<typeof vi.fn>;
 const mockUseCreateSession = useCreateSession as ReturnType<typeof vi.fn>;
 const mockUseRenameSession = useRenameSession as ReturnType<typeof vi.fn>;
 const mockUseDeleteSession = useDeleteSession as ReturnType<typeof vi.fn>;
+const mockUseDuplicateSession = useDuplicateSession as ReturnType<typeof vi.fn>;
 
 const mockSessions = [
   {
@@ -96,6 +99,11 @@ beforeEach(() => {
     isPending: false,
   });
   mockUseDeleteSession.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+    variables: undefined,
+  });
+  mockUseDuplicateSession.mockReturnValue({
     mutate: mockMutate,
     isPending: false,
     variables: undefined,

--- a/web/src/features/sessions/components/__tests__/session-card.test.tsx
+++ b/web/src/features/sessions/components/__tests__/session-card.test.tsx
@@ -24,6 +24,7 @@ const baseSession: GameSession = {
 const onContinue = vi.fn();
 const onRename = vi.fn();
 const onDelete = vi.fn();
+const onDuplicate = vi.fn();
 
 function renderCard(
   session: GameSession = baseSession,
@@ -40,7 +41,9 @@ function renderCard(
         onContinue={onContinue}
         onRename={onRename}
         onDelete={onDelete}
+        onDuplicate={onDuplicate}
         isDeleting={isDeleting}
+        isDuplicating={false}
       />
     </MemoryRouter>,
   );
@@ -250,5 +253,11 @@ describe("SessionCard", () => {
   it("does not show Current badge when isCurrent is undefined", () => {
     renderCard();
     expect(screen.queryByText("Current")).not.toBeInTheDocument();
+  });
+
+  it("calls onDuplicate when duplicate button clicked", () => {
+    renderCard();
+    fireEvent.click(screen.getByLabelText("Duplicate session"));
+    expect(onDuplicate).toHaveBeenCalledWith(baseSession);
   });
 });

--- a/web/src/features/sessions/components/game-sessions.tsx
+++ b/web/src/features/sessions/components/game-sessions.tsx
@@ -7,6 +7,7 @@ import {
   useCreateSession,
   useRenameSession,
   useDeleteSession,
+  useDuplicateSession,
 } from "@/hooks/use-sessions";
 import { useAuth } from "@/hooks/use-auth";
 import { SessionCard } from "./session-card";
@@ -43,6 +44,7 @@ export function GameSessions({ gameId }: GameSessionsProps) {
   const createSession = useCreateSession();
   const renameSession = useRenameSession();
   const deleteSession = useDeleteSession();
+  const duplicateSession = useDuplicateSession();
   const [showNewInput, setShowNewInput] = useState(false);
   const [newName, setNewName] = useState("");
 
@@ -65,6 +67,10 @@ export function GameSessions({ gameId }: GameSessionsProps) {
 
   function handleDelete(session: GameSession) {
     deleteSession.mutate({ id: session.id, gameId });
+  }
+
+  function handleDuplicate(session: GameSession) {
+    duplicateSession.mutate({ id: session.id, gameId });
   }
 
   function handleContinue(session: GameSession) {
@@ -163,9 +169,14 @@ export function GameSessions({ gameId }: GameSessionsProps) {
               onContinue={handleContinue}
               onRename={handleRename}
               onDelete={handleDelete}
+              onDuplicate={handleDuplicate}
               isDeleting={
                 deleteSession.isPending &&
                 deleteSession.variables?.id === session.id
+              }
+              isDuplicating={
+                duplicateSession.isPending &&
+                duplicateSession.variables?.id === session.id
               }
             />
           ))}

--- a/web/src/features/sessions/components/session-card.tsx
+++ b/web/src/features/sessions/components/session-card.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { Play, Pencil, Trash2, Clock, Users, Zap, Share2 } from "lucide-react";
+import { Play, Pencil, Trash2, Clock, Users, Zap, Share2, Copy } from "lucide-react";
 import { Button, ConfirmDeleteModal } from "@/components/ui";
 import { formatPlayTime, formatRelativeTime } from "@/lib/format";
 import type { GameSession } from "@/types/api";
@@ -12,7 +12,9 @@ interface SessionCardProps {
   onContinue: (session: GameSession) => void;
   onRename: (session: GameSession, name: string) => void;
   onDelete: (session: GameSession) => void;
+  onDuplicate: (session: GameSession) => void;
   isDeleting: boolean;
+  isDuplicating: boolean;
 }
 
 export function SessionCard({
@@ -22,7 +24,9 @@ export function SessionCard({
   onContinue,
   onRename,
   onDelete,
+  onDuplicate,
   isDeleting,
+  isDuplicating,
 }: SessionCardProps) {
   const [isEditing, setIsEditing] = useState(false);
   const [editName, setEditName] = useState(session.name);
@@ -170,6 +174,15 @@ export function SessionCard({
 
         {/* Actions */}
         <div className="flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onDuplicate(session)}
+            loading={isDuplicating}
+            aria-label="Duplicate session"
+          >
+            <Copy className="h-3.5 w-3.5" />
+          </Button>
           <Button
             variant="ghost"
             size="sm"

--- a/web/src/hooks/__tests__/use-sessions.test.ts
+++ b/web/src/hooks/__tests__/use-sessions.test.ts
@@ -7,6 +7,7 @@ import {
   useCreateSession,
   useRenameSession,
   useDeleteSession,
+  useDuplicateSession,
 } from "../use-sessions";
 
 vi.mock("@/lib/api-client", () => ({
@@ -157,5 +158,33 @@ describe("useDeleteSession", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(mockApi.delete).toHaveBeenCalledWith("/sessions/ses-1");
+  });
+});
+
+describe("useDuplicateSession", () => {
+  it("duplicates a session", async () => {
+    mockApi.post.mockResolvedValue({ ...mockSessions[0], id: "ses-2", name: "My Session (Copy)" });
+
+    const { result } = renderHook(() => useDuplicateSession(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ id: "ses-1", gameId: "g1" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.post).toHaveBeenCalledWith("/sessions/ses-1/duplicate", {});
+  });
+
+  it("duplicates a session with custom name", async () => {
+    mockApi.post.mockResolvedValue({ ...mockSessions[0], id: "ses-2", name: "Custom" });
+
+    const { result } = renderHook(() => useDuplicateSession(), {
+      wrapper: createWrapper(),
+    });
+
+    result.current.mutate({ id: "ses-1", gameId: "g1", name: "Custom" });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockApi.post).toHaveBeenCalledWith("/sessions/ses-1/duplicate", { name: "Custom" });
   });
 });

--- a/web/src/hooks/use-sessions.ts
+++ b/web/src/hooks/use-sessions.ts
@@ -98,6 +98,25 @@ export function useUpdateSessionCheats() {
   });
 }
 
+export function useDuplicateSession() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      id,
+      name,
+    }: {
+      id: string;
+      gameId: string;
+      name?: string;
+    }) =>
+      api.post<GameSession>(`/sessions/${id}/duplicate`, name ? { name } : {}),
+    onSuccess: (_, { gameId }) => {
+      queryClient.invalidateQueries({ queryKey: ["game-sessions", gameId] });
+    },
+  });
+}
+
 export function useDeleteSessionSave() {
   const queryClient = useQueryClient();
   return useMutation({

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -161,6 +161,7 @@ export type ApiPostPath = WithQuery<
   | `/sessions/${string}/saves/auto`
   | `/sessions/${string}/sram`
   | `/sessions/${string}/play-time`
+  | `/sessions/${string}/duplicate`
 
   // User
   | `/user/favorites/${string}`


### PR DESCRIPTION
## Summary
- Allow users to duplicate game sessions from the session list view (both web and player app)
- Creates a full copy of the session including save states, SRAM, cheat settings, and screenshots
- Session owners and shared session members can both duplicate
- New session appears immediately in the list with "(Copy)" suffix

## Changes
- **Backend**: `POST /api/sessions/:id/duplicate` endpoint with `CopyImageFile` storage helper
- **Web**: Duplicate button (copy icon) on session cards, `useDuplicateSession` hook
- **Player**: Duplicate icon button in SessionsSection, wired through ViewModel/Repository/API client

## Test plan
- [x] 8 Go tests: basic, custom name, copies saves/SRAM/cheats, auth (not owner, not found, shared member)
- [x] Web: `useDuplicateSession` hook tests, `SessionCard` duplicate button test, `GameSessions` mock updated
- [x] Player: Desktop E2E test `duplicateSessionCreatesACopy` verifies copy appears in list
- [x] Full Go test suite passes (410 tests)
- [x] Full web test suite passes (679 tests)  
- [x] Full player desktop test suite passes (427 tests)