### PR TITLE
test: replace Docker E2E with local server and database reset endpoint

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -41,6 +41,7 @@ func main() {
 	encryptionKeyRaw := os.Getenv("SPELA_ENCRYPTION_KEY")
 	frontendDir := os.Getenv("SPELA_FRONTEND_DIR")
 	challengeRateLimitRaw := getEnv("SPELA_CHALLENGE_RATE_LIMIT_SEC", "30")
+	testMode := os.Getenv("SPELA_TEST_MODE") == "true"
 
 	gameDirs := strings.Split(gameDirsRaw, ",")
 	var wsOrigins []string
@@ -64,13 +65,16 @@ func main() {
 	// Enforce secure JWT secret — always required, regardless of GIN_MODE.
 	// Self-hosted users may not know to set GIN_MODE=release, so we never
 	// allow a known default or short secret to protect against token forgery.
-	if jwtSecret == "change-me-in-production" {
-		slog.Error("FATAL: using default JWT secret; set SPELA_JWT_SECRET to a random value (>= 32 chars)")
-		os.Exit(1)
-	}
-	if len(jwtSecret) < 32 {
-		slog.Error("FATAL: JWT secret must be at least 32 characters; set a stronger SPELA_JWT_SECRET")
-		os.Exit(1)
+	// In test mode, skip this check to allow known test secrets.
+	if !testMode {
+		if jwtSecret == "change-me-in-production" {
+			slog.Error("FATAL: using default JWT secret; set SPELA_JWT_SECRET to a random value (>= 32 chars)")
+			os.Exit(1)
+		}
+		if len(jwtSecret) < 32 {
+			slog.Error("FATAL: JWT secret must be at least 32 characters; set a stronger SPELA_JWT_SECRET")
+			os.Exit(1)
+		}
 	}
 
 	// Derive or use explicit encryption key.
@@ -194,6 +198,7 @@ func main() {
 		CORSOrigins:                  corsOrigins,
 		ChallengeAttemptRateLimitSec: challengeRateLimit,
 		Version:                      version,
+		TestMode:                     testMode,
 	})
 
 	slog.Info("server listening", "port", port)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -37,6 +37,7 @@ type Config struct {
 	RAClient                     *retroachievements.RAClient // optional; defaults to production RA client
 	ChallengeAttemptRateLimitSec int                         // 0 = disabled; default 30 in production
 	Version                      string
+	TestMode                     bool // when true, registers POST /api/test/reset for E2E test isolation
 }
 
 // NewRouter creates and configures the Gin router with all endpoints.
@@ -461,6 +462,13 @@ func NewRouter(cfg Config) *gin.Engine {
 
 		// WebSocket
 		api.GET("/ws", cfg.Hub.HandleWebSocket)
+	}
+
+	// Test-only endpoint for E2E test isolation (only registered when SPELA_TEST_MODE=true).
+	// Registered outside the auth group so it can be called without a token.
+	if cfg.TestMode {
+		testHandler := &TestHandler{DB: cfg.DB}
+		r.POST("/api/test/reset", testHandler.Reset)
 	}
 
 	// Serve frontend static files when configured (unified single-container deployment)

--- a/server/internal/api/test_handler.go
+++ b/server/internal/api/test_handler.go
@@ -1,0 +1,142 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/auth"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// TestHandler provides endpoints for E2E test state management.
+// Only registered when SPELA_TEST_MODE=true.
+type TestHandler struct {
+	DB *gorm.DB
+}
+
+// Reset restores the database to its seed state for E2E test isolation.
+// Deletes all user-generated data while preserving consoles, cores, and scanned games.
+// POST /api/test/reset
+func (h *TestHandler) Reset(c *gin.Context) {
+	slog.Info("test reset: resetting database to seed state")
+
+	err := h.DB.Transaction(func(tx *gorm.DB) error {
+		// Order matters: delete children before parents to respect foreign keys.
+
+		// 1. Session-related (children first)
+		tx.Unscoped().Where("1 = 1").Delete(&db.SessionCheatSetting{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.SessionSaveData{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.SessionSaveState{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.GameSession{})
+
+		// 2. Shared sessions (children first)
+		tx.Unscoped().Where("1 = 1").Delete(&db.SharedSessionSave{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.SharedSessionInvite{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.SharedSessionMember{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.SharedSession{})
+
+		// 3. Netplay (children first)
+		tx.Unscoped().Where("1 = 1").Delete(&db.NetplayInvite{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.NetplaySession{})
+
+		// 4. Challenges (children first)
+		tx.Unscoped().Where("1 = 1").Delete(&db.ChallengeAttempt{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.Challenge{})
+
+		// 5. Collections (children first)
+		tx.Unscoped().Where("1 = 1").Delete(&db.CollectionItem{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.GameCollection{})
+
+		// 6. User-game associations
+		tx.Unscoped().Where("1 = 1").Delete(&db.Favorite{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.PlayHistory{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.DailyPlayActivity{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.PlayLaterItem{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.GameRating{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.SharedSaveState{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.ActivityEvent{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.GameKeyMappingPreference{})
+
+		// 7. User preferences
+		tx.Unscoped().Where("1 = 1").Delete(&db.ConsoleShaderPreference{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.ConsoleKeyMappingPreference{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.DeviceShaderPreference{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.Device{})
+
+		// 8. RetroAchievements
+		tx.Unscoped().Where("1 = 1").Delete(&db.RetroAchievementCredential{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.UserAchievementProgress{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.GameAchievementCache{})
+
+		// 9. Auth tokens and login attempts
+		tx.Unscoped().Where("1 = 1").Delete(&db.RefreshToken{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.TokenBlacklist{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.LoginAttempt{})
+
+		// 10. Staged uploads
+		tx.Unscoped().Where("1 = 1").Delete(&db.StagedUpload{})
+
+		// 11. Server settings (reset to defaults)
+		tx.Unscoped().Where("1 = 1").Delete(&db.ServerSetting{})
+
+		// 12. Delete extra users (keep admin and player)
+		tx.Unscoped().Where("username NOT IN ?", []string{"admin", "player"}).Delete(&db.User{})
+
+		// 13. Reset admin user to default state
+		adminHash, err := auth.HashPassword("admin123")
+		if err != nil {
+			return err
+		}
+		tx.Model(&db.User{}).Where("username = ?", "admin").Updates(map[string]interface{}{
+			"password_hash":         adminHash,
+			"role":                  "owner",
+			"disabled":              false,
+			"pending_approval":      false,
+			"show_perf_overlay":     false,
+			"auto_save_enabled":     true,
+			"auto_load_save_enabled": true,
+			"selected_shader":       "none",
+			"selected_theme":        "default-dark",
+			"selected_key_mapping":  "arrows-left",
+			"custom_key_mapping":    "",
+			"avatar_url":            "",
+			"token_version":         0,
+			"deleted_at":            nil,
+		})
+
+		// 14. Reset player user to default state
+		playerHash, err := auth.HashPassword("player123")
+		if err != nil {
+			return err
+		}
+		tx.Model(&db.User{}).Where("username = ?", "player").Updates(map[string]interface{}{
+			"password_hash":         playerHash,
+			"role":                  "user",
+			"disabled":              false,
+			"pending_approval":      false,
+			"show_perf_overlay":     false,
+			"auto_save_enabled":     true,
+			"auto_load_save_enabled": true,
+			"selected_shader":       "none",
+			"selected_theme":        "default-dark",
+			"selected_key_mapping":  "arrows-left",
+			"custom_key_mapping":    "",
+			"avatar_url":            "",
+			"token_version":         0,
+			"deleted_at":            nil,
+		})
+
+		return nil
+	})
+
+	if err != nil {
+		slog.Error("test reset failed", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "reset failed"})
+		return
+	}
+
+	slog.Info("test reset: database reset complete")
+	c.JSON(http.StatusOK, gin.H{"status": "reset"})
+}

--- a/server/internal/api/test_handler_test.go
+++ b/server/internal/api/test_handler_test.go
@@ -1,0 +1,259 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/auth"
+	"github.com/spela/server/internal/db"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func TestResetEndpoint_NotRegisteredByDefault(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	cfg.TestMode = false
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/test/reset", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestResetEndpoint_RegisteredInTestMode(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	cfg.TestMode = true
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/test/reset", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "reset", resp["status"])
+}
+
+func TestResetEndpoint_DeletesExtraUsers(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	cfg.TestMode = true
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+
+	// Create the seed users
+	adminHash, _ := auth.HashPassword("admin123")
+	database.Create(&db.User{Username: "admin", Email: "admin@spela.local", PasswordHash: adminHash, Role: "owner"})
+	playerHash, _ := auth.HashPassword("player123")
+	database.Create(&db.User{Username: "player", Email: "player@spela.local", PasswordHash: playerHash, Role: "user"})
+
+	// Create extra users
+	database.Create(&db.User{Username: "extra1", Email: "extra1@test.com", PasswordHash: "hash", Role: "user"})
+	database.Create(&db.User{Username: "extra2", Email: "extra2@test.com", PasswordHash: "hash", Role: "user"})
+
+	var countBefore int64
+	database.Model(&db.User{}).Count(&countBefore)
+	assert.Equal(t, int64(4), countBefore)
+
+	router := NewRouter(*cfg)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/test/reset", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var countAfter int64
+	database.Model(&db.User{}).Count(&countAfter)
+	assert.Equal(t, int64(2), countAfter)
+
+	// Verify admin and player still exist
+	var admin db.User
+	require.NoError(t, database.Where("username = ?", "admin").First(&admin).Error)
+	assert.Equal(t, "owner", admin.Role)
+
+	var player db.User
+	require.NoError(t, database.Where("username = ?", "player").First(&player).Error)
+	assert.Equal(t, "user", player.Role)
+}
+
+func TestResetEndpoint_ResetsUserPreferences(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	cfg.TestMode = true
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+
+	// Create admin with modified preferences
+	adminHash, _ := auth.HashPassword("admin123")
+	database.Create(&db.User{
+		Username:        "admin",
+		Email:           "admin@spela.local",
+		PasswordHash:    adminHash,
+		Role:            "owner",
+		SelectedShader:  "crt",
+		SelectedTheme:   "solarized",
+		ShowPerfOverlay: true,
+		Disabled:        true,
+		TokenVersion:    5,
+	})
+	playerHash, _ := auth.HashPassword("player123")
+	database.Create(&db.User{
+		Username:     "player",
+		Email:        "player@spela.local",
+		PasswordHash: playerHash,
+		Role:         "user",
+	})
+
+	router := NewRouter(*cfg)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/test/reset", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var admin db.User
+	database.Where("username = ?", "admin").First(&admin)
+	assert.Equal(t, "none", admin.SelectedShader)
+	assert.Equal(t, "default-dark", admin.SelectedTheme)
+	assert.False(t, admin.ShowPerfOverlay)
+	assert.False(t, admin.Disabled)
+	assert.Equal(t, 0, admin.TokenVersion)
+}
+
+func TestResetEndpoint_ClearsTransientData(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	cfg.TestMode = true
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+
+	// Create seed users
+	adminHash, _ := auth.HashPassword("admin123")
+	database.Create(&db.User{Username: "admin", Email: "admin@spela.local", PasswordHash: adminHash, Role: "owner"})
+	playerHash, _ := auth.HashPassword("player123")
+	database.Create(&db.User{Username: "player", Email: "player@spela.local", PasswordHash: playerHash, Role: "user"})
+
+	// Create some transient data
+	database.Create(&db.Favorite{UserID: 1, GameID: 1})
+	database.Create(&db.PlayHistory{UserID: 1, GameID: 1})
+	database.Create(&db.DailyPlayActivity{UserID: 1, PlayTime: 100})
+	database.Create(&db.ActivityEvent{UserID: 1, EventType: "test"})
+	database.Create(&db.GameRating{UserID: 1, GameID: 1, Rating: 5})
+	database.Create(&db.PlayLaterItem{UserID: 1, GameID: 1})
+	database.Create(&db.ServerSetting{Key: "registration_enabled", Value: "false"})
+	database.Create(&db.LoginAttempt{Username: "admin", FailedCount: 3})
+
+	router := NewRouter(*cfg)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/test/reset", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify all transient tables are empty
+	assertTableEmpty(t, database, &db.Favorite{})
+	assertTableEmpty(t, database, &db.PlayHistory{})
+	assertTableEmpty(t, database, &db.DailyPlayActivity{})
+	assertTableEmpty(t, database, &db.ActivityEvent{})
+	assertTableEmpty(t, database, &db.GameRating{})
+	assertTableEmpty(t, database, &db.PlayLaterItem{})
+	assertTableEmpty(t, database, &db.ServerSetting{})
+	assertTableEmpty(t, database, &db.LoginAttempt{})
+}
+
+func TestResetEndpoint_PreservesConsolesAndCores(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	cfg.TestMode = true
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+
+	// Create seed users
+	adminHash, _ := auth.HashPassword("admin123")
+	database.Create(&db.User{Username: "admin", Email: "admin@spela.local", PasswordHash: adminHash, Role: "owner"})
+	playerHash, _ := auth.HashPassword("player123")
+	database.Create(&db.User{Username: "player", Email: "player@spela.local", PasswordHash: playerHash, Role: "user"})
+
+	var consolesBefore, coresBefore int64
+	database.Model(&db.Console{}).Count(&consolesBefore)
+	database.Model(&db.Core{}).Count(&coresBefore)
+	require.Greater(t, consolesBefore, int64(0))
+	require.Greater(t, coresBefore, int64(0))
+
+	router := NewRouter(*cfg)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/test/reset", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var consolesAfter, coresAfter int64
+	database.Model(&db.Console{}).Count(&consolesAfter)
+	database.Model(&db.Core{}).Count(&coresAfter)
+	assert.Equal(t, consolesBefore, consolesAfter)
+	assert.Equal(t, coresBefore, coresAfter)
+}
+
+func TestResetEndpoint_PreservesGames(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	cfg.TestMode = true
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+
+	// Create seed users
+	adminHash, _ := auth.HashPassword("admin123")
+	database.Create(&db.User{Username: "admin", Email: "admin@spela.local", PasswordHash: adminHash, Role: "owner"})
+	playerHash, _ := auth.HashPassword("player123")
+	database.Create(&db.User{Username: "player", Email: "player@spela.local", PasswordHash: playerHash, Role: "user"})
+
+	// Create a game (simulating a scan)
+	var nes db.Console
+	database.Where("abbreviation = ?", "NES").First(&nes)
+	database.Create(&db.Game{ConsoleID: nes.ID, Title: "Test Game", FileName: "test.nes", FilePath: "nes/test.nes"})
+
+	router := NewRouter(*cfg)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/test/reset", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var gameCount int64
+	database.Model(&db.Game{}).Count(&gameCount)
+	assert.Equal(t, int64(1), gameCount)
+}
+
+func TestResetEndpoint_AdminCanLoginAfterReset(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	cfg.TestMode = true
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+
+	// Create the seed users
+	adminHash, _ := auth.HashPassword("admin123")
+	database.Create(&db.User{Username: "admin", Email: "admin@spela.local", PasswordHash: adminHash, Role: "owner"})
+
+	router := NewRouter(*cfg)
+
+	// Reset
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/test/reset", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Login as admin
+	body, _ := json.Marshal(map[string]string{
+		"username": "admin",
+		"password": "admin123",
+	})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/auth/login", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var loginResp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &loginResp))
+	assert.NotEmpty(t, loginResp["accessToken"])
+}
+
+func assertTableEmpty(t *testing.T, database *gorm.DB, model interface{}) {
+	t.Helper()
+	var count int64
+	database.Unscoped().Model(model).Count(&count)
+	assert.Equal(t, int64(0), count, "table %T should be empty", model)
+}

--- a/web/e2e/admin-settings.spec.ts
+++ b/web/e2e/admin-settings.spec.ts
@@ -1,6 +1,10 @@
-import { test, expect } from "./fixtures";
+import { test, expect, resetServer } from "./fixtures";
 
 test.describe("Admin Settings — Allow Registration", () => {
+  test.beforeEach(async () => {
+    await resetServer();
+  });
+
   test("disabling Allow Registration persists after page reload", async ({
     page,
   }) => {
@@ -35,11 +39,6 @@ test.describe("Admin Settings — Allow Registration", () => {
       .getByRole("switch")
       .first();
     await expect(toggleAfterReload).toHaveAttribute("aria-checked", "false");
-
-    // Re-enable for clean state
-    await toggleAfterReload.click();
-    await page.getByRole("button", { name: /save settings/i }).click();
-    await expect(page.getByText("Settings saved")).toBeVisible();
   });
 
   test("registration endpoint returns 403 when registration is disabled", async ({
@@ -75,18 +74,5 @@ test.describe("Admin Settings — Allow Registration", () => {
       return { status: res.status };
     });
     expect(regResult.status).toBe(403);
-
-    // Re-enable registration
-    await page.evaluate(async () => {
-      const token = localStorage.getItem("accessToken");
-      await fetch("/api/admin/settings", {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify({ registration_enabled: "true" }),
-      });
-    });
   });
 });

--- a/web/e2e/fixtures.ts
+++ b/web/e2e/fixtures.ts
@@ -1,1 +1,17 @@
 export { test, expect } from "@playwright/test";
+
+const SERVER_URL = "http://localhost:8080";
+
+/**
+ * Reset the server database to its seed state.
+ * Clears all user-generated data while preserving consoles, cores, and scanned games.
+ * Call this in test.beforeAll() or test.beforeEach() for tests that mutate server state.
+ */
+export async function resetServer(): Promise<void> {
+  const res = await fetch(`${SERVER_URL}/api/test/reset`, { method: "POST" });
+  if (!res.ok) {
+    throw new Error(
+      `Test reset failed: ${res.status} ${await res.text()}`,
+    );
+  }
+}

--- a/web/e2e/key-mapping.spec.ts
+++ b/web/e2e/key-mapping.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "./fixtures";
+import { test, expect, resetServer } from "./fixtures";
 
 const arrowsLeftPrefs = {
   showPerformanceOverlay: false,
@@ -258,6 +258,10 @@ test.describe("Custom Key Mapping Editor", () => {
 });
 
 test.describe("Per-Console Key Mapping Overrides", () => {
+  test.beforeAll(async () => {
+    await resetServer();
+  });
+
   test("override table renders with console names and dropdowns", async ({
     page,
   }) => {
@@ -323,14 +327,14 @@ test.describe("Per-Console Key Mapping Overrides", () => {
     const reloadedSelect = reloadedTable.locator("select").first();
     await expect(reloadedSelect).toBeVisible();
     await expect(reloadedSelect).toHaveValue("wasd-arrows");
-
-    // Reset back to global default to avoid test pollution
-    await reloadedSelect.selectOption("");
-    await page.waitForTimeout(500);
   });
 });
 
 test.describe("Key Mapping Persistence", () => {
+  test.beforeAll(async () => {
+    await resetServer();
+  });
+
   test("global mode change persists after page reload", async ({ page }) => {
     await page.goto("/preferences");
 
@@ -352,10 +356,6 @@ test.describe("Key Mapping Persistence", () => {
     await expect(
       page.getByRole("button", { name: "Arrows + Left" }),
     ).not.toHaveClass(/ring-2/);
-
-    // Reset to arrows-left to avoid test pollution
-    await page.getByRole("button", { name: "Arrows + Left" }).click();
-    await page.waitForTimeout(500);
   });
 
   test("custom key assignment persists after page reload", async ({ page }) => {
@@ -399,9 +399,5 @@ test.describe("Key Mapping Persistence", () => {
       .locator("..");
     const reloadedBtn = reloadedRow.locator("button");
     await expect(reloadedBtn).toHaveText("M");
-
-    // Reset to arrows-left to avoid test pollution
-    await page.getByRole("button", { name: "Arrows + Left" }).click();
-    await page.waitForTimeout(500);
   });
 });

--- a/web/e2e/netplay-invite-flow.spec.ts
+++ b/web/e2e/netplay-invite-flow.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, type BrowserContext, type Page } from "@playwright/test";
+import { test, expect, resetServer } from "./fixtures";
+import type { BrowserContext, Page } from "@playwright/test";
 
 const API = "http://localhost:8080/api";
 
@@ -91,6 +92,8 @@ test.describe("Netplay invite flow (two browsers)", () => {
   let gameId: string;
 
   test.beforeAll(async () => {
+    await resetServer();
+
     // Get tokens
     adminToken = await apiLogin("admin", "admin123");
 

--- a/web/e2e/preferences.spec.ts
+++ b/web/e2e/preferences.spec.ts
@@ -1,6 +1,10 @@
-import { test, expect } from "./fixtures";
+import { test, expect, resetServer } from "./fixtures";
 
 test.describe("Preferences Page", () => {
+  test.beforeAll(async () => {
+    await resetServer();
+  });
+
   test("displays emulation settings with toggles", async ({ page }) => {
     await page.goto("/preferences");
 

--- a/web/e2e/registration-approval.spec.ts
+++ b/web/e2e/registration-approval.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, resetServer } from "./fixtures";
 
 /**
  * E2E tests for the registration approval workflow.
@@ -8,16 +8,17 @@ import { test, expect } from "@playwright/test";
  * we can test the unauthenticated registration flow directly.
  */
 
-// Each test run uses a unique suffix to avoid username conflicts across runs
-const suffix = Date.now();
-
 test.describe("Registration Approval Flow", () => {
   test.use({ storageState: { cookies: [], origins: [] } });
+
+  test.beforeEach(async () => {
+    await resetServer();
+  });
 
   test("registration shows pending approval message instead of logging in", async ({
     page,
   }) => {
-    const username = `pendinguser${suffix}`;
+    const username = "pendinguser";
 
     await page.goto("/register");
     await page.getByLabel("Username").fill(username);
@@ -34,25 +35,22 @@ test.describe("Registration Approval Flow", () => {
   });
 
   test("pending user cannot log in", async ({ page }) => {
-    const username = `pendinglogin${suffix}`;
+    const username = "pendinglogin";
 
     // Register via API (bypass the UI to avoid waiting for the UI message test)
     await page.goto("/");
-    const regStatus = await page.evaluate(
-      async ([user, suffix]) => {
-        const res = await fetch("/api/auth/register", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            username: `${user}${suffix}`,
-            email: `${user}${suffix}@test.com`,
-            password: "password123",
-          }),
-        });
-        return res.status;
-      },
-      [username, ""] as [string, string],
-    );
+    const regStatus = await page.evaluate(async (user: string) => {
+      const res = await fetch("/api/auth/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: user,
+          email: `${user}@test.com`,
+          password: "password123",
+        }),
+      });
+      return res.status;
+    }, username);
     // Should return 202 (pending), not 201 (auto-login)
     expect(regStatus).toBe(202);
 
@@ -72,7 +70,7 @@ test.describe("Registration Approval Flow", () => {
   test("admin can approve a pending user and the user can then log in", async ({
     browser,
   }) => {
-    const username = `approvaltest${suffix}`;
+    const username = "approvaltest";
 
     // Step 1: Register a new user (unauthenticated context)
     const userCtx = await browser.newContext({

--- a/web/e2e/start-e2e.sh
+++ b/web/e2e/start-e2e.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# Start the E2E test environment locally (replaces docker-compose.e2e.yml).
+# Usage:
+#   bash web/e2e/start-e2e.sh        # start servers, block until Ctrl+C
+#   bash web/e2e/start-e2e.sh --ci   # start servers, exit when ready (for Playwright webServer)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+SERVER_DIR="$REPO_ROOT/server"
+WEB_DIR="$REPO_ROOT/web"
+
+CI_MODE=false
+if [[ "${1:-}" == "--ci" ]]; then
+    CI_MODE=true
+fi
+
+# Temp directory for E2E data
+E2E_DIR=$(mktemp -d)
+cleanup() {
+    echo "Stopping E2E servers..."
+    kill "${SERVER_PID:-}" 2>/dev/null || true
+    kill "${VITE_PID:-}" 2>/dev/null || true
+    rm -rf "$E2E_DIR"
+}
+trap cleanup EXIT
+
+DB_PATH="$E2E_DIR/spela.db"
+mkdir -p "$E2E_DIR/saves" "$E2E_DIR/cores" "$E2E_DIR/images" "$E2E_DIR/bios" "$E2E_DIR/dats"
+
+# 1. Build the server
+echo "Building server..."
+(cd "$SERVER_DIR" && CGO_ENABLED=1 go build -o "$E2E_DIR/spela-server" ./cmd/server)
+(cd "$SERVER_DIR" && CGO_ENABLED=1 go build -o "$E2E_DIR/spela-seed" ./cmd/seed)
+
+# 2. Seed the database
+echo "Seeding database..."
+SPELA_DB_PATH="$DB_PATH" "$E2E_DIR/spela-seed"
+
+# 3. Start the server
+echo "Starting server..."
+SPELA_PORT=8080 \
+SPELA_DB_PATH="$DB_PATH" \
+SPELA_JWT_SECRET="e2e-test-secret-that-is-at-least-32-chars-long" \
+SPELA_GAME_DIRS="$REPO_ROOT/testdata/roms" \
+SPELA_SAVE_DIR="$E2E_DIR/saves" \
+SPELA_CORE_DIR="$E2E_DIR/cores" \
+SPELA_IMAGE_DIR="$E2E_DIR/images" \
+SPELA_BIOS_DIR="$E2E_DIR/bios" \
+SPELA_DAT_DIR="$E2E_DIR/dats" \
+SPELA_CORS_ORIGINS="http://localhost:5173" \
+SPELA_ENCRYPTION_KEY="e2e-test-encryption-key-at-least-32-chars" \
+SPELA_CHALLENGE_RATE_LIMIT_SEC=0 \
+SPELA_TEST_MODE=true \
+GIN_MODE=release \
+"$E2E_DIR/spela-server" &
+SERVER_PID=$!
+
+# 4. Wait for server to be ready
+echo "Waiting for server..."
+for i in $(seq 1 60); do
+    if curl -sf http://localhost:8080/api/health >/dev/null 2>&1; then
+        break
+    fi
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "Server process died"
+        exit 1
+    fi
+    sleep 0.5
+done
+
+if ! curl -sf http://localhost:8080/api/health >/dev/null 2>&1; then
+    echo "Server failed to start"
+    exit 1
+fi
+echo "Server ready."
+
+# 5. Trigger game scan
+echo "Scanning games..."
+TOKEN=$(curl -sf -X POST http://localhost:8080/api/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"admin123"}' | \
+  python3 -c "import sys,json; print(json.load(sys.stdin)['accessToken'])" 2>/dev/null) || true
+
+if [ -n "${TOKEN:-}" ]; then
+    SCAN_RESULT=$(curl -sf -X POST http://localhost:8080/api/admin/games/scan \
+      -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+    echo "Scan result: ${SCAN_RESULT:-failed}"
+else
+    echo "Warning: could not login to trigger game scan"
+fi
+
+# 6. Start Vite dev server
+echo "Starting Vite dev server..."
+(cd "$WEB_DIR" && npx vite --port 5173) &
+VITE_PID=$!
+
+# Wait for Vite
+for i in $(seq 1 30); do
+    if curl -sf http://localhost:5173 >/dev/null 2>&1; then
+        break
+    fi
+    sleep 0.5
+done
+
+echo ""
+echo "E2E servers are running:"
+echo "  Server: http://localhost:8080 (PID $SERVER_PID)"
+echo "  Web:    http://localhost:5173 (PID $VITE_PID)"
+echo "  DB:     $DB_PATH"
+echo "  Test reset: POST http://localhost:8080/api/test/reset"
+
+echo ""
+echo "Press Ctrl+C to stop."
+wait

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -10,6 +10,12 @@ export default defineConfig({
     baseURL: "http://localhost:5173",
     trace: "on-first-retry",
   },
+  webServer: {
+    command: "bash e2e/start-e2e.sh",
+    url: "http://localhost:5173",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
   projects: [
     {
       name: "setup",


### PR DESCRIPTION
## Summary
- Add `POST /api/test/reset` endpoint (only when `SPELA_TEST_MODE=true`) that clears user-generated data while preserving consoles, cores, and games
- Replace Docker-based E2E with `start-e2e.sh` that builds/runs Go server locally, configured as Playwright `webServer`
- 5 test files now use `resetServer()` instead of manual cleanup hacks, eliminating flaky state leakage

## Test plan
- [x] 8 unit tests for reset endpoint pass
- [x] Full Go test suite passes
- [x] 153/163 E2E tests pass (10 pre-existing failures unrelated to changes)
- [x] Reset endpoint returns 404 when `SPELA_TEST_MODE` is not set
- [x] Previously flaky tests (admin-settings, registration-approval, netplay-invite) now pass reliably