### PR TITLE
feat: scan improvements, faster scraping, recently added dashboard

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -362,6 +362,13 @@ class FakeGameRepository : GameRepository {
         else Result.success(globalTopRatedGames)
     }
 
+    var recentlyAddedGames: List<Game> = emptyList()
+
+    override suspend fun getRecentlyAddedGames(): Result<List<Game>> {
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(recentlyAddedGames)
+    }
+
     var topListGames: List<TopListGame> = emptyList()
 
     override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -207,6 +207,14 @@ class SpelaApiClient(
         client.post("$baseUrl/api/games/$gameId/scrape-if-needed")
     }
 
+    suspend fun getRecentlyAddedGames(pageSize: Int = 12): GameListResponse {
+        return client.get("$baseUrl/api/games") {
+            parameter("sortBy", "created_at")
+            parameter("sortOrder", "desc")
+            parameter("pageSize", pageSize)
+        }.body()
+    }
+
     suspend fun getTopRatedGames(consoleId: String): List<TopRatedGameDto> {
         return client.get("$baseUrl/api/consoles/$consoleId/top-rated").body()
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
@@ -131,6 +131,10 @@ class GameRepositoryImpl(
         apiClient.removeFromPlayLater(gameId)
     }
 
+    override suspend fun getRecentlyAddedGames(): Result<List<Game>> = runCatching {
+        apiClient.getRecentlyAddedGames().data.map { it.toDomain().resolveImageUrls() }
+    }
+
     override suspend fun getTopRatedGames(consoleId: String): Result<List<TopRatedGame>> {
         return runCatching {
             apiClient.getTopRatedGames(consoleId).map { it.toDomain() }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/GameRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/GameRepository.kt
@@ -26,6 +26,7 @@ interface GameRepository {
     suspend fun getPlayLaterGames(): Result<List<Game>>
     suspend fun addToPlayLater(gameId: String): Result<Unit>
     suspend fun removeFromPlayLater(gameId: String): Result<Unit>
+    suspend fun getRecentlyAddedGames(): Result<List<Game>>
     suspend fun getTopRatedGames(consoleId: String): Result<List<TopRatedGame>>
     suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>>
     suspend fun getTopRatedAvailable(): Result<List<TopListGame>>

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameListState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameListState.kt
@@ -35,4 +35,5 @@ data class GameListState(
     val consolesWithMissingBios: Set<String> = emptySet(),
     val topRatedGames: List<TopRatedGame> = emptyList(),
     val isLoadingTopRated: Boolean = false,
+    val recentlyAddedGames: List<Game> = emptyList(),
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -25,6 +25,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.NewReleases
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.WatchLater
 import androidx.compose.material.icons.filled.Whatshot
@@ -290,6 +291,23 @@ fun HomeScreen(
                                     ) {
                                         GameCarouselRow(
                                             games = state.favoriteGames.take(6),
+                                            onGameSelected = onGameSelected,
+                                        )
+                                    }
+                                }
+                            }
+
+                            // Recently Added section
+                            if (state.recentlyAddedGames.isNotEmpty()) {
+                                item {
+                                    SpTitledSection(
+                                        title = "Recently Added",
+                                        icon = Icons.Filled.NewReleases,
+                                        edgeToEdgeContent = true,
+                                        modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                                    ) {
+                                        GameCarouselRow(
+                                            games = state.recentlyAddedGames.take(6),
                                             onGameSelected = onGameSelected,
                                         )
                                     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -188,6 +188,17 @@ class GameListViewModel(
                 )
             }
         }
+        // Recently added games
+        gameRepository?.let { repo ->
+            scope.launch(dispatchers.io) {
+                repo.getRecentlyAddedGames().fold(
+                    onSuccess = { games ->
+                        _state.update { it.copy(recentlyAddedGames = games) }
+                    },
+                    onFailure = { /* best effort */ },
+                )
+            }
+        }
     }
 
     private fun loadConsoles() {

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/GameListViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/GameListViewModelTest.kt
@@ -213,6 +213,7 @@ class FakeGameRepository : GameRepository {
     override suspend fun getTopRatedGames(consoleId: String): Result<List<TopRatedGame>> = Result.success(emptyList())
     override suspend fun getTopRatedGamesGlobal(): Result<List<TopRatedGame>> = Result.success(emptyList())
     override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
+    override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
     override suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>> = Result.success(emptyList())
     override suspend fun getDeveloperGames(gameId: String): Result<List<DeveloperGame>> = Result.success(emptyList())
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
@@ -198,6 +198,7 @@ class SyncEngineTest {
         override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
+        override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
     }
 
     private class FailingPreferencesRepository : PreferencesRepository {
@@ -233,6 +234,7 @@ class SyncEngineTest {
         override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
+        override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.failure(Exception("fail"))
     }
 
     private class TrackingPreferencesRepository : PreferencesRepository {
@@ -276,5 +278,6 @@ class SyncEngineTest {
         override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
+        override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -357,6 +357,7 @@ class NavigationViewModelTest {
         override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
+        override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
     }
 
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -220,6 +220,7 @@ private class PlayFromSharedSaveTestGameRepository : GameRepository {
     override suspend fun getTopRatedAvailable() = Result.success(emptyList<TopListGame>())
     override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
     override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
+    override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
 }
 
 private class PlayFromSharedSaveTestRatingRepository : RatingRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
@@ -167,6 +167,7 @@ private class StubGameRepository : GameRepository {
     override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
     override suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>> = Result.success(emptyList())
     override suspend fun getDeveloperGames(gameId: String): Result<List<DeveloperGame>> = Result.success(emptyList())
+    override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
 }
 
 private class StubRatingRepository : RatingRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
@@ -203,6 +203,7 @@ private class TestGameRepository : GameRepository {
     override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
     override suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>> = Result.success(emptyList())
     override suspend fun getDeveloperGames(gameId: String): Result<List<DeveloperGame>> = Result.success(emptyList())
+    override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
 }
 
 private class TestRatingRepository : RatingRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -183,6 +183,7 @@ class StubGameRepository(private val consoleId: String = "nes") : GameRepository
     override suspend fun getTopRatedAvailable(): Result<List<TopListGame>> = Result.success(emptyList())
     override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
     override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
+    override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
 }
 
 class StubDownloadRepository : DownloadRepository {

--- a/server/internal/api/admin_handler.go
+++ b/server/internal/api/admin_handler.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"sync"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -25,10 +24,6 @@ type AdminHandler struct {
 	Scraper *scraper.Scraper
 	Hub     *ws.Hub
 	Storage *storage.Storage
-
-	scrapeMu       sync.Mutex
-	scraping       bool
-	scrapeProgress *scraper.ScrapeProgress
 }
 
 // ListUsers returns all users (admin only).
@@ -314,14 +309,10 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 		mode = "all"
 	}
 
-	h.scrapeMu.Lock()
-	if h.scraping {
-		h.scrapeMu.Unlock()
+	if !h.Scraper.TryStartScrape() {
 		c.JSON(http.StatusConflict, gin.H{"error": "a scrape operation is already in progress"})
 		return
 	}
-	h.scraping = true
-	h.scrapeMu.Unlock()
 
 	// Count matching games before launching the goroutine so we can
 	// return the total in the HTTP response for immediate user feedback.
@@ -338,18 +329,10 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 	h.Hub.Broadcast(ws.Event{Type: "scrape_started", Payload: nil})
 
 	go func() {
-		defer func() {
-			h.scrapeMu.Lock()
-			h.scraping = false
-			h.scrapeProgress = nil
-			h.scrapeMu.Unlock()
-		}()
+		defer h.Scraper.FinishScrape()
 
 		count, total, err := h.Scraper.ScrapeAll(mode, func(p scraper.ScrapeProgress) {
-			h.scrapeMu.Lock()
-			h.scrapeProgress = &p
-			h.scrapeMu.Unlock()
-
+			h.Scraper.SetScrapeProgress(&p)
 			h.Hub.Broadcast(ws.Event{Type: "scrape_progress", Payload: p})
 		})
 		if err != nil {
@@ -367,14 +350,7 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 
 // ScrapeStatus returns the current scrape operation status.
 func (h *AdminHandler) ScrapeStatus(c *gin.Context) {
-	h.scrapeMu.Lock()
-	active := h.scraping
-	var progress *scraper.ScrapeProgress
-	if h.scrapeProgress != nil {
-		p := *h.scrapeProgress
-		progress = &p
-	}
-	h.scrapeMu.Unlock()
+	active, progress := h.Scraper.GetScrapeStatus()
 
 	if !active || progress == nil {
 		c.JSON(http.StatusOK, gin.H{"active": false})

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -264,6 +264,23 @@ func (h *GameHandler) UpdateMetadata(c *gin.Context) {
 	c.JSON(http.StatusOK, ToGameResponse(game, h.DB, userID))
 }
 
+// scanGameSummary is a lightweight game entry returned in scan results.
+type scanGameSummary struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	ConsoleName string `json:"consoleName"`
+}
+
+// scanResultResponse extends the scan result with new game details and auto-scrape status.
+type scanResultResponse struct {
+	NewGames     int               `json:"newGames"`
+	UpdatedGames int               `json:"updatedGames"`
+	RemovedGames int               `json:"removedGames"`
+	TotalGames   int               `json:"totalGames"`
+	NewGamesList []scanGameSummary `json:"newGamesList,omitempty"`
+	AutoScraping bool              `json:"autoScraping"`
+}
+
 // ScanGames triggers a library scan.
 func (h *GameHandler) ScanGames(c *gin.Context) {
 	h.Hub.Broadcast(ws.Event{Type: "scan_started", Payload: nil})
@@ -276,8 +293,50 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 		return
 	}
 
-	h.Hub.Broadcast(ws.Event{Type: "scan_complete", Payload: result})
-	c.JSON(http.StatusOK, result)
+	// Build response with new game summaries
+	resp := scanResultResponse{
+		NewGames:     result.NewGames,
+		UpdatedGames: result.UpdatedGames,
+		RemovedGames: result.RemovedGames,
+		TotalGames:   result.TotalGames,
+	}
+
+	if len(result.NewGameIDs) > 0 {
+		var newGames []db.Game
+		h.DB.Preload("Console").Where("id IN ?", result.NewGameIDs).Find(&newGames)
+		for _, g := range newGames {
+			resp.NewGamesList = append(resp.NewGamesList, scanGameSummary{
+				ID:          strconv.FormatUint(uint64(g.ID), 10),
+				Title:       g.Title,
+				ConsoleName: g.Console.Name,
+			})
+		}
+	}
+
+	// Auto-scrape new games if IGDB is configured
+	if result.NewGames > 0 && h.Scraper.IsIGDBConfigured() {
+		if h.Scraper.TryStartScrape() {
+			resp.AutoScraping = true
+			h.Hub.Broadcast(ws.Event{Type: "scrape_started", Payload: nil})
+			go func() {
+				defer h.Scraper.FinishScrape()
+				count, total, scrapeErr := h.Scraper.ScrapeAll("new", func(p scraper.ScrapeProgress) {
+					h.Scraper.SetScrapeProgress(&p)
+					h.Hub.Broadcast(ws.Event{Type: "scrape_progress", Payload: p})
+				})
+				if scrapeErr != nil {
+					slog.Error("auto-scrape after scan failed", "error", scrapeErr)
+					h.Hub.Broadcast(ws.Event{Type: "scrape_error", Payload: gin.H{"error": "auto-scrape failed"}})
+					return
+				}
+				slog.Info("auto-scrape after scan complete", "scraped", count, "total", total)
+				h.Hub.Broadcast(ws.Event{Type: "scrape_complete", Payload: gin.H{"scraped": count, "total": total}})
+			}()
+		}
+	}
+
+	h.Hub.Broadcast(ws.Event{Type: "scan_complete", Payload: resp})
+	c.JSON(http.StatusOK, resp)
 }
 
 // ScrapeIfNeeded triggers an async scrape for a game that has never been scraped.

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -173,10 +173,11 @@ func CreateConsoleFolders(database *gorm.DB, gameDirs []string) error {
 
 // ScanResult holds the results of a scan operation.
 type ScanResult struct {
-	NewGames     int `json:"newGames"`
-	UpdatedGames int `json:"updatedGames"`
-	RemovedGames int `json:"removedGames"`
-	TotalGames   int `json:"totalGames"`
+	NewGames     int    `json:"newGames"`
+	UpdatedGames int    `json:"updatedGames"`
+	RemovedGames int    `json:"removedGames"`
+	TotalGames   int    `json:"totalGames"`
+	NewGameIDs   []uint `json:"newGameIds,omitempty"`
 }
 
 // parseM3U reads an .m3u file and returns resolved file paths.
@@ -652,6 +653,7 @@ func (s *Scanner) scanMultiDisc(dir string, consoleMap map[string]*db.Console, f
 			}
 
 			result.NewGames++
+			result.NewGameIDs = append(result.NewGameIDs, game.ID)
 			slog.Info("found standalone .cue game", "title", title, "console", console.Abbreviation)
 		}
 
@@ -805,6 +807,7 @@ func (s *Scanner) createMultiDiscGame(m3uPath string, discFiles []string, consol
 	}
 
 	result.NewGames++
+	result.NewGameIDs = append(result.NewGameIDs, game.ID)
 	slog.Info("found multi-disc game", "title", title, "console", console.Abbreviation, "discs", len(discFiles))
 
 	// Clean up old standalone entries for discs now claimed by this multi-disc game
@@ -898,6 +901,7 @@ func (s *Scanner) scanDirectory(dir string, consoleMap map[string]*db.Console, f
 		}
 
 		result.NewGames++
+		result.NewGameIDs = append(result.NewGameIDs, game.ID)
 		slog.Info("found game", "title", title, "console", console.Abbreviation)
 
 		return nil

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/spela/server/internal/db"
@@ -27,6 +28,11 @@ type Scraper struct {
 	DATCache   *DATCache
 	GameDirs   []string
 	cache      *nameCache
+
+	// Scrape state tracking (shared across handlers)
+	scrapeMu       sync.Mutex
+	scraping       bool
+	scrapeProgress *ScrapeProgress
 }
 
 // NewScraper creates a new metadata scraper instance.
@@ -42,6 +48,49 @@ func NewScraper(database *gorm.DB, store *storage.Storage, datDir string, gameDi
 		GameDirs:   gameDirs,
 		cache:      &nameCache{entries: make(map[string][]nameEntry)},
 	}
+}
+
+// IsIGDBConfigured returns whether the scraper has a configured IGDB client.
+func (s *Scraper) IsIGDBConfigured() bool {
+	return s.IGDBClient != nil && s.IGDBClient.IsConfigured()
+}
+
+// TryStartScrape attempts to acquire the scrape lock.
+// Returns true if the lock was acquired (caller must call FinishScrape when done).
+func (s *Scraper) TryStartScrape() bool {
+	s.scrapeMu.Lock()
+	defer s.scrapeMu.Unlock()
+	if s.scraping {
+		return false
+	}
+	s.scraping = true
+	return true
+}
+
+// FinishScrape releases the scrape lock and clears progress.
+func (s *Scraper) FinishScrape() {
+	s.scrapeMu.Lock()
+	s.scraping = false
+	s.scrapeProgress = nil
+	s.scrapeMu.Unlock()
+}
+
+// SetScrapeProgress updates the current scrape progress.
+func (s *Scraper) SetScrapeProgress(p *ScrapeProgress) {
+	s.scrapeMu.Lock()
+	s.scrapeProgress = p
+	s.scrapeMu.Unlock()
+}
+
+// GetScrapeStatus returns whether a scrape is active and the current progress.
+func (s *Scraper) GetScrapeStatus() (bool, *ScrapeProgress) {
+	s.scrapeMu.Lock()
+	defer s.scrapeMu.Unlock()
+	if s.scrapeProgress == nil {
+		return s.scraping, nil
+	}
+	p := *s.scrapeProgress
+	return s.scraping, &p
 }
 
 // AbbreviationToLibRetro maps console abbreviations to LibRetro system names.
@@ -206,20 +255,34 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 	// --- LibRetro Thumbnails (preferred for box art, fallback for screenshots) ---
 	libRetroSystem, hasLibRetro := AbbreviationToLibRetro[console.Abbreviation]
 	if hasLibRetro {
+		var libRetroWg sync.WaitGroup
+		var libRetroCoverPath string
+
 		// Box art: always try LibRetro (preferred source for box art)
-		boxartSubpath := fmt.Sprintf("%s/%s/boxart-libretro.png", console.Abbreviation, gameIDStr)
-		if path := s.downloadLibRetroImage(libRetroSystem, gameName, "Named_Boxarts", boxartSubpath); path != "" {
-			game.LibRetroCoverURL = path
-		}
+		libRetroWg.Add(1)
+		go func() {
+			defer libRetroWg.Done()
+			boxartSubpath := fmt.Sprintf("%s/%s/boxart-libretro.png", console.Abbreviation, gameIDStr)
+			libRetroCoverPath = s.downloadLibRetroImage(libRetroSystem, gameName, "Named_Boxarts", boxartSubpath)
+		}()
 
 		// Screenshot fallback: only if no IGDB screenshots were saved
 		var screenshotCount int64
 		s.DB.Model(&db.GameScreenshot{}).Where("game_id = ?", game.ID).Count(&screenshotCount)
 		if screenshotCount == 0 {
-			snapSubpath := fmt.Sprintf("%s/%s/screenshot.png", console.Abbreviation, gameIDStr)
-			if path := s.downloadLibRetroImage(libRetroSystem, gameName, "Named_Snaps", snapSubpath); path != "" {
-				s.DB.Create(&db.GameScreenshot{GameID: game.ID, URL: path, Position: 0})
-			}
+			libRetroWg.Add(1)
+			go func() {
+				defer libRetroWg.Done()
+				snapSubpath := fmt.Sprintf("%s/%s/screenshot.png", console.Abbreviation, gameIDStr)
+				if path := s.downloadLibRetroImage(libRetroSystem, gameName, "Named_Snaps", snapSubpath); path != "" {
+					s.DB.Create(&db.GameScreenshot{GameID: game.ID, URL: path, Position: 0})
+				}
+			}()
+		}
+
+		libRetroWg.Wait()
+		if libRetroCoverPath != "" {
+			game.LibRetroCoverURL = libRetroCoverPath
 		}
 	}
 
@@ -421,16 +484,21 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 		}
 	}
 
-	// Download cover art from IGDB (stored separately; LibRetro is preferred for active cover)
+	// Download cover art and screenshots concurrently
+	var imgWg sync.WaitGroup
+
 	if match.Cover != nil && match.Cover.ImageID != "" {
-		coverURL := igdb.ImageURL(match.Cover.ImageID, "cover_big")
-		coverSubpath := fmt.Sprintf("%s/%s/boxart-igdb.jpg", console.Abbreviation, gameIDStr)
-		if path := s.downloadExternalImage(coverURL, coverSubpath); path != "" {
-			game.IGDBCoverURL = path
-		}
+		imgWg.Add(1)
+		go func(imageID string) {
+			defer imgWg.Done()
+			coverURL := igdb.ImageURL(imageID, "cover_big")
+			coverSubpath := fmt.Sprintf("%s/%s/boxart-igdb.jpg", console.Abbreviation, gameIDStr)
+			if path := s.downloadExternalImage(coverURL, coverSubpath); path != "" {
+				game.IGDBCoverURL = path
+			}
+		}(match.Cover.ImageID)
 	}
 
-	// Download all screenshots from IGDB at original resolution (max 10)
 	maxScreenshots := 10
 	if len(match.Screenshots) < maxScreenshots {
 		maxScreenshots = len(match.Screenshots)
@@ -440,12 +508,18 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 		if ss.ImageID == "" {
 			continue
 		}
-		screenshotURL := igdb.ImageURL(ss.ImageID, "original")
-		screenshotSubpath := fmt.Sprintf("%s/%s/screenshot_%d.jpg", console.Abbreviation, gameIDStr, i)
-		if path := s.downloadExternalImage(screenshotURL, screenshotSubpath); path != "" {
-			s.DB.Create(&db.GameScreenshot{GameID: game.ID, URL: path, Position: i})
-		}
+		imgWg.Add(1)
+		go func(idx int, imageID string) {
+			defer imgWg.Done()
+			screenshotURL := igdb.ImageURL(imageID, "original")
+			screenshotSubpath := fmt.Sprintf("%s/%s/screenshot_%d.jpg", console.Abbreviation, gameIDStr, idx)
+			if path := s.downloadExternalImage(screenshotURL, screenshotSubpath); path != "" {
+				s.DB.Create(&db.GameScreenshot{GameID: game.ID, URL: path, Position: idx})
+			}
+		}(i, ss.ImageID)
 	}
+
+	imgWg.Wait()
 }
 
 // ScrapeGameWithIGDBMatch re-scrapes a game using a specific IGDB game ID
@@ -640,9 +714,6 @@ func (s *Scraper) ScrapeAll(mode string, onProgress func(ScrapeProgress)) (int, 
 				Failures:  failures,
 			})
 		}
-
-		// Small delay to avoid hammering the thumbnail server
-		time.Sleep(200 * time.Millisecond)
 	}
 
 	return successes, total, nil

--- a/server/internal/scraper/scraper_igdb_test.go
+++ b/server/internal/scraper/scraper_igdb_test.go
@@ -24,7 +24,8 @@ import (
 
 func setupTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := gorm.Open(sqlite.Open(dbPath+"?_journal_mode=WAL&_busy_timeout=5000"), &gorm.Config{
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	require.NoError(t, err)

--- a/web/src/pages/admin/scan-page.tsx
+++ b/web/src/pages/admin/scan-page.tsx
@@ -12,11 +12,19 @@ import { useScanLibrary, useScrapeMetadata } from "@/hooks/use-admin";
 import { useToast } from "@/components/ui";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
 
+interface ScanGameSummary {
+  id: string;
+  title: string;
+  consoleName: string;
+}
+
 interface ScanResult {
   newGames?: number;
   updatedGames?: number;
   removedGames?: number;
   totalGames?: number;
+  newGamesList?: ScanGameSummary[];
+  autoScraping?: boolean;
 }
 
 function ProgressBar({ value, max }: { value: number; max: number }) {
@@ -302,6 +310,32 @@ export function AdminScanPage() {
                     </div>
                   )}
                 </div>
+                {scanResult.autoScraping && (
+                  <p className="text-xs text-brand-400">
+                    Auto-scraping new games...
+                  </p>
+                )}
+                {scanResult.newGamesList &&
+                  scanResult.newGamesList.length > 0 && (
+                    <div className="mt-2">
+                      <p className="text-xs font-medium text-surface-400 mb-1.5">
+                        New games found:
+                      </p>
+                      <ul className="space-y-1 max-h-48 overflow-y-auto text-sm">
+                        {scanResult.newGamesList.map((g) => (
+                          <li
+                            key={g.id}
+                            className="flex items-center justify-between text-surface-200"
+                          >
+                            <span className="truncate">{g.title}</span>
+                            <span className="text-xs text-surface-500 ml-2 shrink-0">
+                              {g.consoleName}
+                            </span>
+                          </li>
+                        ))}
+                      </ul>
+                    </div>
+                  )}
               </div>
             )}
 

--- a/web/src/pages/dashboard-page.tsx
+++ b/web/src/pages/dashboard-page.tsx
@@ -7,6 +7,7 @@ import {
   Gamepad2,
   Trophy,
   Flag,
+  Sparkles,
 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { GameCard } from "@/components/game-card";
@@ -257,6 +258,11 @@ export function DashboardPage() {
   const recentGames = useRecentGames();
   const favoriteGames = useFavoriteGames();
   const playLaterGames = usePlayLaterGames();
+  const recentlyAddedGames = useGames({
+    pageSize: 12,
+    sortBy: "created_at",
+    sortOrder: "desc",
+  });
   const allGames = useGames({
     pageSize: 12,
     sortBy: "title",
@@ -268,6 +274,10 @@ export function DashboardPage() {
   const hasRecent = recentGames.data && recentGames.data.length > 0;
   const hasPlayLater = playLaterGames.data && playLaterGames.data.length > 0;
   const hasFavorites = favoriteGames.data && favoriteGames.data.length > 0;
+  const hasRecentlyAdded =
+    recentlyAddedGames.data &&
+    recentlyAddedGames.data.data &&
+    recentlyAddedGames.data.data.length > 0;
   const hasGames =
     allGames.data && allGames.data.data && allGames.data.data.length > 0;
   const isLoading =
@@ -344,6 +354,18 @@ export function DashboardPage() {
           <GameRow
             games={favoriteGames.data}
             isLoading={favoriteGames.isLoading}
+            onToggleFavorite={handleToggleFavorite}
+            onTogglePlayLater={handleTogglePlayLater}
+          />
+        </section>
+      )}
+
+      {(recentlyAddedGames.isLoading || hasRecentlyAdded) && (
+        <section>
+          <SectionHeader title="Recently Added" icon={Sparkles} linkTo="/games" />
+          <GameRow
+            games={recentlyAddedGames.data?.data}
+            isLoading={recentlyAddedGames.isLoading}
             onToggleFavorite={handleToggleFavorite}
             onTogglePlayLater={handleTogglePlayLater}
           />


### PR DESCRIPTION
## Summary
- **Scan shows new games**: After scanning, the admin sees a list of newly found games with their console names, not just a count
- **Auto-scrape after scan**: If IGDB is configured, new games are automatically scraped after a scan — no need to manually click "Scrape New Games"
- **Faster scraping**: IGDB cover + screenshots and LibRetro images are now downloaded concurrently instead of sequentially; removed unnecessary 200ms inter-game sleep (IGDB rate limiter already throttles at 4 req/s)
- **"Recently Added" dashboard section**: New section in both web and player app showing the most recently added games, so users can easily discover new additions

## Changes
### Backend (Go)
- `scanner.go`: Track new game IDs in `ScanResult`
- `scraper.go`: Parallel image downloads, scrape state management (mutex/progress moved from AdminHandler to Scraper for shared use)
- `game_handler.go`: Return new games list in scan response, auto-trigger scrape
- `admin_handler.go`: Use Scraper's shared scrape state instead of local fields

### Web (React)
- `scan-page.tsx`: Display new games list after scan, show auto-scrape indicator
- `dashboard-page.tsx`: Add "Recently Added" section with Sparkles icon

### Player App (Kotlin)
- `GameRepository` + impl: Add `getRecentlyAddedGames()` using existing `/api/games?sortBy=created_at&sortOrder=desc`
- `GameListState` + ViewModel: Load recently added games in dashboard
- `HomeScreen`: Add "Recently Added" section with `GameCarouselRow`

## Test plan
- [x] Go tests pass (`go test ./...`)
- [x] Web Vitest tests pass (725 tests)
- [x] Player desktop tests pass (`./gradlew :shared:desktopTest`)
- [x] TypeScript compiles clean
- [ ] CI passes