### PR TITLE
feat: second screen companion Phase 2 — cheat toggles, save gestures, thumbnails, default page

### DIFF
--- a/design-proposals/second-screen-companion.md
+++ b/design-proposals/second-screen-companion.md
@@ -1,6 +1,6 @@
 # Second Screen Companion Experience
 
-## Status: Phase 1 + Phase 2 Implemented
+## Status: Phase 1 + Phase 2 Complete, Phase 3 Started (Cheat Toggle)
 
 **Date:** 2026-03-09
 **Contributors:** Product Owner, Android Developer, UI/UX Agent

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenDashboardTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenDashboardTest.kt
@@ -1,13 +1,16 @@
 package com.spela.player.desktop.e2e
 
 import androidx.compose.ui.test.*
+import com.spela.player.domain.model.Cheat
 import com.spela.player.presentation.intent.EmulationIntent
+import com.spela.player.presentation.state.SaveSlotInfo
 import com.spela.player.presentation.ui.feature.ingame.SecondaryDashboardPage
 import com.spela.player.presentation.ui.feature.ingame.SecondaryScreenContent
 import com.spela.player.presentation.ui.feature.ingame.SecondarySaveSlotsPage
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlin.test.Test
+import kotlin.test.assertTrue
 
 /**
  * E2E tests for the Second Screen Companion dashboard page and pager infrastructure.
@@ -76,6 +79,7 @@ class SecondaryScreenDashboardTest {
         activeSlot: Int = 1,
         hasCheats: Boolean = false,
         enabledCheatCount: Int = 0,
+        cheats: List<com.spela.player.domain.model.Cheat> = emptyList(),
         isFastForward: Boolean = false,
         rewindEnabled: Boolean = false,
     ) {
@@ -86,6 +90,7 @@ class SecondaryScreenDashboardTest {
                 activeSlot = activeSlot,
                 hasCheats = hasCheats,
                 enabledCheatCount = enabledCheatCount,
+                cheats = cheats,
                 isFastForward = isFastForward,
                 rewindEnabled = rewindEnabled,
                 onSave = {},
@@ -93,6 +98,7 @@ class SecondaryScreenDashboardTest {
                 onScreenshot = {},
                 onToggleFastForward = {},
                 onRewind = {},
+                onToggleCheat = { _, _ -> },
             )
         }
     }
@@ -124,7 +130,7 @@ class SecondaryScreenDashboardTest {
         renderDashboard(hasCheats = true, enabledCheatCount = 2)
 
         // Cheats card should show active count
-        onNodeWithContentDescription("2 cheats active")
+        onNodeWithContentDescription("2 cheats active, tap to manage")
             .assertExists()
             .assertIsDisplayed()
 
@@ -265,7 +271,10 @@ class SecondaryScreenDashboardTest {
         setContent {
             SecondarySaveSlotsPage(
                 activeSlot = 1,
+                saveSlots = emptyMap(),
                 onSelectSlot = {},
+                onSaveToSlot = {},
+                onLoadFromSlot = {},
             )
         }
         waitForIdle()
@@ -287,7 +296,10 @@ class SecondaryScreenDashboardTest {
         setContent {
             SecondarySaveSlotsPage(
                 activeSlot = 7,
+                saveSlots = emptyMap(),
                 onSelectSlot = {},
+                onSaveToSlot = {},
+                onLoadFromSlot = {},
             )
         }
         waitForIdle()
@@ -305,12 +317,15 @@ class SecondaryScreenDashboardTest {
         setContent {
             SecondarySaveSlotsPage(
                 activeSlot = 1,
+                saveSlots = emptyMap(),
                 onSelectSlot = {},
+                onSaveToSlot = {},
+                onLoadFromSlot = {},
             )
         }
         waitForIdle()
 
-        onNodeWithText("Tap to select active slot").assertExists()
+        onNodeWithText("Swipe up: save \u2022 Hold: load").assertExists()
     }
 
     @Test
@@ -319,7 +334,10 @@ class SecondaryScreenDashboardTest {
         setContent {
             SecondarySaveSlotsPage(
                 activeSlot = 1,
+                saveSlots = emptyMap(),
                 onSelectSlot = { selectedSlot = it },
+                onSaveToSlot = {},
+                onLoadFromSlot = {},
             )
         }
         waitForIdle()
@@ -329,5 +347,207 @@ class SecondaryScreenDashboardTest {
         waitForIdle()
 
         assert(selectedSlot == 3) { "Expected selectedSlot to be 3, was $selectedSlot" }
+    }
+
+    // -- Cheat Toggle Panel Tests ----------------------------------------------
+
+    private val testCheats = listOf(
+        Cheat(id = "c1", gameId = "1", index = 0, description = "Infinite Lives", code = "ABCD", enabled = false),
+        Cheat(id = "c2", gameId = "1", index = 1, description = "Invincibility", code = "EFGH", enabled = true),
+        Cheat(id = "c3", gameId = "1", index = 2, description = "Max Score", code = "IJKL", enabled = false),
+    )
+
+    @Test
+    fun cheatsCardTapOpensPanel() = runComposeUiTest {
+        renderDashboard(hasCheats = true, enabledCheatCount = 1, cheats = testCheats)
+
+        // Tap the cheats card to open the panel
+        onNodeWithContentDescription("1 cheats active, tap to manage").performClick()
+        waitForIdle()
+
+        // Verify the cheats panel is shown with the "Cheats" title
+        onNodeWithText("Cheats").assertExists().assertIsDisplayed()
+
+        // Verify individual cheat items are rendered
+        onNodeWithContentDescription("Cheat: Infinite Lives, disabled")
+            .assertExists()
+            .assertIsDisplayed()
+        onNodeWithContentDescription("Cheat: Invincibility, enabled")
+            .assertExists()
+            .assertIsDisplayed()
+        onNodeWithContentDescription("Cheat: Max Score, disabled")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun cheatsPanelClosesOnCloseButton() = runComposeUiTest {
+        renderDashboard(hasCheats = true, enabledCheatCount = 1, cheats = testCheats)
+
+        // Open cheats panel
+        onNodeWithContentDescription("1 cheats active, tap to manage").performClick()
+        waitForIdle()
+
+        // Verify panel is open
+        onNodeWithContentDescription("Close cheats panel").assertExists()
+
+        // Close the panel
+        onNodeWithContentDescription("Close cheats panel").performClick()
+        waitForIdle()
+
+        // Verify we're back to the dashboard — stat cards should be visible again
+        onNodeWithContentDescription("1 cheats active, tap to manage")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Close button should no longer be visible
+        onAllNodesWithContentDescription("Close cheats panel")
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun cheatsPanelToggleCallsCallback() = runComposeUiTest {
+        var toggledCheatId: String? = null
+        var toggledEnabled: Boolean? = null
+
+        setContent {
+            SecondaryDashboardPage(
+                fps = 60f,
+                frameTime = 16.7f,
+                activeSlot = 1,
+                hasCheats = true,
+                enabledCheatCount = 1,
+                cheats = testCheats,
+                isFastForward = false,
+                rewindEnabled = false,
+                onSave = {},
+                onLoad = {},
+                onScreenshot = {},
+                onToggleFastForward = {},
+                onRewind = {},
+                onToggleCheat = { id, enabled ->
+                    toggledCheatId = id
+                    toggledEnabled = enabled
+                },
+            )
+        }
+
+        // Open cheats panel
+        onNodeWithContentDescription("1 cheats active, tap to manage").performClick()
+        waitForIdle()
+
+        // Find the switch within the "Infinite Lives" cheat row and toggle it
+        // The SpSwitch is a child of the cheat row; clicking the row's switch toggles it
+        onNodeWithContentDescription("Cheat: Infinite Lives, disabled")
+            .onChildren()
+            .filterToOne(isToggleable())
+            .performClick()
+        waitForIdle()
+
+        assertTrue(toggledCheatId == "c1", "Expected cheat ID 'c1', got '$toggledCheatId'")
+        assertTrue(toggledEnabled == true, "Expected enabled to be true, got $toggledEnabled")
+    }
+
+    @Test
+    fun cheatsCardNotClickableWhenNoCheats() = runComposeUiTest {
+        renderDashboard(hasCheats = false, enabledCheatCount = 0, cheats = emptyList())
+
+        // "No cheats available" should be present (without "tap to manage")
+        onNodeWithContentDescription("No cheats available")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // "tap to manage" content description should NOT be present
+        onAllNodesWithContentDescription("0 cheats active, tap to manage")
+            .assertCountEquals(0)
+
+        // Tapping the card should not open the panel
+        onNodeWithContentDescription("No cheats available").performClick()
+        waitForIdle()
+
+        // The cheats panel "Close cheats panel" button should not appear
+        onAllNodesWithContentDescription("Close cheats panel")
+            .assertCountEquals(0)
+
+        // "No cheats" text should still be visible (dashboard is still showing)
+        onNodeWithText("No cheats")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    // -- Save Slots Gesture Hint & Thumbnail Tests -----------------------------
+
+    @Test
+    fun saveSlotsHintTextShowsGestures() = runComposeUiTest {
+        setContent {
+            SecondarySaveSlotsPage(
+                activeSlot = 1,
+                saveSlots = emptyMap(),
+                onSelectSlot = {},
+                onSaveToSlot = {},
+                onLoadFromSlot = {},
+            )
+        }
+        waitForIdle()
+
+        // Verify the hint text shows save and load gesture instructions
+        onNodeWithText("Swipe up: save \u2022 Hold: load")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun saveSlotsShowsFilledSlotInfo() = runComposeUiTest {
+        val saveSlots = mapOf(
+            2 to SaveSlotInfo(
+                screenshotUrl = "https://example.com/screenshot.png",
+                timestamp = "12:34",
+                isFilled = true,
+            ),
+        )
+
+        setContent {
+            SecondarySaveSlotsPage(
+                activeSlot = 1,
+                saveSlots = saveSlots,
+                onSelectSlot = {},
+                onSaveToSlot = {},
+                onLoadFromSlot = {},
+            )
+        }
+        waitForIdle()
+
+        // Filled slot 2 should have "filled" in its content description
+        onNodeWithContentDescription("Save slot 2, filled, saved at 12:34")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Empty slot 1 should NOT have "filled" — just "active"
+        onNodeWithContentDescription("Save slot 1, active")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun saveSlotsEmptySlotShowsPlaceholder() = runComposeUiTest {
+        setContent {
+            SecondarySaveSlotsPage(
+                activeSlot = 3,
+                saveSlots = emptyMap(),
+                onSelectSlot = {},
+                onSaveToSlot = {},
+                onLoadFromSlot = {},
+            )
+        }
+        waitForIdle()
+
+        // All empty slots (including active) show "+" placeholder text
+        onAllNodesWithText("+").assertCountEquals(10) // All 10 slots are empty
+
+        // Non-active empty slots show "Empty" label text
+        onAllNodesWithText("Empty").assertCountEquals(9) // 9 non-active empty slots
+
+        // Active empty slot shows "Active" label
+        onNodeWithContentDescription("Save slot 3, active").assertExists()
     }
 }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsSecondScreenTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsSecondScreenTest.kt
@@ -1,0 +1,71 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.viewmodel.SettingsIntent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+
+/**
+ * E2E tests for the Second Screen default page selector in Settings.
+ *
+ * Verifies:
+ * - Settings screen shows a "Second Screen" section
+ * - All four page options are rendered (Art Display, Controls, Dashboard, Save Slots)
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class SettingsSecondScreenTest {
+
+    private fun createLoggedInHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.authRepo.preSetTokens()
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun ComposeUiTest.navigateToSettings(harness: SpelaTestHarness) {
+        harness.settingsViewModel.onIntent(SettingsIntent.LoadSettings)
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.Settings)
+        )
+        advanceFully(harness)
+    }
+
+    @Test
+    fun settingsShowsSecondScreenPageSelector() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        navigateToSettings(harness)
+
+        // Scroll to the "Second Screen" section header
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Second Screen"))
+        onNodeWithText("Second Screen").assertIsDisplayed()
+
+        // Verify all four radio options are present
+        // SpRadioOption uses the title as contentDescription with role RadioButton
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Art Display"))
+        onNodeWithText("Art Display").assertIsDisplayed()
+        onNodeWithText("Game artwork from SteamGridDB").assertIsDisplayed()
+
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Dashboard"))
+        onNodeWithText("Dashboard").assertIsDisplayed()
+        onNodeWithText("Stats and quick actions").assertIsDisplayed()
+
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Save Slots"))
+        onNodeWithText("Save Slots").assertIsDisplayed()
+        onNodeWithText("Visual save slot management").assertIsDisplayed()
+
+        // Controls option (scroll back up if needed)
+        onNodeWithTag("settings_list")
+            .performScrollToNode(hasText("Touch gamepad controls"))
+        onNodeWithText("Controls").assertIsDisplayed()
+        onNodeWithText("Touch gamepad controls").assertIsDisplayed()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -590,6 +590,7 @@ class FakePreferencesRepository : PreferencesRepository {
         selectedShader: String?,
         selectedTheme: String?,
         consoleShaders: Map<String, String>?,
+        defaultSecondScreenPage: String?,
     ): Result<UserPreferences> = Result.success(UserPreferences())
     override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
     override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
@@ -1134,6 +1135,7 @@ class FakeSessionRepository : SessionRepository {
     var sessions: MutableList<GameSession> = mutableListOf()
     private val sessionSaves = mutableMapOf<String, MutableList<SaveState>>()
     private val autoSaves = mutableMapOf<String, ByteArray>()
+    private val slotSaves = mutableMapOf<String, ByteArray>() // key: "$sessionId:$slot"
     private val sram = mutableMapOf<String, ByteArray>()
     private val sessionCheats = mutableMapOf<String, SessionCheatConfig>()
     private var nextId = 1
@@ -1207,6 +1209,26 @@ class FakeSessionRepository : SessionRepository {
     override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> =
         autoSaves[sessionId]?.let { Result.success(it) }
             ?: Result.failure(Exception("No auto-save"))
+
+    override suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<SaveState> {
+        val key = "$sessionId:$slot"
+        slotSaves[key] = data
+        val save = SaveState(
+            id = (sessionSaves[sessionId]?.size?.toLong() ?: 0L) + 1,
+            gameId = 0,
+            name = "Slot $slot",
+            isAuto = false,
+            slot = slot,
+        )
+        sessionSaves.getOrPut(sessionId) { mutableListOf() }.add(save)
+        return Result.success(save)
+    }
+
+    override suspend fun downloadSlotSave(sessionId: String, slot: Int): Result<ByteArray> {
+        val key = "$sessionId:$slot"
+        return slotSaves[key]?.let { Result.success(it) }
+            ?: Result.failure(Exception("No save in slot $slot"))
+    }
 
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String): Result<Unit> {
         sram[sessionId] = data

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1168,6 +1168,37 @@ class SpelaApiClient(
         return response.body()
     }
 
+    suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): SaveStateDto {
+        return client.submitFormWithBinaryData(
+            url = "$baseUrl/api/sessions/$sessionId/saves/slot/$slot",
+            formData = formData {
+                if (coreName.isNotEmpty()) {
+                    append("coreName", coreName)
+                }
+                append("save", data, Headers.build {
+                    append(HttpHeaders.ContentDisposition, "filename=\"slot_${slot}.sav\"")
+                    append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())
+                })
+                if (screenshot != null) {
+                    append("screenshot", screenshot, Headers.build {
+                        append(HttpHeaders.ContentDisposition, "filename=\"screenshot.png\"")
+                        append(HttpHeaders.ContentType, ContentType.Image.PNG.toString())
+                    })
+                }
+            }
+        ) {
+            method = HttpMethod.Put
+        }.body()
+    }
+
+    suspend fun downloadSlotSave(sessionId: String, slot: Int): ByteArray {
+        val response = client.get("$baseUrl/api/sessions/$sessionId/saves/slot/$slot")
+        if (!response.status.isSuccess()) {
+            throw RuntimeException("Slot save download failed: HTTP ${response.status.value}")
+        }
+        return response.body()
+    }
+
     suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String = "") {
         client.submitFormWithBinaryData(
             url = "$baseUrl/api/sessions/$sessionId/sram",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -113,6 +113,7 @@ fun UserPreferencesDto.toDomain(): UserPreferences = UserPreferences(
             customMapping = it.value.customMapping,
         )
     },
+    defaultSecondScreenPage = defaultSecondScreenPage,
 )
 
 fun SharedSaveStateDto.toDomain(): SharedSaveState = SharedSaveState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -176,6 +176,7 @@ data class UserPreferencesDto(
     val selectedKeyMapping: String = "default",
     val customKeyMapping: Map<String, String> = emptyMap(),
     val consoleKeyMappings: Map<String, ConsoleKeyMappingDto> = emptyMap(),
+    val defaultSecondScreenPage: String = "art",
 )
 
 @Serializable
@@ -189,6 +190,7 @@ data class UpdatePreferencesRequest(
     val selectedKeyMapping: String? = null,
     val customKeyMapping: Map<String, String>? = null,
     val consoleKeyMappings: Map<String, ConsoleKeyMappingDto>? = null,
+    val defaultSecondScreenPage: String? = null,
 )
 
 // Devices

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
@@ -61,6 +61,7 @@ class PreferencesRepositoryImpl(
         selectedShader: String?,
         selectedTheme: String?,
         consoleShaders: Map<String, String>?,
+        defaultSecondScreenPage: String?,
     ): Result<UserPreferences> = runCatching {
         apiClient.updatePreferences(
             UpdatePreferencesRequest(
@@ -70,6 +71,7 @@ class PreferencesRepositoryImpl(
                 selectedShader = selectedShader,
                 selectedTheme = selectedTheme,
                 consoleShaders = consoleShaders,
+                defaultSecondScreenPage = defaultSecondScreenPage,
             )
         ).toDomain()
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -66,6 +66,20 @@ class SessionRepositoryImpl(
         apiClient.downloadSessionAutoSave(sessionId)
     }
 
+    override suspend fun uploadSlotSave(
+        sessionId: String,
+        slot: Int,
+        data: ByteArray,
+        screenshot: ByteArray?,
+        coreName: String,
+    ): Result<SaveState> = runCatching {
+        apiClient.uploadSlotSave(sessionId, slot, data, screenshot, coreName).toDomain()
+    }
+
+    override suspend fun downloadSlotSave(sessionId: String, slot: Int): Result<ByteArray> = runCatching {
+        apiClient.downloadSlotSave(sessionId, slot)
+    }
+
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String): Result<Unit> = runCatching {
         apiClient.uploadSessionSram(sessionId, data, coreName)
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -141,6 +141,7 @@ data class UserPreferences(
     val consoleShaders: Map<String, ShaderPreset> = emptyMap(),
     val selectedKeyMapping: String = "default",
     val consoleKeyMappings: Map<String, ConsoleKeyMappingPref> = emptyMap(),
+    val defaultSecondScreenPage: String = "art",
 )
 
 data class DownloadedGame(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PreferencesRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/PreferencesRepository.kt
@@ -12,6 +12,7 @@ interface PreferencesRepository {
         selectedShader: String? = null,
         selectedTheme: String? = null,
         consoleShaders: Map<String, String>? = null,
+        defaultSecondScreenPage: String? = null,
     ): Result<UserPreferences>
     fun getDeviceShaderOverride(consoleId: String): ShaderPreset?
     fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -16,6 +16,8 @@ interface SessionRepository {
     suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray>
     suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<Unit>
     suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray>
+    suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>
+    suspend fun downloadSlotSave(sessionId: String, slot: Int): Result<ByteArray>
     suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String = ""): Result<Unit>
     suspend fun downloadSessionSram(sessionId: String): Result<ByteArray>
     suspend fun getSessionCheats(sessionId: String): Result<SessionCheatConfig>

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -71,6 +71,10 @@ sealed interface EmulationIntent {
     data object QuickSave : EmulationIntent
     data object QuickLoad : EmulationIntent
     data class SelectSlot(val slot: Int) : EmulationIntent
+    /** Save state to the given slot (selects it first, then saves). */
+    data class SaveToSlot(val slot: Int) : EmulationIntent
+    /** Load state from the given slot (selects it first, then loads). */
+    data class LoadFromSlot(val slot: Int) : EmulationIntent
 
     // Rewind
     data object RewindStep : EmulationIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -4,6 +4,15 @@ import com.spela.player.domain.model.AchievementEvent
 import com.spela.player.domain.model.BiosMissingFile
 import com.spela.player.domain.model.ShaderPreset
 
+/**
+ * Information about a single save slot, used for the secondary screen save slots page.
+ */
+data class SaveSlotInfo(
+    val screenshotUrl: String? = null,
+    val timestamp: String? = null,
+    val isFilled: Boolean = false,
+)
+
 data class EmulationState(
     val gameId: String = "",
     val gameTitle: String = "",
@@ -86,6 +95,9 @@ data class EmulationState(
     /** Quick-save slots: currently selected slot number (1-10). */
     val activeSlot: Int = 1,
 
+    /** Quick-save slots: metadata for each slot (1-10), keyed by slot number. */
+    val saveSlots: Map<Int, SaveSlotInfo> = emptyMap(),
+
     /** Rewind: whether the rewind feature is enabled. */
     val rewindEnabled: Boolean = false,
     /** Rewind: whether rewind is currently active (holding down rewind). */
@@ -98,6 +110,9 @@ data class EmulationState(
     val showCoreMismatchDialog: Boolean = false,
     val coreMismatchSaveCoreName: String = "",
     val coreMismatchCurrentCoreName: String = "",
+
+    /** Default second screen page from user preferences. */
+    val defaultSecondScreenPage: String = "art",
 
     /** Cheats */
     val hasCheats: Boolean = false,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryDashboardPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryDashboardPage.kt
@@ -1,6 +1,13 @@
 package com.spela.player.presentation.ui.feature.ingame
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -9,16 +16,25 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FastForward
 import androidx.compose.material.icons.filled.FastRewind
 import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Save
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -27,7 +43,9 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.Cheat
 import com.spela.player.presentation.ui.components.EmulationActionButton
+import com.spela.player.presentation.ui.components.SpSwitch
 import com.spela.player.presentation.ui.components.fpsColor
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -49,6 +67,7 @@ fun SecondaryDashboardPage(
     activeSlot: Int,
     hasCheats: Boolean,
     enabledCheatCount: Int,
+    cheats: List<Cheat>,
     isFastForward: Boolean,
     rewindEnabled: Boolean,
     onSave: () -> Unit,
@@ -56,97 +75,122 @@ fun SecondaryDashboardPage(
     onScreenshot: () -> Unit,
     onToggleFastForward: () -> Unit,
     onRewind: () -> Unit,
+    onToggleCheat: (cheatId: String, enabled: Boolean) -> Unit,
 ) {
-    Column(
-        modifier = Modifier
-            .fillMaxSize()
-            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small),
-        verticalArrangement = Arrangement.Center,
-        horizontalAlignment = Alignment.CenterHorizontally,
-    ) {
-        // Stat cards row
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-        ) {
-            StatCard(
-                value = "%.0f".format(fps),
-                valueColor = fpsColor(fps),
-                label = "%.1fms".format(frameTime),
-                contentDesc = "%.0f FPS, %.1f ms frame time".format(fps, frameTime),
-                modifier = Modifier.weight(1f),
-            )
-            StatCard(
-                value = "Slot $activeSlot",
-                valueColor = SpColor.OnBackground,
-                label = "Save slot",
-                contentDesc = "Active save slot $activeSlot",
-                modifier = Modifier.weight(1f),
-            )
-            StatCard(
-                value = if (hasCheats) "$enabledCheatCount active" else "No cheats",
-                valueColor = if (hasCheats && enabledCheatCount > 0) SpColor.Warning else SpColor.OnBackgroundTertiary,
-                label = "Cheats",
-                contentDesc = if (hasCheats) "$enabledCheatCount cheats active" else "No cheats available",
-                modifier = Modifier.weight(1f),
-            )
-        }
+    var showCheatsPanel by remember { mutableStateOf(false) }
 
-        Spacer(Modifier.height(SpSpacing.Medium))
+    AnimatedContent(
+        targetState = showCheatsPanel,
+        transitionSpec = {
+            (fadeIn() + slideInVertically { it / 4 })
+                .togetherWith(fadeOut() + slideOutVertically { -it / 4 })
+        },
+        label = "dashboardCheatsTransition",
+    ) { showingCheats ->
+        if (showingCheats) {
+            SecondaryCheatsPanel(
+                cheats = cheats,
+                onToggleCheat = onToggleCheat,
+                onDismiss = { showCheatsPanel = false },
+            )
+        } else {
+            Column(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                // Stat cards row
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    StatCard(
+                        value = "%.0f".format(fps),
+                        valueColor = fpsColor(fps),
+                        label = "%.1fms".format(frameTime),
+                        contentDesc = "%.0f FPS, %.1f ms frame time".format(fps, frameTime),
+                        modifier = Modifier.weight(1f),
+                    )
+                    StatCard(
+                        value = "Slot $activeSlot",
+                        valueColor = SpColor.OnBackground,
+                        label = "Save slot",
+                        contentDesc = "Active save slot $activeSlot",
+                        modifier = Modifier.weight(1f),
+                    )
+                    StatCard(
+                        value = if (hasCheats) "$enabledCheatCount active" else "No cheats",
+                        valueColor = if (hasCheats && enabledCheatCount > 0) SpColor.Warning else SpColor.OnBackgroundTertiary,
+                        label = if (hasCheats) "Cheats \u2022 Tap" else "Cheats",
+                        contentDesc = if (hasCheats) "$enabledCheatCount cheats active, tap to manage" else "No cheats available",
+                        modifier = Modifier.weight(1f),
+                        onClick = if (hasCheats) {
+                            { showCheatsPanel = true }
+                        } else {
+                            null
+                        },
+                    )
+                }
 
-        // Quick action row
-        Row(
-            modifier = Modifier.fillMaxWidth(),
-            horizontalArrangement = Arrangement.SpaceEvenly,
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            EmulationActionButton(
-                icon = Icons.Filled.Save,
-                label = "Save",
-                onClick = onSave,
-                buttonSize = ACTION_BUTTON_SIZE,
-                iconSize = ACTION_ICON_SIZE,
-                showLabel = false,
-                useFocusRing = false,
-            )
-            EmulationActionButton(
-                icon = Icons.Filled.FolderOpen,
-                label = "Load",
-                onClick = onLoad,
-                buttonSize = ACTION_BUTTON_SIZE,
-                iconSize = ACTION_ICON_SIZE,
-                showLabel = false,
-                useFocusRing = false,
-            )
-            EmulationActionButton(
-                icon = Icons.Filled.CameraAlt,
-                label = "Screenshot",
-                onClick = onScreenshot,
-                buttonSize = ACTION_BUTTON_SIZE,
-                iconSize = ACTION_ICON_SIZE,
-                showLabel = false,
-                useFocusRing = false,
-            )
-            EmulationActionButton(
-                icon = if (isFastForward) Icons.Filled.PlayArrow else Icons.Filled.FastForward,
-                label = if (isFastForward) "Normal" else "Fast",
-                isActive = isFastForward,
-                onClick = onToggleFastForward,
-                buttonSize = ACTION_BUTTON_SIZE,
-                iconSize = ACTION_ICON_SIZE,
-                showLabel = false,
-                useFocusRing = false,
-            )
-            if (rewindEnabled) {
-                EmulationActionButton(
-                    icon = Icons.Filled.FastRewind,
-                    label = "Rewind",
-                    onClick = onRewind,
-                    buttonSize = 48.dp,
-                    iconSize = 24.dp,
-                    showLabel = false,
-                    useFocusRing = false,
-                )
+                Spacer(Modifier.height(SpSpacing.Medium))
+
+                // Quick action row
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    EmulationActionButton(
+                        icon = Icons.Filled.Save,
+                        label = "Save",
+                        onClick = onSave,
+                        buttonSize = ACTION_BUTTON_SIZE,
+                        iconSize = ACTION_ICON_SIZE,
+                        showLabel = false,
+                        useFocusRing = false,
+                    )
+                    EmulationActionButton(
+                        icon = Icons.Filled.FolderOpen,
+                        label = "Load",
+                        onClick = onLoad,
+                        buttonSize = ACTION_BUTTON_SIZE,
+                        iconSize = ACTION_ICON_SIZE,
+                        showLabel = false,
+                        useFocusRing = false,
+                    )
+                    EmulationActionButton(
+                        icon = Icons.Filled.CameraAlt,
+                        label = "Screenshot",
+                        onClick = onScreenshot,
+                        buttonSize = ACTION_BUTTON_SIZE,
+                        iconSize = ACTION_ICON_SIZE,
+                        showLabel = false,
+                        useFocusRing = false,
+                    )
+                    EmulationActionButton(
+                        icon = if (isFastForward) Icons.Filled.PlayArrow else Icons.Filled.FastForward,
+                        label = if (isFastForward) "Normal" else "Fast",
+                        isActive = isFastForward,
+                        onClick = onToggleFastForward,
+                        buttonSize = ACTION_BUTTON_SIZE,
+                        iconSize = ACTION_ICON_SIZE,
+                        showLabel = false,
+                        useFocusRing = false,
+                    )
+                    if (rewindEnabled) {
+                        EmulationActionButton(
+                            icon = Icons.Filled.FastRewind,
+                            label = "Rewind",
+                            onClick = onRewind,
+                            buttonSize = ACTION_BUTTON_SIZE,
+                            iconSize = ACTION_ICON_SIZE,
+                            showLabel = false,
+                            useFocusRing = false,
+                        )
+                    }
+                }
             }
         }
     }
@@ -159,11 +203,15 @@ private fun StatCard(
     label: String,
     contentDesc: String,
     modifier: Modifier = Modifier,
+    onClick: (() -> Unit)? = null,
 ) {
     Column(
         modifier = modifier
             .clip(RoundedCornerShape(SpSpacing.CardCornerRadius))
             .background(SpColor.Card)
+            .then(
+                if (onClick != null) Modifier.clickable(onClick = onClick) else Modifier
+            )
             .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small)
             .semantics { contentDescription = contentDesc },
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -182,5 +230,96 @@ private fun StatCard(
             textAlign = TextAlign.Center,
             maxLines = 1,
         )
+    }
+}
+
+/**
+ * Compact cheats toggle panel for the secondary dashboard.
+ * Shows a scrollable list of cheats with toggle switches and a close button.
+ */
+@Composable
+private fun SecondaryCheatsPanel(
+    cheats: List<Cheat>,
+    onToggleCheat: (cheatId: String, enabled: Boolean) -> Unit,
+    onDismiss: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small),
+    ) {
+        // Header row with title and close button
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = SpSpacing.Small),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Cheats",
+                style = SpTypography.HeadlineSmall,
+                color = SpColor.OnBackground,
+            )
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.semantics {
+                    contentDescription = "Close cheats panel"
+                },
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Close,
+                    contentDescription = null,
+                    tint = SpColor.OnBackground,
+                )
+            }
+        }
+
+        if (cheats.isEmpty()) {
+            Text(
+                text = "No cheats available for this game.",
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundSecondary,
+                modifier = Modifier.padding(vertical = SpSpacing.Medium),
+            )
+        } else {
+            // Scrollable cheat list
+            Column(
+                modifier = Modifier
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState()),
+            ) {
+                cheats.forEach { cheat ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(SpSpacing.CardCornerRadius))
+                            .background(SpColor.Card)
+                            .clickable { onToggleCheat(cheat.id, !cheat.enabled) }
+                            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Medium)
+                            .semantics {
+                                contentDescription = "Cheat: ${cheat.description}, ${if (cheat.enabled) "enabled" else "disabled"}"
+                            },
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = cheat.description,
+                            style = SpTypography.BodyMedium,
+                            color = SpColor.OnBackground,
+                            modifier = Modifier.weight(1f).padding(end = SpSpacing.Small),
+                            maxLines = 2,
+                        )
+                        SpSwitch(
+                            checked = cheat.enabled,
+                            onCheckedChange = { enabled ->
+                                onToggleCheat(cheat.id, enabled)
+                            },
+                        )
+                    }
+                    Spacer(Modifier.height(SpSpacing.Small))
+                }
+            }
+        }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondarySaveSlotsPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondarySaveSlotsPage.kt
@@ -1,8 +1,12 @@
 package com.spela.player.presentation.ui.feature.ingame
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
-import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.gestures.detectVerticalDragGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -17,13 +21,24 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import com.spela.player.presentation.state.SaveSlotInfo
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -32,6 +47,10 @@ private val SLOT_CARD_WIDTH = 80.dp
 private val SLOT_CARD_HEIGHT = 96.dp
 private val ACTIVE_BORDER_WIDTH = 2.dp
 private val SLOT_RANGE = 1..10
+private const val SWIPE_UP_THRESHOLD = -80f
+private const val FLASH_DURATION_MS = 400
+private val FLASH_COLOR_SAVE = SpColor.Success
+private val FLASH_COLOR_LOAD = SpColor.Accent
 
 /**
  * Save Slots page for the secondary screen companion.
@@ -39,11 +58,19 @@ private val SLOT_RANGE = 1..10
  * Shows a horizontal scrollable row of save slot cards (1-10).
  * The active slot is highlighted with a [SpColor.Primary] border.
  * Tapping a slot card selects it as the active quick-save/load target.
+ *
+ * Gestures:
+ * - Swipe up on any slot to save to it.
+ * - Long-press on a filled slot to load from it.
+ * - Long-press on an empty slot to save to it.
  */
 @Composable
 fun SecondarySaveSlotsPage(
     activeSlot: Int,
+    saveSlots: Map<Int, SaveSlotInfo>,
     onSelectSlot: (Int) -> Unit,
+    onSaveToSlot: (Int) -> Unit,
+    onLoadFromSlot: (Int) -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -71,17 +98,27 @@ fun SecondarySaveSlotsPage(
         ) {
             items(SLOT_RANGE.toList()) { slot ->
                 val isActive = slot == activeSlot
+                val slotInfo = saveSlots[slot]
                 SaveSlotCard(
                     slot = slot,
                     isActive = isActive,
+                    slotInfo = slotInfo,
                     onClick = { onSelectSlot(slot) },
+                    onSwipeUp = { onSaveToSlot(slot) },
+                    onLongPress = {
+                        if (slotInfo?.isFilled == true) {
+                            onLoadFromSlot(slot)
+                        } else {
+                            onSaveToSlot(slot)
+                        }
+                    },
                 )
             }
         }
 
         // Hint text
         Text(
-            text = "Tap to select active slot",
+            text = "Swipe up: save \u2022 Hold: load",
             style = SpTypography.LabelSmall,
             color = SpColor.OnBackgroundTertiary,
             modifier = Modifier
@@ -92,11 +129,15 @@ fun SecondarySaveSlotsPage(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun SaveSlotCard(
     slot: Int,
     isActive: Boolean,
+    slotInfo: SaveSlotInfo?,
     onClick: () -> Unit,
+    onSwipeUp: () -> Unit,
+    onLongPress: () -> Unit,
 ) {
     val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
     val borderModifier = if (isActive) {
@@ -104,32 +145,151 @@ private fun SaveSlotCard(
     } else {
         Modifier.border(ACTIVE_BORDER_WIDTH, SpColor.SurfaceVariant, shape)
     }
-    val semanticDesc = if (isActive) "Save slot $slot, active" else "Save slot $slot"
 
-    Column(
+    val isFilled = slotInfo?.isFilled == true
+    val semanticDesc = buildString {
+        append("Save slot $slot")
+        if (isActive) append(", active")
+        if (isFilled) append(", filled")
+        if (slotInfo?.timestamp != null) append(", saved at ${slotInfo.timestamp}")
+    }
+
+    // Flash overlay animation: increment key to trigger a flash
+    var flashKey by remember { mutableIntStateOf(0) }
+    var flashColor by remember { mutableStateOf(Color.Transparent) }
+    val flashAlpha = remember { Animatable(0f) }
+
+    LaunchedEffect(flashKey) {
+        if (flashKey > 0) {
+            flashAlpha.snapTo(0.5f)
+            flashAlpha.animateTo(0f, animationSpec = tween(FLASH_DURATION_MS))
+        }
+    }
+
+    Box(
         modifier = Modifier
             .width(SLOT_CARD_WIDTH)
             .height(SLOT_CARD_HEIGHT)
             .clip(shape)
             .then(borderModifier)
             .background(SpColor.Card, shape)
-            .clickable(onClick = onClick)
-            .semantics { contentDescription = semanticDesc }
-            .padding(SpSpacing.Small),
+            .combinedClickable(
+                onClick = onClick,
+                onLongClick = {
+                    flashColor = if (isFilled) FLASH_COLOR_LOAD else FLASH_COLOR_SAVE
+                    flashKey++
+                    onLongPress()
+                },
+            )
+            .pointerInput(Unit) {
+                var totalDrag = 0f
+                var gestureHandled = false
+                detectVerticalDragGestures(
+                    onDragStart = {
+                        totalDrag = 0f
+                        gestureHandled = false
+                    },
+                    onVerticalDrag = { _, dragAmount ->
+                        totalDrag += dragAmount
+                        if (!gestureHandled && totalDrag < SWIPE_UP_THRESHOLD) {
+                            gestureHandled = true
+                            flashColor = FLASH_COLOR_SAVE
+                            flashKey++
+                            onSwipeUp()
+                        }
+                    },
+                )
+            }
+            .semantics { contentDescription = semanticDesc },
+    ) {
+        // Thumbnail or placeholder content
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(SpSpacing.Small),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            if (isFilled && slotInfo != null && slotInfo.screenshotUrl != null) {
+                // Thumbnail image
+                SubcomposeAsyncImage(
+                    model = slotInfo.screenshotUrl,
+                    contentDescription = "Save slot $slot screenshot",
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .weight(1f)
+                        .clip(RoundedCornerShape(SpSpacing.CardCornerRadius / 2)),
+                    contentScale = ContentScale.Crop,
+                    loading = {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(SpColor.SurfaceBright.copy(alpha = 0.25f)),
+                        )
+                    },
+                    error = {
+                        SlotPlaceholderContent(slot = slot, isActive = isActive, isFilled = true)
+                    },
+                )
+                // Timestamp below thumbnail
+                if (slotInfo.timestamp != null) {
+                    Text(
+                        text = slotInfo.timestamp,
+                        style = SpTypography.LabelSmall,
+                        color = if (isActive) SpColor.Primary else SpColor.OnBackgroundTertiary,
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(top = SpSpacing.XXSmall),
+                    )
+                }
+            } else {
+                SlotPlaceholderContent(slot = slot, isActive = isActive, isFilled = isFilled)
+            }
+        }
+
+        // Flash overlay for save/load visual feedback
+        if (flashAlpha.value > 0f) {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(flashColor.copy(alpha = flashAlpha.value), shape),
+            )
+        }
+    }
+}
+
+/**
+ * Placeholder content shown when a slot has no screenshot thumbnail.
+ */
+@Composable
+private fun SlotPlaceholderContent(
+    slot: Int,
+    isActive: Boolean,
+    isFilled: Boolean,
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
-        // Slot number
+        // Slot number or plus icon
         Text(
-            text = "$slot",
+            text = if (isFilled) "$slot" else "+",
             style = SpTypography.HeadlineSmall,
-            color = if (isActive) SpColor.Primary else SpColor.OnBackground,
+            color = when {
+                isActive -> SpColor.Primary
+                isFilled -> SpColor.OnBackground
+                else -> SpColor.OnBackgroundTertiary
+            },
             textAlign = TextAlign.Center,
         )
 
         // Label
         Text(
-            text = if (isActive) "Active" else "Slot",
+            text = when {
+                isActive -> "Active"
+                isFilled -> "Slot $slot"
+                else -> "Empty"
+            },
             style = SpTypography.LabelSmall,
             color = if (isActive) SpColor.Primary else SpColor.OnBackgroundTertiary,
             textAlign = TextAlign.Center,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
@@ -104,8 +104,16 @@ fun SecondaryScreenContent(
         label = "burnInAlpha",
     )
 
+    val initialPage = remember(state.defaultSecondScreenPage) {
+        when (state.defaultSecondScreenPage) {
+            "controls" -> PAGE_CONTROLS
+            "dashboard" -> PAGE_DASHBOARD
+            "save_slots" -> PAGE_SAVE_SLOTS
+            else -> PAGE_ART
+        }
+    }
     val pagerState = rememberPagerState(
-        initialPage = PAGE_ART,
+        initialPage = initialPage,
         pageCount = { PAGE_COUNT },
     )
 
@@ -201,6 +209,7 @@ fun SecondaryScreenContent(
                                 activeSlot = state.activeSlot,
                                 hasCheats = state.hasCheats,
                                 enabledCheatCount = state.enabledCheatCount,
+                                cheats = state.cheats,
                                 isFastForward = state.isFastForward,
                                 rewindEnabled = state.rewindEnabled,
                                 onSave = { viewModel.onIntent(EmulationIntent.SaveState) },
@@ -208,13 +217,23 @@ fun SecondaryScreenContent(
                                 onScreenshot = { viewModel.onIntent(EmulationIntent.TakeScreenshot) },
                                 onToggleFastForward = { viewModel.onIntent(EmulationIntent.ToggleFastForward) },
                                 onRewind = { viewModel.onIntent(EmulationIntent.ToggleRewind) },
+                                onToggleCheat = { cheatId, enabled ->
+                                    viewModel.onIntent(EmulationIntent.ToggleCheatInGame(cheatId, enabled))
+                                },
                             )
                         }
                         PAGE_SAVE_SLOTS -> {
                             SecondarySaveSlotsPage(
                                 activeSlot = state.activeSlot,
+                                saveSlots = state.saveSlots,
                                 onSelectSlot = { slot ->
                                     viewModel.onIntent(EmulationIntent.SelectSlot(slot))
+                                },
+                                onSaveToSlot = { slot ->
+                                    viewModel.onIntent(EmulationIntent.SaveToSlot(slot))
+                                },
+                                onLoadFromSlot = { slot ->
+                                    viewModel.onIntent(EmulationIntent.LoadFromSlot(slot))
                                 },
                             )
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
@@ -308,6 +308,32 @@ fun SettingsScreen(
                 }
             }
 
+            // Second Screen section
+            item { Spacer(Modifier.height(SpSpacing.Medium)) }
+            item { SettingsSectionHeader(title = "Second Screen") }
+
+            item {
+                SpCard {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(vertical = SpSpacing.Small),
+                    ) {
+                        SecondScreenPageOption.entries.forEachIndexed { index, option ->
+                            SpRadioOption(
+                                title = option.displayName,
+                                description = option.description,
+                                isSelected = state.defaultSecondScreenPage == option.apiId,
+                                onClick = { viewModel.onIntent(SettingsIntent.SelectDefaultSecondScreenPage(option.apiId)) },
+                            )
+                            if (index < SecondScreenPageOption.entries.size - 1) {
+                                SettingsDivider()
+                            }
+                        }
+                    }
+                }
+            }
+
             // Emulation section
             item { Spacer(Modifier.height(SpSpacing.Medium)) }
             item { SettingsSectionHeader(title = "Emulation") }
@@ -647,4 +673,15 @@ internal enum class ThemeOption(
     NINTENDO_COLORFUL("nintendo-colorful", "Nintendo Colorful", "Bright, joyful, retro"),
     OCEAN_DARK("ocean-dark", "Ocean Dark", "Deep blue dark theme"),
     SUNSET_WARM("sunset-warm", "Sunset Warm", "Warm amber light theme"),
+}
+
+internal enum class SecondScreenPageOption(
+    val apiId: String,
+    val displayName: String,
+    val description: String,
+) {
+    ART("art", "Art Display", "Game artwork from SteamGridDB"),
+    CONTROLS("controls", "Controls", "Touch gamepad controls"),
+    DASHBOARD("dashboard", "Dashboard", "Stats and quick actions"),
+    SAVE_SLOTS("save_slots", "Save Slots", "Visual save slot management"),
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -185,6 +185,14 @@ class EmulationViewModel(
             EmulationIntent.QuickSave -> quickSaveToSlot()
             EmulationIntent.QuickLoad -> quickLoadFromSlot()
             is EmulationIntent.SelectSlot -> _state.update { it.copy(activeSlot = intent.slot) }
+            is EmulationIntent.SaveToSlot -> {
+                _state.update { it.copy(activeSlot = intent.slot) }
+                saveManager.saveToSlot(intent.slot)
+            }
+            is EmulationIntent.LoadFromSlot -> {
+                _state.update { it.copy(activeSlot = intent.slot) }
+                saveManager.loadFromSlot(intent.slot)
+            }
 
             // Rewind
             EmulationIntent.RewindStep -> rewindStep()
@@ -336,6 +344,7 @@ class EmulationViewModel(
                     it.copy(
                         showPerformanceOverlay = currentPreferences.showPerformanceOverlay,
                         selectedShader = resolvedShader,
+                        defaultSecondScreenPage = currentPreferences.defaultSecondScreenPage,
                     )
                 }
             }
@@ -423,6 +432,9 @@ class EmulationViewModel(
                         // the 3-second delay below, otherwise the display stays blank
                         // until achievements/heartbeats finish initializing.
                         showSecondaryDisplayIfAvailable()
+
+                        // Populate save slot thumbnails for the secondary screen
+                        saveManager.refreshSaveSlots()
 
                         // Re-check save state support after core has run a few frames
                         println("[Emulation] Starting 3-second delay for HW render init")
@@ -768,13 +780,13 @@ class EmulationViewModel(
         _state.update { it.copy(isFastForward = newState) }
     }
 
-    // Quick-save/load — uses session-scoped save/load
+    // Quick-save/load — uses the currently active slot
     private fun quickSaveToSlot() {
-        saveManager.saveState()
+        saveManager.saveToSlot(_state.value.activeSlot)
     }
 
     private fun quickLoadFromSlot() {
-        saveManager.loadState()
+        saveManager.loadFromSlot(_state.value.activeSlot)
     }
 
     // Rewind

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -5,12 +5,15 @@ import com.spela.player.domain.controller.ScreenshotCapture
 import com.spela.player.domain.repository.SaveDataRepository
 import com.spela.player.domain.repository.SessionRepository
 import com.spela.player.presentation.state.EmulationState
+import com.spela.player.presentation.state.SaveSlotInfo
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 
 /**
  * Result of attempting to auto-load a save state.
@@ -207,6 +210,7 @@ class SaveManager(
                         withContext(dispatchers.main) {
                             _state.update { it.copy(statusMessage = "State saved") }
                         }
+                        refreshSaveSlots()
                     },
                     onFailure = { error ->
                         withContext(dispatchers.main) {
@@ -219,6 +223,72 @@ class SaveManager(
                 withContext(dispatchers.main) {
                     _state.update { it.copy(statusMessage = "State saved") }
                 }
+            }
+        }
+    }
+
+    /**
+     * Save state to a specific slot. Blocks in challenge/hardcore mode.
+     * Uses the slot-specific API endpoint (PUT /api/sessions/:id/saves/slot/:slot).
+     */
+    fun saveToSlot(slot: Int) {
+        if (_state.value.isChallengeMode) return
+        if (_state.value.isHardcoreMode) {
+            _state.update { it.copy(error = "Save states are disabled in hardcore mode") }
+            return
+        }
+        scope.launch(dispatchers.io) {
+            val saveData = libretroController.serialize() ?: return@launch
+            val sessionId = currentSessionId
+            if (sessionId != null) {
+                val screenshot = screenshotCapture?.captureScreenshot()
+                sessionRepository.uploadSlotSave(sessionId, slot, saveData, screenshot, currentCoreName).fold(
+                    onSuccess = {
+                        withContext(dispatchers.main) {
+                            _state.update { it.copy(statusMessage = "Saved to slot $slot") }
+                        }
+                        refreshSaveSlots()
+                    },
+                    onFailure = { error ->
+                        withContext(dispatchers.main) {
+                            _state.update { it.copy(error = "Failed to save to slot $slot: ${error.message}") }
+                        }
+                    },
+                )
+            } else {
+                withContext(dispatchers.main) {
+                    _state.update { it.copy(statusMessage = "State saved") }
+                }
+            }
+        }
+    }
+
+    /**
+     * Load state from a specific slot. Blocks in challenge/hardcore mode.
+     * Uses the slot-specific API endpoint (GET /api/sessions/:id/saves/slot/:slot).
+     */
+    fun loadFromSlot(slot: Int) {
+        if (_state.value.isChallengeMode) return
+        if (_state.value.isHardcoreMode) {
+            _state.update { it.copy(error = "Save states are disabled in hardcore mode") }
+            return
+        }
+        scope.launch(dispatchers.io) {
+            val sessionId = currentSessionId
+            if (sessionId != null) {
+                sessionRepository.downloadSlotSave(sessionId, slot).fold(
+                    onSuccess = { saveData ->
+                        libretroController.unserialize(saveData)
+                        withContext(dispatchers.main) {
+                            _state.update { it.copy(statusMessage = "Loaded from slot $slot") }
+                        }
+                    },
+                    onFailure = { error ->
+                        withContext(dispatchers.main) {
+                            _state.update { it.copy(error = "Failed to load from slot $slot: ${error.message}") }
+                        }
+                    },
+                )
             }
         }
     }
@@ -272,6 +342,37 @@ class SaveManager(
         if (currentCoreName.isEmpty()) return
         runCatching {
             sessionRepository.updateSession(sessionId, coreName = currentCoreName)
+        }
+    }
+
+    /**
+     * Fetch save states for the current session and update the save slot map.
+     * Each save state with a non-null slot is mapped to its corresponding slot number.
+     * Called on game start and after manual save operations to keep thumbnails fresh.
+     */
+    fun refreshSaveSlots() {
+        val sessionId = currentSessionId ?: return
+        scope.launch(dispatchers.io) {
+            sessionRepository.getSessionSaves(sessionId).onSuccess { saves ->
+                val slotMap = mutableMapOf<Int, SaveSlotInfo>()
+                for (save in saves) {
+                    val slot = save.slot ?: continue
+                    // Only keep the most recent save per slot (saves are ordered by time from server)
+                    if (slot in 1..10 && slot !in slotMap) {
+                        slotMap[slot] = SaveSlotInfo(
+                            screenshotUrl = save.screenshotUrl,
+                            timestamp = save.createdAt?.let { instant ->
+                                val local = instant.toLocalDateTime(TimeZone.currentSystemDefault())
+                                "%02d:%02d".format(local.hour, local.minute)
+                            },
+                            isFilled = true,
+                        )
+                    }
+                }
+                withContext(dispatchers.main) {
+                    _state.update { it.copy(saveSlots = slotMap) }
+                }
+            }
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SettingsViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SettingsViewModel.kt
@@ -57,6 +57,7 @@ data class SettingsState(
     val scrollIndex: Int = 0,
     val scrollOffset: Int = 0,
     val orientationLock: String = "auto",
+    val defaultSecondScreenPage: String = "art",
 )
 
 sealed interface SettingsIntent {
@@ -91,6 +92,7 @@ sealed interface SettingsIntent {
     data class SaveScrollPosition(val index: Int, val offset: Int) : SettingsIntent
     data object SyncNow : SettingsIntent
     data class SetOrientationLock(val mode: String) : SettingsIntent
+    data class SelectDefaultSecondScreenPage(val page: String) : SettingsIntent
 }
 
 class SettingsViewModel(
@@ -176,6 +178,7 @@ class SettingsViewModel(
                 _state.update { it.copy(scrollIndex = intent.index, scrollOffset = intent.offset) }
             SettingsIntent.SyncNow -> syncNow()
             is SettingsIntent.SetOrientationLock -> setOrientationLock(intent.mode)
+            is SettingsIntent.SelectDefaultSecondScreenPage -> selectDefaultSecondScreenPage(intent.page)
         }
     }
 
@@ -236,6 +239,7 @@ class SettingsViewModel(
                         selectedShader = prefs.selectedShader,
                         selectedTheme = prefs.selectedTheme,
                         consoleShaders = prefs.consoleShaders,
+                        defaultSecondScreenPage = prefs.defaultSecondScreenPage,
                     )
                 }
             }
@@ -285,6 +289,16 @@ class SettingsViewModel(
         scope.launch(dispatchers.io) {
             preferencesRepository.updatePreferences(selectedTheme = theme).onFailure {
                 _state.update { it.copy(selectedTheme = previous) }
+            }
+        }
+    }
+
+    private fun selectDefaultSecondScreenPage(page: String) {
+        val previous = _state.value.defaultSecondScreenPage
+        _state.update { it.copy(defaultSecondScreenPage = page) }
+        scope.launch(dispatchers.io) {
+            preferencesRepository.updatePreferences(defaultSecondScreenPage = page).onFailure {
+                _state.update { it.copy(defaultSecondScreenPage = previous) }
             }
         }
     }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
@@ -167,7 +167,7 @@ class SyncEngineTest {
 
     private class NoOpPreferencesRepository : PreferencesRepository {
         override suspend fun getPreferences() = Result.success(UserPreferences())
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()
@@ -203,7 +203,7 @@ class SyncEngineTest {
 
     private class FailingPreferencesRepository : PreferencesRepository {
         override suspend fun getPreferences(): Result<UserPreferences> = throw RuntimeException("Preferences fetch failed")
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()
@@ -243,7 +243,7 @@ class SyncEngineTest {
             getPreferencesCalled = true
             return Result.success(UserPreferences())
         }
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -326,7 +326,7 @@ class NavigationViewModelTest {
 
     private class NoOpPreferencesRepository : PreferencesRepository {
         override suspend fun getPreferences() = Result.success(UserPreferences())
-        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?) = Result.success(UserPreferences())
+        override suspend fun updatePreferences(showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?, selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?, defaultSecondScreenPage: String?) = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}
         override fun getAllDeviceShaderOverrides() = emptyMap<String, ShaderPreset>()

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -176,6 +176,9 @@ private class FakePlayFromSharedSaveSessionRepository : SessionRepository {
     override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
     override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String) = Result.success(Unit)
     override suspend fun downloadSessionAutoSave(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))
+    override suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String) =
+        Result.success(SaveState(id = 1, gameId = 1, name = "Slot $slot"))
+    override suspend fun downloadSlotSave(sessionId: String, slot: Int) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String) = Result.success(Unit)
     override suspend fun downloadSessionSram(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun getSessionCheats(sessionId: String) = Result.success(SessionCheatConfig(false, emptyList()))

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
@@ -327,6 +327,7 @@ class KeyMappingViewModelTest {
         override suspend fun updatePreferences(
             showPerformanceOverlay: Boolean?, autoSaveEnabled: Boolean?, autoLoadSaveEnabled: Boolean?,
             selectedShader: String?, selectedTheme: String?, consoleShaders: Map<String, String>?,
+            defaultSecondScreenPage: String?,
         ): Result<UserPreferences> = Result.success(UserPreferences())
         override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null
         override fun setDeviceShaderOverride(consoleId: String, shader: ShaderPreset?) {}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -251,6 +251,7 @@ class StubPreferencesRepository : PreferencesRepository {
         selectedShader: String?,
         selectedTheme: String?,
         consoleShaders: Map<String, String>?,
+        defaultSecondScreenPage: String?,
     ) = Result.success(UserPreferences())
 
     override fun getDeviceShaderOverride(consoleId: String): ShaderPreset? = null

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -371,6 +371,9 @@ class StubSessionRepository : SessionRepository {
         downloadSessionSramCallCount++
         return downloadSessionSramResult
     }
+    override suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String) =
+        Result.success(SaveState(id = 1, gameId = 1, name = "Slot $slot"))
+    override suspend fun downloadSlotSave(sessionId: String, slot: Int) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun createSessionFromSharedSave(gameId: String, saveId: String) =
         Result.success(GameSession(id = "shared-session-1", gameId = gameId, name = "From shared save $saveId"))
     override suspend fun getSessionCheats(sessionId: String) = Result.success(SessionCheatConfig(false, emptyList()))

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -1028,6 +1028,85 @@ func TestUpdatePreferences_ThemeSelection(t *testing.T) {
 	assert.Equal(t, true, prefs["showPerformanceOverlay"])
 }
 
+func TestGetPreferences_DefaultSecondScreenPage(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/preferences", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var prefs map[string]interface{}
+	err := json.Unmarshal(w.Body.Bytes(), &prefs)
+	require.NoError(t, err)
+	assert.Equal(t, "art", prefs["defaultSecondScreenPage"])
+}
+
+func TestUpdatePreferences_DefaultSecondScreenPage(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	// Test each valid value
+	for _, value := range []string{"art", "controls", "dashboard", "save_slots"} {
+		body, _ := json.Marshal(map[string]interface{}{
+			"defaultSecondScreenPage": value,
+		})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code, "should accept value %q", value)
+
+		var prefs map[string]interface{}
+		json.Unmarshal(w.Body.Bytes(), &prefs)
+		assert.Equal(t, value, prefs["defaultSecondScreenPage"])
+
+		// GET to verify persistence
+		w = httptest.NewRecorder()
+		req = httptest.NewRequest("GET", "/api/user/preferences", nil)
+		req.Header.Set("Authorization", "Bearer "+token)
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusOK, w.Code)
+
+		json.Unmarshal(w.Body.Bytes(), &prefs)
+		assert.Equal(t, value, prefs["defaultSecondScreenPage"])
+	}
+}
+
+func TestUpdatePreferences_DefaultSecondScreenPage_InvalidValue(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+
+	for _, value := range []string{"invalid", "ART", "Controls", "", "game_info"} {
+		body, _ := json.Marshal(map[string]interface{}{
+			"defaultSecondScreenPage": value,
+		})
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+		req.Header.Set("Authorization", "Bearer "+token)
+		req.Header.Set("Content-Type", "application/json")
+		router.ServeHTTP(w, req)
+		assert.Equal(t, http.StatusBadRequest, w.Code, "should reject value %q", value)
+	}
+
+	// Verify the preference was not changed from default
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/preferences", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var prefs map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &prefs)
+	assert.Equal(t, "art", prefs["defaultSecondScreenPage"])
+}
+
 func TestGetOnlineUsers_Empty(t *testing.T) {
 	_, cfg := setupTestEnv(t)
 	router := NewRouter(*cfg)

--- a/server/internal/api/test_handler.go
+++ b/server/internal/api/test_handler.go
@@ -90,20 +90,21 @@ func (h *TestHandler) Reset(c *gin.Context) {
 			return err
 		}
 		tx.Model(&db.User{}).Where("username = ?", "admin").Updates(map[string]interface{}{
-			"password_hash":         adminHash,
-			"role":                  "owner",
-			"disabled":              false,
-			"pending_approval":      false,
-			"show_perf_overlay":     false,
-			"auto_save_enabled":     true,
-			"auto_load_save_enabled": true,
-			"selected_shader":       "none",
-			"selected_theme":        "default-dark",
-			"selected_key_mapping":  "arrows-left",
-			"custom_key_mapping":    "",
-			"avatar_url":            "",
-			"token_version":         0,
-			"deleted_at":            nil,
+			"password_hash":              adminHash,
+			"role":                       "owner",
+			"disabled":                   false,
+			"pending_approval":           false,
+			"show_perf_overlay":          false,
+			"auto_save_enabled":          true,
+			"auto_load_save_enabled":     true,
+			"selected_shader":            "none",
+			"selected_theme":             "default-dark",
+			"default_second_screen_page": "art",
+			"selected_key_mapping":       "arrows-left",
+			"custom_key_mapping":         "",
+			"avatar_url":                 "",
+			"token_version":              0,
+			"deleted_at":                 nil,
 		})
 
 		// 14. Reset player user to default state
@@ -112,20 +113,21 @@ func (h *TestHandler) Reset(c *gin.Context) {
 			return err
 		}
 		tx.Model(&db.User{}).Where("username = ?", "player").Updates(map[string]interface{}{
-			"password_hash":         playerHash,
-			"role":                  "user",
-			"disabled":              false,
-			"pending_approval":      false,
-			"show_perf_overlay":     false,
-			"auto_save_enabled":     true,
-			"auto_load_save_enabled": true,
-			"selected_shader":       "none",
-			"selected_theme":        "default-dark",
-			"selected_key_mapping":  "arrows-left",
-			"custom_key_mapping":    "",
-			"avatar_url":            "",
-			"token_version":         0,
-			"deleted_at":            nil,
+			"password_hash":              playerHash,
+			"role":                       "user",
+			"disabled":                   false,
+			"pending_approval":           false,
+			"show_perf_overlay":          false,
+			"auto_save_enabled":          true,
+			"auto_load_save_enabled":     true,
+			"selected_shader":            "none",
+			"selected_theme":             "default-dark",
+			"default_second_screen_page": "art",
+			"selected_key_mapping":       "arrows-left",
+			"custom_key_mapping":         "",
+			"avatar_url":                 "",
+			"token_version":              0,
+			"deleted_at":                 nil,
 		})
 
 		return nil

--- a/server/internal/api/user_handler.go
+++ b/server/internal/api/user_handler.go
@@ -170,18 +170,19 @@ func (h *UserHandler) ChangePassword(c *gin.Context) {
 
 // preferencesResponse is the JSON shape for the preferences endpoints.
 type preferencesResponse struct {
-	ShowPerformanceOverlay bool                           `json:"showPerformanceOverlay"`
-	AutoSaveEnabled        bool                           `json:"autoSaveEnabled"`
-	AutoLoadSaveEnabled    bool                           `json:"autoLoadSaveEnabled"`
-	SelectedShader         string                         `json:"selectedShader"`
-	SelectedTheme          string                         `json:"selectedTheme"`
-	ConsoleShaders         map[string]string              `json:"consoleShaders"`
-	SelectedKeyMapping     string                         `json:"selectedKeyMapping"`
-	CustomKeyMapping       map[string]string              `json:"customKeyMapping"`
-	ConsoleKeyMappings     map[string]consoleKeyMappingDTO `json:"consoleKeyMappings"`
-	RALinked               bool                           `json:"raLinked"`
-	RAUsername             string                         `json:"raUsername"`
-	RAHardcoreEnabled      bool                           `json:"raHardcoreEnabled"`
+	ShowPerformanceOverlay  bool                           `json:"showPerformanceOverlay"`
+	AutoSaveEnabled         bool                           `json:"autoSaveEnabled"`
+	AutoLoadSaveEnabled     bool                           `json:"autoLoadSaveEnabled"`
+	SelectedShader          string                         `json:"selectedShader"`
+	SelectedTheme           string                         `json:"selectedTheme"`
+	DefaultSecondScreenPage string                         `json:"defaultSecondScreenPage"`
+	ConsoleShaders          map[string]string              `json:"consoleShaders"`
+	SelectedKeyMapping      string                         `json:"selectedKeyMapping"`
+	CustomKeyMapping        map[string]string              `json:"customKeyMapping"`
+	ConsoleKeyMappings      map[string]consoleKeyMappingDTO `json:"consoleKeyMappings"`
+	RALinked                bool                           `json:"raLinked"`
+	RAUsername              string                         `json:"raUsername"`
+	RAHardcoreEnabled       bool                           `json:"raHardcoreEnabled"`
 }
 
 type consoleKeyMappingDTO struct {
@@ -213,22 +214,28 @@ func (h *UserHandler) GetPreferences(c *gin.Context) {
 		selectedTheme = "default-dark"
 	}
 
+	defaultSecondScreenPage := user.DefaultSecondScreenPage
+	if defaultSecondScreenPage == "" {
+		defaultSecondScreenPage = "art"
+	}
+
 	var raCred db.RetroAchievementCredential
 	raLinked := h.DB.Where("user_id = ?", uid).First(&raCred).Error == nil
 
 	c.JSON(http.StatusOK, preferencesResponse{
-		ShowPerformanceOverlay: user.ShowPerfOverlay,
-		AutoSaveEnabled:        user.AutoSaveEnabled,
-		AutoLoadSaveEnabled:    user.AutoLoadSaveEnabled,
-		SelectedShader:         user.SelectedShader,
-		SelectedTheme:          selectedTheme,
-		ConsoleShaders:         consoleShaders,
-		SelectedKeyMapping:     selectedKeyMapping,
-		CustomKeyMapping:       customKeyMapping,
-		ConsoleKeyMappings:     consoleKeyMappings,
-		RALinked:               raLinked,
-		RAUsername:             raCred.RAUsername,
-		RAHardcoreEnabled:      raCred.HardcoreEnabled,
+		ShowPerformanceOverlay:  user.ShowPerfOverlay,
+		AutoSaveEnabled:         user.AutoSaveEnabled,
+		AutoLoadSaveEnabled:     user.AutoLoadSaveEnabled,
+		SelectedShader:          user.SelectedShader,
+		SelectedTheme:           selectedTheme,
+		DefaultSecondScreenPage: defaultSecondScreenPage,
+		ConsoleShaders:          consoleShaders,
+		SelectedKeyMapping:      selectedKeyMapping,
+		CustomKeyMapping:        customKeyMapping,
+		ConsoleKeyMappings:      consoleKeyMappings,
+		RALinked:                raLinked,
+		RAUsername:              raCred.RAUsername,
+		RAHardcoreEnabled:       raCred.HardcoreEnabled,
 	})
 }
 
@@ -243,15 +250,16 @@ func (h *UserHandler) UpdatePreferences(c *gin.Context) {
 	}
 
 	var req struct {
-		ShowPerformanceOverlay *bool                            `json:"showPerformanceOverlay"`
-		AutoSaveEnabled        *bool                            `json:"autoSaveEnabled"`
-		AutoLoadSaveEnabled    *bool                            `json:"autoLoadSaveEnabled"`
-		SelectedShader         *string                          `json:"selectedShader"`
-		SelectedTheme          *string                          `json:"selectedTheme"`
-		ConsoleShaders         map[string]string                `json:"consoleShaders"`
-		SelectedKeyMapping     *string                          `json:"selectedKeyMapping"`
-		CustomKeyMapping       map[string]string                `json:"customKeyMapping"`
-		ConsoleKeyMappings     map[string]consoleKeyMappingDTO  `json:"consoleKeyMappings"`
+		ShowPerformanceOverlay  *bool                            `json:"showPerformanceOverlay"`
+		AutoSaveEnabled         *bool                            `json:"autoSaveEnabled"`
+		AutoLoadSaveEnabled     *bool                            `json:"autoLoadSaveEnabled"`
+		SelectedShader          *string                          `json:"selectedShader"`
+		SelectedTheme           *string                          `json:"selectedTheme"`
+		DefaultSecondScreenPage *string                          `json:"defaultSecondScreenPage"`
+		ConsoleShaders          map[string]string                `json:"consoleShaders"`
+		SelectedKeyMapping      *string                          `json:"selectedKeyMapping"`
+		CustomKeyMapping        map[string]string                `json:"customKeyMapping"`
+		ConsoleKeyMappings      map[string]consoleKeyMappingDTO  `json:"consoleKeyMappings"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
@@ -273,6 +281,14 @@ func (h *UserHandler) UpdatePreferences(c *gin.Context) {
 	}
 	if req.SelectedTheme != nil {
 		user.SelectedTheme = *req.SelectedTheme
+	}
+	if req.DefaultSecondScreenPage != nil {
+		valid := map[string]bool{"art": true, "controls": true, "dashboard": true, "save_slots": true}
+		if !valid[*req.DefaultSecondScreenPage] {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "invalid defaultSecondScreenPage value; must be one of: art, controls, dashboard, save_slots"})
+			return
+		}
+		user.DefaultSecondScreenPage = *req.DefaultSecondScreenPage
 	}
 	if req.SelectedKeyMapping != nil {
 		user.SelectedKeyMapping = *req.SelectedKeyMapping
@@ -366,22 +382,28 @@ func (h *UserHandler) UpdatePreferences(c *gin.Context) {
 		selectedTheme = "default-dark"
 	}
 
+	defaultSecondScreenPage := user.DefaultSecondScreenPage
+	if defaultSecondScreenPage == "" {
+		defaultSecondScreenPage = "art"
+	}
+
 	var raCred db.RetroAchievementCredential
 	raLinked := h.DB.Where("user_id = ?", uid).First(&raCred).Error == nil
 
 	c.JSON(http.StatusOK, preferencesResponse{
-		ShowPerformanceOverlay: user.ShowPerfOverlay,
-		AutoSaveEnabled:        user.AutoSaveEnabled,
-		AutoLoadSaveEnabled:    user.AutoLoadSaveEnabled,
-		SelectedShader:         user.SelectedShader,
-		SelectedTheme:          selectedTheme,
-		ConsoleShaders:         consoleShaders,
-		SelectedKeyMapping:     selectedKeyMapping,
-		CustomKeyMapping:       customKeyMapping,
-		ConsoleKeyMappings:     consoleKeyMappings,
-		RALinked:               raLinked,
-		RAUsername:             raCred.RAUsername,
-		RAHardcoreEnabled:      raCred.HardcoreEnabled,
+		ShowPerformanceOverlay:  user.ShowPerfOverlay,
+		AutoSaveEnabled:         user.AutoSaveEnabled,
+		AutoLoadSaveEnabled:     user.AutoLoadSaveEnabled,
+		SelectedShader:          user.SelectedShader,
+		SelectedTheme:           selectedTheme,
+		DefaultSecondScreenPage: defaultSecondScreenPage,
+		ConsoleShaders:          consoleShaders,
+		SelectedKeyMapping:      selectedKeyMapping,
+		CustomKeyMapping:        customKeyMapping,
+		ConsoleKeyMappings:      consoleKeyMappings,
+		RALinked:                raLinked,
+		RAUsername:              raCred.RAUsername,
+		RAHardcoreEnabled:       raCred.HardcoreEnabled,
 	})
 }
 

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -38,7 +38,8 @@ type User struct {
 	SelectedShader      string         `gorm:"size:64;default:none" json:"selectedShader"`
 	SelectedTheme       string         `gorm:"size:64;default:default-dark" json:"selectedTheme"`
 	SelectedKeyMapping  string         `gorm:"size:64;default:arrows-left" json:"selectedKeyMapping"`
-	CustomKeyMapping    string         `gorm:"type:text" json:"customKeyMapping,omitempty"` // JSON: {"0":"z","1":"x",...}
+	CustomKeyMapping         string         `gorm:"type:text" json:"customKeyMapping,omitempty"` // JSON: {"0":"z","1":"x",...}
+	DefaultSecondScreenPage string         `gorm:"size:64;default:art" json:"defaultSecondScreenPage"`
 }
 
 // LoginAttempt tracks failed login attempts per username for account lockout.


### PR DESCRIPTION
## Summary
- **Cheat toggle panel**: Tap the cheats stat card on the dashboard to open an animated panel with toggle switches for each cheat code
- **Save/load gestures**: Swipe up on a save slot card to save, long-press to load (filled) or save (empty), with green/blue flash feedback
- **Save state thumbnails**: Filled save slots show screenshot thumbnails via Coil SubcomposeAsyncImage with timestamp labels
- **Default second screen page**: New user preference (art/controls/dashboard/save_slots) synced to server, selectable in Settings screen
- **Slot-specific save/load API**: New `PUT/GET /api/sessions/:id/saves/slot/:slot` endpoints wired through the full stack

## Test plan
- [x] 8 new desktop E2E tests (cheats panel open/close/toggle, no-cheats non-clickable, save slot gestures/thumbnails/placeholders)
- [x] 1 new settings test (second screen page selector)
- [x] 3 new Go unit tests (default value, valid updates, invalid value rejection)
- [x] Full desktop test suite passes (435 tests, 0 failures)
- [x] Go tests pass
- [ ] Manual test on dual-screen Android device