### PR TITLE
fix: nativeDistributions jvmArgs leaks $APPDIR into dev run task

### DIFF
--- a/player/desktop/build.gradle.kts
+++ b/player/desktop/build.gradle.kts
@@ -128,10 +128,11 @@ compose.desktop {
     application {
         mainClass = "com.spela.player.desktop.MainKt"
 
+        // Use forward slashes so the path isn't mangled by escape-character
+        // interpretation in the jpackage .cfg file on Windows.
+        jvmArgs += "-Djava.library.path=${nativeBuildDir.get().asFile.absolutePath.replace('\\', '/')}"
+
         nativeDistributions {
-            // Use $APPDIR so the packaged app finds native libs next to its jars.
-            // The dev `run` task gets the build-tree path separately below.
-            jvmArgs += "-Djava.library.path=\$APPDIR"
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "Spela"
             val appVersion = project.findProperty("appVersion")?.toString() ?: "1.0.0"
@@ -168,6 +169,26 @@ tasks.withType<Test> {
     timeout.set(Duration.ofMinutes(5))
     testLogging {
         events("failed")
+    }
+}
+
+// After jpackage creates the distributable, patch the .cfg file to replace the
+// build-machine's absolute native library path with $APPDIR so the packaged app
+// finds its native libs at runtime on end-user machines.
+tasks.matching { it.name == "createDistributable" || it.name == "createReleaseDistributable" }.configureEach {
+    doLast {
+        val nativeAbsPath = nativeBuildDir.get().asFile.absolutePath.replace('\\', '/')
+        val appImageDir = project.layout.buildDirectory.dir("compose/binaries/main/app").get().asFile
+        appImageDir.walkTopDown()
+            .filter { it.name.endsWith(".cfg") }
+            .forEach { cfg ->
+                val original = cfg.readText()
+                val patched = original.replace(nativeAbsPath, "\$APPDIR")
+                if (patched != original) {
+                    cfg.writeText(patched)
+                    logger.lifecycle("Patched native library path in ${cfg.name}")
+                }
+            }
     }
 }
 
@@ -241,8 +262,8 @@ if (org.gradle.internal.os.OperatingSystem.current().isMacOsX) {
     }
 }
 
-// Pass native library path to dev run and Compose Hot Reload tasks.
-tasks.withType<JavaExec>().matching { it.name.startsWith("hotRun") || it.name.startsWith("hotDev") || it.name == "run" }.configureEach {
+// Pass native library path to Compose Hot Reload tasks.
+tasks.withType<JavaExec>().matching { it.name.startsWith("hotRun") || it.name.startsWith("hotDev") }.configureEach {
     jvmArgs("-Djava.library.path=${nativeBuildDir.get().asFile.absolutePath}")
 }
 


### PR DESCRIPTION
## Summary
- Follow-up to #82 — the `nativeDistributions { jvmArgs }` block leaks its values into the `run` task too, so `$APPDIR` (a literal string only resolved by jpackage) causes `UnsatisfiedLinkError` when running `./gradlew :desktop:run`
- Backslashes in the absolute path still get mangled in the `.cfg` file on Windows

## Fix
1. Restore `java.library.path` in `application.jvmArgs` with **forward slashes** to prevent backslash escape mangling in `.cfg`
2. Add a **post-packaging task** on `createDistributable` that patches the `.cfg` file to replace the build-machine absolute path with `$APPDIR`
3. Remove redundant `"run"` from the `JavaExec` matcher since `application.jvmArgs` already covers it

## Test plan
- [x] `./gradlew :desktop:run` finds the native library and launches successfully on Windows
- [ ] `./gradlew :desktop:packageMsi` produces an MSI whose `Spela.cfg` has `$APPDIR` instead of an absolute path
- [ ] Installed MSI launches without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)