### PR TITLE
feat: second screen Phase 3 — achievement tracker and unlock celebrations

### DIFF
--- a/design-proposals/second-screen-companion.md
+++ b/design-proposals/second-screen-companion.md
@@ -1,6 +1,6 @@
 # Second Screen Companion Experience
 
-## Status: Phase 1 + Phase 2 Complete, Phase 3 Started (Cheat Toggle)
+## Status: Phase 1 + Phase 2 + Phase 3 Complete
 
 **Date:** 2026-03-09
 **Contributors:** Product Owner, Android Developer, UI/UX Agent

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenCelebrationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenCelebrationTest.kt
@@ -1,0 +1,108 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.AchievementEvent
+import com.spela.player.domain.model.AchievementEventType
+import com.spela.player.presentation.ui.feature.ingame.SecondaryAchievementCelebration
+import kotlin.test.Test
+
+/**
+ * E2E tests for the SecondaryAchievementCelebration overlay.
+ *
+ * Tests cover:
+ * - Achievement unlock celebration (ACHIEVEMENT_TRIGGERED event)
+ * - Game completion celebration (GAME_COMPLETED event) with distinct visuals
+ *
+ * The SecondaryAchievementCelebration is a stateless composable rendered
+ * directly with explicit parameters. No ViewModel is needed.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SecondaryScreenCelebrationTest {
+
+    @Test
+    fun achievementCelebrationShowsOnEvent() = runComposeUiTest {
+        val event = AchievementEvent(
+            type = AchievementEventType.ACHIEVEMENT_TRIGGERED,
+            title = "First Blood",
+            description = "Defeat the first enemy",
+            points = 10,
+        )
+
+        mainClock.autoAdvance = false
+
+        setContent {
+            SecondaryAchievementCelebration(
+                achievementEvent = event,
+            )
+        }
+
+        // Advance clock to let the LaunchedEffect enqueue and promote the event.
+        // Keep autoAdvance disabled because the celebration has an infinite glow
+        // animation that would cause waitForIdle() to hang.
+        mainClock.advanceTimeBy(1_000)
+        waitForIdle()
+
+        // The celebration overlay should show with correct content description
+        onNodeWithContentDescription("Achievement unlocked: First Blood, 10 points")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // "ACHIEVEMENT UNLOCKED" header text should be visible
+        onNodeWithText("ACHIEVEMENT UNLOCKED")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Achievement title should be visible
+        onNodeWithText("First Blood")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Achievement description should be visible
+        onNodeWithText("Defeat the first enemy")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun gameCompletedCelebrationShowsDistinctly() = runComposeUiTest {
+        val event = AchievementEvent(
+            type = AchievementEventType.GAME_COMPLETED,
+            title = "Castlevania",
+            description = "All achievements unlocked!",
+            points = 0,
+        )
+
+        mainClock.autoAdvance = false
+
+        setContent {
+            SecondaryAchievementCelebration(
+                achievementEvent = event,
+            )
+        }
+
+        // Advance clock to let the LaunchedEffect enqueue and promote the event.
+        // Keep autoAdvance disabled because the celebration has an infinite glow
+        // animation that would cause waitForIdle() to hang.
+        mainClock.advanceTimeBy(1_000)
+        waitForIdle()
+
+        // The celebration overlay should show with game completed content description
+        onNodeWithContentDescription("Game completed celebration: Castlevania")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // "GAME COMPLETED" header text should be visible (distinct from "ACHIEVEMENT UNLOCKED")
+        onNodeWithText("GAME COMPLETED")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // "100%" completion indicator should be visible
+        onNodeWithText("100%")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // "ACHIEVEMENT UNLOCKED" should NOT be present
+        onAllNodesWithText("ACHIEVEMENT UNLOCKED")
+            .assertCountEquals(0)
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenDashboardTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenDashboardTest.kt
@@ -1,9 +1,12 @@
 package com.spela.player.desktop.e2e
 
 import androidx.compose.ui.test.*
+import com.spela.player.domain.model.AchievementProgress
 import com.spela.player.domain.model.Cheat
+import com.spela.player.domain.model.GameAchievement
 import com.spela.player.presentation.intent.EmulationIntent
 import com.spela.player.presentation.state.SaveSlotInfo
+import com.spela.player.presentation.state.SessionAchievementUnlock
 import com.spela.player.presentation.ui.feature.ingame.SecondaryDashboardPage
 import com.spela.player.presentation.ui.feature.ingame.SecondaryScreenContent
 import com.spela.player.presentation.ui.feature.ingame.SecondarySaveSlotsPage
@@ -82,6 +85,16 @@ class SecondaryScreenDashboardTest {
         cheats: List<com.spela.player.domain.model.Cheat> = emptyList(),
         isFastForward: Boolean = false,
         rewindEnabled: Boolean = false,
+        hasAchievements: Boolean = false,
+        achievementUnlockedCount: Int = 0,
+        achievementTotalCount: Int = 0,
+        achievementEarnedPoints: Int = 0,
+        achievementTotalPoints: Int = 0,
+        achievements: List<GameAchievement> = emptyList(),
+        achievementProgress: List<AchievementProgress> = emptyList(),
+        sessionAchievementUnlocks: List<SessionAchievementUnlock> = emptyList(),
+        sessionElapsedSeconds: Long = 0,
+        onToggleCheat: (String, Boolean) -> Unit = { _, _ -> },
     ) {
         setContent {
             SecondaryDashboardPage(
@@ -91,6 +104,15 @@ class SecondaryScreenDashboardTest {
                 hasCheats = hasCheats,
                 enabledCheatCount = enabledCheatCount,
                 cheats = cheats,
+                hasAchievements = hasAchievements,
+                achievementUnlockedCount = achievementUnlockedCount,
+                achievementTotalCount = achievementTotalCount,
+                achievementEarnedPoints = achievementEarnedPoints,
+                achievementTotalPoints = achievementTotalPoints,
+                achievements = achievements,
+                achievementProgress = achievementProgress,
+                sessionAchievementUnlocks = sessionAchievementUnlocks,
+                sessionElapsedSeconds = sessionElapsedSeconds,
                 isFastForward = isFastForward,
                 rewindEnabled = rewindEnabled,
                 onSave = {},
@@ -98,7 +120,7 @@ class SecondaryScreenDashboardTest {
                 onScreenshot = {},
                 onToggleFastForward = {},
                 onRewind = {},
-                onToggleCheat = { _, _ -> },
+                onToggleCheat = onToggleCheat,
             )
         }
     }
@@ -418,6 +440,15 @@ class SecondaryScreenDashboardTest {
                 hasCheats = true,
                 enabledCheatCount = 1,
                 cheats = testCheats,
+                hasAchievements = false,
+                achievementUnlockedCount = 0,
+                achievementTotalCount = 0,
+                achievementEarnedPoints = 0,
+                achievementTotalPoints = 0,
+                achievements = emptyList(),
+                achievementProgress = emptyList(),
+                sessionAchievementUnlocks = emptyList(),
+                sessionElapsedSeconds = 0,
                 isFastForward = false,
                 rewindEnabled = false,
                 onSave = {},
@@ -549,5 +580,223 @@ class SecondaryScreenDashboardTest {
 
         // Active empty slot shows "Active" label
         onNodeWithContentDescription("Save slot 3, active").assertExists()
+    }
+
+    // -- Achievement Tracker Tests ---------------------------------------------
+
+    private val testAchievements = listOf(
+        GameAchievement(id = 1L, title = "First Blood", description = "Defeat the first enemy", points = 5, badgeUrl = null, type = null, displayOrder = 1),
+        GameAchievement(id = 2L, title = "Speed Demon", description = "Complete level 1 in under 60 seconds", points = 10, badgeUrl = null, type = null, displayOrder = 2),
+        GameAchievement(id = 3L, title = "Completionist", description = "Find all secret areas", points = 25, badgeUrl = null, type = null, displayOrder = 3),
+    )
+
+    private val testAchievementProgressMixed = listOf(
+        AchievementProgress(achievementId = 1L, unlockedAt = "2026-01-15T10:30:00Z", isHardcore = false, playTimeAtUnlock = 120L),
+        AchievementProgress(achievementId = 2L, unlockedAt = null, isHardcore = false, playTimeAtUnlock = null),
+        AchievementProgress(achievementId = 3L, unlockedAt = null, isHardcore = false, playTimeAtUnlock = null),
+    )
+
+    private val testSessionUnlocks = listOf(
+        SessionAchievementUnlock(achievementId = 1L, title = "First Blood", points = 5, unlockedAtMs = System.currentTimeMillis() - 30_000),
+    )
+
+    @Test
+    fun achievementsCardShownWhenGameHasAchievements() = runComposeUiTest {
+        renderDashboard(
+            hasAchievements = true,
+            achievementUnlockedCount = 1,
+            achievementTotalCount = 3,
+            achievements = testAchievements,
+            achievementProgress = testAchievementProgressMixed,
+        )
+
+        // Achievements stat card should be visible with correct count
+        onNodeWithContentDescription("1 of 3 achievements unlocked, tap to view")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // The "1/3" text should be visible in the card
+        onNodeWithText("1/3")
+            .assertExists()
+    }
+
+    @Test
+    fun achievementsCardNotShownWhenNoAchievements() = runComposeUiTest {
+        renderDashboard(
+            hasAchievements = false,
+            achievementUnlockedCount = 0,
+            achievementTotalCount = 0,
+            achievements = emptyList(),
+        )
+
+        // No achievements card should be present
+        onAllNodesWithContentDescription("0 of 0 achievements unlocked, tap to view")
+            .assertCountEquals(0)
+
+        // No achievements-related "tap to view" description should be present
+        onAllNodes(hasContentDescription("achievements unlocked, tap to view", substring = true))
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun achievementsCardTapOpensPanel() = runComposeUiTest {
+        renderDashboard(
+            hasAchievements = true,
+            achievementUnlockedCount = 1,
+            achievementTotalCount = 3,
+            achievements = testAchievements,
+            achievementProgress = testAchievementProgressMixed,
+        )
+
+        // Tap the achievements card to open the panel
+        onNodeWithContentDescription("1 of 3 achievements unlocked, tap to view").performClick()
+        waitForIdle()
+
+        // Verify the achievements panel is shown
+        onNodeWithContentDescription("Achievements panel")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Verify the panel header text
+        onNodeWithText("Achievements")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun achievementsPanelShowsProgressSummary() = runComposeUiTest {
+        renderDashboard(
+            hasAchievements = true,
+            achievementUnlockedCount = 1,
+            achievementTotalCount = 3,
+            achievementEarnedPoints = 5,
+            achievementTotalPoints = 40,
+            achievements = testAchievements,
+            achievementProgress = testAchievementProgressMixed,
+        )
+
+        // Open the achievements panel
+        onNodeWithContentDescription("1 of 3 achievements unlocked, tap to view").performClick()
+        waitForIdle()
+
+        // Verify the progress summary text is visible
+        onNodeWithContentDescription("1 of 3 achievements, 5 of 40 points")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun achievementsPanelShowsLockedAndUnlockedAchievements() = runComposeUiTest {
+        renderDashboard(
+            hasAchievements = true,
+            achievementUnlockedCount = 1,
+            achievementTotalCount = 3,
+            achievementEarnedPoints = 5,
+            achievementTotalPoints = 40,
+            achievements = testAchievements,
+            achievementProgress = testAchievementProgressMixed,
+        )
+
+        // Open the achievements panel
+        onNodeWithContentDescription("1 of 3 achievements unlocked, tap to view").performClick()
+        waitForIdle()
+
+        // Unlocked achievement: "First Blood" should show as unlocked
+        onNodeWithContentDescription("First Blood, 5 points, unlocked")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Locked achievements should show as locked
+        onNodeWithContentDescription("Speed Demon, 10 points, locked")
+            .assertExists()
+            .assertIsDisplayed()
+        onNodeWithContentDescription("Completionist, 25 points, locked")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun achievementsPanelClosesOnCloseButton() = runComposeUiTest {
+        renderDashboard(
+            hasAchievements = true,
+            achievementUnlockedCount = 1,
+            achievementTotalCount = 3,
+            achievements = testAchievements,
+            achievementProgress = testAchievementProgressMixed,
+        )
+
+        // Open the achievements panel
+        onNodeWithContentDescription("1 of 3 achievements unlocked, tap to view").performClick()
+        waitForIdle()
+
+        // Verify panel is open
+        onNodeWithContentDescription("Close achievements panel").assertExists()
+
+        // Close the panel
+        onNodeWithContentDescription("Close achievements panel").performClick()
+        waitForIdle()
+
+        // Verify we're back to the dashboard — stat cards should be visible again
+        onNodeWithContentDescription("1 of 3 achievements unlocked, tap to view")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Close button should no longer be visible
+        onAllNodesWithContentDescription("Close achievements panel")
+            .assertCountEquals(0)
+    }
+
+    @Test
+    fun sessionFeedShowsUnlocks() = runComposeUiTest {
+        renderDashboard(
+            hasAchievements = true,
+            achievementUnlockedCount = 1,
+            achievementTotalCount = 3,
+            achievementEarnedPoints = 5,
+            achievementTotalPoints = 40,
+            achievements = testAchievements,
+            achievementProgress = testAchievementProgressMixed,
+            sessionAchievementUnlocks = testSessionUnlocks,
+        )
+
+        // Open the achievements panel
+        onNodeWithContentDescription("1 of 3 achievements unlocked, tap to view").performClick()
+        waitForIdle()
+
+        // "This Session" header should be visible
+        onNodeWithText("This Session")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // The session unlock item should be visible with the achievement title
+        onNode(hasContentDescription("Unlocked: First Blood", substring = true))
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun sessionFeedEmptyState() = runComposeUiTest {
+        renderDashboard(
+            hasAchievements = true,
+            achievementUnlockedCount = 1,
+            achievementTotalCount = 3,
+            achievements = testAchievements,
+            achievementProgress = testAchievementProgressMixed,
+            sessionAchievementUnlocks = emptyList(),
+        )
+
+        // Open the achievements panel
+        onNodeWithContentDescription("1 of 3 achievements unlocked, tap to view").performClick()
+        waitForIdle()
+
+        // "This Session" header should be visible
+        onNodeWithText("This Session")
+            .assertExists()
+            .assertIsDisplayed()
+
+        // Empty state text should be visible
+        onNodeWithText("No unlocks yet this session")
+            .assertExists()
+            .assertIsDisplayed()
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -217,6 +217,7 @@ val commonModule = module {
             scope = get(),
             biosRepository = get(),
             cheatRepository = get(),
+            gameStatsRepository = get(),
         )
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -1,7 +1,9 @@
 package com.spela.player.presentation.state
 
 import com.spela.player.domain.model.AchievementEvent
+import com.spela.player.domain.model.AchievementProgress
 import com.spela.player.domain.model.BiosMissingFile
+import com.spela.player.domain.model.GameAchievement
 import com.spela.player.domain.model.ShaderPreset
 
 /**
@@ -11,6 +13,16 @@ data class SaveSlotInfo(
     val screenshotUrl: String? = null,
     val timestamp: String? = null,
     val isFilled: Boolean = false,
+)
+
+/**
+ * An achievement unlocked during the current play session.
+ */
+data class SessionAchievementUnlock(
+    val achievementId: Long,
+    val title: String,
+    val points: Int,
+    val unlockedAtMs: Long,
 )
 
 data class EmulationState(
@@ -119,7 +131,21 @@ data class EmulationState(
     val enabledCheatCount: Int = 0,
     val showCheatBrowser: Boolean = false,
     val cheats: List<com.spela.player.domain.model.Cheat> = emptyList(),
+
+    /** Achievements: fetched from server for the current game. */
+    val achievements: List<GameAchievement> = emptyList(),
+    val achievementProgress: List<AchievementProgress> = emptyList(),
+    val achievementTotalPoints: Int = 0,
+    val achievementsLoading: Boolean = false,
+    val sessionAchievementUnlocks: List<SessionAchievementUnlock> = emptyList(),
 ) {
     val isNetplayMode: Boolean get() = netplaySessionId != null
     val isChallengeMode: Boolean get() = challengeId != null
+
+    val hasAchievements: Boolean get() = achievements.isNotEmpty()
+    val achievementUnlockedCount: Int get() = achievementProgress.count { it.unlockedAt != null }
+    val achievementEarnedPoints: Int get() {
+        val unlockedIds = achievementProgress.filter { it.unlockedAt != null }.map { it.achievementId }.toSet()
+        return achievements.filter { it.id in unlockedIds }.sumOf { it.points }
+    }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryAchievementCelebration.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryAchievementCelebration.kt
@@ -1,0 +1,294 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.core.FastOutSlowInEasing
+import androidx.compose.animation.core.RepeatMode
+import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.infiniteRepeatable
+import androidx.compose.animation.core.rememberInfiniteTransition
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.scaleIn
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.spela.player.domain.model.AchievementEvent
+import com.spela.player.domain.model.AchievementEventType
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import kotlinx.coroutines.delay
+
+private const val CELEBRATION_DISPLAY_DURATION_MS = 6_000L
+private const val ENTRANCE_ANIMATION_MS = 400
+private const val EXIT_ANIMATION_MS = 300
+private const val GLOW_PULSE_DURATION_MS = 1_500
+private val BANNER_CORNER_RADIUS = SpSpacing.RadiusLarge
+private val BANNER_MAX_WIDTH = 340.dp
+private val GLOW_STROKE_WIDTH = SpSpacing.XXSmall
+
+/**
+ * Achievement celebration overlay for the secondary screen.
+ *
+ * Displays a visually rich banner when achievements are unlocked or the game is completed.
+ * Events are queued so rapid unlocks show one at a time, each for its full duration.
+ *
+ * This composable does NOT consume pointer events, so the user can still interact
+ * with the underlying pager/controls while the celebration is visible.
+ *
+ * @param achievementEvent The current achievement event from [EmulationState], or null.
+ * @param onCelebrationStarted Called when a new celebration begins displaying, so the
+ *   parent can reset burn-in timers or perform other side effects.
+ */
+@Composable
+fun SecondaryAchievementCelebration(
+    achievementEvent: AchievementEvent?,
+    onCelebrationStarted: () -> Unit = {},
+) {
+    // Queue of pending celebrations. We collect events into this list and display
+    // them one at a time. Each event is shown for CELEBRATION_DISPLAY_DURATION_MS
+    // before being removed, which triggers the next one in the queue.
+    val celebrationQueue = remember { mutableStateListOf<AchievementEvent>() }
+    var currentCelebration by remember { mutableStateOf<AchievementEvent?>(null) }
+
+    // Enqueue new achievement events when the parameter changes.
+    // We key on the event identity so each new event fires exactly once.
+    // The event may be cleared from EmulationState by the primary screen's
+    // AchievementPopup, but we've already captured our own copy in the queue.
+    LaunchedEffect(achievementEvent) {
+        val event = achievementEvent ?: return@LaunchedEffect
+        if (event.type == AchievementEventType.ACHIEVEMENT_TRIGGERED ||
+            event.type == AchievementEventType.GAME_COMPLETED
+        ) {
+            celebrationQueue.add(event)
+        }
+    }
+
+    // Promote the next queued item to current when there is no active celebration.
+    LaunchedEffect(celebrationQueue.size, currentCelebration) {
+        if (currentCelebration == null && celebrationQueue.isNotEmpty()) {
+            currentCelebration = celebrationQueue.removeFirst()
+        }
+    }
+
+    // Auto-dismiss the current celebration after the display duration.
+    LaunchedEffect(currentCelebration) {
+        val celebration = currentCelebration ?: return@LaunchedEffect
+        onCelebrationStarted()
+        // Keep the celebration visible for its full duration, then clear it
+        // so the next queued item can be promoted.
+        delay(CELEBRATION_DISPLAY_DURATION_MS)
+        // Only clear if it's still the same celebration (defensive check)
+        if (currentCelebration == celebration) {
+            currentCelebration = null
+        }
+    }
+
+    val isVisible = currentCelebration != null
+
+    // Cache the last non-null celebration so the banner content persists during the
+    // exit fade-out animation (when currentCelebration has already been set to null).
+    var lastCelebration by remember { mutableStateOf<AchievementEvent?>(null) }
+    LaunchedEffect(currentCelebration) {
+        if (currentCelebration != null) lastCelebration = currentCelebration
+    }
+
+    // The overlay does NOT fill the entire screen and does NOT consume pointer events.
+    // It sits in a Box that fills the parent but uses contentAlignment to center the banner.
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        AnimatedVisibility(
+            visible = isVisible,
+            enter = fadeIn(tween(ENTRANCE_ANIMATION_MS)) +
+                scaleIn(
+                    initialScale = 0.8f,
+                    animationSpec = tween(ENTRANCE_ANIMATION_MS),
+                ),
+            exit = fadeOut(tween(EXIT_ANIMATION_MS)),
+        ) {
+            val celebration = lastCelebration ?: return@AnimatedVisibility
+            CelebrationBanner(event = celebration)
+        }
+    }
+}
+
+/**
+ * The visual banner card displayed for a single achievement celebration.
+ */
+@Composable
+private fun CelebrationBanner(event: AchievementEvent) {
+    val isGameCompleted = event.type == AchievementEventType.GAME_COMPLETED
+    val accentColor = if (isGameCompleted) SpColor.Success else SpColor.Warning
+    val headerText = if (isGameCompleted) "GAME COMPLETED" else "ACHIEVEMENT UNLOCKED"
+
+    // Subtle pulsing glow animation
+    val infiniteTransition = rememberInfiniteTransition(label = "celebrationGlow")
+    val glowAlpha by infiniteTransition.animateFloat(
+        initialValue = 0.4f,
+        targetValue = 0.9f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(GLOW_PULSE_DURATION_MS, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "glowAlpha",
+    )
+
+    val cornerRadiusPx = BANNER_CORNER_RADIUS
+    val strokeWidthPx = GLOW_STROKE_WIDTH
+
+    Column(
+        modifier = Modifier
+            .width(BANNER_MAX_WIDTH)
+            .clip(RoundedCornerShape(cornerRadiusPx))
+            .background(SpColor.Surface.copy(alpha = 0.95f))
+            .drawBehind {
+                // Pulsing glow border
+                drawRoundRect(
+                    color = accentColor.copy(alpha = glowAlpha),
+                    cornerRadius = CornerRadius(cornerRadiusPx.toPx()),
+                    style = Stroke(width = strokeWidthPx.toPx()),
+                )
+            }
+            .padding(SpSpacing.Default)
+            .semantics {
+                contentDescription = if (isGameCompleted) {
+                    "Game completed celebration: ${event.title}"
+                } else {
+                    "Achievement unlocked: ${event.title}, ${event.points} points"
+                }
+            },
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Header label
+        Text(
+            text = headerText,
+            style = SpTypography.LabelMedium.copy(
+                letterSpacing = 2.sp,
+                fontWeight = FontWeight.Bold,
+            ),
+            color = accentColor,
+            textAlign = TextAlign.Center,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // Achievement title
+        if (event.title.isNotEmpty()) {
+            Text(
+                text = event.title,
+                style = SpTypography.HeadlineSmall,
+                color = SpColor.OnBackground,
+                textAlign = TextAlign.Center,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(SpSpacing.Small))
+        }
+
+        // Achievement description
+        if (event.description.isNotEmpty()) {
+            Text(
+                text = event.description,
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundSecondary,
+                textAlign = TextAlign.Center,
+                maxLines = 3,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(SpSpacing.Medium))
+        }
+
+        // Points badge or completion indicator
+        if (isGameCompleted) {
+            CompletionIndicator()
+        } else if (event.points > 0) {
+            PointsBadge(points = event.points, accentColor = accentColor)
+        }
+    }
+}
+
+/**
+ * Points display for achievement unlocks, shown as "25 pts" with the accent color.
+ */
+@Composable
+private fun PointsBadge(points: Int, accentColor: Color) {
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .clip(RoundedCornerShape(SpSpacing.RadiusPill))
+            .background(accentColor.copy(alpha = 0.15f))
+            .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small),
+    ) {
+        Text(
+            text = "$points",
+            style = SpTypography.HeadlineMedium,
+            color = accentColor,
+        )
+        Spacer(Modifier.width(SpSpacing.XSmall))
+        Text(
+            text = "pts",
+            style = SpTypography.LabelMedium,
+            color = accentColor.copy(alpha = 0.8f),
+        )
+    }
+}
+
+/**
+ * Special "100%" indicator shown for game completion events.
+ */
+@Composable
+private fun CompletionIndicator() {
+    Box(
+        modifier = Modifier
+            .clip(RoundedCornerShape(SpSpacing.RadiusPill))
+            .background(SpColor.Success.copy(alpha = 0.15f))
+            .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "100%",
+            style = SpTypography.HeadlineMedium.copy(
+                fontWeight = FontWeight.Bold,
+            ),
+            color = SpColor.Success,
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryDashboardPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryDashboardPage.kt
@@ -16,15 +16,19 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
+import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.FastForward
 import androidx.compose.material.icons.filled.FastRewind
 import androidx.compose.material.icons.filled.FolderOpen
+import androidx.compose.material.icons.filled.Lock
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material3.Icon
@@ -41,23 +45,35 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.AchievementProgress
 import com.spela.player.domain.model.Cheat
+import com.spela.player.domain.model.GameAchievement
+import com.spela.player.presentation.state.SessionAchievementUnlock
 import com.spela.player.presentation.ui.components.EmulationActionButton
 import com.spela.player.presentation.ui.components.SpSwitch
 import com.spela.player.presentation.ui.components.fpsColor
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import kotlin.time.Clock
 
 private val ACTION_BUTTON_SIZE = 48.dp
 private val ACTION_ICON_SIZE = 24.dp
 
+/** Which sub-panel is currently displayed on the dashboard. */
+private enum class DashboardPanel {
+    DASHBOARD,
+    CHEATS,
+    ACHIEVEMENTS,
+}
+
 /**
  * Dashboard page for the secondary screen companion.
  *
- * Shows stat cards (FPS, save slot, cheats) and a quick action row
+ * Shows stat cards (FPS, save slot, cheats, and optionally achievements) and a quick action row
  * (save, load, screenshot, fast forward, rewind).
  */
 @Composable
@@ -68,6 +84,15 @@ fun SecondaryDashboardPage(
     hasCheats: Boolean,
     enabledCheatCount: Int,
     cheats: List<Cheat>,
+    hasAchievements: Boolean,
+    achievementUnlockedCount: Int,
+    achievementTotalCount: Int,
+    achievementEarnedPoints: Int,
+    achievementTotalPoints: Int,
+    achievements: List<GameAchievement>,
+    achievementProgress: List<AchievementProgress>,
+    sessionAchievementUnlocks: List<SessionAchievementUnlock>,
+    sessionElapsedSeconds: Long,
     isFastForward: Boolean,
     rewindEnabled: Boolean,
     onSave: () -> Unit,
@@ -77,118 +102,144 @@ fun SecondaryDashboardPage(
     onRewind: () -> Unit,
     onToggleCheat: (cheatId: String, enabled: Boolean) -> Unit,
 ) {
-    var showCheatsPanel by remember { mutableStateOf(false) }
+    var activePanel by remember { mutableStateOf(DashboardPanel.DASHBOARD) }
 
     AnimatedContent(
-        targetState = showCheatsPanel,
+        targetState = activePanel,
         transitionSpec = {
             (fadeIn() + slideInVertically { it / 4 })
                 .togetherWith(fadeOut() + slideOutVertically { -it / 4 })
         },
-        label = "dashboardCheatsTransition",
-    ) { showingCheats ->
-        if (showingCheats) {
-            SecondaryCheatsPanel(
-                cheats = cheats,
-                onToggleCheat = onToggleCheat,
-                onDismiss = { showCheatsPanel = false },
-            )
-        } else {
-            Column(
-                modifier = Modifier
-                    .fillMaxSize()
-                    .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small),
-                verticalArrangement = Arrangement.Center,
-                horizontalAlignment = Alignment.CenterHorizontally,
-            ) {
-                // Stat cards row
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        label = "dashboardPanelTransition",
+    ) { panel ->
+        when (panel) {
+            DashboardPanel.CHEATS -> {
+                SecondaryCheatsPanel(
+                    cheats = cheats,
+                    onToggleCheat = onToggleCheat,
+                    onDismiss = { activePanel = DashboardPanel.DASHBOARD },
+                )
+            }
+            DashboardPanel.ACHIEVEMENTS -> {
+                SecondaryAchievementsPanel(
+                    achievements = achievements,
+                    achievementProgress = achievementProgress,
+                    achievementUnlockedCount = achievementUnlockedCount,
+                    achievementTotalCount = achievementTotalCount,
+                    achievementEarnedPoints = achievementEarnedPoints,
+                    achievementTotalPoints = achievementTotalPoints,
+                    sessionAchievementUnlocks = sessionAchievementUnlocks,
+                    sessionElapsedSeconds = sessionElapsedSeconds,
+                    onDismiss = { activePanel = DashboardPanel.DASHBOARD },
+                )
+            }
+            DashboardPanel.DASHBOARD -> {
+                Column(
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small),
+                    verticalArrangement = Arrangement.Center,
+                    horizontalAlignment = Alignment.CenterHorizontally,
                 ) {
-                    StatCard(
-                        value = "%.0f".format(fps),
-                        valueColor = fpsColor(fps),
-                        label = "%.1fms".format(frameTime),
-                        contentDesc = "%.0f FPS, %.1f ms frame time".format(fps, frameTime),
-                        modifier = Modifier.weight(1f),
-                    )
-                    StatCard(
-                        value = "Slot $activeSlot",
-                        valueColor = SpColor.OnBackground,
-                        label = "Save slot",
-                        contentDesc = "Active save slot $activeSlot",
-                        modifier = Modifier.weight(1f),
-                    )
-                    StatCard(
-                        value = if (hasCheats) "$enabledCheatCount active" else "No cheats",
-                        valueColor = if (hasCheats && enabledCheatCount > 0) SpColor.Warning else SpColor.OnBackgroundTertiary,
-                        label = if (hasCheats) "Cheats \u2022 Tap" else "Cheats",
-                        contentDesc = if (hasCheats) "$enabledCheatCount cheats active, tap to manage" else "No cheats available",
-                        modifier = Modifier.weight(1f),
-                        onClick = if (hasCheats) {
-                            { showCheatsPanel = true }
-                        } else {
-                            null
-                        },
-                    )
-                }
+                    // Stat cards row
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                    ) {
+                        StatCard(
+                            value = "%.0f".format(fps),
+                            valueColor = fpsColor(fps),
+                            label = "%.1fms".format(frameTime),
+                            contentDesc = "%.0f FPS, %.1f ms frame time".format(fps, frameTime),
+                            modifier = Modifier.weight(1f),
+                        )
+                        StatCard(
+                            value = "Slot $activeSlot",
+                            valueColor = SpColor.OnBackground,
+                            label = "Save slot",
+                            contentDesc = "Active save slot $activeSlot",
+                            modifier = Modifier.weight(1f),
+                        )
+                        StatCard(
+                            value = if (hasCheats) "$enabledCheatCount active" else "No cheats",
+                            valueColor = if (hasCheats && enabledCheatCount > 0) SpColor.Warning else SpColor.OnBackgroundTertiary,
+                            label = if (hasCheats) "Cheats \u2022 Tap" else "Cheats",
+                            contentDesc = if (hasCheats) "$enabledCheatCount cheats active, tap to manage" else "No cheats available",
+                            modifier = Modifier.weight(1f),
+                            onClick = if (hasCheats) {
+                                { activePanel = DashboardPanel.CHEATS }
+                            } else {
+                                null
+                            },
+                        )
+                        if (hasAchievements) {
+                            StatCard(
+                                value = "$achievementUnlockedCount/$achievementTotalCount",
+                                valueColor = if (achievementUnlockedCount > 0) SpColor.Success else SpColor.OnBackgroundTertiary,
+                                label = "Trophies \u2022 Tap",
+                                contentDesc = "$achievementUnlockedCount of $achievementTotalCount achievements unlocked, tap to view",
+                                modifier = Modifier.weight(1f),
+                                onClick = { activePanel = DashboardPanel.ACHIEVEMENTS },
+                            )
+                        }
+                    }
 
-                Spacer(Modifier.height(SpSpacing.Medium))
+                    Spacer(Modifier.height(SpSpacing.Medium))
 
-                // Quick action row
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
-                    verticalAlignment = Alignment.CenterVertically,
-                ) {
-                    EmulationActionButton(
-                        icon = Icons.Filled.Save,
-                        label = "Save",
-                        onClick = onSave,
-                        buttonSize = ACTION_BUTTON_SIZE,
-                        iconSize = ACTION_ICON_SIZE,
-                        showLabel = false,
-                        useFocusRing = false,
-                    )
-                    EmulationActionButton(
-                        icon = Icons.Filled.FolderOpen,
-                        label = "Load",
-                        onClick = onLoad,
-                        buttonSize = ACTION_BUTTON_SIZE,
-                        iconSize = ACTION_ICON_SIZE,
-                        showLabel = false,
-                        useFocusRing = false,
-                    )
-                    EmulationActionButton(
-                        icon = Icons.Filled.CameraAlt,
-                        label = "Screenshot",
-                        onClick = onScreenshot,
-                        buttonSize = ACTION_BUTTON_SIZE,
-                        iconSize = ACTION_ICON_SIZE,
-                        showLabel = false,
-                        useFocusRing = false,
-                    )
-                    EmulationActionButton(
-                        icon = if (isFastForward) Icons.Filled.PlayArrow else Icons.Filled.FastForward,
-                        label = if (isFastForward) "Normal" else "Fast",
-                        isActive = isFastForward,
-                        onClick = onToggleFastForward,
-                        buttonSize = ACTION_BUTTON_SIZE,
-                        iconSize = ACTION_ICON_SIZE,
-                        showLabel = false,
-                        useFocusRing = false,
-                    )
-                    if (rewindEnabled) {
+                    // Quick action row
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.SpaceEvenly,
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
                         EmulationActionButton(
-                            icon = Icons.Filled.FastRewind,
-                            label = "Rewind",
-                            onClick = onRewind,
+                            icon = Icons.Filled.Save,
+                            label = "Save",
+                            onClick = onSave,
                             buttonSize = ACTION_BUTTON_SIZE,
                             iconSize = ACTION_ICON_SIZE,
                             showLabel = false,
                             useFocusRing = false,
                         )
+                        EmulationActionButton(
+                            icon = Icons.Filled.FolderOpen,
+                            label = "Load",
+                            onClick = onLoad,
+                            buttonSize = ACTION_BUTTON_SIZE,
+                            iconSize = ACTION_ICON_SIZE,
+                            showLabel = false,
+                            useFocusRing = false,
+                        )
+                        EmulationActionButton(
+                            icon = Icons.Filled.CameraAlt,
+                            label = "Screenshot",
+                            onClick = onScreenshot,
+                            buttonSize = ACTION_BUTTON_SIZE,
+                            iconSize = ACTION_ICON_SIZE,
+                            showLabel = false,
+                            useFocusRing = false,
+                        )
+                        EmulationActionButton(
+                            icon = if (isFastForward) Icons.Filled.PlayArrow else Icons.Filled.FastForward,
+                            label = if (isFastForward) "Normal" else "Fast",
+                            isActive = isFastForward,
+                            onClick = onToggleFastForward,
+                            buttonSize = ACTION_BUTTON_SIZE,
+                            iconSize = ACTION_ICON_SIZE,
+                            showLabel = false,
+                            useFocusRing = false,
+                        )
+                        if (rewindEnabled) {
+                            EmulationActionButton(
+                                icon = Icons.Filled.FastRewind,
+                                label = "Rewind",
+                                onClick = onRewind,
+                                buttonSize = ACTION_BUTTON_SIZE,
+                                iconSize = ACTION_ICON_SIZE,
+                                showLabel = false,
+                                useFocusRing = false,
+                            )
+                        }
                     }
                 }
             }
@@ -321,5 +372,231 @@ private fun SecondaryCheatsPanel(
                 }
             }
         }
+    }
+}
+
+/**
+ * Achievement tracker panel for the secondary dashboard.
+ * Shows progress summary, optional session feed, and a scrollable list of all achievements.
+ */
+@Composable
+private fun SecondaryAchievementsPanel(
+    achievements: List<GameAchievement>,
+    achievementProgress: List<AchievementProgress>,
+    achievementUnlockedCount: Int,
+    achievementTotalCount: Int,
+    achievementEarnedPoints: Int,
+    achievementTotalPoints: Int,
+    sessionAchievementUnlocks: List<SessionAchievementUnlock>,
+    sessionElapsedSeconds: Long,
+    onDismiss: () -> Unit,
+) {
+    val unlockedIds = remember(achievementProgress) {
+        achievementProgress.filter { it.unlockedAt != null }.map { it.achievementId }.toSet()
+    }
+
+    // Sort: locked first (by displayOrder), then unlocked
+    val sortedAchievements = remember(achievements, unlockedIds) {
+        val locked = achievements.filter { it.id !in unlockedIds }
+            .sortedBy { it.displayOrder ?: Int.MAX_VALUE }
+        val unlocked = achievements.filter { it.id in unlockedIds }
+            .sortedBy { it.displayOrder ?: Int.MAX_VALUE }
+        locked + unlocked
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small)
+            .semantics { contentDescription = "Achievements panel" },
+    ) {
+        // Header row with title and close button
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = SpSpacing.Small),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Achievements",
+                style = SpTypography.HeadlineSmall,
+                color = SpColor.OnBackground,
+            )
+            IconButton(
+                onClick = onDismiss,
+                modifier = Modifier.semantics {
+                    contentDescription = "Close achievements panel"
+                },
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Close,
+                    contentDescription = null,
+                    tint = SpColor.OnBackground,
+                )
+            }
+        }
+
+        // Progress summary
+        Text(
+            text = "$achievementUnlockedCount / $achievementTotalCount achievements \u2022 $achievementEarnedPoints / $achievementTotalPoints pts",
+            style = SpTypography.LabelMedium,
+            color = SpColor.OnBackgroundSecondary,
+            modifier = Modifier
+                .padding(bottom = SpSpacing.Small)
+                .semantics {
+                    contentDescription = "$achievementUnlockedCount of $achievementTotalCount achievements, $achievementEarnedPoints of $achievementTotalPoints points"
+                },
+        )
+
+        // Scrollable content: session feed + full list
+        Column(
+            modifier = Modifier
+                .weight(1f)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            // Session achievement feed
+            SessionAchievementFeed(
+                sessionUnlocks = sessionAchievementUnlocks,
+                sessionElapsedSeconds = sessionElapsedSeconds,
+            )
+
+            // Full achievement list
+            sortedAchievements.forEach { achievement ->
+                val isUnlocked = achievement.id in unlockedIds
+                AchievementRow(
+                    achievement = achievement,
+                    isUnlocked = isUnlocked,
+                )
+                Spacer(Modifier.height(SpSpacing.XSmall))
+            }
+        }
+    }
+}
+
+/**
+ * "This Session" section showing achievements unlocked during the current play session.
+ */
+@Composable
+private fun SessionAchievementFeed(
+    sessionUnlocks: List<SessionAchievementUnlock>,
+    sessionElapsedSeconds: Long,
+) {
+    Text(
+        text = "This Session",
+        style = SpTypography.TitleSmall,
+        color = SpColor.OnBackgroundTertiary,
+        modifier = Modifier.padding(bottom = SpSpacing.XSmall),
+    )
+
+    if (sessionUnlocks.isEmpty()) {
+        Text(
+            text = "No unlocks yet this session",
+            style = SpTypography.BodySmall,
+            color = SpColor.OnBackgroundTertiary,
+            modifier = Modifier
+                .padding(bottom = SpSpacing.Medium)
+                .semantics { contentDescription = "No achievements unlocked this session" },
+        )
+    } else {
+        val nowMs = Clock.System.now().toEpochMilliseconds()
+        sessionUnlocks.reversed().forEach { unlock ->
+            val agoText = formatRelativeTime(nowMs - unlock.unlockedAtMs)
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(SpSpacing.CardCornerRadius))
+                    .background(SpColor.SuccessContainer)
+                    .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Medium)
+                    .semantics {
+                        contentDescription = "Unlocked: ${unlock.title}, ${unlock.points} points, $agoText"
+                    },
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text = unlock.title,
+                        style = SpTypography.BodyMedium,
+                        color = SpColor.Success,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Text(
+                        text = "${unlock.points} pts \u2022 $agoText",
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.Success.copy(alpha = 0.7f),
+                    )
+                }
+                Icon(
+                    imageVector = Icons.Filled.Check,
+                    contentDescription = null,
+                    tint = SpColor.Success,
+                    modifier = Modifier.size(SpSpacing.IconDefault),
+                )
+            }
+            Spacer(Modifier.height(SpSpacing.XSmall))
+        }
+        Spacer(Modifier.height(SpSpacing.Small))
+    }
+}
+
+/**
+ * A single achievement row in the tracker list.
+ * Locked achievements are full opacity; unlocked achievements are de-emphasized.
+ */
+@Composable
+private fun AchievementRow(
+    achievement: GameAchievement,
+    isUnlocked: Boolean,
+) {
+    val alpha = if (isUnlocked) 0.7f else 1f
+    val bgColor = if (isUnlocked) SpColor.Card.copy(alpha = 0.6f) else SpColor.Card
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(SpSpacing.CardCornerRadius))
+            .background(bgColor)
+            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Medium)
+            .semantics {
+                contentDescription = "${achievement.title}, ${achievement.points} points, ${if (isUnlocked) "unlocked" else "locked"}"
+            },
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = achievement.title,
+            style = SpTypography.BodyMedium,
+            color = SpColor.OnBackground.copy(alpha = alpha),
+            modifier = Modifier.weight(1f),
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(Modifier.width(SpSpacing.Small))
+        Text(
+            text = "${achievement.points} pts",
+            style = SpTypography.LabelSmall,
+            color = SpColor.OnBackgroundTertiary.copy(alpha = alpha),
+        )
+        Spacer(Modifier.width(SpSpacing.Small))
+        Icon(
+            imageVector = if (isUnlocked) Icons.Filled.Check else Icons.Filled.Lock,
+            contentDescription = if (isUnlocked) "Unlocked" else "Locked",
+            tint = if (isUnlocked) SpColor.Success.copy(alpha = alpha) else SpColor.OnBackgroundTertiary.copy(alpha = alpha),
+            modifier = Modifier.size(SpSpacing.IconSmall),
+        )
+    }
+}
+
+/**
+ * Formats a duration in milliseconds into a human-readable relative time string.
+ */
+private fun formatRelativeTime(durationMs: Long): String {
+    val seconds = durationMs / 1000
+    return when {
+        seconds < 60 -> "just now"
+        seconds < 3600 -> "${seconds / 60} min ago"
+        else -> "${seconds / 3600}h ago"
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
@@ -210,6 +210,15 @@ fun SecondaryScreenContent(
                                 hasCheats = state.hasCheats,
                                 enabledCheatCount = state.enabledCheatCount,
                                 cheats = state.cheats,
+                                hasAchievements = state.hasAchievements,
+                                achievementUnlockedCount = state.achievementUnlockedCount,
+                                achievementTotalCount = state.achievements.size,
+                                achievementEarnedPoints = state.achievementEarnedPoints,
+                                achievementTotalPoints = state.achievementTotalPoints,
+                                achievements = state.achievements,
+                                achievementProgress = state.achievementProgress,
+                                sessionAchievementUnlocks = state.sessionAchievementUnlocks,
+                                sessionElapsedSeconds = state.sessionElapsedSeconds,
                                 isFastForward = state.isFastForward,
                                 rewindEnabled = state.rewindEnabled,
                                 onSave = { viewModel.onIntent(EmulationIntent.SaveState) },
@@ -247,6 +256,16 @@ fun SecondaryScreenContent(
                 )
             }
         }
+
+        // Achievement celebration overlay — shows on top of all pages
+        SecondaryAchievementCelebration(
+            achievementEvent = state.achievementEvent,
+            onCelebrationStarted = {
+                // Reset the OLED burn-in timer so the screen stays lit
+                // during the celebration
+                touchResetKey++
+            },
+        )
 
         // Paused overlay with scrim for readability over art page
         if (state.isPaused) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -3,8 +3,10 @@ package com.spela.player.presentation.viewmodel
 import com.spela.player.data.remote.PresenceService
 import com.spela.player.data.repository.BiosRepository
 import com.spela.player.domain.controller.AchievementsController
+import com.spela.player.domain.model.AchievementEventType
 import com.spela.player.domain.model.UserPreferences
 import com.spela.player.domain.repository.AchievementsRepository
+import com.spela.player.domain.repository.GameStatsRepository
 import com.spela.player.domain.repository.PreferencesRepository
 import com.spela.player.domain.usecase.GetGameDetailUseCase
 import com.spela.player.domain.repository.CheatRepository
@@ -13,8 +15,10 @@ import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.intent.EmulationIntent
 import com.spela.player.presentation.secondarydisplay.PlatformSecondaryDisplay
 import com.spela.player.presentation.state.EmulationState
+import com.spela.player.presentation.state.SessionAchievementUnlock
 import com.spela.player.util.DispatcherProvider
 import com.spela.player.presentation.state.GameSyncState
+import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
@@ -60,6 +64,7 @@ class EmulationViewModel(
     private val scope: CoroutineScope,
     private val biosRepository: BiosRepository? = null,
     private val cheatRepository: CheatRepository? = null,
+    private val gameStatsRepository: GameStatsRepository? = null,
 ) {
     val state: StateFlow<EmulationState> = _state.asStateFlow()
 
@@ -244,6 +249,12 @@ class EmulationViewModel(
                 challengeAttemptId = null,
                 challengeElapsedMs = 0,
                 challengeCompletedAttempt = null,
+                achievementEvent = null,
+                achievements = emptyList(),
+                achievementProgress = emptyList(),
+                achievementTotalPoints = 0,
+                achievementsLoading = false,
+                sessionAchievementUnlocks = emptyList(),
                 error = null,
                 statusMessage = null,
                 isFastForward = false,
@@ -670,6 +681,12 @@ class EmulationViewModel(
                         enabledCheatCount = 0,
                         showCheatBrowser = false,
                         cheats = emptyList(),
+                        achievements = emptyList(),
+                        achievementProgress = emptyList(),
+                        achievementTotalPoints = 0,
+                        achievementsLoading = false,
+                        sessionAchievementUnlocks = emptyList(),
+                        achievementEvent = null,
                     )
                 }
                 saveManager.currentSessionId = null
@@ -831,6 +848,9 @@ class EmulationViewModel(
     }
 
     private fun initAchievements(gameId: String) {
+        // Fetch achievement list + progress from server for the tracker panel
+        fetchAchievements(gameId)
+
         scope.launch(dispatchers.io) {
             achievementsRepository.getRAToken().onSuccess { credentials ->
                 achievementsController.init()
@@ -849,17 +869,103 @@ class EmulationViewModel(
                 // Use gameId as hash for now (server can provide a proper hash later)
                 achievementsController.loadGame(gameId)
 
-                // Collect achievement events for UI
+                // Collect achievement events for UI + track session unlocks
                 scope.launch(dispatchers.default) {
                     achievementsController.events.collect { event ->
                         withContext(dispatchers.main) {
-                            _state.update { it.copy(achievementEvent = event) }
+                            _state.update { state ->
+                                val newState = state.copy(achievementEvent = event)
+                                if (event.type == AchievementEventType.ACHIEVEMENT_TRIGGERED) {
+                                    handleAchievementTriggered(newState, event.title, event.points)
+                                } else {
+                                    newState
+                                }
+                            }
                         }
                     }
                 }
             }
             // If getRAToken fails, RA is not linked — silently skip
         }
+    }
+
+    /**
+     * Fetches achievement list and progress from the server API.
+     * Updates state with achievements data for the tracker panel on the secondary screen.
+     */
+    private fun fetchAchievements(gameId: String) {
+        val repo = gameStatsRepository ?: return
+        scope.launch(dispatchers.io) {
+            withContext(dispatchers.main) {
+                _state.update { it.copy(achievementsLoading = true) }
+            }
+            try {
+                val achievementsResult = repo.getGameAchievements(gameId)
+                val progressResult = repo.getAchievementProgress(gameId)
+
+                val achievements = achievementsResult.getOrDefault(emptyList())
+                val progress = progressResult.getOrDefault(emptyList())
+                val totalPoints = achievements.sumOf { it.points }
+
+                withContext(dispatchers.main) {
+                    _state.update {
+                        it.copy(
+                            achievements = achievements,
+                            achievementProgress = progress,
+                            achievementTotalPoints = totalPoints,
+                            achievementsLoading = false,
+                        )
+                    }
+                }
+            } catch (e: Exception) {
+                println("[Emulation] Failed to fetch achievements: ${e.message}")
+                withContext(dispatchers.main) {
+                    _state.update { it.copy(achievementsLoading = false) }
+                }
+            }
+        }
+    }
+
+    /**
+     * Handles an ACHIEVEMENT_TRIGGERED event by updating the local progress
+     * (marking the achievement as unlocked) and adding it to the session feed.
+     */
+    private fun handleAchievementTriggered(
+        state: EmulationState,
+        title: String,
+        points: Int,
+    ): EmulationState {
+        val nowMs = Clock.System.now().toEpochMilliseconds()
+
+        // Find the matching achievement by title to get its ID
+        val matchedAchievement = state.achievements.find { it.title == title }
+        val achievementId = matchedAchievement?.id ?: 0L
+
+        // Add to session unlocks
+        val sessionUnlock = SessionAchievementUnlock(
+            achievementId = achievementId,
+            title = title,
+            points = points,
+            unlockedAtMs = nowMs,
+        )
+        val updatedSessionUnlocks = state.sessionAchievementUnlocks + sessionUnlock
+
+        // Update local progress — mark this achievement as unlocked if not already
+        val updatedProgress = if (achievementId != 0L && state.achievementProgress.none { it.achievementId == achievementId && it.unlockedAt != null }) {
+            state.achievementProgress + com.spela.player.domain.model.AchievementProgress(
+                achievementId = achievementId,
+                unlockedAt = Clock.System.now().toString(),
+                isHardcore = state.isHardcoreMode,
+                playTimeAtUnlock = state.sessionElapsedSeconds,
+            )
+        } else {
+            state.achievementProgress
+        }
+
+        return state.copy(
+            sessionAchievementUnlocks = updatedSessionUnlocks,
+            achievementProgress = updatedProgress,
+        )
     }
 
     private fun trackPerformance() {


### PR DESCRIPTION
## Summary
- **Achievement tracker panel**: Tappable stat card on the Dashboard showing unlock progress (e.g. "7/42"), opens a scrollable panel with progress summary, session feed, and full achievement list with locked/unlocked indicators
- **Session achievement feed**: Tracks unlocks during the current play session with relative timestamps, resets on game restart
- **Achievement celebration overlay**: Rich animated banner on the second screen for achievement unlocks and game completions with pulsing glow border, queued display for rapid unlocks, 6-second auto-dismiss
- **Game completion** gets distinct visual treatment (green accent, "100%" indicator)
- No backend changes needed — all achievement APIs already exist

## Test plan
- [x] 8 new desktop E2E tests for achievement tracker (stat card, panel open/close, progress summary, locked/unlocked, session feed)
- [x] 2 new desktop E2E tests for celebration overlay (achievement unlocked, game completed)
- [x] Full desktop test suite passes (453 tests, 0 failures)
- [x] Go tests pass
- [ ] Manual test on dual-screen Android device