### PR TITLE
feat: add Top Lists page with play stats

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -330,6 +330,12 @@ class SpelaTestHarness(
         scope = scope,
     )
 
+    val topListsViewModel = TopListsViewModel(
+        gameRepository = gameRepo,
+        dispatchers = dispatchers,
+        scope = scope,
+    )
+
     @Composable
     fun App() {
         androidx.compose.runtime.CompositionLocalProvider(
@@ -360,6 +366,7 @@ class SpelaTestHarness(
             presenceService = presenceService,
             connectivityMonitor = connectivityMonitor,
             sessionDetailViewModel = sessionDetailViewModel,
+            topListsViewModel = topListsViewModel,
             gamepadPortManager = gamepadPortManager,
         )
         }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -362,6 +362,13 @@ class FakeGameRepository : GameRepository {
         else Result.success(globalTopRatedGames)
     }
 
+    var topListGames: List<TopListGame> = emptyList()
+
+    override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> {
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(topListGames)
+    }
+
     var similarGames: List<SimilarGame> = emptyList()
     var developerGamesMap: Map<String, List<DeveloperGame>> = emptyMap()
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TopListsUiTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TopListsUiTest.kt
@@ -1,0 +1,113 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.TopListGame
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for the Top Lists screen.
+ *
+ * Covers:
+ * - Screen renders with games
+ * - Empty state when no games
+ * - Game items show rank, name, console, and rating
+ * - Tapping a game navigates to game detail
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class TopListsUiTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private val sampleGames = listOf(
+        TopListGame(rank = 1, gameId = "42", name = "Super Mario World", coverUrl = null, consoleName = "SNES", consoleId = "snes", rating = 92.5),
+        TopListGame(rank = 2, gameId = "99", name = "The Legend of Zelda", coverUrl = null, consoleName = "NES", consoleId = "nes", rating = 91.0),
+        TopListGame(rank = 3, gameId = "55", name = "Chrono Trigger", coverUrl = null, consoleName = "SNES", consoleId = "snes", rating = 90.3),
+    )
+
+    @Test
+    fun topListsScreenRendersGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.gameRepo.topListGames = sampleGames
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.TopLists))
+        advance(harness)
+
+        onNodeWithTag("top_lists_screen").assertIsDisplayed()
+        onNodeWithText("Top Lists").assertIsDisplayed()
+        onNodeWithText("Super Mario World").assertIsDisplayed()
+        onNodeWithText("The Legend of Zelda").assertIsDisplayed()
+        onNodeWithText("Chrono Trigger").assertIsDisplayed()
+    }
+
+    @Test
+    fun topListsScreenShowsEmptyState() = runComposeUiTest {
+        val harness = createHarness()
+        harness.gameRepo.topListGames = emptyList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.TopLists))
+        advance(harness)
+
+        onNodeWithTag("top_lists_screen").assertIsDisplayed()
+        onNodeWithTag("top_lists_empty").assertIsDisplayed()
+        onNodeWithText("No top rated games yet").assertIsDisplayed()
+    }
+
+    @Test
+    fun topListsShowsConsoleNames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.gameRepo.topListGames = listOf(
+            TopListGame(rank = 1, gameId = "42", name = "Super Mario World", consoleName = "SNES", consoleId = "snes", rating = 92.5),
+            TopListGame(rank = 2, gameId = "99", name = "Mega Man 2", consoleName = "Game Boy", consoleId = "gb", rating = 88.0),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.TopLists))
+        advance(harness)
+
+        // Each game has a unique console name
+        onNodeWithText("SNES").assertExists()
+        onNodeWithText("Game Boy").assertExists()
+    }
+
+    @Test
+    fun topListsShowsRatings() = runComposeUiTest {
+        val harness = createHarness()
+        harness.gameRepo.topListGames = sampleGames
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.TopLists))
+        advance(harness)
+
+        onNodeWithText("92.5").assertExists()
+        onNodeWithText("91.0").assertExists()
+        onNodeWithText("90.3").assertExists()
+    }
+
+    @Test
+    fun tappingGameNavigatesToGameDetail() = runComposeUiTest {
+        val harness = createHarness()
+        harness.gameRepo.topListGames = sampleGames
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.TopLists))
+        advance(harness)
+
+        onNodeWithTag("top_list_item_42").performClick()
+        advance(harness)
+
+        // Should navigate to game detail for game ID 42
+        val navState = harness.navigationViewModel.state.value
+        assertEquals(SpScreen.GameDetail("42"), navState.currentScreen)
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -215,6 +215,10 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/top-rated").body()
     }
 
+    suspend fun getTopRatedAvailable(): List<TopListGameDto> {
+        return client.get("$baseUrl/api/top-lists/top-rated").body()
+    }
+
     suspend fun getSimilarGames(gameId: String): List<SimilarGameDto> {
         return client.get("$baseUrl/api/games/$gameId/similar").body()
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -481,6 +481,16 @@ fun NetplaySessionDto.toDomain(): NetplaySession = NetplaySession(
     endedAt = endedAt,
 )
 
+fun TopListGameDto.toDomain(): TopListGame = TopListGame(
+    rank = rank,
+    gameId = gameId,
+    name = name,
+    coverUrl = coverUrl,
+    consoleName = consoleName,
+    consoleId = consoleId,
+    rating = rating,
+)
+
 fun TopRatedGameDto.toDomain(): TopRatedGame = TopRatedGame(
     rank = rank,
     name = name,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -890,6 +890,19 @@ data class TopRatedGameDto(
     val localGameId: String? = null,
 )
 
+// Top Lists
+
+@Serializable
+data class TopListGameDto(
+    val rank: Int,
+    val gameId: String,
+    val name: String,
+    val coverUrl: String? = null,
+    val consoleName: String = "",
+    val consoleId: String = "",
+    val rating: Double = 0.0,
+)
+
 // Similar Games
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameDetail
 import com.spela.player.domain.model.DeveloperGame
 import com.spela.player.domain.model.SimilarGame
+import com.spela.player.domain.model.TopListGame
 import com.spela.player.domain.model.TopRatedGame
 import com.spela.player.domain.repository.GameRepository
 import kotlin.time.Clock
@@ -139,6 +140,12 @@ class GameRepositoryImpl(
     override suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>> {
         return runCatching {
             apiClient.getTopRatedGamesGlobal().map { it.toDomain() }
+        }
+    }
+
+    override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> {
+        return runCatching {
+            apiClient.getTopRatedAvailable().map { it.toDomain() }
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -315,6 +315,14 @@ val commonModule = module {
         )
     }
 
+    factory {
+        TopListsViewModel(
+            gameRepository = get(),
+            dispatchers = get(),
+            scope = get(),
+        )
+    }
+
     /* Navigation & UI ViewModels */
     single {
         NavigationViewModel(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -590,6 +590,18 @@ data class TopRatedGame(
     val localGameId: String? = null,
 )
 
+// Top Lists
+
+data class TopListGame(
+    val rank: Int,
+    val gameId: String,
+    val name: String,
+    val coverUrl: String? = null,
+    val consoleName: String = "",
+    val consoleId: String = "",
+    val rating: Double = 0.0,
+)
+
 // Similar Games
 
 data class SimilarGame(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/GameRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/GameRepository.kt
@@ -5,6 +5,7 @@ import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameDetail
 import com.spela.player.domain.model.DeveloperGame
 import com.spela.player.domain.model.SimilarGame
+import com.spela.player.domain.model.TopListGame
 import com.spela.player.domain.model.TopRatedGame
 
 interface GameRepository {
@@ -27,6 +28,7 @@ interface GameRepository {
     suspend fun removeFromPlayLater(gameId: String): Result<Unit>
     suspend fun getTopRatedGames(consoleId: String): Result<List<TopRatedGame>>
     suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>>
+    suspend fun getTopRatedAvailable(): Result<List<TopListGame>>
     suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>>
     suspend fun getDeveloperGames(gameId: String): Result<List<DeveloperGame>>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/TopListsIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/TopListsIntent.kt
@@ -1,0 +1,6 @@
+package com.spela.player.presentation.intent
+
+sealed interface TopListsIntent {
+    data object LoadTopLists : TopListsIntent
+    data object DismissError : TopListsIntent
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -27,6 +27,7 @@ sealed class SpScreen(val route: String) {
     data class ChallengeList(val gameId: String, val gameTitle: String) : SpScreen("challenges/$gameId")
     data class ChallengeDetail(val challengeId: String) : SpScreen("challenge/$challengeId")
     data class SessionDetail(val sessionId: String) : SpScreen("sessions/$sessionId")
+    data object TopLists : SpScreen("top_lists")
 }
 
 data class NavigationState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/TopListsState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/TopListsState.kt
@@ -1,0 +1,9 @@
+package com.spela.player.presentation.state
+
+import com.spela.player.domain.model.TopListGame
+
+data class TopListsState(
+    val games: List<TopListGame> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -92,6 +92,7 @@ import com.spela.player.presentation.ui.screen.ChallengeDetailScreen
 import com.spela.player.presentation.ui.screen.ChallengeListScreen
 import com.spela.player.presentation.ui.screen.GlobalChallengesScreen
 import com.spela.player.presentation.ui.screen.StatsScreen
+import com.spela.player.presentation.ui.screen.TopListsScreen
 import com.spela.player.presentation.ui.screen.UserProfileScreen
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -121,6 +122,7 @@ import com.spela.player.presentation.viewmodel.CollectionsViewModel
 import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
 import com.spela.player.presentation.viewmodel.SocialViewModel
 import com.spela.player.presentation.viewmodel.StatsViewModel
+import com.spela.player.presentation.viewmodel.TopListsViewModel
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.ui.components.SpSectionIndicator
 
@@ -150,6 +152,7 @@ fun SpelaApp(
     presenceService: PresenceService,
     connectivityMonitor: ConnectivityMonitor,
     sessionDetailViewModel: SessionDetailViewModel? = null,
+    topListsViewModel: TopListsViewModel? = null,
     navigationEventBus: NavigationEventBus? = null,
     gamepadPortManager: GamepadPortManager? = null,
 ) {
@@ -874,6 +877,22 @@ fun SpelaApp(
                                             )
                                         },
                                         onDeleted = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.TopLists -> {
+                                if (topListsViewModel != null) {
+                                    TopListsScreen(
+                                        viewModel = topListsViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onBack = {
                                             navigationViewModel.onIntent(NavigationIntent.GoBack)
                                         },
                                     )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/TopListsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/TopListsScreen.kt
@@ -1,0 +1,215 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.EmojiEvents
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.TopListGame
+import com.spela.player.presentation.intent.TopListsIntent
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.feature.stats.RankBadge
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.TopListsViewModel
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun TopListsScreen(
+    viewModel: TopListsViewModel,
+    onGameSelected: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.onIntent(TopListsIntent.LoadTopLists)
+    }
+
+    Box(modifier = Modifier.fillMaxSize().testTag("top_lists_screen")) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = "Top Lists",
+                showBack = true,
+                onBack = onBack,
+            )
+
+            if (state.isLoading && state.games.isEmpty()) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    SpLoadingIndicator(message = "Loading top lists...")
+                }
+            } else {
+                PullToRefreshBox(
+                    isRefreshing = state.isLoading,
+                    onRefresh = { viewModel.onIntent(TopListsIntent.LoadTopLists) },
+                    modifier = Modifier.fillMaxSize(),
+                ) {
+                    if (state.games.isEmpty() && !state.isLoading) {
+                        Box(
+                            modifier = Modifier.fillMaxSize().testTag("top_lists_empty"),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            SpEmptyState(
+                                icon = Icons.Filled.EmojiEvents,
+                                title = "No top rated games yet",
+                                message = "Top rated games from your library will appear here",
+                            )
+                        }
+                    } else {
+                        LazyColumn(
+                            modifier = Modifier.fillMaxSize().testTag("top_lists_content"),
+                            contentPadding = PaddingValues(vertical = SpSpacing.Default),
+                        ) {
+                            itemsIndexed(
+                                state.games,
+                                key = { _, item -> "toplist-${item.gameId}" },
+                            ) { _, item ->
+                                TopListGameItem(
+                                    game = item,
+                                    onClick = { onGameSelected(item.gameId) },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        // Error snackbar
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.onIntent(TopListsIntent.DismissError) },
+                )
+            },
+            onDismiss = { viewModel.onIntent(TopListsIntent.DismissError) },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@Composable
+private fun TopListGameItem(
+    game: TopListGame,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        onGradient = true,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XSmall)
+            .testTag("top_list_item_${game.gameId}")
+            .semantics {
+                contentDescription = "Rank ${game.rank}: ${game.name}, rated %.1f".format(game.rating)
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SpSpacing.Default),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            RankBadge(game.rank)
+            Spacer(Modifier.width(SpSpacing.Medium))
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.name} cover",
+                modifier = Modifier.height(64.dp),
+                cornerRadius = SpSpacing.RadiusMedium,
+            )
+            Spacer(Modifier.width(SpSpacing.Medium))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = game.name,
+                    style = SpTypography.TitleLarge,
+                    color = SpColor.OnCard,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (game.consoleName.isNotBlank()) {
+                    Spacer(Modifier.height(SpSpacing.XXSmall))
+                    Text(
+                        text = game.consoleName,
+                        style = SpTypography.BodySmall,
+                        color = SpColor.OnBackgroundTertiary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+                Spacer(Modifier.height(SpSpacing.XSmall))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+                ) {
+                    Icon(
+                        imageVector = Icons.Filled.Star,
+                        contentDescription = null,
+                        tint = SpColor.Warning,
+                        modifier = Modifier.size(16.dp),
+                    )
+                    Text(
+                        text = "%.1f".format(game.rating),
+                        style = SpTypography.LabelMedium.copy(fontWeight = FontWeight.Bold),
+                        color = SpColor.OnCard,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/TopListsViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/TopListsViewModel.kt
@@ -1,0 +1,54 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.domain.repository.GameRepository
+import com.spela.player.presentation.intent.TopListsIntent
+import com.spela.player.presentation.state.TopListsState
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class TopListsViewModel(
+    private val gameRepository: GameRepository,
+    private val dispatchers: DispatcherProvider,
+    private val scope: CoroutineScope,
+) {
+    private val _state = MutableStateFlow(TopListsState())
+    val state: StateFlow<TopListsState> = _state.asStateFlow()
+
+    fun onIntent(intent: TopListsIntent) {
+        when (intent) {
+            TopListsIntent.LoadTopLists -> loadTopLists()
+            TopListsIntent.DismissError -> _state.update { it.copy(error = null) }
+        }
+    }
+
+    private fun loadTopLists() {
+        _state.update { it.copy(isLoading = true) }
+        scope.launch(dispatchers.io) {
+            val result = gameRepository.getTopRatedAvailable()
+            result.fold(
+                onSuccess = { games ->
+                    _state.update {
+                        it.copy(
+                            games = games,
+                            isLoading = false,
+                            error = null,
+                        )
+                    }
+                },
+                onFailure = { e ->
+                    _state.update {
+                        it.copy(
+                            isLoading = false,
+                            error = e.message ?: "Failed to load top lists",
+                        )
+                    }
+                },
+            )
+        }
+    }
+}

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/GameListViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/GameListViewModelTest.kt
@@ -212,6 +212,7 @@ class FakeGameRepository : GameRepository {
     override suspend fun removeFromPlayLater(gameId: String): Result<Unit> = Result.success(Unit)
     override suspend fun getTopRatedGames(consoleId: String): Result<List<TopRatedGame>> = Result.success(emptyList())
     override suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>> = Result.success(emptyList())
+    override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
     override suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>> = Result.success(emptyList())
     override suspend fun getDeveloperGames(gameId: String): Result<List<DeveloperGame>> = Result.success(emptyList())
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
@@ -195,6 +195,7 @@ class SyncEngineTest {
         override suspend fun removeFromPlayLater(gameId: String) = Result.success(Unit)
         override suspend fun getTopRatedGames(consoleId: String) = Result.success(emptyList<TopRatedGame>())
         override suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>> = Result.success(emptyList())
+        override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
     }
@@ -229,6 +230,7 @@ class SyncEngineTest {
         override suspend fun removeFromPlayLater(gameId: String) = Result.success(Unit)
         override suspend fun getTopRatedGames(consoleId: String) = Result.success(emptyList<TopRatedGame>())
         override suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>> = Result.success(emptyList())
+        override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
     }
@@ -271,6 +273,7 @@ class SyncEngineTest {
         override suspend fun removeFromPlayLater(gameId: String) = Result.success(Unit)
         override suspend fun getTopRatedGames(consoleId: String) = Result.success(emptyList<TopRatedGame>())
         override suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>> = Result.success(emptyList())
+        override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
     }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -354,6 +354,7 @@ class NavigationViewModelTest {
         override suspend fun removeFromPlayLater(gameId: String) = Result.success(Unit)
         override suspend fun getTopRatedGames(consoleId: String) = Result.success(emptyList<TopRatedGame>())
     override suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>> = Result.success(emptyList())
+        override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
     }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -217,6 +217,7 @@ private class PlayFromSharedSaveTestGameRepository : GameRepository {
     override suspend fun removeFromPlayLater(gameId: String) = Result.success(Unit)
     override suspend fun getTopRatedGames(consoleId: String) = Result.success(emptyList<TopRatedGame>())
     override suspend fun getTopRatedGamesGlobal() = Result.success(emptyList<TopRatedGame>())
+    override suspend fun getTopRatedAvailable() = Result.success(emptyList<TopListGame>())
     override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
     override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
@@ -164,6 +164,7 @@ private class StubGameRepository : GameRepository {
     override suspend fun removeFromPlayLater(gameId: String): Result<Unit> = Result.success(Unit)
     override suspend fun getTopRatedGames(consoleId: String): Result<List<TopRatedGame>> = Result.success(emptyList())
     override suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>> = Result.success(emptyList())
+    override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
     override suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>> = Result.success(emptyList())
     override suspend fun getDeveloperGames(gameId: String): Result<List<DeveloperGame>> = Result.success(emptyList())
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
@@ -200,6 +200,7 @@ private class TestGameRepository : GameRepository {
     override suspend fun removeFromPlayLater(gameId: String): Result<Unit> = Result.success(Unit)
     override suspend fun getTopRatedGames(consoleId: String): Result<List<TopRatedGame>> = Result.success(emptyList())
     override suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>> = Result.success(emptyList())
+    override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
     override suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>> = Result.success(emptyList())
     override suspend fun getDeveloperGames(gameId: String): Result<List<DeveloperGame>> = Result.success(emptyList())
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -32,6 +32,7 @@ import com.spela.player.domain.model.SharedSessionInvitation
 import com.spela.player.domain.model.SharedSessionSave
 import com.spela.player.domain.model.SaveState
 import com.spela.player.domain.model.ShaderPreset
+import com.spela.player.domain.model.TopListGame
 import com.spela.player.domain.model.TopRatedGame
 import com.spela.player.domain.model.SimilarGame
 import com.spela.player.domain.model.DeveloperGame
@@ -179,6 +180,7 @@ class StubGameRepository(private val consoleId: String = "nes") : GameRepository
     override suspend fun removeFromPlayLater(gameId: String) = Result.success(Unit)
     override suspend fun getTopRatedGames(consoleId: String) = Result.success(emptyList<TopRatedGame>())
     override suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>> = Result.success(emptyList())
+    override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
     override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
     override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
 }

--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -468,6 +468,71 @@ func (h *ConsoleHandler) GetTopRatedGlobal(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
+// TopListGameResponse is the API response for a top-rated IGDB game that is
+// available locally on the server.
+type TopListGameResponse struct {
+	Rank        int     `json:"rank"`
+	GameId      string  `json:"gameId"`
+	Name        string  `json:"name"`
+	CoverUrl    string  `json:"coverUrl"`
+	ConsoleName string  `json:"consoleName"`
+	ConsoleId   string  `json:"consoleId"`
+	Rating      float64 `json:"rating"`
+}
+
+// GetTopListAvailable returns IGDB top-rated games that have a matching local
+// game on the server. Only games with a local title+console match are included,
+// sorted by IGDB rating descending, limited to 50 results.
+func (h *ConsoleHandler) GetTopListAvailable(c *gin.Context) {
+	// Join top_rated_games with games on case-insensitive title AND console_id,
+	// then join consoles for the console name/abbreviation.
+	type row struct {
+		GameID       uint
+		Name         string
+		CoverURL     string
+		ConsoleName  string
+		ConsoleAbbr  string
+		TotalRating  float64
+	}
+
+	var rows []row
+	err := h.DB.
+		Table("top_rated_games").
+		Select(`MIN(games.id) AS game_id,
+				top_rated_games.name AS name,
+				MIN(games.cover_url) AS cover_url,
+				consoles.name AS console_name,
+				consoles.abbreviation AS console_abbr,
+				top_rated_games.total_rating`).
+		Joins("JOIN games ON LOWER(games.title) = LOWER(top_rated_games.name) AND games.console_id = top_rated_games.console_id AND games.deleted_at IS NULL").
+		Joins("JOIN consoles ON consoles.id = top_rated_games.console_id AND consoles.deleted_at IS NULL").
+		Where("top_rated_games.deleted_at IS NULL").
+		Group("top_rated_games.id, top_rated_games.name, consoles.name, consoles.abbreviation, top_rated_games.total_rating").
+		Order("top_rated_games.total_rating DESC").
+		Limit(50).
+		Find(&rows).Error
+	if err != nil {
+		slog.Error("failed to fetch top list", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch top list"})
+		return
+	}
+
+	result := make([]TopListGameResponse, len(rows))
+	for i, r := range rows {
+		result[i] = TopListGameResponse{
+			Rank:        i + 1,
+			GameId:      fmt.Sprintf("%d", r.GameID),
+			Name:        r.Name,
+			CoverUrl:    r.CoverURL,
+			ConsoleName: r.ConsoleName,
+			ConsoleId:   strings.ToLower(r.ConsoleAbbr),
+			Rating:      r.TotalRating,
+		}
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
 // upsertTopRatedGames inserts or updates top-rated games for a console.
 func (h *ConsoleHandler) upsertTopRatedGames(consoleID uint, games []igdb.TopGame) {
 	for i, g := range games {

--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -484,15 +484,13 @@ type TopListGameResponse struct {
 // game on the server. Only games with a local title+console match are included,
 // sorted by IGDB rating descending, limited to 50 results.
 func (h *ConsoleHandler) GetTopListAvailable(c *gin.Context) {
-	// Join top_rated_games with games on case-insensitive title AND console_id,
-	// then join consoles for the console name/abbreviation.
 	type row struct {
-		GameID       uint
-		Name         string
-		CoverURL     string
-		ConsoleName  string
-		ConsoleAbbr  string
-		TotalRating  float64
+		GameID      uint
+		Name        string
+		CoverURL    string
+		ConsoleName string
+		ConsoleAbbr string
+		TotalRating float64
 	}
 
 	var rows []row
@@ -523,7 +521,7 @@ func (h *ConsoleHandler) GetTopListAvailable(c *gin.Context) {
 			Rank:        i + 1,
 			GameId:      fmt.Sprintf("%d", r.GameID),
 			Name:        r.Name,
-			CoverUrl:    r.CoverURL,
+			CoverUrl:    resolveImageURL(r.CoverURL),
 			ConsoleName: r.ConsoleName,
 			ConsoleId:   strings.ToLower(r.ConsoleAbbr),
 			Rating:      r.TotalRating,

--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -295,7 +295,7 @@ func TestGetTopListAvailable_ReturnsOnlyLocalMatches(t *testing.T) {
 
 	assert.Len(t, result, 1, "should return only the game with a local match")
 	assert.Equal(t, "Super Mario Bros.", result[0].Name)
-	assert.Equal(t, "covers/nes/smb.png", result[0].CoverUrl)
+	assert.Equal(t, "/api/images/covers/nes/smb.png", result[0].CoverUrl)
 	assert.Equal(t, "nes", result[0].ConsoleId)
 	assert.Equal(t, 92.5, result[0].Rating)
 }
@@ -466,6 +466,6 @@ func TestGetTopListAvailable_IncludesConsoleInfo(t *testing.T) {
 	require.Len(t, result, 1)
 	assert.Equal(t, "Super Nintendo", result[0].ConsoleName)
 	assert.Equal(t, "snes", result[0].ConsoleId)
-	assert.Equal(t, "covers/snes/smw.png", result[0].CoverUrl)
+	assert.Equal(t, "/api/images/covers/snes/smw.png", result[0].CoverUrl)
 	assert.NotEmpty(t, result[0].GameId)
 }

--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -31,7 +31,7 @@ func setupConsoleTestEnv(t *testing.T) (*gorm.DB, *storage.Storage, *gin.Engine)
 	})
 	require.NoError(t, err)
 
-	err = database.AutoMigrate(&db.Console{}, &db.Game{})
+	err = database.AutoMigrate(&db.Console{}, &db.Game{}, &db.TopRatedGame{})
 	require.NoError(t, err)
 
 	err = db.SeedConsoles(database)
@@ -232,4 +232,240 @@ func TestGetPreviewScreenshot_WorksWithNoLocalGames(t *testing.T) {
 	assert.Equal(t, http.StatusFound, w.Code)
 	expectedLocation := "/api/images/previews/" + console.Abbreviation + "/preview.png"
 	assert.Equal(t, expectedLocation, w.Header().Get("Location"))
+}
+
+// setupTopListTestEnv creates an in-memory DB with seeded consoles, a temp Storage,
+// and a gin router with the top-lists/top-rated route.
+func setupTopListTestEnv(t *testing.T) (*gorm.DB, *gin.Engine) {
+	t.Helper()
+
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+
+	err = database.AutoMigrate(&db.Console{}, &db.Game{}, &db.TopRatedGame{})
+	require.NoError(t, err)
+
+	err = db.SeedConsoles(database)
+	require.NoError(t, err)
+
+	gin.SetMode(gin.TestMode)
+	router := gin.New()
+
+	handler := &ConsoleHandler{DB: database}
+	router.GET("/api/top-lists/top-rated", handler.GetTopListAvailable)
+
+	return database, router
+}
+
+func TestGetTopListAvailable_ReturnsOnlyLocalMatches(t *testing.T) {
+	database, router := setupTopListTestEnv(t)
+
+	var nesConsole db.Console
+	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
+	require.NoError(t, err)
+
+	// Create two top-rated IGDB entries
+	database.Create(&db.TopRatedGame{
+		ConsoleID: nesConsole.ID, IGDBGameID: 100, Name: "Super Mario Bros.",
+		TotalRating: 92.5, TotalRatingCount: 500, Rank: 1,
+	})
+	database.Create(&db.TopRatedGame{
+		ConsoleID: nesConsole.ID, IGDBGameID: 200, Name: "The Legend of Zelda",
+		TotalRating: 90.0, TotalRatingCount: 400, Rank: 2,
+	})
+
+	// Create a local game matching only one of them (case-insensitive)
+	database.Create(&db.Game{
+		ConsoleID: nesConsole.ID, Title: "super mario bros.",
+		FileName: "smb.nes", FilePath: "/games/smb.nes", FileSize: 1024,
+		CoverURL: "covers/nes/smb.png",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []TopListGameResponse
+	err = json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+
+	assert.Len(t, result, 1, "should return only the game with a local match")
+	assert.Equal(t, "Super Mario Bros.", result[0].Name)
+	assert.Equal(t, "covers/nes/smb.png", result[0].CoverUrl)
+	assert.Equal(t, "nes", result[0].ConsoleId)
+	assert.Equal(t, 92.5, result[0].Rating)
+}
+
+func TestGetTopListAvailable_SortedByRatingDesc(t *testing.T) {
+	database, router := setupTopListTestEnv(t)
+
+	var nesConsole db.Console
+	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
+	require.NoError(t, err)
+
+	// Create top-rated entries with varying ratings
+	database.Create(&db.TopRatedGame{
+		ConsoleID: nesConsole.ID, IGDBGameID: 100, Name: "Game A",
+		TotalRating: 80.0, TotalRatingCount: 300, Rank: 3,
+	})
+	database.Create(&db.TopRatedGame{
+		ConsoleID: nesConsole.ID, IGDBGameID: 200, Name: "Game B",
+		TotalRating: 95.0, TotalRatingCount: 500, Rank: 1,
+	})
+	database.Create(&db.TopRatedGame{
+		ConsoleID: nesConsole.ID, IGDBGameID: 300, Name: "Game C",
+		TotalRating: 88.0, TotalRatingCount: 400, Rank: 2,
+	})
+
+	// Create matching local games for all three
+	for _, title := range []string{"Game A", "Game B", "Game C"} {
+		database.Create(&db.Game{
+			ConsoleID: nesConsole.ID, Title: title,
+			FileName: strings.ToLower(title) + ".nes",
+			FilePath: "/games/" + strings.ToLower(title) + ".nes",
+			FileSize: 1024,
+		})
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []TopListGameResponse
+	err = json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+
+	require.Len(t, result, 3)
+	assert.Equal(t, "Game B", result[0].Name)
+	assert.Equal(t, 95.0, result[0].Rating)
+	assert.Equal(t, "Game C", result[1].Name)
+	assert.Equal(t, 88.0, result[1].Rating)
+	assert.Equal(t, "Game A", result[2].Name)
+	assert.Equal(t, 80.0, result[2].Rating)
+}
+
+func TestGetTopListAvailable_SequentialRanks(t *testing.T) {
+	database, router := setupTopListTestEnv(t)
+
+	var nesConsole db.Console
+	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
+	require.NoError(t, err)
+
+	// Create two top-rated entries
+	database.Create(&db.TopRatedGame{
+		ConsoleID: nesConsole.ID, IGDBGameID: 100, Name: "First",
+		TotalRating: 90.0, TotalRatingCount: 500, Rank: 1,
+	})
+	database.Create(&db.TopRatedGame{
+		ConsoleID: nesConsole.ID, IGDBGameID: 200, Name: "Second",
+		TotalRating: 85.0, TotalRatingCount: 400, Rank: 2,
+	})
+
+	// Create matching local games
+	database.Create(&db.Game{
+		ConsoleID: nesConsole.ID, Title: "First",
+		FileName: "first.nes", FilePath: "/games/first.nes", FileSize: 1024,
+	})
+	database.Create(&db.Game{
+		ConsoleID: nesConsole.ID, Title: "Second",
+		FileName: "second.nes", FilePath: "/games/second.nes", FileSize: 1024,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []TopListGameResponse
+	err = json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+
+	require.Len(t, result, 2)
+	assert.Equal(t, 1, result[0].Rank, "first result should have rank 1")
+	assert.Equal(t, 2, result[1].Rank, "second result should have rank 2")
+}
+
+func TestGetTopListAvailable_EmptyWhenNoMatches(t *testing.T) {
+	database, router := setupTopListTestEnv(t)
+
+	var nesConsole db.Console
+	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
+	require.NoError(t, err)
+
+	// Create top-rated entries with no local game matches
+	database.Create(&db.TopRatedGame{
+		ConsoleID: nesConsole.ID, IGDBGameID: 100, Name: "No Match Game",
+		TotalRating: 90.0, TotalRatingCount: 500, Rank: 1,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []TopListGameResponse
+	err = json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+
+	assert.Empty(t, result, "should return empty array when no local matches exist")
+}
+
+func TestGetTopListAvailable_EmptyWithNoData(t *testing.T) {
+	_, router := setupTopListTestEnv(t)
+
+	// No top-rated entries and no games at all
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []TopListGameResponse
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+
+	assert.Empty(t, result, "should return empty array when no data exists")
+}
+
+func TestGetTopListAvailable_IncludesConsoleInfo(t *testing.T) {
+	database, router := setupTopListTestEnv(t)
+
+	var snesConsole db.Console
+	err := database.Where("abbreviation = ?", "SNES").First(&snesConsole).Error
+	require.NoError(t, err)
+
+	database.Create(&db.TopRatedGame{
+		ConsoleID: snesConsole.ID, IGDBGameID: 100, Name: "Super Mario World",
+		TotalRating: 95.0, TotalRatingCount: 600, Rank: 1,
+	})
+
+	database.Create(&db.Game{
+		ConsoleID: snesConsole.ID, Title: "Super Mario World",
+		FileName: "smw.sfc", FilePath: "/games/smw.sfc", FileSize: 2048,
+		CoverURL: "covers/snes/smw.png",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []TopListGameResponse
+	err = json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "Super Nintendo", result[0].ConsoleName)
+	assert.Equal(t, "snes", result[0].ConsoleId)
+	assert.Equal(t, "covers/snes/smw.png", result[0].CoverUrl)
+	assert.NotEmpty(t, result[0].GameId)
 }

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -296,6 +296,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/user/preferences", userHandler.GetPreferences)
 		api.PUT("/user/preferences", userHandler.UpdatePreferences)
 		api.GET("/user/stats", userHandler.GetUserStats)
+		api.GET("/user/play-stats", userHandler.GetPlayStats)
 		api.GET("/user/recent", userHandler.GetRecentGames)
 		api.GET("/user/favorites", userHandler.GetFavorites)
 		api.POST("/user/favorites/:gameId", userHandler.AddFavorite)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -222,6 +222,9 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/consoles/:id/top-rated", consoleHandler.GetTopRated)
 		api.GET("/top-rated", consoleHandler.GetTopRatedGlobal)
 
+		// Top Lists
+		api.GET("/top-lists/top-rated", consoleHandler.GetTopListAvailable)
+
 		// Games
 		api.GET("/games", gameHandler.ListGames)
 		api.GET("/games/:id", gameHandler.GetGame)

--- a/server/internal/api/user_handler.go
+++ b/server/internal/api/user_handler.go
@@ -767,3 +767,37 @@ func calculateStreaks(playDates []time.Time, today time.Time) (currentStreak, lo
 
 	return currentStreak, longestStreak
 }
+
+// PlayStatsEntry represents play stats for a single game.
+type PlayStatsEntry struct {
+	GameID       uint   `json:"gameId"`
+	PlayTime     int64  `json:"playTime"`
+	LastPlayedAt string `json:"lastPlayedAt"`
+}
+
+// GetPlayStats returns the current user's play history for all games they've played.
+// Returns a flat array of {gameId, playTime, lastPlayedAt} entries.
+func (h *UserHandler) GetPlayStats(c *gin.Context) {
+	userID, _ := c.Get("userId")
+
+	var histories []db.PlayHistory
+	if err := h.DB.Where("user_id = ?", userID).Find(&histories).Error; err != nil {
+		slog.Error("failed to fetch play stats", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch play stats"})
+		return
+	}
+
+	result := make([]PlayStatsEntry, 0, len(histories))
+	for _, ph := range histories {
+		if ph.PlayTime <= 0 && ph.LastPlayed.IsZero() {
+			continue
+		}
+		result = append(result, PlayStatsEntry{
+			GameID:       ph.GameID,
+			PlayTime:     ph.PlayTime,
+			LastPlayedAt: ph.LastPlayed.Format(time.RFC3339),
+		})
+	}
+
+	c.JSON(http.StatusOK, result)
+}

--- a/server/internal/api/user_play_stats_test.go
+++ b/server/internal/api/user_play_stats_test.go
@@ -1,0 +1,151 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetPlayStats_ReturnsPlayHistory(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	var console db.Console
+	database.First(&console)
+
+	game1 := db.Game{ConsoleID: console.ID, Title: "Game A", FileName: "a.nes", FilePath: "/tmp/a.nes", FileSize: 100}
+	game2 := db.Game{ConsoleID: console.ID, Title: "Game B", FileName: "b.nes", FilePath: "/tmp/b.nes", FileSize: 100}
+	database.Create(&game1)
+	database.Create(&game2)
+
+	var user db.User
+	database.First(&user)
+
+	now := time.Now().UTC()
+	database.Create(&db.PlayHistory{
+		UserID: user.ID, GameID: game1.ID,
+		PlayTime: 3600, LastPlayed: now.Add(-1 * time.Hour),
+	})
+	database.Create(&db.PlayHistory{
+		UserID: user.ID, GameID: game2.ID,
+		PlayTime: 120, LastPlayed: now.Add(-24 * time.Hour),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/play-stats", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []PlayStatsEntry
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+
+	assert.Len(t, result, 2)
+
+	statsMap := make(map[uint]PlayStatsEntry)
+	for _, s := range result {
+		statsMap[s.GameID] = s
+	}
+
+	assert.Equal(t, int64(3600), statsMap[game1.ID].PlayTime)
+	assert.Equal(t, int64(120), statsMap[game2.ID].PlayTime)
+	assert.NotEmpty(t, statsMap[game1.ID].LastPlayedAt)
+	assert.NotEmpty(t, statsMap[game2.ID].LastPlayedAt)
+}
+
+func TestGetPlayStats_EmptyWhenNoHistory(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/play-stats", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []PlayStatsEntry
+	err := json.Unmarshal(w.Body.Bytes(), &result)
+	require.NoError(t, err)
+
+	assert.Empty(t, result)
+}
+
+func TestGetPlayStats_ExcludesOtherUsers(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	var console db.Console
+	database.First(&console)
+
+	game := db.Game{ConsoleID: console.ID, Title: "Shared Game", FileName: "s.nes", FilePath: "/tmp/s.nes", FileSize: 100}
+	database.Create(&game)
+
+	// Create play history for the owner (user ID 1)
+	var owner db.User
+	database.First(&owner)
+	database.Create(&db.PlayHistory{
+		UserID: owner.ID, GameID: game.ID,
+		PlayTime: 5000, LastPlayed: time.Now().UTC(),
+	})
+
+	// Create play history for a different user ID directly
+	database.Create(&db.PlayHistory{
+		UserID: 9999, GameID: game.ID,
+		PlayTime: 999, LastPlayed: time.Now().UTC(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/play-stats", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []PlayStatsEntry
+	json.Unmarshal(w.Body.Bytes(), &result)
+	require.Len(t, result, 1, "should only return current user's play history")
+	assert.Equal(t, int64(5000), result[0].PlayTime)
+}
+
+func TestGetPlayStats_SkipsZeroPlayTime(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	var console db.Console
+	database.First(&console)
+
+	game := db.Game{ConsoleID: console.ID, Title: "Never Played", FileName: "np.nes", FilePath: "/tmp/np.nes", FileSize: 100}
+	database.Create(&game)
+
+	var user db.User
+	database.First(&user)
+
+	// Create a play history with zero play time and zero timestamp
+	database.Create(&db.PlayHistory{
+		UserID: user.ID, GameID: game.ID,
+		PlayTime: 0, LastPlayed: time.Time{},
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/play-stats", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []PlayStatsEntry
+	json.Unmarshal(w.Body.Bytes(), &result)
+	assert.Empty(t, result, "should skip entries with zero play time and no last played")
+}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -33,6 +33,7 @@ import { NetplayPage } from "@/pages/netplay-page";
 import { NetplaySessionPage } from "@/pages/netplay-session-page";
 import { LicensesPage } from "@/pages/licenses-page";
 import { ChallengesPage } from "@/pages/challenges-page";
+import { TopListsPage } from "@/pages/top-lists-page";
 import { ChallengeDetailPage } from "@/pages/challenge-detail-page";
 import { SessionDetailPage } from "@/pages/session-detail-page";
 import { SetupWizardPage } from "@/pages/setup-wizard-page";
@@ -102,6 +103,7 @@ export function App() {
                     />
                     <Route path="stats" element={<StatsPage />} />
                     <Route path="activity" element={<ActivityPage />} />
+                    <Route path="top-lists" element={<TopListsPage />} />
                     <Route path="challenges" element={<ChallengesPage />} />
                     <Route
                       path="challenges/:id"

--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -16,6 +16,7 @@ import {
   Cpu,
   Upload,
   Menu,
+  Trophy,
   Gamepad2,
 } from "lucide-react";
 import { Sidebar } from "@/components/ui";
@@ -69,6 +70,7 @@ export function AppLayout() {
           ],
         },
         { to: "/stats", icon: BarChart3, label: "Stats" },
+        { to: "/top-lists", icon: Trophy, label: "Top Lists" },
         { to: "/activity", icon: Activity, label: "Activity" },
         {
           to: "/challenges",

--- a/web/src/components/play-info.tsx
+++ b/web/src/components/play-info.tsx
@@ -1,0 +1,34 @@
+import { Clock, Calendar } from "lucide-react";
+import { usePlayStats } from "@/hooks/use-play-stats";
+import { formatPlayTime, formatRelativeTime } from "@/lib/format";
+
+interface PlayInfoProps {
+  gameId: string | number;
+  className?: string;
+}
+
+export function PlayInfo({ gameId, className }: PlayInfoProps) {
+  const { data: stats } = usePlayStats();
+
+  const entry = stats?.find((s) => String(s.gameId) === String(gameId));
+  if (!entry) return null;
+
+  return (
+    <span
+      className={`inline-flex items-center gap-3 text-xs text-surface-500 ${className ?? ""}`}
+    >
+      {entry.playTime > 0 && (
+        <span className="inline-flex items-center gap-1">
+          <Clock className="h-3 w-3" />
+          {formatPlayTime(entry.playTime)}
+        </span>
+      )}
+      {entry.lastPlayedAt && (
+        <span className="inline-flex items-center gap-1">
+          <Calendar className="h-3 w-3" />
+          {formatRelativeTime(entry.lastPlayedAt)}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/web/src/hooks/use-play-stats.ts
+++ b/web/src/hooks/use-play-stats.ts
@@ -1,0 +1,11 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type { PlayStatsEntry } from "@/types/api";
+
+export function usePlayStats() {
+  return useQuery({
+    queryKey: ["user", "play-stats"],
+    queryFn: () => api.get<PlayStatsEntry[]>("/user/play-stats"),
+    staleTime: 60_000,
+  });
+}

--- a/web/src/hooks/use-top-lists.ts
+++ b/web/src/hooks/use-top-lists.ts
@@ -1,0 +1,10 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type { TopListGame } from "@/types/api";
+
+export function useTopRated() {
+  return useQuery({
+    queryKey: ["top-lists", "top-rated"],
+    queryFn: () => api.get<TopListGame[]>("/top-lists/top-rated"),
+  });
+}

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -105,6 +105,9 @@ export type ApiGetPath = WithQuery<
   | "/collections/public"
   | `/collections/${string}`
 
+  // Top Lists
+  | "/top-lists/top-rated"
+
   // Challenges
   | "/challenges"
   | `/challenges/${string}`

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -72,6 +72,7 @@ export type ApiGetPath = WithQuery<
   | "/user/stats"
   | "/user/recent"
   | "/user/favorites"
+  | "/user/play-stats"
   | "/user/play-later"
   | "/user/devices"
   | `/user/devices/${string}/preferences`

--- a/web/src/pages/__tests__/top-lists-page.test.tsx
+++ b/web/src/pages/__tests__/top-lists-page.test.tsx
@@ -9,6 +9,10 @@ vi.mock("@/hooks/use-top-lists", () => ({
   useTopRated: vi.fn(),
 }));
 
+vi.mock("@/hooks/use-play-stats", () => ({
+  usePlayStats: vi.fn(),
+}));
+
 vi.mock("@/components/ui", async () => {
   const actual =
     await vi.importActual<Record<string, unknown>>("@/components/ui");
@@ -19,8 +23,10 @@ vi.mock("@/components/ui", async () => {
 });
 
 import { useTopRated } from "@/hooks/use-top-lists";
+import { usePlayStats } from "@/hooks/use-play-stats";
 
 const mockUseTopRated = useTopRated as ReturnType<typeof vi.fn>;
+const mockUsePlayStats = usePlayStats as ReturnType<typeof vi.fn>;
 
 // ---------------------------------------------------------------------------
 // Mock Data
@@ -56,6 +62,11 @@ const mockTopRatedGames = [
   },
 ];
 
+const mockPlayStats = [
+  { gameId: 42, playTime: 3600, lastPlayedAt: "2026-03-01T12:00:00Z" },
+  { gameId: 55, playTime: 7200, lastPlayedAt: "2026-02-28T08:00:00Z" },
+];
+
 function renderPage() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -73,6 +84,10 @@ beforeEach(() => {
   vi.clearAllMocks();
   mockUseTopRated.mockReturnValue({
     data: mockTopRatedGames,
+    isLoading: false,
+  });
+  mockUsePlayStats.mockReturnValue({
+    data: mockPlayStats,
     isLoading: false,
   });
 });
@@ -154,5 +169,13 @@ describe("TopListsPage", () => {
     // Rank numbers 1, 2, 3 should be visible
     const rankBadges = screen.getAllByText(/^[123]$/);
     expect(rankBadges).toHaveLength(3);
+  });
+
+  it("renders play info for games with play history", () => {
+    renderPage();
+    // Game 42 has 3600s = 1h 0m
+    expect(screen.getByText("1h 0m")).toBeInTheDocument();
+    // Game 55 has 7200s = 2h 0m
+    expect(screen.getByText("2h 0m")).toBeInTheDocument();
   });
 });

--- a/web/src/pages/__tests__/top-lists-page.test.tsx
+++ b/web/src/pages/__tests__/top-lists-page.test.tsx
@@ -1,0 +1,158 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { TopListsPage } from "../top-lists-page";
+
+vi.mock("@/hooks/use-top-lists", () => ({
+  useTopRated: vi.fn(),
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual =
+    await vi.importActual<Record<string, unknown>>("@/components/ui");
+  return {
+    ...actual,
+    useToast: () => ({ toast: vi.fn() }),
+  };
+});
+
+import { useTopRated } from "@/hooks/use-top-lists";
+
+const mockUseTopRated = useTopRated as ReturnType<typeof vi.fn>;
+
+// ---------------------------------------------------------------------------
+// Mock Data
+// ---------------------------------------------------------------------------
+
+const mockTopRatedGames = [
+  {
+    rank: 1,
+    gameId: "42",
+    name: "Super Mario World",
+    coverUrl: "/api/images/covers/smw.jpg",
+    consoleName: "SNES",
+    consoleId: "2",
+    rating: 92.5,
+  },
+  {
+    rank: 2,
+    gameId: "99",
+    name: "The Legend of Zelda",
+    coverUrl: "/api/images/covers/zelda.jpg",
+    consoleName: "NES",
+    consoleId: "1",
+    rating: 91.0,
+  },
+  {
+    rank: 3,
+    gameId: "55",
+    name: "Chrono Trigger",
+    coverUrl: "/api/images/covers/ct.jpg",
+    consoleName: "SNES",
+    consoleId: "2",
+    rating: 90.3,
+  },
+];
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <TopListsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseTopRated.mockReturnValue({
+    data: mockTopRatedGames,
+    isLoading: false,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("TopListsPage", () => {
+  it("renders page heading", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /Top Lists/i, level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders section heading", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /Top Rated Games/i, level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders game list when data is loaded", () => {
+    renderPage();
+    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+    expect(screen.getByText("The Legend of Zelda")).toBeInTheDocument();
+    expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
+  });
+
+  it("renders console badges", () => {
+    renderPage();
+    expect(screen.getAllByText("SNES")).toHaveLength(2);
+    expect(screen.getByText("NES")).toBeInTheDocument();
+  });
+
+  it("renders star ratings", () => {
+    renderPage();
+    expect(screen.getByText("92.5")).toBeInTheDocument();
+    expect(screen.getByText("91.0")).toBeInTheDocument();
+    expect(screen.getByText("90.3")).toBeInTheDocument();
+  });
+
+  it("renders game links pointing to game detail", () => {
+    renderPage();
+    const links = screen.getAllByRole("link");
+    expect(links[0]).toHaveAttribute("href", "/games/42");
+    expect(links[1]).toHaveAttribute("href", "/games/99");
+    expect(links[2]).toHaveAttribute("href", "/games/55");
+  });
+
+  it("shows empty state when no games", () => {
+    mockUseTopRated.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No top rated games yet")).toBeInTheDocument();
+  });
+
+  it("shows empty state when data is undefined", () => {
+    mockUseTopRated.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No top rated games yet")).toBeInTheDocument();
+  });
+
+  it("renders loading skeletons when loading", () => {
+    mockUseTopRated.mockReturnValue({ data: undefined, isLoading: true });
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders rank badges for top 3", () => {
+    renderPage();
+    // Rank numbers 1, 2, 3 should be visible
+    const rankBadges = screen.getAllByText(/^[123]$/);
+    expect(rankBadges).toHaveLength(3);
+  });
+});

--- a/web/src/pages/top-lists-page.tsx
+++ b/web/src/pages/top-lists-page.tsx
@@ -1,0 +1,148 @@
+import { Link } from "react-router-dom";
+import { Trophy, Star } from "lucide-react";
+import { Badge, Skeleton, EmptyState } from "@/components/ui";
+import { useTopRated } from "@/hooks/use-top-lists";
+import { cn } from "@/lib/cn";
+
+function rankStyle(rank: number): { text: string; bg: string } {
+  if (rank === 1)
+    return {
+      text: "text-amber-400",
+      bg: "bg-amber-400/15 border border-amber-400/30",
+    };
+  if (rank === 2)
+    return {
+      text: "text-surface-300",
+      bg: "bg-surface-300/15 border border-surface-300/30",
+    };
+  if (rank === 3)
+    return {
+      text: "text-amber-700",
+      bg: "bg-amber-700/15 border border-amber-700/30",
+    };
+  return { text: "text-surface-500", bg: "" };
+}
+
+function RankBadge({ rank }: { rank: number }) {
+  const style = rankStyle(rank);
+  const isTop3 = rank <= 3;
+
+  if (isTop3) {
+    return (
+      <span
+        className={cn(
+          "inline-flex items-center justify-center h-7 w-7 rounded-full text-xs font-bold",
+          style.bg,
+          style.text,
+        )}
+      >
+        {rank}
+      </span>
+    );
+  }
+
+  return (
+    <span className="inline-flex items-center justify-center h-7 w-7 text-sm font-medium text-surface-500">
+      {rank}
+    </span>
+  );
+}
+
+function TopRatedSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 10 }, (_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-4 rounded-xl px-4 py-3 bg-surface-900/50"
+        >
+          <Skeleton className="h-7 w-7 rounded-full" />
+          <Skeleton className="h-10 w-8 rounded-lg" />
+          <div className="flex-1 space-y-1">
+            <Skeleton className="h-4 w-40" />
+            <Skeleton className="h-3 w-20" />
+          </div>
+          <Skeleton className="h-4 w-16" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function TopListsPage() {
+  const { data: topRated, isLoading } = useTopRated();
+
+  const games = topRated ?? [];
+
+  return (
+    <div className="max-w-5xl space-y-10">
+      <div>
+        <h1 className="text-3xl font-bold text-surface-100 flex items-center gap-3">
+          <Trophy className="h-8 w-8 text-brand-400" />
+          Top Lists
+        </h1>
+        <p className="mt-1 text-surface-400">
+          The highest rated games across your library.
+        </p>
+      </div>
+
+      <section>
+        <div className="flex items-center gap-2.5 mb-5">
+          <Star className="h-5 w-5 text-brand-400" />
+          <h2 className="text-xl font-bold text-surface-100">
+            Top Rated Games
+          </h2>
+        </div>
+
+        {isLoading ? (
+          <TopRatedSkeleton />
+        ) : games.length === 0 ? (
+          <EmptyState
+            icon={Star}
+            title="No top rated games yet"
+            description="Top rated games from your library will appear here."
+          />
+        ) : (
+          <div className="space-y-2">
+            {games.map((game) => (
+              <Link
+                key={game.gameId}
+                to={`/games/${game.gameId}`}
+                className="flex items-center gap-4 rounded-xl px-4 py-3 bg-surface-900/50 hover:bg-surface-900/80 transition-colors"
+              >
+                <RankBadge rank={game.rank} />
+                <div className="h-10 w-8 rounded-lg overflow-hidden bg-surface-800 flex-shrink-0">
+                  {game.coverUrl ? (
+                    <img
+                      src={game.coverUrl}
+                      alt={game.name}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="h-full w-full flex items-center justify-center text-xs font-bold text-surface-600">
+                      {game.name.charAt(0)}
+                    </div>
+                  )}
+                </div>
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-surface-200 truncate">
+                    {game.name}
+                  </p>
+                  {game.consoleName && (
+                    <Badge variant="brand" className="mt-0.5">
+                      {game.consoleName}
+                    </Badge>
+                  )}
+                </div>
+                <span className="flex items-center gap-1 text-sm font-mono text-amber-400 whitespace-nowrap">
+                  <Star className="h-3.5 w-3.5 fill-amber-400" />
+                  {game.rating.toFixed(1)}
+                </span>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/src/pages/top-lists-page.tsx
+++ b/web/src/pages/top-lists-page.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Trophy, Star } from "lucide-react";
 import { Badge, Skeleton, EmptyState } from "@/components/ui";
 import { useTopRated } from "@/hooks/use-top-lists";
+import { PlayInfo } from "@/components/play-info";
 import { cn } from "@/lib/cn";
 
 function rankStyle(rank: number): { text: string; bg: string } {
@@ -57,10 +58,10 @@ function TopRatedSkeleton() {
           className="flex items-center gap-4 rounded-xl px-4 py-3 bg-surface-900/50"
         >
           <Skeleton className="h-7 w-7 rounded-full" />
-          <Skeleton className="h-10 w-8 rounded-lg" />
-          <div className="flex-1 space-y-1">
-            <Skeleton className="h-4 w-40" />
-            <Skeleton className="h-3 w-20" />
+          <Skeleton className="h-16 w-14 rounded-lg" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-5 w-48" />
+            <Skeleton className="h-4 w-20" />
           </div>
           <Skeleton className="h-4 w-16" />
         </div>
@@ -111,28 +112,29 @@ export function TopListsPage() {
                 className="flex items-center gap-4 rounded-xl px-4 py-3 bg-surface-900/50 hover:bg-surface-900/80 transition-colors"
               >
                 <RankBadge rank={game.rank} />
-                <div className="h-10 w-8 rounded-lg overflow-hidden bg-surface-800 flex-shrink-0">
+                <div className="w-14 h-16 flex items-center justify-center flex-shrink-0">
                   {game.coverUrl ? (
                     <img
                       src={game.coverUrl}
                       alt={game.name}
-                      className="h-full w-full object-cover"
+                      className="max-h-16 max-w-14 rounded-lg object-contain"
                     />
                   ) : (
-                    <div className="h-full w-full flex items-center justify-center text-xs font-bold text-surface-600">
+                    <div className="h-16 w-12 rounded-lg bg-surface-800 flex items-center justify-center text-sm font-bold text-surface-600">
                       {game.name.charAt(0)}
                     </div>
                   )}
                 </div>
                 <div className="flex-1 min-w-0">
-                  <p className="text-sm font-medium text-surface-200 truncate">
+                  <p className="text-base font-semibold text-surface-200 truncate">
                     {game.name}
                   </p>
-                  {game.consoleName && (
-                    <Badge variant="brand" className="mt-0.5">
-                      {game.consoleName}
-                    </Badge>
-                  )}
+                  <div className="mt-1.5 flex items-center gap-2">
+                    {game.consoleName && (
+                      <Badge variant="brand">{game.consoleName}</Badge>
+                    )}
+                  </div>
+                  <PlayInfo gameId={game.gameId} className="mt-1.5" />
                 </div>
                 <span className="flex items-center gap-1 text-sm font-mono text-amber-400 whitespace-nowrap">
                   <Star className="h-3.5 w-3.5 fill-amber-400" />

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -614,6 +614,12 @@ export interface TopListGame {
   rating: number;
 }
 
+export interface PlayStatsEntry {
+  gameId: number;
+  playTime: number;
+  lastPlayedAt: string;
+}
+
 // --- Session Saves & Cheats ---
 
 export interface SessionSave {

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -602,6 +602,18 @@ export interface BiosResponse {
 export type BiosFileStatus = BiosFile["status"];
 export type BiosConsoleStatus = BiosConsole["status"];
 
+// --- Top Lists ---
+
+export interface TopListGame {
+  rank: number;
+  gameId: string;
+  name: string;
+  coverUrl: string;
+  consoleName: string;
+  consoleId: string;
+  rating: number;
+}
+
 // --- Session Saves & Cheats ---
 
 export interface SessionSave {


### PR DESCRIPTION
## Summary

- **Top Lists page** across all three components (Go backend, React web, KMP player) showing the highest-rated IGDB games available on the server
- **Backend**: `GET /api/top-lists/top-rated` endpoint joins `top_rated_games` with local `games` on case-insensitive title + console_id, deduplicates with GROUP BY, returns up to 50 results sorted by IGDB rating
- **Reusable play stats**: New `GET /api/user/play-stats` endpoint returns all user play history. Web gets a self-fetching `<PlayInfo>` component and `usePlayStats()` hook — usable anywhere a game ID is known
- **Cover URL fix**: Top list now correctly resolves relative cover paths with `/api/images/` prefix
- **Web layout**: Larger box art (no aspect ratio constraint), bigger titles, platform badges with gap, inline play time and last played info
- **Player app**: Full TopListsScreen with SpCoverArt, RankBadge, pull-to-refresh, empty state, and navigation to game detail

## Test plan

- [x] 6 Go tests for top-list endpoint (local matches, sorting, ranks, empty states, console info)
- [x] 4 Go tests for play-stats endpoint (returns history, empty state, user isolation, skips zero)
- [x] 11 Vitest tests for web TopListsPage (headings, game list, badges, ratings, links, empty states, skeletons, ranks, play info)
- [x] 5 desktop E2E tests for player TopListsScreen (renders games, empty state, console names, ratings, navigation)
- [x] Visual verification: box art loads correctly in e2e docker compose