### PR TITLE
feat: top players clickable links to user profile pages

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailCommunitySectionsTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailCommunitySectionsTest.kt
@@ -79,6 +79,30 @@ class GameDetailCommunitySectionsTest {
     }
 
     @Test
+    fun clickingTopPlayerNavigatesToUserProfile() = runComposeUiTest {
+        val harness = createHarnessOnGameDetail()
+        harness.gameStatsRepo.gameStats = GameStats(
+            totalPlayers = 5,
+            totalPlayTime = 100000,
+            averagePlayTime = 20000,
+            topPlayers = listOf(
+                TopPlayer("user-42", "SpeedKing", null, 50000),
+                TopPlayer("user-43", "CasualGamer", null, 30000),
+            ),
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness)
+
+        scrollToSection(hasTestTag("community_stats_section"))
+        onNodeWithText("SpeedKing").performClick()
+        advance(harness)
+
+        // UserProfile screen should be shown (profile fails to load in fake repo, shows fallback)
+        onNodeWithText("Profile not found").assertIsDisplayed()
+    }
+
+    @Test
     fun communityStatsShowsTopPlayers() = runComposeUiTest {
         val harness = createHarnessOnGameDetail()
         harness.gameStatsRepo.gameStats = GameStats(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -544,6 +544,11 @@ fun SpelaApp(
                                             NavigationIntent.NavigateTo(SpScreen.GameDetail(targetGameId))
                                         )
                                     },
+                                    onNavigateToUser = { userId ->
+                                        navigationViewModel.onIntent(
+                                            NavigationIntent.NavigateTo(SpScreen.UserProfile(userId))
+                                        )
+                                    },
                                 )
                             }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameCommunityStatsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameCommunityStatsSection.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.ui.feature.gamedetail
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -37,6 +38,7 @@ internal fun GameCommunityStatsSection(
     stats: GameStats?,
     isLoading: Boolean,
     modifier: Modifier = Modifier,
+    onPlayerClicked: ((userId: String) -> Unit)? = null,
 ) {
     if (isLoading || stats == null || stats.totalPlayers == 0) return
 
@@ -83,6 +85,7 @@ internal fun GameCommunityStatsSection(
                     rank = index + 1,
                     player = player,
                     maxPlayTime = maxPlayTime,
+                    onClick = onPlayerClicked?.let { { it(player.userId) } },
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(vertical = SpSpacing.XXSmall),
@@ -121,6 +124,7 @@ private fun TopPlayerRow(
     rank: Int,
     player: TopPlayer,
     maxPlayTime: Long,
+    onClick: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     val rankColor = when (rank) {
@@ -130,7 +134,9 @@ private fun TopPlayerRow(
         else -> SpColor.OnBackgroundTertiary
     }
 
-    SpInnerCard(modifier = modifier) {
+    SpInnerCard(modifier = modifier.then(
+        if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier
+    )) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -111,6 +111,7 @@ fun GameDetailScreen(
     onNavigateToChallenges: ((gameId: String, gameTitle: String) -> Unit)? = null,
     onNavigateToSharedSession: ((sharedSessionId: String) -> Unit)? = null,
     onNavigateToGame: ((gameId: String) -> Unit)? = null,
+    onNavigateToUser: ((userId: String) -> Unit)? = null,
     syncState: GameSyncState? = null,
     onPlayWithLocalSave: () -> Unit = {},
     onCancelLaunch: () -> Unit = {},
@@ -257,6 +258,7 @@ fun GameDetailScreen(
                     GameCommunityStatsSection(
                         stats = state.gameStats,
                         isLoading = state.isLoadingStats,
+                        onPlayerClicked = onNavigateToUser,
                     )
                 }
 

--- a/web/src/components/ui/leaderboard-row.tsx
+++ b/web/src/components/ui/leaderboard-row.tsx
@@ -1,4 +1,5 @@
 import { type ReactNode } from "react";
+import { Link } from "react-router-dom";
 import { cn } from "@/lib/cn";
 import { PlayerAvatar } from "@/components/player-avatar";
 
@@ -8,6 +9,7 @@ interface LeaderboardRowProps {
   avatarUrl?: string;
   rank: ReactNode;
   children: ReactNode;
+  href?: string;
   usernameClassName?: string;
   "data-testid"?: string;
 }
@@ -18,6 +20,7 @@ export function LeaderboardRow({
   avatarUrl,
   rank,
   children,
+  href,
   usernameClassName,
   "data-testid": testId,
 }: LeaderboardRowProps) {
@@ -33,15 +36,28 @@ export function LeaderboardRow({
     >
       {rank}
       <PlayerAvatar username={username} avatarUrl={avatarUrl} />
-      <span
-        className={cn(
-          "text-sm font-medium truncate",
-          usernameClassName ?? "flex-shrink-0 w-28",
-          isCurrentUser ? "text-brand-400" : "text-surface-200",
-        )}
-      >
-        {username}
-      </span>
+      {href ? (
+        <Link
+          to={href}
+          className={cn(
+            "text-sm font-medium truncate hover:underline",
+            usernameClassName ?? "flex-shrink-0 w-28",
+            isCurrentUser ? "text-brand-400" : "text-surface-200",
+          )}
+        >
+          {username}
+        </Link>
+      ) : (
+        <span
+          className={cn(
+            "text-sm font-medium truncate",
+            usernameClassName ?? "flex-shrink-0 w-28",
+            isCurrentUser ? "text-brand-400" : "text-surface-200",
+          )}
+        >
+          {username}
+        </span>
+      )}
       {children}
     </div>
   );

--- a/web/src/features/game-detail/components/game-community-stats.tsx
+++ b/web/src/features/game-detail/components/game-community-stats.tsx
@@ -135,6 +135,7 @@ export function GameCommunityStats({ gameId, game }: GameCommunityStatsProps) {
                   isCurrentUser={isCurrentUser}
                   username={player.username}
                   avatarUrl={player.avatarUrl}
+                  href={`/users/${player.userId}`}
                   rank={
                     <span
                       className={cn(


### PR DESCRIPTION
## Summary

- **Player app**: Tapping a username in the "Top Players" leaderboard on the Game Detail screen navigates to that user's profile page
- **Web**: Usernames in the Top Players list render as links (`/users/:id`) that navigate to the user profile page
- **LeaderboardRow** component (web) gains an optional `href` prop so the pattern can be reused if other leaderboards need profile links in future

## Changes

### Player (Kotlin Multiplatform)
- `GameCommunityStatsSection`: added `onPlayerClicked` callback; `TopPlayerRow` is conditionally clickable via `Modifier.clickable`
- `GameDetailScreen`: forwards `onNavigateToUser` callback down to the stats section
- `SpelaApp`: wires callback to `NavigationIntent.NavigateTo(SpScreen.UserProfile(userId))`

### Web (React)
- `LeaderboardRow`: optional `href` prop — username renders as `<Link>` when set, plain `<span>` otherwise
- `game-community-stats`: passes `href={/users/${player.userId}}` to each row

### Tests
- New desktop E2E: `clickingTopPlayerNavigatesToUserProfile` — clicks a top player row and asserts navigation to the UserProfile screen

## Test plan
- [x] `./gradlew compileKotlinDesktop` — no errors
- [x] `./player/run-desktop-tests.sh` — 412 tests, 0 failures
- [ ] Manual: Game Detail → Top Players → click username → User Profile screen opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)