### PR TITLE
feat: add player invite UX with search, pagination, and recent partners

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/NetplayInviteTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/NetplayInviteTest.kt
@@ -1,0 +1,500 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.NetplaySession
+import com.spela.player.domain.model.NetplaySessionStatus
+import com.spela.player.domain.model.SharedSessionDetail
+import com.spela.player.domain.model.SharedSessionMember
+import com.spela.player.domain.model.UserSearchResult
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * E2E tests for Netplay Lobby invite and Shared Session invite functionality.
+ * Tests: invite button visibility, invite sheet dialog, search, invite action,
+ * and shared session invite sheet.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class NetplayInviteTest {
+
+    private fun createLoggedInHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.authRepo.simulateLoggedIn()
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun createHostSession(
+        clientUserId: String? = null,
+        clientUsername: String? = null,
+        status: NetplaySessionStatus = NetplaySessionStatus.WAITING,
+    ) = NetplaySession(
+        id = "session-1",
+        gameId = "1",
+        gameTitle = "Castlevania",
+        gameConsoleName = "NES",
+        hostUserId = "1",
+        hostUsername = "player",
+        clientUserId = clientUserId,
+        clientUsername = clientUsername,
+        status = status,
+        inputDelay = 3,
+        inviteCode = "ABCD1234",
+    )
+
+    private fun ComposeUiTest.navigateToNetplayLobby(harness: SpelaTestHarness) {
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.NetplayLobby("session-1"))
+        )
+        advanceFully(harness)
+    }
+
+    // ---- Netplay lobby: invite button visibility ----
+
+    @Test
+    fun netplayLobbyShowsInviteButtonWhenHostAndWaiting() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.netplayRepo.currentSession = createHostSession()
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        // Verify session loaded
+        onNodeWithText("Castlevania").assertExists()
+        // Scroll to and verify invite button (may be below fold in LazyColumn)
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").assertExists()
+    }
+
+    @Test
+    fun netplayLobbyHidesInviteButtonWhenNotHost() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        // Current user is "1" (from FakeAuthRepository), but host is "2"
+        harness.netplayRepo.currentSession = NetplaySession(
+            id = "session-1",
+            gameId = "1",
+            gameTitle = "Castlevania",
+            hostUserId = "2",
+            hostUsername = "other-player",
+            clientUserId = "1",
+            clientUsername = "player",
+            status = NetplaySessionStatus.WAITING,
+            inputDelay = 3,
+            inviteCode = "ABCD1234",
+        )
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        // Verify session loaded (we can see the game title)
+        onNodeWithText("Castlevania").assertExists()
+        // Invite Player should NOT exist — user is not host
+        onNodeWithText("Invite Player").assertDoesNotExist()
+    }
+
+    @Test
+    fun netplayLobbyHidesInviteButtonWhenClientHasJoined() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.netplayRepo.currentSession = createHostSession(
+            clientUserId = "2",
+            clientUsername = "alice",
+        )
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        onNodeWithText("Castlevania").assertExists()
+        // Invite Player should NOT exist — client has joined
+        onNodeWithText("Invite Player").assertDoesNotExist()
+    }
+
+    @Test
+    fun netplayLobbyHidesInviteButtonWhenSessionInProgress() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.netplayRepo.currentSession = createHostSession(
+            clientUserId = "2",
+            clientUsername = "alice",
+            status = NetplaySessionStatus.IN_PROGRESS,
+        )
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        onNodeWithText("Castlevania").assertExists()
+        // Invite Player should NOT exist — session is in progress
+        onNodeWithText("Invite Player").assertDoesNotExist()
+    }
+
+    // ---- Netplay lobby: invite sheet opens/closes ----
+
+    @Test
+    fun clickingInvitePlayerOpensInviteSheet() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.netplayRepo.currentSession = createHostSession()
+        harness.userRepo.searchResults = listOf(
+            UserSearchResult(id = "2", username = "alice", avatarUrl = null),
+        )
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        // Scroll to and click the Invite Player button
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        // The invite sheet dialog should be open — header text "Invite Player" in dialog
+        // plus search field and user list section
+        onNodeWithText("Search users...").assertExists()
+        onNodeWithText("All Users").assertExists()
+    }
+
+    @Test
+    fun closingInviteSheetDismissesDialog() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.netplayRepo.currentSession = createHostSession()
+        harness.userRepo.searchResults = listOf(
+            UserSearchResult(id = "2", username = "alice", avatarUrl = null),
+        )
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        // Open the invite sheet
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        // Close via X button
+        onNodeWithContentDescription("Close").performClick()
+        advanceQuick(harness)
+
+        // Dialog should be gone — "All Users" only appears in the dialog
+        onNodeWithText("All Users").assertDoesNotExist()
+    }
+
+    // ---- Netplay lobby: invite sheet content ----
+
+    @Test
+    fun inviteSheetShowsUserList() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.netplayRepo.currentSession = createHostSession()
+        harness.userRepo.searchResults = listOf(
+            UserSearchResult(id = "2", username = "alice", avatarUrl = null),
+            UserSearchResult(id = "3", username = "bob", avatarUrl = null),
+        )
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        // User list should show both users
+        onNodeWithText("alice").assertExists()
+        onNodeWithText("bob").assertExists()
+    }
+
+    @Test
+    fun inviteSheetShowsRecentPartners() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.netplayRepo.currentSession = createHostSession()
+        harness.userRepo.recentPartners = listOf(
+            UserSearchResult(id = "5", username = "recent-buddy", avatarUrl = null),
+        )
+        harness.userRepo.searchResults = listOf(
+            UserSearchResult(id = "2", username = "alice", avatarUrl = null),
+        )
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        // Recent partners section should be visible
+        onNodeWithText("Previous").assertExists()
+        onNodeWithText("recent-buddy").assertExists()
+    }
+
+    @Test
+    fun inviteSheetShowsNoUsersFoundWhenEmpty() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.netplayRepo.currentSession = createHostSession()
+        harness.userRepo.searchResults = emptyList()
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        onNodeWithText("No users found").assertExists()
+    }
+
+    // ---- Netplay lobby: invite action ----
+
+    @Test
+    fun invitingUserMarksThemAsInvited() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.netplayRepo.currentSession = createHostSession()
+        harness.userRepo.searchResults = listOf(
+            UserSearchResult(id = "2", username = "alice", avatarUrl = null),
+        )
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        // Open invite sheet
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        // alice should be invitable
+        onNodeWithContentDescription("alice, tap to invite").assertExists()
+        // Click the Invite button in alice's row
+        onAllNodesWithText("Invite").filterToOne(hasClickAction()).performClick()
+        advanceFully(harness)
+
+        // alice should now show as invited
+        onNodeWithContentDescription("alice, already invited").assertExists()
+        onNodeWithContentDescription("Invited").assertExists()
+    }
+
+    @Test
+    fun invitedUserCannotBeInvitedAgain() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.netplayRepo.currentSession = createHostSession()
+        harness.userRepo.searchResults = listOf(
+            UserSearchResult(id = "2", username = "alice", avatarUrl = null),
+            UserSearchResult(id = "3", username = "bob", avatarUrl = null),
+        )
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        // Open invite sheet
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        // Invite alice
+        onAllNodesWithText("Invite").onFirst().performClick()
+        advanceFully(harness)
+
+        // alice should be marked as invited
+        onNodeWithContentDescription("alice, already invited").assertExists()
+        // bob should still be invitable
+        onNodeWithContentDescription("bob, tap to invite").assertExists()
+    }
+
+    @Test
+    fun inviteShowsSuccessMessage() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.netplayRepo.currentSession = createHostSession()
+        harness.userRepo.searchResults = listOf(
+            UserSearchResult(id = "2", username = "alice", avatarUrl = null),
+        )
+
+        setContent { harness.App() }
+        navigateToNetplayLobby(harness)
+
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        onAllNodesWithText("Invite").filterToOne(hasClickAction()).performClick()
+        // Use advanceQuick (2000ms) — enough for coroutine to complete but
+        // before SpSnackbar's 3000ms auto-dismiss clears inviteSuccessMessage.
+        advanceQuick(harness)
+
+        // ViewModel state should have success message
+        val state = harness.netplayLobbyViewModel.state.value
+        assertEquals("Invite sent to alice", state.inviteSuccessMessage)
+        assertTrue(state.invitedUsernames.contains("alice"))
+    }
+
+    // ---- Shared session detail: invite button and sheet ----
+
+    @Test
+    fun sharedSessionDetailInviteButtonOpensInviteSheet() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.sharedSessionRepo.sharedSessionDetail = SharedSessionDetail(
+            id = "ss1",
+            name = "Test Session",
+            gameId = "1",
+            gameTitle = "Castlevania",
+            ownerId = "1",
+            ownerUsername = "player",
+            memberCount = 1,
+            members = listOf(
+                SharedSessionMember(userId = "1", username = "player", role = "owner"),
+            ),
+        )
+        harness.userRepo.searchResults = listOf(
+            UserSearchResult(id = "2", username = "alice", avatarUrl = null),
+        )
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.SharedSessionDetail("ss1"))
+        )
+        advanceFully(harness)
+
+        // The "Invite a friend" section should be visible
+        onNodeWithText("Invite a friend").assertExists()
+
+        // Click the "Invite Player" button
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        // The invite sheet dialog should open
+        onNodeWithText("Search users...").assertExists()
+        onNodeWithText("All Users").assertExists()
+    }
+
+    @Test
+    fun sharedSessionInviteSheetShowsUsersAndRecentPartners() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.sharedSessionRepo.sharedSessionDetail = SharedSessionDetail(
+            id = "ss1",
+            name = "Test Session",
+            gameId = "1",
+            gameTitle = "Castlevania",
+            ownerId = "1",
+            ownerUsername = "player",
+            memberCount = 1,
+            members = emptyList(),
+        )
+        harness.userRepo.searchResults = listOf(
+            UserSearchResult(id = "2", username = "alice", avatarUrl = null),
+            UserSearchResult(id = "3", username = "charlie", avatarUrl = null),
+        )
+        harness.userRepo.recentPartners = listOf(
+            UserSearchResult(id = "4", username = "old-friend", avatarUrl = null),
+        )
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.SharedSessionDetail("ss1"))
+        )
+        advanceFully(harness)
+
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        // Should show recent partners
+        onNodeWithText("Previous").assertExists()
+        onNodeWithText("old-friend").assertExists()
+        // Should show all users
+        onNodeWithText("alice").assertExists()
+        onNodeWithText("charlie").assertExists()
+    }
+
+    @Test
+    fun sharedSessionInviteSheetInviteMarksUserAsInvited() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.sharedSessionRepo.sharedSessionDetail = SharedSessionDetail(
+            id = "ss1",
+            name = "Test Session",
+            gameId = "1",
+            gameTitle = "Castlevania",
+            ownerId = "1",
+            ownerUsername = "player",
+            memberCount = 1,
+            members = emptyList(),
+        )
+        harness.userRepo.searchResults = listOf(
+            UserSearchResult(id = "2", username = "alice", avatarUrl = null),
+        )
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.SharedSessionDetail("ss1"))
+        )
+        advanceFully(harness)
+
+        // Open invite sheet
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        // Invite alice
+        onNodeWithContentDescription("alice, tap to invite").assertExists()
+        onAllNodesWithText("Invite").filterToOne(hasClickAction()).performClick()
+        advanceFully(harness)
+
+        // alice should be marked as invited
+        onNodeWithContentDescription("alice, already invited").assertExists()
+
+        // ViewModel state should reflect the invite
+        val state = harness.sharedSessionDetailViewModel.state.value
+        assertTrue(state.invitedUsernames.contains("alice"))
+    }
+
+    @Test
+    fun sharedSessionInviteSheetCloseButton() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.sharedSessionRepo.sharedSessionDetail = SharedSessionDetail(
+            id = "ss1",
+            name = "Test Session",
+            gameId = "1",
+            gameTitle = "Castlevania",
+            ownerId = "1",
+            ownerUsername = "player",
+            memberCount = 1,
+            members = emptyList(),
+        )
+        harness.userRepo.searchResults = listOf(
+            UserSearchResult(id = "2", username = "alice", avatarUrl = null),
+        )
+
+        setContent { harness.App() }
+
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.SharedSessionDetail("ss1"))
+        )
+        advanceFully(harness)
+
+        // Open invite sheet
+        onNode(hasScrollToNodeAction())
+            .performScrollToNode(hasText("Invite Player"))
+        onNodeWithText("Invite Player").performClick()
+        advanceFully(harness)
+
+        // Verify sheet is open
+        onNodeWithText("Search users...").assertExists()
+
+        // Close it
+        onNodeWithContentDescription("Close").performClick()
+        advanceQuick(harness)
+
+        // Dialog should be gone
+        onNodeWithText("All Users").assertDoesNotExist()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SharedSessionFeaturesTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SharedSessionFeaturesTest.kt
@@ -554,6 +554,6 @@ class SharedSessionFeaturesTest {
         advance(harness)
 
         onNodeWithText("Invite a friend").assertExists()
-        onNodeWithText("Invite").assertExists()
+        onNodeWithText("Invite Player").assertExists()
     }
 }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -264,8 +264,11 @@ class SpelaTestHarness(
         scope = scope,
     )
 
+    val userRepo = FakeUserRepository()
+
     val sharedSessionDetailViewModel = SharedSessionDetailViewModel(
         sharedSessionRepository = sharedSessionRepo,
+        userRepository = userRepo,
         dispatchers = dispatchers,
         scope = scope,
     )
@@ -326,6 +329,7 @@ class SpelaTestHarness(
     val netplayLobbyViewModel = NetplayLobbyViewModel(
         netplayRepository = netplayRepo,
         authRepository = authRepo,
+        userRepository = userRepo,
         dispatchers = dispatchers,
         scope = scope,
     )

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -162,6 +162,11 @@ class FakeAuthRepository : AuthRepository {
     var registeredUsers = mutableMapOf("player" to "player123")
     private var tokens: AuthTokens? = null
 
+    /** Pre-set tokens so getCurrentUser() returns success without calling login(). */
+    fun simulateLoggedIn() {
+        tokens = AuthTokens("test-access-token", "test-refresh-token")
+    }
+
     override suspend fun login(
         serverUrl: String,
         username: String,
@@ -860,6 +865,26 @@ class FakeNetplayRepository : NetplayRepository {
     override suspend fun updateInputDelay(sessionId: String, inputDelay: Int): Result<NetplaySession> =
         currentSession?.let { Result.success(it.copy(inputDelay = inputDelay)) }
             ?: Result.failure(Exception("Session not found"))
+    override suspend fun sendNetplayInvite(sessionId: String, username: String): Result<Unit> =
+        Result.success(Unit)
+}
+
+class FakeUserRepository : UserRepository {
+    var searchResults: List<UserSearchResult> = emptyList()
+    var recentPartners: List<UserSearchResult> = emptyList()
+
+    override suspend fun searchUsers(query: String, page: Int, pageSize: Int): Result<UserSearchPage> =
+        Result.success(
+            UserSearchPage(
+                data = searchResults.filter { query.isEmpty() || it.username.contains(query, ignoreCase = true) },
+                total = searchResults.size.toLong(),
+                page = page,
+                pageSize = pageSize,
+            )
+        )
+
+    override suspend fun getRecentPartners(): Result<List<UserSearchResult>> =
+        Result.success(recentPartners)
 }
 
 class FakeChallengeRepository : ChallengeRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -768,6 +768,26 @@ class SpelaApiClient(
         }.body()
     }
 
+    suspend fun sendNetplayInvite(sessionId: String, request: SendNetplayInviteRequest) {
+        client.post("$baseUrl/api/netplay/sessions/$sessionId/invites") {
+            setBody(request)
+        }
+    }
+
+    // User Search
+
+    suspend fun searchUsers(query: String = "", page: Int = 1, pageSize: Int = 20): UserSearchResponse {
+        return client.get("$baseUrl/api/users/search") {
+            parameter("q", query)
+            parameter("page", page)
+            parameter("pageSize", pageSize)
+        }.body()
+    }
+
+    suspend fun getRecentPartners(): List<UserSearchResultDto> {
+        return client.get("$baseUrl/api/users/recent-partners").body()
+    }
+
     // Challenges
 
     suspend fun getChallenges(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -456,6 +456,14 @@ fun ChallengeLeaderboardEntryDto.toDomain(): ChallengeLeaderboardEntry = Challen
     isCurrentUser = isCurrentUser,
 )
 
+// User Search mappers
+
+fun UserSearchResultDto.toDomain(): UserSearchResult = UserSearchResult(
+    id = id,
+    username = username,
+    avatarUrl = avatarUrl,
+)
+
 // Netplay mappers
 
 fun NetplaySessionDto.toDomain(): NetplaySession = NetplaySession(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -741,6 +741,26 @@ data class UpdateNetplaySettingsRequest(
     val inputDelay: Int,
 )
 
+@Serializable
+data class SendNetplayInviteRequest(
+    val username: String,
+)
+
+@Serializable
+data class UserSearchResultDto(
+    val id: String,
+    val username: String,
+    val avatarUrl: String? = null,
+)
+
+@Serializable
+data class UserSearchResponse(
+    val data: List<UserSearchResultDto>,
+    val total: Long,
+    val page: Int,
+    val pageSize: Int,
+)
+
 // Game Stats
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/NetplayRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/NetplayRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.spela.player.data.repository
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.CreateNetplaySessionRequest
 import com.spela.player.data.remote.dto.JoinByInviteCodeRequest
+import com.spela.player.data.remote.dto.SendNetplayInviteRequest
 import com.spela.player.data.remote.dto.UpdateNetplaySettingsRequest
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.NetplaySession
@@ -43,5 +44,9 @@ class NetplayRepositoryImpl(
 
     override suspend fun updateInputDelay(sessionId: String, inputDelay: Int): Result<NetplaySession> = runCatching {
         apiClient.updateNetplaySettings(sessionId, UpdateNetplaySettingsRequest(inputDelay)).toDomain()
+    }
+
+    override suspend fun sendNetplayInvite(sessionId: String, username: String): Result<Unit> = runCatching {
+        apiClient.sendNetplayInvite(sessionId, SendNetplayInviteRequest(username))
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/UserRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/UserRepositoryImpl.kt
@@ -1,0 +1,30 @@
+package com.spela.player.data.repository
+
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.dto.toDomain
+import com.spela.player.domain.model.UserSearchResult
+import com.spela.player.domain.repository.UserRepository
+import com.spela.player.domain.repository.UserSearchPage
+
+class UserRepositoryImpl(
+    private val apiClient: SpelaApiClient,
+) : UserRepository {
+
+    override suspend fun searchUsers(
+        query: String,
+        page: Int,
+        pageSize: Int,
+    ): Result<UserSearchPage> = runCatching {
+        val response = apiClient.searchUsers(query, page, pageSize)
+        UserSearchPage(
+            data = response.data.map { it.toDomain() },
+            total = response.total,
+            page = response.page,
+            pageSize = response.pageSize,
+        )
+    }
+
+    override suspend fun getRecentPartners(): Result<List<UserSearchResult>> = runCatching {
+        apiClient.getRecentPartners().map { it.toDomain() }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -64,6 +64,7 @@ val commonModule = module {
     single<CollectionRepository> { CollectionRepositoryImpl(get()) }
     single<StatsRepository> { StatsRepositoryImpl(get()) }
     single<NetplayRepository> { NetplayRepositoryImpl(get()) }
+    single<UserRepository> { UserRepositoryImpl(get()) }
     single<ChallengeRepository> { ChallengeRepositoryImpl(get()) }
     single<GameStatsRepository> { GameStatsRepositoryImpl(get()) }
     single<CheatRepository> { CheatRepositoryImpl(get(), get()) }
@@ -240,6 +241,7 @@ val commonModule = module {
     factory {
         SharedSessionDetailViewModel(
             sharedSessionRepository = get(),
+            userRepository = get(),
             dispatchers = get(),
             scope = get(),
         )
@@ -257,6 +259,7 @@ val commonModule = module {
         NetplayLobbyViewModel(
             netplayRepository = get(),
             authRepository = get(),
+            userRepository = get(),
             dispatchers = get(),
             scope = get(),
         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -645,6 +645,14 @@ data class SessionCheatConfig(
     val enabledIndices: List<Int>,
 )
 
+// User Search
+
+data class UserSearchResult(
+    val id: String,
+    val username: String,
+    val avatarUrl: String?,
+)
+
 // BIOS
 
 data class BiosConsoleStatus(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/NetplayRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/NetplayRepository.kt
@@ -10,4 +10,5 @@ interface NetplayRepository {
     suspend fun leaveSession(sessionId: String): Result<Unit>
     suspend fun deleteSession(sessionId: String): Result<Unit>
     suspend fun updateInputDelay(sessionId: String, inputDelay: Int): Result<NetplaySession>
+    suspend fun sendNetplayInvite(sessionId: String, username: String): Result<Unit>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/UserRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/UserRepository.kt
@@ -1,0 +1,15 @@
+package com.spela.player.domain.repository
+
+import com.spela.player.domain.model.UserSearchResult
+
+interface UserRepository {
+    suspend fun searchUsers(query: String = "", page: Int = 1, pageSize: Int = 20): Result<UserSearchPage>
+    suspend fun getRecentPartners(): Result<List<UserSearchResult>>
+}
+
+data class UserSearchPage(
+    val data: List<UserSearchResult>,
+    val total: Long,
+    val page: Int,
+    val pageSize: Int,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/delegate/InviteSheetDelegate.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/delegate/InviteSheetDelegate.kt
@@ -1,0 +1,135 @@
+package com.spela.player.presentation.delegate
+
+import com.spela.player.domain.model.UserSearchResult
+import com.spela.player.domain.repository.UserRepository
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+/**
+ * State for the invite sheet, embedded in parent ViewModel states.
+ */
+data class InviteSheetState(
+    val showInviteSheet: Boolean = false,
+    val inviteSearchQuery: String = "",
+    val inviteSearchResults: List<UserSearchResult> = emptyList(),
+    val inviteSearchTotal: Long = 0,
+    val inviteSearchPage: Int = 1,
+    val recentPartners: List<UserSearchResult> = emptyList(),
+    val isSearchingUsers: Boolean = false,
+    val isLoadingRecentPartners: Boolean = false,
+    val invitingUsername: String? = null,
+    val invitedUsernames: List<String> = emptyList(),
+    val inviteSuccessMessage: String? = null,
+)
+
+/**
+ * Delegate that handles invite sheet logic (search, pagination, recent partners).
+ * Used by both NetplayLobbyViewModel and SharedSessionDetailViewModel to avoid duplication.
+ */
+class InviteSheetDelegate(
+    private val userRepository: UserRepository,
+    private val dispatchers: DispatcherProvider,
+    private val scope: CoroutineScope,
+    private val onStateUpdate: (InviteSheetState) -> Unit,
+    private val getState: () -> InviteSheetState,
+    private val onError: (String?) -> Unit,
+) {
+    private var searchJob: Job? = null
+
+    fun show() {
+        onStateUpdate(
+            InviteSheetState(
+                showInviteSheet = true,
+            )
+        )
+        loadRecentPartners()
+        searchUsers(page = 1)
+    }
+
+    fun hide() {
+        searchJob?.cancel()
+        onStateUpdate(InviteSheetState())
+    }
+
+    fun updateSearchQuery(query: String) {
+        onStateUpdate(getState().copy(inviteSearchQuery = query, inviteSearchPage = 1))
+        searchJob?.cancel()
+        searchJob = scope.launch(dispatchers.io) {
+            delay(300)
+            searchUsersInternal(query, 1)
+        }
+    }
+
+    fun changePage(page: Int) {
+        onStateUpdate(getState().copy(inviteSearchPage = page))
+        scope.launch(dispatchers.io) {
+            searchUsersInternal(getState().inviteSearchQuery, page)
+        }
+    }
+
+    fun markInviteSending(username: String) {
+        onStateUpdate(getState().copy(invitingUsername = username))
+    }
+
+    fun markInviteSuccess(username: String) {
+        onStateUpdate(
+            getState().copy(
+                invitingUsername = null,
+                invitedUsernames = getState().invitedUsernames + username,
+                inviteSuccessMessage = "Invite sent to $username",
+            )
+        )
+    }
+
+    fun markInviteFailed() {
+        onStateUpdate(getState().copy(invitingUsername = null))
+    }
+
+    fun dismissInviteSuccess() {
+        onStateUpdate(getState().copy(inviteSuccessMessage = null))
+    }
+
+    private suspend fun searchUsersInternal(query: String, page: Int) {
+        onStateUpdate(getState().copy(isSearchingUsers = true))
+        userRepository.searchUsers(query, page).fold(
+            onSuccess = { searchPage ->
+                onStateUpdate(
+                    getState().copy(
+                        inviteSearchResults = searchPage.data,
+                        inviteSearchTotal = searchPage.total,
+                        inviteSearchPage = searchPage.page,
+                        isSearchingUsers = false,
+                    )
+                )
+            },
+            onFailure = { error ->
+                onStateUpdate(getState().copy(isSearchingUsers = false))
+                onError(error.message)
+            },
+        )
+    }
+
+    private fun loadRecentPartners() {
+        onStateUpdate(getState().copy(isLoadingRecentPartners = true))
+        scope.launch(dispatchers.io) {
+            userRepository.getRecentPartners().fold(
+                onSuccess = { partners ->
+                    onStateUpdate(getState().copy(recentPartners = partners, isLoadingRecentPartners = false))
+                },
+                onFailure = {
+                    onStateUpdate(getState().copy(isLoadingRecentPartners = false))
+                },
+            )
+        }
+    }
+
+    private fun searchUsers(page: Int) {
+        onStateUpdate(getState().copy(inviteSearchPage = page))
+        scope.launch(dispatchers.io) {
+            searchUsersInternal(getState().inviteSearchQuery, page)
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/NetplayIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/NetplayIntent.kt
@@ -14,4 +14,10 @@ sealed interface NetplayLobbyIntent {
     data class UpdateInputDelay(val inputDelay: Int) : NetplayLobbyIntent
     data object LeaveSession : NetplayLobbyIntent
     data object DismissError : NetplayLobbyIntent
+    data object ShowInviteSheet : NetplayLobbyIntent
+    data object HideInviteSheet : NetplayLobbyIntent
+    data class UpdateInviteSearchQuery(val query: String) : NetplayLobbyIntent
+    data class InviteSearchPage(val page: Int) : NetplayLobbyIntent
+    data class SendInvite(val username: String) : NetplayLobbyIntent
+    data object DismissInviteSuccess : NetplayLobbyIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/SharedSessionIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/SharedSessionIntent.kt
@@ -21,4 +21,8 @@ sealed interface SharedSessionDetailIntent {
     data class CopySaveToGame(val sharedSessionId: String, val saveId: Long) : SharedSessionDetailIntent
     data object DismissError : SharedSessionDetailIntent
     data object DismissSuccess : SharedSessionDetailIntent
+    data object ShowInviteSheet : SharedSessionDetailIntent
+    data object HideInviteSheet : SharedSessionDetailIntent
+    data class UpdateInviteSearchQuery(val query: String) : SharedSessionDetailIntent
+    data class InviteSearchPage(val page: Int) : SharedSessionDetailIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/NetplayState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/NetplayState.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.state
 
 import com.spela.player.domain.model.NetplaySession
+import com.spela.player.domain.model.UserSearchResult
 
 data class NetplayState(
     val sessions: List<NetplaySession> = emptyList(),
@@ -16,4 +17,15 @@ data class NetplayLobbyState(
     val isUpdatingSettings: Boolean = false,
     val error: String? = null,
     val sessionLeft: Boolean = false,
+    val showInviteSheet: Boolean = false,
+    val inviteSearchQuery: String = "",
+    val inviteSearchResults: List<UserSearchResult> = emptyList(),
+    val inviteSearchTotal: Long = 0,
+    val inviteSearchPage: Int = 1,
+    val recentPartners: List<UserSearchResult> = emptyList(),
+    val isSearchingUsers: Boolean = false,
+    val isLoadingRecentPartners: Boolean = false,
+    val invitingUsername: String? = null,
+    val invitedUsernames: List<String> = emptyList(),
+    val inviteSuccessMessage: String? = null,
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SharedSessionState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SharedSessionState.kt
@@ -4,6 +4,7 @@ import com.spela.player.domain.model.SharedSession
 import com.spela.player.domain.model.SharedSessionDetail
 import com.spela.player.domain.model.SharedSessionInvitation
 import com.spela.player.domain.model.SharedSessionSave
+import com.spela.player.domain.model.UserSearchResult
 
 data class SharedSessionListState(
     val sharedSessions: List<SharedSession> = emptyList(),
@@ -27,4 +28,15 @@ data class SharedSessionDetailState(
     val copyingSaveId: Long? = null,
     val error: String? = null,
     val successMessage: String? = null,
+    val showInviteSheet: Boolean = false,
+    val inviteSearchQuery: String = "",
+    val inviteSearchResults: List<UserSearchResult> = emptyList(),
+    val inviteSearchTotal: Long = 0,
+    val inviteSearchPage: Int = 1,
+    val recentPartners: List<UserSearchResult> = emptyList(),
+    val isSearchingUsers: Boolean = false,
+    val isLoadingRecentPartners: Boolean = false,
+    val invitingUsername: String? = null,
+    val invitedUsernames: List<String> = emptyList(),
+    val inviteSuccessMessage: String? = null,
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/InvitePlayerSheet.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/InvitePlayerSheet.kt
@@ -1,0 +1,291 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.PersonAdd
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.spela.player.domain.model.UserSearchResult
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * A dialog for searching and inviting players.
+ * Used by both Netplay Lobby and Shared Session Detail screens.
+ */
+@Composable
+fun InvitePlayerSheet(
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    searchResults: List<UserSearchResult>,
+    searchTotal: Long,
+    searchPage: Int,
+    pageSize: Int = 20,
+    recentPartners: List<UserSearchResult>,
+    isSearching: Boolean,
+    isLoadingRecentPartners: Boolean,
+    invitingUsername: String?,
+    invitedUsernames: List<String>,
+    onInvite: (String) -> Unit,
+    onPageChange: (Int) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.9f)
+                .heightIn(max = 600.dp)
+                .clip(RoundedCornerShape(SpSpacing.RadiusPill))
+                .background(SpColor.SurfaceElevated)
+                .padding(SpSpacing.XLarge),
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = "Invite Player",
+                    style = SpTypography.HeadlineMedium,
+                    color = SpColor.OnBackground,
+                )
+                IconButton(onClick = onDismiss) {
+                    Icon(
+                        imageVector = Icons.Filled.Close,
+                        contentDescription = "Close",
+                        tint = SpColor.OnBackgroundTertiary,
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(SpSpacing.Default))
+
+            // Search field
+            SpTextField(
+                value = searchQuery,
+                onValueChange = onSearchQueryChange,
+                placeholder = "Search users...",
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(Modifier.height(SpSpacing.Default))
+
+            // Content
+            LazyColumn(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f, fill = false),
+            ) {
+                // Recent partners section (only when query is empty and partners exist)
+                if (searchQuery.isEmpty() && recentPartners.isNotEmpty()) {
+                    item {
+                        Text(
+                            text = "Previous",
+                            style = SpTypography.TitleLarge,
+                            color = SpColor.OnBackgroundSecondary,
+                        )
+                        Spacer(Modifier.height(SpSpacing.Small))
+                    }
+                    items(recentPartners, key = { "partner-${it.id}" }) { user ->
+                        UserInviteRow(
+                            user = user,
+                            isInvited = user.username in invitedUsernames,
+                            isSendingThisUser = invitingUsername == user.username,
+                            onInvite = { onInvite(user.username) },
+                        )
+                    }
+                    item {
+                        Spacer(Modifier.height(SpSpacing.Default))
+                    }
+                }
+
+                if (isLoadingRecentPartners && searchQuery.isEmpty() && recentPartners.isEmpty()) {
+                    item {
+                        Box(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = SpSpacing.Default),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 2.dp,
+                                color = SpColor.Primary,
+                            )
+                        }
+                    }
+                }
+
+                // User list section
+                item {
+                    Text(
+                        text = if (searchQuery.isNotEmpty()) "Results" else "All Users",
+                        style = SpTypography.TitleLarge,
+                        color = SpColor.OnBackgroundSecondary,
+                    )
+                    Spacer(Modifier.height(SpSpacing.Small))
+                }
+
+                if (isSearching) {
+                    item {
+                        Box(
+                            modifier = Modifier.fillMaxWidth().padding(vertical = SpSpacing.Default),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(24.dp),
+                                strokeWidth = 2.dp,
+                                color = SpColor.Primary,
+                            )
+                        }
+                    }
+                } else {
+                    if (searchResults.isEmpty()) {
+                        item {
+                            Text(
+                                text = "No users found",
+                                style = SpTypography.BodyMedium,
+                                color = SpColor.OnBackgroundTertiary,
+                                modifier = Modifier.padding(vertical = SpSpacing.Default),
+                            )
+                        }
+                    } else {
+                        items(searchResults, key = { "user-${it.id}" }) { user ->
+                            UserInviteRow(
+                                user = user,
+                                isInvited = user.username in invitedUsernames,
+                                isSendingThisUser = invitingUsername == user.username,
+                                onInvite = { onInvite(user.username) },
+                            )
+                        }
+                    }
+                }
+
+                // Pagination controls
+                val totalPages = if (pageSize > 0) ((searchTotal + pageSize - 1) / pageSize).toInt() else 1
+                if (totalPages > 1) {
+                    item {
+                        Spacer(Modifier.height(SpSpacing.Default))
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.Center,
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            SpButton(
+                                text = "Previous",
+                                onClick = { onPageChange(searchPage - 1) },
+                                style = SpButtonStyle.Ghost,
+                                enabled = searchPage > 1,
+                            )
+                            Spacer(Modifier.width(SpSpacing.Small))
+                            Text(
+                                text = "$searchPage / $totalPages",
+                                style = SpTypography.BodyMedium,
+                                color = SpColor.OnBackgroundSecondary,
+                            )
+                            Spacer(Modifier.width(SpSpacing.Small))
+                            SpButton(
+                                text = "Next",
+                                onClick = { onPageChange(searchPage + 1) },
+                                style = SpButtonStyle.Ghost,
+                                enabled = searchPage < totalPages,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun UserInviteRow(
+    user: UserSearchResult,
+    isInvited: Boolean,
+    isSendingThisUser: Boolean,
+    onInvite: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = SpSpacing.XSmall)
+            .semantics {
+                contentDescription = if (isInvited) {
+                    "${user.username}, already invited"
+                } else {
+                    "${user.username}, tap to invite"
+                }
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        SpAvatar(
+            username = user.username,
+            avatarUrl = user.avatarUrl,
+            size = 36.dp,
+        )
+        Spacer(Modifier.width(SpSpacing.Medium))
+        Text(
+            text = user.username,
+            style = SpTypography.TitleLarge,
+            color = SpColor.OnBackground,
+            modifier = Modifier.weight(1f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        if (isInvited) {
+            Icon(
+                imageVector = Icons.Filled.Check,
+                contentDescription = "Invited",
+                tint = SpColor.Success,
+                modifier = Modifier.size(24.dp),
+            )
+        } else {
+            SpButton(
+                text = "Invite",
+                onClick = onInvite,
+                style = SpButtonStyle.Outlined,
+                enabled = !isSendingThisUser,
+                isLoading = isSendingThisUser,
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Filled.PersonAdd,
+                        contentDescription = null,
+                        modifier = Modifier.size(16.dp),
+                    )
+                },
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sharedsession/SharedSessionDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sharedsession/SharedSessionDetailComponents.kt
@@ -242,9 +242,8 @@ internal fun MemberItem(
 internal fun InviteSection(
     isInviting: Boolean,
     onInvite: (String) -> Unit,
+    onShowInviteSheet: () -> Unit = {},
 ) {
-    var username by remember { mutableStateOf("") }
-
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -256,28 +255,10 @@ internal fun InviteSection(
             color = SpColor.OnBackground,
         )
         Spacer(Modifier.height(SpSpacing.Small))
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-        ) {
-            SpTextField(
-                value = username,
-                onValueChange = { username = it },
-                placeholder = "Username",
-                modifier = Modifier.weight(1f),
-            )
-            SpButton(
-                text = "Invite",
-                onClick = {
-                    if (username.isNotBlank()) {
-                        onInvite(username.trim())
-                        username = ""
-                    }
-                },
-                isLoading = isInviting,
-                enabled = username.isNotBlank(),
-            )
-        }
+        SpButton(
+            text = "Invite Player",
+            onClick = onShowInviteSheet,
+        )
     }
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
@@ -40,6 +40,7 @@ import com.spela.player.domain.model.NetplaySessionStatus
 import com.spela.player.presentation.intent.NetplayLobbyIntent
 import com.spela.player.presentation.ui.feature.netplay.InputDelaySection
 import com.spela.player.presentation.ui.feature.netplay.LobbyHeader
+import com.spela.player.presentation.ui.components.InvitePlayerSheet
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
@@ -266,6 +267,21 @@ fun NetplayLobbyScreen(
                             )
                         }
 
+                        // Invite Player button (host only, while waiting, no client yet)
+                        if (session.hostUserId == currentUserId &&
+                            session.status == NetplaySessionStatus.WAITING &&
+                            session.clientUserId == null
+                        ) {
+                            item {
+                                Spacer(Modifier.height(SpSpacing.Default))
+                                SpButton(
+                                    text = "Invite Player",
+                                    onClick = { viewModel.onIntent(NetplayLobbyIntent.ShowInviteSheet) },
+                                    modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                                )
+                            }
+                        }
+
                         // Action buttons
                         item {
                             Spacer(Modifier.height(SpSpacing.XLarge))
@@ -299,6 +315,37 @@ fun NetplayLobbyScreen(
             },
             onDismiss = { viewModel.onIntent(NetplayLobbyIntent.DismissError) },
             modifier = Modifier.align(Alignment.BottomCenter),
+        )
+
+        // Invite success snackbar
+        SpSnackbar(
+            data = state.inviteSuccessMessage?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Success,
+                )
+            },
+            onDismiss = { viewModel.onIntent(NetplayLobbyIntent.DismissInviteSuccess) },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+
+    // Invite player dialog
+    if (state.showInviteSheet) {
+        InvitePlayerSheet(
+            searchQuery = state.inviteSearchQuery,
+            onSearchQueryChange = { viewModel.onIntent(NetplayLobbyIntent.UpdateInviteSearchQuery(it)) },
+            searchResults = state.inviteSearchResults,
+            searchTotal = state.inviteSearchTotal,
+            searchPage = state.inviteSearchPage,
+            recentPartners = state.recentPartners,
+            isSearching = state.isSearchingUsers,
+            isLoadingRecentPartners = state.isLoadingRecentPartners,
+            invitingUsername = state.invitingUsername,
+            invitedUsernames = state.invitedUsernames,
+            onInvite = { viewModel.onIntent(NetplayLobbyIntent.SendInvite(it)) },
+            onPageChange = { viewModel.onIntent(NetplayLobbyIntent.InviteSearchPage(it)) },
+            onDismiss = { viewModel.onIntent(NetplayLobbyIntent.HideInviteSheet) },
         )
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
@@ -25,6 +25,7 @@ import com.spela.player.presentation.ui.feature.sharedsession.InviteSection
 import com.spela.player.presentation.ui.feature.sharedsession.MemberItem
 import com.spela.player.presentation.ui.feature.sharedsession.SharedSessionHeader
 import com.spela.player.presentation.ui.feature.sharedsession.SharedSessionSaveItem
+import com.spela.player.presentation.ui.components.InvitePlayerSheet
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSectionHeader
@@ -129,6 +130,9 @@ fun SharedSessionDetailScreen(
                                 onInvite = { username ->
                                     viewModel.onIntent(SharedSessionDetailIntent.InviteUser(sharedSessionId, username))
                                 },
+                                onShowInviteSheet = {
+                                    viewModel.onIntent(SharedSessionDetailIntent.ShowInviteSheet)
+                                },
                             )
                             Spacer(Modifier.height(SpSpacing.XLarge))
                         }
@@ -194,6 +198,27 @@ fun SharedSessionDetailScreen(
             },
             onDismiss = { viewModel.onIntent(SharedSessionDetailIntent.DismissSuccess) },
             modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+
+    // Invite player dialog
+    if (state.showInviteSheet) {
+        InvitePlayerSheet(
+            searchQuery = state.inviteSearchQuery,
+            onSearchQueryChange = { viewModel.onIntent(SharedSessionDetailIntent.UpdateInviteSearchQuery(it)) },
+            searchResults = state.inviteSearchResults,
+            searchTotal = state.inviteSearchTotal,
+            searchPage = state.inviteSearchPage,
+            recentPartners = state.recentPartners,
+            isSearching = state.isSearchingUsers,
+            isLoadingRecentPartners = state.isLoadingRecentPartners,
+            invitingUsername = state.invitingUsername,
+            invitedUsernames = state.invitedUsernames,
+            onInvite = { username ->
+                viewModel.onIntent(SharedSessionDetailIntent.InviteUser(sharedSessionId, username))
+            },
+            onPageChange = { viewModel.onIntent(SharedSessionDetailIntent.InviteSearchPage(it)) },
+            onDismiss = { viewModel.onIntent(SharedSessionDetailIntent.HideInviteSheet) },
         )
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/NetplayLobbyViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/NetplayLobbyViewModel.kt
@@ -2,6 +2,9 @@ package com.spela.player.presentation.viewmodel
 
 import com.spela.player.domain.repository.AuthRepository
 import com.spela.player.domain.repository.NetplayRepository
+import com.spela.player.domain.repository.UserRepository
+import com.spela.player.presentation.delegate.InviteSheetDelegate
+import com.spela.player.presentation.delegate.InviteSheetState
 import com.spela.player.presentation.intent.NetplayLobbyIntent
 import com.spela.player.presentation.state.NetplayLobbyState
 import com.spela.player.util.DispatcherProvider
@@ -15,6 +18,7 @@ import kotlinx.coroutines.launch
 class NetplayLobbyViewModel(
     private val netplayRepository: NetplayRepository,
     private val authRepository: AuthRepository,
+    userRepository: UserRepository,
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
 ) {
@@ -23,12 +27,27 @@ class NetplayLobbyViewModel(
 
     private var currentSessionId: String = ""
 
+    private val inviteDelegate = InviteSheetDelegate(
+        userRepository = userRepository,
+        dispatchers = dispatchers,
+        scope = scope,
+        onStateUpdate = { inviteState -> _state.update { it.applyInviteState(inviteState) } },
+        getState = { _state.value.toInviteSheetState() },
+        onError = { msg -> _state.update { it.copy(error = msg) } },
+    )
+
     fun onIntent(intent: NetplayLobbyIntent) {
         when (intent) {
             is NetplayLobbyIntent.LoadSession -> loadSession(intent.sessionId)
             is NetplayLobbyIntent.UpdateInputDelay -> updateInputDelay(intent.inputDelay)
             NetplayLobbyIntent.LeaveSession -> leaveSession()
             NetplayLobbyIntent.DismissError -> _state.update { it.copy(error = null) }
+            NetplayLobbyIntent.ShowInviteSheet -> inviteDelegate.show()
+            NetplayLobbyIntent.HideInviteSheet -> inviteDelegate.hide()
+            is NetplayLobbyIntent.UpdateInviteSearchQuery -> inviteDelegate.updateSearchQuery(intent.query)
+            is NetplayLobbyIntent.InviteSearchPage -> inviteDelegate.changePage(intent.page)
+            is NetplayLobbyIntent.SendInvite -> sendInvite(intent.username)
+            NetplayLobbyIntent.DismissInviteSuccess -> inviteDelegate.dismissInviteSuccess()
         }
     }
 
@@ -36,7 +55,6 @@ class NetplayLobbyViewModel(
         currentSessionId = sessionId
         _state.update { it.copy(isLoading = true) }
         scope.launch(dispatchers.io) {
-            // Fetch current user ID if not yet known
             if (_state.value.currentUserId.isEmpty()) {
                 authRepository.getCurrentUser().onSuccess { user ->
                     _state.update { it.copy(currentUserId = user.id) }
@@ -81,4 +99,48 @@ class NetplayLobbyViewModel(
             )
         }
     }
+
+    private fun sendInvite(username: String) {
+        if (currentSessionId.isEmpty()) return
+        inviteDelegate.markInviteSending(username)
+        scope.launch(dispatchers.io) {
+            netplayRepository.sendNetplayInvite(currentSessionId, username).fold(
+                onSuccess = {
+                    inviteDelegate.markInviteSuccess(username)
+                },
+                onFailure = { error ->
+                    inviteDelegate.markInviteFailed()
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
 }
+
+private fun NetplayLobbyState.toInviteSheetState() = InviteSheetState(
+    showInviteSheet = showInviteSheet,
+    inviteSearchQuery = inviteSearchQuery,
+    inviteSearchResults = inviteSearchResults,
+    inviteSearchTotal = inviteSearchTotal,
+    inviteSearchPage = inviteSearchPage,
+    recentPartners = recentPartners,
+    isSearchingUsers = isSearchingUsers,
+    isLoadingRecentPartners = isLoadingRecentPartners,
+    invitingUsername = invitingUsername,
+    invitedUsernames = invitedUsernames,
+    inviteSuccessMessage = inviteSuccessMessage,
+)
+
+private fun NetplayLobbyState.applyInviteState(s: InviteSheetState) = copy(
+    showInviteSheet = s.showInviteSheet,
+    inviteSearchQuery = s.inviteSearchQuery,
+    inviteSearchResults = s.inviteSearchResults,
+    inviteSearchTotal = s.inviteSearchTotal,
+    inviteSearchPage = s.inviteSearchPage,
+    recentPartners = s.recentPartners,
+    isSearchingUsers = s.isSearchingUsers,
+    isLoadingRecentPartners = s.isLoadingRecentPartners,
+    invitingUsername = s.invitingUsername,
+    invitedUsernames = s.invitedUsernames,
+    inviteSuccessMessage = s.inviteSuccessMessage,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SharedSessionDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SharedSessionDetailViewModel.kt
@@ -1,6 +1,9 @@
 package com.spela.player.presentation.viewmodel
 
 import com.spela.player.domain.repository.SharedSessionRepository
+import com.spela.player.domain.repository.UserRepository
+import com.spela.player.presentation.delegate.InviteSheetDelegate
+import com.spela.player.presentation.delegate.InviteSheetState
 import com.spela.player.presentation.intent.SharedSessionDetailIntent
 import com.spela.player.presentation.state.SharedSessionDetailState
 import com.spela.player.util.DispatcherProvider
@@ -13,11 +16,21 @@ import kotlinx.coroutines.launch
 
 class SharedSessionDetailViewModel(
     private val sharedSessionRepository: SharedSessionRepository,
+    userRepository: UserRepository,
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
 ) {
     private val _state = MutableStateFlow(SharedSessionDetailState())
     val state: StateFlow<SharedSessionDetailState> = _state.asStateFlow()
+
+    private val inviteDelegate = InviteSheetDelegate(
+        userRepository = userRepository,
+        dispatchers = dispatchers,
+        scope = scope,
+        onStateUpdate = { inviteState -> _state.update { it.applyInviteState(inviteState) } },
+        getState = { _state.value.toInviteSheetState() },
+        onError = { msg -> _state.update { it.copy(error = msg) } },
+    )
 
     fun onIntent(intent: SharedSessionDetailIntent) {
         when (intent) {
@@ -30,6 +43,10 @@ class SharedSessionDetailViewModel(
             is SharedSessionDetailIntent.CopySaveToGame -> copySaveToGame(intent.sharedSessionId, intent.saveId)
             SharedSessionDetailIntent.DismissError -> _state.update { it.copy(error = null) }
             SharedSessionDetailIntent.DismissSuccess -> _state.update { it.copy(successMessage = null) }
+            SharedSessionDetailIntent.ShowInviteSheet -> inviteDelegate.show()
+            SharedSessionDetailIntent.HideInviteSheet -> inviteDelegate.hide()
+            is SharedSessionDetailIntent.UpdateInviteSearchQuery -> inviteDelegate.updateSearchQuery(intent.query)
+            is SharedSessionDetailIntent.InviteSearchPage -> inviteDelegate.changePage(intent.page)
         }
     }
 
@@ -62,14 +79,22 @@ class SharedSessionDetailViewModel(
     }
 
     private fun inviteUser(sharedSessionId: String, username: String) {
+        inviteDelegate.markInviteSending(username)
         _state.update { it.copy(isInviting = true) }
         scope.launch(dispatchers.io) {
             sharedSessionRepository.inviteUser(sharedSessionId, username).fold(
                 onSuccess = {
-                    _state.update { it.copy(isInviting = false, successMessage = "Invitation sent to $username") }
+                    inviteDelegate.markInviteSuccess(username)
+                    _state.update {
+                        it.copy(
+                            isInviting = false,
+                            successMessage = "Invitation sent to $username",
+                        )
+                    }
                     loadSharedSession(sharedSessionId)
                 },
                 onFailure = { error ->
+                    inviteDelegate.markInviteFailed()
                     _state.update { it.copy(error = error.message, isInviting = false) }
                 },
             )
@@ -133,3 +158,31 @@ class SharedSessionDetailViewModel(
         }
     }
 }
+
+private fun SharedSessionDetailState.toInviteSheetState() = InviteSheetState(
+    showInviteSheet = showInviteSheet,
+    inviteSearchQuery = inviteSearchQuery,
+    inviteSearchResults = inviteSearchResults,
+    inviteSearchTotal = inviteSearchTotal,
+    inviteSearchPage = inviteSearchPage,
+    recentPartners = recentPartners,
+    isSearchingUsers = isSearchingUsers,
+    isLoadingRecentPartners = isLoadingRecentPartners,
+    invitingUsername = invitingUsername,
+    invitedUsernames = invitedUsernames,
+    inviteSuccessMessage = inviteSuccessMessage,
+)
+
+private fun SharedSessionDetailState.applyInviteState(s: InviteSheetState) = copy(
+    showInviteSheet = s.showInviteSheet,
+    inviteSearchQuery = s.inviteSearchQuery,
+    inviteSearchResults = s.inviteSearchResults,
+    inviteSearchTotal = s.inviteSearchTotal,
+    inviteSearchPage = s.inviteSearchPage,
+    recentPartners = s.recentPartners,
+    isSearchingUsers = s.isSearchingUsers,
+    isLoadingRecentPartners = s.isLoadingRecentPartners,
+    invitingUsername = s.invitingUsername,
+    invitedUsernames = s.invitedUsernames,
+    inviteSuccessMessage = s.inviteSuccessMessage,
+)

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SharedSessionDetailViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SharedSessionDetailViewModelTest.kt
@@ -3,6 +3,9 @@ package com.spela.player.presentation.viewmodel
 import com.spela.player.domain.model.SharedSessionDetail
 import com.spela.player.domain.model.SharedSessionMember
 import com.spela.player.domain.model.SharedSessionSave
+import com.spela.player.domain.model.UserSearchResult
+import com.spela.player.domain.repository.UserRepository
+import com.spela.player.domain.repository.UserSearchPage
 import com.spela.player.presentation.intent.SharedSessionDetailIntent
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineDispatcher
@@ -27,11 +30,13 @@ class SharedSessionDetailViewModelTest {
     }
 
     private lateinit var fakeRepo: FakeSharedSessionRepo
+    private lateinit var fakeUserRepo: FakeUserRepo
 
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(testDispatcher)
         fakeRepo = FakeSharedSessionRepo()
+        fakeUserRepo = FakeUserRepo()
     }
 
     @AfterTest
@@ -43,6 +48,7 @@ class SharedSessionDetailViewModelTest {
         val scope = CoroutineScope(testDispatcher)
         return SharedSessionDetailViewModel(
             sharedSessionRepository = fakeRepo,
+            userRepository = fakeUserRepo,
             dispatchers = testDispatchers,
             scope = scope,
         )
@@ -307,4 +313,12 @@ class SharedSessionDetailViewModelTest {
         vm.onIntent(SharedSessionDetailIntent.DismissSuccess)
         assertNull(vm.state.value.successMessage)
     }
+}
+
+private class FakeUserRepo : UserRepository {
+    override suspend fun searchUsers(query: String, page: Int, pageSize: Int): Result<UserSearchPage> =
+        Result.success(UserSearchPage(data = emptyList(), total = 0, page = page, pageSize = pageSize))
+
+    override suspend fun getRecentPartners(): Result<List<UserSearchResult>> =
+        Result.success(emptyList())
 }

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -2042,6 +2042,18 @@ func TestSearchUsers(t *testing.T) {
 		createNonOwnerUser(t, router, token, name, name+"@example.com", "password123")
 	}
 
+	// Helper to extract []map[string]interface{} from PaginatedResponse.Data
+	parseSearchResults := func(t *testing.T, body []byte) ([]map[string]interface{}, int64) {
+		t.Helper()
+		var resp map[string]interface{}
+		require.NoError(t, json.Unmarshal(body, &resp))
+		total := int64(resp["total"].(float64))
+		dataRaw, _ := json.Marshal(resp["data"])
+		var results []map[string]interface{}
+		json.Unmarshal(dataRaw, &results)
+		return results, total
+	}
+
 	t.Run("returns matching users by prefix", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/api/users/search?q=al", nil)
@@ -2049,8 +2061,8 @@ func TestSearchUsers(t *testing.T) {
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var results []map[string]interface{}
-		json.Unmarshal(w.Body.Bytes(), &results)
+		results, total := parseSearchResults(t, w.Body.Bytes())
+		assert.Equal(t, int64(2), total)
 		assert.Len(t, results, 2) // alice, alex
 		usernames := []string{results[0]["username"].(string), results[1]["username"].(string)}
 		assert.Contains(t, usernames, "alice")
@@ -2064,21 +2076,21 @@ func TestSearchUsers(t *testing.T) {
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var results []map[string]interface{}
-		json.Unmarshal(w.Body.Bytes(), &results)
+		results, total := parseSearchResults(t, w.Body.Bytes())
+		assert.Equal(t, int64(0), total)
 		assert.Len(t, results, 0) // "apitest" is the current user
 	})
 
-	t.Run("returns empty for short query", func(t *testing.T) {
+	t.Run("single char query now works", func(t *testing.T) {
 		w := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/api/users/search?q=a", nil)
 		req.Header.Set("Authorization", "Bearer "+token)
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var results []map[string]interface{}
-		json.Unmarshal(w.Body.Bytes(), &results)
-		assert.Len(t, results, 0)
+		results, total := parseSearchResults(t, w.Body.Bytes())
+		assert.Equal(t, int64(2), total) // alice, alex
+		assert.Len(t, results, 2)
 	})
 
 	t.Run("returns empty for no match", func(t *testing.T) {
@@ -2088,8 +2100,8 @@ func TestSearchUsers(t *testing.T) {
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var results []map[string]interface{}
-		json.Unmarshal(w.Body.Bytes(), &results)
+		results, total := parseSearchResults(t, w.Body.Bytes())
+		assert.Equal(t, int64(0), total)
 		assert.Len(t, results, 0)
 	})
 
@@ -2100,8 +2112,7 @@ func TestSearchUsers(t *testing.T) {
 		router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var results []map[string]interface{}
-		json.Unmarshal(w.Body.Bytes(), &results)
+		results, _ := parseSearchResults(t, w.Body.Bytes())
 		assert.Len(t, results, 1)
 		assert.Equal(t, "bob", results[0]["username"])
 		assert.NotEmpty(t, results[0]["id"])

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -386,6 +386,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/social/online", socialHandler.GetOnlineUsers)
 		api.GET("/social/activity", socialHandler.GetActivityFeed)
 		api.GET("/users/search", socialHandler.SearchUsers)
+		api.GET("/users/recent-partners", socialHandler.GetRecentPartners)
 		api.GET("/users/:id/profile", socialHandler.GetPublicProfile)
 		api.GET("/users/:id/play-heatmap", statsHandler.GetPublicPlayHeatmap)
 

--- a/server/internal/api/social_handler.go
+++ b/server/internal/api/social_handler.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/db"
@@ -200,17 +201,33 @@ func toPublicProfileGame(g db.Game, playTime int64) PublicProfileGame {
 }
 
 // SearchUsers returns users matching a search query, excluding the current user.
+// Supports pagination via page and pageSize query params (defaults: page=1, pageSize=20, max 50).
+// If q is empty, returns all non-disabled users (excluding self).
 func (h *SocialHandler) SearchUsers(c *gin.Context) {
 	uid := getUserID(c)
 	query := strings.TrimSpace(c.Query("q"))
-	if len(query) < 2 {
-		c.JSON(http.StatusOK, []UserSearchResult{})
-		return
+
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("pageSize", "20"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 50 {
+		pageSize = 20
 	}
 
+	base := h.DB.Where("id != ? AND disabled = ?", uid, false)
+	if query != "" {
+		base = base.Where("username LIKE ? ESCAPE '\\'", escapeLikePattern(query)+"%")
+	}
+
+	var total int64
+	base.Model(&db.User{}).Count(&total)
+
 	var users []db.User
-	if err := h.DB.Where("username LIKE ? ESCAPE '\\' AND id != ? AND disabled = ?", escapeLikePattern(query)+"%", uid, false).
-		Limit(10).
+	if err := base.Order("username ASC").
+		Offset((page - 1) * pageSize).
+		Limit(pageSize).
 		Find(&users).Error; err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to search users"})
 		return
@@ -223,6 +240,148 @@ func (h *SocialHandler) SearchUsers(c *gin.Context) {
 			Username:  u.Username,
 			AvatarURL: u.AvatarURL,
 		})
+	}
+
+	c.JSON(http.StatusOK, PaginatedResponse{
+		Data:     result,
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+	})
+}
+
+// GetRecentPartners returns users the current user has played with recently
+// (last 6 months) via netplay sessions or shared sessions.
+func (h *SocialHandler) GetRecentPartners(c *gin.Context) {
+	uid := getUserID(c)
+	sixMonthsAgo := time.Now().AddDate(0, -6, 0)
+
+	// partnerInfo tracks the most recent interaction time per partner.
+	type partnerInfo struct {
+		lastSeen time.Time
+	}
+	partners := make(map[uint]*partnerInfo)
+
+	// 1. NetplaySession: find sessions where the current user was host or client.
+	var netplaySessions []db.NetplaySession
+	h.DB.Where(
+		"(host_user_id = ? OR client_user_id = ?) AND created_at >= ?",
+		uid, uid, sixMonthsAgo,
+	).Find(&netplaySessions)
+
+	for _, s := range netplaySessions {
+		var partnerID uint
+		if s.HostUserID == uid {
+			if s.ClientUserID == nil {
+				continue
+			}
+			partnerID = *s.ClientUserID
+		} else {
+			partnerID = s.HostUserID
+		}
+		if partnerID == uid {
+			continue
+		}
+		ts := s.CreatedAt
+		if p, ok := partners[partnerID]; ok {
+			if ts.After(p.lastSeen) {
+				p.lastSeen = ts
+			}
+		} else {
+			partners[partnerID] = &partnerInfo{lastSeen: ts}
+		}
+	}
+
+	// 2. SharedSessionMember: find shared sessions the user is a member of,
+	//    then find other members of those sessions.
+	var myMemberships []db.SharedSessionMember
+	h.DB.Where("user_id = ?", uid).Find(&myMemberships)
+
+	if len(myMemberships) > 0 {
+		sessionIDs := make([]uint, 0, len(myMemberships))
+		for _, m := range myMemberships {
+			sessionIDs = append(sessionIDs, m.SharedSessionID)
+		}
+
+		var otherMembers []db.SharedSessionMember
+		h.DB.Where("shared_session_id IN ? AND user_id != ?", sessionIDs, uid).
+			Find(&otherMembers)
+
+		// Look up creation time of the shared sessions for recency sorting.
+		var sharedSessions []db.SharedSession
+		h.DB.Where("id IN ? AND created_at >= ?", sessionIDs, sixMonthsAgo).
+			Find(&sharedSessions)
+		sessionCreatedAt := make(map[uint]time.Time, len(sharedSessions))
+		for _, ss := range sharedSessions {
+			sessionCreatedAt[ss.ID] = ss.CreatedAt
+		}
+
+		for _, m := range otherMembers {
+			ts, ok := sessionCreatedAt[m.SharedSessionID]
+			if !ok {
+				// Session was created more than 6 months ago; skip.
+				continue
+			}
+			if p, exists := partners[m.UserID]; exists {
+				if ts.After(p.lastSeen) {
+					p.lastSeen = ts
+				}
+			} else {
+				partners[m.UserID] = &partnerInfo{lastSeen: ts}
+			}
+		}
+	}
+
+	if len(partners) == 0 {
+		c.JSON(http.StatusOK, []UserSearchResult{})
+		return
+	}
+
+	// Collect partner IDs and sort by most recent first.
+	partnerIDs := make([]uint, 0, len(partners))
+	for id := range partners {
+		partnerIDs = append(partnerIDs, id)
+	}
+
+	// Fetch user records, excluding disabled users.
+	var users []db.User
+	h.DB.Where("id IN ? AND disabled = ?", partnerIDs, false).Find(&users)
+
+	// Build response sorted by most recent interaction.
+	type sortableResult struct {
+		result   UserSearchResult
+		lastSeen time.Time
+	}
+	sortable := make([]sortableResult, 0, len(users))
+	for _, u := range users {
+		p := partners[u.ID]
+		sortable = append(sortable, sortableResult{
+			result: UserSearchResult{
+				ID:        strconv.FormatUint(uint64(u.ID), 10),
+				Username:  u.Username,
+				AvatarURL: u.AvatarURL,
+			},
+			lastSeen: p.lastSeen,
+		})
+	}
+
+	// Sort by lastSeen descending (most recent first).
+	for i := 0; i < len(sortable); i++ {
+		for j := i + 1; j < len(sortable); j++ {
+			if sortable[j].lastSeen.After(sortable[i].lastSeen) {
+				sortable[i], sortable[j] = sortable[j], sortable[i]
+			}
+		}
+	}
+
+	// Limit to 10 results.
+	if len(sortable) > 10 {
+		sortable = sortable[:10]
+	}
+
+	result := make([]UserSearchResult, len(sortable))
+	for i, s := range sortable {
+		result[i] = s.result
 	}
 
 	c.JSON(http.StatusOK, result)

--- a/server/internal/api/social_search_test.go
+++ b/server/internal/api/social_search_test.go
@@ -1,0 +1,625 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// --- SearchUsers pagination tests ---
+
+func TestSearchUsers_EmptyQuery_ReturnsAllUsers(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router) // creates "apitest" user
+
+	// Create additional users
+	createNonOwnerUser(t, router, ownerToken, "alice", "alice@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "bob", "bob@test.com", "password123")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/search", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp PaginatedResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+
+	// Owner is excluded (self), so alice and bob should be returned
+	assert.Equal(t, int64(2), resp.Total)
+	assert.Equal(t, 1, resp.Page)
+	assert.Equal(t, 20, resp.PageSize)
+
+	data, _ := json.Marshal(resp.Data)
+	var users []UserSearchResult
+	json.Unmarshal(data, &users)
+	assert.Len(t, users, 2)
+
+	// Verify disabled users are excluded
+	var alice db.User
+	database.Where("username = ?", "alice").First(&alice)
+	database.Model(&alice).Update("disabled", true)
+
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/users/search", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), resp.Total)
+}
+
+func TestSearchUsers_WithQuery_MatchesByPrefix(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	createNonOwnerUser(t, router, ownerToken, "alice", "alice@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "bob", "bob@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "alex", "alex@test.com", "password123")
+
+	// Search with single character
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/search?q=a", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp PaginatedResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), resp.Total) // alice, alex (apitest excluded as self)
+
+	// Search with two characters
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/users/search?q=al", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), resp.Total) // alice, alex
+}
+
+func TestSearchUsers_Pagination(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	// Create 5 users
+	for i := 0; i < 5; i++ {
+		createNonOwnerUser(t, router, ownerToken,
+			fmt.Sprintf("user%02d", i),
+			fmt.Sprintf("user%02d@test.com", i),
+			"password123",
+		)
+	}
+
+	// Page 1, pageSize 2
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/search?page=1&pageSize=2", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp PaginatedResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), resp.Total)
+	assert.Equal(t, 1, resp.Page)
+	assert.Equal(t, 2, resp.PageSize)
+
+	data, _ := json.Marshal(resp.Data)
+	var users []UserSearchResult
+	json.Unmarshal(data, &users)
+	assert.Len(t, users, 2)
+
+	// Page 3 should have 1 result
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/users/search?page=3&pageSize=2", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	err = json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), resp.Total)
+
+	data, _ = json.Marshal(resp.Data)
+	json.Unmarshal(data, &users)
+	assert.Len(t, users, 1)
+}
+
+func TestSearchUsers_PageSizeClampedTo50(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/search?pageSize=100", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp PaginatedResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, 20, resp.PageSize) // clamped to default 20 since >50
+}
+
+func TestSearchUsers_ReturnsPaginatedResponse(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/search", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Verify the response has PaginatedResponse structure
+	var raw map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &raw)
+	require.NoError(t, err)
+
+	assert.Contains(t, raw, "data")
+	assert.Contains(t, raw, "total")
+	assert.Contains(t, raw, "page")
+	assert.Contains(t, raw, "pageSize")
+}
+
+func TestSearchUsers_ExcludesSelf(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	// Search for "apitest" (the owner's username)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/search?q=apitest", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp PaginatedResponse
+	err := json.Unmarshal(w.Body.Bytes(), &resp)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), resp.Total) // self excluded
+}
+
+// --- GetRecentPartners tests ---
+
+func TestRecentPartners_Empty(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/recent-partners", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []UserSearchResult
+	err := json.Unmarshal(w.Body.Bytes(), &results)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestRecentPartners_NetplayPartners(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	// Create users
+	createNonOwnerUser(t, router, ownerToken, "alice", "alice@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "bob", "bob@test.com", "password123")
+
+	var owner, alice, bob db.User
+	database.Where("username = ?", "apitest").First(&owner)
+	database.Where("username = ?", "alice").First(&alice)
+	database.Where("username = ?", "bob").First(&bob)
+
+	// Create a game for the netplay session
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Test Game", FileName: "test.nes", FilePath: "/tmp/test_rp.nes", FileSize: 100}
+	database.Create(&game)
+
+	// Create netplay sessions: owner hosted with alice, bob was client with owner
+	aliceID := alice.ID
+	database.Create(&db.NetplaySession{
+		HostUserID:   owner.ID,
+		ClientUserID: &aliceID,
+		GameID:       game.ID,
+		Status:       "ended",
+		InviteCode:   "ABC123",
+		CoreName:     "nestopia",
+	})
+
+	ownerID := owner.ID
+	database.Create(&db.NetplaySession{
+		HostUserID:   bob.ID,
+		ClientUserID: &ownerID,
+		GameID:       game.ID,
+		Status:       "ended",
+		InviteCode:   "DEF456",
+		CoreName:     "nestopia",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/recent-partners", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []UserSearchResult
+	err := json.Unmarshal(w.Body.Bytes(), &results)
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	// Verify both alice and bob are in results
+	usernames := make([]string, len(results))
+	for i, r := range results {
+		usernames[i] = r.Username
+	}
+	assert.Contains(t, usernames, "alice")
+	assert.Contains(t, usernames, "bob")
+}
+
+func TestRecentPartners_SharedSessionPartners(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	createNonOwnerUser(t, router, ownerToken, "carol", "carol@test.com", "password123")
+
+	var owner, carol db.User
+	database.Where("username = ?", "apitest").First(&owner)
+	database.Where("username = ?", "carol").First(&carol)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Shared Game", FileName: "shared.nes", FilePath: "/tmp/shared_rp.nes", FileSize: 100}
+	database.Create(&game)
+
+	// Create a shared session with both users as members
+	sharedSession := db.SharedSession{
+		OwnerID: owner.ID,
+		GameID:  game.ID,
+		Name:    "Test Shared Session",
+		Status:  "active",
+	}
+	database.Create(&sharedSession)
+
+	database.Create(&db.SharedSessionMember{
+		SharedSessionID: sharedSession.ID,
+		UserID:          owner.ID,
+		Role:            "owner",
+		JoinedAt:        time.Now(),
+	})
+	database.Create(&db.SharedSessionMember{
+		SharedSessionID: sharedSession.ID,
+		UserID:          carol.ID,
+		Role:            "member",
+		JoinedAt:        time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/recent-partners", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []UserSearchResult
+	err := json.Unmarshal(w.Body.Bytes(), &results)
+	require.NoError(t, err)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "carol", results[0].Username)
+}
+
+func TestRecentPartners_ExcludesDisabledUsers(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	createNonOwnerUser(t, router, ownerToken, "disabled_user", "disabled@test.com", "password123")
+
+	var owner, disabled db.User
+	database.Where("username = ?", "apitest").First(&owner)
+	database.Where("username = ?", "disabled_user").First(&disabled)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Test Game", FileName: "test2.nes", FilePath: "/tmp/test2_rp.nes", FileSize: 100}
+	database.Create(&game)
+
+	disabledID := disabled.ID
+	database.Create(&db.NetplaySession{
+		HostUserID:   owner.ID,
+		ClientUserID: &disabledID,
+		GameID:       game.ID,
+		Status:       "ended",
+		InviteCode:   "DIS123",
+		CoreName:     "nestopia",
+	})
+
+	// Disable the user
+	database.Model(&disabled).Update("disabled", true)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/recent-partners", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []UserSearchResult
+	err := json.Unmarshal(w.Body.Bytes(), &results)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestRecentPartners_ExcludesOldSessions(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	createNonOwnerUser(t, router, ownerToken, "old_partner", "old@test.com", "password123")
+
+	var owner, oldPartner db.User
+	database.Where("username = ?", "apitest").First(&owner)
+	database.Where("username = ?", "old_partner").First(&oldPartner)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Old Game", FileName: "old.nes", FilePath: "/tmp/old_rp.nes", FileSize: 100}
+	database.Create(&game)
+
+	oldPartnerID := oldPartner.ID
+	session := db.NetplaySession{
+		HostUserID:   owner.ID,
+		ClientUserID: &oldPartnerID,
+		GameID:       game.ID,
+		Status:       "ended",
+		InviteCode:   "OLD123",
+		CoreName:     "nestopia",
+	}
+	database.Create(&session)
+
+	// Backdate the session to 7 months ago
+	sevenMonthsAgo := time.Now().AddDate(0, -7, 0)
+	database.Model(&session).Update("created_at", sevenMonthsAgo)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/recent-partners", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []UserSearchResult
+	err := json.Unmarshal(w.Body.Bytes(), &results)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestRecentPartners_SortedByMostRecent(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	createNonOwnerUser(t, router, ownerToken, "first", "first@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "second", "second@test.com", "password123")
+
+	var owner, first, second db.User
+	database.Where("username = ?", "apitest").First(&owner)
+	database.Where("username = ?", "first").First(&first)
+	database.Where("username = ?", "second").First(&second)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Sort Game", FileName: "sort.nes", FilePath: "/tmp/sort_rp.nes", FileSize: 100}
+	database.Create(&game)
+
+	// Create older session with "first"
+	firstID := first.ID
+	s1 := db.NetplaySession{
+		HostUserID:   owner.ID,
+		ClientUserID: &firstID,
+		GameID:       game.ID,
+		Status:       "ended",
+		InviteCode:   "SRT001",
+		CoreName:     "nestopia",
+	}
+	database.Create(&s1)
+	twoMonthsAgo := time.Now().AddDate(0, -2, 0)
+	database.Model(&s1).Update("created_at", twoMonthsAgo)
+
+	// Create newer session with "second"
+	secondID := second.ID
+	s2 := db.NetplaySession{
+		HostUserID:   owner.ID,
+		ClientUserID: &secondID,
+		GameID:       game.ID,
+		Status:       "ended",
+		InviteCode:   "SRT002",
+		CoreName:     "nestopia",
+	}
+	database.Create(&s2)
+	oneMonthAgo := time.Now().AddDate(0, -1, 0)
+	database.Model(&s2).Update("created_at", oneMonthAgo)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/recent-partners", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []UserSearchResult
+	err := json.Unmarshal(w.Body.Bytes(), &results)
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	// "second" should be first (more recent session)
+	assert.Equal(t, "second", results[0].Username)
+	assert.Equal(t, "first", results[1].Username)
+}
+
+func TestRecentPartners_NetplayWithoutClient_Excluded(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	var owner db.User
+	database.Where("username = ?", "apitest").First(&owner)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Solo Game", FileName: "solo.nes", FilePath: "/tmp/solo_rp.nes", FileSize: 100}
+	database.Create(&game)
+
+	// Create a netplay session with no client (waiting state)
+	database.Create(&db.NetplaySession{
+		HostUserID:   owner.ID,
+		ClientUserID: nil,
+		GameID:       game.ID,
+		Status:       "waiting",
+		InviteCode:   "SOLO01",
+		CoreName:     "nestopia",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/recent-partners", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []UserSearchResult
+	err := json.Unmarshal(w.Body.Bytes(), &results)
+	require.NoError(t, err)
+	assert.Empty(t, results)
+}
+
+func TestRecentPartners_MaxTenResults(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	var owner db.User
+	database.Where("username = ?", "apitest").First(&owner)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Max Game", FileName: "max.nes", FilePath: "/tmp/max_rp.nes", FileSize: 100}
+	database.Create(&game)
+
+	// Create 12 partners via netplay
+	for i := 0; i < 12; i++ {
+		username := fmt.Sprintf("partner%02d", i)
+		createNonOwnerUser(t, router, ownerToken, username, fmt.Sprintf("%s@test.com", username), "password123")
+
+		var partner db.User
+		database.Where("username = ?", username).First(&partner)
+
+		partnerID := partner.ID
+		database.Create(&db.NetplaySession{
+			HostUserID:   owner.ID,
+			ClientUserID: &partnerID,
+			GameID:       game.ID,
+			Status:       "ended",
+			InviteCode:   fmt.Sprintf("MAX%03d", i),
+			CoreName:     "nestopia",
+		})
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/recent-partners", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []UserSearchResult
+	err := json.Unmarshal(w.Body.Bytes(), &results)
+	require.NoError(t, err)
+	assert.Len(t, results, 10) // capped at 10
+}
+
+func TestRecentPartners_CombinesNetplayAndSharedSessions(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	ownerToken := registerAndGetToken(t, router)
+
+	createNonOwnerUser(t, router, ownerToken, "netplay_friend", "nf@test.com", "password123")
+	createNonOwnerUser(t, router, ownerToken, "shared_friend", "sf@test.com", "password123")
+
+	var owner, netplayFriend, sharedFriend db.User
+	database.Where("username = ?", "apitest").First(&owner)
+	database.Where("username = ?", "netplay_friend").First(&netplayFriend)
+	database.Where("username = ?", "shared_friend").First(&sharedFriend)
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{ConsoleID: console.ID, Title: "Combo Game", FileName: "combo.nes", FilePath: "/tmp/combo_rp.nes", FileSize: 100}
+	database.Create(&game)
+
+	// Netplay partner
+	nfID := netplayFriend.ID
+	database.Create(&db.NetplaySession{
+		HostUserID:   owner.ID,
+		ClientUserID: &nfID,
+		GameID:       game.ID,
+		Status:       "ended",
+		InviteCode:   "CMB001",
+		CoreName:     "nestopia",
+	})
+
+	// Shared session partner
+	sharedSession := db.SharedSession{
+		OwnerID: owner.ID,
+		GameID:  game.ID,
+		Name:    "Combo Shared",
+		Status:  "active",
+	}
+	database.Create(&sharedSession)
+	database.Create(&db.SharedSessionMember{
+		SharedSessionID: sharedSession.ID,
+		UserID:          owner.ID,
+		Role:            "owner",
+		JoinedAt:        time.Now(),
+	})
+	database.Create(&db.SharedSessionMember{
+		SharedSessionID: sharedSession.ID,
+		UserID:          sharedFriend.ID,
+		Role:            "member",
+		JoinedAt:        time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/users/recent-partners", nil)
+	req.Header.Set("Authorization", "Bearer "+ownerToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var results []UserSearchResult
+	err := json.Unmarshal(w.Body.Bytes(), &results)
+	require.NoError(t, err)
+	assert.Len(t, results, 2)
+
+	usernames := make([]string, len(results))
+	for i, r := range results {
+		usernames[i] = r.Username
+	}
+	assert.Contains(t, usernames, "netplay_friend")
+	assert.Contains(t, usernames, "shared_friend")
+}

--- a/web/src/components/invite-modal.tsx
+++ b/web/src/components/invite-modal.tsx
@@ -1,0 +1,212 @@
+import { useState } from "react";
+import { Check, Search, Loader2, UserPlus, Clock } from "lucide-react";
+import { Button, Modal } from "@/components/ui";
+import { useSearchUsers, useRecentPartners } from "@/hooks/use-social";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { Pagination } from "@/components/pagination";
+import type { UserSearchResult } from "@/types/api";
+
+interface InviteModalProps {
+  title: string;
+  closeLabel?: string;
+  open: boolean;
+  onClose: () => void;
+  onInvite: (username: string) => void;
+  isInviting: boolean;
+  invitingUsername?: string;
+}
+
+const PAGE_SIZE = 10;
+
+function UserAvatar({ user }: { user: UserSearchResult }) {
+  if (user.avatarUrl) {
+    return (
+      <img
+        src={user.avatarUrl}
+        alt=""
+        className="h-8 w-8 rounded-full object-cover"
+      />
+    );
+  }
+  return (
+    <div className="h-8 w-8 rounded-full bg-surface-600 flex items-center justify-center text-xs font-medium text-surface-300">
+      {user.username[0]?.toUpperCase()}
+    </div>
+  );
+}
+
+export function InviteModal({
+  title,
+  closeLabel = "Close",
+  open,
+  onClose,
+  onInvite,
+  isInviting,
+  invitingUsername,
+}: InviteModalProps) {
+  const [query, setQuery] = useState("");
+  const [page, setPage] = useState(1);
+  const [invitedUsers, setInvitedUsers] = useState<string[]>([]);
+  const debouncedQuery = useDebouncedValue(query, 300);
+
+  const { data: searchResponse, isLoading: isSearching } = useSearchUsers(
+    debouncedQuery,
+    page,
+    PAGE_SIZE,
+  );
+  const { data: recentPartners, isLoading: isLoadingPartners } =
+    useRecentPartners();
+
+  const showRecentPartners =
+    !debouncedQuery && recentPartners && recentPartners.length > 0;
+
+  function handleInvite(user: UserSearchResult) {
+    onInvite(user.username);
+    setInvitedUsers((prev) => [...prev, user.username]);
+  }
+
+  function handleClose() {
+    setQuery("");
+    setPage(1);
+    setInvitedUsers([]);
+    onClose();
+  }
+
+  function handleSearchChange(value: string) {
+    setQuery(value);
+    setPage(1);
+  }
+
+  const users = searchResponse?.data ?? [];
+
+  function renderUserRow(user: UserSearchResult) {
+    const isInvited = invitedUsers.includes(user.username);
+    return (
+      <div
+        key={user.id}
+        className="flex items-center justify-between px-3 py-2 rounded-lg hover:bg-surface-800 transition-colors"
+      >
+        <div className="flex items-center gap-2.5">
+          <UserAvatar user={user} />
+          <span className="text-sm text-surface-200">{user.username}</span>
+        </div>
+        {isInvited ? (
+          <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium bg-brand-500/15 text-brand-400">
+            <Check className="h-3 w-3" />
+            Invited
+          </span>
+        ) : (
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={() => handleInvite(user)}
+            loading={isInviting && invitingUsername === user.username}
+          >
+            <UserPlus className="h-3.5 w-3.5" />
+            Invite
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <Modal open={open} onClose={handleClose} title={title} size="md">
+      <div className="space-y-4">
+        {/* Search input */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-surface-500 pointer-events-none" />
+          <input
+            type="text"
+            placeholder="Search users..."
+            value={query}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            autoFocus
+            autoComplete="off"
+            aria-label="Search users"
+            className="w-full rounded-lg border border-surface-700 bg-surface-800 py-2.5 pl-10 pr-3 text-sm text-surface-100 placeholder:text-surface-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+          />
+        </div>
+
+        {/* Invited this session chips */}
+        {invitedUsers.length > 0 && (
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-surface-500">
+              Invited this session
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {invitedUsers.map((username) => (
+                <span
+                  key={username}
+                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-brand-500/15 text-brand-400"
+                >
+                  <Check className="h-3 w-3" />
+                  {username}
+                </span>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Recent partners section */}
+        {showRecentPartners && (
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5">
+              <Clock className="h-3.5 w-3.5 text-surface-500" />
+              <p className="text-xs font-medium text-surface-500">Previous</p>
+            </div>
+            <div className="space-y-1">
+              {recentPartners.map((partner) => renderUserRow(partner))}
+            </div>
+          </div>
+        )}
+
+        {/* Loading state for partners when no query */}
+        {!debouncedQuery && isLoadingPartners && (
+          <div className="flex items-center gap-2 px-3 py-2 text-sm text-surface-500">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading recent partners...
+          </div>
+        )}
+
+        {/* Divider between partners and user list */}
+        {showRecentPartners && (
+          <div className="border-t border-surface-800" />
+        )}
+
+        {/* User list */}
+        <div className="space-y-1">
+          {isSearching ? (
+            <div className="flex items-center gap-2 px-3 py-4 text-sm text-surface-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              Searching...
+            </div>
+          ) : users.length > 0 ? (
+            users.map((user) => renderUserRow(user))
+          ) : (
+            <div className="px-3 py-4 text-sm text-surface-500 text-center">
+              No users found
+            </div>
+          )}
+        </div>
+
+        {/* Pagination */}
+        {searchResponse && (
+          <Pagination
+            total={searchResponse.total}
+            pageSize={PAGE_SIZE}
+            currentPage={page}
+            onPageChange={setPage}
+          />
+        )}
+
+        {/* Footer */}
+        <div className="flex justify-end pt-2">
+          <Button variant="secondary" onClick={handleClose}>
+            {closeLabel}
+          </Button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/web/src/features/netplay/components/__tests__/netplay-invite-modal.test.tsx
+++ b/web/src/features/netplay/components/__tests__/netplay-invite-modal.test.tsx
@@ -14,14 +14,20 @@ vi.mock("@/hooks/use-netplay", () => ({
 }));
 
 vi.mock("@/hooks/use-social", () => ({
-  useSearchUsers: vi.fn((query: string) => ({
-    data:
-      query.length >= 2
-        ? [
-            { id: "u1", username: "alice", avatarUrl: null },
-            { id: "u2", username: "bob", avatarUrl: "https://example.com/bob.png" },
-          ]
-        : [],
+  useSearchUsers: vi.fn((_query: string) => ({
+    data: {
+      data: [
+        { id: "u1", username: "alice", avatarUrl: null },
+        { id: "u2", username: "bob", avatarUrl: "https://example.com/bob.png" },
+      ],
+      total: 2,
+      page: 1,
+      pageSize: 10,
+    },
+    isLoading: false,
+  })),
+  useRecentPartners: vi.fn(() => ({
+    data: [],
     isLoading: false,
   })),
 }));
@@ -84,7 +90,7 @@ describe("NetplayInviteModal", () => {
     expect(screen.queryByText("Invite Player")).not.toBeInTheDocument();
   });
 
-  it("disables submit when no username is entered", () => {
+  it("shows user list with all users", () => {
     const Wrapper = createWrapper();
     render(
       <Wrapper>
@@ -95,31 +101,12 @@ describe("NetplayInviteModal", () => {
         />
       </Wrapper>,
     );
-
-    const sendButton = screen.getByText("Send Invite").closest("button");
-    expect(sendButton).toBeDisabled();
-  });
-
-  it("shows search results when typing", async () => {
-    const Wrapper = createWrapper();
-    render(
-      <Wrapper>
-        <NetplayInviteModal
-          sessionId="s1"
-          open={true}
-          onClose={vi.fn()}
-        />
-      </Wrapper>,
-    );
-
-    const searchInput = screen.getByPlaceholderText("Search for a user...");
-    await userEvent.type(searchInput, "al");
 
     expect(screen.getByText("alice")).toBeInTheDocument();
     expect(screen.getByText("bob")).toBeInTheDocument();
   });
 
-  it("selects a user and fills the input when clicked", async () => {
+  it("calls mutate when invite button is clicked on a user", async () => {
     const Wrapper = createWrapper();
     render(
       <Wrapper>
@@ -131,31 +118,8 @@ describe("NetplayInviteModal", () => {
       </Wrapper>,
     );
 
-    const searchInput = screen.getByPlaceholderText("Search for a user...");
-    await userEvent.type(searchInput, "al");
-    await userEvent.click(screen.getByText("alice"));
-
-    expect(searchInput).toHaveValue("alice");
-  });
-
-  it("calls mutate with sessionId and username on submit", async () => {
-    const Wrapper = createWrapper();
-    render(
-      <Wrapper>
-        <NetplayInviteModal
-          sessionId="s1"
-          open={true}
-          onClose={vi.fn()}
-        />
-      </Wrapper>,
-    );
-
-    const searchInput = screen.getByPlaceholderText("Search for a user...");
-    await userEvent.type(searchInput, "al");
-    await userEvent.click(screen.getByText("alice"));
-
-    const sendButton = screen.getByText("Send Invite").closest("button")!;
-    await userEvent.click(sendButton);
+    const inviteButtons = screen.getAllByText("Invite");
+    await userEvent.click(inviteButtons[0]);
 
     expect(mockMutate).toHaveBeenCalledWith(
       { sessionId: "s1", username: "alice" },
@@ -180,7 +144,7 @@ describe("NetplayInviteModal", () => {
     expect(onClose).toHaveBeenCalledOnce();
   });
 
-  it("shows helper text about searching users", () => {
+  it("has a search input", () => {
     const Wrapper = createWrapper();
     render(
       <Wrapper>
@@ -193,9 +157,7 @@ describe("NetplayInviteModal", () => {
     );
 
     expect(
-      screen.getByText(
-        "Search for users by name and invite them to this netplay session.",
-      ),
+      screen.getByPlaceholderText("Search users..."),
     ).toBeInTheDocument();
   });
 });

--- a/web/src/features/netplay/components/netplay-invite-modal.tsx
+++ b/web/src/features/netplay/components/netplay-invite-modal.tsx
@@ -1,11 +1,6 @@
-import { useState, useRef, useEffect } from "react";
-import { UserPlus, Check, Search, Loader2 } from "lucide-react";
-import { Button, Modal } from "@/components/ui";
 import { useToast } from "@/components/ui";
+import { InviteModal } from "@/components/invite-modal";
 import { useSendNetplayInvite } from "@/hooks/use-netplay";
-import { useSearchUsers } from "@/hooks/use-social";
-import { useDebouncedValue } from "@/hooks/use-debounced-value";
-import type { UserSearchResult } from "@/types/api";
 
 interface NetplayInviteModalProps {
   sessionId: string;
@@ -18,52 +13,15 @@ export function NetplayInviteModal({
   open,
   onClose,
 }: NetplayInviteModalProps) {
-  const [query, setQuery] = useState("");
-  const [selectedUser, setSelectedUser] = useState<UserSearchResult | null>(
-    null,
-  );
-  const [invitedUsers, setInvitedUsers] = useState<string[]>([]);
-  const [showDropdown, setShowDropdown] = useState(false);
   const sendInvite = useSendNetplayInvite();
   const { toast } = useToast();
-  const debouncedQuery = useDebouncedValue(query, 300);
-  const { data: searchResults, isLoading: isSearching } =
-    useSearchUsers(debouncedQuery);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
-      ) {
-        setShowDropdown(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  function handleSelectUser(user: UserSearchResult) {
-    setSelectedUser(user);
-    setQuery(user.username);
-    setShowDropdown(false);
-  }
-
-  function handleInvite() {
-    const username = selectedUser?.username ?? query.trim();
-    if (!username) return;
-
+  function handleInvite(username: string) {
     sendInvite.mutate(
       { sessionId, username },
       {
         onSuccess: () => {
           toast("success", `Invitation sent to ${username}`);
-          setInvitedUsers((prev) => [...prev, username]);
-          setQuery("");
-          setSelectedUser(null);
-          inputRef.current?.focus();
         },
         onError: (error) => {
           toast(
@@ -77,130 +35,15 @@ export function NetplayInviteModal({
     );
   }
 
-  function handleClose() {
-    setQuery("");
-    setSelectedUser(null);
-    setInvitedUsers([]);
-    setShowDropdown(false);
-    onClose();
-  }
-
-  const filteredResults = (searchResults ?? []).filter(
-    (u) => !invitedUsers.includes(u.username),
-  );
-
   return (
-    <Modal open={open} onClose={handleClose} title="Invite Player">
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          handleInvite();
-        }}
-        className="space-y-4"
-      >
-        <div className="relative" ref={dropdownRef}>
-          <label
-            htmlFor="netplay-invite-username"
-            className="block text-sm font-medium text-surface-300 mb-1.5"
-          >
-            Username
-          </label>
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-surface-500 pointer-events-none" />
-            <input
-              ref={inputRef}
-              id="netplay-invite-username"
-              type="text"
-              placeholder="Search for a user..."
-              value={query}
-              onChange={(e) => {
-                setQuery(e.target.value);
-                setSelectedUser(null);
-                setShowDropdown(e.target.value.length >= 2);
-              }}
-              onFocus={() => {
-                if (query.length >= 2) setShowDropdown(true);
-              }}
-              autoFocus
-              autoComplete="off"
-              className="w-full rounded-lg border border-surface-700 bg-surface-800 py-2.5 pl-10 pr-3 text-sm text-surface-100 placeholder:text-surface-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
-            />
-          </div>
-          {showDropdown && query.length >= 2 && (
-            <div className="absolute z-50 mt-1 w-full rounded-lg border border-surface-700 bg-surface-800 shadow-lg max-h-48 overflow-y-auto">
-              {isSearching ? (
-                <div className="flex items-center gap-2 px-3 py-2 text-sm text-surface-500">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Searching...
-                </div>
-              ) : filteredResults.length > 0 ? (
-                filteredResults.map((user) => (
-                  <button
-                    key={user.id}
-                    type="button"
-                    className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm hover:bg-surface-700 transition-colors"
-                    onClick={() => handleSelectUser(user)}
-                  >
-                    {user.avatarUrl ? (
-                      <img
-                        src={user.avatarUrl}
-                        alt=""
-                        className="h-6 w-6 rounded-full object-cover"
-                      />
-                    ) : (
-                      <div className="h-6 w-6 rounded-full bg-surface-600 flex items-center justify-center text-xs font-medium text-surface-300">
-                        {user.username[0]?.toUpperCase()}
-                      </div>
-                    )}
-                    <span className="text-surface-200">{user.username}</span>
-                  </button>
-                ))
-              ) : (
-                <div className="px-3 py-2 text-sm text-surface-500">
-                  No users found
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-
-        {invitedUsers.length > 0 && (
-          <div className="space-y-1.5">
-            <p className="text-xs font-medium text-surface-500">
-              Invited this session
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {invitedUsers.map((user) => (
-                <span
-                  key={user}
-                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-brand-500/15 text-brand-400"
-                >
-                  <Check className="h-3 w-3" />
-                  {user}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-
-        <p className="text-xs text-surface-500">
-          Search for users by name and invite them to this netplay session.
-        </p>
-
-        <div className="flex justify-end gap-3">
-          <Button variant="secondary" type="button" onClick={handleClose}>
-            Close
-          </Button>
-          <Button
-            type="submit"
-            loading={sendInvite.isPending}
-            disabled={!query.trim()}
-          >
-            <UserPlus className="h-4 w-4" />
-            Send Invite
-          </Button>
-        </div>
-      </form>
-    </Modal>
+    <InviteModal
+      title="Invite Player"
+      closeLabel="Close"
+      open={open}
+      onClose={onClose}
+      onInvite={handleInvite}
+      isInviting={sendInvite.isPending}
+      invitingUsername={sendInvite.variables?.username}
+    />
   );
 }

--- a/web/src/features/shared-sessions/components/__tests__/shared-session-invite-modal.test.tsx
+++ b/web/src/features/shared-sessions/components/__tests__/shared-session-invite-modal.test.tsx
@@ -1,10 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SharedSessionInviteModal } from "../shared-session-invite-modal";
 
 const mockMutate = vi.fn();
-const mockSearchResults: { id: string; username: string; avatarUrl?: string }[] = [];
 
 vi.mock("@/hooks/use-shared-sessions", () => ({
   useInviteToSharedSession: vi.fn(() => ({
@@ -13,11 +13,29 @@ vi.mock("@/hooks/use-shared-sessions", () => ({
   })),
 }));
 
+const mockUsers = [
+  { id: "1", username: "charlie" },
+  { id: "2", username: "charlotte" },
+];
+
 vi.mock("@/hooks/use-social", () => ({
   useSearchUsers: vi.fn(() => ({
-    data: mockSearchResults,
+    data: {
+      data: mockUsers,
+      total: 2,
+      page: 1,
+      pageSize: 10,
+    },
     isLoading: false,
   })),
+  useRecentPartners: vi.fn(() => ({
+    data: [],
+    isLoading: false,
+  })),
+}));
+
+vi.mock("@/hooks/use-debounced-value", () => ({
+  useDebouncedValue: vi.fn((value: string) => value),
 }));
 
 vi.mock("@/components/ui", async () => {
@@ -28,61 +46,83 @@ vi.mock("@/components/ui", async () => {
   };
 });
 
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
-  mockSearchResults.length = 0;
 });
 
 describe("SharedSessionInviteModal", () => {
   it("renders when open", () => {
+    const Wrapper = createWrapper();
     render(
-      <SharedSessionInviteModal
-        sharedSessionId="ss-1"
-        open={true}
-        onClose={vi.fn()}
-      />,
+      <Wrapper>
+        <SharedSessionInviteModal
+          sharedSessionId="ss-1"
+          open={true}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
     );
 
-    expect(screen.getByLabelText("Username")).toBeInTheDocument();
-    expect(screen.getByText("Send Invite")).toBeInTheDocument();
+    expect(screen.getByText("Invite Players")).toBeInTheDocument();
+    expect(screen.getByPlaceholderText("Search users...")).toBeInTheDocument();
   });
 
   it("does not render when closed", () => {
+    const Wrapper = createWrapper();
     render(
-      <SharedSessionInviteModal
-        sharedSessionId="ss-1"
-        open={false}
-        onClose={vi.fn()}
-      />,
+      <Wrapper>
+        <SharedSessionInviteModal
+          sharedSessionId="ss-1"
+          open={false}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
     );
 
-    expect(screen.queryByLabelText("Username")).not.toBeInTheDocument();
+    expect(screen.queryByText("Invite Players")).not.toBeInTheDocument();
   });
 
-  it("disables submit when search input is empty", () => {
+  it("shows user list", () => {
+    const Wrapper = createWrapper();
     render(
-      <SharedSessionInviteModal
-        sharedSessionId="ss-1"
-        open={true}
-        onClose={vi.fn()}
-      />,
+      <Wrapper>
+        <SharedSessionInviteModal
+          sharedSessionId="ss-1"
+          open={true}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
     );
 
-    expect(screen.getByText("Send Invite").closest("button")).toBeDisabled();
+    expect(screen.getByText("charlie")).toBeInTheDocument();
+    expect(screen.getByText("charlotte")).toBeInTheDocument();
   });
 
-  it("calls invite mutation with typed username", async () => {
+  it("calls invite mutation when invite button is clicked", async () => {
+    const Wrapper = createWrapper();
     render(
-      <SharedSessionInviteModal
-        sharedSessionId="ss-1"
-        open={true}
-        onClose={vi.fn()}
-      />,
+      <Wrapper>
+        <SharedSessionInviteModal
+          sharedSessionId="ss-1"
+          open={true}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
     );
 
-    const input = screen.getByLabelText("Username");
-    await userEvent.type(input, "charlie");
-    await userEvent.click(screen.getByText("Send Invite"));
+    const inviteButtons = screen.getAllByText("Invite");
+    await userEvent.click(inviteButtons[0]);
 
     expect(mockMutate).toHaveBeenCalledWith(
       { sharedSessionId: "ss-1", username: "charlie" },
@@ -92,74 +132,35 @@ describe("SharedSessionInviteModal", () => {
 
   it("calls onClose when done is clicked", async () => {
     const onClose = vi.fn();
+    const Wrapper = createWrapper();
     render(
-      <SharedSessionInviteModal
-        sharedSessionId="ss-1"
-        open={true}
-        onClose={onClose}
-      />,
+      <Wrapper>
+        <SharedSessionInviteModal
+          sharedSessionId="ss-1"
+          open={true}
+          onClose={onClose}
+        />
+      </Wrapper>,
     );
 
     await userEvent.click(screen.getByText("Done"));
     expect(onClose).toHaveBeenCalledOnce();
   });
 
-  it("shows search results dropdown when typing", async () => {
-    mockSearchResults.push(
-      { id: "1", username: "charlie" },
-      { id: "2", username: "charlotte" },
-    );
-
-    render(
-      <SharedSessionInviteModal
-        sharedSessionId="ss-1"
-        open={true}
-        onClose={vi.fn()}
-      />,
-    );
-
-    const input = screen.getByLabelText("Username");
-    await userEvent.type(input, "ch");
-
-    expect(screen.getByText("charlie")).toBeInTheDocument();
-    expect(screen.getByText("charlotte")).toBeInTheDocument();
-  });
-
-  it("selects user from dropdown and invites them", async () => {
-    mockSearchResults.push(
-      { id: "1", username: "charlie" },
-    );
-
-    render(
-      <SharedSessionInviteModal
-        sharedSessionId="ss-1"
-        open={true}
-        onClose={vi.fn()}
-      />,
-    );
-
-    const input = screen.getByLabelText("Username");
-    await userEvent.type(input, "ch");
-    await userEvent.click(screen.getByText("charlie"));
-    await userEvent.click(screen.getByText("Send Invite"));
-
-    expect(mockMutate).toHaveBeenCalledWith(
-      { sharedSessionId: "ss-1", username: "charlie" },
-      expect.any(Object),
-    );
-  });
-
   it("has a search placeholder", () => {
+    const Wrapper = createWrapper();
     render(
-      <SharedSessionInviteModal
-        sharedSessionId="ss-1"
-        open={true}
-        onClose={vi.fn()}
-      />,
+      <Wrapper>
+        <SharedSessionInviteModal
+          sharedSessionId="ss-1"
+          open={true}
+          onClose={vi.fn()}
+        />
+      </Wrapper>,
     );
 
     expect(
-      screen.getByPlaceholderText("Search for a user..."),
+      screen.getByPlaceholderText("Search users..."),
     ).toBeInTheDocument();
   });
 });

--- a/web/src/features/shared-sessions/components/__tests__/shared-session-members-list.test.tsx
+++ b/web/src/features/shared-sessions/components/__tests__/shared-session-members-list.test.tsx
@@ -22,9 +22,17 @@ vi.mock("@/hooks/use-shared-sessions", () => ({
 
 vi.mock("@/hooks/use-social", () => ({
   useSearchUsers: vi.fn(() => ({
+    data: { data: [], total: 0, page: 1, pageSize: 10 },
+    isLoading: false,
+  })),
+  useRecentPartners: vi.fn(() => ({
     data: [],
     isLoading: false,
   })),
+}));
+
+vi.mock("@/hooks/use-debounced-value", () => ({
+  useDebouncedValue: vi.fn((value: string) => value),
 }));
 
 vi.mock("@/components/ui", async () => {

--- a/web/src/features/shared-sessions/components/shared-session-invite-modal.tsx
+++ b/web/src/features/shared-sessions/components/shared-session-invite-modal.tsx
@@ -1,11 +1,6 @@
-import { useState, useRef, useEffect } from "react";
-import { UserPlus, Check, Search, Loader2 } from "lucide-react";
-import { Button, Modal } from "@/components/ui";
 import { useToast } from "@/components/ui";
+import { InviteModal } from "@/components/invite-modal";
 import { useInviteToSharedSession } from "@/hooks/use-shared-sessions";
-import { useSearchUsers } from "@/hooks/use-social";
-import { useDebouncedValue } from "@/hooks/use-debounced-value";
-import type { UserSearchResult } from "@/types/api";
 
 interface SharedSessionInviteModalProps {
   sharedSessionId: string;
@@ -18,52 +13,15 @@ export function SharedSessionInviteModal({
   open,
   onClose,
 }: SharedSessionInviteModalProps) {
-  const [query, setQuery] = useState("");
-  const [selectedUser, setSelectedUser] = useState<UserSearchResult | null>(
-    null,
-  );
-  const [invitedUsers, setInvitedUsers] = useState<string[]>([]);
-  const [showDropdown, setShowDropdown] = useState(false);
   const inviteUser = useInviteToSharedSession();
   const { toast } = useToast();
-  const debouncedQuery = useDebouncedValue(query, 300);
-  const { data: searchResults, isLoading: isSearching } =
-    useSearchUsers(debouncedQuery);
-  const dropdownRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
 
-  useEffect(() => {
-    function handleClickOutside(e: MouseEvent) {
-      if (
-        dropdownRef.current &&
-        !dropdownRef.current.contains(e.target as Node)
-      ) {
-        setShowDropdown(false);
-      }
-    }
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  function handleSelectUser(user: UserSearchResult) {
-    setSelectedUser(user);
-    setQuery(user.username);
-    setShowDropdown(false);
-  }
-
-  function handleInvite() {
-    const username = selectedUser?.username ?? query.trim();
-    if (!username) return;
-
+  function handleInvite(username: string) {
     inviteUser.mutate(
       { sharedSessionId, username },
       {
         onSuccess: () => {
           toast("success", `Invitation sent to ${username}`);
-          setInvitedUsers((prev) => [...prev, username]);
-          setQuery("");
-          setSelectedUser(null);
-          inputRef.current?.focus();
         },
         onError: (error) => {
           toast(
@@ -77,130 +35,15 @@ export function SharedSessionInviteModal({
     );
   }
 
-  function handleClose() {
-    setQuery("");
-    setSelectedUser(null);
-    setInvitedUsers([]);
-    setShowDropdown(false);
-    onClose();
-  }
-
-  const filteredResults = (searchResults ?? []).filter(
-    (u) => !invitedUsers.includes(u.username),
-  );
-
   return (
-    <Modal open={open} onClose={handleClose} title="Invite Players">
-      <form
-        onSubmit={(e) => {
-          e.preventDefault();
-          handleInvite();
-        }}
-        className="space-y-4"
-      >
-        <div className="relative" ref={dropdownRef}>
-          <label
-            htmlFor="invite-username"
-            className="block text-sm font-medium text-surface-300 mb-1.5"
-          >
-            Username
-          </label>
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-surface-500 pointer-events-none" />
-            <input
-              ref={inputRef}
-              id="invite-username"
-              type="text"
-              placeholder="Search for a user..."
-              value={query}
-              onChange={(e) => {
-                setQuery(e.target.value);
-                setSelectedUser(null);
-                setShowDropdown(e.target.value.length >= 2);
-              }}
-              onFocus={() => {
-                if (query.length >= 2) setShowDropdown(true);
-              }}
-              autoFocus
-              autoComplete="off"
-              className="w-full rounded-lg border border-surface-700 bg-surface-800 py-2.5 pl-10 pr-3 text-sm text-surface-100 placeholder:text-surface-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
-            />
-          </div>
-          {showDropdown && query.length >= 2 && (
-            <div className="absolute z-50 mt-1 w-full rounded-lg border border-surface-700 bg-surface-800 shadow-lg max-h-48 overflow-y-auto">
-              {isSearching ? (
-                <div className="flex items-center gap-2 px-3 py-2 text-sm text-surface-500">
-                  <Loader2 className="h-4 w-4 animate-spin" />
-                  Searching...
-                </div>
-              ) : filteredResults.length > 0 ? (
-                filteredResults.map((user) => (
-                  <button
-                    key={user.id}
-                    type="button"
-                    className="flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm hover:bg-surface-700 transition-colors"
-                    onClick={() => handleSelectUser(user)}
-                  >
-                    {user.avatarUrl ? (
-                      <img
-                        src={user.avatarUrl}
-                        alt=""
-                        className="h-6 w-6 rounded-full object-cover"
-                      />
-                    ) : (
-                      <div className="h-6 w-6 rounded-full bg-surface-600 flex items-center justify-center text-xs font-medium text-surface-300">
-                        {user.username[0]?.toUpperCase()}
-                      </div>
-                    )}
-                    <span className="text-surface-200">{user.username}</span>
-                  </button>
-                ))
-              ) : (
-                <div className="px-3 py-2 text-sm text-surface-500">
-                  No users found
-                </div>
-              )}
-            </div>
-          )}
-        </div>
-
-        {invitedUsers.length > 0 && (
-          <div className="space-y-1.5">
-            <p className="text-xs font-medium text-surface-500">
-              Invited this session
-            </p>
-            <div className="flex flex-wrap gap-2">
-              {invitedUsers.map((user) => (
-                <span
-                  key={user}
-                  className="inline-flex items-center gap-1 px-2.5 py-1 rounded-full text-xs font-medium bg-brand-500/15 text-brand-400"
-                >
-                  <Check className="h-3 w-3" />
-                  {user}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-
-        <p className="text-xs text-surface-500">
-          Search for users by name and invite them to this shared session.
-        </p>
-
-        <div className="flex justify-end gap-3">
-          <Button variant="secondary" type="button" onClick={handleClose}>
-            Done
-          </Button>
-          <Button
-            type="submit"
-            loading={inviteUser.isPending}
-            disabled={!query.trim()}
-          >
-            <UserPlus className="h-4 w-4" />
-            Send Invite
-          </Button>
-        </div>
-      </form>
-    </Modal>
+    <InviteModal
+      title="Invite Players"
+      closeLabel="Done"
+      open={open}
+      onClose={onClose}
+      onInvite={handleInvite}
+      isInviting={inviteUser.isPending}
+      invitingUsername={inviteUser.variables?.username}
+    />
   );
 }

--- a/web/src/hooks/use-social.ts
+++ b/web/src/hooks/use-social.ts
@@ -6,6 +6,7 @@ import type {
   ActivityFeedResponse,
   ActivityEvent,
   UserSearchResult,
+  UserSearchResponse,
 } from "@/types/api";
 
 export function useOnlineUsers() {
@@ -26,12 +27,24 @@ export function useActivityFeed(page: number = 1, pageSize: number = 20) {
   });
 }
 
-export function useSearchUsers(query: string) {
+export function useSearchUsers(
+  query: string,
+  page: number = 1,
+  pageSize: number = 20,
+) {
   return useQuery({
-    queryKey: ["users", "search", query],
+    queryKey: ["users", "search", query, page, pageSize],
     queryFn: () =>
-      api.get<UserSearchResult[]>(`/users/search?q=${encodeURIComponent(query)}`),
-    enabled: query.length >= 2,
+      api.get<UserSearchResponse>(
+        `/users/search?q=${encodeURIComponent(query)}&page=${page}&pageSize=${pageSize}`,
+      ),
+  });
+}
+
+export function useRecentPartners() {
+  return useQuery({
+    queryKey: ["users", "recent-partners"],
+    queryFn: () => api.get<UserSearchResult[]>("/users/recent-partners"),
   });
 }
 

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -103,6 +103,7 @@ export type ApiGetPath = WithQuery<
   | "/social/online"
   | "/social/activity"
   | `/users/search`
+  | `/users/recent-partners`
   | `/users/${string}/profile`
   | `/users/${string}/play-heatmap`
 

--- a/web/src/pages/__tests__/netplay-session-page.test.tsx
+++ b/web/src/pages/__tests__/netplay-session-page.test.tsx
@@ -23,6 +23,10 @@ vi.mock("@/hooks/use-netplay", () => ({
 
 vi.mock("@/hooks/use-social", () => ({
   useSearchUsers: vi.fn(() => ({
+    data: { data: [], total: 0, page: 1, pageSize: 10 },
+    isLoading: false,
+  })),
+  useRecentPartners: vi.fn(() => ({
     data: [],
     isLoading: false,
   })),
@@ -152,7 +156,7 @@ describe("NetplaySessionPage", () => {
 
     expect(
       screen.getByText(
-        "Open this session in the Spela player app to join and play.",
+        "Netplay requires the Spela player app. Set up your session here, then open it in the app to play.",
       ),
     ).toBeInTheDocument();
   });
@@ -223,7 +227,7 @@ describe("NetplaySessionPage", () => {
 
     expect(
       screen.queryByText(
-        "Open this session in the Spela player app to join and play.",
+        "Netplay requires the Spela player app. Set up your session here, then open it in the app to play.",
       ),
     ).not.toBeInTheDocument();
   });

--- a/web/src/pages/netplay-session-page.tsx
+++ b/web/src/pages/netplay-session-page.tsx
@@ -164,7 +164,7 @@ export function NetplaySessionPage() {
               <div className="flex items-center gap-2 px-3.5 py-2.5 rounded-lg bg-brand-500/10 border border-brand-500/20">
                 <Monitor className="h-4 w-4 text-brand-400 flex-shrink-0" />
                 <p className="text-sm text-brand-300">
-                  Open this session in the Spela player app to join and play.
+                  Netplay requires the Spela player app. Set up your session here, then open it in the app to play.
                 </p>
               </div>
             )}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -316,6 +316,13 @@ export interface UserSearchResult {
   avatarUrl?: string;
 }
 
+export interface UserSearchResponse {
+  data: UserSearchResult[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
 export interface OnlineUser {
   id: string;
   username: string;


### PR DESCRIPTION
## Summary
- Add direct user invite flow to netplay lobby and shared session screens in both web frontend and player app
- New paginated user search API (`GET /api/users/search`) with debounced search and empty-query support for browsing all users
- New recent partners API (`GET /api/users/recent-partners`) showing users played with in the last 6 months from netplay and shared sessions
- Shared `InviteModal` component (web) and `InvitePlayerSheet` composable (app) with "Previous" section for recent partners
- `InviteSheetDelegate` pattern to deduplicate ViewModel logic across netplay and shared session screens
- Per-user loading state on invite buttons (instead of disabling all buttons globally)
- Web netplay page notice that gameplay requires the native Spela app

## Test plan
- [x] 15 backend tests for user search and recent partners API (`social_search_test.go`)
- [x] Updated web tests for invite modals and netplay session page (721 tests passing)
- [x] 16 new desktop E2E tests for netplay invite flow (`NetplayInviteTest.kt`)
- [x] All existing test suites pass with no regressions (421 desktop tests, 721 web tests, all Go tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)