### PR TITLE
feat: add P2 controls toggle and game info card to second screen

### DIFF
--- a/design-proposals/second-screen-companion.md
+++ b/design-proposals/second-screen-companion.md
@@ -1,6 +1,6 @@
 # Second Screen Companion Experience
 
-## Status: Phase 1 + Phase 2 + Phase 3 + Phase 4 Complete
+## Status: Phase 1 + Phase 2 + Phase 3 + Phase 4 + Phase 5 Complete
 
 **Date:** 2026-03-09
 **Contributors:** Product Owner, Android Developer, UI/UX Agent

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenArtPageTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenArtPageTest.kt
@@ -1,0 +1,248 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.intent.EmulationIntent
+import com.spela.player.presentation.ui.feature.ingame.SecondaryArtPage
+import com.spela.player.presentation.ui.feature.ingame.SecondaryScreenContent
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+
+/**
+ * E2E tests for the SecondaryArtPage game info card.
+ *
+ * Tests cover:
+ * - Game info card rendering when metadata is present
+ * - Card hidden when no metadata is available
+ * - Description text display
+ * - Rating display with star
+ * - Player count display
+ * - Integration test via full harness for metadata propagation
+ * - Edge cases: empty string metadata, hero URL branch, session timer
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class SecondaryScreenArtPageTest {
+
+    @Test
+    fun artPageShowsGameInfoCard() = runComposeUiTest {
+        setContent {
+            SecondaryArtPage(
+                heroUrl = null,
+                gameTitle = "Super Metroid",
+                sessionElapsedSeconds = 3600,
+                consoleId = "snes",
+                consoleColorTheme = null,
+                gameDeveloper = "Nintendo R&D1",
+                gamePublisher = "Nintendo",
+                gameReleaseDate = "1994",
+                gameGenre = "Action",
+                gameRating = 4.5,
+                gamePlayers = 1,
+            )
+        }
+
+        onNodeWithContentDescription("Game information").assertExists()
+        onNodeWithText("Nintendo R&D1").assertExists()
+        onNodeWithText("Nintendo").assertExists()
+        onNodeWithText("1994").assertExists()
+        onNodeWithText("Action").assertExists()
+    }
+
+    @Test
+    fun artPageHidesCardWhenNoMetadata() = runComposeUiTest {
+        setContent {
+            SecondaryArtPage(
+                heroUrl = null,
+                gameTitle = "Unknown ROM",
+                sessionElapsedSeconds = 0,
+                consoleId = "nes",
+                consoleColorTheme = null,
+            )
+        }
+
+        onNodeWithContentDescription("Game information").assertDoesNotExist()
+    }
+
+    @Test
+    fun artPageShowsDescription() = runComposeUiTest {
+        setContent {
+            SecondaryArtPage(
+                heroUrl = null,
+                gameTitle = "Chrono Trigger",
+                sessionElapsedSeconds = 120,
+                consoleId = "snes",
+                consoleColorTheme = null,
+                gameDescription = "A classic JRPG about time travel and saving the world.",
+            )
+        }
+
+        onNodeWithContentDescription("Game information").assertExists()
+        onNodeWithText("A classic JRPG about time travel and saving the world.").assertExists()
+    }
+
+    @Test
+    fun artPageShowsRating() = runComposeUiTest {
+        setContent {
+            SecondaryArtPage(
+                heroUrl = null,
+                gameTitle = "Final Fantasy VI",
+                sessionElapsedSeconds = 60,
+                consoleId = "snes",
+                consoleColorTheme = null,
+                gameRating = 4.8,
+            )
+        }
+
+        onNodeWithContentDescription("Game information").assertExists()
+        onNodeWithText("4.8").assertExists()
+        // Star character
+        onNodeWithText("\u2605 ").assertExists()
+    }
+
+    @Test
+    fun artPageShowsPlayerCount() = runComposeUiTest {
+        setContent {
+            SecondaryArtPage(
+                heroUrl = null,
+                gameTitle = "Street Fighter II",
+                sessionElapsedSeconds = 300,
+                consoleId = "snes",
+                consoleColorTheme = null,
+                gamePlayers = 2,
+            )
+        }
+
+        onNodeWithContentDescription("Game information").assertExists()
+        onNodeWithText("1-2 Players").assertExists()
+    }
+
+    @Test
+    fun artPageShowsSinglePlayer() = runComposeUiTest {
+        setContent {
+            SecondaryArtPage(
+                heroUrl = null,
+                gameTitle = "Mega Man X",
+                sessionElapsedSeconds = 180,
+                consoleId = "snes",
+                consoleColorTheme = null,
+                gamePlayers = 1,
+            )
+        }
+
+        onNodeWithContentDescription("Game information").assertExists()
+        onNodeWithText("1 Player").assertExists()
+    }
+
+    // -- Helpers ---------------------------------------------------------------
+
+    private fun createHarnessWithNesGame(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.downloadRepo.preCacheGame("1")
+        return harness
+    }
+
+    private fun ComposeUiTest.advanceSeconds(harness: SpelaTestHarness, seconds: Int) {
+        mainClock.autoAdvance = false
+        repeat(seconds) {
+            harness.testDispatcher.scheduler.advanceTimeBy(1_000)
+            harness.testDispatcher.scheduler.runCurrent()
+            mainClock.advanceTimeBy(1_000)
+            waitForIdle()
+        }
+        mainClock.autoAdvance = true
+    }
+
+    private fun ComposeUiTest.startGameAndRenderSecondary(
+        harness: SpelaTestHarness,
+        gameId: String = "1",
+    ) {
+        harness.emulationViewModel.onIntent(EmulationIntent.StartGame(gameId = gameId))
+        mainClock.autoAdvance = false
+        repeat(4) {
+            harness.testDispatcher.scheduler.advanceTimeBy(1_000)
+            harness.testDispatcher.scheduler.runCurrent()
+        }
+        mainClock.autoAdvance = true
+
+        setContent {
+            SecondaryScreenContent(
+                viewModel = harness.emulationViewModel,
+                controller = harness.libretroController,
+            )
+        }
+        advanceSeconds(harness, 1)
+    }
+
+    // -- Integration test via full harness ------------------------------------
+
+    @Test
+    fun artPageShowsGameInfoViaHarness() = runComposeUiTest {
+        val harness = createHarnessWithNesGame()
+        startGameAndRenderSecondary(harness)
+
+        // The fake game repo returns game "1" as Castlevania with developer+publisher "Konami"
+        // The art page is the default page (page 0) so it should be visible
+        onNodeWithContentDescription("Game information").assertExists()
+        // Developer and publisher are both "Konami", producing two text nodes
+        onAllNodesWithText("Konami").assertCountEquals(2)
+        // Also verify the genre to confirm metadata propagation
+        onNodeWithText("Action").assertExists()
+    }
+
+    // -- Edge case: empty string metadata -------------------------------------
+
+    @Test
+    fun artPageHandlesEmptyStringMetadata() = runComposeUiTest {
+        setContent {
+            SecondaryArtPage(
+                heroUrl = null,
+                gameTitle = "Unknown ROM",
+                sessionElapsedSeconds = 0,
+                consoleId = "nes",
+                consoleColorTheme = null,
+                gameDeveloper = "",
+                gamePublisher = "",
+            )
+        }
+
+        // Empty strings should be treated as no data — card should NOT exist
+        onNodeWithContentDescription("Game information").assertDoesNotExist()
+    }
+
+    // -- Hero URL branch shows title ------------------------------------------
+
+    @Test
+    fun artPageWithHeroUrlShowsTitle() = runComposeUiTest {
+        setContent {
+            SecondaryArtPage(
+                heroUrl = "https://example.com/hero.jpg",
+                gameTitle = "Super Metroid",
+                sessionElapsedSeconds = 120,
+                consoleId = "snes",
+                consoleColorTheme = null,
+            )
+        }
+
+        // The image will fail to load in tests but the title text should still be present
+        onNodeWithText("Super Metroid").assertExists()
+    }
+
+    // -- Session timer rendering ----------------------------------------------
+
+    @Test
+    fun artPageShowsSessionTimer() = runComposeUiTest {
+        setContent {
+            SecondaryArtPage(
+                heroUrl = "https://example.com/hero.jpg",
+                gameTitle = "Test Game",
+                sessionElapsedSeconds = 3661, // 1h 1m 1s
+                consoleId = "nes",
+                consoleColorTheme = null,
+            )
+        }
+
+        // formatSessionDuration(3661) => "1:01:01"
+        // Timer is shown in the title row below the hero image
+        onNodeWithText("1:01:01").assertExists()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenControlsTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenControlsTest.kt
@@ -1,0 +1,166 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.intent.EmulationIntent
+import com.spela.player.presentation.ui.feature.ingame.SecondaryControlsPage
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * E2E tests for the secondary screen controls page P1/P2 port selector.
+ *
+ * Since PlatformTouchControls is a no-op on desktop, these tests focus
+ * on verifying the port toggle UI (P1/P2 buttons, selection state, callback).
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class SecondaryScreenControlsTest {
+
+    @Test
+    fun controlsPageShowsPortSelector() = runComposeUiTest {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+
+        setContent {
+            SecondaryControlsPage(
+                controller = harness.libretroController,
+                touchControlPort = 0,
+                onSelectPort = {},
+            )
+        }
+        waitForIdle()
+
+        onNodeWithContentDescription("Player 1 controls").assertExists()
+        onNodeWithContentDescription("Player 2 controls").assertExists()
+        onNodeWithContentDescription("Control port: Player 1").assertExists()
+    }
+
+    @Test
+    fun portSelectorSwitchesToP2() = runComposeUiTest {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+
+        setContent {
+            SecondaryControlsPage(
+                controller = harness.libretroController,
+                touchControlPort = 1,
+                onSelectPort = {},
+            )
+        }
+        waitForIdle()
+
+        // When port=1, the row should describe "Player 2"
+        onNodeWithContentDescription("Control port: Player 2").assertExists()
+        // Both buttons should still exist
+        onNodeWithContentDescription("Player 1 controls").assertExists()
+        onNodeWithContentDescription("Player 2 controls").assertExists()
+    }
+
+    @Test
+    fun portSelectorCallsCallback() = runComposeUiTest {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        var selectedPort = -1
+
+        setContent {
+            SecondaryControlsPage(
+                controller = harness.libretroController,
+                touchControlPort = 0,
+                onSelectPort = { selectedPort = it },
+            )
+        }
+        waitForIdle()
+
+        // Click P2 button
+        onNodeWithContentDescription("Player 2 controls").performClick()
+        waitForIdle()
+
+        assertEquals(1, selectedPort, "Expected selectedPort to be 1 after clicking P2")
+    }
+
+    // -- Helpers ---------------------------------------------------------------
+
+    private fun createHarnessWithNesGame(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.downloadRepo.preCacheGame("1")
+        return harness
+    }
+
+    private fun ComposeUiTest.advanceSeconds(harness: SpelaTestHarness, seconds: Int) {
+        mainClock.autoAdvance = false
+        repeat(seconds) {
+            harness.testDispatcher.scheduler.advanceTimeBy(1_000)
+            harness.testDispatcher.scheduler.runCurrent()
+            mainClock.advanceTimeBy(1_000)
+            waitForIdle()
+        }
+        mainClock.autoAdvance = true
+    }
+
+    // -- Integration tests via full harness ------------------------------------
+
+    @Test
+    fun touchControlPortResetsOnNewGame() = runComposeUiTest {
+        val harness = createHarnessWithNesGame()
+
+        // Start a game
+        harness.emulationViewModel.onIntent(EmulationIntent.StartGame(gameId = "1"))
+        mainClock.autoAdvance = false
+        repeat(4) {
+            harness.testDispatcher.scheduler.advanceTimeBy(1_000)
+            harness.testDispatcher.scheduler.runCurrent()
+        }
+        mainClock.autoAdvance = true
+
+        // Set touchControlPort to 1
+        harness.emulationViewModel.onIntent(EmulationIntent.SelectTouchControlPort(1))
+        mainClock.autoAdvance = false
+        repeat(2) {
+            harness.testDispatcher.scheduler.advanceTimeBy(1_000)
+            harness.testDispatcher.scheduler.runCurrent()
+        }
+        mainClock.autoAdvance = true
+
+        // Verify state is 1
+        assertEquals(
+            1,
+            harness.emulationViewModel.state.value.touchControlPort,
+            "Expected touchControlPort to be 1 after selecting port 1"
+        )
+
+        // Stop game
+        harness.emulationViewModel.onIntent(EmulationIntent.StopGame)
+        mainClock.autoAdvance = false
+        repeat(4) {
+            harness.testDispatcher.scheduler.advanceTimeBy(1_000)
+            harness.testDispatcher.scheduler.runCurrent()
+        }
+        mainClock.autoAdvance = true
+
+        // Verify touchControlPort reset to 0
+        assertEquals(
+            0,
+            harness.emulationViewModel.state.value.touchControlPort,
+            "Expected touchControlPort to reset to 0 after stopping game"
+        )
+    }
+
+    @Test
+    fun portSelectorCallsCallbackForP1() = runComposeUiTest {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        var selectedPort = -1
+
+        setContent {
+            SecondaryControlsPage(
+                controller = harness.libretroController,
+                touchControlPort = 1,
+                onSelectPort = { selectedPort = it },
+            )
+        }
+        waitForIdle()
+
+        // Click P1 button while on P2
+        onNodeWithContentDescription("Player 1 controls").performClick()
+        waitForIdle()
+
+        assertEquals(0, selectedPort, "Expected selectedPort to be 0 after clicking P1")
+    }
+}

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/TouchGamepadOverlay.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/TouchGamepadOverlay.kt
@@ -61,6 +61,7 @@ private val PressedAlpha = 0.60f
 fun TouchGamepadOverlay(
     controller: AndroidLibretroController,
     modifier: Modifier = Modifier,
+    port: Int = 0,
 ) {
     val buttonColor = Color.White.copy(alpha = IdleAlpha)
     val pressedColor = Color.White.copy(alpha = PressedAlpha)
@@ -85,6 +86,7 @@ fun TouchGamepadOverlay(
                 buttonColor = buttonColor,
                 pressedColor = pressedColor,
                 textColor = textColor,
+                port = port,
             )
         }
 
@@ -99,6 +101,7 @@ fun TouchGamepadOverlay(
                 buttonColor = buttonColor,
                 pressedColor = pressedColor,
                 textColor = textColor,
+                port = port,
             )
         }
 
@@ -121,6 +124,7 @@ fun TouchGamepadOverlay(
                 height = 40.dp,
                 shape = RoundedCornerShape(12.dp),
                 fontSize = 10,
+                port = port,
             )
             Spacer(Modifier.width(20.dp))
             GamepadButton(
@@ -135,6 +139,7 @@ fun TouchGamepadOverlay(
                 height = 40.dp,
                 shape = RoundedCornerShape(12.dp),
                 fontSize = 10,
+                port = port,
             )
         }
     }
@@ -150,6 +155,7 @@ private fun DPad(
     buttonColor: Color,
     pressedColor: Color,
     textColor: Color,
+    port: Int,
 ) {
     val btnSize = 38.dp
     val gap = 2.dp
@@ -169,6 +175,7 @@ private fun DPad(
                 topStart = 12.dp, topEnd = 12.dp,
                 bottomStart = 4.dp, bottomEnd = 4.dp,
             ),
+            port = port,
         )
         Spacer(Modifier.height(gap))
         // Left - Center - Right
@@ -187,6 +194,7 @@ private fun DPad(
                     topStart = 12.dp, bottomStart = 12.dp,
                     topEnd = 4.dp, bottomEnd = 4.dp,
                 ),
+                port = port,
             )
             Spacer(Modifier.width(gap))
             // Center filler
@@ -211,6 +219,7 @@ private fun DPad(
                     topEnd = 12.dp, bottomEnd = 12.dp,
                     topStart = 4.dp, bottomStart = 4.dp,
                 ),
+                port = port,
             )
         }
         Spacer(Modifier.height(gap))
@@ -229,6 +238,7 @@ private fun DPad(
                 bottomStart = 12.dp, bottomEnd = 12.dp,
                 topStart = 4.dp, topEnd = 4.dp,
             ),
+            port = port,
         )
     }
 }
@@ -243,6 +253,7 @@ private fun ActionButtons(
     buttonColor: Color,
     pressedColor: Color,
     textColor: Color,
+    port: Int,
 ) {
     val btnSize = 56.dp
     val gap = 12.dp
@@ -261,6 +272,7 @@ private fun ActionButtons(
                 width = btnSize,
                 height = btnSize,
                 shape = CircleShape,
+                port = port,
             )
         }
         Spacer(Modifier.width(gap))
@@ -276,6 +288,7 @@ private fun ActionButtons(
             width = btnSize,
             height = btnSize,
             shape = CircleShape,
+            port = port,
         )
     }
 }
@@ -298,6 +311,7 @@ private fun GamepadButton(
     height: Dp,
     shape: Shape,
     fontSize: Int = 15,
+    port: Int = 0,
 ) {
     val isPressed = remember { mutableStateOf(false) }
 
@@ -307,25 +321,25 @@ private fun GamepadButton(
             .clip(shape)
             .background(if (isPressed.value) pressedColor else buttonColor)
             .semantics { contentDescription = accessibilityLabel }
-            .pointerInput(buttonId) {
+            .pointerInput(buttonId, port) {
                 awaitPointerEventScope {
                     while (true) {
                         val event = awaitPointerEvent()
                         when (event.type) {
                             PointerEventType.Press -> {
                                 isPressed.value = true
-                                controller.setButton(0, buttonId, true)
+                                controller.setButton(port, buttonId, true)
                             }
                             PointerEventType.Release -> {
                                 val anyDown = event.changes.any { it.pressed }
                                 if (!anyDown) {
                                     isPressed.value = false
-                                    controller.setButton(0, buttonId, false)
+                                    controller.setButton(port, buttonId, false)
                                 }
                             }
                             PointerEventType.Exit -> {
                                 isPressed.value = false
-                                controller.setButton(0, buttonId, false)
+                                controller.setButton(port, buttonId, false)
                             }
                         }
                         event.changes.forEach { it.consume() }

--- a/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformTouchControls.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformTouchControls.android.kt
@@ -15,6 +15,7 @@ import com.spela.player.presentation.viewmodel.LibretroController
 actual fun PlatformTouchControls(
     controller: LibretroController,
     modifier: Modifier,
+    port: Int,
 ) {
     val androidController = controller as? AndroidLibretroController ?: return
 
@@ -29,6 +30,7 @@ actual fun PlatformTouchControls(
         TouchGamepadOverlay(
             controller = androidController,
             modifier = modifier,
+            port = port,
         )
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -104,4 +104,7 @@ sealed interface EmulationIntent {
 
     // Secondary screen toast
     data object ClearSecondaryToast : EmulationIntent
+
+    // Secondary screen touch control port
+    data class SelectTouchControlPort(val port: Int) : EmulationIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -49,6 +49,13 @@ data class EmulationState(
     val consoleId: String = "",
     val consoleColorTheme: String? = null,
     val heroUrl: String? = null,
+    val gameDescription: String? = null,
+    val gameDeveloper: String? = null,
+    val gamePublisher: String? = null,
+    val gameReleaseDate: String? = null,
+    val gameGenre: String? = null,
+    val gameRating: Double = 0.0,
+    val gamePlayers: Int = 0,
     val isRunning: Boolean = false,
     val isPaused: Boolean = false,
     /** True when paused by Android lifecycle (e.g. clamshell close). */
@@ -159,6 +166,9 @@ data class EmulationState(
 
     /** Secondary screen toast: brief notification after save/load operations. */
     val secondaryToast: SecondaryToastData? = null,
+
+    /** Which port the touch controls target (0 = Player 1, 1 = Player 2). */
+    val touchControlPort: Int = 0,
 ) {
     val isNetplayMode: Boolean get() = netplaySessionId != null
     val isChallengeMode: Boolean get() = challengeId != null

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformTouchControls.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformTouchControls.kt
@@ -13,4 +13,5 @@ import com.spela.player.presentation.viewmodel.LibretroController
 expect fun PlatformTouchControls(
     controller: LibretroController,
     modifier: Modifier = Modifier,
+    port: Int = 0,
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryArtPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryArtPage.kt
@@ -4,22 +4,29 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.Shadow
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.presentation.ui.feature.library.getConsoleGradient
 import com.spela.player.presentation.ui.screen.formatSessionDuration
@@ -30,12 +37,12 @@ import com.spela.player.presentation.ui.theme.SpTypography
 /**
  * Art Display page for the secondary screen companion.
  *
- * When `heroUrl` is available, displays the game's hero artwork as a full-bleed
- * background with a subtle gradient overlay and game title + session timer at
- * the bottom-right.
+ * Shows hero artwork (or a console gradient fallback) at the top, followed by the
+ * game title, session timer, and an optional game info card with metadata such as
+ * developer, publisher, release year, genre, rating, and description.
  *
- * When `heroUrl` is null, falls back to a centered game title with the console
- * gradient as a subtle background accent ("Focus" mode).
+ * The entire page scrolls vertically so all metadata is accessible even on small
+ * secondary displays.
  */
 @Composable
 fun SecondaryArtPage(
@@ -44,162 +51,266 @@ fun SecondaryArtPage(
     sessionElapsedSeconds: Long,
     consoleId: String,
     consoleColorTheme: String?,
+    gameDescription: String? = null,
+    gameDeveloper: String? = null,
+    gamePublisher: String? = null,
+    gameReleaseDate: String? = null,
+    gameGenre: String? = null,
+    gameRating: Double = 0.0,
+    gamePlayers: Int = 0,
 ) {
     val timeText = formatSessionDuration(sessionElapsedSeconds)
+    val (gradientFrom, _) = getConsoleGradient(consoleId, consoleColorTheme)
 
-    if (heroUrl != null) {
-        // Full-bleed hero artwork mode
-        Box(
-            modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background)
-                .semantics {
-                    contentDescription = "Art display: $gameTitle"
-                },
-        ) {
-            // Hero image filling the entire page
+    val hasGameInfo = !gameDeveloper.isNullOrEmpty() || !gamePublisher.isNullOrEmpty() || !gameGenre.isNullOrEmpty() ||
+        !gameReleaseDate.isNullOrEmpty() || !gameDescription.isNullOrEmpty() || gamePlayers > 0 || gameRating > 0.0
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SpColor.Background)
+            .verticalScroll(rememberScrollState())
+            .semantics {
+                contentDescription = "Art display: $gameTitle"
+            },
+    ) {
+        if (heroUrl != null) {
+            // Hero image at fixed aspect ratio
             SubcomposeAsyncImage(
                 model = heroUrl,
                 contentDescription = "Hero artwork for $gameTitle",
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(16f / 9f),
                 contentScale = ContentScale.Crop,
                 loading = {
                     Box(
                         modifier = Modifier
-                            .fillMaxSize()
+                            .fillMaxWidth()
+                            .aspectRatio(16f / 9f)
                             .background(SpColor.SurfaceVariant),
                     )
                 },
                 error = {
-                    // On error, fall back to the gradient mode
-                    FallbackArtContent(
-                        gameTitle = gameTitle,
-                        timeText = timeText,
-                        consoleId = consoleId,
-                        consoleColorTheme = consoleColorTheme,
+                    // On error, show console gradient header instead
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(16f / 9f)
+                            .background(
+                                Brush.verticalGradient(
+                                    colors = listOf(
+                                        gradientFrom.copy(alpha = 0.15f),
+                                        SpColor.Background,
+                                    ),
+                                )
+                            ),
                     )
                 },
             )
-
-            // Gradient overlay: transparent at top, dark at bottom
+        } else {
+            // Fallback: decorative console gradient area (title/timer already in CompanionHeader)
             Box(
                 modifier = Modifier
-                    .fillMaxSize()
+                    .fillMaxWidth()
+                    .height(80.dp)
                     .background(
                         Brush.verticalGradient(
                             colors = listOf(
-                                Color.Transparent,
-                                Color.Transparent,
-                                SpColor.Background.copy(alpha = 0.4f),
-                                SpColor.Background.copy(alpha = 0.85f),
+                                gradientFrom.copy(alpha = 0.15f),
+                                SpColor.Background,
                             ),
                         )
                     ),
-            )
-
-            // Title + timer overlaid at bottom-right
-            Column(
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .padding(SpSpacing.Medium),
-                horizontalAlignment = Alignment.End,
+                contentAlignment = Alignment.Center,
             ) {
                 Text(
-                    text = gameTitle,
-                    style = SpTypography.TitleLarge.copy(
-                        shadow = Shadow(
-                            color = Color.Black.copy(alpha = 0.7f),
-                            offset = Offset(1f, 1f),
-                            blurRadius = 4f,
-                        ),
-                    ),
-                    color = SpColor.OnBackground,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                    textAlign = TextAlign.End,
-                )
-                Text(
-                    text = timeText,
-                    style = SpTypography.HeadlineSmall.copy(
-                        shadow = Shadow(
-                            color = Color.Black.copy(alpha = 0.7f),
-                            offset = Offset(1f, 1f),
-                            blurRadius = 4f,
-                        ),
-                    ),
-                    color = SpColor.OnBackgroundSecondary,
+                    text = consoleId.uppercase(),
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
                 )
             }
         }
-    } else {
-        // Fallback "Focus" mode: console gradient background with centered title
-        FallbackArtContent(
-            gameTitle = gameTitle,
-            timeText = timeText,
-            consoleId = consoleId,
-            consoleColorTheme = consoleColorTheme,
+
+        // Title + timer row (shown below hero image, or below fallback header content is already in the header)
+        if (heroUrl != null) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween,
+            ) {
+                Text(
+                    text = gameTitle,
+                    style = SpTypography.TitleLarge,
+                    color = SpColor.OnBackground,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+                Text(
+                    text = timeText,
+                    style = SpTypography.LabelLarge,
+                    color = SpColor.OnBackgroundTertiary,
+                )
+            }
+        }
+
+        // Game info card
+        if (hasGameInfo) {
+            GameInfoCard(
+                gameDeveloper = gameDeveloper,
+                gamePublisher = gamePublisher,
+                gameReleaseDate = gameReleaseDate,
+                gameGenre = gameGenre,
+                gameRating = gameRating,
+                gamePlayers = gamePlayers,
+                gameDescription = gameDescription,
+            )
+        }
+    }
+}
+
+/**
+ * Card displaying game metadata: developer, publisher, release year, genre,
+ * player count, rating, and description.
+ *
+ * Only rows with non-null, non-empty values are rendered.
+ */
+@Composable
+private fun GameInfoCard(
+    gameDeveloper: String?,
+    gamePublisher: String?,
+    gameReleaseDate: String?,
+    gameGenre: String?,
+    gameRating: Double,
+    gamePlayers: Int,
+    gameDescription: String?,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small)
+            .clip(RoundedCornerShape(SpSpacing.CardCornerRadius))
+            .background(SpColor.Card)
+            .padding(SpSpacing.Medium)
+            .semantics {
+                contentDescription = "Game information"
+            },
+    ) {
+        var hasRow = false
+
+        if (!gameDeveloper.isNullOrEmpty()) {
+            MetadataRow(label = "Developer", value = gameDeveloper)
+            hasRow = true
+        }
+
+        if (!gamePublisher.isNullOrEmpty()) {
+            if (hasRow) Spacer(Modifier.height(SpSpacing.XSmall))
+            MetadataRow(label = "Publisher", value = gamePublisher)
+            hasRow = true
+        }
+
+        if (!gameReleaseDate.isNullOrEmpty()) {
+            if (hasRow) Spacer(Modifier.height(SpSpacing.XSmall))
+            MetadataRow(label = "Released", value = gameReleaseDate)
+            hasRow = true
+        }
+
+        if (!gameGenre.isNullOrEmpty()) {
+            if (hasRow) Spacer(Modifier.height(SpSpacing.XSmall))
+            MetadataRow(label = "Genre", value = gameGenre)
+            hasRow = true
+        }
+
+        if (gamePlayers > 0) {
+            if (hasRow) Spacer(Modifier.height(SpSpacing.XSmall))
+            val playersText = if (gamePlayers == 1) "1 Player" else "1-$gamePlayers Players"
+            MetadataRow(label = "Players", value = playersText)
+            hasRow = true
+        }
+
+        if (gameRating > 0.0) {
+            if (hasRow) Spacer(Modifier.height(SpSpacing.XSmall))
+            RatingRow(rating = gameRating)
+            hasRow = true
+        }
+
+        if (!gameDescription.isNullOrEmpty()) {
+            if (hasRow) {
+                Spacer(Modifier.height(SpSpacing.Small))
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(1.dp)
+                        .background(SpColor.Divider),
+                )
+                Spacer(Modifier.height(SpSpacing.Small))
+            }
+            Text(
+                text = gameDescription,
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundSecondary,
+                maxLines = 4,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+    }
+}
+
+/**
+ * A single metadata row with a label on the left and value on the right.
+ */
+@Composable
+private fun MetadataRow(label: String, value: String) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = label,
+            style = SpTypography.LabelMedium,
+            color = SpColor.OnBackgroundTertiary,
+        )
+        Spacer(Modifier.width(SpSpacing.Small))
+        Text(
+            text = value,
+            style = SpTypography.BodyMedium,
+            color = SpColor.OnBackground,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            textAlign = TextAlign.End,
+            modifier = Modifier.weight(1f),
         )
     }
 }
 
 /**
- * Fallback content when no hero artwork is available.
- * Shows a subtle console gradient background with the game title centered.
+ * Rating row showing a star character followed by the numeric rating.
  */
 @Composable
-private fun FallbackArtContent(
-    gameTitle: String,
-    timeText: String,
-    consoleId: String,
-    consoleColorTheme: String?,
-) {
-    val (gradientFrom, gradientTo) = getConsoleGradient(consoleId, consoleColorTheme)
-
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(
-                Brush.verticalGradient(
-                    colors = listOf(
-                        gradientFrom.copy(alpha = 0.15f),
-                        SpColor.Background,
-                    ),
-                )
-            )
-            .semantics {
-                contentDescription = "Art display: $gameTitle (no artwork)"
-            },
-        contentAlignment = Alignment.Center,
+private fun RatingRow(rating: Double) {
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
     ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(SpSpacing.Large),
-            horizontalAlignment = Alignment.CenterHorizontally,
-            verticalArrangement = Arrangement.Center,
-        ) {
+        Text(
+            text = "Rating",
+            style = SpTypography.LabelMedium,
+            color = SpColor.OnBackgroundTertiary,
+        )
+        Row {
             Text(
-                text = gameTitle,
-                style = SpTypography.TitleLarge,
+                text = "\u2605 ",
+                style = SpTypography.BodyMedium,
+                color = SpColor.Rating,
+            )
+            Text(
+                text = "%.1f".format(rating),
+                style = SpTypography.BodyMedium,
                 color = SpColor.OnBackground,
-                textAlign = TextAlign.Center,
-                maxLines = 3,
-                overflow = TextOverflow.Ellipsis,
             )
-            Text(
-                text = timeText,
-                style = SpTypography.HeadlineSmall,
-                color = SpColor.OnBackgroundSecondary,
-                textAlign = TextAlign.Center,
-            )
-            if (consoleId.isNotEmpty()) {
-                Text(
-                    text = consoleId.uppercase(),
-                    style = SpTypography.LabelMedium,
-                    color = SpColor.OnBackgroundTertiary,
-                    textAlign = TextAlign.Center,
-                )
-            }
         }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryControlsPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryControlsPage.kt
@@ -1,0 +1,127 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.LibretroController
+
+/**
+ * Controls page for the secondary screen companion.
+ *
+ * Shows a P1/P2 port selector toggle above the platform touch controls,
+ * allowing the user to choose which player port the on-screen buttons target.
+ */
+@Composable
+fun SecondaryControlsPage(
+    controller: LibretroController,
+    touchControlPort: Int,
+    onSelectPort: (Int) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        // Port selector toggle row
+        PortSelectorRow(
+            selectedPort = touchControlPort,
+            onSelectPort = onSelectPort,
+        )
+
+        // Touch controls filling remaining space
+        PlatformTouchControls(
+            controller = controller,
+            modifier = Modifier.weight(1f),
+            port = touchControlPort,
+        )
+    }
+}
+
+/**
+ * Segmented button row for selecting the touch control port (P1 / P2).
+ */
+@Composable
+private fun PortSelectorRow(
+    selectedPort: Int,
+    onSelectPort: (Int) -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .padding(vertical = SpSpacing.Small)
+            .semantics {
+                contentDescription = "Control port: Player ${selectedPort + 1}"
+            },
+        horizontalArrangement = Arrangement.Center,
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        PortPillButton(
+            label = "P1",
+            port = 0,
+            isSelected = selectedPort == 0,
+            onSelect = onSelectPort,
+        )
+
+        Spacer(Modifier.width(SpSpacing.Small))
+
+        PortPillButton(
+            label = "P2",
+            port = 1,
+            isSelected = selectedPort == 1,
+            onSelect = onSelectPort,
+        )
+    }
+}
+
+/**
+ * A small pill-shaped button for port selection.
+ */
+@Composable
+private fun PortPillButton(
+    label: String,
+    port: Int,
+    isSelected: Boolean,
+    onSelect: (Int) -> Unit,
+) {
+    val backgroundColor = if (isSelected) SpColor.Primary else SpColor.SurfaceVariant
+    val textColor = if (isSelected) SpColor.OnBackground else SpColor.OnBackgroundSecondary
+    val playerNumber = port + 1
+
+    Box(
+        modifier = Modifier
+            .defaultMinSize(minHeight = 44.dp)
+            .clip(RoundedCornerShape(SpSpacing.Small))
+            .background(backgroundColor)
+            .clickable { onSelect(port) }
+            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small)
+            .semantics {
+                contentDescription = "Player $playerNumber controls"
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = label,
+            style = SpTypography.LabelMedium,
+            color = textColor,
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
@@ -195,11 +195,22 @@ fun SecondaryScreenContent(
                                 sessionElapsedSeconds = state.sessionElapsedSeconds,
                                 consoleId = state.consoleId,
                                 consoleColorTheme = state.consoleColorTheme,
+                                gameDescription = state.gameDescription,
+                                gameDeveloper = state.gameDeveloper,
+                                gamePublisher = state.gamePublisher,
+                                gameReleaseDate = state.gameReleaseDate,
+                                gameGenre = state.gameGenre,
+                                gameRating = state.gameRating,
+                                gamePlayers = state.gamePlayers,
                             )
                         }
                         PAGE_CONTROLS -> {
-                            PlatformTouchControls(
+                            SecondaryControlsPage(
                                 controller = controller,
+                                touchControlPort = state.touchControlPort,
+                                onSelectPort = { port ->
+                                    viewModel.onIntent(EmulationIntent.SelectTouchControlPort(port))
+                                },
                             )
                         }
                         PAGE_DASHBOARD -> {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -220,6 +220,9 @@ class EmulationViewModel(
 
             // Secondary screen toast
             EmulationIntent.ClearSecondaryToast -> _state.update { it.copy(secondaryToast = null) }
+
+            // Secondary screen touch control port
+            is EmulationIntent.SelectTouchControlPort -> _state.update { it.copy(touchControlPort = intent.port.coerceIn(0, 1)) }
         }
     }
 
@@ -264,6 +267,7 @@ class EmulationViewModel(
                 supportsSaveStates = true,
                 isHwRenderEnabled = false,
                 secondaryToast = null,
+                touchControlPort = 0,
             )
         }
 
@@ -298,6 +302,13 @@ class EmulationViewModel(
                             gameTitle = detail.game.title,
                             consoleId = detail.game.consoleId,
                             heroUrl = detail.game.heroUrl,
+                            gameDescription = detail.game.description,
+                            gameDeveloper = detail.game.developer,
+                            gamePublisher = detail.game.publisher,
+                            gameReleaseDate = detail.game.releaseDate,
+                            gameGenre = detail.game.genre,
+                            gameRating = detail.game.rating,
+                            gamePlayers = detail.game.players,
                         )
                     }
                 }
@@ -678,6 +689,13 @@ class EmulationViewModel(
                         sessionId = null,
                         consoleColorTheme = null,
                         heroUrl = null,
+                        gameDescription = null,
+                        gameDeveloper = null,
+                        gamePublisher = null,
+                        gameReleaseDate = null,
+                        gameGenre = null,
+                        gameRating = 0.0,
+                        gamePlayers = 0,
                         showCoreMismatchDialog = false,
                         coreMismatchSaveCoreName = "",
                         coreMismatchCurrentCoreName = "",
@@ -692,6 +710,7 @@ class EmulationViewModel(
                         sessionAchievementUnlocks = emptyList(),
                         achievementEvent = null,
                         secondaryToast = null,
+                        touchControlPort = 0,
                     )
                 }
                 saveManager.currentSessionId = null

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformTouchControls.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/feature/ingame/PlatformTouchControls.desktop.kt
@@ -8,6 +8,7 @@ import com.spela.player.presentation.viewmodel.LibretroController
 actual fun PlatformTouchControls(
     controller: LibretroController,
     modifier: Modifier,
+    port: Int,
 ) {
     // No-op on desktop: keyboard and physical controller input is used instead.
 }


### PR DESCRIPTION
## Summary
- **Player 2 Controls Toggle**: P1/P2 pill selector on the controls page lets touch controls target port 0 or 1, with proper port propagation through TouchGamepadOverlay
- **Game Info Card**: Art page redesigned with scrollable layout showing game metadata (developer, publisher, release year, genre, rating, players, description) below hero artwork
- Phase 5 of the second screen companion — all 5 phases now complete

## Test plan
- [x] 478 desktop E2E tests pass (15 new: 5 controls + 10 art page)
- [x] Integration tests verify touchControlPort resets on start/stop game
- [x] Integration test verifies art page metadata wiring via full harness
- [x] Edge cases covered: empty string metadata, hero/no-hero branches, timer formatting
- [ ] Manual test on AYN Thor: verify P2 toggle sends input to port 1
- [ ] Manual test: verify game info card renders for scraped games with metadata