### PR TITLE
chore: upgrade build JDK from 17 to 21

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -12,11 +12,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Set up Android SDK
         uses: android-actions/setup-android@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Cache Gradle
         uses: actions/cache@v4
         with:

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -29,11 +29,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
@@ -87,11 +87,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Install Linux dependencies
         run: |
@@ -133,11 +133,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Install Linux dependencies
         run: |
@@ -152,7 +152,7 @@ jobs:
           sudo flatpak install -y --noninteractive flathub \
             org.freedesktop.Platform//24.08 \
             org.freedesktop.Sdk//24.08 \
-            org.freedesktop.Sdk.Extension.openjdk17//24.08
+            org.freedesktop.Sdk.Extension.openjdk21//24.08
 
       - name: Cache Gradle
         uses: actions/cache@v4
@@ -187,11 +187,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
 
       - name: Install Linux dependencies
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -105,7 +105,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 21
       - uses: android-actions/setup-android@v3
       - name: Cache Gradle
         uses: actions/cache@v4
@@ -164,7 +164,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: jetbrains
-          java-version: 17
+          java-version: 21
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
@@ -217,7 +217,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: jetbrains
-          java-version: 17
+          java-version: 21
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -255,7 +255,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: jetbrains
-          java-version: 17
+          java-version: 21
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -268,7 +268,7 @@ jobs:
           sudo flatpak install -y --noninteractive flathub \
             org.freedesktop.Platform//24.08 \
             org.freedesktop.Sdk//24.08 \
-            org.freedesktop.Sdk.Extension.openjdk17//24.08
+            org.freedesktop.Sdk.Extension.openjdk21//24.08
       - name: Cache Gradle
         uses: actions/cache@v4
         with:
@@ -301,7 +301,7 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: jetbrains
-          java-version: 17
+          java-version: 21
       - uses: android-actions/setup-android@v3
         with:
           packages: ''

--- a/player/linux/flatpak/com.spela.player.yml
+++ b/player/linux/flatpak/com.spela.player.yml
@@ -3,7 +3,7 @@ runtime: org.freedesktop.Platform
 runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
-  - org.freedesktop.Sdk.Extension.openjdk17
+  - org.freedesktop.Sdk.Extension.openjdk21
 command: spela
 
 finish-args:


### PR DESCRIPTION
## Summary
- Upgrade build JDK from 17 to 21 (current LTS) across all CI workflows
- Update Flatpak SDK extension from openjdk17 to openjdk21
- Android bytecode target stays at JVM_17 for compatibility

## Files changed
- `.github/workflows/ci.yml` — player-test JDK 17 → 21
- `.github/workflows/release.yml` — all 6 build jobs JDK 17 → 21, Flatpak extension openjdk17 → openjdk21
- `.github/workflows/desktop-build.yml` — all 4 build jobs JDK 17 → 21, Flatpak extension openjdk17 → openjdk21
- `.github/workflows/android-build.yml` — JDK 17 → 21
- `player/linux/flatpak/com.spela.player.yml` — openjdk17 → openjdk21

## Test plan
- [x] Local compilation passes with JDK 21
- [x] Desktop unit tests pass
- [ ] CI passes (player-test job compiles and runs tests with JDK 21)