### PR TITLE
feat: prefer US/World box art for non-preferred region ROMs

### DIFF
--- a/server/internal/scraper/namematch_test.go
+++ b/server/internal/scraper/namematch_test.go
@@ -358,6 +358,57 @@ func TestFindBestMatch(t *testing.T) {
 	}
 }
 
+func TestFindBestMatch_PrefersUSAOverJapan(t *testing.T) {
+	entry := func(raw string) nameEntry {
+		return nameEntry{
+			Raw:        raw,
+			Normalized: normalizeName(raw),
+			Priority:   computePriority(raw),
+		}
+	}
+
+	// Simulate LibRetro entries for Ice Climber with Japan listed first
+	entries := []nameEntry{
+		entry("Ice Climber (Japan)"),
+		entry("Ice Climber (USA, Europe)"),
+	}
+
+	tests := []struct {
+		name    string
+		query   string
+		wantRaw string
+	}{
+		{
+			name:    "Japan ROM prefers USA entry",
+			query:   "Ice Climber (Japan)",
+			wantRaw: "Ice Climber (USA, Europe)",
+		},
+		{
+			name:    "multi-region ROM prefers USA entry",
+			query:   "Ice Climber (Japan, USA)",
+			wantRaw: "Ice Climber (USA, Europe)",
+		},
+		{
+			name:    "bare name prefers USA entry",
+			query:   "Ice Climber",
+			wantRaw: "Ice Climber (USA, Europe)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			normalized := normalizeName(tt.query)
+			match, _, found := findBestMatch(normalized, entries, 0.88)
+			if !found {
+				t.Fatalf("findBestMatch(%q): expected match, got none", tt.query)
+			}
+			if match.Raw != tt.wantRaw {
+				t.Errorf("findBestMatch(%q): got %q, want %q", tt.query, match.Raw, tt.wantRaw)
+			}
+		})
+	}
+}
+
 func TestFindBestMatch_EmptyInputs(t *testing.T) {
 	_, _, found := findBestMatch("", []nameEntry{{Raw: "test", Normalized: "test"}}, 0.88)
 	if found {

--- a/server/internal/scraper/region.go
+++ b/server/internal/scraper/region.go
@@ -1,6 +1,9 @@
 package scraper
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 // regionPattern matches parenthesized region tags in No-Intro filenames,
 // e.g. "(USA)", "(Japan)", "(USA, Europe)", "(World)".
@@ -18,4 +21,21 @@ func ExtractRegion(filename string) string {
 		return ""
 	}
 	return match[1]
+}
+
+// hasNonPreferredRegion returns true if the name contains a region tag with
+// at least one non-preferred region (anything other than USA, US, or World).
+// Returns false for names with no region tags or only preferred regions.
+func hasNonPreferredRegion(name string) bool {
+	region := ExtractRegion(name)
+	if region == "" {
+		return false
+	}
+	for _, part := range strings.Split(region, ",") {
+		part = strings.TrimSpace(strings.ToLower(part))
+		if part != "usa" && part != "world" && part != "us" {
+			return true
+		}
+	}
+	return false
 }

--- a/server/internal/scraper/region_test.go
+++ b/server/internal/scraper/region_test.go
@@ -36,3 +36,29 @@ func TestExtractRegion(t *testing.T) {
 		})
 	}
 }
+
+func TestHasNonPreferredRegion(t *testing.T) {
+	tests := []struct {
+		name string
+		input string
+		want bool
+	}{
+		{"USA only", "Castlevania (USA)", false},
+		{"World only", "Tetris (World)", false},
+		{"no region", "Homebrew", false},
+		{"Japan only", "Ice Climber (Japan)", true},
+		{"Europe only", "Sonic (Europe)", true},
+		{"Japan and USA", "Ice Climber (Japan, USA)", true},
+		{"USA and Europe", "Mega Man 2 (USA, Europe)", true},
+		{"Japan only with extension", "Ice Climber (Japan).nes", true},
+		{"USA only with extension", "Castlevania (USA).nes", false},
+		{"Korea", "Game (Korea)", true},
+		{"Brazil", "Game (Brazil)", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := hasNonPreferredRegion(tt.input)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -177,16 +177,22 @@ func (s *Scraper) tryDownloadImage(system, name, imageType, subpath string) stri
 }
 
 // downloadLibRetroImage downloads an image from LibRetro Thumbnails and saves it locally.
-// Tries the exact game name first, then falls back to fuzzy matching against the
-// full LibRetro directory listing for the system.
+// When the game name contains a non-preferred region (e.g. Japan, Europe), it skips
+// the exact name match and goes straight to fuzzy matching, which prefers USA/World
+// entries via hasPreferredRegion tie-breaking. For games with preferred regions only
+// (USA, World) or no region tags, it tries the exact name first as a fast path.
 // Returns the relative storage path on success, or empty string if the image was not found.
 func (s *Scraper) downloadLibRetroImage(system, gameName, imageType, subpath string) string {
-	// Try exact name first (single HTTP request)
-	if path := s.tryDownloadImage(system, gameName, imageType, subpath); path != "" {
-		return path
+	// Fast path: try exact name match when the name already has a preferred
+	// region or no region at all. Skip this for non-preferred regions so the
+	// fuzzy matcher can find a USA/World alternative.
+	if !hasNonPreferredRegion(gameName) {
+		if path := s.tryDownloadImage(system, gameName, imageType, subpath); path != "" {
+			return path
+		}
 	}
 
-	// Fuzzy fallback: fetch the full name listing and find the best match
+	// Fuzzy matching: prefers USA/World entries via hasPreferredRegion tie-breaking.
 	entries, err := s.cache.getOrLoad(system, s.HTTPClient)
 	if err != nil {
 		slog.Warn("failed to load LibRetro name listing", "system", system, "error", err)


### PR DESCRIPTION
## Summary

- When a ROM has a non-preferred region (Japan, Europe, Korea, etc.), the scraper now skips the exact LibRetro thumbnail name match and uses fuzzy matching instead, which prefers USA/World entries via `hasPreferredRegion` tie-breaking
- Fixes the issue where games like "Ice Climber (Japan, USA)" would get Japanese box art instead of US box art
- Games with preferred-only regions (USA, World) or no region tags keep the fast exact-match path — no behavior change for them

### What changed

| File | Change |
|------|--------|
| `region.go` | Added `hasNonPreferredRegion()` — returns true if the game name contains any non-preferred region tag |
| `scraper.go` | Modified `downloadLibRetroImage()` to skip exact match for non-preferred regions |
| `region_test.go` | 11 test cases for `hasNonPreferredRegion` |
| `namematch_test.go` | 3 test cases verifying fuzzy matching prefers USA over Japan |

### Regarding multiple region ROMs of the same game

Adding multiple region ROMs (e.g., Japanese, US, and European versions) creates separate game entries — each with its own metadata, cover art, saves, and play history. This is intentional and correct behavior for a ROM library: different regions often have real differences (language, censorship, content), and collectors expect to manage them independently.

## Test plan

- [x] `TestHasNonPreferredRegion` — 11 cases covering USA-only, World, Japan, Europe, mixed regions, no region, with/without extensions
- [x] `TestFindBestMatch_PrefersUSAOverJapan` — verifies Japan ROM, multi-region ROM, and bare name all prefer USA LibRetro entry
- [x] Full backend test suite passes (`go test ./...`) — zero regressions