### PR TITLE
feat: add netplay user invite system

### DIFF
--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -56,6 +56,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.SharedSessionInvite{},
 		&db.SharedSessionSave{},
 		&db.NetplaySession{},
+		&db.NetplayInvite{},
 		&db.Challenge{},
 		&db.ChallengeAttempt{},
 		&db.GameKeyMappingPreference{},

--- a/server/internal/api/netplay_handler.go
+++ b/server/internal/api/netplay_handler.go
@@ -230,6 +230,9 @@ func (h *NetplayHandler) JoinByInviteCode(c *gin.Context) {
 	// Reload with associations
 	h.DB.Preload("HostUser").Preload("ClientUser").Preload("Game").Preload("Game.Console").First(&session, session.ID)
 
+	// Expire remaining pending invites now that the session is full (AC-5.1)
+	h.expireNetplayInvites(session.ID)
+
 	if h.Hub != nil {
 		h.Hub.Broadcast(ws.Event{Type: "netplay_player_joined", Payload: h.toSessionResponse(session)})
 	}
@@ -271,6 +274,9 @@ func (h *NetplayHandler) LeaveSession(c *gin.Context) {
 		"ended_at":   now,
 	})
 
+	// Expire pending invites when session ends (AC-5.2)
+	h.expireNetplayInvites(session.ID)
+
 	if h.Hub != nil {
 		h.Hub.Broadcast(ws.Event{Type: "netplay_session_ended", Payload: gin.H{
 			"sessionId": strconv.FormatUint(uint64(session.ID), 10),
@@ -306,6 +312,9 @@ func (h *NetplayHandler) DeleteSession(c *gin.Context) {
 		"end_reason": "host_left",
 		"ended_at":   now,
 	})
+
+	// Expire pending invites when session is cancelled (AC-5.2)
+	h.expireNetplayInvites(session.ID)
 
 	if h.Hub != nil {
 		h.Hub.Broadcast(ws.Event{Type: "netplay_session_deleted", Payload: gin.H{

--- a/server/internal/api/netplay_invite_handler.go
+++ b/server/internal/api/netplay_invite_handler.go
@@ -1,0 +1,298 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	ws "github.com/spela/server/internal/websocket"
+	"gorm.io/gorm"
+)
+
+// SendInvite sends a netplay session invite to a user by username.
+func (h *NetplayHandler) SendInvite(c *gin.Context) {
+	uid := getUserID(c)
+
+	session, ok := h.loadSession(c)
+	if !ok {
+		return
+	}
+
+	// Only the host can send invites (AC-1.7)
+	if session.HostUserID != uid {
+		c.JSON(http.StatusForbidden, gin.H{"error": "only the host can send invites"})
+		return
+	}
+
+	// Session must be waiting (AC-1.1)
+	if session.Status != "waiting" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "can only invite players to a waiting session"})
+		return
+	}
+
+	var req struct {
+		Username string `json:"username" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request: username is required"})
+		return
+	}
+
+	// Find invitee
+	var invitee db.User
+	if err := h.DB.Where("username = ?", req.Username).First(&invitee).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "user not found"})
+		return
+	}
+
+	// Cannot invite yourself (AC-1.3 — exclude myself)
+	if invitee.ID == uid {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "cannot invite yourself"})
+		return
+	}
+
+	// Check if already has a pending invite (AC-1.8)
+	var existingInvite db.NetplayInvite
+	if err := h.DB.Where("netplay_session_id = ? AND invitee_id = ? AND status = ?", session.ID, invitee.ID, "pending").First(&existingInvite).Error; err == nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "user already has a pending invite for this session"})
+		return
+	}
+
+	// If previously declined, hard-delete the old invite and create the new one
+	// atomically to avoid unique constraint violations under concurrent requests.
+	var invite db.NetplayInvite
+	txErr := h.DB.Transaction(func(tx *gorm.DB) error {
+		tx.Unscoped().Where("netplay_session_id = ? AND invitee_id = ? AND status = ?", session.ID, invitee.ID, "declined").Delete(&db.NetplayInvite{})
+
+		invite = db.NetplayInvite{
+			NetplaySessionID: session.ID,
+			InviterID:        uid,
+			InviteeID:        invitee.ID,
+			Status:           "pending",
+		}
+		return tx.Create(&invite).Error
+	})
+	if txErr != nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "failed to create invite"})
+		return
+	}
+
+	// Reload with associations
+	h.DB.Preload("Inviter").Preload("Invitee").
+		Preload("NetplaySession").Preload("NetplaySession.HostUser").
+		Preload("NetplaySession.Game").Preload("NetplaySession.Game.Console").
+		First(&invite, invite.ID)
+
+	resp := h.toNetplayInviteResponse(invite)
+
+	if h.Hub != nil {
+		h.Hub.Broadcast(ws.Event{Type: "netplay_invite_sent", Payload: resp})
+	}
+
+	c.JSON(http.StatusCreated, resp)
+}
+
+// ListSessionInvites lists all invites for a session (host view, AC-3.1).
+func (h *NetplayHandler) ListSessionInvites(c *gin.Context) {
+	uid := getUserID(c)
+
+	session, ok := h.loadSession(c)
+	if !ok {
+		return
+	}
+
+	// Only the host can view session invites
+	if session.HostUserID != uid {
+		c.JSON(http.StatusForbidden, gin.H{"error": "only the host can view session invites"})
+		return
+	}
+
+	var invites []db.NetplayInvite
+	if err := h.DB.Where("netplay_session_id = ?", session.ID).
+		Preload("Inviter").Preload("Invitee").
+		Preload("NetplaySession").Preload("NetplaySession.HostUser").
+		Preload("NetplaySession.Game").Preload("NetplaySession.Game.Console").
+		Order("created_at DESC").
+		Find(&invites).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch invites"})
+		return
+	}
+
+	result := make([]NetplayInviteResponse, 0, len(invites))
+	for _, inv := range invites {
+		result = append(result, h.toNetplayInviteResponse(inv))
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// ListMyNetplayInvites returns pending netplay invites for the current user (AC-2.3).
+func (h *NetplayHandler) ListMyNetplayInvites(c *gin.Context) {
+	uid := getUserID(c)
+
+	var invites []db.NetplayInvite
+	if err := h.DB.Where("invitee_id = ? AND status = ?", uid, "pending").
+		Preload("Inviter").Preload("Invitee").
+		Preload("NetplaySession").Preload("NetplaySession.HostUser").
+		Preload("NetplaySession.Game").Preload("NetplaySession.Game.Console").
+		Order("created_at DESC").
+		Find(&invites).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch invites"})
+		return
+	}
+
+	result := make([]NetplayInviteResponse, 0, len(invites))
+	for _, inv := range invites {
+		result = append(result, h.toNetplayInviteResponse(inv))
+	}
+
+	c.JSON(http.StatusOK, gin.H{"data": result, "total": len(result)})
+}
+
+// GetPendingNetplayInviteCount returns the number of pending netplay invites for the current user (AC-2.2).
+func (h *NetplayHandler) GetPendingNetplayInviteCount(c *gin.Context) {
+	uid := getUserID(c)
+
+	var count int64
+	if err := h.DB.Model(&db.NetplayInvite{}).Where("invitee_id = ? AND status = ?", uid, "pending").Count(&count).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to count invites"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"count": count})
+}
+
+// AcceptNetplayInvite accepts a netplay invite (AC-2.5, AC-2.6).
+func (h *NetplayHandler) AcceptNetplayInvite(c *gin.Context) {
+	uid := getUserID(c)
+	inviteID := c.Param("inviteId")
+
+	var invite db.NetplayInvite
+	if err := h.DB.Preload("NetplaySession").First(&invite, inviteID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "invite not found"})
+		return
+	}
+
+	if invite.InviteeID != uid {
+		c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
+		return
+	}
+
+	if invite.Status != "pending" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invite is no longer pending"})
+		return
+	}
+
+	// Check session is still waiting
+	if invite.NetplaySession.Status != "waiting" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "session is no longer accepting players"})
+		return
+	}
+
+	// Update invite status
+	invite.Status = "accepted"
+	if err := h.DB.Save(&invite).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to accept invite"})
+		return
+	}
+
+	// Expire all other pending invites for this session (AC-5.1)
+	h.DB.Model(&db.NetplayInvite{}).
+		Where("netplay_session_id = ? AND id != ? AND status = ?", invite.NetplaySessionID, invite.ID, "pending").
+		Update("status", "expired")
+
+	// Reload with associations for response
+	h.DB.Preload("Inviter").Preload("Invitee").
+		Preload("NetplaySession").Preload("NetplaySession.HostUser").
+		Preload("NetplaySession.Game").Preload("NetplaySession.Game.Console").
+		First(&invite, invite.ID)
+
+	resp := h.toNetplayInviteResponse(invite)
+
+	if h.Hub != nil {
+		h.Hub.Broadcast(ws.Event{Type: "netplay_invite_accepted", Payload: resp})
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+// DeclineNetplayInvite declines a netplay invite (AC-2.5, AC-2.7).
+func (h *NetplayHandler) DeclineNetplayInvite(c *gin.Context) {
+	uid := getUserID(c)
+	inviteID := c.Param("inviteId")
+
+	var invite db.NetplayInvite
+	if err := h.DB.First(&invite, inviteID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "invite not found"})
+		return
+	}
+
+	if invite.InviteeID != uid {
+		c.JSON(http.StatusForbidden, gin.H{"error": "not authorized"})
+		return
+	}
+
+	if invite.Status != "pending" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invite is no longer pending"})
+		return
+	}
+
+	invite.Status = "declined"
+	if err := h.DB.Save(&invite).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to decline invite"})
+		return
+	}
+
+	if h.Hub != nil {
+		h.Hub.Broadcast(ws.Event{Type: "netplay_invite_declined", Payload: gin.H{
+			"netplaySessionId": strconv.FormatUint(uint64(invite.NetplaySessionID), 10),
+			"inviteeId":        strconv.FormatUint(uint64(uid), 10),
+		}})
+	}
+
+	c.JSON(http.StatusOK, gin.H{"message": "invite declined"})
+}
+
+// expireNetplayInvites marks all pending invites for a session as expired (AC-5.1, AC-5.2).
+func (h *NetplayHandler) expireNetplayInvites(sessionID uint) {
+	h.DB.Model(&db.NetplayInvite{}).
+		Where("netplay_session_id = ? AND status = ?", sessionID, "pending").
+		Update("status", "expired")
+}
+
+// --- Response converter ---
+
+func (h *NetplayHandler) toNetplayInviteResponse(inv db.NetplayInvite) NetplayInviteResponse {
+	coverURL := inv.NetplaySession.Game.CoverURL
+	if coverURL != "" && !strings.HasPrefix(coverURL, "http") {
+		coverURL = "/api/images/" + coverURL
+	}
+
+	consoleName := ""
+	if inv.NetplaySession.Game.Console.ID != 0 {
+		consoleName = inv.NetplaySession.Game.Console.Name
+	}
+
+	hostUsername := inv.NetplaySession.HostUser.Username
+
+	return NetplayInviteResponse{
+		ID:               strconv.FormatUint(uint64(inv.ID), 10),
+		NetplaySessionID: strconv.FormatUint(uint64(inv.NetplaySessionID), 10),
+		InviterID:        strconv.FormatUint(uint64(inv.InviterID), 10),
+		InviterUsername:  inv.Inviter.Username,
+		InviterAvatarURL: inv.Inviter.AvatarURL,
+		InviteeID:        strconv.FormatUint(uint64(inv.InviteeID), 10),
+		InviteeUsername:  inv.Invitee.Username,
+		InviteeAvatarURL: inv.Invitee.AvatarURL,
+		GameID:           strconv.FormatUint(uint64(inv.NetplaySession.GameID), 10),
+		GameTitle:        inv.NetplaySession.Game.Title,
+		GameCoverURL:     coverURL,
+		ConsoleName:      consoleName,
+		HostUsername:     hostUsername,
+		InputDelay:       inv.NetplaySession.InputDelay,
+		Status:           inv.Status,
+		CreatedAt:        inv.CreatedAt,
+	}
+}

--- a/server/internal/api/netplay_invite_test.go
+++ b/server/internal/api/netplay_invite_test.go
@@ -1,0 +1,537 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetplayInvite_SendInvite(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code)
+
+	var resp NetplayInviteResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.NotEmpty(t, resp.ID)
+	assert.Equal(t, session.ID, resp.NetplaySessionID)
+	assert.Equal(t, "pending", resp.Status)
+	assert.Equal(t, "client", resp.InviteeUsername)
+	assert.Equal(t, "Mega Man", resp.GameTitle)
+	assert.NotEmpty(t, resp.HostUsername)
+}
+
+func TestNetplayInvite_SendInvite_NotHost(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	body, _ := json.Marshal(map[string]interface{}{"username": "host"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestNetplayInvite_SendInvite_CannotInviteSelf(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	body, _ := json.Marshal(map[string]interface{}{"username": "host"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNetplayInvite_SendInvite_DuplicatePending(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+
+	// First invite
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Duplicate invite
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusConflict, w.Code)
+}
+
+func TestNetplayInvite_SendInvite_UserNotFound(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	body, _ := json.Marshal(map[string]interface{}{"username": "nonexistent"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNetplayInvite_SendInvite_NotWaiting(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// End the session first
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/leave", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNetplayInvite_ListMyInvites(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Send invite
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Client lists their invites
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/invites", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var listResp struct {
+		Data  []NetplayInviteResponse `json:"data"`
+		Total int                     `json:"total"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &listResp)
+	assert.Equal(t, 1, listResp.Total)
+	assert.Len(t, listResp.Data, 1)
+	assert.Equal(t, "pending", listResp.Data[0].Status)
+	assert.Equal(t, "Mega Man", listResp.Data[0].GameTitle)
+}
+
+func TestNetplayInvite_PendingCount(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// No invites yet
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/netplay/invites/count", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var countResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &countResp)
+	assert.Equal(t, float64(0), countResp["count"])
+
+	// Send invite
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Now count should be 1
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/invites/count", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	json.Unmarshal(w.Body.Bytes(), &countResp)
+	assert.Equal(t, float64(1), countResp["count"])
+}
+
+func TestNetplayInvite_AcceptInvite(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Send invite
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+	var invite NetplayInviteResponse
+	json.Unmarshal(w.Body.Bytes(), &invite)
+
+	// Client accepts
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/invites/"+invite.ID+"/accept", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp NetplayInviteResponse
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "accepted", resp.Status)
+}
+
+func TestNetplayInvite_AcceptInvite_NotInvitee(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+	var invite NetplayInviteResponse
+	json.Unmarshal(w.Body.Bytes(), &invite)
+
+	// Host tries to accept (wrong user)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/invites/"+invite.ID+"/accept", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestNetplayInvite_DeclineInvite(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+	var invite NetplayInviteResponse
+	json.Unmarshal(w.Body.Bytes(), &invite)
+
+	// Client declines
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/invites/"+invite.ID+"/decline", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Invite should no longer appear in pending list
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/invites", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	var listResp struct {
+		Data  []NetplayInviteResponse `json:"data"`
+		Total int                     `json:"total"`
+	}
+	json.Unmarshal(w.Body.Bytes(), &listResp)
+	assert.Equal(t, 0, listResp.Total)
+	assert.Len(t, listResp.Data, 0)
+}
+
+func TestNetplayInvite_DeclineAndReinvite(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+
+	// Send first invite
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+	var invite NetplayInviteResponse
+	json.Unmarshal(w.Body.Bytes(), &invite)
+
+	// Client declines
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/invites/"+invite.ID+"/decline", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Host can send a new invite (old declined one is cleaned up)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusCreated, w.Code)
+}
+
+func TestNetplayInvite_ListSessionInvites(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Send invite
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Host lists session invites (AC-3.1)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/sessions/"+session.ID+"/invites", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var invites []NetplayInviteResponse
+	json.Unmarshal(w.Body.Bytes(), &invites)
+	assert.Len(t, invites, 1)
+}
+
+func TestNetplayInvite_ListSessionInvites_NotHost(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/netplay/sessions/"+session.ID+"/invites", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestNetplayInvite_ExpireOnJoin(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Send invite to client
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Someone joins via invite code (the invite should expire)
+	body, _ = json.Marshal(map[string]interface{}{"inviteCode": session.InviteCode})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/sessions/join", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Client's pending invite count should be 0
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/invites/count", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	var countResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &countResp)
+	assert.Equal(t, float64(0), countResp["count"])
+}
+
+func TestNetplayInvite_ExpireOnDelete(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Send invite
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Host cancels session
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("DELETE", "/api/netplay/sessions/"+session.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Client's pending invite count should be 0 (AC-5.2, AC-5.3)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/invites/count", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	var countResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &countResp)
+	assert.Equal(t, float64(0), countResp["count"])
+}
+
+func TestNetplayInvite_AcceptExpireOthers(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+
+	// Need a third user to have two pending invites
+	session := createSession(t, ctx)
+
+	// We need the owner token from setupNetplayCtx - let's use a fresh setup
+	// Create a third user
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+
+	var nes db.Console
+	database.Where("abbreviation = ?", "NES").First(&nes)
+	game := db.Game{ConsoleID: nes.ID, Title: "Mega Man", FileName: "megaman.nes", FilePath: "/tmp/megaman.nes"}
+	database.Create(&game)
+
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+	hostToken := registerUserAndGetToken(t, router, ownerToken, "host2", "host2@test.com")
+	client1Token := registerUserAndGetToken(t, router, ownerToken, "player1", "p1@test.com")
+	client2Token := registerUserAndGetToken(t, router, ownerToken, "player2", "p2@test.com")
+
+	// Create session
+	body, _ := json.Marshal(map[string]interface{}{"gameId": "1"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+hostToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &session)
+
+	// Invite player1
+	body, _ = json.Marshal(map[string]interface{}{"username": "player1"})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+hostToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+	var invite1 NetplayInviteResponse
+	json.Unmarshal(w.Body.Bytes(), &invite1)
+
+	// Invite player2
+	body, _ = json.Marshal(map[string]interface{}{"username": "player2"})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+hostToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Player1 accepts
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/invites/"+invite1.ID+"/accept", nil)
+	req.Header.Set("Authorization", "Bearer "+client1Token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Player2's invite should be expired now (AC-5.1 via accept)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/invites/count", nil)
+	req.Header.Set("Authorization", "Bearer "+client2Token)
+	router.ServeHTTP(w, req)
+	var countResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &countResp)
+	assert.Equal(t, float64(0), countResp["count"])
+}
+
+func TestNetplayInvite_AcceptEndedSession(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Send invite
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+	var invite NetplayInviteResponse
+	json.Unmarshal(w.Body.Bytes(), &invite)
+
+	// Host ends the session
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/leave", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Client tries to accept the invite — should fail because session ended
+	// Note: the invite was already expired by the leave handler, so status != pending
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/invites/"+invite.ID+"/accept", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNetplayInvite_MultipleInvitesDifferentSessions(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+
+	// Create two sessions
+	session1 := createSession(t, ctx)
+	session2 := createSession(t, ctx)
+
+	// Send invite from both sessions
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session1.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/sessions/"+session2.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Client should see 2 pending invites
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/invites/count", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	var countResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &countResp)
+	assert.Equal(t, float64(2), countResp["count"])
+}

--- a/server/internal/api/netplay_ws_test.go
+++ b/server/internal/api/netplay_ws_test.go
@@ -1,0 +1,245 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// dialNetplayWS upgrades a connection to the netplay WebSocket endpoint.
+// Returns the websocket connection or fails the test.
+func dialNetplayWS(t *testing.T, server *httptest.Server, sessionID, token string) *websocket.Conn {
+	t.Helper()
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/netplay/sessions/" + sessionID + "/ws"
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+token)
+	conn, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	if err != nil {
+		if resp != nil {
+			t.Fatalf("WebSocket dial failed with status %d: %v", resp.StatusCode, err)
+		}
+		t.Fatalf("WebSocket dial failed: %v", err)
+	}
+	return conn
+}
+
+// readJSONMessage reads a JSON message from the WS connection with a timeout.
+func readJSONMessage(t *testing.T, conn *websocket.Conn, timeout time.Duration) map[string]interface{} {
+	t.Helper()
+	conn.SetReadDeadline(time.Now().Add(timeout))
+	_, data, err := conn.ReadMessage()
+	require.NoError(t, err, "expected to read a JSON message")
+	var msg map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &msg))
+	return msg
+}
+
+func TestNetplay_WebSocket_PeerJoined(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Client joins the session via REST
+	body, _ := json.Marshal(map[string]interface{}{"inviteCode": session.InviteCode})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/join", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Start a real HTTP server for WebSocket upgrade
+	server := httptest.NewServer(ctx.router)
+	defer server.Close()
+
+	// Host connects first
+	hostConn := dialNetplayWS(t, server, session.ID, ctx.hostToken)
+	defer hostConn.Close()
+
+	// Client connects — host should receive peer_joined
+	clientConn := dialNetplayWS(t, server, session.ID, ctx.clientToken)
+	defer clientConn.Close()
+
+	msg := readJSONMessage(t, hostConn, 3*time.Second)
+	assert.Equal(t, "peer_joined", msg["type"])
+	assert.NotZero(t, msg["senderId"])
+}
+
+func TestNetplay_WebSocket_BinaryInputRelay(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Client joins via REST
+	body, _ := json.Marshal(map[string]interface{}{"inviteCode": session.InviteCode})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/join", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	server := httptest.NewServer(ctx.router)
+	defer server.Close()
+
+	hostConn := dialNetplayWS(t, server, session.ID, ctx.hostToken)
+	defer hostConn.Close()
+
+	clientConn := dialNetplayWS(t, server, session.ID, ctx.clientToken)
+	defer clientConn.Close()
+
+	// Drain the peer_joined message that the host receives
+	readJSONMessage(t, hostConn, 3*time.Second)
+
+	// Host sends a binary input frame
+	inputFrame := []byte{0x01, 0x02, 0x03, 0x04, 0xFF}
+	err := hostConn.WriteMessage(websocket.BinaryMessage, inputFrame)
+	require.NoError(t, err)
+
+	// Client should receive the binary frame
+	clientConn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	msgType, data, err := clientConn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, websocket.BinaryMessage, msgType)
+	assert.Equal(t, inputFrame, data)
+
+	// Client sends binary back to host
+	replyFrame := []byte{0xAA, 0xBB}
+	err = clientConn.WriteMessage(websocket.BinaryMessage, replyFrame)
+	require.NoError(t, err)
+
+	hostConn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	msgType, data, err = hostConn.ReadMessage()
+	require.NoError(t, err)
+	assert.Equal(t, websocket.BinaryMessage, msgType)
+	assert.Equal(t, replyFrame, data)
+}
+
+func TestNetplay_WebSocket_PeerLeft(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Client joins via REST
+	body, _ := json.Marshal(map[string]interface{}{"inviteCode": session.InviteCode})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/join", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	server := httptest.NewServer(ctx.router)
+	defer server.Close()
+
+	hostConn := dialNetplayWS(t, server, session.ID, ctx.hostToken)
+	defer hostConn.Close()
+
+	clientConn := dialNetplayWS(t, server, session.ID, ctx.clientToken)
+
+	// Drain peer_joined
+	readJSONMessage(t, hostConn, 3*time.Second)
+
+	// Client disconnects
+	clientConn.Close()
+
+	// Host should receive peer_left
+	msg := readJSONMessage(t, hostConn, 3*time.Second)
+	assert.Equal(t, "peer_left", msg["type"])
+	assert.NotZero(t, msg["senderId"])
+}
+
+func TestNetplay_WebSocket_NonParticipant403(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+	// Note: clientToken user has NOT joined the session via REST
+
+	server := httptest.NewServer(ctx.router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/netplay/sessions/" + session.ID + "/ws"
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+ctx.clientToken)
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	require.Error(t, err, "expected WS dial to fail for non-participant")
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+}
+
+func TestNetplay_WebSocket_JSONTextRelay(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Client joins via REST
+	body, _ := json.Marshal(map[string]interface{}{"inviteCode": session.InviteCode})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/join", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	server := httptest.NewServer(ctx.router)
+	defer server.Close()
+
+	hostConn := dialNetplayWS(t, server, session.ID, ctx.hostToken)
+	defer hostConn.Close()
+
+	clientConn := dialNetplayWS(t, server, session.ID, ctx.clientToken)
+	defer clientConn.Close()
+
+	// Drain peer_joined
+	readJSONMessage(t, hostConn, 3*time.Second)
+
+	// Host sends a chat-type JSON text message (broadcast to all except sender)
+	chatMsg := map[string]interface{}{
+		"type": "chat",
+		"data": map[string]string{"text": "hello"},
+	}
+	chatBytes, _ := json.Marshal(chatMsg)
+	err := hostConn.WriteMessage(websocket.TextMessage, chatBytes)
+	require.NoError(t, err)
+
+	// Client should receive the relayed message with senderId
+	msg := readJSONMessage(t, clientConn, 3*time.Second)
+	assert.Equal(t, "chat", msg["type"])
+	assert.NotZero(t, msg["senderId"])
+}
+
+func TestNetplay_WebSocket_EndedSession(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Client joins then host ends the session
+	body, _ := json.Marshal(map[string]interface{}{"inviteCode": session.InviteCode})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/join", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Host leaves to end the session
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/leave", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Trying to connect WS to an ended session should fail
+	server := httptest.NewServer(ctx.router)
+	defer server.Close()
+
+	wsURL := "ws" + strings.TrimPrefix(server.URL, "http") + "/api/netplay/sessions/" + session.ID + "/ws"
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+ctx.hostToken)
+	_, resp, err := websocket.DefaultDialer.Dial(wsURL, header)
+	require.Error(t, err)
+	require.NotNil(t, resp)
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
+}

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -584,6 +584,26 @@ type NetplaySessionResponse struct {
 	EndedAt          *time.Time `json:"endedAt,omitempty"`
 }
 
+// NetplayInviteResponse is the API response for a netplay session invite.
+type NetplayInviteResponse struct {
+	ID               string    `json:"id"`
+	NetplaySessionID string    `json:"netplaySessionId"`
+	InviterID        string    `json:"inviterId"`
+	InviterUsername  string    `json:"inviterUsername"`
+	InviterAvatarURL string    `json:"inviterAvatarUrl,omitempty"`
+	InviteeID        string    `json:"inviteeId"`
+	InviteeUsername  string    `json:"inviteeUsername"`
+	InviteeAvatarURL string    `json:"inviteeAvatarUrl,omitempty"`
+	GameID           string    `json:"gameId"`
+	GameTitle        string    `json:"gameTitle"`
+	GameCoverURL     string    `json:"gameCoverUrl,omitempty"`
+	ConsoleName      string    `json:"consoleName,omitempty"`
+	HostUsername     string    `json:"hostUsername"`
+	InputDelay       int       `json:"inputDelay"`
+	Status           string    `json:"status"`
+	CreatedAt        time.Time `json:"createdAt"`
+}
+
 // ChallengeResponse is the API response for a game challenge.
 type ChallengeResponse struct {
 	ID              string     `json:"id"`

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -368,6 +368,12 @@ func NewRouter(cfg Config) *gin.Engine {
 			netplay.DELETE("/sessions/:id", netplayHandler.DeleteSession)
 			netplay.PUT("/sessions/:id/settings", netplayHandler.UpdateSettings)
 			netplay.GET("/sessions/:id/ws", netplayHandler.HandleWebSocket)
+			netplay.POST("/sessions/:id/invites", netplayHandler.SendInvite)
+			netplay.GET("/sessions/:id/invites", netplayHandler.ListSessionInvites)
+			netplay.GET("/invites", netplayHandler.ListMyNetplayInvites)
+			netplay.GET("/invites/count", netplayHandler.GetPendingNetplayInviteCount)
+			netplay.POST("/invites/:inviteId/accept", netplayHandler.AcceptNetplayInvite)
+			netplay.POST("/invites/:inviteId/decline", netplayHandler.DeclineNetplayInvite)
 		}
 
 		// Social

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -137,6 +137,7 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&SharedSessionInvite{},
 		&SharedSessionSave{},
 		&NetplaySession{},
+		&NetplayInvite{},
 		&Challenge{},
 		&ChallengeAttempt{},
 		&GameKeyMappingPreference{},

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -443,6 +443,20 @@ type NetplaySession struct {
 	EndedAt      *time.Time     `json:"endedAt,omitempty"`
 }
 
+// NetplayInvite represents a user-to-user invitation to join a netplay session.
+type NetplayInvite struct {
+	ID               uint           `gorm:"primarykey" json:"id"`
+	CreatedAt        time.Time      `json:"createdAt"`
+	DeletedAt        gorm.DeletedAt `gorm:"index" json:"-"`
+	NetplaySessionID uint           `gorm:"uniqueIndex:idx_netplay_invite_session_invitee;not null" json:"netplaySessionId"`
+	NetplaySession   NetplaySession `gorm:"foreignKey:NetplaySessionID" json:"-"`
+	InviterID        uint           `gorm:"not null" json:"inviterId"`
+	Inviter          User           `gorm:"foreignKey:InviterID" json:"-"`
+	InviteeID        uint           `gorm:"uniqueIndex:idx_netplay_invite_session_invitee;not null" json:"inviteeId"`
+	Invitee          User           `gorm:"foreignKey:InviteeID" json:"-"`
+	Status           string         `gorm:"size:32;default:pending;not null" json:"status"` // "pending", "accepted", "declined", "expired"
+}
+
 // Challenge represents a user-created game challenge.
 type Challenge struct {
 	ID              uint           `gorm:"primarykey" json:"id"`

--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -23,6 +23,7 @@ import { Sidebar } from "@/components/ui";
 import { useAuth } from "@/hooks/use-auth";
 import { useGameScrapedListener } from "@/hooks/use-game-scraped-listener";
 import { usePendingInvitationCount } from "@/hooks/use-shared-sessions";
+import { usePendingNetplayInviteCount } from "@/hooks/use-netplay";
 import { useNotifications } from "@/hooks/use-notifications";
 import { useBiosStatus } from "@/hooks/use-bios";
 import { useIgdbStatus } from "@/hooks/use-admin";
@@ -36,6 +37,8 @@ export function AppLayout() {
   useNotifications();
   const { data: invitationCountData } = usePendingInvitationCount();
   const sharedSessionBadge = invitationCountData?.count;
+  const { data: netplayInviteCountData } = usePendingNetplayInviteCount();
+  const netplayBadge = netplayInviteCountData?.count;
   const { data: biosData } = useBiosStatus();
   const hasMissingBios =
     biosData?.consoles.some((c) => c.status === "missing") ?? false;
@@ -90,6 +93,7 @@ export function AppLayout() {
           icon: Wifi,
           label: "Netplay",
           matchPaths: ["/netplay"],
+          badge: netplayBadge,
         },
         { to: "/preferences", icon: SlidersHorizontal, label: "Preferences" },
       ],

--- a/web/src/features/netplay/components/__tests__/netplay-invitations-section.test.tsx
+++ b/web/src/features/netplay/components/__tests__/netplay-invitations-section.test.tsx
@@ -1,0 +1,141 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { NetplayInvitationsSection } from "../netplay-invitations-section";
+import type { NetplayInvite } from "@/types/api";
+
+const mockPendingInvite: NetplayInvite = {
+  id: "inv1",
+  netplaySessionId: "s1",
+  inviterId: "u1",
+  inviterUsername: "alice",
+  inviterAvatarUrl: null,
+  inviteeId: "u2",
+  inviteeUsername: "bob",
+  inviteeAvatarUrl: null,
+  gameId: "g1",
+  gameTitle: "Super Mario World",
+  gameCoverUrl: null,
+  consoleName: "Super Nintendo",
+  hostUsername: "alice",
+  inputDelay: 3,
+  status: "pending",
+  createdAt: new Date().toISOString(),
+};
+
+const mockDeclinedInvite: NetplayInvite = {
+  ...mockPendingInvite,
+  id: "inv2",
+  status: "declined",
+};
+
+let mockInvitesData: { data: NetplayInvite[]; total: number } | undefined;
+let mockIsLoading = false;
+
+vi.mock("@/hooks/use-netplay", () => ({
+  useNetplayInvites: vi.fn(() => ({
+    data: mockInvitesData,
+    isLoading: mockIsLoading,
+  })),
+  useAcceptNetplayInvite: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+  useDeclineNetplayInvite: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual("@/components/ui");
+  return {
+    ...actual,
+    useToast: vi.fn(() => ({ toast: vi.fn() })),
+  };
+});
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockInvitesData = undefined;
+  mockIsLoading = false;
+});
+
+describe("NetplayInvitationsSection", () => {
+  it("renders nothing when there are no pending invites", () => {
+    mockInvitesData = { data: [], total: 0 };
+    const Wrapper = createWrapper();
+    const { container } = render(
+      <Wrapper>
+        <NetplayInvitationsSection />
+      </Wrapper>,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when all invites are non-pending", () => {
+    mockInvitesData = { data: [mockDeclinedInvite], total: 1 };
+    const Wrapper = createWrapper();
+    const { container } = render(
+      <Wrapper>
+        <NetplayInvitationsSection />
+      </Wrapper>,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders the section header with count when there are pending invites", () => {
+    mockInvitesData = { data: [mockPendingInvite], total: 1 };
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInvitationsSection />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Invitations")).toBeInTheDocument();
+    expect(screen.getByText("(1)")).toBeInTheDocument();
+  });
+
+  it("renders invite cards for pending invites", () => {
+    mockInvitesData = { data: [mockPendingInvite], total: 1 };
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInvitationsSection />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+    expect(screen.getByText("Accept")).toBeInTheDocument();
+    expect(screen.getByText("Decline")).toBeInTheDocument();
+  });
+
+  it("shows skeleton when loading", () => {
+    mockIsLoading = true;
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInvitationsSection />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Invitations")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/netplay/components/__tests__/netplay-invite-card.test.tsx
+++ b/web/src/features/netplay/components/__tests__/netplay-invite-card.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { NetplayInviteCard } from "../netplay-invite-card";
+import type { NetplayInvite } from "@/types/api";
+
+const mockAcceptMutate = vi.fn();
+const mockDeclineMutate = vi.fn();
+
+vi.mock("@/hooks/use-netplay", () => ({
+  useAcceptNetplayInvite: vi.fn(() => ({
+    mutate: mockAcceptMutate,
+    isPending: false,
+  })),
+  useDeclineNetplayInvite: vi.fn(() => ({
+    mutate: mockDeclineMutate,
+    isPending: false,
+  })),
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual("@/components/ui");
+  return {
+    ...actual,
+    useToast: vi.fn(() => ({ toast: vi.fn() })),
+  };
+});
+
+const mockInvite: NetplayInvite = {
+  id: "inv1",
+  netplaySessionId: "s1",
+  inviterId: "u1",
+  inviterUsername: "alice",
+  inviterAvatarUrl: null,
+  inviteeId: "u2",
+  inviteeUsername: "bob",
+  inviteeAvatarUrl: null,
+  gameId: "g1",
+  gameTitle: "Super Mario World",
+  gameCoverUrl: "https://example.com/smw.png",
+  consoleName: "Super Nintendo",
+  hostUsername: "alice",
+  inputDelay: 3,
+  status: "pending",
+  createdAt: new Date().toISOString(),
+};
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>{children}</MemoryRouter>
+      </QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("NetplayInviteCard", () => {
+  it("renders the game title", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteCard invite={mockInvite} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+  });
+
+  it("renders the console badge", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteCard invite={mockInvite} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Super Nintendo")).toBeInTheDocument();
+  });
+
+  it("renders the inviter username", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteCard invite={mockInvite} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("alice")).toBeInTheDocument();
+  });
+
+  it("renders accept and decline buttons", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteCard invite={mockInvite} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Accept")).toBeInTheDocument();
+    expect(screen.getByText("Decline")).toBeInTheDocument();
+  });
+
+  it("calls accept mutation when Accept is clicked", async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteCard invite={mockInvite} />
+      </Wrapper>,
+    );
+
+    await userEvent.click(screen.getByText("Accept"));
+    expect(mockAcceptMutate).toHaveBeenCalledWith(
+      "inv1",
+      expect.any(Object),
+    );
+  });
+
+  it("calls decline mutation when Decline is clicked", async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteCard invite={mockInvite} />
+      </Wrapper>,
+    );
+
+    await userEvent.click(screen.getByText("Decline"));
+    expect(mockDeclineMutate).toHaveBeenCalledWith(
+      "inv1",
+      expect.any(Object),
+    );
+  });
+
+  it("renders the cover art image", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteCard invite={mockInvite} />
+      </Wrapper>,
+    );
+
+    const img = screen.getByAltText("Super Mario World");
+    expect(img).toHaveAttribute("src", "https://example.com/smw.png");
+  });
+
+  it("renders placeholder when no cover art", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteCard invite={{ ...mockInvite, gameCoverUrl: null }} />
+      </Wrapper>,
+    );
+
+    expect(screen.queryByAltText("Super Mario World")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/netplay/components/__tests__/netplay-invite-modal.test.tsx
+++ b/web/src/features/netplay/components/__tests__/netplay-invite-modal.test.tsx
@@ -1,0 +1,201 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NetplayInviteModal } from "../netplay-invite-modal";
+
+const mockMutate = vi.fn();
+
+vi.mock("@/hooks/use-netplay", () => ({
+  useSendNetplayInvite: vi.fn(() => ({
+    mutate: mockMutate,
+    isPending: false,
+  })),
+}));
+
+vi.mock("@/hooks/use-social", () => ({
+  useSearchUsers: vi.fn((query: string) => ({
+    data:
+      query.length >= 2
+        ? [
+            { id: "u1", username: "alice", avatarUrl: null },
+            { id: "u2", username: "bob", avatarUrl: "https://example.com/bob.png" },
+          ]
+        : [],
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@/hooks/use-debounced-value", () => ({
+  useDebouncedValue: vi.fn((value: string) => value),
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual("@/components/ui");
+  return {
+    ...actual,
+    useToast: vi.fn(() => ({ toast: vi.fn() })),
+  };
+});
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("NetplayInviteModal", () => {
+  it("renders modal title when open", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteModal
+          sessionId="s1"
+          open={true}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Invite Player")).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteModal
+          sessionId="s1"
+          open={false}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    expect(screen.queryByText("Invite Player")).not.toBeInTheDocument();
+  });
+
+  it("disables submit when no username is entered", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteModal
+          sessionId="s1"
+          open={true}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    const sendButton = screen.getByText("Send Invite").closest("button");
+    expect(sendButton).toBeDisabled();
+  });
+
+  it("shows search results when typing", async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteModal
+          sessionId="s1"
+          open={true}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search for a user...");
+    await userEvent.type(searchInput, "al");
+
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("bob")).toBeInTheDocument();
+  });
+
+  it("selects a user and fills the input when clicked", async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteModal
+          sessionId="s1"
+          open={true}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search for a user...");
+    await userEvent.type(searchInput, "al");
+    await userEvent.click(screen.getByText("alice"));
+
+    expect(searchInput).toHaveValue("alice");
+  });
+
+  it("calls mutate with sessionId and username on submit", async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteModal
+          sessionId="s1"
+          open={true}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    const searchInput = screen.getByPlaceholderText("Search for a user...");
+    await userEvent.type(searchInput, "al");
+    await userEvent.click(screen.getByText("alice"));
+
+    const sendButton = screen.getByText("Send Invite").closest("button")!;
+    await userEvent.click(sendButton);
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { sessionId: "s1", username: "alice" },
+      expect.any(Object),
+    );
+  });
+
+  it("calls onClose when Close is clicked", async () => {
+    const onClose = vi.fn();
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteModal
+          sessionId="s1"
+          open={true}
+          onClose={onClose}
+        />
+      </Wrapper>,
+    );
+
+    await userEvent.click(screen.getByText("Close"));
+    expect(onClose).toHaveBeenCalledOnce();
+  });
+
+  it("shows helper text about searching users", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplayInviteModal
+          sessionId="s1"
+          open={true}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.getByText(
+        "Search for users by name and invite them to this netplay session.",
+      ),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/features/netplay/components/__tests__/netplay-session-invites.test.tsx
+++ b/web/src/features/netplay/components/__tests__/netplay-session-invites.test.tsx
@@ -1,0 +1,156 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { NetplaySessionInvites } from "../netplay-session-invites";
+import type { NetplayInvite } from "@/types/api";
+
+const mockInvites: NetplayInvite[] = [
+  {
+    id: "inv1",
+    netplaySessionId: "s1",
+    inviterId: "u1",
+    inviterUsername: "host",
+    inviterAvatarUrl: null,
+    inviteeId: "u2",
+    inviteeUsername: "alice",
+    inviteeAvatarUrl: null,
+    gameId: "g1",
+    gameTitle: "Super Mario World",
+    gameCoverUrl: null,
+    consoleName: "Super Nintendo",
+    hostUsername: "host",
+    inputDelay: 3,
+    status: "pending",
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: "inv2",
+    netplaySessionId: "s1",
+    inviterId: "u1",
+    inviterUsername: "host",
+    inviterAvatarUrl: null,
+    inviteeId: "u3",
+    inviteeUsername: "bob",
+    inviteeAvatarUrl: null,
+    gameId: "g1",
+    gameTitle: "Super Mario World",
+    gameCoverUrl: null,
+    consoleName: "Super Nintendo",
+    hostUsername: "host",
+    inputDelay: 3,
+    status: "accepted",
+    createdAt: new Date().toISOString(),
+  },
+  {
+    id: "inv3",
+    netplaySessionId: "s1",
+    inviterId: "u1",
+    inviterUsername: "host",
+    inviterAvatarUrl: null,
+    inviteeId: "u4",
+    inviteeUsername: "charlie",
+    inviteeAvatarUrl: null,
+    gameId: "g1",
+    gameTitle: "Super Mario World",
+    gameCoverUrl: null,
+    consoleName: "Super Nintendo",
+    hostUsername: "host",
+    inputDelay: 3,
+    status: "declined",
+    createdAt: new Date().toISOString(),
+  },
+];
+
+let mockData: NetplayInvite[] | undefined;
+let mockIsLoading = false;
+
+vi.mock("@/hooks/use-netplay", () => ({
+  useSessionNetplayInvites: vi.fn(() => ({
+    data: mockData,
+    isLoading: mockIsLoading,
+  })),
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockData = undefined;
+  mockIsLoading = false;
+});
+
+describe("NetplaySessionInvites", () => {
+  it("renders nothing when there are no invites", () => {
+    mockData = [];
+    const Wrapper = createWrapper();
+    const { container } = render(
+      <Wrapper>
+        <NetplaySessionInvites sessionId="s1" />
+      </Wrapper>,
+    );
+
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders the section header with count", () => {
+    mockData = mockInvites;
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplaySessionInvites sessionId="s1" />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Invited Players")).toBeInTheDocument();
+    expect(screen.getByText("(3)")).toBeInTheDocument();
+  });
+
+  it("renders invite rows with usernames", () => {
+    mockData = mockInvites;
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplaySessionInvites sessionId="s1" />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("bob")).toBeInTheDocument();
+    expect(screen.getByText("charlie")).toBeInTheDocument();
+  });
+
+  it("renders status badges for each invite", () => {
+    mockData = mockInvites;
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplaySessionInvites sessionId="s1" />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Pending")).toBeInTheDocument();
+    expect(screen.getByText("Accepted")).toBeInTheDocument();
+    expect(screen.getByText("Declined")).toBeInTheDocument();
+  });
+
+  it("shows skeleton when loading", () => {
+    mockIsLoading = true;
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <NetplaySessionInvites sessionId="s1" />
+      </Wrapper>,
+    );
+
+    expect(screen.getByText("Invited Players")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/netplay/components/netplay-invitations-section.tsx
+++ b/web/src/features/netplay/components/netplay-invitations-section.tsx
@@ -1,0 +1,69 @@
+import { Mail } from "lucide-react";
+import { Skeleton } from "@/components/ui";
+import { useNetplayInvites } from "@/hooks/use-netplay";
+import { NetplayInviteCard } from "@/features/netplay/components/netplay-invite-card";
+
+function InvitationsSkeleton() {
+  return (
+    <div className="space-y-3">
+      {Array.from({ length: 2 }, (_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-4 px-4 py-4 rounded-xl bg-surface-900/50"
+        >
+          <Skeleton className="h-16 w-12 rounded-lg flex-shrink-0" />
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-48" />
+            <Skeleton className="h-3 w-32" />
+          </div>
+          <div className="flex gap-2">
+            <Skeleton className="h-8 w-20 rounded-lg" />
+            <Skeleton className="h-8 w-20 rounded-lg" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function NetplayInvitationsSection() {
+  const { data: invitesData, isLoading } = useNetplayInvites();
+
+  const pendingInvites = (invitesData?.data ?? []).filter(
+    (inv) => inv.status === "pending",
+  );
+
+  if (isLoading) {
+    return (
+      <section>
+        <div className="flex items-center gap-2.5 mb-4">
+          <Mail className="h-5 w-5 text-brand-400" />
+          <h2 className="text-xl font-bold text-surface-100">Invitations</h2>
+        </div>
+        <InvitationsSkeleton />
+      </section>
+    );
+  }
+
+  if (pendingInvites.length === 0) {
+    return null;
+  }
+
+  return (
+    <section>
+      <div className="flex items-center gap-2.5 mb-4">
+        <Mail className="h-5 w-5 text-brand-400" />
+        <h2 className="text-xl font-bold text-surface-100">Invitations</h2>
+        <span className="text-sm text-surface-500">
+          ({pendingInvites.length})
+        </span>
+      </div>
+
+      <div className="space-y-3">
+        {pendingInvites.map((invite) => (
+          <NetplayInviteCard key={invite.id} invite={invite} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/src/features/netplay/components/netplay-invite-card.tsx
+++ b/web/src/features/netplay/components/netplay-invite-card.tsx
@@ -1,0 +1,111 @@
+import { useNavigate } from "react-router-dom";
+import { Gamepad2, Check, X } from "lucide-react";
+import { Button, Badge } from "@/components/ui";
+import { useToast } from "@/components/ui";
+import { PlayerAvatar } from "@/components/player-avatar";
+import {
+  useAcceptNetplayInvite,
+  useDeclineNetplayInvite,
+} from "@/hooks/use-netplay";
+import { formatRelativeTime } from "@/lib/format";
+import type { NetplayInvite } from "@/types/api";
+
+interface NetplayInviteCardProps {
+  invite: NetplayInvite;
+}
+
+export function NetplayInviteCard({ invite }: NetplayInviteCardProps) {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const acceptInvite = useAcceptNetplayInvite();
+  const declineInvite = useDeclineNetplayInvite();
+
+  function handleAccept() {
+    acceptInvite.mutate(invite.id, {
+      onSuccess: () => {
+        toast("success", "Invite accepted");
+        navigate(`/netplay/${invite.netplaySessionId}`);
+      },
+      onError: () => {
+        toast("error", "Failed to accept invite. The session may have ended.");
+      },
+    });
+  }
+
+  function handleDecline() {
+    declineInvite.mutate(invite.id, {
+      onSuccess: () => {
+        toast("success", "Invite declined");
+      },
+      onError: () => {
+        toast("error", "Failed to decline invite");
+      },
+    });
+  }
+
+  return (
+    <div
+      className="flex items-center gap-4 px-4 py-4 rounded-xl bg-surface-900/50"
+      data-testid={`netplay-invite-${invite.id}`}
+    >
+      {/* Cover art thumbnail */}
+      <div className="h-16 w-12 flex-shrink-0 rounded-lg overflow-hidden bg-surface-800">
+        {invite.gameCoverUrl ? (
+          <img
+            src={invite.gameCoverUrl}
+            alt={invite.gameTitle}
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="h-full w-full flex items-center justify-center">
+            <Gamepad2 className="h-5 w-5 text-surface-600" />
+          </div>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="flex-1 min-w-0 space-y-1">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-medium text-surface-100 truncate">
+            {invite.gameTitle}
+          </p>
+          <Badge variant="brand" className="flex-shrink-0">
+            {invite.consoleName}
+          </Badge>
+        </div>
+        <div className="flex items-center gap-2 text-xs text-surface-500">
+          <PlayerAvatar
+            username={invite.inviterUsername}
+            avatarUrl={invite.inviterAvatarUrl ?? undefined}
+            size="xs"
+          />
+          <span>{invite.inviterUsername}</span>
+          <span>&middot;</span>
+          <span>{formatRelativeTime(invite.createdAt)}</span>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2 flex-shrink-0">
+        <Button
+          variant="secondary"
+          size="sm"
+          onClick={handleDecline}
+          loading={declineInvite.isPending}
+        >
+          <X className="h-4 w-4" />
+          Decline
+        </Button>
+        <Button
+          size="sm"
+          onClick={handleAccept}
+          loading={acceptInvite.isPending}
+        >
+          <Check className="h-4 w-4" />
+          Accept
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/netplay/components/netplay-invite-modal.tsx
+++ b/web/src/features/netplay/components/netplay-invite-modal.tsx
@@ -1,0 +1,206 @@
+import { useState, useRef, useEffect } from "react";
+import { UserPlus, Check, Search, Loader2 } from "lucide-react";
+import { Button, Modal } from "@/components/ui";
+import { useToast } from "@/components/ui";
+import { useSendNetplayInvite } from "@/hooks/use-netplay";
+import { useSearchUsers } from "@/hooks/use-social";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import type { UserSearchResult } from "@/types/api";
+
+interface NetplayInviteModalProps {
+  sessionId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function NetplayInviteModal({
+  sessionId,
+  open,
+  onClose,
+}: NetplayInviteModalProps) {
+  const [query, setQuery] = useState("");
+  const [selectedUser, setSelectedUser] = useState<UserSearchResult | null>(
+    null,
+  );
+  const [invitedUsers, setInvitedUsers] = useState<string[]>([]);
+  const [showDropdown, setShowDropdown] = useState(false);
+  const sendInvite = useSendNetplayInvite();
+  const { toast } = useToast();
+  const debouncedQuery = useDebouncedValue(query, 300);
+  const { data: searchResults, isLoading: isSearching } =
+    useSearchUsers(debouncedQuery);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        dropdownRef.current &&
+        !dropdownRef.current.contains(e.target as Node)
+      ) {
+        setShowDropdown(false);
+      }
+    }
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  function handleSelectUser(user: UserSearchResult) {
+    setSelectedUser(user);
+    setQuery(user.username);
+    setShowDropdown(false);
+  }
+
+  function handleInvite() {
+    const username = selectedUser?.username ?? query.trim();
+    if (!username) return;
+
+    sendInvite.mutate(
+      { sessionId, username },
+      {
+        onSuccess: () => {
+          toast("success", `Invitation sent to ${username}`);
+          setInvitedUsers((prev) => [...prev, username]);
+          setQuery("");
+          setSelectedUser(null);
+          inputRef.current?.focus();
+        },
+        onError: (error) => {
+          toast(
+            "error",
+            error instanceof Error
+              ? error.message
+              : "Failed to send invitation",
+          );
+        },
+      },
+    );
+  }
+
+  function handleClose() {
+    setQuery("");
+    setSelectedUser(null);
+    setInvitedUsers([]);
+    setShowDropdown(false);
+    onClose();
+  }
+
+  const filteredResults = (searchResults ?? []).filter(
+    (u) => !invitedUsers.includes(u.username),
+  );
+
+  return (
+    <Modal open={open} onClose={handleClose} title="Invite Player">
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          handleInvite();
+        }}
+        className="space-y-4"
+      >
+        <div className="relative" ref={dropdownRef}>
+          <label
+            htmlFor="netplay-invite-username"
+            className="block text-sm font-medium text-surface-300 mb-1.5"
+          >
+            Username
+          </label>
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-surface-500 pointer-events-none" />
+            <input
+              ref={inputRef}
+              id="netplay-invite-username"
+              type="text"
+              placeholder="Search for a user..."
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setSelectedUser(null);
+                setShowDropdown(e.target.value.length >= 2);
+              }}
+              onFocus={() => {
+                if (query.length >= 2) setShowDropdown(true);
+              }}
+              autoFocus
+              autoComplete="off"
+              className="w-full rounded-lg border border-surface-700 bg-surface-800 py-2.5 pl-10 pr-3 text-sm text-surface-100 placeholder:text-surface-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+            />
+          </div>
+          {showDropdown && query.length >= 2 && (
+            <div className="absolute z-50 mt-1 w-full rounded-lg border border-surface-700 bg-surface-800 shadow-lg max-h-48 overflow-y-auto">
+              {isSearching ? (
+                <div className="flex items-center gap-2 px-3 py-2 text-sm text-surface-500">
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Searching...
+                </div>
+              ) : filteredResults.length > 0 ? (
+                filteredResults.map((user) => (
+                  <button
+                    key={user.id}
+                    type="button"
+                    className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm hover:bg-surface-700 transition-colors"
+                    onClick={() => handleSelectUser(user)}
+                  >
+                    {user.avatarUrl ? (
+                      <img
+                        src={user.avatarUrl}
+                        alt=""
+                        className="h-6 w-6 rounded-full object-cover"
+                      />
+                    ) : (
+                      <div className="h-6 w-6 rounded-full bg-surface-600 flex items-center justify-center text-xs font-medium text-surface-300">
+                        {user.username[0]?.toUpperCase()}
+                      </div>
+                    )}
+                    <span className="text-surface-200">{user.username}</span>
+                  </button>
+                ))
+              ) : (
+                <div className="px-3 py-2 text-sm text-surface-500">
+                  No users found
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {invitedUsers.length > 0 && (
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-surface-500">
+              Invited this session
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {invitedUsers.map((user) => (
+                <span
+                  key={user}
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-brand-500/15 text-brand-400"
+                >
+                  <Check className="h-3 w-3" />
+                  {user}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <p className="text-xs text-surface-500">
+          Search for users by name and invite them to this netplay session.
+        </p>
+
+        <div className="flex justify-end gap-3">
+          <Button variant="secondary" type="button" onClick={handleClose}>
+            Close
+          </Button>
+          <Button
+            type="submit"
+            loading={sendInvite.isPending}
+            disabled={!query.trim()}
+          >
+            <UserPlus className="h-4 w-4" />
+            Send Invite
+          </Button>
+        </div>
+      </form>
+    </Modal>
+  );
+}

--- a/web/src/features/netplay/components/netplay-session-invites.tsx
+++ b/web/src/features/netplay/components/netplay-session-invites.tsx
@@ -1,0 +1,105 @@
+import { Mail, Clock, Check, X, AlertCircle } from "lucide-react";
+import { Badge, Skeleton } from "@/components/ui";
+import { PlayerAvatar } from "@/components/player-avatar";
+import { useSessionNetplayInvites } from "@/hooks/use-netplay";
+import { formatRelativeTime } from "@/lib/format";
+import type { NetplayInvite } from "@/types/api";
+
+const statusConfig: Record<
+  NetplayInvite["status"],
+  { icon: typeof Clock; label: string; variant: "warning" | "success" | "danger" | "default" }
+> = {
+  pending: { icon: Clock, label: "Pending", variant: "warning" },
+  accepted: { icon: Check, label: "Accepted", variant: "success" },
+  declined: { icon: X, label: "Declined", variant: "danger" },
+  expired: { icon: AlertCircle, label: "Expired", variant: "default" },
+};
+
+interface NetplaySessionInvitesProps {
+  sessionId: string;
+}
+
+function InvitesSkeleton() {
+  return (
+    <div className="space-y-2">
+      {Array.from({ length: 2 }, (_, i) => (
+        <div
+          key={i}
+          className="flex items-center gap-4 px-4 py-3 rounded-xl bg-surface-900/50"
+        >
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-24" />
+          </div>
+          <Skeleton className="h-6 w-16 rounded-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function NetplaySessionInvites({ sessionId }: NetplaySessionInvitesProps) {
+  const { data: invites, isLoading } = useSessionNetplayInvites(sessionId);
+
+  if (isLoading) {
+    return (
+      <section>
+        <div className="flex items-center gap-2.5 mb-4">
+          <Mail className="h-5 w-5 text-brand-400" />
+          <h2 className="text-xl font-bold text-surface-100">
+            Invited Players
+          </h2>
+        </div>
+        <InvitesSkeleton />
+      </section>
+    );
+  }
+
+  if (!invites || invites.length === 0) {
+    return null;
+  }
+
+  return (
+    <section>
+      <div className="flex items-center gap-2.5 mb-4">
+        <Mail className="h-5 w-5 text-brand-400" />
+        <h2 className="text-xl font-bold text-surface-100">
+          Invited Players
+        </h2>
+        <span className="text-sm text-surface-500">({invites.length})</span>
+      </div>
+
+      <div className="space-y-2">
+        {invites.map((invite) => {
+          const config = statusConfig[invite.status];
+          const StatusIcon = config.icon;
+          return (
+            <div
+              key={invite.id}
+              className="flex items-center gap-4 px-4 py-3 rounded-xl bg-surface-900/50"
+              data-testid={`session-invite-${invite.inviteeUsername}`}
+            >
+              <PlayerAvatar
+                username={invite.inviteeUsername}
+                avatarUrl={invite.inviteeAvatarUrl ?? undefined}
+              />
+              <div className="flex-1 min-w-0">
+                <p className="text-sm font-medium text-surface-200 truncate">
+                  {invite.inviteeUsername}
+                </p>
+                <p className="text-xs text-surface-500">
+                  Invited {formatRelativeTime(invite.createdAt)}
+                </p>
+              </div>
+              <Badge variant={config.variant}>
+                <StatusIcon className="h-3 w-3 mr-1" />
+                {config.label}
+              </Badge>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/web/src/hooks/use-netplay.ts
+++ b/web/src/hooks/use-netplay.ts
@@ -1,8 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
+import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
   NetplaySession,
   NetplaySessionsResponse,
+  NetplayInvite,
+  NetplayInvitesResponse,
 } from "@/types/api";
 
 export function useNetplaySessions(page = 1, pageSize = 20) {
@@ -88,5 +91,113 @@ export function useDeleteNetplaySession() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["netplay", "sessions"] });
     },
+  });
+}
+
+// ── Netplay Invites ──────────────────────────────────────────────────────────
+
+export function useNetplayInvites() {
+  return useQuery({
+    queryKey: ["netplay", "invites"],
+    queryFn: () => api.get<NetplayInvitesResponse>("/netplay/invites"),
+  });
+}
+
+export function usePendingNetplayInviteCount() {
+  return useQuery({
+    queryKey: ["netplay", "invites", "count"],
+    queryFn: () => api.get<{ count: number }>("/netplay/invites/count"),
+    refetchInterval: 30000,
+  });
+}
+
+export function useSessionNetplayInvites(sessionId: string) {
+  return useQuery({
+    queryKey: ["netplay", "sessions", sessionId, "invites"],
+    queryFn: () =>
+      api.get<NetplayInvite[]>(`/netplay/sessions/${sessionId}/invites`),
+    enabled: !!sessionId,
+  });
+}
+
+export function useSendNetplayInvite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({
+      sessionId,
+      username,
+    }: {
+      sessionId: string;
+      username: string;
+    }) => api.post(`/netplay/sessions/${sessionId}/invites`, { username }),
+    onSuccess: (_, { sessionId }) => {
+      queryClient.invalidateQueries({
+        queryKey: ["netplay", "sessions", sessionId, "invites"],
+      });
+    },
+  });
+}
+
+export function useAcceptNetplayInvite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (inviteId: string) =>
+      api.post(`/netplay/invites/${inviteId}/accept`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["netplay", "invites"] });
+      queryClient.invalidateQueries({ queryKey: ["netplay", "sessions"] });
+    },
+  });
+}
+
+export function useDeclineNetplayInvite() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (inviteId: string) =>
+      api.post(`/netplay/invites/${inviteId}/decline`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["netplay", "invites"] });
+    },
+  });
+}
+
+export function useNetplayInvitesRealtime(sessionId?: string) {
+  const queryClient = useQueryClient();
+
+  useWebSocketEvent("netplay_invite_sent", () => {
+    queryClient.invalidateQueries({ queryKey: ["netplay", "invites"] });
+    queryClient.invalidateQueries({
+      queryKey: ["netplay", "invites", "count"],
+    });
+    if (sessionId) {
+      queryClient.invalidateQueries({
+        queryKey: ["netplay", "sessions", sessionId, "invites"],
+      });
+    }
+  });
+
+  useWebSocketEvent("netplay_invite_accepted", () => {
+    if (sessionId) {
+      queryClient.invalidateQueries({
+        queryKey: ["netplay", "sessions", sessionId, "invites"],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["netplay", "sessions", sessionId],
+      });
+    }
+    queryClient.invalidateQueries({ queryKey: ["netplay", "invites"] });
+    queryClient.invalidateQueries({ queryKey: ["netplay", "sessions"] });
+  });
+
+  useWebSocketEvent("netplay_invite_declined", () => {
+    if (sessionId) {
+      queryClient.invalidateQueries({
+        queryKey: ["netplay", "sessions", sessionId, "invites"],
+      });
+    }
+    queryClient.invalidateQueries({ queryKey: ["netplay", "invites"] });
   });
 }

--- a/web/src/hooks/use-notifications.ts
+++ b/web/src/hooks/use-notifications.ts
@@ -1,5 +1,6 @@
 import { useWebSocketEvent } from "@/hooks/use-websocket";
 import { useToast } from "@/components/ui";
+import { useAuth } from "@/hooks/use-auth";
 
 interface SharedSessionInvitePayload {
   sharedSessionName: string;
@@ -12,6 +13,12 @@ interface NetplaySessionPayload {
   gameTitle: string;
 }
 
+interface NetplayInvitePayload {
+  inviteeId: string;
+  inviterUsername: string;
+  gameTitle: string;
+}
+
 /**
  * Global WebSocket notification hook — shows toast notifications
  * for shared session invites and netplay session events.
@@ -19,6 +26,7 @@ interface NetplaySessionPayload {
  */
 export function useNotifications() {
   const { toast } = useToast();
+  const { user } = useAuth();
 
   useWebSocketEvent("shared_session_invite_sent", (payload: SharedSessionInvitePayload) => {
     toast(
@@ -41,6 +49,17 @@ export function useNotifications() {
     "netplay_player_joined",
     (payload: NetplaySessionPayload) => {
       toast("info", `A player joined the netplay session for ${payload.gameTitle}`);
+    },
+  );
+
+  useWebSocketEvent(
+    "netplay_invite_sent",
+    (payload: NetplayInvitePayload) => {
+      if (payload.inviteeId !== user?.id) return;
+      toast(
+        "info",
+        `${payload.inviterUsername} invited you to play ${payload.gameTitle}`,
+      );
     },
   );
 }

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -95,6 +95,9 @@ export type ApiGetPath = WithQuery<
   // Netplay
   | "/netplay/sessions"
   | `/netplay/sessions/${string}`
+  | `/netplay/sessions/${string}/invites`
+  | "/netplay/invites"
+  | "/netplay/invites/count"
 
   // Social
   | "/social/online"
@@ -194,7 +197,10 @@ export type ApiPostPath = WithQuery<
   // Netplay
   | "/netplay/sessions"
   | "/netplay/sessions/join"
+  | `/netplay/sessions/${string}/invites`
   | `/netplay/sessions/${string}/leave`
+  | `/netplay/invites/${string}/accept`
+  | `/netplay/invites/${string}/decline`
 
   // Challenges
   | "/challenges"

--- a/web/src/pages/__tests__/netplay-page.test.tsx
+++ b/web/src/pages/__tests__/netplay-page.test.tsx
@@ -15,6 +15,19 @@ vi.mock("@/hooks/use-netplay", () => ({
     mutate: vi.fn(),
     isPending: false,
   })),
+  useNetplayInvitesRealtime: vi.fn(),
+  useNetplayInvites: vi.fn(() => ({
+    data: { data: [], total: 0 },
+    isLoading: false,
+  })),
+  useAcceptNetplayInvite: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+  useDeclineNetplayInvite: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
 }));
 
 vi.mock("@/hooks/use-games", () => ({

--- a/web/src/pages/__tests__/netplay-session-page.test.tsx
+++ b/web/src/pages/__tests__/netplay-session-page.test.tsx
@@ -10,6 +10,26 @@ vi.mock("@/hooks/use-netplay", () => ({
     mutate: vi.fn(),
     isPending: false,
   })),
+  useNetplayInvitesRealtime: vi.fn(),
+  useSessionNetplayInvites: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+  })),
+  useSendNetplayInvite: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
+}));
+
+vi.mock("@/hooks/use-social", () => ({
+  useSearchUsers: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@/hooks/use-debounced-value", () => ({
+  useDebouncedValue: vi.fn((val: string) => val),
 }));
 
 vi.mock("@/hooks/use-auth", () => ({

--- a/web/src/pages/netplay-page.tsx
+++ b/web/src/pages/netplay-page.tsx
@@ -11,10 +11,12 @@ import { useToast } from "@/components/ui";
 import {
   useNetplaySessions,
   useJoinNetplaySession,
+  useNetplayInvitesRealtime,
 } from "@/hooks/use-netplay";
 import { NetplaySessionRow } from "@/features/netplay/components/netplay-session-row";
 import { NetplayCreateModal } from "@/features/netplay/components/netplay-create-modal";
 import { Pagination } from "@/components/pagination";
+import { NetplayInvitationsSection } from "@/features/netplay/components/netplay-invitations-section";
 
 function SessionListSkeleton() {
   return (
@@ -46,6 +48,7 @@ export function NetplayPage() {
   const { toast } = useToast();
   const { data: sessionsData, isLoading } = useNetplaySessions(page, pageSize);
   const joinLookup = useJoinNetplaySession();
+  useNetplayInvitesRealtime();
 
   const sessions = sessionsData?.data ?? [];
 
@@ -80,6 +83,9 @@ export function NetplayPage() {
           Create Session
         </Button>
       </div>
+
+      {/* Pending invitations */}
+      <NetplayInvitationsSection />
 
       {/* Find session by invite code */}
       <div className="flex items-end gap-3">

--- a/web/src/pages/netplay-session-page.tsx
+++ b/web/src/pages/netplay-session-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Gamepad2, Trash2, Monitor, Plus } from "lucide-react";
+import { Gamepad2, Trash2, Monitor, Plus, UserPlus } from "lucide-react";
 import {
   Button,
   BackButton,
@@ -13,6 +13,7 @@ import { useToast } from "@/components/ui";
 import {
   useNetplaySession,
   useDeleteNetplaySession,
+  useNetplayInvitesRealtime,
 } from "@/hooks/use-netplay";
 import { useAuth } from "@/hooks/use-auth";
 import {
@@ -22,6 +23,8 @@ import {
 } from "@/features/netplay/components/netplay-status";
 import { SessionCode } from "@/features/netplay/components/session-code";
 import { NetplayPlayerList } from "@/features/netplay/components/netplay-player-list";
+import { NetplayInviteModal } from "@/features/netplay/components/netplay-invite-modal";
+import { NetplaySessionInvites } from "@/features/netplay/components/netplay-session-invites";
 import { formatDate } from "@/lib/format";
 
 function NetplaySessionSkeleton() {
@@ -58,6 +61,8 @@ export function NetplaySessionPage() {
   const deleteSession = useDeleteNetplaySession();
 
   const [showCancelModal, setShowCancelModal] = useState(false);
+  const [showInviteModal, setShowInviteModal] = useState(false);
+  useNetplayInvitesRealtime(id);
 
   const isHost = session?.hostId === user?.id;
 
@@ -136,11 +141,19 @@ export function NetplaySessionPage() {
               </div>
             </div>
 
-            {/* Invite code -- prominent display for waiting sessions */}
+            {/* Invite player button — primary action for host (AC-1.1) */}
+            {isHost && session.status === "waiting" && (
+              <Button onClick={() => setShowInviteModal(true)}>
+                <UserPlus className="h-4 w-4" />
+                Invite Player
+              </Button>
+            )}
+
+            {/* Invite code — secondary mechanism (AC-4.2) */}
             {session.status === "waiting" && (
               <div className="space-y-1.5">
                 <p className="text-xs font-medium text-surface-500 uppercase tracking-wider">
-                  Invite Code
+                  Or share an invite code
                 </p>
                 <SessionCode code={session.inviteCode} />
               </div>
@@ -247,6 +260,18 @@ export function NetplaySessionPage() {
 
       {/* Player list */}
       <NetplayPlayerList session={session} />
+
+      {/* Invited players — host sees all invites with status (AC-3.1) */}
+      {isHost && <NetplaySessionInvites sessionId={session.id} />}
+
+      {/* Invite player modal */}
+      {isHost && (
+        <NetplayInviteModal
+          sessionId={session.id}
+          open={showInviteModal}
+          onClose={() => setShowInviteModal(false)}
+        />
+      )}
 
       {/* Cancel confirm modal */}
       <Modal

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -562,6 +562,30 @@ export interface NetplaySessionsResponse {
   pageSize: number;
 }
 
+export interface NetplayInvite {
+  id: string;
+  netplaySessionId: string;
+  inviterId: string;
+  inviterUsername: string;
+  inviterAvatarUrl: string | null;
+  inviteeId: string;
+  inviteeUsername: string;
+  inviteeAvatarUrl: string | null;
+  gameId: string;
+  gameTitle: string;
+  gameCoverUrl: string | null;
+  consoleName: string;
+  hostUsername: string;
+  inputDelay: number;
+  status: "pending" | "accepted" | "declined" | "expired";
+  createdAt: string;
+}
+
+export interface NetplayInvitesResponse {
+  data: NetplayInvite[];
+  total: number;
+}
+
 export interface BiosFile {
   name: string;
   size: number;


### PR DESCRIPTION
## Summary
- Add user-to-user invite system for netplay sessions (search by username, send invite, accept/decline)
- Invite codes remain as secondary mechanism for external users
- Real-time WebSocket notifications for invite events with client-side filtering
- Invite count badge in sidebar navigation
- 7 WebSocket integration tests + 19 invite handler tests + 25 web component tests (51 new tests total)

## Changes

### Backend
- `NetplayInvite` model with unique constraint on `(session_id, invitee_id)`
- 6 REST endpoints: send, list mine, count, list session invites, accept, decline
- Atomic transaction for re-inviting declined users (prevents race conditions)
- Auto-expiry of pending invites when sessions end or another invite is accepted
- `resolveImageURL` used for cover art URLs (replaces fragile character check)

### Web Frontend
- **Invite modal**: debounced user search, dropdown selection, multi-invite support
- **Invitations section**: pending invites at top of netplay page with accept/decline
- **Session detail**: host sees "Invite Player" button and list of sent invites with status badges
- **Notifications**: toast filtered to only show for the actual invitee (not all users)
- **Sidebar**: invite count badge on Netplay nav item

## Code Review
- Reviewed by code-reviewer agent: 2 critical issues found and fixed (API response shape mismatch, fragile cover URL check)
- Reviewed by ui-agent: no critical visual issues, minor polish suggestions addressed ("Done" → "Close")

## Test plan
- [x] Go tests pass: `go test ./...` (all packages green)
- [x] Web tests pass: `npx vitest run` (76 files, 724 tests, 0 failures)
- [ ] CI passes on PR