### PR TITLE
fix: update emulator E2E tests for session-based play routing

### DIFF
--- a/web/e2e/emulator-real.spec.ts
+++ b/web/e2e/emulator-real.spec.ts
@@ -30,6 +30,8 @@ function monitorPageErrors(page: import("@playwright/test").Page) {
       if (response.status() === 404 && url.includes("/shared-saves")) return;
       // BIOS files may not be present in the E2E environment
       if (response.status() === 404 && url.includes("/api/bios/")) return;
+      // Session screenshots may not exist in E2E (no real saves)
+      if (url.includes("/save-screenshots/")) return;
       failedRequests.push(`${response.status()} ${url}`);
     }
   });
@@ -127,7 +129,7 @@ test.describe("EmulatorJS Real Integration", () => {
 
     // Click Play in Browser
     await page.getByTestId("play-in-browser-btn").click();
-    await expect(page).toHaveURL(`/games/${gameId}/play`);
+    await expect(page).toHaveURL(new RegExp(`/games/${gameId}/play/`));
 
     // Wait for the iframe to appear
     const iframe = page.locator('iframe[src="/emulator.html"]');
@@ -215,7 +217,7 @@ test.describe("EmulatorJS Real Integration", () => {
 
     // Click Play in Browser
     await page.getByTestId("play-in-browser-btn").click();
-    await expect(page).toHaveURL(`/games/${gameId}/play`);
+    await expect(page).toHaveURL(new RegExp(`/games/${gameId}/play/`));
 
     // Wait for the iframe to appear
     await expect(page.locator('iframe[src="/emulator.html"]')).toBeVisible({
@@ -225,16 +227,17 @@ test.describe("EmulatorJS Real Integration", () => {
     // Simulate game-started (WASM may not fully start in headless Chrome)
     await simulatePlaying(page);
 
-    // Intercept the auto-save POST so we can verify it was called
+    // Intercept the auto-save POST so we can verify it was called.
+    // Saves are now session-scoped: POST /api/sessions/:sessionId/saves/auto
     let autoSaveCalled = false;
-    await page.route(`**/api/games/${gameId}/saves/auto`, (route) => {
+    await page.route("**/api/sessions/*/saves/auto", (route) => {
       if (route.request().method() === "POST") {
         autoSaveCalled = true;
         route.fulfill({
           status: 201,
           json: {
             id: 99,
-            gameId: parseInt(gameId!),
+            sessionId: "1",
             userId: 1,
             name: "auto",
             fileSize: 1024,
@@ -279,7 +282,7 @@ test.describe("EmulatorJS Real Integration", () => {
     monitor.assertClean();
   });
 
-  test("save and load buttons become enabled after game starts", async ({
+  test("save button becomes enabled after game starts", async ({
     page,
   }) => {
     const monitor = monitorPageErrors(page);
@@ -292,23 +295,21 @@ test.describe("EmulatorJS Real Integration", () => {
     const gameId = page.url().match(/\/games\/(\d+)$/)?.[1];
     expect(gameId).toBeTruthy();
 
-    await page.goto(`/games/${gameId}/play`);
+    await page.goto(`/games/${gameId}/play/new`);
 
     // Wait for iframe
     await expect(page.locator('iframe[src="/emulator.html"]')).toBeVisible({
       timeout: 15_000,
     });
 
-    // Save/Load should be disabled initially
+    // Save should be disabled initially
     const saveButton = page.getByTitle("Save State");
-    const loadButton = page.getByTitle("Load State");
     await expect(saveButton).toBeVisible({ timeout: 15_000 });
     await expect(saveButton).toBeDisabled();
-    await expect(loadButton).toBeDisabled();
 
     // Simulate game-started (WASM may not fully start in headless Chrome)
     await simulatePlaying(page);
-    await expect(loadButton).toBeEnabled({ timeout: 5_000 });
+    await expect(saveButton).toBeEnabled({ timeout: 5_000 });
 
     // Verify no unexpected errors occurred
     monitor.assertClean();

--- a/web/e2e/emulator-saves.spec.ts
+++ b/web/e2e/emulator-saves.spec.ts
@@ -91,15 +91,15 @@ test.describe("Emulator Save State Sync", () => {
 
       const gameId = await navigateToPlayPage(page);
 
-      // Intercept auto-save uploads to track them
+      // Intercept session-scoped auto-save uploads to track them
       const autoSaveRequests: string[] = [];
-      await page.route(`**/api/games/${gameId}/saves/auto`, (route) => {
+      await page.route("**/api/sessions/*/saves/auto", (route) => {
         autoSaveRequests.push(route.request().method());
         route.fulfill({
           status: 200,
           json: {
             id: 1,
-            gameId: parseInt(gameId),
+            sessionId: "1",
             userId: 1,
             name: "Auto Save",
             fileSize: 1024,
@@ -110,7 +110,7 @@ test.describe("Emulator Save State Sync", () => {
         });
       });
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/new`);
       await expect(page.locator('iframe[src="/emulator.html"]')).toBeVisible({
         timeout: 15_000,
       });
@@ -170,9 +170,20 @@ test.describe("Emulator Save State Sync", () => {
 
       const gameId = await navigateToPlayPage(page);
 
-      // Intercept auto-save download to track if it's fetched
+      // Create a session first so we have a real session ID (auto-load is
+      // skipped for fresh sessions created via /play/new)
+      let sessionId: string | undefined;
+      const sessionCreatePromise = page.waitForResponse(
+        (resp) => resp.url().includes(`/api/games/${gameId}/sessions`) && resp.request().method() === "POST",
+      );
+      await page.goto(`/games/${gameId}/play/new`);
+      const createResp = await sessionCreatePromise;
+      const sessionData = await createResp.json();
+      sessionId = sessionData.id;
+
+      // Now navigate to the play page with the real session ID so auto-load triggers
       let autoLoadRequested = false;
-      await page.route(`**/api/games/${gameId}/saves/auto`, (route) => {
+      await page.route("**/api/sessions/*/saves/auto", (route) => {
         if (route.request().method() === "GET") {
           autoLoadRequested = true;
           // Return a fake save state
@@ -188,7 +199,7 @@ test.describe("Emulator Save State Sync", () => {
         }
       });
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/${sessionId}`);
       await expect(page.locator('iframe[src="/emulator.html"]')).toBeVisible({
         timeout: 15_000,
       });
@@ -225,15 +236,24 @@ test.describe("Emulator Save State Sync", () => {
 
       const gameId = await navigateToPlayPage(page);
 
+      // Create a session first so we have a real session ID
+      const sessionCreatePromise = page.waitForResponse(
+        (resp) => resp.url().includes(`/api/games/${gameId}/sessions`) && resp.request().method() === "POST",
+      );
+      await page.goto(`/games/${gameId}/play/new`);
+      const createResp = await sessionCreatePromise;
+      const sessionData = await createResp.json();
+      const sessionId = sessionData.id;
+
       let autoLoadRequested = false;
-      await page.route(`**/api/games/${gameId}/saves/auto`, (route) => {
+      await page.route("**/api/sessions/*/saves/auto", (route) => {
         if (route.request().method() === "GET") {
           autoLoadRequested = true;
         }
         route.continue();
       });
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/${sessionId}`);
       await expect(page.locator('iframe[src="/emulator.html"]')).toBeVisible({
         timeout: 15_000,
       });
@@ -251,9 +271,10 @@ test.describe("Emulator Save State Sync", () => {
     }) => {
       const gameId = await navigateToPlayPage(page);
 
-      // Intercept manual save uploads with a delay so "Saving..." indicator is visible
+      // Intercept session-scoped save uploads with a delay so "Saving..." indicator is visible
       let manualSaveUploaded = false;
-      await page.route(`**/api/games/${gameId}/saves`, async (route) => {
+      await page.route("**/api/sessions/*/saves", async (route) => {
+        if (route.request().url().includes("/saves/auto")) return route.continue();
         if (route.request().method() === "POST") {
           manualSaveUploaded = true;
           await new Promise((r) => setTimeout(r, 1_500));
@@ -261,7 +282,7 @@ test.describe("Emulator Save State Sync", () => {
             status: 201,
             json: {
               id: 42,
-              gameId: parseInt(gameId),
+              sessionId: "1",
               userId: 1,
               name: "save",
               fileSize: 2048,
@@ -275,7 +296,7 @@ test.describe("Emulator Save State Sync", () => {
         }
       });
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/new`);
       await expect(page.locator('iframe[src="/emulator.html"]')).toBeVisible({
         timeout: 15_000,
       });
@@ -307,95 +328,6 @@ test.describe("Emulator Save State Sync", () => {
       expect(manualSaveUploaded).toBe(true);
     });
 
-    test("load state modal shows save list and allows loading", async ({
-      page,
-    }) => {
-      const gameId = await navigateToPlayPage(page);
-
-      const mockSaves = [
-        {
-          id: 1,
-          gameId: parseInt(gameId),
-          userId: 1,
-          name: "Before Boss Fight",
-          fileSize: 4096,
-          isAuto: false,
-          createdAt: "2025-01-15T12:00:00Z",
-          updatedAt: "2025-01-15T12:00:00Z",
-        },
-        {
-          id: 2,
-          gameId: parseInt(gameId),
-          userId: 1,
-          name: "Auto Save",
-          fileSize: 4096,
-          isAuto: true,
-          createdAt: "2025-01-16T08:30:00Z",
-          updatedAt: "2025-01-16T08:30:00Z",
-        },
-      ];
-
-      await page.route(`**/api/games/${gameId}/saves`, (route) => {
-        if (route.request().method() === "GET") {
-          route.fulfill({ json: mockSaves });
-        } else {
-          route.continue();
-        }
-      });
-
-      // Intercept save state download
-      let loadedSaveId: string | null = null;
-      await page.route(`**/api/games/${gameId}/saves/*`, (route) => {
-        if (route.request().method() === "GET") {
-          const url = route.request().url();
-          const match = url.match(/\/saves\/(\d+)$/);
-          if (match) {
-            loadedSaveId = match[1];
-            route.fulfill({
-              status: 200,
-              body: Buffer.from("loaded-save-state-data"),
-              headers: { "Content-Type": "application/octet-stream" },
-            });
-          } else {
-            route.continue();
-          }
-        } else {
-          route.continue();
-        }
-      });
-
-      await page.goto(`/games/${gameId}/play`);
-      await expect(page.locator('iframe[src="/emulator.html"]')).toBeVisible({
-        timeout: 15_000,
-      });
-
-      // Simulate playing state
-      await simulatePlaying(page);
-
-      // Open load modal
-      await page.getByTitle("Load State").click();
-
-      // Modal should show the save list
-      await expect(page.getByText("Load Save State")).toBeVisible({
-        timeout: 3_000,
-      });
-      await expect(page.getByText("Before Boss Fight")).toBeVisible();
-      await expect(page.getByText("Auto Save")).toBeVisible();
-      // Auto badge should be visible on the auto-save entry
-      await expect(page.getByText("Auto").first()).toBeVisible();
-
-      // Click on "Before Boss Fight" to load it
-      await page.getByText("Before Boss Fight").click();
-
-      // Modal should close
-      await expect(page.getByText("Load Save State")).not.toBeVisible({
-        timeout: 3_000,
-      });
-
-      // Wait for the save download
-      await page.waitForTimeout(1_000);
-      expect(loadedSaveId).toBe("1");
-    });
   });
 
   test.describe("Screenshot Upload", () => {
@@ -404,19 +336,20 @@ test.describe("Emulator Save State Sync", () => {
     }) => {
       const gameId = await navigateToPlayPage(page);
 
-      // Intercept save uploads
-      await page.route(`**/api/games/${gameId}/saves`, async (route) => {
+      // Intercept session-scoped save uploads
+      await page.route("**/api/sessions/*/saves", async (route) => {
+        if (route.request().url().includes("/saves/auto")) return route.continue();
         if (route.request().method() === "POST") {
           route.fulfill({
             status: 201,
             json: {
               id: 50,
-              gameId: parseInt(gameId),
+              sessionId: "1",
               userId: 1,
               name: "save",
               fileSize: 2048,
               isAuto: false,
-              screenshotUrl: "/images/save-screenshots/user_1/game_1/screenshot.png",
+              screenshotUrl: "/images/save-screenshots/sessions/session_1/screenshot.png",
               createdAt: new Date().toISOString(),
               updatedAt: new Date().toISOString(),
             },
@@ -426,7 +359,7 @@ test.describe("Emulator Save State Sync", () => {
         }
       });
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/new`);
       await expect(page.locator('iframe[src="/emulator.html"]')).toBeVisible({
         timeout: 15_000,
       });
@@ -481,13 +414,14 @@ test.describe("Emulator Save State Sync", () => {
     }) => {
       const gameId = await navigateToPlayPage(page);
 
-      await page.route(`**/api/games/${gameId}/saves`, async (route) => {
+      await page.route("**/api/sessions/*/saves", async (route) => {
+        if (route.request().url().includes("/saves/auto")) return route.continue();
         if (route.request().method() === "POST") {
           route.fulfill({
             status: 201,
             json: {
               id: 51,
-              gameId: parseInt(gameId),
+              sessionId: "1",
               userId: 1,
               name: "save",
               fileSize: 2048,
@@ -501,7 +435,7 @@ test.describe("Emulator Save State Sync", () => {
         }
       });
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/new`);
       await expect(page.locator('iframe[src="/emulator.html"]')).toBeVisible({
         timeout: 15_000,
       });
@@ -551,7 +485,7 @@ test.describe("Emulator Save State Sync", () => {
     }) => {
       const gameId = await navigateToPlayPage(page);
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/new`);
       await expect(
         page.locator('iframe[src="/emulator.html"]'),
       ).toBeVisible({ timeout: 15_000 });
@@ -582,8 +516,9 @@ test.describe("Emulator Save State Sync", () => {
     }) => {
       const gameId = await navigateToPlayPage(page);
 
-      // Slow down the save endpoint to keep the saving indicator visible
-      await page.route(`**/api/games/${gameId}/saves`, async (route) => {
+      // Slow down the session-scoped save endpoint to keep the saving indicator visible
+      await page.route("**/api/sessions/*/saves", async (route) => {
+        if (route.request().url().includes("/saves/auto")) return route.continue();
         if (route.request().method() === "POST") {
           // Delay response to keep saving indicator visible
           await new Promise((r) => setTimeout(r, 2_000));
@@ -591,7 +526,7 @@ test.describe("Emulator Save State Sync", () => {
             status: 201,
             json: {
               id: 99,
-              gameId: parseInt(gameId),
+              sessionId: "1",
               userId: 1,
               name: "save",
               fileSize: 1024,
@@ -605,7 +540,7 @@ test.describe("Emulator Save State Sync", () => {
         }
       });
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/new`);
       await expect(page.locator('iframe[src="/emulator.html"]')).toBeVisible({
         timeout: 15_000,
       });

--- a/web/e2e/emulator.spec.ts
+++ b/web/e2e/emulator.spec.ts
@@ -46,7 +46,7 @@ test.describe("Emulator Page", () => {
       expect(gameId).toBeTruthy();
 
       await page.getByTestId("play-in-browser-btn").click();
-      await expect(page).toHaveURL(`/games/${gameId}/play`);
+      await expect(page).toHaveURL(new RegExp(`/games/${gameId}/play/`));
     });
   });
 
@@ -63,8 +63,8 @@ test.describe("Emulator Page", () => {
       const gameId = page.url().match(/\/games\/(\d+)$/)?.[1];
       expect(gameId).toBeTruthy();
 
-      // Navigate to the play page
-      await page.goto(`/games/${gameId}/play`);
+      // Navigate to the play page (use "new" to auto-create a session)
+      await page.goto(`/games/${gameId}/play/new`);
 
       // Game title should be displayed in the top bar
       await expect(page.getByText("Castlevania", { exact: false })).toBeVisible(
@@ -78,10 +78,9 @@ test.describe("Emulator Page", () => {
         page.getByRole("button", { name: "Back", exact: true }),
       ).toBeVisible();
 
-      // Toolbar buttons should be present (Save, Load, Fullscreen)
+      // Toolbar buttons should be present (Save, Fullscreen)
       await expect(page.getByTitle("Save State")).toBeVisible();
-      await expect(page.getByTitle("Load State")).toBeVisible();
-      await expect(page.getByTitle("Fullscreen")).toBeVisible();
+      await expect(page.getByTitle("Fullscreen (F11)")).toBeVisible();
     });
 
     test("shows emulator iframe", async ({ page }) => {
@@ -92,7 +91,7 @@ test.describe("Emulator Page", () => {
       await page.getByText("Castlevania", { exact: false }).first().click();
       const gameId = page.url().match(/\/games\/(\d+)$/)?.[1];
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/new`);
 
       // The iframe hosting EmulatorJS should be present
       const iframe = page.locator('iframe[src="/emulator.html"]');
@@ -111,7 +110,7 @@ test.describe("Emulator Page", () => {
       await page.getByText("Castlevania", { exact: false }).first().click();
       const gameId = page.url().match(/\/games\/(\d+)$/)?.[1];
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/new`);
 
       // Wait for the page to finish loading game data first
       await expect(
@@ -154,7 +153,7 @@ test.describe("Emulator Page", () => {
       await page.getByText("Castlevania", { exact: false }).first().click();
       const gameId = page.url().match(/\/games\/(\d+)$/)?.[1];
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/new`);
 
       // Wait for the page to be ready (use exact match to avoid matching "Back to Game")
       await expect(
@@ -197,7 +196,7 @@ test.describe("Emulator Page", () => {
       await expect(page).toHaveURL(/\/games\/\d+$/);
       const gameId = page.url().match(/\/games\/(\d+)$/)?.[1];
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/new`);
 
       await expect(page.getByText("Browser Play Not Available")).toBeVisible({
         timeout: 15_000,
@@ -248,7 +247,7 @@ test.describe("Emulator Page", () => {
   });
 
   test.describe("Toolbar Controls", () => {
-    test("save and load buttons are disabled before emulator is playing", async ({
+    test("save button is disabled before emulator is playing", async ({
       page,
     }) => {
       await page.goto("/games");
@@ -258,73 +257,19 @@ test.describe("Emulator Page", () => {
       await page.getByText("Castlevania", { exact: false }).first().click();
       const gameId = page.url().match(/\/games\/(\d+)$/)?.[1];
 
-      await page.goto(`/games/${gameId}/play`);
+      await page.goto(`/games/${gameId}/play/new`);
 
-      // Before the emulator is fully loaded and playing, save/load should be disabled
+      // Before the emulator is fully loaded and playing, save should be disabled
       const saveButton = page.getByTitle("Save State");
-      const loadButton = page.getByTitle("Load State");
 
       await expect(saveButton).toBeVisible({ timeout: 15_000 });
       await expect(saveButton).toBeDisabled();
-      await expect(loadButton).toBeDisabled();
-    });
-
-    test("load state modal shows empty state when no saves exist", async ({
-      page,
-    }) => {
-      await page.goto("/games");
-      await page.getByPlaceholder(/search/i).fill("Castlevania");
-      await page.keyboard.press("Enter");
-
-      await page.getByText("Castlevania", { exact: false }).first().click();
-      const gameId = page.url().match(/\/games\/(\d+)$/)?.[1];
-
-      // Simulate the emulator being in "playing" state by intercepting postMessage
-      // Instead, we can enable the Load button by sending a game-started message
-      // from the iframe. Since we can't easily do that in E2E, we test the modal
-      // via a more direct route: route the game saves API to return empty.
-      await page.route(`**/api/games/${gameId}/saves`, (route) => {
-        route.fulfill({ json: [] });
-      });
-
-      // Simulate the playing state by posting a message from within the page
-      await page.goto(`/games/${gameId}/play`);
-      await expect(page.locator('iframe[src="/emulator.html"]')).toBeVisible({
-        timeout: 15_000,
-      });
-
-      // Send game-started messages continuously until the button enables.
-      // initEmulator() resets status to "loading", so a single message can
-      // lose the race — we keep sending until the effect has settled.
-      const loadButton = page.getByTitle("Load State");
-      const interval = setInterval(async () => {
-        await page
-          .evaluate(() => {
-            window.postMessage(
-              { type: "game-started" },
-              window.location.origin,
-            );
-          })
-          .catch(() => {});
-      }, 200);
-
-      try {
-        await expect(loadButton).toBeEnabled({ timeout: 15_000 });
-      } finally {
-        clearInterval(interval);
-      }
-
-      await loadButton.click();
-
-      // The modal should show "No save states available"
-      await expect(page.getByText("Load Save State")).toBeVisible();
-      await expect(page.getByText(/no save states available/i)).toBeVisible();
     });
   });
 
   test.describe("Game Not Found", () => {
     test("shows not found message for invalid game ID", async ({ page }) => {
-      await page.goto("/games/999999/play");
+      await page.goto("/games/999999/play/new");
 
       await expect(page.getByText("Game not found")).toBeVisible({
         timeout: 15_000,


### PR DESCRIPTION
## Summary

- Update emulator E2E tests to use session-based play URL (`/games/:id/play/:sessionId` instead of `/games/:id/play`)
- Replace game-scoped save endpoint mocks (`/api/games/:id/saves`) with session-scoped ones (`/api/sessions/:id/saves`)
- Remove Load State button tests (button was removed from toolbar in earlier PR)
- Fix auto-load tests to create a real session first (fresh starts via `/play/new` skip auto-load by design)

## Test plan

- [x] All 24 emulator E2E tests pass (`emulator.spec.ts`, `emulator-real.spec.ts`, `emulator-saves.spec.ts`)
- [x] Full E2E suite: 151 passed, 9 failed (all 9 failures are pre-existing and unrelated — challenges, key-mapping, netplay, social-features, registration-approval)