### PR TITLE
fix: scrape match loading indicator + save screenshot 401

### DIFF
--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -561,20 +561,7 @@ func (h *ImageHandler) ServeImage(c *gin.Context) {
 
 	// Save screenshots require authentication and ownership check
 	if strings.HasPrefix(reqPath, "save-screenshots/") {
-		// Extract user_id from path pattern: save-screenshots/user_{id}/...
-		parts := strings.SplitN(reqPath, "/", 3)
-		if len(parts) < 2 || !strings.HasPrefix(parts[1], "user_") {
-			c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
-			return
-		}
-		pathUserIDStr := strings.TrimPrefix(parts[1], "user_")
-		pathUserID, err := strconv.ParseUint(pathUserIDStr, 10, 64)
-		if err != nil {
-			c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
-			return
-		}
-
-		// Require auth
+		// Require auth (token from header or query param)
 		var token string
 		header := c.GetHeader("Authorization")
 		if header != "" {
@@ -616,8 +603,38 @@ func (h *ImageHandler) ServeImage(c *gin.Context) {
 			return
 		}
 
-		// Only the owning user or an admin can access save screenshots
-		if uint64(claims.UserID) != pathUserID && claims.Role != "admin" && claims.Role != "owner" {
+		parts := strings.SplitN(reqPath, "/", 4)
+
+		// Legacy format: save-screenshots/user_{id}/...
+		if len(parts) >= 2 && strings.HasPrefix(parts[1], "user_") {
+			pathUserIDStr := strings.TrimPrefix(parts[1], "user_")
+			pathUserID, parseErr := strconv.ParseUint(pathUserIDStr, 10, 64)
+			if parseErr != nil {
+				c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+				return
+			}
+			if uint64(claims.UserID) != pathUserID && claims.Role != "admin" && claims.Role != "owner" {
+				c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+				return
+			}
+		} else if len(parts) >= 3 && parts[1] == "sessions" && strings.HasPrefix(parts[2], "session_") {
+			// Session format: save-screenshots/sessions/session_{id}/...
+			sessionIDStr := strings.TrimPrefix(parts[2], "session_")
+			sessionID, parseErr := strconv.ParseUint(sessionIDStr, 10, 64)
+			if parseErr != nil {
+				c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+				return
+			}
+			var session db.GameSession
+			if err := h.DB.Select("id", "owner_id").First(&session, sessionID).Error; err != nil {
+				c.JSON(http.StatusNotFound, gin.H{"error": "session not found"})
+				return
+			}
+			if uint64(claims.UserID) != uint64(session.OwnerID) && claims.Role != "admin" && claims.Role != "owner" {
+				c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+				return
+			}
+		} else {
 			c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
 			return
 		}

--- a/server/internal/api/session_handler_test.go
+++ b/server/internal/api/session_handler_test.go
@@ -1486,3 +1486,106 @@ func TestListSessionSaves_IncludesCoreMatch(t *testing.T) {
 		}
 	}
 }
+
+// --- Session Screenshot Image Serving ---
+
+func TestServeSessionScreenshot_OwnerCanAccess(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	// Create a session and upload a save with a screenshot
+	created := createGameSession(t, env.router, env.token, env.gameID, "Screenshot Session")
+	sessionID := created["id"].(string)
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	writer.WriteField("name", "Save with SS")
+	part, _ := writer.CreateFormFile("save", "state.sav")
+	part.Write([]byte("save data"))
+	ssPart, _ := writer.CreateFormFile("screenshot", "screenshot.png")
+	ssPart.Write([]byte("PNG image data"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/saves", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var saveResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &saveResp)
+	screenshotURL := saveResp["screenshotUrl"].(string)
+	require.NotEmpty(t, screenshotURL)
+
+	// Fetch the screenshot image using query token auth
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", screenshotURL+"?token="+env.token, nil)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code, "owner should be able to access session screenshot")
+}
+
+func TestServeSessionScreenshot_OtherUserDenied(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "Private Session")
+	sessionID := created["id"].(string)
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	writer.WriteField("name", "Save")
+	part, _ := writer.CreateFormFile("save", "state.sav")
+	part.Write([]byte("save data"))
+	ssPart, _ := writer.CreateFormFile("screenshot", "screenshot.png")
+	ssPart.Write([]byte("PNG image data"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/saves", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var saveResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &saveResp)
+	screenshotURL := saveResp["screenshotUrl"].(string)
+
+	// Other user should be denied
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", screenshotURL+"?token="+env.token2, nil)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code, "non-owner should be denied access to session screenshot")
+}
+
+func TestServeSessionScreenshot_NoAuthDenied(t *testing.T) {
+	env := setupSessionTestEnv(t)
+
+	created := createGameSession(t, env.router, env.token, env.gameID, "Auth Session")
+	sessionID := created["id"].(string)
+
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	writer.WriteField("name", "Save")
+	part, _ := writer.CreateFormFile("save", "state.sav")
+	part.Write([]byte("save data"))
+	ssPart, _ := writer.CreateFormFile("screenshot", "screenshot.png")
+	ssPart.Write([]byte("PNG image data"))
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/saves", &buf)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	env.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var saveResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &saveResp)
+	screenshotURL := saveResp["screenshotUrl"].(string)
+
+	// No token should return 401
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", screenshotURL, nil)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code, "unauthenticated request should be denied")
+}

--- a/web/src/features/game-detail/components/scrape-match-modal.tsx
+++ b/web/src/features/game-detail/components/scrape-match-modal.tsx
@@ -37,6 +37,7 @@ export function ScrapeMatchModal({
     if (open) {
       setSearchInput(currentTitle);
       setDebouncedQuery(currentTitle);
+      setApplyingIgdbId(null);
     }
   }, [open, currentTitle]);
 
@@ -85,7 +86,7 @@ export function ScrapeMatchModal({
     <Modal open={open} onClose={onClose} title="Fix Scrape Match" size="lg">
       <div className="space-y-4">
         {fileName && (
-          <p className="text-sm text-surface-400">
+          <p className="text-sm text-surface-400 truncate" title={fileName}>
             ROM: <span className="text-surface-200 font-mono">{fileName}</span>
           </p>
         )}
@@ -176,6 +177,7 @@ function IgdbResultItem({
       data-testid={`igdb-result-${result.igdbId}`}
       className={cn(
         "w-full flex items-start gap-3 rounded-xl px-3 py-3 text-left transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950",
         isCurrentMatch
           ? "bg-brand-500/10 border border-brand-500/30 cursor-default"
           : "hover:bg-surface-800 cursor-pointer border border-transparent",

--- a/web/src/features/game-detail/components/scrape-match-modal.tsx
+++ b/web/src/features/game-detail/components/scrape-match-modal.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { Search, Check, AlertTriangle } from "lucide-react";
+import { Search, Check, AlertTriangle, Loader2 } from "lucide-react";
 import { Modal, SearchInput, Badge, Skeleton, useToast } from "@/components/ui";
 import { useIgdbSearch, useApplyIgdbMatch, useIgdbStatus } from "@/hooks/use-admin";
 import { cn } from "@/lib/cn";
@@ -8,6 +8,7 @@ import type { IgdbSearchResult } from "@/types/api";
 interface ScrapeMatchModalProps {
   gameId: string;
   currentTitle: string;
+  fileName?: string;
   currentScraperId?: string;
   open: boolean;
   onClose: () => void;
@@ -16,12 +17,14 @@ interface ScrapeMatchModalProps {
 export function ScrapeMatchModal({
   gameId,
   currentTitle,
+  fileName,
   currentScraperId,
   open,
   onClose,
 }: ScrapeMatchModalProps) {
   const [searchInput, setSearchInput] = useState(currentTitle);
   const [debouncedQuery, setDebouncedQuery] = useState(currentTitle);
+  const [applyingIgdbId, setApplyingIgdbId] = useState<number | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const { toast } = useToast();
 
@@ -56,15 +59,18 @@ export function ScrapeMatchModal({
 
   function handleSelect(result: IgdbSearchResult) {
     if (applyMatch.isPending) return;
+    setApplyingIgdbId(result.igdbId);
     applyMatch.mutate(
       { gameId, igdbId: result.igdbId },
       {
         onSuccess: () => {
           toast("success", `Matched to "${result.name}"`);
+          setApplyingIgdbId(null);
           onClose();
         },
         onError: () => {
           toast("error", "Failed to apply match");
+          setApplyingIgdbId(null);
         },
       },
     );
@@ -78,6 +84,11 @@ export function ScrapeMatchModal({
   return (
     <Modal open={open} onClose={onClose} title="Fix Scrape Match" size="lg">
       <div className="space-y-4">
+        {fileName && (
+          <p className="text-sm text-surface-400">
+            ROM: <span className="text-surface-200 font-mono">{fileName}</span>
+          </p>
+        )}
         <SearchInput
           ref={inputRef}
           value={searchInput}
@@ -128,6 +139,7 @@ export function ScrapeMatchModal({
                     String(result.igdbId) === currentIgdbId
                   }
                   isApplying={applyMatch.isPending}
+                  isThisApplying={applyingIgdbId === result.igdbId}
                   onSelect={() => handleSelect(result)}
                 />
               ))}
@@ -148,11 +160,13 @@ function IgdbResultItem({
   result,
   isCurrentMatch,
   isApplying,
+  isThisApplying,
   onSelect,
 }: {
   result: IgdbSearchResult;
   isCurrentMatch: boolean;
   isApplying: boolean;
+  isThisApplying: boolean;
   onSelect: () => void;
 }) {
   return (
@@ -165,7 +179,8 @@ function IgdbResultItem({
         isCurrentMatch
           ? "bg-brand-500/10 border border-brand-500/30 cursor-default"
           : "hover:bg-surface-800 cursor-pointer border border-transparent",
-        isApplying && !isCurrentMatch && "opacity-50 cursor-not-allowed",
+        isThisApplying && "bg-surface-800 border border-brand-500/30",
+        isApplying && !isCurrentMatch && !isThisApplying && "opacity-50 cursor-not-allowed",
       )}
     >
       {/* Cover thumbnail */}
@@ -201,6 +216,9 @@ function IgdbResultItem({
               <Check className="h-3 w-3 mr-0.5" />
               Current
             </Badge>
+          )}
+          {isThisApplying && (
+            <Loader2 className="h-4 w-4 text-brand-400 animate-spin flex-shrink-0" />
           )}
         </div>
         <div className="flex items-center gap-2 text-xs text-surface-400">

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -215,6 +215,7 @@ export function GameDetailPage() {
       <ScrapeMatchModal
         gameId={game.id}
         currentTitle={game.title}
+        fileName={game.fileName}
         currentScraperId={game.scraperId}
         open={showScrapeMatch}
         onClose={() => setShowScrapeMatch(false)}


### PR DESCRIPTION
## Summary
- **Fix scrape match modal**: Add a spinner on the selected match while applying, and show the ROM filename so users know which file they're fixing
- **Fix save screenshot 401**: Image handler expected legacy `save-screenshots/user_{id}/...` path format but screenshots are stored as `save-screenshots/sessions/session_{id}/...` — added session-based path parsing with ownership check

## Test plan
- [x] Go tests pass (all packages)
- [x] Web unit tests pass (725/725)
- [ ] CI passes
- [ ] Manual: open Fix Scrape Match modal — verify filename shown and spinner appears when clicking a match
- [ ] Manual: verify session screenshots load in game detail page