### PR TITLE
test: add two-process netplay E2E screenshot verification

### DIFF
--- a/player/desktop/build.gradle.kts
+++ b/player/desktop/build.gradle.kts
@@ -103,6 +103,7 @@ kotlin {
                 implementation(compose.desktop.currentOs)
                 implementation(libs.kotlinx.coroutines.swing)
                 implementation(libs.koin.core)
+                implementation(libs.ktor.client.cio)
             }
         }
 
@@ -242,4 +243,30 @@ if (org.gradle.internal.os.OperatingSystem.current().isMacOsX) {
 // Pass native library path to Compose Hot Reload tasks.
 tasks.withType<JavaExec>().matching { it.name.startsWith("hotRun") || it.name.startsWith("hotDev") }.configureEach {
     jvmArgs("-Djava.library.path=${nativeBuildDir.get().asFile.absolutePath}")
+}
+
+// Headless netplay test runner — used by run-netplay-e2e.sh to launch two processes.
+val runNetplayTestRunner by tasks.registering(JavaExec::class) {
+    group = "application"
+    description = "Run the headless netplay test runner (pass args via --args)"
+    dependsOn(buildNativeLibrary, "desktopJar")
+
+    mainClass.set("com.spela.player.desktop.NetplayTestRunnerKt")
+    classpath = files(
+        tasks.named("desktopJar").map { it.outputs.files },
+        configurations.named("desktopRuntimeClasspath"),
+    )
+    jvmArgs("-Djava.library.path=${nativeBuildDir.get().asFile.absolutePath}")
+}
+
+// Print the runtime classpath for the shell script to use when launching JVM directly.
+tasks.register("printRuntimeClasspath") {
+    group = "help"
+    description = "Print the desktop runtime classpath (used by run-netplay-e2e.sh)"
+    doLast {
+        val desktopJar = tasks.named("desktopJar").get().outputs.files.singleFile
+        val runtimeCp = configurations.named("desktopRuntimeClasspath").get().resolve()
+        val allJars = listOf(desktopJar) + runtimeCp
+        println(allJars.joinToString(File.pathSeparator) { it.absolutePath })
+    }
 }

--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/NetplayTestRunner.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/NetplayTestRunner.kt
@@ -1,0 +1,413 @@
+package com.spela.player.desktop
+
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.dto.CreateNetplaySessionRequest
+import com.spela.player.data.remote.dto.JoinByInviteCodeRequest
+import com.spela.player.data.remote.dto.LoginRequest
+import com.spela.player.data.remote.interceptor.TokenManager
+import com.spela.player.libretro.DesktopLibretroController
+import com.spela.player.libretro.LibretroJni
+import com.spela.player.netplay.NetplayInputBuffer
+import com.spela.player.netplay.NetplaySignaling
+import com.spela.player.netplay.WebSocketRelayTransport
+import com.spela.player.platform.DesktopFileStorage
+import com.spela.player.util.DispatcherProvider
+import io.ktor.client.engine.cio.CIO
+import kotlinx.coroutines.*
+import com.spela.player.netplay.ControlMessage
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.takeWhile
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+
+/**
+ * Headless netplay emulator process for E2E testing.
+ *
+ * Runs a libretro core + ROM in netplay lockstep mode, controlled via stdin commands.
+ * Two instances of this program (host + client) connect to the same server and
+ * play the same game in sync. A shell script orchestrates both processes.
+ *
+ * Usage:
+ *   NetplayTestRunner --server-url URL --username USER --password PASS
+ *                     --role host|client --invite-code CODE
+ *                     --core-path PATH --rom-path PATH
+ *                     [--input-delay N]
+ *
+ * Stdin commands (one per line):
+ *   press <button>        - Press and release a button (select, start, a, b, up, down, left, right)
+ *   screenshot <path>     - Save current video frame as PNG
+ *   wait <ms>             - Sleep for N milliseconds
+ *   wait-frames <n>       - Wait for N emulation frames
+ *   quit                  - Stop emulation and exit
+ *
+ * Stdout protocol:
+ *   READY                 - Emulation is running, accepting commands
+ *   OK <command>          - Command completed successfully
+ *   ERROR <message>       - Something failed
+ */
+fun main(args: Array<String>) {
+    val config = parseArgs(args)
+    runBlocking {
+        try {
+            NetplayTestRunnerImpl(config).run()
+        } catch (e: Exception) {
+            println("ERROR ${e.message}")
+            System.exit(1)
+        }
+    }
+}
+
+private data class Config(
+    val serverUrl: String,
+    val username: String,
+    val password: String,
+    val role: String, // "host" or "client"
+    val inviteCode: String?, // null for host (will create), required for client
+    val corePath: String,
+    val romPath: String,
+    val inputDelay: Int = 3,
+    val solo: Boolean = false, // skip netplay, run single-player (debug mode)
+)
+
+private fun parseArgs(args: Array<String>): Config {
+    val map = mutableMapOf<String, String>()
+    var i = 0
+    while (i < args.size) {
+        if (args[i].startsWith("--") && i + 1 < args.size) {
+            map[args[i].removePrefix("--")] = args[i + 1]
+            i += 2
+        } else {
+            i++
+        }
+    }
+    return Config(
+        serverUrl = map["server-url"] ?: error("--server-url required"),
+        username = map["username"] ?: error("--username required"),
+        password = map["password"] ?: error("--password required"),
+        role = map["role"] ?: error("--role required (host or client)"),
+        inviteCode = map["invite-code"],
+        corePath = map["core-path"] ?: error("--core-path required"),
+        romPath = map["rom-path"] ?: error("--rom-path required"),
+        inputDelay = map["input-delay"]?.toIntOrNull() ?: 3,
+        solo = map["solo"] == "true",
+    )
+}
+
+private class NetplayTestRunnerImpl(private val config: Config) {
+    private val fileStorage = DesktopFileStorage()
+    private val jni = LibretroJni()
+    private val controller = DesktopLibretroController(jni, fileStorage)
+    private val tokenManager = TokenManager()
+    private val apiClient = SpelaApiClient(
+        engineFactory = CIO,
+        tokenManager = tokenManager,
+    )
+
+    private val dispatchers = object : DispatcherProvider {
+        override val main = Dispatchers.Default
+        override val io = Dispatchers.IO
+        override val default = Dispatchers.Default
+    }
+
+    @Volatile
+    private var running = false
+
+    @Volatile
+    private var emulationStarted = false
+
+    suspend fun run() {
+        log("Starting netplay test runner as ${config.role}")
+
+        // 1. Configure API client
+        apiClient.setBaseUrl(config.serverUrl)
+
+        // 2. Login
+        log("Logging in as ${config.username}...")
+        val authResponse = apiClient.login(LoginRequest(config.username, config.password))
+        tokenManager.setTokens(authResponse.accessToken, authResponse.refreshToken)
+        log("Logged in successfully")
+
+        // 3. Create or join session
+        val sessionId: String
+        val localPort: Int
+
+        if (config.role == "host") {
+            // Find the game ID for Chip 'n Dale by listing NES games
+            log("Finding game on server...")
+            val gamesResponse = apiClient.getGamesForConsole("nes", page = 1, pageSize = 100)
+            val game = gamesResponse.data.firstOrNull { it.title.contains("Chip", ignoreCase = true) }
+                ?: gamesResponse.data.firstOrNull { it.title.contains("Rescue", ignoreCase = true) }
+                ?: error("Could not find Chip 'n Dale game on server. Available: ${gamesResponse.data.map { it.title }}")
+
+            log("Creating netplay session for '${game.title}' (ID: ${game.id})...")
+            val session = apiClient.createNetplaySession(
+                CreateNetplaySessionRequest(gameId = game.id, inputDelay = config.inputDelay)
+            )
+            sessionId = session.id
+            localPort = 0 // Host is always port 0
+            // Print invite code for the orchestration script to capture
+            println("INVITE_CODE ${session.inviteCode}")
+            System.out.flush()
+            log("Session created: ${session.id}, invite code: ${session.inviteCode}")
+            log("Waiting for client to join...")
+        } else {
+            val code = config.inviteCode ?: error("--invite-code required for client role")
+            log("Joining session with invite code: $code...")
+            val session = apiClient.joinNetplayByInviteCode(JoinByInviteCodeRequest(code))
+            sessionId = session.id
+            localPort = 1 // Client is always port 1
+            log("Joined session: ${session.id}")
+        }
+
+        // 4. Load core and ROM
+        log("Loading core: ${config.corePath}")
+        controller.loadCore(config.corePath)
+        log("Loading ROM: ${config.romPath}")
+        controller.loadGame(config.romPath)
+
+        // 5. Set up netplay transport (skip in solo mode)
+        val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+        var inputCollectorJob: Job? = null
+
+        if (!config.solo) {
+            log("Setting up netplay transport...")
+            val signaling = NetplaySignaling(
+                apiClient = apiClient,
+                engineFactory = CIO,
+                dispatchers = dispatchers,
+                scope = scope,
+                sessionId = sessionId,
+            )
+            val transport = WebSocketRelayTransport(signaling, scope)
+            val inputBuffer = NetplayInputBuffer()
+
+            // Connect transport
+            transport.connect()
+            delay(2000) // Let WebSocket establish and both sides connect
+
+            // Skip state transfer — both sides loaded the same ROM and are at
+            // the same initial state. State sync would be needed for mid-game
+            // joins but for E2E testing from fresh start it's unnecessary.
+            log("Both sides loaded same ROM — skipping state transfer")
+
+            // Configure lockstep mode
+            controller.setNetplayMode(transport, inputBuffer, localPort, config.inputDelay)
+
+            // Start collecting remote inputs
+            inputCollectorJob = scope.launch(Dispatchers.IO) {
+                transport.remoteInputs.collect { remote ->
+                    inputBuffer.setRemoteInput(remote.frame, remote.port, remote.input)
+                }
+            }
+        } else {
+            log("Solo mode — skipping netplay setup")
+        }
+
+        // Give collectors time to subscribe to SharedFlows
+        delay(100)
+
+        // Signal ready — both sides must be READY before starting emulation
+        running = true
+        println("READY")
+        System.out.flush()
+        log("Waiting for 'go' command to start emulation...")
+
+        // 7. Read and execute stdin commands
+        // Wait for "go" command before starting emulation
+        val reader = System.`in`.bufferedReader()
+        while (running) {
+            val line = withContext(Dispatchers.IO) { reader.readLine() } ?: break
+            val parts = line.trim().split(" ", limit = 2)
+            if (parts.isEmpty()) continue
+
+            try {
+                when (parts[0].lowercase()) {
+                    "go" -> {
+                        if (!emulationStarted) {
+                            log("Starting emulation...")
+                            emulationStarted = true
+                            controller.start()
+                        }
+                        println("OK go")
+                    }
+                    "press" -> {
+                        val button = parts.getOrNull(1) ?: error("Usage: press <button>")
+                        pressButton(localPort, button)
+                        println("OK press $button")
+                    }
+                    "screenshot" -> {
+                        val path = parts.getOrNull(1) ?: error("Usage: screenshot <path>")
+                        takeScreenshot(path)
+                        println("OK screenshot $path")
+                    }
+                    "wait" -> {
+                        val ms = parts.getOrNull(1)?.toLongOrNull() ?: error("Usage: wait <ms>")
+                        delay(ms)
+                        println("OK wait $ms")
+                    }
+                    "wait-frames" -> {
+                        val n = parts.getOrNull(1)?.toIntOrNull() ?: error("Usage: wait-frames <n>")
+                        // Wait approximately N frames at 60fps
+                        delay((n * 16.67).toLong())
+                        println("OK wait-frames $n")
+                    }
+                    "quit" -> {
+                        println("OK quit")
+                        running = false
+                    }
+                    else -> println("ERROR unknown command: ${parts[0]}")
+                }
+            } catch (e: Exception) {
+                println("ERROR ${e.message}")
+            }
+            System.out.flush()
+        }
+
+        // 8. Cleanup
+        log("Shutting down...")
+        controller.stop()
+        inputCollectorJob?.cancel()
+        scope.cancel()
+        log("Done")
+    }
+
+    private fun pressButton(port: Int, button: String) {
+        val buttonId = when (button.lowercase()) {
+            "b" -> 0
+            "y" -> 1
+            "select" -> 2
+            "start" -> 3
+            "up" -> 4
+            "down" -> 5
+            "left" -> 6
+            "right" -> 7
+            "a" -> 8
+            "x" -> 9
+            "l" -> 10
+            "r" -> 11
+            else -> error("Unknown button: $button")
+        }
+        // Use controller.setButton which writes to both JNI and the Kotlin-side
+        // netplayLocalButtons variable (read by captureNetplayLocalInput in the
+        // netplay emulation loop, avoiding the JNI feedback loop).
+        val holdMs = 200L // ~10 frames at 50fps
+        log("pressButton: port=$port buttonId=$buttonId holding for ${holdMs}ms")
+        controller.setButton(port, buttonId, true)
+        Thread.sleep(holdMs)
+        controller.setButton(port, buttonId, false)
+        log("pressButton: released")
+    }
+
+    private fun takeScreenshot(path: String) {
+        val width = jni.nativeGetVideoWidth()
+        val height = jni.nativeGetVideoHeight()
+        if (width <= 0 || height <= 0) error("Invalid video dimensions: ${width}x${height}")
+
+        val frame: ByteArray
+        val isBgra: Boolean
+
+        if (jni.nativeGpuIsActive()) {
+            // GPU renderer is active — read back from GPU as BGRA
+            val buf = ByteArray(width * height * 4)
+            val written = jni.nativeGpuRenderToBgra(buf)
+            if (written <= 0) error("GPU readback failed")
+            frame = buf
+            isBgra = true
+        } else {
+            // Software path — use the frame buffer directly
+            frame = jni.nativeGetVideoFrame() ?: error("No video frame available")
+            isBgra = false
+        }
+
+        val expectedPixels = width * height
+        val actualBpp = frame.size / expectedPixels
+        // Use BGRA if GPU is active or if buffer is 4bpp
+        val pixelFormat = if (isBgra || actualBpp >= 4) 2 else jni.nativeGetPixelFormat()
+
+        val image = BufferedImage(width, height, BufferedImage.TYPE_INT_RGB)
+        for (y in 0 until height) {
+            for (x in 0 until width) {
+                val offset = (y * width + x)
+                val rgb = when (pixelFormat) {
+                    0 -> { // XRGB1555
+                        val pixel = (frame[offset * 2 + 1].toInt() and 0xFF shl 8) or
+                            (frame[offset * 2].toInt() and 0xFF)
+                        val r = ((pixel shr 10) and 0x1F) * 255 / 31
+                        val g = ((pixel shr 5) and 0x1F) * 255 / 31
+                        val b = (pixel and 0x1F) * 255 / 31
+                        (r shl 16) or (g shl 8) or b
+                    }
+                    1 -> { // RGB565
+                        val pixel = (frame[offset * 2 + 1].toInt() and 0xFF shl 8) or
+                            (frame[offset * 2].toInt() and 0xFF)
+                        val r = ((pixel shr 11) and 0x1F) * 255 / 31
+                        val g = ((pixel shr 5) and 0x3F) * 255 / 63
+                        val b = (pixel and 0x1F) * 255 / 31
+                        (r shl 16) or (g shl 8) or b
+                    }
+                    2 -> { // XRGB8888 / BGRA
+                        val b2 = frame[offset * 4].toInt() and 0xFF
+                        val g2 = frame[offset * 4 + 1].toInt() and 0xFF
+                        val r2 = frame[offset * 4 + 2].toInt() and 0xFF
+                        (r2 shl 16) or (g2 shl 8) or b2
+                    }
+                    else -> 0
+                }
+                image.setRGB(x, y, rgb)
+            }
+        }
+
+        val file = File(path)
+        file.parentFile?.mkdirs()
+        ImageIO.write(image, "PNG", file)
+        log("Screenshot saved: $path (${width}x${height}, format=$pixelFormat, gpu=${jni.nativeGpuIsActive()})")
+    }
+
+    private fun sendStateChunks(transport: WebSocketRelayTransport, stateData: ByteArray) {
+        val chunkSize = 16_384
+        val totalChunks = (stateData.size + chunkSize - 1) / chunkSize
+        for (i in 0 until totalChunks) {
+            val offset = i * chunkSize
+            val end = minOf(offset + chunkSize, stateData.size)
+            val chunk = stateData.copyOfRange(offset, end)
+            val encoded = com.spela.player.netplay.NetplayProtocol.encodeStateChunk(
+                chunkIndex = i, totalChunks = totalChunks, totalSize = stateData.size, data = chunk,
+            )
+            transport.sendBinary(encoded)
+        }
+    }
+
+    private suspend fun receiveStateChunks(transport: WebSocketRelayTransport): ByteArray? {
+        val receivedChunks = mutableMapOf<Int, ByteArray>()
+        var totalChunks = -1
+        var totalSize = -1
+
+        kotlinx.coroutines.withTimeoutOrNull(10_000) {
+            transport.remoteBinary.takeWhile { msg ->
+                val chunk = com.spela.player.netplay.NetplayProtocol.decodeStateChunk(msg.data)
+                if (chunk != null) {
+                    totalChunks = chunk.totalChunks
+                    totalSize = chunk.totalSize
+                    receivedChunks[chunk.chunkIndex] = chunk.data
+                }
+                receivedChunks.size < totalChunks || totalChunks < 0
+            }.collect {}
+        } ?: return null
+
+        if (totalSize < 0 || receivedChunks.size < totalChunks) return null
+
+        val result = ByteArray(totalSize)
+        var offset = 0
+        for (i in 0 until totalChunks) {
+            val chunkData = receivedChunks[i] ?: return null
+            chunkData.copyInto(result, offset)
+            offset += chunkData.size
+        }
+        return result
+    }
+
+    private fun log(msg: String) {
+        System.err.println("[${config.role}] $msg")
+    }
+}

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -1224,6 +1224,16 @@ JNI_FUNC(void, nativeSetInputAnalog)(JNIEnv *env, jobject thiz,
     input_set_analog((unsigned)port, (unsigned)index, (unsigned)id, (int16_t)value);
 }
 
+JNI_FUNC(jboolean, nativeGetInputButton)(JNIEnv *env, jobject thiz,
+                                          jint port, jint id) {
+    return input_get_button((unsigned)port, (unsigned)id) ? JNI_TRUE : JNI_FALSE;
+}
+
+JNI_FUNC(jshort, nativeGetInputAnalog)(JNIEnv *env, jobject thiz,
+                                        jint port, jint index, jint id) {
+    return (jshort)input_get_analog((unsigned)port, (unsigned)index, (unsigned)id);
+}
+
 JNI_FUNC(jdouble, nativeGetTargetFps)(JNIEnv *env, jobject thiz) {
     return g_core.av_info.timing.fps;
 }

--- a/player/native/src/libretro_bridge.h
+++ b/player/native/src/libretro_bridge.h
@@ -47,6 +47,8 @@ void input_init(void);
 void input_deinit(void);
 void input_poll_callback(void);
 int16_t input_state_callback(unsigned port, unsigned device, unsigned index, unsigned id);
+bool input_get_button(unsigned port, unsigned id);
+int16_t input_get_analog(unsigned port, unsigned index, unsigned id);
 void input_set_button(unsigned port, unsigned id, bool pressed);
 void input_set_analog(unsigned port, unsigned index, unsigned id, int16_t value);
 void input_set_pointer(unsigned port, int16_t x, int16_t y, bool pressed);

--- a/player/native/src/libretro_input.c
+++ b/player/native/src/libretro_input.c
@@ -99,6 +99,22 @@ int16_t input_state_callback(unsigned port, unsigned device, unsigned index, uns
     return 0;
 }
 
+/* Called from Kotlin/JNI to read button state */
+bool input_get_button(unsigned port, unsigned id) {
+    if (port < MAX_PORTS && id < MAX_BUTTONS) {
+        return input_state.buttons[port][id];
+    }
+    return false;
+}
+
+/* Called from Kotlin/JNI to read analog axis state */
+int16_t input_get_analog(unsigned port, unsigned index, unsigned id) {
+    if (port < MAX_PORTS && index < 2 && id < 2) {
+        return input_state.analog[port][index][id];
+    }
+    return 0;
+}
+
 /* Called from Kotlin/JNI to set button state */
 void input_set_button(unsigned port, unsigned id, bool pressed) {
     if (port < MAX_PORTS && id < MAX_BUTTONS) {

--- a/player/run-netplay-e2e.sh
+++ b/player/run-netplay-e2e.sh
@@ -1,0 +1,495 @@
+#!/usr/bin/env bash
+#
+# Netplay E2E Test — Two-Process Screenshot Verification
+#
+# Spins up the E2E docker backend, launches two headless desktop player
+# instances in netplay mode, and verifies cross-player input propagation
+# by comparing screenshots.
+#
+# ROM: Chip 'n Dale: Rescue Rangers (NES)
+# Test flow:
+#   Phase 1 (title screen): P1 presses Select → P2's screen changes
+#   Phase 2 (in-game):      P2 presses A (jump) → P1's screen changes
+#
+# Usage: ./run-netplay-e2e.sh [--skip-docker] [--skip-build]
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PLAYER_DIR="$SCRIPT_DIR"
+OUTPUT_DIR="$PLAYER_DIR/build/netplay-e2e"
+
+# Parse flags
+SKIP_DOCKER=false
+SKIP_BUILD=false
+for arg in "$@"; do
+    case "$arg" in
+        --skip-docker) SKIP_DOCKER=true ;;
+        --skip-build)  SKIP_BUILD=true ;;
+    esac
+done
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+log() { echo -e "${YELLOW}[netplay-e2e]${NC} $1"; }
+pass() { echo -e "${GREEN}[PASS]${NC} $1"; }
+fail() { echo -e "${RED}[FAIL]${NC} $1"; }
+
+HOST_PID=""
+CLIENT_PID=""
+
+cleanup() {
+    log "Cleaning up..."
+    [[ -n "$HOST_PID" ]] && kill "$HOST_PID" 2>/dev/null || true
+    [[ -n "$CLIENT_PID" ]] && kill "$CLIENT_PID" 2>/dev/null || true
+    [[ -n "$HOST_PID" ]] && wait "$HOST_PID" 2>/dev/null || true
+    [[ -n "$CLIENT_PID" ]] && wait "$CLIENT_PID" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ---------------------------------------------------------------------------
+# 1. Ensure docker E2E environment is running
+# ---------------------------------------------------------------------------
+if [[ "$SKIP_DOCKER" == "false" ]]; then
+    log "Starting E2E docker environment..."
+    docker compose -f "$PROJECT_ROOT/docker-compose.e2e.yml" up -d --build --wait
+else
+    log "Skipping docker setup (--skip-docker)"
+fi
+
+SERVER_URL="http://localhost:8080"
+
+# Wait for server to be ready
+log "Waiting for server at $SERVER_URL..."
+for i in $(seq 1 30); do
+    if curl -sf "$SERVER_URL/api/health" > /dev/null 2>&1; then
+        break
+    fi
+    if [[ $i -eq 30 ]]; then
+        fail "Server did not become ready in 30 seconds"
+        exit 1
+    fi
+    sleep 1
+done
+log "Server is ready"
+
+# ---------------------------------------------------------------------------
+# 2. Find ROM and core
+# ---------------------------------------------------------------------------
+ROM_PATH="$PROJECT_ROOT/testdata/roms/nes/Chip 'n Dale - Rescue Rangers (Europe).nes"
+if [[ ! -f "$ROM_PATH" ]]; then
+    # Try alternate names
+    ROM_PATH=$(find "$PROJECT_ROOT/testdata/roms/nes" -iname "*chip*dale*" -o -iname "*rescue*ranger*" 2>/dev/null | head -1)
+    if [[ -z "$ROM_PATH" || ! -f "$ROM_PATH" ]]; then
+        fail "Could not find Chip 'n Dale ROM in testdata/roms/nes/"
+        exit 1
+    fi
+fi
+log "ROM: $ROM_PATH"
+
+# Find or download nestopia core
+CORE_DIR="$HOME/Library/Application Support/Spela/cores"
+if [[ "$(uname)" == "Linux" ]]; then
+    CORE_DIR="$HOME/.local/share/spela/cores"
+fi
+CORE_PATH=""
+for ext in dylib so dll; do
+    candidate="$CORE_DIR/nestopia_libretro.$ext"
+    if [[ -f "$candidate" ]]; then
+        CORE_PATH="$candidate"
+        break
+    fi
+done
+
+if [[ -z "$CORE_PATH" ]]; then
+    log "Nestopia core not found locally, downloading..."
+    mkdir -p "$CORE_DIR"
+    OS_NAME="$(uname -s)"
+    case "$OS_NAME" in
+        Darwin) CORE_URL="https://buildbot.libretro.com/nightly/apple/osx/arm64/latest/nestopia_libretro.dylib.zip"
+                CORE_EXT="dylib" ;;
+        Linux)  CORE_URL="https://buildbot.libretro.com/nightly/linux/x86_64/latest/nestopia_libretro.so.zip"
+                CORE_EXT="so" ;;
+        *)      fail "Unsupported OS: $OS_NAME"; exit 1 ;;
+    esac
+    CORE_PATH="$CORE_DIR/nestopia_libretro.$CORE_EXT"
+    curl -L "$CORE_URL" -o /tmp/nestopia_core.zip
+    unzip -o /tmp/nestopia_core.zip -d "$CORE_DIR"
+    rm -f /tmp/nestopia_core.zip
+    if [[ ! -f "$CORE_PATH" ]]; then
+        fail "Failed to download nestopia core"
+        exit 1
+    fi
+fi
+log "Core: $CORE_PATH"
+
+# ---------------------------------------------------------------------------
+# 3. Build the desktop app (includes native library)
+# ---------------------------------------------------------------------------
+if [[ "$SKIP_BUILD" == "false" ]]; then
+    log "Building desktop app and native library..."
+    cd "$PLAYER_DIR"
+    ./gradlew :desktop:desktopJar :desktop:buildNativeLibrary --quiet 2>&1 | tail -5
+    cd "$PROJECT_ROOT"
+else
+    log "Skipping build (--skip-build)"
+fi
+
+# ---------------------------------------------------------------------------
+# 4. Prepare output directory
+# ---------------------------------------------------------------------------
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+# ---------------------------------------------------------------------------
+# 5. Build the classpath and JVM args for the test runner
+# ---------------------------------------------------------------------------
+NATIVE_LIB_DIR="$PLAYER_DIR/desktop/build/native"
+GRADLE_RUN="cd $PLAYER_DIR && ./gradlew -q :desktop:runNetplayTestRunner"
+
+# We'll use the Gradle task to run each process. To pass different args to each,
+# we use the --args flag. But since we need two concurrent processes, we'll
+# invoke Gradle twice in parallel. However, that's slow.
+#
+# Better approach: run the JVM directly using the jar + classpath from Gradle.
+# Let's find the classpath by running a helper.
+
+log "Resolving classpath..."
+DESKTOP_JAR=$(find "$PLAYER_DIR/desktop/build/libs" -name "*.jar" | head -1)
+if [[ -z "$DESKTOP_JAR" ]]; then
+    fail "Desktop JAR not found. Run build first."
+    exit 1
+fi
+
+# Build a classpath from the Gradle cache — collect all runtime JARs
+CLASSPATH_FILE="$OUTPUT_DIR/classpath.txt"
+cd "$PLAYER_DIR"
+./gradlew -q :desktop:printRuntimeClasspath 2>/dev/null > "$CLASSPATH_FILE" || true
+cd "$PROJECT_ROOT"
+
+# If the printRuntimeClasspath task doesn't exist, fall back to Gradle exec
+if [[ ! -s "$CLASSPATH_FILE" ]]; then
+    log "Using Gradle JavaExec for test runners (slower)..."
+    USE_GRADLE=true
+else
+    CLASSPATH=$(cat "$CLASSPATH_FILE")
+    USE_GRADLE=false
+fi
+
+# ---------------------------------------------------------------------------
+# 6. Launch host process
+# ---------------------------------------------------------------------------
+log "Launching host process..."
+HOST_STDIN="$OUTPUT_DIR/host_stdin"
+HOST_STDOUT="$OUTPUT_DIR/host_stdout"
+HOST_STDERR="$OUTPUT_DIR/host_stderr"
+mkfifo "$HOST_STDIN"
+: > "$HOST_STDOUT"
+
+# Launch java reading from FIFO. The FIFO open blocks until we open the write end.
+# We launch java in background, then immediately open the write end.
+java \
+    -Djava.library.path="$NATIVE_LIB_DIR" \
+    -cp "$CLASSPATH" \
+    com.spela.player.desktop.NetplayTestRunnerKt \
+    --server-url "$SERVER_URL" \
+    --username admin \
+    --password admin123 \
+    --role host \
+    --core-path "$CORE_PATH" \
+    --rom-path "$ROM_PATH" \
+    --input-delay 1 \
+    < "$HOST_STDIN" > "$HOST_STDOUT" 2>"$HOST_STDERR" &
+HOST_PID=$!
+
+# Open write end of FIFO (unblocks java's stdin)
+exec 3>"$HOST_STDIN"
+
+# Wait for INVITE_CODE from host
+log "Waiting for host to create session..."
+INVITE_CODE=""
+for i in $(seq 1 60); do
+    INVITE_CODE=$(grep "^INVITE_CODE " "$HOST_STDOUT" 2>/dev/null | head -1 | awk '{print $2}' || true)
+    if [[ -n "$INVITE_CODE" ]]; then
+        break
+    fi
+    # Check if host process died
+    if ! kill -0 "$HOST_PID" 2>/dev/null; then
+        fail "Host process exited prematurely"
+        cat "$HOST_STDERR" 2>/dev/null || true
+        exit 1
+    fi
+    sleep 1
+done
+
+if [[ -z "$INVITE_CODE" ]]; then
+    fail "Host did not produce an invite code within 60 seconds"
+    cat "$HOST_STDERR" 2>/dev/null || true
+    exit 1
+fi
+log "Got invite code: $INVITE_CODE"
+
+# ---------------------------------------------------------------------------
+# 7. Launch client process
+# ---------------------------------------------------------------------------
+log "Launching client process..."
+CLIENT_STDIN="$OUTPUT_DIR/client_stdin"
+CLIENT_STDOUT="$OUTPUT_DIR/client_stdout"
+CLIENT_STDERR="$OUTPUT_DIR/client_stderr"
+mkfifo "$CLIENT_STDIN"
+: > "$CLIENT_STDOUT"
+
+java \
+    -Djava.library.path="$NATIVE_LIB_DIR" \
+    -cp "$CLASSPATH" \
+    com.spela.player.desktop.NetplayTestRunnerKt \
+    --server-url "$SERVER_URL" \
+    --username player \
+    --password player123 \
+    --role client \
+    --invite-code "$INVITE_CODE" \
+    --core-path "$CORE_PATH" \
+    --rom-path "$ROM_PATH" \
+    --input-delay 1 \
+    < "$CLIENT_STDIN" > "$CLIENT_STDOUT" 2>"$CLIENT_STDERR" &
+CLIENT_PID=$!
+
+exec 4>"$CLIENT_STDIN"
+
+# ---------------------------------------------------------------------------
+# 8. Wait for both to be READY
+# ---------------------------------------------------------------------------
+wait_for_ready() {
+    local name="$1"
+    local stdout_file="$2"
+    local timeout=60
+    for i in $(seq 1 $timeout); do
+        if grep -q "^READY" "$stdout_file" 2>/dev/null; then
+            log "$name is READY"
+            return 0
+        fi
+        sleep 1
+    done
+    fail "$name did not become ready within ${timeout}s"
+    return 1
+}
+
+wait_for_ready "Host" "$HOST_STDOUT"
+wait_for_ready "Client" "$CLIENT_STDOUT"
+
+# Helper: send a command to a process and wait for OK
+# (defined before "go" so it's available)
+send_cmd() {
+    local name="$1"
+    local fd="$2"
+    local stdout_file="$3"
+    local cmd="$4"
+
+    local before_count
+    before_count=$(wc -l < "$stdout_file" 2>/dev/null || echo 0)
+
+    echo "$cmd" >&"$fd"
+
+    # Wait for response line
+    for i in $(seq 1 30); do
+        local current_count
+        current_count=$(wc -l < "$stdout_file" 2>/dev/null || echo 0)
+        if [[ "$current_count" -gt "$before_count" ]]; then
+            local last_line
+            last_line=$(tail -1 "$stdout_file")
+            if [[ "$last_line" == OK* ]]; then
+                return 0
+            elif [[ "$last_line" == ERROR* ]]; then
+                fail "$name command '$cmd' failed: $last_line"
+                return 1
+            fi
+        fi
+        sleep 0.5
+    done
+    fail "$name command '$cmd' timed out"
+    return 1
+}
+
+# ---------------------------------------------------------------------------
+# 9. Start emulation on both sides simultaneously
+# ---------------------------------------------------------------------------
+log "Starting emulation on both processes..."
+send_cmd "Host" 3 "$HOST_STDOUT" "go"
+send_cmd "Client" 4 "$CLIENT_STDOUT" "go"
+
+# ---------------------------------------------------------------------------
+# 10. Execute test sequence
+# ---------------------------------------------------------------------------
+log ""
+log "=========================================="
+log " Phase 1: Title Screen Input Test (P1→P2)"
+log "=========================================="
+log ""
+
+# Wait for title screen to render
+log "Waiting 3s for title screen..."
+send_cmd "Host" 3 "$HOST_STDOUT" "wait 3000"
+send_cmd "Client" 4 "$CLIENT_STDOUT" "wait 3000"
+
+# P2 takes screenshot of title screen (cursor on "1 PLAYER")
+log "P2: taking 'before' screenshot (cursor on 1 PLAYER)..."
+send_cmd "Client" 4 "$CLIENT_STDOUT" "screenshot $OUTPUT_DIR/phase1_before.png"
+
+# P1 presses Select (toggles cursor from "1 PLAYER" to "2 Players")
+log "P1: pressing Select to switch to 2 Players..."
+send_cmd "Host" 3 "$HOST_STDOUT" "press select"
+
+# Wait for input to propagate through netplay
+log "Waiting 2s for input to propagate..."
+send_cmd "Client" 4 "$CLIENT_STDOUT" "wait 2000"
+
+# P2 takes screenshot (cursor should now be on "2 Players")
+log "P2: taking 'after' screenshot..."
+send_cmd "Client" 4 "$CLIENT_STDOUT" "screenshot $OUTPUT_DIR/phase1_after.png"
+
+# Compare: cursor position should differ
+PHASE1_RESULT="FAIL"
+if [[ -f "$OUTPUT_DIR/phase1_before.png" && -f "$OUTPUT_DIR/phase1_after.png" ]]; then
+    if ! cmp -s "$OUTPUT_DIR/phase1_before.png" "$OUTPUT_DIR/phase1_after.png"; then
+        PHASE1_RESULT="PASS"
+        pass "Phase 1: P1's Select input propagated to P2 (cursor moved)"
+    else
+        fail "Phase 1: Screenshots identical — P1's Select did not reach P2"
+    fi
+else
+    fail "Phase 1: Screenshot files missing"
+fi
+
+log ""
+log "=========================================="
+log " Phase 2: In-Game Input Test (P2→P1)"
+log "=========================================="
+log ""
+
+# Start the game in 2-player mode
+log "P1: pressing Start to begin 2-player game..."
+send_cmd "Host" 3 "$HOST_STDOUT" "press start"
+
+# Wait for cutscene to appear, then press Start to skip it
+log "Waiting 1s for cutscene..."
+send_cmd "Host" 3 "$HOST_STDOUT" "wait 1000"
+log "P1: pressing Start to skip cutscene..."
+send_cmd "Host" 3 "$HOST_STDOUT" "press start"
+
+# We might be on the map/zone select screen — press A to enter the zone
+log "Waiting 1s, then pressing A to enter zone..."
+send_cmd "Host" 3 "$HOST_STDOUT" "wait 1000"
+send_cmd "Host" 3 "$HOST_STDOUT" "press a"
+
+# Wait for level to load
+log "Waiting 3s for in-game..."
+send_cmd "Host" 3 "$HOST_STDOUT" "wait 3000"
+send_cmd "Client" 4 "$CLIENT_STDOUT" "wait 3000"
+
+# Verify game is running: P1 presses Right (moves Chip). If screen doesn't
+# change, game is paused — press Start to unpause and try again.
+log "Verifying game is running..."
+send_cmd "Host" 3 "$HOST_STDOUT" "screenshot $OUTPUT_DIR/verify_a.png"
+send_cmd "Host" 3 "$HOST_STDOUT" "press right"
+send_cmd "Host" 3 "$HOST_STDOUT" "wait 500"
+send_cmd "Host" 3 "$HOST_STDOUT" "screenshot $OUTPUT_DIR/verify_b.png"
+
+if cmp -s "$OUTPUT_DIR/verify_a.png" "$OUTPUT_DIR/verify_b.png"; then
+    log "Game is paused — pressing Start to unpause..."
+    send_cmd "Host" 3 "$HOST_STDOUT" "press start"
+    send_cmd "Host" 3 "$HOST_STDOUT" "wait 500"
+    # Verify again
+    send_cmd "Host" 3 "$HOST_STDOUT" "screenshot $OUTPUT_DIR/verify_c.png"
+    send_cmd "Host" 3 "$HOST_STDOUT" "press right"
+    send_cmd "Host" 3 "$HOST_STDOUT" "wait 500"
+    send_cmd "Host" 3 "$HOST_STDOUT" "screenshot $OUTPUT_DIR/verify_d.png"
+    if cmp -s "$OUTPUT_DIR/verify_c.png" "$OUTPUT_DIR/verify_d.png"; then
+        log "WARNING: Game still not responding after unpause"
+    else
+        log "Game is now running"
+    fi
+else
+    log "Game is running"
+fi
+
+# P1 takes screenshot of gameplay
+log "P1: taking 'before' screenshot..."
+send_cmd "Host" 3 "$HOST_STDOUT" "screenshot $OUTPUT_DIR/phase2_before.png"
+
+# P2 presses A (jump as Dale). The press command blocks for ~200ms (hold time).
+# During that time the host keeps emulating. We need to catch the screenshot
+# WHILE Dale is mid-jump, so we fire the press without waiting for completion,
+# then immediately tell the host to wait a bit and screenshot.
+log "P2: pressing A (jump as Dale)..."
+echo "press a" >&4  # Fire and forget to client
+
+# The A press needs ~200ms to register + propagate through netplay.
+# Wait 400ms then screenshot — Dale should be mid-jump at this point.
+log "Waiting 400ms to catch mid-jump on host..."
+send_cmd "Host" 3 "$HOST_STDOUT" "wait 400"
+
+log "P1: taking 'after' screenshot..."
+send_cmd "Host" 3 "$HOST_STDOUT" "screenshot $OUTPUT_DIR/phase2_after.png"
+
+# Now wait for client press to finish (it will have printed OK by now)
+sleep 0.5
+
+# Compare screenshots: Dale's jump should change the screen
+PHASE2_RESULT="FAIL"
+if [[ -f "$OUTPUT_DIR/phase2_before.png" && -f "$OUTPUT_DIR/phase2_after.png" ]]; then
+    if ! cmp -s "$OUTPUT_DIR/phase2_before.png" "$OUTPUT_DIR/phase2_after.png"; then
+        PHASE2_RESULT="PASS"
+        pass "Phase 2: P2's A input propagated to P1 (Dale jumped)"
+    else
+        fail "Phase 2: Screenshots are identical — P2's A did not reach P1"
+    fi
+else
+    fail "Phase 2: Screenshot files missing"
+fi
+
+# ---------------------------------------------------------------------------
+# 10. Quit both processes
+# ---------------------------------------------------------------------------
+log ""
+log "Sending quit commands..."
+send_cmd "Host" 3 "$HOST_STDOUT" "quit" || true
+send_cmd "Client" 4 "$CLIENT_STDOUT" "quit" || true
+
+# Close stdin pipes
+exec 3>&-
+exec 4>&-
+
+# Wait for processes to exit
+wait "$HOST_PID" 2>/dev/null || true
+wait "$CLIENT_PID" 2>/dev/null || true
+HOST_PID=""
+CLIENT_PID=""
+
+# ---------------------------------------------------------------------------
+# 11. Report results
+# ---------------------------------------------------------------------------
+log ""
+log "=========================================="
+log " Results"
+log "=========================================="
+log ""
+log "  Phase 1 (title select, P1→P2): $PHASE1_RESULT"
+log "  Phase 2 (in-game, P2→P1):      $PHASE2_RESULT"
+log ""
+log "  Screenshots: $OUTPUT_DIR/"
+log "  Host stderr: $HOST_STDERR"
+log "  Client stderr: $CLIENT_STDERR"
+log ""
+
+if [[ "$PHASE1_RESULT" == "PASS" && "$PHASE2_RESULT" == "PASS" ]]; then
+    pass "All netplay E2E tests passed!"
+    exit 0
+else
+    fail "Some netplay E2E tests failed"
+    exit 1
+fi

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -733,7 +733,7 @@ data class CreateNetplaySessionRequest(
 
 @Serializable
 data class JoinByInviteCodeRequest(
-    val code: String,
+    val inviteCode: String,
 )
 
 @Serializable

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
@@ -46,6 +46,15 @@ class DesktopLibretroController(
     @Volatile
     private var netplayDisconnected = false
 
+    /**
+     * External button state for netplay. When in netplay mode, captureLocalInput
+     * reads from this instead of the JNI table to avoid a feedback loop where
+     * applyInputToJni's output is re-captured as new input.
+     * Written by setButton (from pressButton / UI thread), read by emulation thread.
+     */
+    @Volatile
+    private var netplayLocalButtons: Int = 0
+
     /** Callback invoked on the emulation thread when the remote peer times out. */
     var onNetplayPeerTimeout: (() -> Unit)? = null
 
@@ -167,6 +176,15 @@ class DesktopLibretroController(
 
     fun setButton(port: Int, buttonId: Int, pressed: Boolean) {
         jni.nativeSetInputButton(port, buttonId, pressed)
+        // Also update netplay-side button state (avoids JNI feedback loop)
+        if (port == netplayLocalPort && netplayTransport != null) {
+            val mask = 1 shl buttonId
+            if (pressed) {
+                netplayLocalButtons = netplayLocalButtons or mask
+            } else {
+                netplayLocalButtons = netplayLocalButtons and mask.inv()
+            }
+        }
     }
 
     fun setAnalog(port: Int, stickIndex: Int, axisId: Int, value: Short) {
@@ -315,6 +333,19 @@ class DesktopLibretroController(
         var fpsCounter = 0
         var fpsTimer = System.nanoTime()
 
+        // Seed frames 0 through inputDelay-1 with empty inputs for both ports.
+        // The loop sends input for frame F + inputDelay, so without seeding
+        // the early frames would never have inputs and the loop would deadlock.
+        val emptyInput = InputState()
+        for (f in 0L until inputDelay.toLong()) {
+            for (p in 0 until playerCount) {
+                runBlocking {
+                    inputBuffer.setLocalInput(f, p, emptyInput)
+                }
+                transport.sendInput(f, p, emptyInput)
+            }
+        }
+
         while (running) {
             if (paused) {
                 Thread.sleep(16)
@@ -324,17 +355,18 @@ class DesktopLibretroController(
             val frameStart = System.nanoTime()
             val currentFrame = frameCounter
 
-            // 1. Capture local input state from the JNI input table
-            val localInput = captureLocalInput(localPort)
+            // 1. Capture local input from netplayLocalButtons (set by setButton),
+            //    NOT from the JNI table (which has stale applyInputToJni state).
+            val localInput = captureNetplayLocalInput()
 
-            // 2. Buffer local input for frame F + inputDelay and send to remote
+            // 3. Buffer local input for frame F + inputDelay and send to remote
             val targetFrame = currentFrame + inputDelay
             runBlocking {
                 inputBuffer.setLocalInput(targetFrame, localPort, localInput)
             }
             transport.sendInput(targetFrame, localPort, localInput)
 
-            // 3. Block until we have both players' inputs for the current frame
+            // 4. Block until we have both players' inputs for the current frame
             val frameInputs = runBlocking {
                 inputBuffer.awaitInputsForFrame(currentFrame, playerCount, timeoutMs = 5000)
             }
@@ -355,12 +387,12 @@ class DesktopLibretroController(
                 netplayDisconnected = false
             }
 
-            // 4. Apply all player inputs via JNI
+            // 5. Apply all player inputs via JNI
             for ((port, input) in frameInputs) {
                 applyInputToJni(port, input)
             }
 
-            // 5. Run one emulation frame
+            // 6. Run one emulation frame
             jni.nativeRun()
 
             if (jni.nativeGpuIsActive()) {
@@ -412,6 +444,15 @@ class DesktopLibretroController(
      * Capture the current local input state from the JNI input table.
      * Returns an InputState with the current button and analog values.
      */
+    /**
+     * Capture local input from netplayLocalButtons (Kotlin-side state).
+     * Reads the buttons set by setButton() on the external thread,
+     * avoiding the JNI feedback loop with applyInputToJni.
+     */
+    private fun captureNetplayLocalInput(): InputState {
+        return InputState(netplayLocalButtons.toUShort(), 0, 0)
+    }
+
     private fun captureLocalInput(port: Int): InputState {
         // Read button state: libretro uses 16 button IDs (0..15)
         var buttons: UShort = 0u


### PR DESCRIPTION
## Summary
- Add headless `NetplayTestRunner` that runs two JVM processes (host + client) in netplay lockstep mode, connected via WebSocket relay
- Add `run-netplay-e2e.sh` shell script that orchestrates both processes, sends button presses via stdin FIFOs, and compares screenshots to verify cross-player input propagation
- Fix JNI feedback loop in netplay input capture by introducing `netplayLocalButtons` Kotlin-side state, preventing `applyInputToJni` output from being re-captured as new input

## Test plan
- [x] Phase 1 (title screen): P1 presses Select → cursor moves from "1 PLAYER" to "2 Players" on P2's screen
- [x] Phase 2 (in-game): P2 presses A (Dale jumps) → visible change on P1's screen
- [x] 4/4 consecutive runs pass
- [x] Go backend tests pass (404 tests)
- [x] Web frontend tests pass (724 tests)
- [x] Desktop player tests pass (404 tests)