### PR TITLE
feat: save state core compatibility tracking and warnings

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1142,10 +1142,13 @@ class FakeSessionRepository : SessionRepository {
         return Result.success(session)
     }
 
-    override suspend fun updateSession(sessionId: String, name: String): Result<GameSession> {
+    override suspend fun updateSession(sessionId: String, name: String?, coreName: String?): Result<GameSession> {
         val idx = sessions.indexOfFirst { it.id == sessionId }
         if (idx < 0) return Result.failure(Exception("Session not found"))
-        sessions[idx] = sessions[idx].copy(name = name)
+        var updated = sessions[idx]
+        if (name != null) updated = updated.copy(name = name)
+        if (coreName != null) updated = updated.copy(coreName = coreName)
+        sessions[idx] = updated
         return Result.success(sessions[idx])
     }
 
@@ -1157,7 +1160,7 @@ class FakeSessionRepository : SessionRepository {
     override suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>> =
         Result.success(sessionSaves[sessionId] ?: emptyList())
 
-    override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?): Result<SaveState> {
+    override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<SaveState> {
         val save = SaveState(
             id = (sessionSaves[sessionId]?.size?.toLong() ?: 0L) + 1,
             gameId = 0,
@@ -1171,7 +1174,7 @@ class FakeSessionRepository : SessionRepository {
     override suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray> =
         Result.success(ByteArray(256) { it.toByte() })
 
-    override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?): Result<Unit> {
+    override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<Unit> {
         autoSaves[sessionId] = data
         return Result.success(Unit)
     }
@@ -1180,7 +1183,7 @@ class FakeSessionRepository : SessionRepository {
         autoSaves[sessionId]?.let { Result.success(it) }
             ?: Result.failure(Exception("No auto-save"))
 
-    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray): Result<Unit> {
+    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String): Result<Unit> {
         sram[sessionId] = data
         return Result.success(Unit)
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1067,9 +1067,9 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/sessions/$sessionId").body()
     }
 
-    suspend fun updateSession(sessionId: String, name: String): GameSessionDto {
+    suspend fun updateSession(sessionId: String, name: String? = null, coreName: String? = null): GameSessionDto {
         return client.put("$baseUrl/api/sessions/$sessionId") {
-            setBody(UpdateSessionRequest(name = name))
+            setBody(UpdateSessionRequest(name = name, coreName = coreName))
         }.body()
     }
 
@@ -1089,11 +1089,14 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/sessions/$sessionId/saves").body()
     }
 
-    suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?): SaveStateDto {
+    suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): SaveStateDto {
         return client.submitFormWithBinaryData(
             url = "$baseUrl/api/sessions/$sessionId/saves",
             formData = formData {
                 append("name", name)
+                if (coreName.isNotEmpty()) {
+                    append("coreName", coreName)
+                }
                 append("save", data, Headers.build {
                     append(HttpHeaders.ContentDisposition, "filename=\"save.sav\"")
                     append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())
@@ -1116,10 +1119,13 @@ class SpelaApiClient(
         return response.body()
     }
 
-    suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?) {
+    suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String = "") {
         client.submitFormWithBinaryData(
             url = "$baseUrl/api/sessions/$sessionId/saves/auto",
             formData = formData {
+                if (coreName.isNotEmpty()) {
+                    append("coreName", coreName)
+                }
                 append("save", data, Headers.build {
                     append(HttpHeaders.ContentDisposition, "filename=\"autosave.sav\"")
                     append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())
@@ -1142,10 +1148,13 @@ class SpelaApiClient(
         return response.body()
     }
 
-    suspend fun uploadSessionSram(sessionId: String, data: ByteArray) {
+    suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String = "") {
         client.submitFormWithBinaryData(
             url = "$baseUrl/api/sessions/$sessionId/sram",
             formData = formData {
+                if (coreName.isNotEmpty()) {
+                    append("coreName", coreName)
+                }
                 append("file", data, Headers.build {
                     append(HttpHeaders.ContentDisposition, "filename=\"sram.srm\"")
                     append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -521,6 +521,7 @@ fun GameSessionDto.toDomain(): GameSession = GameSession(
     lastPlayedByUsername = lastPlayedByUsername,
     totalPlayTime = totalPlayTime,
     screenshotUrl = screenshotUrl,
+    coreName = coreName,
     cheatsEnabled = cheatsEnabled,
     isSharedSession = isSharedSession,
     sharedSessionId = sharedSessionId,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -936,6 +936,7 @@ data class GameSessionDto(
     val lastPlayedByUsername: String? = null,
     val totalPlayTime: Long = 0,
     val screenshotUrl: String? = null,
+    val coreName: String? = null,
     val cheatsEnabled: Boolean = false,
     val isSharedSession: Boolean = false,
     val sharedSessionId: String? = null,
@@ -951,7 +952,8 @@ data class CreateSessionRequest(
 
 @Serializable
 data class UpdateSessionRequest(
-    val name: String,
+    val name: String? = null,
+    val coreName: String? = null,
 )
 
 // Session Cheats

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -27,8 +27,8 @@ class SessionRepositoryImpl(
         apiClient.createSessionFromSharedSave(gameId, saveId).toDomain()
     }
 
-    override suspend fun updateSession(sessionId: String, name: String): Result<GameSession> = runCatching {
-        apiClient.updateSession(sessionId, name).toDomain()
+    override suspend fun updateSession(sessionId: String, name: String?, coreName: String?): Result<GameSession> = runCatching {
+        apiClient.updateSession(sessionId, name, coreName).toDomain()
     }
 
     override suspend fun deleteSession(sessionId: String): Result<Unit> = runCatching {
@@ -44,8 +44,9 @@ class SessionRepositoryImpl(
         name: String,
         data: ByteArray,
         screenshot: ByteArray?,
+        coreName: String,
     ): Result<SaveState> = runCatching {
-        apiClient.uploadSessionSave(sessionId, name, data, screenshot).toDomain()
+        apiClient.uploadSessionSave(sessionId, name, data, screenshot, coreName).toDomain()
     }
 
     override suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray> = runCatching {
@@ -56,16 +57,17 @@ class SessionRepositoryImpl(
         sessionId: String,
         data: ByteArray,
         screenshot: ByteArray?,
+        coreName: String,
     ): Result<Unit> = runCatching {
-        apiClient.uploadSessionAutoSave(sessionId, data, screenshot)
+        apiClient.uploadSessionAutoSave(sessionId, data, screenshot, coreName)
     }
 
     override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> = runCatching {
         apiClient.downloadSessionAutoSave(sessionId)
     }
 
-    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray): Result<Unit> = runCatching {
-        apiClient.uploadSessionSram(sessionId, data)
+    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String): Result<Unit> = runCatching {
+        apiClient.uploadSessionSram(sessionId, data, coreName)
     }
 
     override suspend fun downloadSessionSram(sessionId: String): Result<ByteArray> = runCatching {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -631,6 +631,7 @@ data class GameSession(
     val lastPlayedByUsername: String? = null,
     val totalPlayTime: Long = 0,
     val screenshotUrl: String? = null,
+    val coreName: String? = null,
     val cheatsEnabled: Boolean = false,
     val isSharedSession: Boolean = false,
     val sharedSessionId: String? = null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -9,14 +9,14 @@ interface SessionRepository {
     suspend fun getSession(sessionId: String): Result<GameSession>
     suspend fun createSession(gameId: String, name: String): Result<GameSession>
     suspend fun createSessionFromSharedSave(gameId: String, saveId: String): Result<GameSession>
-    suspend fun updateSession(sessionId: String, name: String): Result<GameSession>
+    suspend fun updateSession(sessionId: String, name: String? = null, coreName: String? = null): Result<GameSession>
     suspend fun deleteSession(sessionId: String): Result<Unit>
     suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>>
-    suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?): Result<SaveState>
+    suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>
     suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray>
-    suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?): Result<Unit>
+    suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<Unit>
     suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray>
-    suspend fun uploadSessionSram(sessionId: String, data: ByteArray): Result<Unit>
+    suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String = ""): Result<Unit>
     suspend fun downloadSessionSram(sessionId: String): Result<ByteArray>
     suspend fun getSessionCheats(sessionId: String): Result<SessionCheatConfig>
     suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>): Result<SessionCheatConfig>

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -85,6 +85,14 @@ sealed interface EmulationIntent {
     data object PlayWithLocalSave : EmulationIntent
     data object CancelLaunch : EmulationIntent
 
+    // Core mismatch
+    /** User chose "Try Loading Anyway" — attempt to load the mismatched save state. */
+    data object CoreMismatchTryAnyway : EmulationIntent
+    /** User chose "Start with Game Save Only" — skip save state, SRAM already loaded. */
+    data object CoreMismatchGameSaveOnly : EmulationIntent
+    /** User chose "Start Fresh" — skip all saves. */
+    data object CoreMismatchStartFresh : EmulationIntent
+
     // Cheats
     data object ShowCheatBrowser : EmulationIntent
     data object HideCheatBrowser : EmulationIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -92,6 +92,11 @@ data class EmulationState(
     /** Session: set when playing within a game session. */
     val sessionId: String? = null,
 
+    /** Core mismatch: shown when auto-load detects a save from a different core. */
+    val showCoreMismatchDialog: Boolean = false,
+    val coreMismatchSaveCoreName: String = "",
+    val coreMismatchCurrentCoreName: String = "",
+
     /** Cheats */
     val hasCheats: Boolean = false,
     val enabledCheatCount: Int = 0,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/CoreMismatchDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/CoreMismatchDialog.kt
@@ -1,0 +1,115 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpButtonStyle
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Dialog shown when auto-load detects that the last save point was created
+ * with a different emulator core than the one currently in use.
+ * Presents three options to the user.
+ */
+@Composable
+internal fun CoreMismatchDialog(
+    saveCoreName: String,
+    currentCoreName: String,
+    onTryAnyway: () -> Unit,
+    onGameSaveOnly: () -> Unit,
+    onStartFresh: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SpColor.Scrim)
+            .clickable(
+                interactionSource = remember { MutableInteractionSource() },
+                indication = null,
+                onClick = {}, // Block click-through
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.75f)
+                .clip(RoundedCornerShape(SpSpacing.RadiusXLarge))
+                .background(SpColor.SurfaceElevated)
+                .clickable(
+                    interactionSource = remember { MutableInteractionSource() },
+                    indication = null,
+                    onClick = {}, // Prevent click-through
+                )
+                .padding(SpSpacing.XLarge),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Text(
+                text = "Save State Compatibility Warning",
+                style = SpTypography.HeadlineMedium,
+                color = SpColor.Warning,
+            )
+            Spacer(Modifier.height(SpSpacing.Small))
+
+            val bodyText = buildAnnotatedString {
+                val boldStyle = SpanStyle(fontWeight = FontWeight.Bold, color = SpColor.OnBackground)
+                append("Your last save state was created with a different emulator configuration (")
+                withStyle(boldStyle) { append(saveCoreName) }
+                append(" vs current ")
+                withStyle(boldStyle) { append(currentCoreName) }
+                append("). It may not load correctly on this platform.")
+            }
+            Text(
+                text = bodyText,
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundSecondary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(SpSpacing.XLarge))
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            ) {
+                SpButton(
+                    text = "Try Loading Anyway",
+                    onClick = onTryAnyway,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                SpButton(
+                    text = "Start with Game Save Only",
+                    onClick = onGameSaveOnly,
+                    style = SpButtonStyle.Outlined,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                SpButton(
+                    text = "Start Fresh",
+                    onClick = onStartFresh,
+                    style = SpButtonStyle.Ghost,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -16,6 +16,7 @@ import com.spela.player.domain.model.DefaultKeyMappings
 import com.spela.player.presentation.intent.EmulationIntent
 import com.spela.player.presentation.ui.feature.ingame.ChallengeCompletedDialog
 import com.spela.player.presentation.ui.feature.ingame.CheatsDialog
+import com.spela.player.presentation.ui.feature.ingame.CoreMismatchDialog
 import com.spela.player.presentation.ui.feature.ingame.ChallengeTimerHud
 import com.spela.player.presentation.ui.feature.ingame.FpsHud
 import com.spela.player.presentation.ui.feature.ingame.InGameOverlayPanel
@@ -208,6 +209,17 @@ fun InGameOverlay(
                 viewModel.onIntent(EmulationIntent.StopGame)
                 onExit()
             },
+        )
+    }
+
+    // Core mismatch dialog
+    if (state.showCoreMismatchDialog) {
+        CoreMismatchDialog(
+            saveCoreName = state.coreMismatchSaveCoreName,
+            currentCoreName = state.coreMismatchCurrentCoreName,
+            onTryAnyway = { viewModel.onIntent(EmulationIntent.CoreMismatchTryAnyway) },
+            onGameSaveOnly = { viewModel.onIntent(EmulationIntent.CoreMismatchGameSaveOnly) },
+            onStartFresh = { viewModel.onIntent(EmulationIntent.CoreMismatchStartFresh) },
         )
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -195,6 +195,11 @@ class EmulationViewModel(
             EmulationIntent.PlayWithLocalSave -> playWithLocalSave()
             EmulationIntent.CancelLaunch -> cancelLaunch()
 
+            // Core mismatch
+            EmulationIntent.CoreMismatchTryAnyway -> handleCoreMismatchTryAnyway()
+            EmulationIntent.CoreMismatchGameSaveOnly -> handleCoreMismatchGameSaveOnly()
+            EmulationIntent.CoreMismatchStartFresh -> handleCoreMismatchStartFresh()
+
             // Cheats
             EmulationIntent.ShowCheatBrowser -> _state.update { it.copy(showCheatBrowser = true) }
             EmulationIntent.HideCheatBrowser -> _state.update { it.copy(showCheatBrowser = false) }
@@ -379,6 +384,9 @@ class EmulationViewModel(
                         challengeManager.currentCoreName = resolvedCoreName
                         saveManager.currentCoreName = resolvedCoreName
 
+                        // Update session with current core name (best effort)
+                        saveManager.updateSessionCoreName()
+
                         // Challenge mode: load challenge save state and start attempt
                         if (challengeId != null) {
                             challengeManager.loadChallengeSave(challengeId, challengeSaveDataArg)
@@ -390,7 +398,7 @@ class EmulationViewModel(
                             // For non-HW cores, load save state immediately.
                             // HW render cores (e.g. Dolphin) boot asynchronously — their
                             // GPU thread isn't ready for retro_unserialize yet. Deferred below.
-                            saveManager.autoLoadSaveState(gameId)
+                            handleAutoLoadResult(saveManager.autoLoadSaveState(gameId))
                         }
 
                         // Set up netplay transport if in netplay mode
@@ -427,7 +435,7 @@ class EmulationViewModel(
                         if (hwRender && currentPreferences.autoLoadSaveEnabled && !skipAutoLoad
                             && challengeId == null && sharedSessionId == null
                         ) {
-                            saveManager.autoLoadSaveState(gameId)
+                            handleAutoLoadResult(saveManager.autoLoadSaveState(gameId))
                         }
 
                         // Initialize achievements if RA is linked (skip for netplay)
@@ -635,6 +643,9 @@ class EmulationViewModel(
                         showGiveUpConfirm = false,
                         challengeCompletedAttempt = null,
                         sessionId = null,
+                        showCoreMismatchDialog = false,
+                        coreMismatchSaveCoreName = "",
+                        coreMismatchCurrentCoreName = "",
                         hasCheats = false,
                         enabledCheatCount = 0,
                         showCheatBrowser = false,
@@ -643,6 +654,67 @@ class EmulationViewModel(
                 }
                 saveManager.currentSessionId = null
             }
+        }
+    }
+
+    /**
+     * Handles the result of an auto-load attempt.
+     * On core mismatch, pauses emulation and shows a dialog.
+     */
+    private suspend fun handleAutoLoadResult(result: AutoLoadResult) {
+        when (result) {
+            is AutoLoadResult.Loaded -> {
+                // Already unserialized by SaveManager — nothing else to do
+            }
+            is AutoLoadResult.CoreMismatch -> {
+                println("[Emulation] Core mismatch detected: save='${result.saveCoreName}' current='${result.currentCoreName}'")
+                withContext(dispatchers.main) {
+                    _state.update {
+                        it.copy(
+                            showCoreMismatchDialog = true,
+                            coreMismatchSaveCoreName = result.saveCoreName,
+                            coreMismatchCurrentCoreName = result.currentCoreName,
+                        )
+                    }
+                }
+            }
+            is AutoLoadResult.NoSave -> {
+                // No save to load — game starts fresh
+            }
+            is AutoLoadResult.Error -> {
+                println("[Emulation] Auto-load error: ${result.message}")
+            }
+        }
+    }
+
+    private fun handleCoreMismatchTryAnyway() {
+        _state.update { it.copy(showCoreMismatchDialog = false) }
+        scope.launch(dispatchers.io) {
+            val success = saveManager.forceAutoLoadSaveState()
+            val message = if (success) {
+                "Save state loaded (compatibility not guaranteed)"
+            } else {
+                "Failed to load save state \u2014 starting without it"
+            }
+            withContext(dispatchers.main) {
+                _state.update { it.copy(statusMessage = message) }
+            }
+        }
+    }
+
+    private fun handleCoreMismatchGameSaveOnly() {
+        // SRAM was already loaded before the auto-save check, so just dismiss the dialog.
+        // The game will start from the title screen with in-game save progress intact.
+        _state.update { it.copy(showCoreMismatchDialog = false) }
+    }
+
+    private fun handleCoreMismatchStartFresh() {
+        // Dismiss dialog and clear SRAM so the game truly starts fresh with no
+        // in-game save data. This is destructive — the user chose to discard both
+        // the save state AND the in-game save progress.
+        _state.update { it.copy(showCoreMismatchDialog = false) }
+        scope.launch(dispatchers.io) {
+            libretroController.setSRAM(ByteArray(0))
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -13,6 +13,24 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**
+ * Result of attempting to auto-load a save state.
+ * Used to communicate core compatibility issues to the caller.
+ */
+sealed class AutoLoadResult {
+    /** Save state loaded successfully. */
+    data object Loaded : AutoLoadResult()
+
+    /** Save state exists but was created with a different core. */
+    data class CoreMismatch(val saveCoreName: String, val currentCoreName: String) : AutoLoadResult()
+
+    /** No auto-save exists for this session. */
+    data object NoSave : AutoLoadResult()
+
+    /** An error occurred while loading. */
+    data class Error(val message: String) : AutoLoadResult()
+}
+
+/**
  * Manages all save-related operations: SRAM load/save, auto-save/load,
  * and manual save/load state. All operations are session-scoped.
  * When no session is active, operations are silently skipped.
@@ -67,12 +85,12 @@ class SaveManager(
 
             val sramData = libretroController.getSRAM()
             if (sramData != null && sramData.isNotEmpty()) {
-                runCatching { sessionRepository.uploadSessionSram(sessionId, sramData) }
+                runCatching { sessionRepository.uploadSessionSram(sessionId, sramData, currentCoreName) }
             } else {
                 // Directory-save fallback for cores like Dolphin
                 val zipData = saveDataRepository.zipSaveDirectory(gameId)
                 if (zipData != null) {
-                    runCatching { sessionRepository.uploadSessionSram(sessionId, zipData) }
+                    runCatching { sessionRepository.uploadSessionSram(sessionId, zipData, currentCoreName) }
                 }
             }
         } catch (_: Exception) {
@@ -83,20 +101,65 @@ class SaveManager(
     /**
      * Auto-load save state on game start (if enabled and applicable).
      * Downloads from session auto-save endpoint.
+     * Checks core compatibility before loading: if the save was created with a
+     * different core, returns [AutoLoadResult.CoreMismatch] instead of loading.
      * Called from within an IO coroutine.
      */
-    suspend fun autoLoadSaveState(gameId: String) {
-        val sessionId = currentSessionId ?: return
+    suspend fun autoLoadSaveState(gameId: String): AutoLoadResult {
+        val sessionId = currentSessionId ?: return AutoLoadResult.NoSave
+
+        println("[SaveManager] autoLoadSaveState: checking session $sessionId for core compatibility")
+
+        // Fetch session detail to check core name before downloading save data
+        val sessionCoreName = sessionRepository.getSession(sessionId).getOrNull()?.coreName
+        if (!sessionCoreName.isNullOrEmpty() && currentCoreName.isNotEmpty()
+            && sessionCoreName != currentCoreName
+        ) {
+            println("[SaveManager] autoLoadSaveState: core mismatch — save='$sessionCoreName' current='$currentCoreName'")
+            return AutoLoadResult.CoreMismatch(
+                saveCoreName = sessionCoreName,
+                currentCoreName = currentCoreName,
+            )
+        }
 
         println("[SaveManager] autoLoadSaveState: loading session $sessionId auto-save")
-        sessionRepository.downloadSessionAutoSave(sessionId).fold(
+        return sessionRepository.downloadSessionAutoSave(sessionId).fold(
             onSuccess = { saveData ->
                 println("[SaveManager] autoLoadSaveState: got ${saveData.size} bytes from session, unserializing")
                 val ok = libretroController.unserialize(saveData)
                 println("[SaveManager] autoLoadSaveState: unserialize result=$ok")
+                AutoLoadResult.Loaded
             },
             onFailure = { e ->
                 println("[SaveManager] autoLoadSaveState: session auto-save failed: ${e.message}")
+                // Treat 404 / no-data as NoSave, other errors as Error
+                if (e.message?.contains("404") == true || e.message?.contains("not found", ignoreCase = true) == true) {
+                    AutoLoadResult.NoSave
+                } else {
+                    AutoLoadResult.Error(e.message ?: "Unknown error")
+                }
+            },
+        )
+    }
+
+    /**
+     * Force-load the auto-save despite a core mismatch.
+     * Called when the user chooses "Try Loading Anyway" after a mismatch warning.
+     * @return true if the save state was loaded successfully, false otherwise.
+     */
+    suspend fun forceAutoLoadSaveState(): Boolean {
+        val sessionId = currentSessionId ?: return false
+        println("[SaveManager] forceAutoLoadSaveState: loading session $sessionId auto-save (ignoring core mismatch)")
+        return sessionRepository.downloadSessionAutoSave(sessionId).fold(
+            onSuccess = { saveData ->
+                println("[SaveManager] forceAutoLoadSaveState: got ${saveData.size} bytes, unserializing")
+                val ok = libretroController.unserialize(saveData)
+                println("[SaveManager] forceAutoLoadSaveState: unserialize result=$ok")
+                ok
+            },
+            onFailure = { e ->
+                println("[SaveManager] forceAutoLoadSaveState: failed: ${e.message}")
+                false
             },
         )
     }
@@ -115,7 +178,7 @@ class SaveManager(
                 val sessionId = currentSessionId
                 if (sessionId != null) {
                     val screenshot = screenshotCapture?.captureScreenshot()
-                    val result = sessionRepository.uploadSessionAutoSave(sessionId, saveData, screenshot)
+                    val result = sessionRepository.uploadSessionAutoSave(sessionId, saveData, screenshot, currentCoreName)
                     println("[SaveManager] autoSaveOnStop: session upload result=${result.isSuccess}")
                 }
             }
@@ -139,7 +202,7 @@ class SaveManager(
             val sessionId = currentSessionId
             if (sessionId != null) {
                 val screenshot = screenshotCapture?.captureScreenshot()
-                sessionRepository.uploadSessionSave(sessionId, "Manual Save", saveData, screenshot).fold(
+                sessionRepository.uploadSessionSave(sessionId, "Manual Save", saveData, screenshot, currentCoreName).fold(
                     onSuccess = {
                         withContext(dispatchers.main) {
                             _state.update { it.copy(statusMessage = "State saved") }
@@ -196,6 +259,19 @@ class SaveManager(
                     }
                 }
             }
+        }
+    }
+
+    /**
+     * Update the session's core name on the server.
+     * Called at emulation start so the session tracks which core is being used,
+     * even if the game crashes before any save is uploaded.
+     */
+    suspend fun updateSessionCoreName() {
+        val sessionId = currentSessionId ?: return
+        if (currentCoreName.isEmpty()) return
+        runCatching {
+            sessionRepository.updateSession(sessionId, coreName = currentCoreName)
         }
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -168,15 +168,15 @@ private class FakePlayFromSharedSaveSessionRepository : SessionRepository {
         )
         return Result.success(session)
     }
-    override suspend fun updateSession(sessionId: String, name: String) = Result.failure<GameSession>(Exception("stub"))
+    override suspend fun updateSession(sessionId: String, name: String?, coreName: String?) = Result.failure<GameSession>(Exception("stub"))
     override suspend fun deleteSession(sessionId: String) = Result.success(Unit)
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
-    override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?) =
+    override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String) =
         Result.success(SaveState(id = 1, gameId = 1, name = name))
     override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
-    override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?) = Result.success(Unit)
+    override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String) = Result.success(Unit)
     override suspend fun downloadSessionAutoSave(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))
-    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray) = Result.success(Unit)
+    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String) = Result.success(Unit)
     override suspend fun downloadSessionSram(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun getSessionCheats(sessionId: String) = Result.success(SessionCheatConfig(false, emptyList()))
     override suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>) =

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -345,15 +345,15 @@ class StubSessionRepository : SessionRepository {
     override suspend fun getSessionsForGame(gameId: String) = Result.success(emptyList<GameSession>())
     override suspend fun getSession(sessionId: String) = Result.failure<GameSession>(Exception("stub"))
     override suspend fun createSession(gameId: String, name: String) = Result.failure<GameSession>(Exception("stub"))
-    override suspend fun updateSession(sessionId: String, name: String) = Result.failure<GameSession>(Exception("stub"))
+    override suspend fun updateSession(sessionId: String, name: String?, coreName: String?) = Result.failure<GameSession>(Exception("stub"))
     override suspend fun deleteSession(sessionId: String) = Result.success(Unit)
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
-    override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?): Result<SaveState> {
+    override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<SaveState> {
         uploadSessionSaveCallCount++
         return Result.success(SaveState(id = 1, gameId = 1, name = name))
     }
     override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
-    override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?): Result<Unit> {
+    override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<Unit> {
         uploadSessionAutoSaveCallCount++
         return Result.success(Unit)
     }
@@ -361,7 +361,7 @@ class StubSessionRepository : SessionRepository {
         downloadSessionAutoSaveCallCount++
         return downloadSessionAutoSaveResult
     }
-    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray): Result<Unit> {
+    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String): Result<Unit> {
         uploadSessionSramCallCount++
         return Result.success(Unit)
     }

--- a/server/internal/api/admin_handler.go
+++ b/server/internal/api/admin_handler.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -942,6 +943,41 @@ func (h *AdminHandler) GetCheatStats(c *gin.Context) {
 		"totalGames":     totalGames,
 		"verifiedGames":  verifiedGames,
 	})
+}
+
+// CoreCompatibilityEntry is the API response for a single console's core compatibility.
+type CoreCompatibilityEntry struct {
+	ConsoleID   string `json:"consoleId"`
+	ConsoleName string `json:"consoleName"`
+	NativeCore  string `json:"nativeCore"`
+	WebCore     string `json:"webCore"`
+	Matched     bool   `json:"matched"`
+}
+
+// GetCoreCompatibility returns a list of consoles showing core compatibility
+// between the native player (DefaultCore) and the web browser (EmulatorJSCore).
+// GET /api/admin/core-compatibility
+func (h *AdminHandler) GetCoreCompatibility(c *gin.Context) {
+	var consoles []db.Console
+	if err := h.DB.Order("name ASC").Find(&consoles).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch consoles"})
+		return
+	}
+
+	result := make([]CoreCompatibilityEntry, 0, len(consoles))
+	for _, console := range consoles {
+		abbr := strings.ToLower(console.Abbreviation)
+		matched := console.DefaultCore == console.EmulatorJSCore
+		result = append(result, CoreCompatibilityEntry{
+			ConsoleID:   abbr,
+			ConsoleName: console.Name,
+			NativeCore:  console.DefaultCore,
+			WebCore:     console.EmulatorJSCore,
+			Matched:     matched,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{"consoles": result})
 }
 
 // IGDBSource returns "env" if IGDB credentials are set via environment variables,

--- a/server/internal/api/core_compatibility_test.go
+++ b/server/internal/api/core_compatibility_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCoreCompatibility_AdminOnly(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	// Non-admin user should be rejected
+	userToken := createNonOwnerUser(t, router, ownerToken, "regular", "regular@test.com", "password123")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/core-compatibility", nil)
+	req.Header.Set("Authorization", "Bearer "+userToken)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestGetCoreCompatibility_ReturnsConsoles(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/core-compatibility", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var wrapper struct {
+		Consoles []CoreCompatibilityEntry `json:"consoles"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	result := wrapper.Consoles
+	assert.Greater(t, len(result), 0, "should return at least one console")
+
+	// Verify all entries have required fields
+	for _, entry := range result {
+		assert.NotEmpty(t, entry.ConsoleID, "consoleId should not be empty")
+		assert.NotEmpty(t, entry.ConsoleName, "consoleName should not be empty")
+	}
+}
+
+func TestGetCoreCompatibility_MatchedField(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/core-compatibility", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var wrapper struct {
+		Consoles []CoreCompatibilityEntry `json:"consoles"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	result := wrapper.Consoles
+
+	// Find NES (should match: nestopia/nestopia)
+	var nes *CoreCompatibilityEntry
+	// Find NDS (should NOT match: desmume/melonds)
+	var nds *CoreCompatibilityEntry
+	for i := range result {
+		if result[i].ConsoleID == "nes" {
+			nes = &result[i]
+		}
+		if result[i].ConsoleID == "nds" {
+			nds = &result[i]
+		}
+	}
+
+	require.NotNil(t, nes, "NES should be present")
+	assert.Equal(t, "nestopia", nes.NativeCore)
+	assert.Equal(t, "nestopia", nes.WebCore)
+	assert.True(t, nes.Matched, "NES cores should match")
+
+	require.NotNil(t, nds, "NDS should be present")
+	assert.Equal(t, "desmume", nds.NativeCore)
+	assert.Equal(t, "melonds", nds.WebCore)
+	assert.False(t, nds.Matched, "NDS cores should not match")
+}
+
+func TestGetCoreCompatibility_NonPlayableConsolesIncluded(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/core-compatibility", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var wrapper struct {
+		Consoles []CoreCompatibilityEntry `json:"consoles"`
+	}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &wrapper))
+	result := wrapper.Consoles
+
+	// Non-playable consoles (e.g., PS3) should be included and show empty cores with matched=true
+	var ps3 *CoreCompatibilityEntry
+	for i := range result {
+		if result[i].ConsoleID == "ps3" {
+			ps3 = &result[i]
+		}
+	}
+	require.NotNil(t, ps3, "PS3 should be present")
+	assert.Empty(t, ps3.NativeCore)
+	assert.Empty(t, ps3.WebCore)
+	assert.True(t, ps3.Matched, "empty cores should match (both empty)")
+}

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -510,6 +510,7 @@ type SharedSessionResponse struct {
 	ActiveUserID   *string    `json:"activeUserId"`
 	ActiveUsername string     `json:"activeUsername,omitempty"`
 	TurnTakenAt    *time.Time `json:"turnTakenAt"`
+	CoreName       string     `json:"coreName,omitempty"`
 	MemberCount    int        `json:"memberCount"`
 	SessionID      *string    `json:"sessionId,omitempty"`
 	CreatedAt      time.Time  `json:"createdAt"`
@@ -697,6 +698,8 @@ type SessionSaveResponse struct {
 	IsAuto        bool      `json:"isAuto"`
 	IsCurrent     bool      `json:"isCurrent"`
 	CoreName      string    `json:"coreName,omitempty"`
+	CoreMatch     *bool     `json:"coreMatch,omitempty"`
+	CurrentCore   string    `json:"currentCore,omitempty"`
 	Notes         string    `json:"notes,omitempty"`
 	Slot          *int      `json:"slot,omitempty"`
 	CreatedAt     time.Time `json:"createdAt"`

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -446,6 +446,7 @@ func NewRouter(cfg Config) *gin.Engine {
 			admin.PUT("/games/:id/verification-tag", gameHandler.UpdateVerificationTag)
 			admin.POST("/cheats/import", adminHandler.TriggerCheatImport)
 			admin.GET("/cheats/stats", adminHandler.GetCheatStats)
+			admin.GET("/core-compatibility", adminHandler.GetCoreCompatibility)
 
 			// ROM uploads
 			admin.POST("/uploads", uploadHandler.UploadROMs)

--- a/server/internal/api/session_handler.go
+++ b/server/internal/api/session_handler.go
@@ -490,9 +490,11 @@ func (h *SessionHandler) ListSessionSaves(c *gin.Context) {
 		return
 	}
 
+	currentCore := h.getRecommendedCoreName(session.GameID)
+
 	result := make([]SessionSaveResponse, len(saves))
 	for i, s := range saves {
-		result[i] = h.toSaveResponse(s)
+		result[i] = h.toSaveResponse(s, currentCore)
 	}
 
 	c.JSON(http.StatusOK, result)
@@ -570,7 +572,7 @@ func (h *SessionHandler) UploadSessionSave(c *gin.Context) {
 	h.DB.Model(&session).Updates(updates)
 
 	h.DB.Preload("User").First(&save, save.ID)
-	c.JSON(http.StatusCreated, h.toSaveResponse(save))
+	c.JSON(http.StatusCreated, h.toSaveResponse(save, h.getRecommendedCoreName(session.GameID)))
 }
 
 // DownloadSessionSave serves a session save state file.
@@ -669,7 +671,7 @@ func (h *SessionHandler) UpdateSessionSave(c *gin.Context) {
 	}
 
 	h.DB.Preload("User").First(&save, save.ID)
-	c.JSON(http.StatusOK, h.toSaveResponse(save))
+	c.JSON(http.StatusOK, h.toSaveResponse(save, h.getRecommendedCoreName(session.GameID)))
 }
 
 // UploadAutoSave uploads an auto-save to a session.
@@ -757,7 +759,7 @@ func (h *SessionHandler) UploadAutoSave(c *gin.Context) {
 	h.DB.Model(&session).Updates(updates)
 
 	h.DB.Preload("User").First(&save, save.ID)
-	c.JSON(http.StatusCreated, h.toSaveResponse(save))
+	c.JSON(http.StatusCreated, h.toSaveResponse(save, h.getRecommendedCoreName(session.GameID)))
 }
 
 // GetAutoSave returns the latest auto-save for a session.
@@ -868,7 +870,7 @@ func (h *SessionHandler) UpsertSlotSave(c *gin.Context) {
 	h.DB.Model(&session).Updates(updates)
 
 	h.DB.Preload("User").First(&save, save.ID)
-	c.JSON(http.StatusOK, h.toSaveResponse(save))
+	c.JSON(http.StatusOK, h.toSaveResponse(save, h.getRecommendedCoreName(session.GameID)))
 }
 
 // DownloadSlotSave downloads the save from a specific slot.
@@ -920,9 +922,11 @@ func (h *SessionHandler) ListSlotSaves(c *gin.Context) {
 		return
 	}
 
+	currentCore := h.getRecommendedCoreName(session.GameID)
+
 	result := make([]SessionSaveResponse, len(saves))
 	for i, s := range saves {
-		result[i] = h.toSaveResponse(s)
+		result[i] = h.toSaveResponse(s, currentCore)
 	}
 
 	c.JSON(http.StatusOK, result)
@@ -1230,8 +1234,8 @@ func (h *SessionHandler) resolveLastPlayedByUsernames(sessions []db.GameSession)
 	return result
 }
 
-func (h *SessionHandler) toSaveResponse(s db.SessionSaveState) SessionSaveResponse {
-	return SessionSaveResponse{
+func (h *SessionHandler) toSaveResponse(s db.SessionSaveState, currentCore string) SessionSaveResponse {
+	resp := SessionSaveResponse{
 		ID:            strconv.FormatUint(uint64(s.ID), 10),
 		SessionID:     strconv.FormatUint(uint64(s.SessionID), 10),
 		UserID:        strconv.FormatUint(uint64(s.UserID), 10),
@@ -1247,6 +1251,27 @@ func (h *SessionHandler) toSaveResponse(s db.SessionSaveState) SessionSaveRespon
 		CreatedAt:     s.CreatedAt,
 		UpdatedAt:     s.UpdatedAt,
 	}
+	if currentCore != "" {
+		resp.CurrentCore = currentCore
+		if s.CoreName != "" {
+			match := s.CoreName == currentCore
+			resp.CoreMatch = &match
+		}
+	}
+	return resp
+}
+
+// getRecommendedCoreName returns the recommended core name for a game,
+// considering the game's core override and the console's default core.
+func (h *SessionHandler) getRecommendedCoreName(gameID uint) string {
+	var game db.Game
+	if err := h.DB.Preload("Console").First(&game, gameID).Error; err != nil {
+		return ""
+	}
+	if game.CoreOverride != "" {
+		return game.CoreOverride
+	}
+	return game.Console.DefaultCore
 }
 
 // enrichWithSharedSessionData looks up whether a session backs a shared session

--- a/server/internal/api/session_handler_test.go
+++ b/server/internal/api/session_handler_test.go
@@ -1361,3 +1361,128 @@ func TestDuplicateSession_SharedSessionMember(t *testing.T) {
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.Contains(t, resp["name"], "(Copy)")
 }
+
+// --- Core Match Tests ---
+
+func uploadSessionSaveWithCore(t *testing.T, router http.Handler, token, sessionID, name, coreName string, data []byte) map[string]interface{} {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	writer.WriteField("name", name)
+	if coreName != "" {
+		writer.WriteField("coreName", coreName)
+	}
+	part, _ := writer.CreateFormFile("save", "state.sav")
+	part.Write(data)
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/saves", &buf)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "upload save failed: %s", w.Body.String())
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	return resp
+}
+
+func TestSaveResponse_CoreMatch_Matching(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	// The default console from setupSessionTestEnv is NES with DefaultCore "nestopia"
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Upload save with matching core name
+	resp := uploadSessionSaveWithCore(t, env.router, env.token, sessionID, "Save 1", "nestopia", []byte("data"))
+
+	assert.Equal(t, "nestopia", resp["coreName"])
+	assert.Equal(t, "nestopia", resp["currentCore"])
+	assert.Equal(t, true, resp["coreMatch"])
+}
+
+func TestSaveResponse_CoreMatch_Mismatched(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Upload save with a different core name
+	resp := uploadSessionSaveWithCore(t, env.router, env.token, sessionID, "Save 1", "fceux", []byte("data"))
+
+	assert.Equal(t, "fceux", resp["coreName"])
+	assert.Equal(t, "nestopia", resp["currentCore"])
+	assert.Equal(t, false, resp["coreMatch"])
+}
+
+func TestSaveResponse_CoreMatch_NoCoreName(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Upload save without core name
+	resp := uploadSessionSaveWithCore(t, env.router, env.token, sessionID, "Save 1", "", []byte("data"))
+
+	assert.Empty(t, resp["coreName"])
+	assert.Equal(t, "nestopia", resp["currentCore"])
+	// coreMatch should be nil (omitted) when save has no core name
+	assert.Nil(t, resp["coreMatch"])
+}
+
+func TestSaveResponse_CoreMatch_WithCoreOverride(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	// Set a core override on the game
+	env.database.Model(&db.Game{}).Where("id = ?", env.gameID).Update("core_override", "fceux")
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "Override Session")
+	sessionID := created["id"].(string)
+
+	// Upload save with the override core - should match
+	resp := uploadSessionSaveWithCore(t, env.router, env.token, sessionID, "Save 1", "fceux", []byte("data"))
+
+	assert.Equal(t, "fceux", resp["coreName"])
+	assert.Equal(t, "fceux", resp["currentCore"])
+	assert.Equal(t, true, resp["coreMatch"])
+
+	// Upload save with the default core - should NOT match because override takes priority
+	resp2 := uploadSessionSaveWithCore(t, env.router, env.token, sessionID, "Save 2", "nestopia", []byte("data2"))
+
+	assert.Equal(t, "nestopia", resp2["coreName"])
+	assert.Equal(t, "fceux", resp2["currentCore"])
+	assert.Equal(t, false, resp2["coreMatch"])
+}
+
+func TestListSessionSaves_IncludesCoreMatch(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "My Session")
+	sessionID := created["id"].(string)
+
+	// Upload saves with different cores
+	uploadSessionSaveWithCore(t, env.router, env.token, sessionID, "Matching", "nestopia", []byte("data1"))
+	uploadSessionSaveWithCore(t, env.router, env.token, sessionID, "Mismatched", "fceux", []byte("data2"))
+
+	// List saves
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/sessions/"+sessionID+"/saves", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var saves []map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &saves)
+	require.Len(t, saves, 2)
+
+	for _, save := range saves {
+		assert.Equal(t, "nestopia", save["currentCore"])
+		if save["coreName"] == "nestopia" {
+			assert.Equal(t, true, save["coreMatch"])
+		} else {
+			assert.Equal(t, false, save["coreMatch"])
+		}
+	}
+}

--- a/server/internal/api/shared_session_handler.go
+++ b/server/internal/api/shared_session_handler.go
@@ -46,18 +46,25 @@ func (h *SharedSessionHandler) CreateSharedSession(c *gin.Context) {
 		return
 	}
 
-	// Verify game exists
+	// Verify game exists and load console for core resolution
 	var game db.Game
-	if err := h.DB.First(&game, gid).Error; err != nil {
+	if err := h.DB.Preload("Console").First(&game, gid).Error; err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "game not found"})
 		return
 	}
 
+	// Determine the recommended core name for this game
+	coreName := game.CoreOverride
+	if coreName == "" {
+		coreName = game.Console.DefaultCore
+	}
+
 	// Create a GameSession to back this shared session
 	session := db.GameSession{
-		OwnerID: uid,
-		GameID:  uint(gid),
-		Name:    "Shared Session: " + req.Name,
+		OwnerID:  uid,
+		GameID:   uint(gid),
+		Name:     "Shared Session: " + req.Name,
+		CoreName: coreName,
 	}
 	if err := h.DB.Create(&session).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create session for shared session"})
@@ -69,6 +76,7 @@ func (h *SharedSessionHandler) CreateSharedSession(c *gin.Context) {
 		GameID:    uint(gid),
 		Name:      req.Name,
 		Status:    "active",
+		CoreName:  coreName,
 		SessionID: &session.ID,
 	}
 	if err := h.DB.Create(&ss).Error; err != nil {
@@ -1091,6 +1099,7 @@ func (h *SharedSessionHandler) toSharedSessionResponse(r db.SharedSession) Share
 		ActiveUserID:   uintPtrToStringPtr(r.ActiveUserID),
 		ActiveUsername: activeUsername,
 		TurnTakenAt:    r.TurnTakenAt,
+		CoreName:       r.CoreName,
 		MemberCount:    len(r.Members),
 		SessionID:      uintPtrToStringPtr(r.SessionID),
 		CreatedAt:      r.CreatedAt,

--- a/server/internal/api/shared_session_handler_test.go
+++ b/server/internal/api/shared_session_handler_test.go
@@ -1781,3 +1781,65 @@ func TestSharedSession_SessionTurnValidation_CannotUploadWithoutTurn(t *testing.
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusForbidden, w.Code, "session owner should be blocked when shared session turn is held by another user")
 }
+
+// --- Core Name Tests ---
+
+func TestSharedSession_Create_IncludesCoreName(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	// Create a game on NES (DefaultCore = "nestopia")
+	var console db.Console
+	database.Where("abbreviation = ?", "NES").First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "NES Game", FileName: "test.nes", FilePath: "/tmp/core_test.nes", FileSize: 100}
+	database.Create(&game)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	resp := createSharedSession(t, router, token, gameID, "Core Test Session")
+
+	assert.Equal(t, "nestopia", resp["coreName"], "shared session should include the recommended core name")
+}
+
+func TestSharedSession_Create_UsesGameCoreOverride(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	// Create a game on NES with a core override
+	var console db.Console
+	database.Where("abbreviation = ?", "NES").First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Override NES Game", FileName: "override.nes", FilePath: "/tmp/override_test.nes", FileSize: 100, CoreOverride: "fceux"}
+	database.Create(&game)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	resp := createSharedSession(t, router, token, gameID, "Override Core Session")
+
+	assert.Equal(t, "fceux", resp["coreName"], "shared session should use the game's core override")
+}
+
+func TestSharedSession_GetDetail_IncludesCoreName(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	var console db.Console
+	database.Where("abbreviation = ?", "SNES").First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "SNES Game", FileName: "test.sfc", FilePath: "/tmp/snes_core.sfc", FileSize: 100}
+	database.Create(&game)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	created := createSharedSession(t, router, token, gameID, "SNES Session")
+	sharedSessionID := created["id"].(string)
+
+	// GET detail
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/shared-sessions/"+sharedSessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var detail map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &detail)
+	assert.Equal(t, "snes9x", detail["coreName"])
+}

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -373,6 +373,7 @@ type SharedSession struct {
 	ActiveUserID *uint                  `json:"activeUserId,omitempty"`
 	TurnToken    string                 `gorm:"size:64" json:"-"`
 	TurnTakenAt  *time.Time             `json:"turnTakenAt,omitempty"`
+	CoreName     string                 `gorm:"size:128" json:"coreName,omitempty"`
 	SessionID    *uint                  `gorm:"index" json:"sessionId"`
 	Session      *GameSession           `json:"-"`
 	Members      []SharedSessionMember  `gorm:"foreignKey:SharedSessionID" json:"members,omitempty"`

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -19,6 +19,7 @@ import { AdminScanPage } from "@/pages/admin/scan-page";
 import { MetadataFixPage } from "@/pages/admin/metadata-fix-page";
 import { AdminCheatsPage } from "@/pages/admin/cheats-page";
 import { AdminBiosPage } from "@/pages/admin/bios-page";
+import { CoreCompatibilityPage } from "@/pages/admin/core-compatibility-page";
 import { UploadRomsPage } from "@/pages/admin/upload-roms-page";
 import { PreferencesPage } from "@/pages/preferences-page";
 import { PlayPage } from "@/pages/play-page";
@@ -171,6 +172,14 @@ export function App() {
                       element={
                         <ProtectedRoute requireAdmin>
                           <AdminCheatsPage />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="admin/core-compatibility"
+                      element={
+                        <ProtectedRoute requireAdmin>
+                          <CoreCompatibilityPage />
                         </ProtectedRoute>
                       }
                     />

--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -18,6 +18,7 @@ import {
   Menu,
   Trophy,
   Gamepad2,
+  GitCompareArrows,
 } from "lucide-react";
 import { Sidebar } from "@/components/ui";
 import { useAuth } from "@/hooks/use-auth";
@@ -124,6 +125,11 @@ export function AppLayout() {
                 label: "Metadata Fix",
               },
               { to: "/admin/cheats", icon: Gamepad2, label: "Cheats" },
+              {
+                to: "/admin/core-compatibility",
+                icon: GitCompareArrows,
+                label: "Core Compatibility",
+              },
             ],
           },
         ]

--- a/web/src/features/play/components/core-mismatch-modal.tsx
+++ b/web/src/features/play/components/core-mismatch-modal.tsx
@@ -1,0 +1,61 @@
+import { AlertTriangle } from "lucide-react";
+import { Modal, Button } from "@/components/ui";
+
+export type CoreMismatchChoice = "try-loading" | "sram-only" | "fresh";
+
+interface CoreMismatchModalProps {
+  open: boolean;
+  onChoice: (choice: CoreMismatchChoice) => void;
+}
+
+export function CoreMismatchModal({ open, onChoice }: CoreMismatchModalProps) {
+  return (
+    <Modal
+      open={open}
+      onClose={() => onChoice("sram-only")}
+      title="Save State Compatibility Warning"
+    >
+      <div className="space-y-4">
+        <div className="flex items-start gap-3">
+          <AlertTriangle className="h-6 w-6 text-warning-500 flex-shrink-0 mt-0.5" />
+          <p className="text-sm text-surface-300">
+            Your last save state was created with a different emulator
+            configuration. It may not load correctly on this platform.
+          </p>
+        </div>
+
+        <div className="pt-2">
+          <div className="space-y-1">
+            <Button
+              variant="primary"
+              className="w-full justify-center"
+              onClick={() => onChoice("sram-only")}
+            >
+              Start with Game Save Only
+            </Button>
+            <p className="text-xs text-surface-500 text-center px-4">
+              Loads your in-game progress (battery save) but skips the save state.
+              The game starts from the title screen.
+            </p>
+          </div>
+          <div className="mt-4 space-y-2">
+            <Button
+              variant="secondary"
+              className="w-full justify-center"
+              onClick={() => onChoice("try-loading")}
+            >
+              Try Loading Anyway
+            </Button>
+            <Button
+              variant="ghost"
+              className="w-full justify-center"
+              onClick={() => onChoice("fresh")}
+            >
+              Start Fresh
+            </Button>
+          </div>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -7,6 +7,7 @@ import type {
   MetadataMatchesResponse,
   IgdbSearchResult,
   RateLimitStatus,
+  CoreCompatibilityResponse,
 } from "@/types/api";
 
 export function useAdminUsers() {
@@ -341,5 +342,13 @@ export function useResetRateLimit() {
         queryKey: ["admin", "users", userId, "rate-limit"],
       });
     },
+  });
+}
+
+export function useCoreCompatibility() {
+  return useQuery({
+    queryKey: ["admin", "core-compatibility"],
+    queryFn: () =>
+      api.get<CoreCompatibilityResponse>("/admin/core-compatibility"),
   });
 }

--- a/web/src/hooks/use-sessions.ts
+++ b/web/src/hooks/use-sessions.ts
@@ -1,6 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
-import type { GameSession, SessionSave, SessionCheatConfig } from "@/types/api";
+import type {
+  GameSession,
+  SessionSave,
+  SessionCheatConfig,
+} from "@/types/api";
 
 export function useGameSessions(gameId: string) {
   return useQuery({
@@ -132,6 +136,16 @@ export function useDeleteSessionSave() {
         queryKey: ["session-saves", sessionId],
       });
     },
+  });
+}
+
+/** Fetch the latest auto-save metadata (not the file) to check core compatibility. */
+export function useAutoSaveInfo(sessionId: string | undefined) {
+  return useQuery({
+    queryKey: ["session-saves", sessionId],
+    queryFn: () => api.get<SessionSave[]>(`/sessions/${sessionId}/saves`),
+    enabled: !!sessionId,
+    select: (saves) => saves.find((s) => s.isAuto) ?? null,
   });
 }
 

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -142,6 +142,7 @@ export type ApiGetPath = WithQuery<
   | "/admin/igdb/status"
   | "/admin/cheats/stats"
   | "/admin/uploads"
+  | "/admin/core-compatibility"
 
   // WebSocket
   | "/ws"

--- a/web/src/pages/admin/core-compatibility-page.tsx
+++ b/web/src/pages/admin/core-compatibility-page.tsx
@@ -1,0 +1,125 @@
+import { AlertTriangle, CheckCircle2, Cpu } from "lucide-react";
+import { Card, CardHeader, CardContent, Skeleton, Badge } from "@/components/ui";
+import { useCoreCompatibility } from "@/hooks/use-admin";
+
+export function CoreCompatibilityPage() {
+  const { data, isLoading, isError } = useCoreCompatibility();
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6 max-w-3xl">
+        <Skeleton className="h-8 w-48" />
+        <Skeleton className="h-64 w-full rounded-2xl" />
+      </div>
+    );
+  }
+
+  const consoles = data?.consoles ?? [];
+  const mismatchCount = consoles.filter((c) => !c.matched).length;
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <div>
+        <h1 className="text-3xl font-bold text-surface-100">
+          Core Compatibility
+        </h1>
+        <p className="mt-1 text-surface-400">
+          Compare emulator cores used on native devices versus the web browser.
+          Mismatched cores mean save states are not portable between platforms.
+        </p>
+      </div>
+
+      {mismatchCount > 0 && (
+        <div className="flex items-start gap-3 rounded-xl border border-warning-500/30 bg-warning-500/10 px-4 py-3">
+          <AlertTriangle className="h-5 w-5 text-warning-500 flex-shrink-0 mt-0.5" />
+          <p className="text-sm text-warning-400">
+            {mismatchCount} console{mismatchCount !== 1 ? "s" : ""} ha
+            {mismatchCount !== 1 ? "ve" : "s"} different cores for native and
+            web play. Save states created on one platform may not work on the
+            other.
+          </p>
+        </div>
+      )}
+
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+            <Cpu className="h-5 w-5 text-brand-400" />
+            Consoles
+          </h2>
+        </CardHeader>
+        <CardContent>
+          {isError ? (
+            <p className="text-sm text-danger-500">
+              Failed to load core compatibility data.
+            </p>
+          ) : consoles.length === 0 ? (
+            <p className="text-sm text-surface-400">
+              No console data available.
+            </p>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b border-surface-800 text-left">
+                    <th className="py-2 pr-4 font-medium text-surface-400">
+                      Console
+                    </th>
+                    <th className="py-2 pr-4 font-medium text-surface-400">
+                      Native Core
+                    </th>
+                    <th className="py-2 pr-4 font-medium text-surface-400">
+                      Web Core
+                    </th>
+                    <th className="py-2 font-medium text-surface-400">
+                      Status
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {consoles.map((entry) => (
+                    <tr
+                      key={entry.consoleId}
+                      className={
+                        !entry.matched
+                          ? "bg-warning-500/5"
+                          : "hover:bg-surface-800/30"
+                      }
+                    >
+                      <td className="py-2.5 pr-4 text-surface-100 font-medium">
+                        {entry.consoleName}
+                      </td>
+                      <td className="py-2.5 pr-4 text-surface-300 font-mono text-xs">
+                        {entry.nativeCore || (
+                          <span className="text-surface-500 italic">none</span>
+                        )}
+                      </td>
+                      <td className="py-2.5 pr-4 text-surface-300 font-mono text-xs">
+                        {entry.webCore || (
+                          <span className="text-surface-500 italic">none</span>
+                        )}
+                      </td>
+                      <td className="py-2.5">
+                        {entry.matched ? (
+                          <Badge variant="success">
+                            <CheckCircle2 className="h-3 w-3 mr-1" />
+                            Matched
+                          </Badge>
+                        ) : (
+                          <Badge variant="warning">
+                            <AlertTriangle className="h-3 w-3 mr-1" />
+                            Mismatched
+                          </Badge>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -14,11 +14,16 @@ import { usePlaySession } from "@/hooks/use-play-session";
 import { useFullscreen } from "@/hooks/use-fullscreen";
 import { useToast } from "@/components/ui";
 import { useGamepadConnected } from "@/hooks/use-gamepad";
+import { useAutoSaveInfo } from "@/hooks/use-sessions";
 import { useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
 import { toEmulatorJsShader } from "@/lib/shader-mapping";
 import { PlayToolbar } from "@/features/play/components/play-toolbar";
 import { EmulatorOverlay } from "@/features/play/components/emulator-overlay";
+import {
+  CoreMismatchModal,
+  type CoreMismatchChoice,
+} from "@/features/play/components/core-mismatch-modal";
 import type { EmulatorPreferences } from "@/lib/emulator-protocol";
 import type { GameSession } from "@/types/api";
 
@@ -61,10 +66,16 @@ export function PlayPage() {
       .filter((f) => f.status === "missing" && f.required)
       .map((f) => f.fileName) ?? [];
 
+  const { data: autoSaveInfo } = useAutoSaveInfo(
+    !isFreshStart ? sessionId : undefined,
+  );
+
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const [isExitSaving, setIsExitSaving] = useState(false);
   const [isSwitchingDisc, setIsSwitchingDisc] = useState(false);
   const [currentDisc, setCurrentDisc] = useState(1);
+  const [showCoreMismatchModal, setShowCoreMismatchModal] = useState(false);
+  const coreMismatchChoiceRef = useRef<CoreMismatchChoice | null>(null);
   const sessionStartRef = useRef<number>(Date.now());
   const pendingDiscSwitchRef = useRef<{
     targetDisc: number; // 0-indexed for EmulatorJS
@@ -234,6 +245,17 @@ export function PlayPage() {
 
     // Normal initialization flow
     async function init() {
+      // Check for core mismatch before loading the auto-save
+      if (
+        !isFreshStart &&
+        autoSaveInfo &&
+        autoSaveInfo.coreMatch === false &&
+        !coreMismatchChoiceRef.current
+      ) {
+        setShowCoreMismatchModal(true);
+        return; // Wait for user choice — will re-enter after choice is made
+      }
+
       const token = api.getAccessToken();
       const tokenSuffix = token
         ? `?token=${encodeURIComponent(token)}`
@@ -247,7 +269,13 @@ export function PlayPage() {
       const romUrl = isMultiDisc
         ? `/api/games/${game!.id}/discs/1/download?format=zip${token ? `&token=${encodeURIComponent(token)}` : ""}`
         : `/api/games/${game!.id}/download${tokenSuffix}`;
-      const saveStateData = await saveManager.loadInitialSave(isFreshStart);
+
+      // Determine whether to load the save state based on user choice
+      const choice = coreMismatchChoiceRef.current;
+      const skipSaveState = choice === "fresh" || choice === "sram-only";
+      const saveStateData = await saveManager.loadInitialSave(
+        isFreshStart || skipSaveState,
+      );
 
       // Build authenticated BIOS file URLs
       const biosUrls =
@@ -268,7 +296,8 @@ export function PlayPage() {
     }
 
     init();
-  }, [iframeLoaded, game?.id, isSupported, emulatorJsCore]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [iframeLoaded, game?.id, isSupported, emulatorJsCore, autoSaveInfo]);
 
   async function handleBack() {
     if (isExitSaving) return;
@@ -285,6 +314,21 @@ export function PlayPage() {
     queryClient.invalidateQueries({ queryKey: ["game-sessions"] });
     navigate(-1);
   }
+
+  const handleCoreMismatchChoice = useCallback(
+    (choice: CoreMismatchChoice) => {
+      coreMismatchChoiceRef.current = choice;
+      setShowCoreMismatchModal(false);
+      // Re-trigger init by toggling iframeLoaded — the init useEffect will
+      // re-run and use the stored choice.
+      setIframeLoaded(false);
+      const iframe = emulator.iframeRef.current;
+      if (iframe) {
+        iframe.src = "/emulator.html";
+      }
+    },
+    [emulator.iframeRef],
+  );
 
   // ── Loading state ─────────────────────────────────────────────────
 
@@ -340,6 +384,11 @@ export function PlayPage() {
 
   return (
     <div className="flex flex-col h-screen">
+      <CoreMismatchModal
+        open={showCoreMismatchModal}
+        onChoice={handleCoreMismatchChoice}
+      />
+
       <PlayToolbar
         game={game}
         emulatorStatus={emulator.status}

--- a/web/src/pages/session-detail-page.tsx
+++ b/web/src/pages/session-detail-page.tsx
@@ -9,6 +9,7 @@ import {
   Zap,
   Layers,
   Save,
+  AlertTriangle,
 } from "lucide-react";
 import {
   Button,
@@ -291,6 +292,15 @@ export function SessionDetailPage() {
                       <Badge variant="success" className="ml-2">
                         Current
                       </Badge>
+                    )}
+                    {save.coreMatch === false && (
+                      <span
+                        className="inline-flex items-center ml-2"
+                        title="This save state was created with a different emulator core and may not load correctly"
+                        aria-label="Core mismatch warning"
+                      >
+                        <AlertTriangle className="h-3.5 w-3.5 text-warning-500" />
+                      </span>
                     )}
                   </p>
                   <p className="text-xs text-surface-500">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -660,9 +660,23 @@ export interface SessionSave {
   isAuto: boolean;
   isCurrent: boolean;
   coreName: string | null;
+  coreMatch: boolean | null;
+  currentCore: string | null;
   notes: string | null;
   slot: number | null;
   createdAt: string;
+}
+
+export interface CoreCompatibilityEntry {
+  consoleId: string;
+  consoleName: string;
+  nativeCore: string;
+  webCore: string;
+  matched: boolean;
+}
+
+export interface CoreCompatibilityResponse {
+  consoles: CoreCompatibilityEntry[];
 }
 
 export interface SessionCheatConfig {


### PR DESCRIPTION
## Summary
- Adds core compatibility tracking to save states across all three components (server, web, player app)
- When a save state was created with a different emulator core than what the current platform uses, users are warned and given options: load SRAM only (safe), try loading anyway (risky), or start fresh
- Fixes critical bug where the player app tracked `coreName` locally but never sent it with save uploads — save states in the DB had empty core names
- New admin page showing which consoles have different cores between native and web platforms (9 out of 35 have mismatches)

## Changes

### Server
- `coreMatch` (bool) and `currentCore` (string) fields on save state API responses
- `GET /api/admin/core-compatibility` endpoint for admin visibility
- `CoreName` field on `SharedSession` model
- 12 new tests covering core match logic, admin endpoint, and shared sessions

### Web
- Core mismatch warning modal on play page with three clear options
- Warning icons on save states in session detail when core doesn't match
- Admin "Core Compatibility" page with per-console native vs web core comparison
- Accessible, user-friendly language — no technical jargon in user-facing UI

### Player (KMP)
- `SaveManager` now sends `coreName` with all save/SRAM uploads (critical bug fix)
- Core mismatch detection before auto-loading save states
- `CoreMismatchDialog` with bold core names and three action options
- `forceAutoLoadSaveState` returns success/failure for proper feedback
- "Start Fresh" clears SRAM via `setSRAM(ByteArray(0))`

## Test plan
- [ ] All Go tests pass (12 new tests for core compat)
- [ ] All 725 web unit tests pass
- [ ] All 818 player desktop tests pass (414 shared + 404 desktop)
- [ ] TypeScript compiles cleanly
- [ ] Player compiles for both desktop and Android
- [ ] Manual: play a game on web, verify save state uploads include core name
- [ ] Manual: create a save state, change core override in admin, reload — verify warning modal appears
- [ ] Manual: verify admin Core Compatibility page shows mismatched consoles