### PR TITLE
fix: remove flaky choco cmake install from Windows release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -185,8 +185,7 @@ jobs:
           Start-Process -FilePath .\vulkan_sdk.exe -ArgumentList "--accept-licenses --default-answer --confirm-command install" -Wait
           echo "VULKAN_SDK=C:\VulkanSDK\$ver" >> $env:GITHUB_ENV
           echo "C:\VulkanSDK\$ver\Bin" >> $env:GITHUB_PATH
-          choco install ninja cmake --installargs 'ADD_CMAKE_TO_PATH=System' -y
-          echo "C:\Program Files\CMake\bin" >> $env:GITHUB_PATH
+          choco install ninja -y
       - name: Cache Gradle
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
## Summary
- Remove `cmake` from `choco install` in Windows release build — `windows-latest` runners already have CMake pre-installed via Visual Studio
- The Chocolatey cmake package intermittently fails to resolve, breaking the v0.0.56 release

## Test plan
- [x] Re-run of v0.0.56 release will validate the fix