### PR TITLE
feat: second screen companion experience with SteamGridDB art

### DIFF
--- a/design-proposals/second-screen-companion.md
+++ b/design-proposals/second-screen-companion.md
@@ -1,0 +1,502 @@
+# Second Screen Companion Experience
+
+## Status: Phase 1 + Phase 2 Implemented
+
+**Date:** 2026-03-09
+**Contributors:** Product Owner, Android Developer, UI/UX Agent
+
+---
+
+## Problem Statement
+
+When playing single-screen games (NES, SNES, GBA, etc.) on dual-screen Android devices,
+the secondary screen currently shows touch gamepad controls, a game info bar, quick actions
+(save/load/screenshot/fast forward), and FPS metrics.
+
+On devices with built-in gamepads (like the AYN Thor clamshell handheld), the touch controls
+are dead space. The second screen could be a genuinely valuable companion to gameplay instead
+of wasted real estate.
+
+The touch controls must remain available as an option for devices without physical gamepads.
+
+---
+
+## Current Implementation
+
+**File:** `SecondaryScreenContent.kt`
+
+The secondary screen currently shows three fixed sections for single-screen games:
+
+1. **Game Info Bar** — Game title + elapsed session time
+2. **Touch Gamepad Controls** — Platform-specific virtual button layout
+3. **Quick Action Bar** — Save, Load, Screenshot, Fast Forward buttons + FPS/frame time
+4. **OLED Burn-in Protection** — Fades to black after 15 seconds of inactivity
+
+For dual-screen games (DS/3DS), the secondary screen renders the bottom screen with touch input.
+
+**Available data during gameplay** (`EmulationState`):
+- `fps`, `frameTime` — performance metrics
+- `gameTitle`, `sessionElapsedSeconds` — session info
+- `isRunning`, `isPaused`, `isFastForward` — game state
+- `selectedShader` — current video filter
+- `hasCheats`, `enabledCheatCount`, `cheats: List<Cheat>` — cheat state
+- `challengeId`, `challengeObjective`, `challengeElapsedMs` — challenge mode
+- `netplayPeerUsername`, `netplayPeerLatencyMs` — netplay state
+- `achievementEvent` — RetroAchievements events
+- `activeSlot` — current quick-save slot
+
+**Additional data accessible** (from repositories/API):
+- Game metadata (console, description, cover art, release year, genre, developer, publisher)
+- Save states with screenshot thumbnails
+- Play history (total play time, sessions)
+- RetroAchievements (full achievement list, progress, unlock status)
+- Online users and what they're playing
+- Challenge leaderboards
+
+---
+
+## Core Design: Swipeable Pages with Persistent Header
+
+Replace the single fixed layout with **swipeable pages** behind a persistent header.
+A page indicator (dot row) at the bottom shows which page is active.
+
+```
++------------------------------------------------------+
+| * Super Mario World              01:23:45       SNES |  <- Persistent header
++------------------------------------------------------+
+|                                                      |
+|                                                      |
+|              [ Swipeable Page Content ]               |
+|                                                      |
+|                                                      |
++------------------------------------------------------+
+|                    *  o  o  o                        |  <- Page indicator dots
++------------------------------------------------------+
+```
+
+A mode selector in settings (or long-press on second screen) lets users pick their
+default page. Devices with gamepads default to Art/Dashboard; without to Controls.
+
+### Persistent Header
+
+- Game title + session timer + console badge
+- Thin 2dp gradient line at the top using `getConsoleGradient()` for console identity
+- Adapts contextually: shows "PAUSE" when paused, peer info during netplay, etc.
+
+### OLED Burn-in Protection
+
+**Fade to black after 15 seconds of inactivity** — the current approach, preserved as-is.
+Burn-in protection is non-negotiable. We will NOT use pixel drift or any approach that
+risks burn-in on user devices. On touch, the screen wakes instantly.
+
+---
+
+## Page 1: Art Display (SteamGridDB Integration)
+
+**The default page for devices with gamepads.** A visually stunning ambient display
+featuring high-quality game artwork from SteamGridDB.
+
+### SteamGridDB Art Types
+
+SteamGridDB is a community-driven database of game artwork with four asset types:
+
+| Art Type | Description | Use on Second Screen |
+|----------|-------------|---------------------|
+| **Hero** | Wide banner artwork (typically ~1920x620). Cinematic, often featuring the game's key art with logo. | Primary display — fills the screen beautifully in landscape |
+| **Grid** | Vertical cover art (~600x900) or horizontal (~920x430). Box art style. | Fallback when no hero available, or as a centered element |
+| **Logo** | Transparent PNG of the game's logo/title treatment. | Overlay on top of hero art, or standalone with dark background |
+| **Icon** | Square game icon (~512x512). | Small accent element, not primary use |
+
+**Hero images are the star here.** A high-quality hero banner filling the secondary screen
+with the game's cinematic art, overlaid with a subtle session timer, would look incredible
+on the AYN Thor's OLED.
+
+### Layout Concept
+
+```
++------------------------------------------------------+
+|                                                      |
+|           [  Hero Banner - Full Bleed  ]             |
+|           [  Beautiful cinematic art   ]             |
+|           [  from SteamGridDB          ]             |
+|                                                      |
+|                         Super Mario World            |
+|                            01:23:45                  |
++------------------------------------------------------+
+|                    *  o  o  o                        |
++------------------------------------------------------+
+```
+
+- Hero image fills the content area edge-to-edge with slight vignette darkening at bottom
+- Game title + timer overlaid at bottom with text shadow for readability
+- If no hero available, fall back to centered grid/cover art with ambient glow (extract
+  dominant color with Android `Palette` API)
+- Console gradient accent line in header provides system identity
+
+### SteamGridDB Integration Details
+
+**API:** REST API v2, requires API key (free registration)
+
+**Server-side integration:**
+- New server config: SteamGridDB API key (stored in `ServerSetting`, configured in admin)
+- New endpoint: `GET /api/games/:id/artwork` returns available art URLs
+- Server caches artwork URLs/images to avoid repeated API calls
+- Search by game name + platform to find matches
+- Store artwork references in DB, link to games during scraping or on-demand
+
+**Matching strategy:**
+- Search SteamGridDB by game name + platform during metadata scraping (alongside existing
+  LibRetro Thumbnails and ScreenScraper)
+- Allow manual matching in web admin for games that don't auto-match
+- Cache hero/grid/logo URLs per game in a new `GameArtwork` table
+
+**Fallback chain:**
+1. SteamGridDB hero image (preferred)
+2. SteamGridDB grid/cover art
+3. Existing cover art from ScreenScraper/LibRetro Thumbnails
+4. Console-colored background with game title text
+
+**Player app changes:**
+- New field on `GameDetail`: `heroUrl`, `logoUrl` (optional, from server API)
+- `EmulationState` carries `heroUrl` for the secondary screen
+- Coil/image loading for the artwork on the secondary display
+
+---
+
+## Page 2: Dashboard
+
+The information-rich page. Designed like Apple Watch complications — dense but glanceable
+data in a card grid with quick actions.
+
+```
++------------------------------------------------------+
+| * Super Mario World              01:23:45       SNES |
++------------------------------------------------------+
+|                                                      |
+|  +-------------+  +-------------+  +-------------+  |
+|  |   60 FPS    |  |  Slot 3     |  |  CHEATS     |  |
+|  |  16.7ms     |  |  _ _ X _ _  |  |   2 active  |  |
+|  +-------------+  +-------------+  +-------------+  |
+|                                                      |
+|  +-------+ +-------+ +-------+ +-------+ +-------+  |
+|  | Save  | | Load  | | Shot  | | Fast  | |Rewind |  |
+|  +-------+ +-------+ +-------+ +-------+ +-------+  |
+|                                                      |
+|                    o  *  o  o                        |
++------------------------------------------------------+
+```
+
+### Stat Cards (top row)
+
+Three cards showing glanceable info. Tap a card to cycle its content:
+
+- **FPS Card**: FPS only -> FPS + frame time -> FPS + frame time sparkline graph
+- **Slot Card**: Shows active slot (1-10) as a visual strip. Tap to cycle active slot.
+- **Cheats Card**: Shows enabled count. Tap to open cheat toggle panel.
+
+### Quick Action Row (bottom)
+
+Same actions as current `QuickActionBar` but in a single horizontal row:
+Save, Load, Screenshot, Fast Forward, Rewind
+
+### Cheat Toggle Panel
+
+When cheats card is tapped, a bottom sheet slides up showing the full cheat list.
+Each cheat has a toggle switch. Cheats can be toggled on/off **without pausing the game**.
+This is a genuine workflow improvement — e.g., toggle infinite lives on when stuck, off
+when you want to play "for real."
+
+### Shader Quick-Switch
+
+Add a shader icon to the action row or as a fourth stat card. Tap to cycle through the
+6 shader presets instantly without opening any menu.
+
+---
+
+## Page 3: Save States
+
+Visual save state management with screenshot thumbnails.
+
+```
++------------------------------------------------------+
+| * Super Mario World              01:23:45       SNES |
++------------------------------------------------------+
+|  Save Slots                                          |
+|  +--------+ +--------+ +--------+ +--------+        |
+|  | [img]  | | [img]  | | [ 3 ]  | | [img]  |  ...  |
+|  | Slot 1 | | Slot 2 | | Slot 3 | | Slot 4 |        |
+|  | 0:12   | | 0:45   | | ACTIVE | | 1:02   |        |
+|  +--------+ +--------+ +--------+ +--------+        |
+|                                                      |
+|  Tap to select  |  Swipe up: save  |  Hold: load    |
+|                                                      |
+|                    o  o  *  o                        |
++------------------------------------------------------+
+```
+
+- Horizontal scrollable row of save slot cards
+- Each card shows: screenshot thumbnail, slot number, session timestamp
+- Active slot highlighted with `SpColor.Primary` border
+- Empty slots show placeholder with "+" icon
+
+### Gestures
+
+| Gesture | Action | Feedback |
+|---------|--------|----------|
+| Tap a slot | Select as active slot | Border highlight changes |
+| Swipe up on active slot | Quick save | Green flash confirmation |
+| Long-press a filled slot | Load from that slot | Blue flash + confirmation dialog |
+| Long-press empty slot | Save to that slot | Green flash confirmation |
+
+### Data Source
+
+- `SaveState` model already has `screenshotUrl`, `createdAt`, `slot`
+- `EmulationState` already has `activeSlot`
+- `SaveManager` handles save/load operations
+- Need to fetch save state list at game start and keep it updated
+
+---
+
+## Page 4: Controls (Existing)
+
+The current touch gamepad layout, preserved as-is for devices without physical gamepads.
+
+**Enhancement:** Also support mapping to Player 2 input. The input system already supports
+8 ports. A toggle at the top of the controls page: "Player 1 / Player 2" — this turns
+the second screen into a P2 controller for local multiplayer.
+
+---
+
+## Additional Features (Cross-Page)
+
+### Live Achievement Tracker
+
+A persistent achievement overlay or dedicated sub-section (accessible from Dashboard).
+
+- Compact list of RetroAchievements with unlock status and progress bars
+- In-progress achievements highlighted, unlocked ones show checkmark
+- When an achievement unlocks during gameplay, animated celebration on second screen
+- Achievement unlock feed: scrolling log of session unlocks with badges and timestamps
+
+**Data:** `AchievementsRepository`, `GameAchievement`, `AchievementProgress` models exist.
+Need to wire `achievementsRepository.getGameAchievements()` into secondary screen.
+May need new JNI to query `rc_client_get_achievement_list()` for full progress data.
+
+### Input Visualization
+
+Real-time display of which buttons are pressed. A visual controller graphic that
+lights up with actual inputs.
+
+- Console-themed layouts (SNES pad vs N64 vs PlayStation)
+- For fighting games: input history log showing last N inputs as combo notation
+- `nativeGetInputButton(port, id)` already exists in JNI — 20 calls at 30fps is negligible
+
+Could be a Dashboard sub-mode or its own swipeable page.
+
+### Performance Dashboard (Power User)
+
+Expanded performance view beyond the stat card:
+
+- FPS graph: rolling 60-second line chart (ring buffer of 120 frame times)
+- Frame time distribution: target line at 16.67ms, min/max/avg
+- Audio buffer utilization bar (needs new JNI: `nativeGetAudioBufferUtilization()`)
+- Current shader name, rewind buffer status
+- Core variable display (needs new JNI: `nativeGetCoreVariables()`)
+
+### Context-Aware State Transitions
+
+The screen adapts automatically based on game state:
+
+**Paused:** Header shows "PAUSE" in warning color, timer pulses. Content dims.
+Tap anywhere to resume.
+
+**Challenge Mode:** Dashboard transforms — large challenge timer, objective text,
+complete/restart/give up actions. Challenge leaderboard position if available.
+
+**Netplay:** Header shows peer username + latency. Dashboard includes ping sparkline
+graph, connection quality indicator, who-paused status.
+
+**Save/Load performed:** Transient toast notification slides in (2 seconds),
+overlaying current page. Green for save, blue for load.
+
+### Who's Online
+
+Compact display of other users on the server and what they're playing.
+`PresenceService` exists, needs periodic polling during gameplay. Could be a
+Dashboard card or sub-section.
+
+### Game Info Card
+
+Game metadata display: cover art, description, developer, publisher, release year,
+genre, community rating. "Back of the box" feel.
+
+All data available from `GameDetail` model. Nice for the Focus/Art page as
+supplementary info below the hero image.
+
+---
+
+## Technical Feasibility Notes (Android Developer)
+
+### Easy (existing data, pure Compose UI)
+
+| Feature | Notes |
+|---------|-------|
+| Swipeable pages | `HorizontalPager` from Compose Foundation |
+| Dashboard stat cards | Existing `EmulationState` fields |
+| Quick action row | Existing `EmulationActionButton` components |
+| Shader quick-switch | 6 `ShaderPreset` enum values |
+| Input visualization | `nativeGetInputButton` already in JNI |
+| Last frame on pause | `frameBitmap` StateFlow persists after pause |
+| Ambient color extraction | Android `Palette` API on `frameBitmap` |
+| Player 2 controls | Input system supports 8 ports |
+| Performance graphs | Ring buffer + Compose Canvas |
+
+### Medium (needs new data wiring or JNI)
+
+| Feature | Notes |
+|---------|-------|
+| Save state thumbnails | Server screenshots exist, need API call during gameplay |
+| Achievement tracker | Need JNI to query rcheevos achievement list |
+| SteamGridDB integration | New server endpoints, API key config, DB table |
+| Cheat toggling | Need new `EmulationIntent` for per-cheat toggle |
+| Who's online | Need periodic API polling during gameplay |
+| Challenge leaderboard | Need to fetch leaderboard at challenge start |
+| RAM viewer | New JNI `nativeReadMemory()`, ~10 lines of C |
+
+### Performance Considerations
+
+- Reading game memory: negligible (direct pointer, achievements already do it every frame)
+- Frame sharing (software cores): zero overhead (`frameBitmap` already generated)
+- Frame sharing (GPU cores): `PixelCopy` at 5-10fps adds ~1ms per capture
+- Input polling (20 JNI calls at 30fps): negligible
+- Palette color extraction: run every 0.5s on background thread, no impact
+
+---
+
+## SteamGridDB Server Integration Plan
+
+### New Database Model
+
+```go
+type GameArtwork struct {
+    ID           uint   `gorm:"primaryKey"`
+    GameID       uint   `gorm:"index;not null"`
+    SteamGridID  int    // SteamGridDB game ID for future lookups
+    HeroURL      string // Hero/banner art URL (wide, cinematic)
+    GridURL      string // Vertical cover art URL
+    LogoURL      string // Transparent logo URL
+    IconURL      string // Square icon URL
+    Source       string // "steamgriddb"
+    CachedLocally bool  // Whether images are cached on server filesystem
+    CreatedAt    time.Time
+    UpdatedAt    time.Time
+}
+```
+
+### New Server Settings
+
+- `steamgriddb_api_key` — API key for SteamGridDB v2 API
+- Configured in admin settings panel alongside existing scraper credentials
+
+### New API Endpoint
+
+```
+GET /api/games/:id/artwork
+Response: { heroUrl, gridUrl, logoUrl, iconUrl }
+```
+
+### Scraper Integration
+
+- During metadata scraping, also query SteamGridDB by game name + platform
+- SteamGridDB has excellent retro game coverage (community-contributed)
+- Cache downloaded images on server filesystem (like existing cover art)
+- Allow manual SteamGridDB matching in web admin for unmatched games
+
+### Player App Changes
+
+- `GameDetail` gains optional `heroUrl`, `logoUrl` fields
+- `EmulationState` carries `heroUrl` for secondary screen
+- Image loading via Coil on the secondary display Compose tree
+
+---
+
+## Priority & Phasing
+
+### Phase 1: Foundation + Art Display
+
+**Goal:** Make the second screen beautiful and useful out of the box.
+
+1. Swipeable page infrastructure (`HorizontalPager` + page dots)
+2. Persistent header with console gradient accent
+3. **Art Display page** (SteamGridDB heroes) — the wow factor
+4. Dashboard page (stat cards + quick actions)
+5. Controls page (existing, preserved)
+6. Fade-to-black burn-in protection (preserved)
+7. Mode selector in settings (default page per device)
+
+**Backend:** SteamGridDB API integration, `GameArtwork` model, artwork endpoint.
+
+### Phase 2: Save State Management
+
+8. Save Slots page with visual thumbnails
+9. Quick slot switcher on Dashboard
+10. Save/Load gestures (swipe up to save, hold to load)
+
+**Backend:** Expose save state list during gameplay (endpoint exists, need new data flow).
+
+### Phase 3: Achievements & Cheats
+
+11. Live Achievement Tracker (Dashboard sub-section or overlay)
+12. Cheat toggle panel (tap cheats card on Dashboard)
+13. Achievement unlock animations
+
+**Backend:** None. JNI additions for rcheevos queries.
+
+### Phase 4: Social & Context
+
+14. Challenge Mode dashboard transformation
+15. Netplay peer info with latency graph
+16. Who's Online display
+17. Context-aware state transitions (pause, save confirmation toasts)
+
+### Phase 5: Power User Features
+
+18. Input visualization with combo history
+19. Performance dashboard with frame time graphs
+20. Player 2 controls toggle
+21. Game Info Card with metadata
+
+### Future Ideas (Backlog)
+
+- Widget-based custom layout (Stream Deck style) — ship presets first, learn what users want
+- RAM Watch / Cheat Search — read game memory for game-specific info
+- Auto-Save Timeline — visual scrubber through auto-save history
+- Frame mirroring / mini-map view
+- Ambient color extraction from game frame for background tint
+
+---
+
+## Design System Notes
+
+- Use `SpColor`, `SpSpacing`, `SpTypography` tokens throughout
+- Dark theme primary — minimal bright pixels for OLED
+- Console gradient accents via `getConsoleGradient()`
+- Stat cards: `SpColor.Card` background, `SpSpacing.CardCornerRadius` (16dp)
+- Action buttons: existing `EmulationActionButton` at 48dp
+- Text minimum: `SpTypography.LabelSmall` (10sp) — nothing smaller on 3.92" screen
+- Most-used actions in bottom-left/bottom-right thumb zones
+- Page transitions: standard `HorizontalPager` slide animation
+- Toast notifications: `SpColor.SuccessContainer` background, 2-second duration
+- Touch latency: generous gesture windows (500ms long-press, 200ms swipe)
+
+---
+
+## Inspiration Sources
+
+- **Nintendo DS** — Bottom screen as companion info/controls
+- **Wii U GamePad** — Companion display for main screen gameplay
+- **Elgato Stream Deck** — Customizable quick-action grid
+- **Car instrument clusters** — Glanceable info while focus is elsewhere
+- **Apple Watch complications** — Dense, glanceable data widgets
+- **Xbox achievement sidebar** — Session unlock feed
+- **RetroArch** — Performance overlay, shader switching

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenBurnInTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenBurnInTest.kt
@@ -92,11 +92,8 @@ class SecondaryScreenBurnInTest {
         val harness = createHarnessWithNesGame()
         startGameAndRenderSecondary(harness)
 
-        // Game title should be visible in the info bar
+        // Game title should be visible in the persistent header
         onNodeWithContentDescription("Now playing: Castlevania").assertIsDisplayed()
-
-        // Save button should be visible in the quick action bar
-        onNodeWithContentDescription("Save").assertIsDisplayed()
 
         // Dimming overlay should NOT exist yet
         onAllNodesWithContentDescription("Screen dimmed for OLED protection")

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenDashboardTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenDashboardTest.kt
@@ -1,0 +1,333 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.intent.EmulationIntent
+import com.spela.player.presentation.ui.feature.ingame.SecondaryDashboardPage
+import com.spela.player.presentation.ui.feature.ingame.SecondaryScreenContent
+import com.spela.player.presentation.ui.feature.ingame.SecondarySaveSlotsPage
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+
+/**
+ * E2E tests for the Second Screen Companion dashboard page and pager infrastructure.
+ *
+ * Tests cover:
+ * - Dashboard stat cards (FPS, save slot, cheats)
+ * - Quick action buttons (Save, Load, Screenshot, Fast Forward, Rewind)
+ * - Conditional rendering (rewind button, fast forward toggle state, cheats display)
+ * - Companion header with game title
+ * - Page indicator dots
+ *
+ * The SecondaryDashboardPage is a stateless composable so most tests render it
+ * directly with explicit parameters. Tests for the companion header and page
+ * indicator dots use SecondaryScreenContent through the test harness.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class SecondaryScreenDashboardTest {
+
+    // -- Helpers ---------------------------------------------------------------
+
+    private fun ComposeUiTest.advanceSeconds(harness: SpelaTestHarness, seconds: Int) {
+        mainClock.autoAdvance = false
+        repeat(seconds) {
+            harness.testDispatcher.scheduler.advanceTimeBy(1_000)
+            harness.testDispatcher.scheduler.runCurrent()
+            mainClock.advanceTimeBy(1_000)
+            waitForIdle()
+        }
+        mainClock.autoAdvance = true
+    }
+
+    private fun createHarnessWithNesGame(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.downloadRepo.preCacheGame("1")
+        return harness
+    }
+
+    private fun ComposeUiTest.startGameAndRenderSecondary(
+        harness: SpelaTestHarness,
+        gameId: String = "1",
+    ) {
+        harness.emulationViewModel.onIntent(EmulationIntent.StartGame(gameId = gameId))
+        mainClock.autoAdvance = false
+        repeat(4) {
+            harness.testDispatcher.scheduler.advanceTimeBy(1_000)
+            harness.testDispatcher.scheduler.runCurrent()
+        }
+        mainClock.autoAdvance = true
+
+        setContent {
+            SecondaryScreenContent(
+                viewModel = harness.emulationViewModel,
+                controller = harness.libretroController,
+            )
+        }
+        advanceSeconds(harness, 1)
+    }
+
+    /**
+     * Render the dashboard page directly with the given parameters.
+     * Since SecondaryDashboardPage is a stateless composable, no ViewModel is needed.
+     */
+    private fun ComposeUiTest.renderDashboard(
+        fps: Float = 60f,
+        frameTime: Float = 16.7f,
+        activeSlot: Int = 1,
+        hasCheats: Boolean = false,
+        enabledCheatCount: Int = 0,
+        isFastForward: Boolean = false,
+        rewindEnabled: Boolean = false,
+    ) {
+        setContent {
+            SecondaryDashboardPage(
+                fps = fps,
+                frameTime = frameTime,
+                activeSlot = activeSlot,
+                hasCheats = hasCheats,
+                enabledCheatCount = enabledCheatCount,
+                isFastForward = isFastForward,
+                rewindEnabled = rewindEnabled,
+                onSave = {},
+                onLoad = {},
+                onScreenshot = {},
+                onToggleFastForward = {},
+                onRewind = {},
+            )
+        }
+    }
+
+    // -- Dashboard stat cards --------------------------------------------------
+
+    @Test
+    fun dashboardStatCardsRenderCorrectly() = runComposeUiTest {
+        renderDashboard(fps = 60f, frameTime = 16.7f, activeSlot = 3)
+
+        // FPS card with frame time
+        onNodeWithContentDescription("60 FPS, 16.7 ms frame time")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Save slot card
+        onNodeWithContentDescription("Active save slot 3")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Cheats card (no cheats by default)
+        onNodeWithContentDescription("No cheats available")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun dashboardWithCheatsActive() = runComposeUiTest {
+        renderDashboard(hasCheats = true, enabledCheatCount = 2)
+
+        // Cheats card should show active count
+        onNodeWithContentDescription("2 cheats active")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // "2 active" text visible in the card
+        onNodeWithText("2 active")
+            .assertExists()
+
+        // No cheats description should NOT be present
+        onAllNodesWithContentDescription("No cheats available")
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun dashboardWithNoCheats() = runComposeUiTest {
+        renderDashboard(hasCheats = false, enabledCheatCount = 0)
+
+        // No cheats available description
+        onNodeWithContentDescription("No cheats available")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // "No cheats" text visible in the card
+        onNodeWithText("No cheats")
+            .assertExists()
+
+        // Active cheats description should NOT be present
+        onAllNodesWithContentDescription("0 cheats active")
+            .assertCountEquals(0)
+    }
+
+    // -- Quick action buttons --------------------------------------------------
+
+    @Test
+    fun dashboardQuickActionsPresent() = runComposeUiTest {
+        renderDashboard()
+
+        // All standard quick action buttons should exist
+        onNodeWithContentDescription("Save")
+            .assertExists()
+            .assertIsDisplayed()
+
+        onNodeWithContentDescription("Load")
+            .assertExists()
+            .assertIsDisplayed()
+
+        onNodeWithContentDescription("Screenshot")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Fast forward button (shows "Fast" label when not active)
+        onNodeWithContentDescription("Fast")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun dashboardRewindButtonShownWhenEnabled() = runComposeUiTest {
+        renderDashboard(rewindEnabled = true)
+
+        onNodeWithContentDescription("Rewind")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun dashboardRewindButtonHiddenWhenDisabled() = runComposeUiTest {
+        renderDashboard(rewindEnabled = false)
+
+        onAllNodesWithContentDescription("Rewind")
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun dashboardFastForwardToggleShowsNormalWhenActive() = runComposeUiTest {
+        renderDashboard(isFastForward = true)
+
+        // When fast forward is active, button label is "Normal" (to indicate tapping returns to normal)
+        onNodeWithContentDescription("Normal")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // "Fast" label should not be present
+        onAllNodesWithContentDescription("Fast")
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun dashboardFastForwardToggleShowsFastWhenInactive() = runComposeUiTest {
+        renderDashboard(isFastForward = false)
+
+        // When fast forward is inactive, button label is "Fast"
+        onNodeWithContentDescription("Fast")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // "Normal" label should not be present
+        onAllNodesWithContentDescription("Normal")
+            .assertCountEquals(0)
+    }
+
+    // -- Companion header (via SecondaryScreenContent) -------------------------
+
+    @Test
+    fun companionHeaderRendersWithGameTitle() = runComposeUiTest {
+        val harness = createHarnessWithNesGame()
+        startGameAndRenderSecondary(harness)
+
+        // Companion header should show the game title in its semantic description
+        onNodeWithContentDescription("Now playing: Castlevania")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    // -- Page indicator dots (via SecondaryScreenContent) ----------------------
+
+    @Test
+    fun pageIndicatorDotsPresent() = runComposeUiTest {
+        val harness = createHarnessWithNesGame()
+        startGameAndRenderSecondary(harness)
+
+        // Page 1 should be active (initial page is Art = page 0, displayed as "Page 1 of 4")
+        onNodeWithContentDescription("Page 1 of 4, active")
+            .assertExists()
+
+        // Pages 2, 3, 4 should be present but not active
+        onNodeWithContentDescription("Page 2 of 4")
+            .assertExists()
+        onNodeWithContentDescription("Page 3 of 4")
+            .assertExists()
+        onNodeWithContentDescription("Page 4 of 4")
+            .assertExists()
+    }
+
+    // --- Save Slots Page Tests ---
+
+    @Test
+    fun saveSlotsPageRendersAllSlots() = runComposeUiTest {
+        setContent {
+            SecondarySaveSlotsPage(
+                activeSlot = 1,
+                onSelectSlot = {},
+            )
+        }
+        waitForIdle()
+
+        // Title
+        onNodeWithText("Save Slots").assertExists()
+
+        // Active slot 1
+        onNodeWithContentDescription("Save slot 1, active").assertExists()
+
+        // A few inactive slots
+        onNodeWithContentDescription("Save slot 2").assertExists()
+        onNodeWithContentDescription("Save slot 5").assertExists()
+        onNodeWithContentDescription("Save slot 10").assertExists()
+    }
+
+    @Test
+    fun saveSlotsPageHighlightsActiveSlot() = runComposeUiTest {
+        setContent {
+            SecondarySaveSlotsPage(
+                activeSlot = 7,
+                onSelectSlot = {},
+            )
+        }
+        waitForIdle()
+
+        // Slot 7 should be active
+        onNodeWithContentDescription("Save slot 7, active").assertExists()
+
+        // Slot 1 should NOT be active
+        onNodeWithContentDescription("Save slot 1, active").assertDoesNotExist()
+        onNodeWithContentDescription("Save slot 1").assertExists()
+    }
+
+    @Test
+    fun saveSlotsPageShowsHintText() = runComposeUiTest {
+        setContent {
+            SecondarySaveSlotsPage(
+                activeSlot = 1,
+                onSelectSlot = {},
+            )
+        }
+        waitForIdle()
+
+        onNodeWithText("Tap to select active slot").assertExists()
+    }
+
+    @Test
+    fun saveSlotsPageCallsOnSelectSlot() = runComposeUiTest {
+        var selectedSlot = -1
+        setContent {
+            SecondarySaveSlotsPage(
+                activeSlot = 1,
+                onSelectSlot = { selectedSlot = it },
+            )
+        }
+        waitForIdle()
+
+        // Tap slot 3
+        onNodeWithContentDescription("Save slot 3").performClick()
+        waitForIdle()
+
+        assert(selectedSlot == 3) { "Expected selectedSlot to be 3, was $selectedSlot" }
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenDashboardTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenDashboardTest.kt
@@ -245,16 +245,16 @@ class SecondaryScreenDashboardTest {
         val harness = createHarnessWithNesGame()
         startGameAndRenderSecondary(harness)
 
-        // Page 1 should be active (initial page is Art = page 0, displayed as "Page 1 of 4")
-        onNodeWithContentDescription("Page 1 of 4, active")
+        // Art page should be active (initial page)
+        onNodeWithContentDescription("Art, 1 of 4, active")
             .assertExists()
 
-        // Pages 2, 3, 4 should be present but not active
-        onNodeWithContentDescription("Page 2 of 4")
+        // Other pages should be present but not active
+        onNodeWithContentDescription("Controls, 2 of 4")
             .assertExists()
-        onNodeWithContentDescription("Page 3 of 4")
+        onNodeWithContentDescription("Dashboard, 3 of 4")
             .assertExists()
-        onNodeWithContentDescription("Page 4 of 4")
+        onNodeWithContentDescription("Save Slots, 4 of 4")
             .assertExists()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -72,6 +72,8 @@ fun GameDto.toDomain(): Game = Game(
     verificationTag = verificationTag,
     region = region,
     playable = playable,
+    heroUrl = heroUrl,
+    logoUrl = logoUrl,
 )
 
 /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -102,6 +102,8 @@ data class GameDto(
     val verificationTag: String? = null,
     val region: String? = null,
     val playable: Boolean = true,
+    val heroUrl: String? = null,
+    val logoUrl: String? = null,
     val createdAt: String? = null,
     val updatedAt: String? = null,
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -78,6 +78,8 @@ data class Game(
     val verificationTag: String? = null,
     val region: String? = null,
     val playable: Boolean = true,
+    val heroUrl: String? = null,
+    val logoUrl: String? = null,
 )
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -8,6 +8,8 @@ data class EmulationState(
     val gameId: String = "",
     val gameTitle: String = "",
     val consoleId: String = "",
+    val consoleColorTheme: String? = null,
+    val heroUrl: String? = null,
     val isRunning: Boolean = false,
     val isPaused: Boolean = false,
     /** True when paused by Android lifecycle (e.g. clamshell close). */

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryArtPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryArtPage.kt
@@ -1,0 +1,205 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Shadow
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import coil3.compose.SubcomposeAsyncImage
+import com.spela.player.presentation.ui.feature.library.getConsoleGradient
+import com.spela.player.presentation.ui.screen.formatSessionDuration
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Art Display page for the secondary screen companion.
+ *
+ * When `heroUrl` is available, displays the game's hero artwork as a full-bleed
+ * background with a subtle gradient overlay and game title + session timer at
+ * the bottom-right.
+ *
+ * When `heroUrl` is null, falls back to a centered game title with the console
+ * gradient as a subtle background accent ("Focus" mode).
+ */
+@Composable
+fun SecondaryArtPage(
+    heroUrl: String?,
+    gameTitle: String,
+    sessionElapsedSeconds: Long,
+    consoleId: String,
+    consoleColorTheme: String?,
+) {
+    val timeText = formatSessionDuration(sessionElapsedSeconds)
+
+    if (heroUrl != null) {
+        // Full-bleed hero artwork mode
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background)
+                .semantics {
+                    contentDescription = "Art display: $gameTitle"
+                },
+        ) {
+            // Hero image filling the entire page
+            SubcomposeAsyncImage(
+                model = heroUrl,
+                contentDescription = "Hero artwork for $gameTitle",
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+                loading = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(SpColor.SurfaceVariant),
+                    )
+                },
+                error = {
+                    // On error, fall back to the gradient mode
+                    FallbackArtContent(
+                        gameTitle = gameTitle,
+                        timeText = timeText,
+                        consoleId = consoleId,
+                        consoleColorTheme = consoleColorTheme,
+                    )
+                },
+            )
+
+            // Gradient overlay: transparent at top, dark at bottom
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                Color.Transparent,
+                                SpColor.Background.copy(alpha = 0.4f),
+                                SpColor.Background.copy(alpha = 0.85f),
+                            ),
+                        )
+                    ),
+            )
+
+            // Title + timer overlaid at bottom-right
+            Column(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(SpSpacing.Medium),
+                horizontalAlignment = Alignment.End,
+            ) {
+                Text(
+                    text = gameTitle,
+                    style = SpTypography.TitleLarge.copy(
+                        shadow = Shadow(
+                            color = Color.Black.copy(alpha = 0.7f),
+                            offset = Offset(1f, 1f),
+                            blurRadius = 4f,
+                        ),
+                    ),
+                    color = SpColor.OnBackground,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.End,
+                )
+                Text(
+                    text = timeText,
+                    style = SpTypography.HeadlineSmall.copy(
+                        shadow = Shadow(
+                            color = Color.Black.copy(alpha = 0.7f),
+                            offset = Offset(1f, 1f),
+                            blurRadius = 4f,
+                        ),
+                    ),
+                    color = SpColor.OnBackgroundSecondary,
+                )
+            }
+        }
+    } else {
+        // Fallback "Focus" mode: console gradient background with centered title
+        FallbackArtContent(
+            gameTitle = gameTitle,
+            timeText = timeText,
+            consoleId = consoleId,
+            consoleColorTheme = consoleColorTheme,
+        )
+    }
+}
+
+/**
+ * Fallback content when no hero artwork is available.
+ * Shows a subtle console gradient background with the game title centered.
+ */
+@Composable
+private fun FallbackArtContent(
+    gameTitle: String,
+    timeText: String,
+    consoleId: String,
+    consoleColorTheme: String?,
+) {
+    val (gradientFrom, gradientTo) = getConsoleGradient(consoleId, consoleColorTheme)
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                Brush.verticalGradient(
+                    colors = listOf(
+                        gradientFrom.copy(alpha = 0.15f),
+                        SpColor.Background,
+                    ),
+                )
+            )
+            .semantics {
+                contentDescription = "Art display: $gameTitle (no artwork)"
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SpSpacing.Large),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            Text(
+                text = gameTitle,
+                style = SpTypography.TitleLarge,
+                color = SpColor.OnBackground,
+                textAlign = TextAlign.Center,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = timeText,
+                style = SpTypography.HeadlineSmall,
+                color = SpColor.OnBackgroundSecondary,
+                textAlign = TextAlign.Center,
+            )
+            if (consoleId.isNotEmpty()) {
+                Text(
+                    text = consoleId.uppercase(),
+                    style = SpTypography.LabelMedium,
+                    color = SpColor.OnBackgroundTertiary,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryDashboardPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryDashboardPage.kt
@@ -1,0 +1,183 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.FastForward
+import androidx.compose.material.icons.filled.FastRewind
+import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Save
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.components.EmulationActionButton
+import com.spela.player.presentation.ui.components.fpsColor
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Dashboard page for the secondary screen companion.
+ *
+ * Shows stat cards (FPS, save slot, cheats) and a quick action row
+ * (save, load, screenshot, fast forward, rewind).
+ */
+@Composable
+fun SecondaryDashboardPage(
+    fps: Float,
+    frameTime: Float,
+    activeSlot: Int,
+    hasCheats: Boolean,
+    enabledCheatCount: Int,
+    isFastForward: Boolean,
+    rewindEnabled: Boolean,
+    onSave: () -> Unit,
+    onLoad: () -> Unit,
+    onScreenshot: () -> Unit,
+    onToggleFastForward: () -> Unit,
+    onRewind: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Stat cards row
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            StatCard(
+                value = "%.0f".format(fps),
+                valueColor = fpsColor(fps),
+                label = "%.1fms".format(frameTime),
+                contentDesc = "%.0f FPS, %.1f ms frame time".format(fps, frameTime),
+                modifier = Modifier.weight(1f),
+            )
+            StatCard(
+                value = "Slot $activeSlot",
+                valueColor = SpColor.OnBackground,
+                label = "Save slot",
+                contentDesc = "Active save slot $activeSlot",
+                modifier = Modifier.weight(1f),
+            )
+            StatCard(
+                value = if (hasCheats) "$enabledCheatCount active" else "No cheats",
+                valueColor = if (hasCheats && enabledCheatCount > 0) SpColor.Warning else SpColor.OnBackgroundTertiary,
+                label = "Cheats",
+                contentDesc = if (hasCheats) "$enabledCheatCount cheats active" else "No cheats available",
+                modifier = Modifier.weight(1f),
+            )
+        }
+
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // Quick action row
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            EmulationActionButton(
+                icon = Icons.Filled.Save,
+                label = "Save",
+                onClick = onSave,
+                buttonSize = 48.dp,
+                iconSize = 24.dp,
+                showLabel = false,
+                useFocusRing = false,
+            )
+            EmulationActionButton(
+                icon = Icons.Filled.FolderOpen,
+                label = "Load",
+                onClick = onLoad,
+                buttonSize = 48.dp,
+                iconSize = 24.dp,
+                showLabel = false,
+                useFocusRing = false,
+            )
+            EmulationActionButton(
+                icon = Icons.Filled.CameraAlt,
+                label = "Screenshot",
+                onClick = onScreenshot,
+                buttonSize = 48.dp,
+                iconSize = 24.dp,
+                showLabel = false,
+                useFocusRing = false,
+            )
+            EmulationActionButton(
+                icon = if (isFastForward) Icons.Filled.PlayArrow else Icons.Filled.FastForward,
+                label = if (isFastForward) "Normal" else "Fast",
+                isActive = isFastForward,
+                onClick = onToggleFastForward,
+                buttonSize = 48.dp,
+                iconSize = 24.dp,
+                showLabel = false,
+                useFocusRing = false,
+            )
+            if (rewindEnabled) {
+                EmulationActionButton(
+                    icon = Icons.Filled.FastRewind,
+                    label = "Rewind",
+                    onClick = onRewind,
+                    buttonSize = 48.dp,
+                    iconSize = 24.dp,
+                    showLabel = false,
+                    useFocusRing = false,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatCard(
+    value: String,
+    valueColor: Color,
+    label: String,
+    contentDesc: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(SpSpacing.CardCornerRadius))
+            .background(SpColor.Card)
+            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small)
+            .semantics { contentDescription = contentDesc },
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            text = value,
+            style = SpTypography.HeadlineSmall,
+            color = valueColor,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+        )
+        Text(
+            text = label,
+            style = SpTypography.LabelSmall,
+            color = SpColor.OnBackgroundTertiary,
+            textAlign = TextAlign.Center,
+            maxLines = 1,
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryDashboardPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryDashboardPage.kt
@@ -33,6 +33,9 @@ import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 
+private val ACTION_BUTTON_SIZE = 48.dp
+private val ACTION_ICON_SIZE = 24.dp
+
 /**
  * Dashboard page for the secondary screen companion.
  *
@@ -101,8 +104,8 @@ fun SecondaryDashboardPage(
                 icon = Icons.Filled.Save,
                 label = "Save",
                 onClick = onSave,
-                buttonSize = 48.dp,
-                iconSize = 24.dp,
+                buttonSize = ACTION_BUTTON_SIZE,
+                iconSize = ACTION_ICON_SIZE,
                 showLabel = false,
                 useFocusRing = false,
             )
@@ -110,8 +113,8 @@ fun SecondaryDashboardPage(
                 icon = Icons.Filled.FolderOpen,
                 label = "Load",
                 onClick = onLoad,
-                buttonSize = 48.dp,
-                iconSize = 24.dp,
+                buttonSize = ACTION_BUTTON_SIZE,
+                iconSize = ACTION_ICON_SIZE,
                 showLabel = false,
                 useFocusRing = false,
             )
@@ -119,8 +122,8 @@ fun SecondaryDashboardPage(
                 icon = Icons.Filled.CameraAlt,
                 label = "Screenshot",
                 onClick = onScreenshot,
-                buttonSize = 48.dp,
-                iconSize = 24.dp,
+                buttonSize = ACTION_BUTTON_SIZE,
+                iconSize = ACTION_ICON_SIZE,
                 showLabel = false,
                 useFocusRing = false,
             )
@@ -129,8 +132,8 @@ fun SecondaryDashboardPage(
                 label = if (isFastForward) "Normal" else "Fast",
                 isActive = isFastForward,
                 onClick = onToggleFastForward,
-                buttonSize = 48.dp,
-                iconSize = 24.dp,
+                buttonSize = ACTION_BUTTON_SIZE,
+                iconSize = ACTION_ICON_SIZE,
                 showLabel = false,
                 useFocusRing = false,
             )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondarySaveSlotsPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondarySaveSlotsPage.kt
@@ -1,0 +1,138 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+private val SLOT_CARD_WIDTH = 80.dp
+private val SLOT_CARD_HEIGHT = 96.dp
+private val ACTIVE_BORDER_WIDTH = 2.dp
+private val SLOT_RANGE = 1..10
+
+/**
+ * Save Slots page for the secondary screen companion.
+ *
+ * Shows a horizontal scrollable row of save slot cards (1-10).
+ * The active slot is highlighted with a [SpColor.Primary] border.
+ * Tapping a slot card selects it as the active quick-save/load target.
+ */
+@Composable
+fun SecondarySaveSlotsPage(
+    activeSlot: Int,
+    onSelectSlot: (Int) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(vertical = SpSpacing.Medium),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Title
+        Text(
+            text = "Save Slots",
+            style = SpTypography.HeadlineSmall,
+            color = SpColor.OnBackground,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = SpSpacing.Medium)
+                .padding(bottom = SpSpacing.Medium)
+                .semantics { contentDescription = "Save Slots" },
+        )
+
+        // Horizontal scrollable row of slot cards
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = SpSpacing.Medium),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            items(SLOT_RANGE.toList()) { slot ->
+                val isActive = slot == activeSlot
+                SaveSlotCard(
+                    slot = slot,
+                    isActive = isActive,
+                    onClick = { onSelectSlot(slot) },
+                )
+            }
+        }
+
+        // Hint text
+        Text(
+            text = "Tap to select active slot",
+            style = SpTypography.LabelSmall,
+            color = SpColor.OnBackgroundTertiary,
+            modifier = Modifier
+                .padding(top = SpSpacing.Medium)
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+@Composable
+private fun SaveSlotCard(
+    slot: Int,
+    isActive: Boolean,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
+    val borderModifier = if (isActive) {
+        Modifier.border(ACTIVE_BORDER_WIDTH, SpColor.Primary, shape)
+    } else {
+        Modifier.border(ACTIVE_BORDER_WIDTH, SpColor.SurfaceVariant, shape)
+    }
+    val semanticDesc = if (isActive) "Save slot $slot, active" else "Save slot $slot"
+
+    Column(
+        modifier = Modifier
+            .width(SLOT_CARD_WIDTH)
+            .height(SLOT_CARD_HEIGHT)
+            .clip(shape)
+            .then(borderModifier)
+            .background(SpColor.Card, shape)
+            .clickable(onClick = onClick)
+            .semantics { contentDescription = semanticDesc }
+            .padding(SpSpacing.Small),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center,
+    ) {
+        // Slot number
+        Text(
+            text = "$slot",
+            style = SpTypography.HeadlineSmall,
+            color = if (isActive) SpColor.Primary else SpColor.OnBackground,
+            textAlign = TextAlign.Center,
+        )
+
+        // Label
+        Text(
+            text = if (isActive) "Active" else "Slot",
+            style = SpTypography.LabelSmall,
+            color = if (isActive) SpColor.Primary else SpColor.OnBackgroundTertiary,
+            textAlign = TextAlign.Center,
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
@@ -13,13 +13,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.CameraAlt
-import androidx.compose.material.icons.filled.FastForward
-import androidx.compose.material.icons.filled.FolderOpen
-import androidx.compose.material.icons.filled.PlayArrow
-import androidx.compose.material.icons.filled.Save
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -29,21 +28,23 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.input.pointer.PointerEventPass
 import androidx.compose.ui.input.pointer.pointerInput
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.collectLatest
 import com.spela.player.presentation.intent.EmulationIntent
+import com.spela.player.presentation.ui.feature.library.getConsoleGradient
 import com.spela.player.presentation.ui.screen.formatSessionDuration
-import com.spela.player.presentation.ui.components.EmulationActionButton
-import com.spela.player.presentation.ui.components.fpsColor
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -53,22 +54,34 @@ import org.koin.compose.koinInject
 
 private const val BURN_IN_IDLE_TIMEOUT_MS = 15_000L
 private const val BURN_IN_FADE_DURATION_MS = 5_000
+private const val PAGE_COUNT = 4
+private const val PAGE_ART = 0
+private const val PAGE_CONTROLS = 1
+private const val PAGE_DASHBOARD = 2
+private const val PAGE_SAVE_SLOTS = 3
 
 /**
  * Content composable displayed on the secondary screen during gameplay.
  *
- * Layout for ~3.92" screen:
+ * Layout for ~3.92" screen with swipeable pages:
  * ```
- * ┌─────────────────────────┐
- * │  Game Title    00:45:12  │  <- Game info bar
- * ├─────────────────────────┤
- * │                         │
- * │    [Touch Controls]     │  <- Main area: platform touch gamepad
- * │                         │
- * ├─────────────────────────┤
- * │ Save Load Shot FF │ FPS │  <- Quick actions + FPS
- * └─────────────────────────┘
+ * ┌─────────────────────────────┐
+ * │ ▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀ │  <- 2dp console gradient line
+ * │  Game Title    00:45:12 SNES │  <- Persistent header
+ * ├─────────────────────────────┤
+ * │                             │
+ * │   [ Swipeable Page Content ] │  <- HorizontalPager
+ * │                             │
+ * ├─────────────────────────────┤
+ * │          *  o               │  <- Page indicator dots
+ * └─────────────────────────────┘
  * ```
+ *
+ * Pages:
+ * - Page 0: Art Display — hero artwork or focus mode
+ * - Page 1: Controls — platform touch gamepad
+ * - Page 2: Dashboard — stat cards + quick actions
+ * - Page 3: Save Slots — visual save slot selection
  */
 @Composable
 fun SecondaryScreenContent(
@@ -87,7 +100,19 @@ fun SecondaryScreenContent(
         label = "burnInAlpha",
     )
 
+    val pagerState = rememberPagerState(
+        initialPage = PAGE_ART,
+        pageCount = { PAGE_COUNT },
+    )
+
+    // Reset burn-in timer when swiping between pages
     if (!state.isDualScreenConsole) {
+        LaunchedEffect(pagerState) {
+            snapshotFlow { pagerState.currentPage }.collectLatest {
+                touchResetKey++
+            }
+        }
+
         LaunchedEffect(touchResetKey, state.isPaused) {
             isDimmed = false
             delay(BURN_IN_IDLE_TIMEOUT_MS)
@@ -135,33 +160,67 @@ fun SecondaryScreenContent(
                     .fillMaxSize()
                     .graphicsLayer { alpha = contentAlpha * burnInAlpha },
             ) {
-                // Game info bar
-                GameInfoBar(
+                // Persistent header with console gradient accent
+                CompanionHeader(
                     gameTitle = state.gameTitle,
                     sessionElapsedSeconds = state.sessionElapsedSeconds,
+                    consoleId = state.consoleId,
+                    consoleColorTheme = state.consoleColorTheme,
                 )
 
-                // Main content area (takes remaining space)
-                Box(
+                // Swipeable page content
+                HorizontalPager(
+                    state = pagerState,
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth(),
-                ) {
-                    // Normal mode: touch gamepad controls
-                    PlatformTouchControls(
-                        controller = controller,
-                    )
+                ) { page ->
+                    when (page) {
+                        PAGE_ART -> {
+                            SecondaryArtPage(
+                                heroUrl = state.heroUrl,
+                                gameTitle = state.gameTitle,
+                                sessionElapsedSeconds = state.sessionElapsedSeconds,
+                                consoleId = state.consoleId,
+                                consoleColorTheme = state.consoleColorTheme,
+                            )
+                        }
+                        PAGE_CONTROLS -> {
+                            PlatformTouchControls(
+                                controller = controller,
+                            )
+                        }
+                        PAGE_DASHBOARD -> {
+                            SecondaryDashboardPage(
+                                fps = state.fps,
+                                frameTime = state.frameTime,
+                                activeSlot = state.activeSlot,
+                                hasCheats = state.hasCheats,
+                                enabledCheatCount = state.enabledCheatCount,
+                                isFastForward = state.isFastForward,
+                                rewindEnabled = state.rewindEnabled,
+                                onSave = { viewModel.onIntent(EmulationIntent.SaveState) },
+                                onLoad = { viewModel.onIntent(EmulationIntent.LoadState) },
+                                onScreenshot = { viewModel.onIntent(EmulationIntent.TakeScreenshot) },
+                                onToggleFastForward = { viewModel.onIntent(EmulationIntent.ToggleFastForward) },
+                                onRewind = { viewModel.onIntent(EmulationIntent.ToggleRewind) },
+                            )
+                        }
+                        PAGE_SAVE_SLOTS -> {
+                            SecondarySaveSlotsPage(
+                                activeSlot = state.activeSlot,
+                                onSelectSlot = { slot ->
+                                    viewModel.onIntent(EmulationIntent.SelectSlot(slot))
+                                },
+                            )
+                        }
+                    }
                 }
 
-                // Quick action bar + performance HUD
-                QuickActionBar(
-                    fps = state.fps,
-                    frameTime = state.frameTime,
-                    isFastForward = state.isFastForward,
-                    onSave = { viewModel.onIntent(EmulationIntent.SaveState) },
-                    onLoad = { viewModel.onIntent(EmulationIntent.LoadState) },
-                    onScreenshot = { viewModel.onIntent(EmulationIntent.TakeScreenshot) },
-                    onToggleFastForward = { viewModel.onIntent(EmulationIntent.ToggleFastForward) },
+                // Page indicator dots
+                PageIndicatorDots(
+                    pagerState = pagerState,
+                    pageCount = PAGE_COUNT,
                 )
             }
         }
@@ -203,123 +262,102 @@ fun SecondaryScreenContent(
     }
 }
 
+/**
+ * Persistent header with console gradient accent line, game title, session timer,
+ * and console badge.
+ */
 @Composable
-private fun GameInfoBar(
+private fun CompanionHeader(
     gameTitle: String,
     sessionElapsedSeconds: Long,
+    consoleId: String,
+    consoleColorTheme: String?,
 ) {
     val timeText = formatSessionDuration(sessionElapsedSeconds)
+    val (gradientFrom, gradientTo) = getConsoleGradient(consoleId, consoleColorTheme)
 
-    Row(
+    Column(
         modifier = Modifier
             .fillMaxWidth()
-            .background(SpColor.SurfaceVariant)
-            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small)
             .semantics {
                 contentDescription = "Now playing: $gameTitle"
             },
-        verticalAlignment = Alignment.CenterVertically,
     ) {
-        Text(
-            text = gameTitle,
-            style = SpTypography.TitleMedium,
-            color = SpColor.OnBackground,
-            maxLines = 1,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.weight(1f),
+        // Thin 2dp gradient accent line
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(2.dp)
+                .background(
+                    Brush.horizontalGradient(listOf(gradientFrom, gradientTo))
+                ),
         )
-        Spacer(Modifier.width(SpSpacing.Small))
-        Text(
-            text = timeText,
-            style = SpTypography.LabelLarge,
-            color = SpColor.OnBackgroundTertiary,
-        )
+
+        // Header content
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(SpColor.SurfaceVariant)
+                .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = gameTitle,
+                style = SpTypography.TitleMedium,
+                color = SpColor.OnBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.weight(1f),
+            )
+            Spacer(Modifier.width(SpSpacing.Small))
+            Text(
+                text = timeText,
+                style = SpTypography.LabelLarge,
+                color = SpColor.OnBackgroundTertiary,
+            )
+            if (consoleId.isNotEmpty()) {
+                Spacer(Modifier.width(SpSpacing.Small))
+                Text(
+                    text = consoleId.uppercase(),
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
+                )
+            }
+        }
     }
 }
 
+/**
+ * Horizontal row of page indicator dots. Active page dot uses [SpColor.Primary],
+ * inactive dots use [SpColor.OnBackgroundTertiary] at reduced alpha.
+ */
 @Composable
-private fun QuickActionBar(
-    fps: Float,
-    frameTime: Float,
-    isFastForward: Boolean,
-    onSave: () -> Unit,
-    onLoad: () -> Unit,
-    onScreenshot: () -> Unit,
-    onToggleFastForward: () -> Unit,
+private fun PageIndicatorDots(
+    pagerState: PagerState,
+    pageCount: Int,
 ) {
     Row(
         modifier = Modifier
             .fillMaxWidth()
-            .background(SpColor.SurfaceVariant)
-            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Medium),
+            .padding(vertical = SpSpacing.Small),
+        horizontalArrangement = Arrangement.Center,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        // Quick action buttons
-        Row(
-            modifier = Modifier.weight(1f),
-            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-        ) {
-            QuickActionButton(
-                icon = Icons.Filled.Save,
-                label = "Save",
-                onClick = onSave,
-            )
-            QuickActionButton(
-                icon = Icons.Filled.FolderOpen,
-                label = "Load",
-                onClick = onLoad,
-            )
-            QuickActionButton(
-                icon = Icons.Filled.CameraAlt,
-                label = "Screenshot",
-                onClick = onScreenshot,
-            )
-            QuickActionButton(
-                icon = if (isFastForward) Icons.Filled.PlayArrow else Icons.Filled.FastForward,
-                label = if (isFastForward) "Normal" else "Fast",
-                isActive = isFastForward,
-                onClick = onToggleFastForward,
-            )
-        }
-
-        Spacer(Modifier.width(SpSpacing.Small))
-
-        // Performance HUD
-        Column(
-            horizontalAlignment = Alignment.End,
-            modifier = Modifier.semantics {
-                contentDescription = "%.0f FPS, %.1f ms frame time".format(fps, frameTime)
-            },
-        ) {
-            Text(
-                text = "%.0f FPS".format(fps),
-                style = SpTypography.LabelLarge,
-                color = fpsColor(fps),
-            )
-            Text(
-                text = "%.1fms".format(frameTime),
-                style = SpTypography.LabelSmall,
-                color = SpColor.OnBackgroundTertiary,
+        repeat(pageCount) { index ->
+            val isActive = pagerState.currentPage == index
+            val color = if (isActive) SpColor.Primary else SpColor.OnBackgroundTertiary.copy(alpha = 0.4f)
+            if (index > 0) {
+                Spacer(Modifier.width(4.dp))
+            }
+            Box(
+                modifier = Modifier
+                    .size(6.dp)
+                    .clip(CircleShape)
+                    .background(color)
+                    .semantics {
+                        contentDescription = if (isActive) "Page ${index + 1} of $pageCount, active" else "Page ${index + 1} of $pageCount"
+                    },
             )
         }
     }
-}
-
-@Composable
-private fun QuickActionButton(
-    icon: ImageVector,
-    label: String,
-    isActive: Boolean = false,
-    onClick: () -> Unit,
-) {
-    EmulationActionButton(
-        icon = icon,
-        label = label,
-        onClick = onClick,
-        isActive = isActive,
-        buttonSize = 48.dp,
-        iconSize = 24.dp,
-        showLabel = false,
-        useFocusRing = false,
-    )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
@@ -59,6 +59,10 @@ private const val PAGE_ART = 0
 private const val PAGE_CONTROLS = 1
 private const val PAGE_DASHBOARD = 2
 private const val PAGE_SAVE_SLOTS = 3
+private val GRADIENT_LINE_HEIGHT = 2.dp
+private val DOT_SIZE = 6.dp
+private val DOT_SPACING = 4.dp
+private val PAGE_NAMES = arrayOf("Art", "Controls", "Dashboard", "Save Slots")
 
 /**
  * Content composable displayed on the secondary screen during gameplay.
@@ -225,11 +229,12 @@ fun SecondaryScreenContent(
             }
         }
 
-        // Paused overlay
+        // Paused overlay with scrim for readability over art page
         if (state.isPaused) {
             Box(
                 modifier = Modifier
                     .fillMaxSize()
+                    .background(SpColor.Scrim)
                     .graphicsLayer { alpha = burnInAlpha },
                 contentAlignment = Alignment.Center,
             ) {
@@ -287,7 +292,7 @@ private fun CompanionHeader(
         Box(
             modifier = Modifier
                 .fillMaxWidth()
-                .height(2.dp)
+                .height(GRADIENT_LINE_HEIGHT)
                 .background(
                     Brush.horizontalGradient(listOf(gradientFrom, gradientTo))
                 ),
@@ -347,15 +352,16 @@ private fun PageIndicatorDots(
             val isActive = pagerState.currentPage == index
             val color = if (isActive) SpColor.Primary else SpColor.OnBackgroundTertiary.copy(alpha = 0.4f)
             if (index > 0) {
-                Spacer(Modifier.width(4.dp))
+                Spacer(Modifier.width(DOT_SPACING))
             }
+            val pageName = PAGE_NAMES.getOrElse(index) { "Page" }
             Box(
                 modifier = Modifier
-                    .size(6.dp)
+                    .size(DOT_SIZE)
                     .clip(CircleShape)
                     .background(color)
                     .semantics {
-                        contentDescription = if (isActive) "Page ${index + 1} of $pageCount, active" else "Page ${index + 1} of $pageCount"
+                        contentDescription = if (isActive) "$pageName, ${index + 1} of $pageCount, active" else "$pageName, ${index + 1} of $pageCount"
                     },
             )
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -267,11 +267,17 @@ class EmulationViewModel(
             var consoleId = ""
             var consoleName = ""
             getGameDetailUseCase(gameId).onSuccess { detail ->
-                withContext(dispatchers.main) {
-                    _state.update { it.copy(gameTitle = detail.game.title, consoleId = detail.game.consoleId) }
-                }
                 consoleId = detail.game.consoleId
                 consoleName = detail.game.consoleName
+                withContext(dispatchers.main) {
+                    _state.update {
+                        it.copy(
+                            gameTitle = detail.game.title,
+                            consoleId = detail.game.consoleId,
+                            heroUrl = detail.game.heroUrl,
+                        )
+                    }
+                }
             }
 
             // Pre-launch BIOS check
@@ -643,6 +649,8 @@ class EmulationViewModel(
                         showGiveUpConfirm = false,
                         challengeCompletedAttempt = null,
                         sessionId = null,
+                        consoleColorTheme = null,
+                        heroUrl = null,
                         showCoreMismatchDialog = false,
                         coreMismatchSaveCoreName = "",
                         coreMismatchCurrentCoreName = "",

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -49,6 +49,7 @@ import com.spela.player.domain.repository.SaveDataRepository
 import com.spela.player.domain.model.GameSession
 import com.spela.player.domain.model.SessionCheatConfig
 import com.spela.player.domain.repository.SessionRepository
+import com.spela.player.domain.usecase.GetConsolesUseCase
 import com.spela.player.domain.usecase.GetGameDetailUseCase
 import com.spela.player.domain.usecase.PrepareGameUseCase
 import com.spela.player.libretro.GamepadPortManager

--- a/server/internal/api/admin_handler.go
+++ b/server/internal/api/admin_handler.go
@@ -193,7 +193,8 @@ func (h *AdminHandler) UpdateUser(c *gin.Context) {
 
 // secretSettingKeys are settings that should be masked in GET responses.
 var secretSettingKeys = map[string]bool{
-	"igdb_client_secret": true,
+	"igdb_client_secret":   true,
+	"steamgriddb_api_key":  true,
 }
 
 // GetSettings returns server settings (admin only).
@@ -226,6 +227,7 @@ var allowedSettingKeys = map[string]bool{
 	"igdb_client_id":       true,
 	"igdb_client_secret":   true,
 	"bios_auto_download":   true,
+	"steamgriddb_api_key":  true,
 }
 
 // UpdateSettings updates server settings (admin only).
@@ -304,6 +306,7 @@ func (h *AdminHandler) MetadataMatches(c *gin.Context) {
 // Legacy ?force=true is equivalent to ?mode=all.
 func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 	h.tryConfigureIGDB()
+	h.tryConfigureSteamGridDB()
 
 	mode := c.Query("mode")
 	if mode == "" && c.Query("force") == "true" {
@@ -573,6 +576,7 @@ func (h *AdminHandler) ScrapeGame(c *gin.Context) {
 	}
 
 	h.tryConfigureIGDB()
+	h.tryConfigureSteamGridDB()
 
 	if err := h.Scraper.ScrapeGame(&game); err != nil {
 		slog.Warn("scrape failed", "game", game.Title, "error", err)
@@ -608,6 +612,26 @@ func (h *AdminHandler) tryConfigureIGDB() {
 		h.Scraper.IGDBClient.Close()
 	}
 	h.Scraper.IGDBClient = igdb.NewClient(clientID, clientSecret)
+}
+
+// tryConfigureSteamGridDB loads the SteamGridDB API key from environment or database
+// settings and configures the scraper's SteamGridDB client.
+func (h *AdminHandler) tryConfigureSteamGridDB() {
+	apiKey := steamGridDBAPIKey(h.DB)
+	h.Scraper.ConfigureSteamGridDB(apiKey)
+}
+
+// steamGridDBAPIKey returns the SteamGridDB API key from the environment
+// variable SPELA_STEAMGRIDDB_API_KEY, falling back to the database setting.
+func steamGridDBAPIKey(database *gorm.DB) string {
+	if key := os.Getenv("SPELA_STEAMGRIDDB_API_KEY"); key != "" {
+		return key
+	}
+	var setting db.ServerSetting
+	if err := database.Where("key = ?", "steamgriddb_api_key").First(&setting).Error; err != nil {
+		return ""
+	}
+	return setting.Value
 }
 
 // CoverOption represents a single available cover art source.
@@ -903,6 +927,7 @@ func (h *AdminHandler) ApplyIGDBMatch(c *gin.Context) {
 	}
 
 	h.tryConfigureIGDB()
+	h.tryConfigureSteamGridDB()
 
 	if err := h.Scraper.ScrapeGameWithIGDBMatch(&game, req.IGDBID); err != nil {
 		slog.Warn("IGDB match failed", "game", game.Title, "igdbId", req.IGDBID, "error", err)

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -70,6 +70,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.SessionSaveData{},
 		&db.SessionCheatSetting{},
 		&db.DailyPlayActivity{},
+		&db.GameArtwork{},
 	)
 	require.NoError(t, err)
 	err = db.SeedConsoles(database)

--- a/server/internal/api/artwork_handler.go
+++ b/server/internal/api/artwork_handler.go
@@ -1,0 +1,42 @@
+package api
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// ArtworkHandler handles game artwork endpoints.
+type ArtworkHandler struct {
+	DB *gorm.DB
+}
+
+// GameArtworkResponse is the API response for a game's artwork URLs.
+type GameArtworkResponse struct {
+	HeroURL string `json:"heroUrl,omitempty"`
+	GridURL string `json:"gridUrl,omitempty"`
+	LogoURL string `json:"logoUrl,omitempty"`
+	IconURL string `json:"iconUrl,omitempty"`
+}
+
+// GetGameArtwork returns the SteamGridDB artwork for a game.
+// If artwork exists in the DB, return it. If not, return empty (no scrape triggered).
+func (h *ArtworkHandler) GetGameArtwork(c *gin.Context) {
+	id := c.Param("id")
+
+	var artwork db.GameArtwork
+	if err := h.DB.Where("game_id = ?", id).First(&artwork).Error; err != nil {
+		// No artwork found — return empty response (not an error)
+		c.JSON(http.StatusOK, GameArtworkResponse{})
+		return
+	}
+
+	c.JSON(http.StatusOK, GameArtworkResponse{
+		HeroURL: artwork.HeroURL,
+		GridURL: artwork.GridURL,
+		LogoURL: artwork.LogoURL,
+		IconURL: artwork.IconURL,
+	})
+}

--- a/server/internal/api/artwork_handler_test.go
+++ b/server/internal/api/artwork_handler_test.go
@@ -1,0 +1,167 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGameArtwork_NoArtwork(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	// Create a game
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     "Test Game",
+		FileName:  "test.nes",
+		FilePath:  "nes/test.nes",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	// Request artwork for the game (none exists)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.FormatUint(uint64(game.ID), 10)+"/artwork", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp GameArtworkResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.HeroURL)
+	assert.Empty(t, resp.GridURL)
+	assert.Empty(t, resp.LogoURL)
+	assert.Empty(t, resp.IconURL)
+}
+
+func TestGetGameArtwork_WithArtwork(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	// Create a game
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     "Super Mario World",
+		FileName:  "smw.sfc",
+		FilePath:  "snes/smw.sfc",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	// Create artwork for the game
+	artwork := db.GameArtwork{
+		GameID:        game.ID,
+		SteamGridDBID: 5432,
+		HeroURL:       "https://cdn.steamgriddb.com/hero/smw.png",
+		GridURL:       "https://cdn.steamgriddb.com/grid/smw.png",
+		LogoURL:       "https://cdn.steamgriddb.com/logo/smw.png",
+		IconURL:       "https://cdn.steamgriddb.com/icon/smw.png",
+	}
+	require.NoError(t, database.Create(&artwork).Error)
+
+	// Request artwork
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.FormatUint(uint64(game.ID), 10)+"/artwork", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp GameArtworkResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://cdn.steamgriddb.com/hero/smw.png", resp.HeroURL)
+	assert.Equal(t, "https://cdn.steamgriddb.com/grid/smw.png", resp.GridURL)
+	assert.Equal(t, "https://cdn.steamgriddb.com/logo/smw.png", resp.LogoURL)
+	assert.Equal(t, "https://cdn.steamgriddb.com/icon/smw.png", resp.IconURL)
+}
+
+func TestGetGameArtwork_IncludedInGameDetail(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	// Create a game with console
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     "Metroid",
+		FileName:  "metroid.nes",
+		FilePath:  "nes/metroid.nes",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	// Create artwork
+	artwork := db.GameArtwork{
+		GameID:  game.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/metroid.png",
+		LogoURL: "https://cdn.steamgriddb.com/logo/metroid.png",
+	}
+	require.NoError(t, database.Create(&artwork).Error)
+
+	// Get game detail — should include heroUrl and logoUrl
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.FormatUint(uint64(game.ID), 10), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "https://cdn.steamgriddb.com/hero/metroid.png", resp.HeroURL)
+	assert.Equal(t, "https://cdn.steamgriddb.com/logo/metroid.png", resp.LogoURL)
+}
+
+func TestGetGameArtwork_GameDetailNoArtwork(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	// Create a game without artwork
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     "Zelda",
+		FileName:  "zelda.nes",
+		FilePath:  "nes/zelda.nes",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	// Get game detail — heroUrl and logoUrl should be empty
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.FormatUint(uint64(game.ID), 10), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.HeroURL)
+	assert.Empty(t, resp.LogoURL)
+}
+
+func TestSteamGridDBSettingsAllowed(t *testing.T) {
+	// Verify that steamgriddb_api_key is in the allowed settings and secret settings
+	assert.True(t, allowedSettingKeys["steamgriddb_api_key"], "steamgriddb_api_key should be in allowedSettingKeys")
+	assert.True(t, secretSettingKeys["steamgriddb_api_key"], "steamgriddb_api_key should be in secretSettingKeys")
+}

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -313,6 +313,11 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 		}
 	}
 
+	// Configure SteamGridDB if API key is set (best-effort artwork during auto-scrape)
+	if apiKey := steamGridDBAPIKey(h.DB); apiKey != "" {
+		h.Scraper.ConfigureSteamGridDB(apiKey)
+	}
+
 	// Auto-scrape new games if IGDB is configured
 	if result.NewGames > 0 && h.Scraper.IsIGDBConfigured() {
 		if h.Scraper.TryStartScrape() {
@@ -352,6 +357,11 @@ func (h *GameHandler) ScrapeIfNeeded(c *gin.Context) {
 	if game.ScrapeAttempts > 0 {
 		c.JSON(http.StatusOK, gin.H{"status": "already_scraped"})
 		return
+	}
+
+	// Configure SteamGridDB if API key is set (best-effort artwork)
+	if apiKey := steamGridDBAPIKey(h.DB); apiKey != "" {
+		h.Scraper.ConfigureSteamGridDB(apiKey)
 	}
 
 	go func() {

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -68,6 +68,8 @@ type GameResponse struct {
 	VerificationStatus  string         `json:"verificationStatus,omitempty"`
 	VerificationTag     string         `json:"verificationTag,omitempty"`
 	Region              string         `json:"region,omitempty"`
+	HeroURL        string         `json:"heroUrl,omitempty"`
+	LogoURL        string         `json:"logoUrl,omitempty"`
 	BiosStatus     string         `json:"biosStatus,omitempty"`
 	IsFavorite     bool           `json:"isFavorite"`
 	IsInPlayLater  bool           `json:"isInPlayLater"`
@@ -130,6 +132,7 @@ type userGameData struct {
 	playHistory map[uint]*db.PlayHistory
 	userRatings map[uint]int            // gameID -> user's rating (1-5)
 	ratingAggs  map[uint]ratingAggregate // gameID -> aggregate rating data
+	artworks    map[uint]*db.GameArtwork // gameID -> artwork (hero, logo, etc.)
 }
 
 // loadUserGameData batch-loads favorites, play later, play history, ratings, and
@@ -142,9 +145,17 @@ func loadUserGameData(database *gorm.DB, userID uint, gameIDs []uint) userGameDa
 		playHistory: make(map[uint]*db.PlayHistory, len(gameIDs)),
 		userRatings: make(map[uint]int, len(gameIDs)),
 		ratingAggs:  make(map[uint]ratingAggregate, len(gameIDs)),
+		artworks:    make(map[uint]*db.GameArtwork, len(gameIDs)),
 	}
 	if database == nil || len(gameIDs) == 0 {
 		return data
+	}
+
+	// Batch-load artwork (hero/logo URLs from SteamGridDB)
+	var artworks []db.GameArtwork
+	database.Where("game_id IN ?", gameIDs).Find(&artworks)
+	for i := range artworks {
+		data.artworks[artworks[i].GameID] = &artworks[i]
 	}
 
 	// Batch-load rating aggregates (works even without a logged-in user)
@@ -292,6 +303,10 @@ func toGameResponseWithData(g db.Game, data *userGameData) GameResponse {
 		}
 		if rating, ok := data.userRatings[g.ID]; ok {
 			resp.UserRating = &rating
+		}
+		if artwork, ok := data.artworks[g.ID]; ok {
+			resp.HeroURL = artwork.HeroURL
+			resp.LogoURL = artwork.LogoURL
 		}
 	}
 

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -171,6 +171,7 @@ func NewRouter(cfg Config) *gin.Engine {
 	challengeHandler := NewChallengeHandler(cfg.DB, cfg.Storage, cfg.Hub)
 	challengeHandler.AttemptRateLimitSeconds = cfg.ChallengeAttemptRateLimitSec
 	sessionHandler := &SessionHandler{DB: cfg.DB, Storage: cfg.Storage}
+	artworkHandler := &ArtworkHandler{DB: cfg.DB}
 	discoveryHandler := &GameDiscoveryHandler{DB: cfg.DB, Scraper: cfg.Scraper}
 	setupHandler := &SetupHandler{
 		DB:            cfg.DB,
@@ -241,6 +242,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.DELETE("/games/:id/play-time", gameHandler.StopPlaying)
 		api.GET("/games/:id/stats", gameHandler.GetGameStats)
 		api.GET("/games/:id/cheats", gameHandler.GetGameCheats)
+		api.GET("/games/:id/artwork", artworkHandler.GetGameArtwork)
 		api.GET("/games/:id/similar", discoveryHandler.GetSimilarGames)
 		api.GET("/games/:id/developer-games", discoveryHandler.GetDeveloperGames)
 

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -153,6 +153,7 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&SessionSaveData{},
 		&SessionCheatSetting{},
 		&DailyPlayActivity{},
+		&GameArtwork{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)
@@ -373,6 +374,9 @@ func mergeGameData(database *gorm.DB, keeperID, dupID uint) {
 
 	// SharedSaveState — move all
 	database.Model(&SharedSaveState{}).Where("game_id = ?", dupID).Update("game_id", keeperID)
+
+	// GameArtwork — delete duplicate (keeper keeps its own or we skip)
+	database.Where("game_id = ?", dupID).Delete(&GameArtwork{})
 
 	// GameAchievementCache — move all
 	database.Model(&GameAchievementCache{}).Where("game_id = ?", dupID).Update("game_id", keeperID)

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -622,6 +622,19 @@ type SessionCheatSetting struct {
 	Enabled    bool      `gorm:"default:false" json:"enabled"`
 }
 
+// GameArtwork stores SteamGridDB artwork URLs for a game (hero banners, grids, logos, icons).
+type GameArtwork struct {
+	ID            uint      `gorm:"primarykey" json:"id"`
+	GameID        uint      `gorm:"uniqueIndex;not null" json:"gameId"`
+	SteamGridDBID int       `json:"steamGridDbId,omitempty"`
+	HeroURL       string    `gorm:"size:1024" json:"heroUrl,omitempty"`
+	GridURL       string    `gorm:"size:1024" json:"gridUrl,omitempty"`
+	LogoURL       string    `gorm:"size:1024" json:"logoUrl,omitempty"`
+	IconURL       string    `gorm:"size:1024" json:"iconUrl,omitempty"`
+	CreatedAt     time.Time `json:"createdAt"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+}
+
 // StagedUpload represents a ROM file uploaded to the staging area pending admin review.
 type StagedUpload struct {
 	ID               uint           `gorm:"primarykey" json:"id"`

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -21,13 +21,14 @@ import (
 
 // Scraper fetches game metadata from IGDB and box art from LibRetro Thumbnails (preferred) with IGDB fallback.
 type Scraper struct {
-	DB         *gorm.DB
-	Storage    *storage.Storage
-	HTTPClient *http.Client
-	IGDBClient *igdb.Client
-	DATCache   *DATCache
-	GameDirs   []string
-	cache      *nameCache
+	DB               *gorm.DB
+	Storage          *storage.Storage
+	HTTPClient       *http.Client
+	IGDBClient       *igdb.Client
+	SteamGridDBClient *SteamGridDBClient
+	DATCache         *DATCache
+	GameDirs         []string
+	cache            *nameCache
 
 	// Scrape state tracking (shared across handlers)
 	scrapeMu       sync.Mutex
@@ -327,6 +328,9 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 	if game.Region == "" {
 		game.Region = ExtractRegion(game.FileName)
 	}
+
+	// --- SteamGridDB artwork (best-effort) ---
+	s.scrapeSteamGridDBArtwork(game, console)
 
 	game.ScrapeAttempts++
 
@@ -631,6 +635,9 @@ func (s *Scraper) ScrapeGameWithIGDBMatch(game *db.Game, igdbID int) error {
 		}
 	}
 
+	// --- SteamGridDB artwork (best-effort) ---
+	s.scrapeSteamGridDBArtwork(game, console)
+
 	game.ScrapeAttempts++
 
 	if err := s.DB.Save(game).Error; err != nil {
@@ -664,6 +671,46 @@ func (s *Scraper) downloadExternalImage(imageURL, subpath string) string {
 
 	slog.Debug("downloaded external image", "url", imageURL)
 	return savedPath
+}
+
+// scrapeSteamGridDBArtwork fetches artwork from SteamGridDB and saves it to the DB.
+// This is best-effort: if the API key is not configured, or SteamGridDB returns no results,
+// the game scrape still succeeds.
+func (s *Scraper) scrapeSteamGridDBArtwork(game *db.Game, console db.Console) {
+	if s.SteamGridDBClient == nil {
+		return
+	}
+
+	// Check if artwork already exists for this game
+	var existing db.GameArtwork
+	if err := s.DB.Where("game_id = ?", game.ID).First(&existing).Error; err == nil {
+		// Artwork already exists, skip
+		return
+	}
+
+	artwork, err := s.SteamGridDBClient.GetBestArtwork(game.Title, console.Abbreviation)
+	if err != nil {
+		slog.Debug("SteamGridDB artwork fetch failed", "game", game.Title, "error", err)
+		return
+	}
+
+	artwork.GameID = game.ID
+	if err := s.DB.Create(artwork).Error; err != nil {
+		slog.Warn("failed to save SteamGridDB artwork", "game", game.Title, "error", err)
+		return
+	}
+
+	slog.Info("saved SteamGridDB artwork", "game", game.Title, "steamGridDbId", artwork.SteamGridDBID)
+}
+
+// ConfigureSteamGridDB sets up the SteamGridDB client from the given API key.
+// If apiKey is empty, the client is set to nil (disabled).
+func (s *Scraper) ConfigureSteamGridDB(apiKey string) {
+	if apiKey == "" {
+		s.SteamGridDBClient = nil
+		return
+	}
+	s.SteamGridDBClient = NewSteamGridDBClient(apiKey)
 }
 
 // ScrapeProgress holds progress information for a bulk scrape operation.

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -710,6 +710,9 @@ func (s *Scraper) ConfigureSteamGridDB(apiKey string) {
 		s.SteamGridDBClient = nil
 		return
 	}
+	if s.SteamGridDBClient != nil && s.SteamGridDBClient.APIKey == apiKey {
+		return
+	}
 	s.SteamGridDBClient = NewSteamGridDBClient(apiKey)
 }
 

--- a/server/internal/scraper/steamgriddb.go
+++ b/server/internal/scraper/steamgriddb.go
@@ -72,7 +72,7 @@ func (c *SteamGridDBClient) doRequest(path string) ([]byte, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
 	if err != nil {
 		return nil, fmt.Errorf("reading response body: %w", err)
 	}

--- a/server/internal/scraper/steamgriddb.go
+++ b/server/internal/scraper/steamgriddb.go
@@ -1,0 +1,210 @@
+package scraper
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"sort"
+	"time"
+
+	"github.com/spela/server/internal/db"
+)
+
+const steamGridDBBaseURL = "https://www.steamgriddb.com/api/v2"
+
+// SteamGridDBClient interacts with the SteamGridDB API v2.
+type SteamGridDBClient struct {
+	APIKey     string
+	BaseURL    string
+	HTTPClient *http.Client
+}
+
+// SteamGridDBImage represents an image returned by SteamGridDB.
+type SteamGridDBImage struct {
+	ID     int    `json:"id"`
+	URL    string `json:"url"`
+	Thumb  string `json:"thumb"`
+	Width  int    `json:"width"`
+	Height int    `json:"height"`
+	Style  string `json:"style"`
+	Score  int    `json:"score"`
+}
+
+// steamGridDBSearchResult represents a game result from the search endpoint.
+type steamGridDBSearchResult struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// steamGridDBResponse wraps the common API response structure.
+type steamGridDBResponse[T any] struct {
+	Success bool `json:"success"`
+	Data    T    `json:"data"`
+}
+
+// NewSteamGridDBClient creates a new SteamGridDB API client.
+func NewSteamGridDBClient(apiKey string) *SteamGridDBClient {
+	return &SteamGridDBClient{
+		APIKey:  apiKey,
+		BaseURL: steamGridDBBaseURL,
+		HTTPClient: &http.Client{
+			Timeout: 15 * time.Second,
+		},
+	}
+}
+
+// doRequest performs an authenticated GET request to the SteamGridDB API.
+func (c *SteamGridDBClient) doRequest(path string) ([]byte, error) {
+	reqURL := c.BaseURL + path
+
+	req, err := http.NewRequest("GET", reqURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+c.APIKey)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("executing request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading response body: %w", err)
+	}
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("not found: %s", path)
+	}
+	if resp.StatusCode == http.StatusUnauthorized {
+		return nil, fmt.Errorf("unauthorized: invalid SteamGridDB API key")
+	}
+	if resp.StatusCode == http.StatusTooManyRequests {
+		return nil, fmt.Errorf("rate limited by SteamGridDB")
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+// SearchGame searches SteamGridDB for a game by name and returns the best match game ID.
+// The platform parameter is currently unused (search is name-based) but reserved for future filtering.
+func (c *SteamGridDBClient) SearchGame(name string, platform string) (int, error) {
+	encodedName := url.PathEscape(name)
+	body, err := c.doRequest("/search/autocomplete/" + encodedName)
+	if err != nil {
+		return 0, fmt.Errorf("searching SteamGridDB for %q: %w", name, err)
+	}
+
+	var resp steamGridDBResponse[[]steamGridDBSearchResult]
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return 0, fmt.Errorf("parsing search response: %w", err)
+	}
+
+	if !resp.Success || len(resp.Data) == 0 {
+		return 0, fmt.Errorf("no results found for %q", name)
+	}
+
+	// Return the first (best) match
+	return resp.Data[0].ID, nil
+}
+
+// GetHeroes returns hero images for a SteamGridDB game ID.
+func (c *SteamGridDBClient) GetHeroes(gameID int) ([]SteamGridDBImage, error) {
+	return c.getImages(fmt.Sprintf("/heroes/game/%d", gameID))
+}
+
+// GetGrids returns grid/cover images for a SteamGridDB game ID.
+func (c *SteamGridDBClient) GetGrids(gameID int) ([]SteamGridDBImage, error) {
+	return c.getImages(fmt.Sprintf("/grids/game/%d", gameID))
+}
+
+// GetLogos returns logo images for a SteamGridDB game ID.
+func (c *SteamGridDBClient) GetLogos(gameID int) ([]SteamGridDBImage, error) {
+	return c.getImages(fmt.Sprintf("/logos/game/%d", gameID))
+}
+
+// GetIcons returns icon images for a SteamGridDB game ID.
+func (c *SteamGridDBClient) GetIcons(gameID int) ([]SteamGridDBImage, error) {
+	return c.getImages(fmt.Sprintf("/icons/game/%d", gameID))
+}
+
+// getImages fetches images from a SteamGridDB endpoint and returns them sorted by score (highest first).
+func (c *SteamGridDBClient) getImages(path string) ([]SteamGridDBImage, error) {
+	body, err := c.doRequest(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp steamGridDBResponse[[]SteamGridDBImage]
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("parsing image response: %w", err)
+	}
+
+	if !resp.Success {
+		return nil, fmt.Errorf("SteamGridDB returned unsuccessful response")
+	}
+
+	// Sort by score descending
+	images := resp.Data
+	sort.Slice(images, func(i, j int) bool {
+		return images[i].Score > images[j].Score
+	})
+
+	return images, nil
+}
+
+// bestImageURL returns the URL of the highest-scored image, or empty if none available.
+func bestImageURL(images []SteamGridDBImage) string {
+	if len(images) == 0 {
+		return ""
+	}
+	return images[0].URL
+}
+
+// GetBestArtwork searches SteamGridDB for a game and fetches the highest-scored artwork
+// of each type (hero, grid, logo, icon). Returns a GameArtwork with URLs populated.
+// Returns nil if the game is not found on SteamGridDB.
+func (c *SteamGridDBClient) GetBestArtwork(name string, platform string) (*db.GameArtwork, error) {
+	gameID, err := c.SearchGame(name, platform)
+	if err != nil {
+		return nil, fmt.Errorf("searching game: %w", err)
+	}
+
+	artwork := &db.GameArtwork{
+		SteamGridDBID: gameID,
+	}
+
+	// Fetch all image types, continuing on individual failures
+	if heroes, err := c.GetHeroes(gameID); err != nil {
+		slog.Debug("SteamGridDB: failed to fetch heroes", "gameId", gameID, "error", err)
+	} else {
+		artwork.HeroURL = bestImageURL(heroes)
+	}
+
+	if grids, err := c.GetGrids(gameID); err != nil {
+		slog.Debug("SteamGridDB: failed to fetch grids", "gameId", gameID, "error", err)
+	} else {
+		artwork.GridURL = bestImageURL(grids)
+	}
+
+	if logos, err := c.GetLogos(gameID); err != nil {
+		slog.Debug("SteamGridDB: failed to fetch logos", "gameId", gameID, "error", err)
+	} else {
+		artwork.LogoURL = bestImageURL(logos)
+	}
+
+	if icons, err := c.GetIcons(gameID); err != nil {
+		slog.Debug("SteamGridDB: failed to fetch icons", "gameId", gameID, "error", err)
+	} else {
+		artwork.IconURL = bestImageURL(icons)
+	}
+
+	return artwork, nil
+}

--- a/server/internal/scraper/steamgriddb_test.go
+++ b/server/internal/scraper/steamgriddb_test.go
@@ -1,0 +1,353 @@
+package scraper
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSteamGridDBClient_SearchGame(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "Bearer test-api-key", r.Header.Get("Authorization"))
+		assert.Equal(t, "/api/v2/search/autocomplete/Super Mario World", r.URL.Path)
+
+		resp := steamGridDBResponse[[]steamGridDBSearchResult]{
+			Success: true,
+			Data: []steamGridDBSearchResult{
+				{ID: 5432, Name: "Super Mario World"},
+				{ID: 9999, Name: "Super Mario World 2"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := &SteamGridDBClient{
+		APIKey:     "test-api-key",
+		BaseURL:    server.URL + "/api/v2",
+		HTTPClient: server.Client(),
+	}
+
+	gameID, err := client.SearchGame("Super Mario World", "")
+	require.NoError(t, err)
+	assert.Equal(t, 5432, gameID)
+}
+
+func TestSteamGridDBClient_SearchGame_NoResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := steamGridDBResponse[[]steamGridDBSearchResult]{
+			Success: true,
+			Data:    []steamGridDBSearchResult{},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := &SteamGridDBClient{
+		APIKey:     "test-api-key",
+		BaseURL:    server.URL + "/api/v2",
+		HTTPClient: server.Client(),
+	}
+
+	_, err := client.SearchGame("NonexistentGame12345", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no results found")
+}
+
+func TestSteamGridDBClient_SearchGame_Unauthorized(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"success":false}`))
+	}))
+	defer server.Close()
+
+	client := &SteamGridDBClient{
+		APIKey:     "bad-key",
+		BaseURL:    server.URL + "/api/v2",
+		HTTPClient: server.Client(),
+	}
+
+	_, err := client.SearchGame("Test", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unauthorized")
+}
+
+func TestSteamGridDBClient_GetHeroes(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/heroes/game/5432", r.URL.Path)
+
+		resp := steamGridDBResponse[[]SteamGridDBImage]{
+			Success: true,
+			Data: []SteamGridDBImage{
+				{ID: 1, URL: "https://cdn.steamgriddb.com/hero/1.png", Score: 5, Width: 1920, Height: 620},
+				{ID: 2, URL: "https://cdn.steamgriddb.com/hero/2.png", Score: 10, Width: 1920, Height: 620},
+				{ID: 3, URL: "https://cdn.steamgriddb.com/hero/3.png", Score: 3, Width: 1920, Height: 620},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := &SteamGridDBClient{
+		APIKey:     "test-api-key",
+		BaseURL:    server.URL + "/api/v2",
+		HTTPClient: server.Client(),
+	}
+
+	heroes, err := client.GetHeroes(5432)
+	require.NoError(t, err)
+	require.Len(t, heroes, 3)
+
+	// Verify sorted by score descending
+	assert.Equal(t, 10, heroes[0].Score)
+	assert.Equal(t, "https://cdn.steamgriddb.com/hero/2.png", heroes[0].URL)
+	assert.Equal(t, 5, heroes[1].Score)
+	assert.Equal(t, 3, heroes[2].Score)
+}
+
+func TestSteamGridDBClient_GetGrids(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/grids/game/100", r.URL.Path)
+
+		resp := steamGridDBResponse[[]SteamGridDBImage]{
+			Success: true,
+			Data: []SteamGridDBImage{
+				{ID: 10, URL: "https://cdn.steamgriddb.com/grid/10.png", Score: 8},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := &SteamGridDBClient{
+		APIKey:     "test-api-key",
+		BaseURL:    server.URL + "/api/v2",
+		HTTPClient: server.Client(),
+	}
+
+	grids, err := client.GetGrids(100)
+	require.NoError(t, err)
+	require.Len(t, grids, 1)
+	assert.Equal(t, "https://cdn.steamgriddb.com/grid/10.png", grids[0].URL)
+}
+
+func TestSteamGridDBClient_GetLogos(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/logos/game/200", r.URL.Path)
+
+		resp := steamGridDBResponse[[]SteamGridDBImage]{
+			Success: true,
+			Data: []SteamGridDBImage{
+				{ID: 20, URL: "https://cdn.steamgriddb.com/logo/20.png", Score: 12},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := &SteamGridDBClient{
+		APIKey:     "test-api-key",
+		BaseURL:    server.URL + "/api/v2",
+		HTTPClient: server.Client(),
+	}
+
+	logos, err := client.GetLogos(200)
+	require.NoError(t, err)
+	require.Len(t, logos, 1)
+	assert.Equal(t, "https://cdn.steamgriddb.com/logo/20.png", logos[0].URL)
+}
+
+func TestSteamGridDBClient_GetIcons(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/v2/icons/game/300", r.URL.Path)
+
+		resp := steamGridDBResponse[[]SteamGridDBImage]{
+			Success: true,
+			Data: []SteamGridDBImage{
+				{ID: 30, URL: "https://cdn.steamgriddb.com/icon/30.png", Score: 7},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := &SteamGridDBClient{
+		APIKey:     "test-api-key",
+		BaseURL:    server.URL + "/api/v2",
+		HTTPClient: server.Client(),
+	}
+
+	icons, err := client.GetIcons(300)
+	require.NoError(t, err)
+	require.Len(t, icons, 1)
+	assert.Equal(t, "https://cdn.steamgriddb.com/icon/30.png", icons[0].URL)
+}
+
+func TestSteamGridDBClient_GetBestArtwork(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/api/v2/search/autocomplete/Zelda":
+			resp := steamGridDBResponse[[]steamGridDBSearchResult]{
+				Success: true,
+				Data:    []steamGridDBSearchResult{{ID: 42, Name: "The Legend of Zelda"}},
+			}
+			json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/api/v2/heroes/game/42":
+			resp := steamGridDBResponse[[]SteamGridDBImage]{
+				Success: true,
+				Data:    []SteamGridDBImage{{ID: 1, URL: "https://cdn.steamgriddb.com/hero/zelda.png", Score: 15}},
+			}
+			json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/api/v2/grids/game/42":
+			resp := steamGridDBResponse[[]SteamGridDBImage]{
+				Success: true,
+				Data:    []SteamGridDBImage{{ID: 2, URL: "https://cdn.steamgriddb.com/grid/zelda.png", Score: 10}},
+			}
+			json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/api/v2/logos/game/42":
+			resp := steamGridDBResponse[[]SteamGridDBImage]{
+				Success: true,
+				Data:    []SteamGridDBImage{{ID: 3, URL: "https://cdn.steamgriddb.com/logo/zelda.png", Score: 8}},
+			}
+			json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/api/v2/icons/game/42":
+			resp := steamGridDBResponse[[]SteamGridDBImage]{
+				Success: true,
+				Data:    []SteamGridDBImage{{ID: 4, URL: "https://cdn.steamgriddb.com/icon/zelda.png", Score: 5}},
+			}
+			json.NewEncoder(w).Encode(resp)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := &SteamGridDBClient{
+		APIKey:     "test-api-key",
+		BaseURL:    server.URL + "/api/v2",
+		HTTPClient: server.Client(),
+	}
+
+	artwork, err := client.GetBestArtwork("Zelda", "")
+	require.NoError(t, err)
+	require.NotNil(t, artwork)
+
+	assert.Equal(t, 42, artwork.SteamGridDBID)
+	assert.Equal(t, "https://cdn.steamgriddb.com/hero/zelda.png", artwork.HeroURL)
+	assert.Equal(t, "https://cdn.steamgriddb.com/grid/zelda.png", artwork.GridURL)
+	assert.Equal(t, "https://cdn.steamgriddb.com/logo/zelda.png", artwork.LogoURL)
+	assert.Equal(t, "https://cdn.steamgriddb.com/icon/zelda.png", artwork.IconURL)
+
+	// 1 search + 4 image type requests
+	assert.Equal(t, 5, callCount)
+}
+
+func TestSteamGridDBClient_GetBestArtwork_PartialFailure(t *testing.T) {
+	// Test that partial failures (e.g. no logos) don't fail the whole request
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+
+		switch {
+		case r.URL.Path == "/api/v2/search/autocomplete/Tetris":
+			resp := steamGridDBResponse[[]steamGridDBSearchResult]{
+				Success: true,
+				Data:    []steamGridDBSearchResult{{ID: 99, Name: "Tetris"}},
+			}
+			json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/api/v2/heroes/game/99":
+			resp := steamGridDBResponse[[]SteamGridDBImage]{
+				Success: true,
+				Data:    []SteamGridDBImage{{ID: 1, URL: "https://cdn.steamgriddb.com/hero/tetris.png", Score: 5}},
+			}
+			json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/api/v2/grids/game/99":
+			// No grids available
+			resp := steamGridDBResponse[[]SteamGridDBImage]{
+				Success: true,
+				Data:    []SteamGridDBImage{},
+			}
+			json.NewEncoder(w).Encode(resp)
+
+		case r.URL.Path == "/api/v2/logos/game/99":
+			// Server error
+			w.WriteHeader(http.StatusNotFound)
+
+		case r.URL.Path == "/api/v2/icons/game/99":
+			// Server error
+			w.WriteHeader(http.StatusInternalServerError)
+
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	client := &SteamGridDBClient{
+		APIKey:     "test-api-key",
+		BaseURL:    server.URL + "/api/v2",
+		HTTPClient: server.Client(),
+	}
+
+	artwork, err := client.GetBestArtwork("Tetris", "")
+	require.NoError(t, err)
+	require.NotNil(t, artwork)
+
+	assert.Equal(t, 99, artwork.SteamGridDBID)
+	assert.Equal(t, "https://cdn.steamgriddb.com/hero/tetris.png", artwork.HeroURL)
+	assert.Empty(t, artwork.GridURL)  // empty array
+	assert.Empty(t, artwork.LogoURL)  // 404 error
+	assert.Empty(t, artwork.IconURL)  // 500 error
+}
+
+func TestSteamGridDBClient_RateLimited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer server.Close()
+
+	client := &SteamGridDBClient{
+		APIKey:     "test-api-key",
+		BaseURL:    server.URL + "/api/v2",
+		HTTPClient: server.Client(),
+	}
+
+	_, err := client.SearchGame("Test", "")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "rate limited")
+}
+
+func TestBestImageURL(t *testing.T) {
+	t.Run("empty slice returns empty string", func(t *testing.T) {
+		assert.Empty(t, bestImageURL(nil))
+		assert.Empty(t, bestImageURL([]SteamGridDBImage{}))
+	})
+
+	t.Run("returns first image URL", func(t *testing.T) {
+		images := []SteamGridDBImage{
+			{URL: "https://example.com/best.png", Score: 10},
+			{URL: "https://example.com/worst.png", Score: 1},
+		}
+		assert.Equal(t, "https://example.com/best.png", bestImageURL(images))
+	})
+}

--- a/web/src/pages/admin/settings-page.tsx
+++ b/web/src/pages/admin/settings-page.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { Settings, Plus, X } from "lucide-react";
+import { Settings, Plus, X, Image } from "lucide-react";
 import {
   Button,
   Card,
@@ -31,6 +31,7 @@ export function AdminSettingsPage() {
   const [biosAutoDownload, setBiosAutoDownload] = useState(true);
   const [igdbClientId, setIgdbClientId] = useState("");
   const [igdbClientSecret, setIgdbClientSecret] = useState("");
+  const [steamgriddbApiKey, setSteamgriddbApiKey] = useState("");
 
   useEffect(() => {
     if (settings) {
@@ -41,6 +42,7 @@ export function AdminSettingsPage() {
       setBiosAutoDownload(settings["bios_auto_download"] !== "false");
       setIgdbClientId(settings["igdb_client_id"] ?? "");
       setIgdbClientSecret(settings["igdb_client_secret"] ?? "");
+      setSteamgriddbApiKey(settings["steamgriddb_api_key"] ?? "");
     }
   }, [settings]);
 
@@ -68,6 +70,7 @@ export function AdminSettingsPage() {
       payload.igdb_client_id = igdbClientId;
       payload.igdb_client_secret = igdbClientSecret;
     }
+    payload.steamgriddb_api_key = steamgriddbApiKey;
     updateSettings.mutate(payload, {
       onSuccess: () => toast("success", "Settings saved"),
       onError: (err) =>
@@ -196,6 +199,37 @@ export function AdminSettingsPage() {
         onClientSecretChange={setIgdbClientSecret}
         envConfigured={igdbEnvConfigured}
       />
+
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+            <Image className="h-5 w-5 text-brand-400" />
+            SteamGridDB
+          </h2>
+          <p className="text-xs text-surface-500 mt-1">
+            Used for hero artwork on the companion display. Get a free API key
+            at{" "}
+            <a
+              href="https://www.steamgriddb.com/profile/preferences/api"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-brand-400 hover:text-brand-300 underline"
+            >
+              steamgriddb.com
+            </a>
+            .
+          </p>
+        </CardHeader>
+        <CardContent>
+          <Input
+            label="SteamGridDB API Key"
+            type="password"
+            placeholder="SteamGridDB API Key"
+            value={steamgriddbApiKey}
+            onChange={(e) => setSteamgriddbApiKey(e.target.value)}
+          />
+        </CardContent>
+      </Card>
 
       <div className="flex justify-end">
         <Button


### PR DESCRIPTION
## Summary

- Transforms the secondary display into a 4-page swipeable companion experience using `HorizontalPager`
- **Art Display page** (default): full-bleed SteamGridDB hero artwork with gradient overlay, falls back to console-gradient focus mode
- **Controls page**: existing touch gamepad preserved for devices without physical gamepads
- **Dashboard page**: stat cards (FPS, save slot, cheats) + quick action buttons (save, load, screenshot, fast forward, rewind)
- **Save Slots page**: visual slot picker (1-10) with tap-to-select for quick-save/load targeting
- Persistent header with console gradient accent line, game title, session timer, and console badge on all pages
- Page indicator dots with accessibility semantics
- SteamGridDB API v2 integration on the server for hero/grid/logo/icon artwork, fetched during metadata scraping
- Admin settings UI for SteamGridDB API key configuration
- OLED burn-in protection (fade to black) preserved on all pages

## Test plan

- [x] 418 desktop E2E tests pass (14 new for dashboard, save slots, pager infrastructure)
- [x] All Go server tests pass (new tests for SteamGridDB client and artwork handler)
- [x] Web TypeScript compiles cleanly
- [ ] Manual test on AYN Thor: verify page swiping, art display, dashboard stats, save slot selection
- [ ] Manual test: configure SteamGridDB API key in admin, trigger scrape, verify hero art appears
- [ ] Manual test: verify burn-in protection works on all pages (15s idle → fade to black)
- [ ] Manual test: verify DS/3DS games bypass the pager (bottom screen only)