### PR TITLE
fix: bust browser cache for session screenshots

### DIFF
--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 )
 
 // Storage manages file operations for ROMs, saves, cores, and images.
@@ -492,8 +493,13 @@ func (s *Storage) WriteSessionSRAM(sessionID uint, filename string, data io.Read
 }
 
 // WriteSessionScreenshot stores a session screenshot image.
+// A Unix timestamp is embedded in the filename so each upload produces a unique
+// URL, preventing browsers from serving a stale cached version.
 func (s *Storage) WriteSessionScreenshot(sessionID uint, filename string, data io.Reader) (string, error) {
-	subpath := fmt.Sprintf("save-screenshots/sessions/session_%d/%s", sessionID, sanitizeFilename(filename))
+	ext := filepath.Ext(filename)
+	base := strings.TrimSuffix(sanitizeFilename(filename), ext)
+	timestamped := fmt.Sprintf("%s_%d%s", base, time.Now().Unix(), ext)
+	subpath := fmt.Sprintf("save-screenshots/sessions/session_%d/%s", sessionID, timestamped)
 	return s.WriteImage(subpath, data)
 }
 


### PR DESCRIPTION
## Summary
- Session screenshots always used the same filename (`screenshot.png`), causing browsers to serve stale cached images after a new save
- Each upload now embeds a Unix timestamp in the filename (e.g. `screenshot_1710023400.png`) so the URL changes on every save

## Test plan
- [x] Go tests pass (`go test ./...`)
- [ ] Manual: play a game, exit, verify screenshot updates immediately on game detail page