### PR TITLE
fix: heatmap DST offset bug

### DIFF
--- a/web/src/components/play-heatmap.tsx
+++ b/web/src/components/play-heatmap.tsx
@@ -118,9 +118,19 @@ export function PlayHeatmap({ data, className }: PlayHeatmapProps) {
       const playTime = activityMap.get(key) ?? 0;
       if (playTime > max) max = playTime;
 
-      const diffDays = Math.floor(
-        (current.getTime() - startDay.getTime()) / 86400000,
-      );
+      // Use UTC to avoid DST shifts when computing day offsets
+      const diffMs =
+        Date.UTC(
+          current.getFullYear(),
+          current.getMonth(),
+          current.getDate(),
+        ) -
+        Date.UTC(
+          startDay.getFullYear(),
+          startDay.getMonth(),
+          startDay.getDate(),
+        );
+      const diffDays = Math.round(diffMs / 86400000);
       const week = Math.floor(diffDays / 7);
       const day = diffDays % 7;
 


### PR DESCRIPTION
## Summary
- Fix heatmap cells being offset by one row between DST transitions (March→October in CET/CEST timezones)
- Root cause: `Math.floor((current.getTime() - startDay.getTime()) / 86400000)` uses local midnight timestamps, which differ by 25 hours (not 24) when crossing a DST boundary
- Fix: use `Date.UTC()` to normalize both dates before computing day differences, making the calculation timezone-immune

## Test plan
- [x] All 8 PlayHeatmap tests pass
- [x] Visual verification on stats page