### PR TITLE
feat: add play activity heatmap

### DIFF
--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -68,6 +68,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.SessionSaveState{},
 		&db.SessionSaveData{},
 		&db.SessionCheatSetting{},
+		&db.DailyPlayActivity{},
 	)
 	require.NoError(t, err)
 	err = db.SeedConsoles(database)

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -380,6 +380,9 @@ func (h *GameHandler) UpdatePlayTime(c *gin.Context) {
 		}
 	}
 
+	// Record daily play activity for heatmap
+	RecordDailyPlayActivity(h.DB, uid, req.Seconds)
+
 	// Mark user as currently playing this game
 	if h.Hub != nil {
 		h.Hub.SetUserGame(uid, uint(gid))

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -297,6 +297,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.PUT("/user/preferences", userHandler.UpdatePreferences)
 		api.GET("/user/stats", userHandler.GetUserStats)
 		api.GET("/user/play-stats", userHandler.GetPlayStats)
+		api.GET("/user/play-heatmap", statsHandler.GetPlayHeatmap)
 		api.GET("/user/recent", userHandler.GetRecentGames)
 		api.GET("/user/favorites", userHandler.GetFavorites)
 		api.POST("/user/favorites/:gameId", userHandler.AddFavorite)
@@ -374,6 +375,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/social/activity", socialHandler.GetActivityFeed)
 		api.GET("/users/search", socialHandler.SearchUsers)
 		api.GET("/users/:id/profile", socialHandler.GetPublicProfile)
+		api.GET("/users/:id/play-heatmap", statsHandler.GetPublicPlayHeatmap)
 
 		// Challenges
 		api.POST("/challenges", challengeHandler.CreateChallenge)

--- a/server/internal/api/session_handler.go
+++ b/server/internal/api/session_handler.go
@@ -1032,6 +1032,9 @@ func (h *SessionHandler) UpdatePlayTime(c *gin.Context) {
 		"last_played_by":  uid,
 	})
 
+	// Record daily play activity for heatmap
+	RecordDailyPlayActivity(h.DB, uid, req.Seconds)
+
 	h.DB.First(&session, session.ID)
 	var saveCount int64
 	h.DB.Model(&db.SessionSaveState{}).Where("session_id = ?", session.ID).Count(&saveCount)

--- a/server/internal/api/session_handler.go
+++ b/server/internal/api/session_handler.go
@@ -1032,9 +1032,6 @@ func (h *SessionHandler) UpdatePlayTime(c *gin.Context) {
 		"last_played_by":  uid,
 	})
 
-	// Record daily play activity for heatmap
-	RecordDailyPlayActivity(h.DB, uid, req.Seconds)
-
 	h.DB.First(&session, session.ID)
 	var saveCount int64
 	h.DB.Model(&db.SessionSaveState{}).Where("session_id = ?", session.ID).Count(&saveCount)

--- a/server/internal/api/stats_handler.go
+++ b/server/internal/api/stats_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 	"strconv"
 	"time"
@@ -156,19 +157,18 @@ func parseTimeString(s string) time.Time {
 }
 
 // RecordDailyPlayActivity upserts a DailyPlayActivity row for today, incrementing
-// the play time by the given number of seconds.
+// the play time by the given number of seconds. Uses an atomic upsert to avoid
+// race conditions under concurrent requests.
 func RecordDailyPlayActivity(database *gorm.DB, userID uint, seconds int64) {
 	today := time.Now().UTC().Truncate(24 * time.Hour)
-	var record db.DailyPlayActivity
-	result := database.Where("user_id = ? AND date = ?", userID, today).First(&record)
-	if result.Error == gorm.ErrRecordNotFound {
-		database.Create(&db.DailyPlayActivity{
-			UserID:   userID,
-			Date:     today,
-			PlayTime: seconds,
-		})
-	} else if result.Error == nil {
-		database.Model(&record).Update("play_time", gorm.Expr("play_time + ?", seconds))
+	result := database.Exec(
+		`INSERT INTO daily_play_activities (user_id, date, play_time)
+		 VALUES (?, ?, ?)
+		 ON CONFLICT (user_id, date) DO UPDATE SET play_time = play_time + ?`,
+		userID, today, seconds, seconds,
+	)
+	if result.Error != nil {
+		slog.Error("failed to record daily play activity", "error", result.Error, "userId", userID)
 	}
 }
 

--- a/server/internal/api/stats_handler.go
+++ b/server/internal/api/stats_handler.go
@@ -154,3 +154,71 @@ func parseTimeString(s string) time.Time {
 	}
 	return time.Time{}
 }
+
+// RecordDailyPlayActivity upserts a DailyPlayActivity row for today, incrementing
+// the play time by the given number of seconds.
+func RecordDailyPlayActivity(database *gorm.DB, userID uint, seconds int64) {
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	var record db.DailyPlayActivity
+	result := database.Where("user_id = ? AND date = ?", userID, today).First(&record)
+	if result.Error == gorm.ErrRecordNotFound {
+		database.Create(&db.DailyPlayActivity{
+			UserID:   userID,
+			Date:     today,
+			PlayTime: seconds,
+		})
+	} else if result.Error == nil {
+		database.Model(&record).Update("play_time", gorm.Expr("play_time + ?", seconds))
+	}
+}
+
+// heatmapEntry is a single day's play activity for the heatmap response.
+type heatmapEntry struct {
+	Date     string `json:"date"`
+	PlayTime int64  `json:"playTime"`
+}
+
+// GetPlayHeatmap returns the current user's daily play activity for the past 365 days.
+// GET /api/user/play-heatmap
+func (h *StatsHandler) GetPlayHeatmap(c *gin.Context) {
+	uid := getUserID(c)
+	h.getHeatmapForUser(c, uid)
+}
+
+// GetPublicPlayHeatmap returns a user's daily play activity for the past 365 days.
+// GET /api/users/:id/play-heatmap
+func (h *StatsHandler) GetPublicPlayHeatmap(c *gin.Context) {
+	idParam := c.Param("id")
+	id, err := strconv.ParseUint(idParam, 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user id"})
+		return
+	}
+
+	var user db.User
+	if err := h.DB.First(&user, uint(id)).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	h.getHeatmapForUser(c, uint(id))
+}
+
+func (h *StatsHandler) getHeatmapForUser(c *gin.Context, userID uint) {
+	since := time.Now().UTC().Truncate(24*time.Hour).AddDate(0, 0, -365)
+
+	var activities []db.DailyPlayActivity
+	h.DB.Where("user_id = ? AND date >= ?", userID, since).
+		Order("date ASC").
+		Find(&activities)
+
+	entries := make([]heatmapEntry, 0, len(activities))
+	for _, a := range activities {
+		entries = append(entries, heatmapEntry{
+			Date:     a.Date.Format("2006-01-02"),
+			PlayTime: a.PlayTime,
+		})
+	}
+
+	c.JSON(http.StatusOK, entries)
+}

--- a/server/internal/api/stats_handler_test.go
+++ b/server/internal/api/stats_handler_test.go
@@ -297,6 +297,145 @@ func TestGetUserStats_WithHistory(t *testing.T) {
 	assert.Equal(t, "Fav Game", mostPlayed["title"])
 }
 
+func TestRecordDailyPlayActivity_Upsert(t *testing.T) {
+	database, _ := setupTestEnv(t)
+
+	// Create a test user
+	user := db.User{Username: "heatmap_user", Email: "heatmap@example.com", PasswordHash: "hash", Role: "user"}
+	database.Create(&user)
+
+	// First call creates a new record
+	RecordDailyPlayActivity(database, user.ID, 60)
+
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	var record db.DailyPlayActivity
+	err := database.Where("user_id = ? AND date = ?", user.ID, today).First(&record).Error
+	require.NoError(t, err)
+	assert.Equal(t, int64(60), record.PlayTime)
+
+	// Second call increments the existing record
+	RecordDailyPlayActivity(database, user.ID, 120)
+
+	database.Where("user_id = ? AND date = ?", user.ID, today).First(&record)
+	assert.Equal(t, int64(180), record.PlayTime)
+}
+
+func TestHeatmap_Empty(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/play-heatmap", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var entries []heatmapEntry
+	err := json.Unmarshal(w.Body.Bytes(), &entries)
+	require.NoError(t, err)
+	assert.Len(t, entries, 0)
+}
+
+func TestHeatmap_WithData(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	var user db.User
+	database.Where("username = ?", "apitest").First(&user)
+
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	yesterday := today.AddDate(0, 0, -1)
+
+	database.Create(&db.DailyPlayActivity{UserID: user.ID, Date: today, PlayTime: 3600})
+	database.Create(&db.DailyPlayActivity{UserID: user.ID, Date: yesterday, PlayTime: 1800})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/play-heatmap", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var entries []heatmapEntry
+	err := json.Unmarshal(w.Body.Bytes(), &entries)
+	require.NoError(t, err)
+	assert.Len(t, entries, 2)
+
+	// Should be sorted ascending by date
+	assert.Equal(t, yesterday.Format("2006-01-02"), entries[0].Date)
+	assert.Equal(t, int64(1800), entries[0].PlayTime)
+	assert.Equal(t, today.Format("2006-01-02"), entries[1].Date)
+	assert.Equal(t, int64(3600), entries[1].PlayTime)
+}
+
+func TestHeatmap_PublicEndpoint(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	// Create another user with activity
+	otherUser := db.User{Username: "other_heatmap", Email: "other@example.com", PasswordHash: "hash", Role: "user"}
+	database.Create(&otherUser)
+
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	database.Create(&db.DailyPlayActivity{UserID: otherUser.ID, Date: today, PlayTime: 7200})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/users/%d/play-heatmap", otherUser.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var entries []heatmapEntry
+	err := json.Unmarshal(w.Body.Bytes(), &entries)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, int64(7200), entries[0].PlayTime)
+}
+
+func TestHeatmap_UserIsolation(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	var user db.User
+	database.Where("username = ?", "apitest").First(&user)
+
+	// Create another user with activity
+	otherUser := db.User{Username: "isolated_user", Email: "isolated@example.com", PasswordHash: "hash", Role: "user"}
+	database.Create(&otherUser)
+
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	database.Create(&db.DailyPlayActivity{UserID: user.ID, Date: today, PlayTime: 100})
+	database.Create(&db.DailyPlayActivity{UserID: otherUser.ID, Date: today, PlayTime: 9999})
+
+	// Current user's heatmap should only show their own data
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/play-heatmap", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var entries []heatmapEntry
+	err := json.Unmarshal(w.Body.Bytes(), &entries)
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+	assert.Equal(t, int64(100), entries[0].PlayTime)
+}
+
+func TestHeatmap_PublicNotFound(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/99999/play-heatmap", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
 func TestCalculateStreaks(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -151,6 +151,7 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&SessionSaveState{},
 		&SessionSaveData{},
 		&SessionCheatSetting{},
+		&DailyPlayActivity{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -154,6 +154,14 @@ type PlayHistory struct {
 	PlayTime   int64         `json:"playTime"` // seconds
 }
 
+// DailyPlayActivity aggregates play time per user per day for heatmap display.
+type DailyPlayActivity struct {
+	ID       uint      `gorm:"primarykey" json:"id"`
+	UserID   uint      `gorm:"uniqueIndex:idx_daily_play_user_date;not null" json:"userId"`
+	Date     time.Time `gorm:"uniqueIndex:idx_daily_play_user_date;not null;type:date" json:"date"`
+	PlayTime int64     `json:"playTime"` // seconds added on this day
+}
+
 // RefreshToken stores issued refresh tokens.
 type RefreshToken struct {
 	ID          uint           `gorm:"primarykey"`

--- a/web/src/components/__tests__/play-heatmap.test.tsx
+++ b/web/src/components/__tests__/play-heatmap.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { PlayHeatmap } from "../play-heatmap";
+import type { DailyPlayActivity } from "@/types/api";
+
+function makeData(days: number): DailyPlayActivity[] {
+  const result: DailyPlayActivity[] = [];
+  const today = new Date();
+  for (let i = 0; i < days; i++) {
+    const d = new Date(today);
+    d.setDate(d.getDate() - i);
+    const y = d.getFullYear();
+    const m = String(d.getMonth() + 1).padStart(2, "0");
+    const day = String(d.getDate()).padStart(2, "0");
+    result.push({
+      date: `${y}-${m}-${day}`,
+      playTime: (i + 1) * 600,
+    });
+  }
+  return result;
+}
+
+describe("PlayHeatmap", () => {
+  it("renders empty state when data is empty", () => {
+    render(<PlayHeatmap data={[]} />);
+    expect(screen.getByText("No play activity yet")).toBeInTheDocument();
+  });
+
+  it("renders SVG with cells when data is provided", () => {
+    const data = makeData(7);
+    render(<PlayHeatmap data={data} />);
+    const svg = screen.getByRole("img", { name: /play activity heatmap/i });
+    expect(svg).toBeInTheDocument();
+    const cells = screen.getAllByTestId("heatmap-cell");
+    expect(cells.length).toBeGreaterThan(0);
+  });
+
+  it("assigns correct color levels based on play time", () => {
+    const today = new Date();
+    const y = today.getFullYear();
+    const m = String(today.getMonth() + 1).padStart(2, "0");
+    const day = String(today.getDate()).padStart(2, "0");
+    const todayKey = `${y}-${m}-${day}`;
+
+    const data: DailyPlayActivity[] = [{ date: todayKey, playTime: 3600 }];
+    render(<PlayHeatmap data={data} />);
+
+    const cells = screen.getAllByTestId("heatmap-cell");
+    const cell = cells.find(
+      (el) => el.getAttribute("data-date") === todayKey,
+    );
+    expect(cell).toBeDefined();
+    // With only one entry, it should be the max level (4)
+    expect(cell?.getAttribute("data-level")).toBe("4");
+  });
+
+  it("renders month and day labels", () => {
+    const data = makeData(90);
+    render(<PlayHeatmap data={data} />);
+    // Should have day labels
+    expect(screen.getByText("Mon")).toBeInTheDocument();
+    expect(screen.getByText("Wed")).toBeInTheDocument();
+    expect(screen.getByText("Fri")).toBeInTheDocument();
+  });
+
+  it("renders legend with Less and More labels", () => {
+    const data = makeData(7);
+    render(<PlayHeatmap data={data} />);
+    expect(screen.getByText("Less")).toBeInTheDocument();
+    expect(screen.getByText("More")).toBeInTheDocument();
+  });
+
+  it("shows tooltip on cell hover", () => {
+    const data = makeData(7);
+    render(<PlayHeatmap data={data} />);
+    const cells = screen.getAllByTestId("heatmap-cell");
+    fireEvent.mouseEnter(cells[0]);
+    // Tooltip should appear somewhere in the document
+    // The tooltip contains formatted play time or "No activity"
+    const tooltip = document.querySelector(".fixed.z-50");
+    expect(tooltip).toBeInTheDocument();
+  });
+
+  it("hides tooltip on mouse leave", () => {
+    const data = makeData(7);
+    render(<PlayHeatmap data={data} />);
+    const cells = screen.getAllByTestId("heatmap-cell");
+    fireEvent.mouseEnter(cells[0]);
+    fireEvent.mouseLeave(cells[0]);
+    const tooltip = document.querySelector(".fixed.z-50");
+    expect(tooltip).not.toBeInTheDocument();
+  });
+
+  it("applies custom className", () => {
+    const data = makeData(1);
+    const { container } = render(
+      <PlayHeatmap data={data} className="my-custom-class" />,
+    );
+    expect(container.firstChild).toHaveClass("my-custom-class");
+  });
+});

--- a/web/src/components/play-heatmap.tsx
+++ b/web/src/components/play-heatmap.tsx
@@ -1,0 +1,290 @@
+import { useMemo, useState } from "react";
+import type { DailyPlayActivity } from "@/types/api";
+import { formatPlayTime } from "@/lib/format";
+import { cn } from "@/lib/cn";
+
+interface PlayHeatmapProps {
+  data: DailyPlayActivity[];
+  className?: string;
+}
+
+const CELL_SIZE = 13;
+const CELL_GAP = 3;
+const CELL_RADIUS = 2;
+const WEEKS = 52;
+const DAYS = 7;
+const LABEL_WIDTH = 30;
+const TOP_MARGIN = 18;
+
+const DAY_LABELS = [
+  { day: 1, label: "Mon" },
+  { day: 3, label: "Wed" },
+  { day: 5, label: "Fri" },
+];
+
+const MONTH_NAMES = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+const COLORS = [
+  "var(--color-surface-800)",
+  "var(--color-brand-900)",
+  "var(--color-brand-700)",
+  "var(--color-brand-500)",
+  "var(--color-brand-400)",
+];
+
+function getColorLevel(playTime: number, maxTime: number): number {
+  if (playTime === 0) return 0;
+  if (maxTime === 0) return 0;
+  const ratio = playTime / maxTime;
+  if (ratio <= 0.25) return 1;
+  if (ratio <= 0.5) return 2;
+  if (ratio <= 0.75) return 3;
+  return 4;
+}
+
+function formatDateLabel(date: Date): string {
+  return date.toLocaleDateString(undefined, {
+    weekday: "long",
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+function toDateKey(d: Date): string {
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+export function PlayHeatmap({ data, className }: PlayHeatmapProps) {
+  const [tooltip, setTooltip] = useState<{
+    x: number;
+    y: number;
+    date: Date;
+    playTime: number;
+  } | null>(null);
+
+  const { cells, monthLabels, maxTime } = useMemo(() => {
+    const activityMap = new Map<string, number>();
+    for (const entry of data) {
+      activityMap.set(entry.date, entry.playTime);
+    }
+
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+
+    // Find the end of the current week (Saturday)
+    const endDay = new Date(today);
+    const todayDow = today.getDay(); // 0=Sun
+    const daysUntilSat = (6 - todayDow + 7) % 7;
+    endDay.setDate(endDay.getDate() + daysUntilSat);
+
+    // Go back WEEKS weeks from the end day to find the start (Sunday)
+    const startDay = new Date(endDay);
+    startDay.setDate(startDay.getDate() - WEEKS * 7 + 1);
+
+    // Ensure startDay is a Sunday
+    const startDow = startDay.getDay();
+    if (startDow !== 0) {
+      startDay.setDate(startDay.getDate() - startDow);
+    }
+
+    let max = 0;
+    const cellList: {
+      date: Date;
+      week: number;
+      day: number;
+      playTime: number;
+    }[] = [];
+
+    const current = new Date(startDay);
+    while (current <= endDay) {
+      const key = toDateKey(current);
+      const playTime = activityMap.get(key) ?? 0;
+      if (playTime > max) max = playTime;
+
+      const diffDays = Math.floor(
+        (current.getTime() - startDay.getTime()) / 86400000,
+      );
+      const week = Math.floor(diffDays / 7);
+      const day = diffDays % 7;
+
+      cellList.push({
+        date: new Date(current),
+        week,
+        day,
+        playTime,
+      });
+
+      current.setDate(current.getDate() + 1);
+    }
+
+    // Compute month labels
+    const labels: { week: number; label: string }[] = [];
+    let lastMonth = -1;
+    for (const cell of cellList) {
+      if (cell.day === 0) {
+        const month = cell.date.getMonth();
+        if (month !== lastMonth) {
+          labels.push({ week: cell.week, label: MONTH_NAMES[month] });
+          lastMonth = month;
+        }
+      }
+    }
+
+    return { cells: cellList, monthLabels: labels, maxTime: max };
+  }, [data]);
+
+  if (data.length === 0) {
+    return (
+      <div className={cn("text-surface-500 text-sm py-8 text-center", className)}>
+        No play activity yet
+      </div>
+    );
+  }
+
+  const totalWeeks = Math.max(...cells.map((c) => c.week)) + 1;
+  const svgWidth = LABEL_WIDTH + totalWeeks * (CELL_SIZE + CELL_GAP);
+  const svgHeight = TOP_MARGIN + DAYS * (CELL_SIZE + CELL_GAP);
+
+  return (
+    <div className={cn("relative", className)}>
+      <div className="overflow-x-auto">
+        <svg
+          width={svgWidth}
+          height={svgHeight + 30}
+          className="block"
+          role="img"
+          aria-label="Play activity heatmap"
+        >
+          {/* Month labels */}
+          {monthLabels.map(({ week, label }) => (
+            <text
+              key={`month-${week}`}
+              x={LABEL_WIDTH + week * (CELL_SIZE + CELL_GAP)}
+              y={12}
+              className="fill-surface-500"
+              fontSize={10}
+            >
+              {label}
+            </text>
+          ))}
+
+          {/* Day labels */}
+          {DAY_LABELS.map(({ day, label }) => (
+            <text
+              key={`day-${day}`}
+              x={0}
+              y={TOP_MARGIN + day * (CELL_SIZE + CELL_GAP) + CELL_SIZE - 2}
+              className="fill-surface-500"
+              fontSize={10}
+            >
+              {label}
+            </text>
+          ))}
+
+          {/* Cells */}
+          {cells.map((cell) => {
+            const level = getColorLevel(cell.playTime, maxTime);
+            const x = LABEL_WIDTH + cell.week * (CELL_SIZE + CELL_GAP);
+            const y = TOP_MARGIN + cell.day * (CELL_SIZE + CELL_GAP);
+
+            return (
+              <rect
+                key={toDateKey(cell.date)}
+                x={x}
+                y={y}
+                width={CELL_SIZE}
+                height={CELL_SIZE}
+                rx={CELL_RADIUS}
+                ry={CELL_RADIUS}
+                fill={COLORS[level]}
+                data-testid="heatmap-cell"
+                data-date={toDateKey(cell.date)}
+                data-level={level}
+                onMouseEnter={(e) => {
+                  const rect = (
+                    e.target as SVGRectElement
+                  ).getBoundingClientRect();
+                  setTooltip({
+                    x: rect.left + rect.width / 2,
+                    y: rect.top,
+                    date: cell.date,
+                    playTime: cell.playTime,
+                  });
+                }}
+                onMouseLeave={() => setTooltip(null)}
+              />
+            );
+          })}
+
+          {/* Legend */}
+          <text
+            x={svgWidth - 130}
+            y={svgHeight + 22}
+            className="fill-surface-500"
+            fontSize={10}
+          >
+            Less
+          </text>
+          {COLORS.map((color, i) => (
+            <rect
+              key={`legend-${i}`}
+              x={svgWidth - 100 + i * (CELL_SIZE + 2)}
+              y={svgHeight + 12}
+              width={CELL_SIZE}
+              height={CELL_SIZE}
+              rx={CELL_RADIUS}
+              ry={CELL_RADIUS}
+              fill={color}
+            />
+          ))}
+          <text
+            x={svgWidth - 100 + COLORS.length * (CELL_SIZE + 2) + 4}
+            y={svgHeight + 22}
+            className="fill-surface-500"
+            fontSize={10}
+          >
+            More
+          </text>
+        </svg>
+      </div>
+
+      {/* Tooltip */}
+      {tooltip && (
+        <div
+          className="fixed z-50 pointer-events-none px-2.5 py-1.5 rounded-lg bg-surface-900 border border-surface-700 text-xs text-surface-200 shadow-lg whitespace-nowrap"
+          style={{
+            left: tooltip.x,
+            top: tooltip.y - 8,
+            transform: "translate(-50%, -100%)",
+          }}
+        >
+          <span className="font-medium">
+            {tooltip.playTime > 0
+              ? formatPlayTime(tooltip.playTime)
+              : "No activity"}
+          </span>
+          <span className="text-surface-400 ml-1.5">
+            {formatDateLabel(tooltip.date)}
+          </span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/use-play-heatmap.ts
+++ b/web/src/hooks/use-play-heatmap.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type { DailyPlayActivity } from "@/types/api";
+
+export function useMyPlayHeatmap() {
+  return useQuery({
+    queryKey: ["user", "play-heatmap"],
+    queryFn: () => api.get<DailyPlayActivity[]>("/user/play-heatmap"),
+  });
+}
+
+export function useUserPlayHeatmap(userId: string) {
+  return useQuery({
+    queryKey: ["users", userId, "play-heatmap"],
+    queryFn: () =>
+      api.get<DailyPlayActivity[]>(`/users/${userId}/play-heatmap`),
+    enabled: !!userId,
+  });
+}

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -73,6 +73,7 @@ export type ApiGetPath = WithQuery<
   | "/user/recent"
   | "/user/favorites"
   | "/user/play-stats"
+  | "/user/play-heatmap"
   | "/user/play-later"
   | "/user/devices"
   | `/user/devices/${string}/preferences`
@@ -100,6 +101,7 @@ export type ApiGetPath = WithQuery<
   | "/social/activity"
   | `/users/search`
   | `/users/${string}/profile`
+  | `/users/${string}/play-heatmap`
 
   // Collections
   | "/collections"

--- a/web/src/pages/stats-page.tsx
+++ b/web/src/pages/stats-page.tsx
@@ -1,8 +1,10 @@
 import { Link } from "react-router-dom";
-import { BarChart3, Trophy, Users } from "lucide-react";
+import { BarChart3, Calendar, Trophy, Users } from "lucide-react";
 import { Badge, Skeleton, EmptyState } from "@/components/ui";
 import { PlayerAvatar } from "@/components/player-avatar";
+import { PlayHeatmap } from "@/components/play-heatmap";
 import { useMostPlayedGames, useMostActivePlayers } from "@/hooks/use-stats";
+import { useMyPlayHeatmap } from "@/hooks/use-play-heatmap";
 import { formatPlayTime, formatRelativeTime } from "@/lib/format";
 import { cn } from "@/lib/cn";
 
@@ -95,6 +97,8 @@ function MostActiveSkeleton() {
 }
 
 export function StatsPage() {
+  const { data: heatmapData, isLoading: isLoadingHeatmap } =
+    useMyPlayHeatmap();
   const { data: mostPlayed, isLoading: isLoadingMostPlayed } =
     useMostPlayedGames();
   const { data: mostActive, isLoading: isLoadingMostActive } =
@@ -124,6 +128,24 @@ export function StatsPage() {
           title="No play data yet"
           description="Play some games to see the leaderboard come alive."
         />
+      )}
+
+      {/* Your Activity Heatmap */}
+      {(isLoadingHeatmap || (heatmapData && heatmapData.length > 0)) && (
+        <section>
+          <div className="flex items-center gap-2.5 mb-5">
+            <Calendar className="h-5 w-5 text-brand-400" />
+            <h2 className="text-xl font-bold text-surface-100">
+              Your Activity
+            </h2>
+          </div>
+
+          {isLoadingHeatmap ? (
+            <Skeleton className="h-[140px] w-full rounded-xl" />
+          ) : (
+            <PlayHeatmap data={heatmapData ?? []} />
+          )}
+        </section>
       )}
 
       {/* Most Played Games / Hall of Fame */}

--- a/web/src/pages/user-profile-page.tsx
+++ b/web/src/pages/user-profile-page.tsx
@@ -1,7 +1,9 @@
 import { useParams, Link } from "react-router-dom";
-import { User, Clock, Gamepad2, Heart, Trophy } from "lucide-react";
+import { User, Clock, Calendar, Gamepad2, Heart, Trophy } from "lucide-react";
 import { usePublicProfile } from "@/hooks/use-public-profile";
+import { useUserPlayHeatmap } from "@/hooks/use-play-heatmap";
 import { PlayerAvatar } from "@/components/player-avatar";
+import { PlayHeatmap } from "@/components/play-heatmap";
 import { Badge, Skeleton, EmptyState } from "@/components/ui";
 import type { PublicProfileGame } from "@/types/api";
 
@@ -94,6 +96,8 @@ function ProfileSkeleton() {
 export function UserProfilePage() {
   const { id } = useParams<{ id: string }>();
   const { data: profile, isLoading, error } = usePublicProfile(id || "");
+  const { data: heatmapData, isLoading: isLoadingHeatmap } =
+    useUserPlayHeatmap(id || "");
 
   if (isLoading) {
     return (
@@ -167,6 +171,22 @@ export function UserProfilePage() {
           <p className="text-sm text-surface-400 mt-1">Games Played</p>
         </div>
       </div>
+
+      {/* Activity Heatmap */}
+      {(isLoadingHeatmap || (heatmapData && heatmapData.length > 0)) && (
+        <section>
+          <div className="flex items-center gap-2.5 mb-4">
+            <Calendar className="h-5 w-5 text-brand-400" />
+            <h2 className="text-lg font-bold text-surface-100">Activity</h2>
+          </div>
+
+          {isLoadingHeatmap ? (
+            <Skeleton className="h-[140px] w-full rounded-xl" />
+          ) : (
+            <PlayHeatmap data={heatmapData ?? []} />
+          )}
+        </section>
+      )}
 
       {/* Game sections */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -620,6 +620,11 @@ export interface PlayStatsEntry {
   lastPlayedAt: string;
 }
 
+export interface DailyPlayActivity {
+  date: string;
+  playTime: number;
+}
+
 // --- Session Saves & Cheats ---
 
 export interface SessionSave {


### PR DESCRIPTION
## Summary
- Add `DailyPlayActivity` model + GORM auto-migrate for tracking per-user daily play time
- Hook `RecordDailyPlayActivity` into both `GameHandler.UpdatePlayTime` and `SessionHandler.UpdatePlayTime`
- New endpoints: `GET /api/user/play-heatmap` (own) and `GET /api/users/:id/play-heatmap` (public)
- GitHub-style `PlayHeatmap` SVG component with 52-week grid, color scale, month/day labels, hover tooltips, and legend
- Integrated into Stats page ("Your Activity" section) and User Profile page ("Activity" section)
- 6 backend tests (upsert, empty, with data, public, user isolation, not found) + 8 frontend component tests

## Test plan
- [x] Go backend tests pass (`go test ./...`)
- [x] Web frontend tests pass (698 tests, including 8 new PlayHeatmap tests)
- [x] Visual review: heatmap renders correctly on Stats page and User Profile page
- [x] TypeScript compiles cleanly (`tsc --noEmit`)