### PR TITLE
feat: add Linux transparent title bar, fix CI build with JBR

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: jetbrains
           java-version: 17
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -216,7 +216,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: jetbrains
           java-version: 17
       - name: Install dependencies
         run: |
@@ -254,7 +254,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: jetbrains
           java-version: 17
       - name: Install dependencies
         run: |
@@ -300,7 +300,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: jetbrains
           java-version: 17
       - uses: android-actions/setup-android@v3
         with:

--- a/player/desktop/build.gradle.kts
+++ b/player/desktop/build.gradle.kts
@@ -132,12 +132,7 @@ compose.desktop {
         // interpretation in the jpackage .cfg file on Windows.
         jvmArgs += "-Djava.library.path=${nativeBuildDir.get().asFile.absolutePath.replace('\\', '/')}"
 
-        // Windows: AWT peer reflection + JDK FFM for transparent title bar
-        if (org.gradle.internal.os.OperatingSystem.current().isWindows) {
-            jvmArgs += "--add-opens=java.desktop/java.awt=ALL-UNNAMED"
-            jvmArgs += "--add-opens=java.desktop/sun.awt.windows=ALL-UNNAMED"
-            jvmArgs += "--enable-native-access=ALL-UNNAMED"
-        }
+        // JBR custom title bar doesn't need --add-opens; no FFM fallback.
 
         nativeDistributions {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)

--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/Main.kt
@@ -21,11 +21,6 @@ import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.NavigationViewModel
 import com.spela.player.presentation.viewmodel.EmulationViewModel
-import java.lang.foreign.Arena
-import java.lang.foreign.FunctionDescriptor
-import java.lang.foreign.Linker
-import java.lang.foreign.SymbolLookup
-import java.lang.foreign.ValueLayout
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
@@ -35,6 +30,7 @@ import org.koin.java.KoinJavaComponent.getKoin
 
 private val isMacOS = System.getProperty("os.name").orEmpty().contains("Mac", ignoreCase = true)
 private val isWindows = System.getProperty("os.name").orEmpty().contains("Windows", ignoreCase = true)
+private val isLinux = System.getProperty("os.name").orEmpty().contains("Linux", ignoreCase = true)
 
 fun main(args: Array<String>) {
     val autoStartGameId = args.indexOf("--game").let { idx ->
@@ -91,22 +87,23 @@ fun main(args: Array<String>) {
             }
         }
 
-        // Windows: transparent title bar matching the macOS appearance.
-        // On JBR (packaged MSI): uses JetBrains custom title bar API.
-        // On standard JDKs (dev): falls back to DWM via JDK 21 FFM API.
-        if (isWindows) {
+        // Windows / Linux: transparent title bar matching the macOS appearance.
+        // Uses JetBrains Runtime (JBR) custom title bar API when available
+        // (always present in packaged distributions). Gracefully degrades
+        // to standard title bar on other JDKs (dev mode).
+        if (isWindows || isLinux) {
             LaunchedEffect(Unit) {
-                applyWindowsTransparentTitleBar(window)
+                applyJbrTransparentTitleBar(window)
             }
         }
 
-        // On macOS, provide the title bar inset so SpTopBar and floating-bar screens
-        // can offset their content below the native traffic light buttons.
+        // Provide the title bar inset so SpTopBar and floating-bar screens
+        // can offset their content below the native window controls.
         // The app's background/gradient extends to the top of the window, showing
         // through the transparent title bar.
         val titleBarInset = when {
             isMacOS -> 28.dp
-            isWindows -> 32.dp
+            (isWindows || isLinux) && isJbrTitleBarActive -> 32.dp
             else -> 0.dp
         }
         CompositionLocalProvider(LocalTitleBarInset provides titleBarInset) {
@@ -127,52 +124,28 @@ fun main(args: Array<String>) {
     }
 }
 
-/** Apply transparent/dark title bar on Windows via JBR API or DWM fallback. */
-private fun applyWindowsTransparentTitleBar(window: java.awt.Window) {
-    // Try JBR custom title bar first (works on JetBrains Runtime bundled in MSI)
-    if (System.getProperty("java.vendor").orEmpty().contains("JetBrains", ignoreCase = true)) {
-        try {
-            val rootPane = (window as? javax.swing.JFrame)?.rootPane ?: return
-            rootPane.putClientProperty("jetbrains.awt.customTitleBar.enabled", true)
-            rootPane.putClientProperty("jetbrains.awt.transparentTitleBarAppearance", true)
-            val bg = java.awt.Color(10, 10, 16)
-            window.background = bg
-            rootPane.background = bg
-            window.contentPane.background = bg
-            return
-        } catch (_: Exception) { /* fall through to DWM */ }
+/** Track whether JBR title bar was successfully applied. */
+private var isJbrTitleBarActive = false
+
+/**
+ * Apply transparent title bar via JetBrains Runtime (JBR) custom title bar API.
+ * Works on Windows and Linux when the app is packaged with JBR (MSI, DEB, AppImage, Flatpak).
+ * Gracefully degrades to standard title bar on non-JBR JDKs (dev mode).
+ */
+private fun applyJbrTransparentTitleBar(window: java.awt.Window) {
+    if (!System.getProperty("java.vendor").orEmpty().contains("JetBrains", ignoreCase = true)) {
+        return
     }
-
-    // Fallback: DWM API via JDK 21 Foreign Function & Memory API
     try {
-        val peerField = java.awt.Component::class.java.getDeclaredField("peer")
-        peerField.isAccessible = true
-        val peer = peerField.get(window) ?: return
-        val hwnd = peer.javaClass.getMethod("getHWnd").invoke(peer) as Long
-
-        val linker = Linker.nativeLinker()
-        val dwm = SymbolLookup.libraryLookup("dwmapi.dll", Arena.global())
-        val dwmSetWindowAttribute = linker.downcallHandle(
-            dwm.find("DwmSetWindowAttribute").orElseThrow(),
-            FunctionDescriptor.of(
-                ValueLayout.JAVA_INT, ValueLayout.JAVA_LONG,
-                ValueLayout.JAVA_INT, ValueLayout.ADDRESS, ValueLayout.JAVA_INT,
-            ),
-        )
-
-        Arena.ofConfined().use { arena ->
-            // DWMWA_USE_IMMERSIVE_DARK_MODE (20) — light caption icons on dark bg
-            val trueVal = arena.allocate(ValueLayout.JAVA_INT, 1)
-            dwmSetWindowAttribute.invoke(hwnd, 20, trueVal, 4)
-            // DWMWA_SYSTEMBACKDROP_TYPE (38) — Mica material (value 2)
-            val mica = arena.allocate(ValueLayout.JAVA_INT, 2)
-            dwmSetWindowAttribute.invoke(hwnd, 38, mica, 4)
-        }
-
-        val bg = java.awt.Color(10, 10, 16)
+        val rootPane = (window as? javax.swing.JFrame)?.rootPane ?: return
+        rootPane.putClientProperty("jetbrains.awt.customTitleBar.enabled", true)
+        rootPane.putClientProperty("jetbrains.awt.transparentTitleBarAppearance", true)
+        val bg = java.awt.Color(10, 10, 16) // #0A0A10 — fallback before Compose renders
         window.background = bg
-    } catch (e: Exception) {
-        // Graceful degradation — standard title bar on older Windows
-        System.err.println("Windows transparent title bar: ${e.message}")
+        rootPane.background = bg
+        window.contentPane.background = bg
+        isJbrTitleBarActive = true
+    } catch (_: Exception) {
+        // Graceful degradation — standard title bar
     }
 }


### PR DESCRIPTION
## Summary
- Replace Java Foreign Function API (JDK 22+) DWM fallback with JetBrains Runtime custom title bar API (works on JDK 17)
- Switch desktop CI builds from Temurin to JBR so packaged apps get transparent title bars
- Add Linux transparent title bar support using the same JBR API as Windows
- Graceful degradation to standard title bar on non-JBR JDKs (dev mode)

## Test plan
- [x] `compileKotlinDesktop` succeeds locally on JDK 17
- [ ] CI builds pass (macOS, Windows, Linux DEB, AppImage, Flatpak, ARM64)