### PR TITLE
fix: return 404 for missing emulator assets instead of SPA fallback

### DIFF
--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -506,6 +506,15 @@ func serveFrontend(frontendDir string) gin.HandlerFunc {
 			return
 		}
 
+		// Static asset paths must resolve to real files — never fall through
+		// to SPA. This prevents the SPA fallback from returning index.html
+		// (200 OK) for missing files, which breaks EmulatorJS CDN fallback
+		// (it checks for HTTP errors, not content type).
+		if strings.HasPrefix(reqPath, "/emulatorjs/") || strings.HasPrefix(reqPath, "/assets/") {
+			c.Status(http.StatusNotFound)
+			return
+		}
+
 		// SPA fallback: serve index.html for any non-file path
 		c.File(filepath.Join(frontendDir, "index.html"))
 	}

--- a/web/public/emulator.js
+++ b/web/public/emulator.js
@@ -118,9 +118,9 @@
     // This also triggers a CDN version check that is harmlessly blocked by CSP.
     window.EJS_DEBUG_XX = true;
 
-    // Enable threaded WASM cores for full-speed emulation.
-    // Requires COOP/COEP headers (set by server and Vite dev config).
-    window.EJS_threads = true;
+    // Enable threaded WASM cores when SharedArrayBuffer is available.
+    // Requires COOP/COEP headers; falls back to non-threaded cores otherwise.
+    window.EJS_threads = typeof SharedArrayBuffer === "function";
 
     // Auto-load save state if provided
     if (config.saveStateData) {


### PR DESCRIPTION
## Summary
- Server now returns 404 for missing files under `/emulatorjs/` and `/assets/` instead of serving `index.html` via SPA fallback, which broke EmulatorJS core loading (it received HTML instead of a 7z archive)
- `EJS_threads` is now set based on runtime `SharedArrayBuffer` availability instead of being hardcoded to `true`, so browsers without cross-origin isolation gracefully fall back to non-threaded cores

## Root cause
EmulatorJS constructs core filenames dynamically (e.g. `nestopia-thread-legacy-wasm.data`). When a requested `.data` file didn't exist on disk, the SPA fallback returned `index.html` with 200 OK. EmulatorJS treated this as a successful download, tried to decompress HTML as 7z, and the resulting blob script didn't define `EJS_Runtime` — causing a fatal crash.

## Test plan
- [ ] Launch a game in the web UI — verify it loads without `EJS_Runtime is not defined` error
- [ ] Verify `/emulatorjs/data/nonexistent.file` returns 404, not index.html
- [ ] Verify threaded cores still work in Chrome (where `SharedArrayBuffer` is available with COOP/COEP headers)