### PR TITLE
feat: Explore page — Phase 1: hero carousel + curated shelves

### DIFF
--- a/design-proposals/explore-page-phase1-stories.md
+++ b/design-proposals/explore-page-phase1-stories.md
@@ -1,0 +1,317 @@
+# Explore Page -- Phase 1 User Stories
+
+## Context
+
+Phase 1 introduces a new "Explore" page alongside the existing Dashboard. The Explore page is a visually rich, art-forward discovery surface that highlights the best games in the library. It is fully algorithmic -- no admin curation required. All data is derived from existing metadata (IGDB ratings, SteamGridDB artwork, play history, library creation dates).
+
+This document defines user stories and acceptance criteria from the user's perspective. It does not prescribe implementation details.
+
+---
+
+## Story 1: Navigate to the Explore page
+
+**As a** logged-in user,
+**I want to** find and navigate to an Explore page,
+**so that** I can discover games beyond my personal play history.
+
+### Acceptance Criteria
+
+#### Web
+- A new "Explore" link appears in the sidebar navigation, between "Dashboard" and "Library".
+- Clicking it navigates to `/explore`.
+- The link shows an appropriate icon and the label "Explore".
+- The Explore link is visually distinct as a top-level navigation item (same prominence as Dashboard).
+- The sidebar correctly highlights "Explore" when the user is on the Explore page.
+
+#### Player App
+- A new "Explore" tab appears in the bottom navigation bar, between "Home" and "Consoles".
+- Tapping it navigates to the Explore screen.
+- The tab shows an appropriate icon and the label "Explore".
+- The tab is highlighted when the Explore screen is active.
+- Controller navigation (L1/R1 tab cycling) includes the new Explore tab.
+
+#### Both
+- The existing Dashboard/Home page is unchanged and remains accessible.
+- Navigation between Dashboard and Explore is instant (no full page reload).
+
+---
+
+## Story 2: Hero carousel -- featured games with hero art
+
+**As a** user viewing the Explore page,
+**I want to** see a visually stunning full-width carousel of featured games,
+**so that** I am drawn to high-quality games I might want to play.
+
+### Acceptance Criteria
+
+#### Visual presentation
+- The hero carousel is the first element on the Explore page, taking up significant visual space.
+- Each slide displays:
+  - A full-width hero banner image (the SteamGridDB hero art for the game).
+  - The game's logo image overlaid in the bottom-left area (if available; fall back to the game title as text).
+  - A console badge showing which platform the game is for.
+  - The IGDB rating displayed as a visual indicator.
+  - The game's genre(s) displayed as small chips/tags.
+  - A primary action button to navigate to the game's detail page.
+- The hero image fills the full width of the content area without letterboxing.
+
+#### Carousel behavior
+- The carousel auto-rotates to the next slide every 8 seconds.
+- On web: auto-rotation pauses when the user hovers over the carousel, and resumes when the mouse leaves.
+- On player app: auto-rotation pauses when the user interacts with the carousel (swipe/focus), and resumes after a delay.
+- The user can manually navigate between slides:
+  - Web: left/right arrow buttons on the edges of the carousel, plus navigation dots at the bottom.
+  - Player app: horizontal swipe gesture, plus navigation dots.
+- Transitions between slides are smooth crossfades (not abrupt cuts).
+- The carousel wraps around: advancing past the last slide returns to the first.
+
+#### Content selection
+- The carousel displays between 3 and 8 featured games.
+- Featured games are selected automatically: the highest-rated games (by IGDB rating) that have both hero art and are in the user's library.
+- If fewer than 3 games have hero art, the carousel still renders with however many are available (even 1).
+- Each featured game appears at most once in the carousel.
+
+#### Edge case: No hero art available
+- If zero games in the library have hero art, the hero carousel section is not displayed at all.
+- The page begins with the first shelf row instead.
+- No error message or broken layout is shown.
+
+---
+
+## Story 3: "Top Rated" shelf row
+
+**As a** user viewing the Explore page,
+**I want to** see a horizontal row of the highest-rated games across all consoles,
+**so that** I can discover critically acclaimed games I might have overlooked.
+
+### Acceptance Criteria
+
+- A section titled "Top Rated" appears below the hero carousel.
+- The section displays up to 20 games in a horizontally scrollable row.
+- Games are sorted by IGDB rating, highest first, across all consoles in the library.
+- Each game card in the row shows:
+  - Cover art.
+  - Game title.
+  - Console badge (so the user knows which platform it belongs to).
+  - Rating indicator.
+- Tapping/clicking a game card navigates to that game's detail page.
+
+#### Web-specific
+- Left and right scroll arrow buttons appear at the edges of the row when there are more games than fit on screen.
+- Scrolling is smooth (not jump-by-page).
+
+#### Player app-specific
+- The row is a horizontal scrollable list.
+- Focus/selection state is clearly visible on the active card.
+
+---
+
+## Story 4: "Recently Added" shelf row
+
+**As a** user viewing the Explore page,
+**I want to** see a row of the most recently added games,
+**so that** I can quickly find new additions to the library.
+
+### Acceptance Criteria
+
+- A section titled "Recently Added" appears on the Explore page.
+- The section displays up to 20 games in a horizontally scrollable row.
+- Games are sorted by the date they were added to the library (newest first).
+- Each game card shows cover art, title, console badge, and rating.
+- Tapping/clicking a game card navigates to that game's detail page.
+- The same scroll/navigation affordances as the Top Rated row apply (arrows on web, swipe on player).
+
+---
+
+## Story 5: "Hidden Gems" shelf row
+
+**As a** user viewing the Explore page,
+**I want to** see a row of highly rated games that few people on the server have played,
+**so that** I can discover underappreciated games.
+
+### Acceptance Criteria
+
+- A section titled "Hidden Gems" appears on the Explore page.
+- The section displays up to 20 games in a horizontally scrollable row.
+- A game qualifies as a "hidden gem" if it has a high IGDB rating but low total play count across all users on the server.
+- Games that no one has played are included (zero play count is valid for a hidden gem).
+- Each game card shows cover art, title, console badge, and rating.
+- Tapping/clicking a game card navigates to that game's detail page.
+
+#### Edge case: New server with no play history
+- If no one has played any games yet, all highly rated games qualify. The row still appears, showing the highest rated games (effectively identical to Top Rated in this degenerate case, which is acceptable).
+
+#### Edge case: Server with very few games
+- If the library has fewer than 5 games total, this section is hidden (it adds no value when the library is tiny).
+
+---
+
+## Story 6: "Most Played on Your Server" shelf row
+
+**As a** user viewing the Explore page,
+**I want to** see which games are most popular on this server,
+**so that** I can see what the community enjoys and find games with social proof.
+
+### Acceptance Criteria
+
+- A section titled "Most Played on Your Server" appears on the Explore page.
+- The section displays up to 20 games in a horizontally scrollable row.
+- Games are sorted by total play time across all users on the server, highest first.
+- Each game card shows cover art, title, console badge, and rating.
+- Tapping/clicking a game card navigates to that game's detail page.
+
+#### Edge case: No play history on server
+- If no games have any play history, this section is hidden entirely.
+- No empty state message is shown; the section simply does not appear.
+
+---
+
+## Story 7: Explore page layout and ordering
+
+**As a** user viewing the Explore page,
+**I want** the sections to be arranged in a logical, visually appealing order,
+**so that** the page feels curated and intentional.
+
+### Acceptance Criteria
+
+- The page layout from top to bottom is:
+  1. Hero carousel (if any games have hero art).
+  2. "Top Rated" shelf.
+  3. "Recently Added" shelf.
+  4. "Hidden Gems" shelf (if applicable).
+  5. "Most Played on Your Server" shelf (if any play history exists).
+- Sections that have no data are omitted entirely (no empty placeholders, no "No games found" messages within the page flow).
+- The page scrolls vertically through all sections.
+- On web: the page is responsive and works at all viewport widths (mobile through ultrawide).
+- On player app: the page renders correctly in both portrait and landscape orientations.
+
+---
+
+## Story 8: Loading states
+
+**As a** user navigating to the Explore page,
+**I want to** see loading indicators while data is being fetched,
+**so that** I know the page is working and not broken.
+
+### Acceptance Criteria
+
+- While the hero carousel data is loading, a skeleton placeholder of the appropriate size is shown (full-width, same height as the carousel would be).
+- While shelf rows are loading, skeleton card placeholders are shown in a horizontal row matching the expected card size and count.
+- Skeleton states animate subtly (shimmer or pulse) to indicate loading is in progress.
+- The page does not show a single full-page spinner. Each section loads its own skeleton independently.
+- If one section loads faster than another, it renders immediately while others continue showing skeletons.
+
+---
+
+## Story 9: Empty library state
+
+**As a** user whose server has no games in the library,
+**I want to** see a helpful message on the Explore page,
+**so that** I understand why the page is empty and what to do about it.
+
+### Acceptance Criteria
+
+- If the library contains zero games, the Explore page shows a single centered empty state:
+  - A relevant icon or illustration.
+  - A title like "Nothing to explore yet".
+  - A description explaining that games need to be added to the library first.
+  - For admin users: a link or button to the library scan page.
+  - For non-admin users: a message suggesting they contact an admin.
+- No hero carousel, no shelf rows, no skeleton states -- just the empty state.
+
+---
+
+## Story 10: Game cards show console badge across consoles
+
+**As a** user browsing cross-console shelf rows (Top Rated, Hidden Gems, etc.),
+**I want to** see which console each game belongs to,
+**so that** I can tell at a glance whether a game is for SNES, GBA, PS1, etc.
+
+### Acceptance Criteria
+
+- Every game card in every Explore shelf row includes a console badge.
+- The console badge displays the console abbreviation (e.g., "SNES", "GBA", "PS1") and/or the console icon.
+- The badge uses the console's color theme for visual distinction.
+- The badge is consistently positioned on all game cards (same location, same size).
+- The badge does not obscure the cover art in a way that makes the game unrecognizable.
+
+---
+
+## Story 11: Clicking a featured game navigates to its detail page
+
+**As a** user who sees an interesting game in the hero carousel or a shelf row,
+**I want to** click/tap on it and arrive at the game's full detail page,
+**so that** I can learn more about it, see screenshots, and start playing.
+
+### Acceptance Criteria
+
+- Clicking/tapping a game card in any shelf row navigates to `/games/{id}` (web) or the GameDetail screen (player app).
+- Clicking/tapping the action button in the hero carousel navigates to the game's detail page.
+- Navigation is smooth (no full page reload on web; normal screen transition on player app).
+- The back button/gesture returns the user to the Explore page, scrolled to the same position they left.
+
+---
+
+## Story 12: Shelf row game cards show favorite and play-later status
+
+**As a** user browsing shelf rows on the Explore page,
+**I want to** see which games I have already favorited or added to my Play Later queue,
+**so that** I can quickly identify games I have already marked for later.
+
+### Acceptance Criteria
+
+- Game cards in shelf rows reflect the user's favorite status (heart icon or similar indicator, consistent with how favorites are shown elsewhere in the app).
+- Game cards in shelf rows reflect the user's Play Later status (clock/bookmark icon or similar indicator, consistent with the rest of the app).
+- On web: hovering over a game card reveals quick actions to toggle favorite and Play Later status (consistent with game card behavior on other pages).
+- On player app: the favorite/Play Later indicators are visible on the card without requiring interaction.
+
+---
+
+## Story 13: Hero carousel handles missing logo gracefully
+
+**As a** user viewing a featured game in the hero carousel,
+**I want** the slide to look good even if the game's logo image is missing,
+**so that** the page never looks broken.
+
+### Acceptance Criteria
+
+- If a featured game has hero art but no logo image:
+  - The game's title is displayed as styled text in the position where the logo would be.
+  - The text is clearly readable against the hero art background (text shadow, gradient overlay, or similar treatment).
+- If a featured game has both hero art and a logo image, the logo image is used (no text fallback).
+- There is no broken image icon or layout shift in either case.
+
+---
+
+## Story 14: Explore page data is cached and works when external APIs are down
+
+**As a** a user,
+**I want** the Explore page to load quickly and work reliably,
+**so that** I am never blocked from discovering games.
+
+### Acceptance Criteria
+
+- All data powering the Explore page (ratings, artwork URLs, play counts) comes from the server's local database, not from live external API calls.
+- The Explore page loads successfully even if IGDB and SteamGridDB are completely unreachable.
+- If artwork images fail to load (CDN down, URL expired), the game card degrades gracefully:
+  - A placeholder or the cover art is shown instead of a broken image.
+  - The card remains interactive and navigable.
+- Response times for the Explore page API calls are fast enough that the user does not perceive a significant delay (comparable to loading the Dashboard).
+
+---
+
+## Non-functional requirements
+
+### Performance
+- The Explore page should render its above-the-fold content (hero carousel + first visible shelf row) within 2 seconds of navigation on a typical connection.
+- Images below the fold should lazy-load as the user scrolls.
+
+### Accessibility
+- All interactive elements (carousel controls, game cards, navigation dots) are keyboard-accessible on web.
+- Carousel auto-rotation respects `prefers-reduced-motion`: if the user has this setting enabled, auto-rotation is disabled by default.
+- All images have appropriate alt text (game title for cover art, "Hero art for [game title]" for hero banners).
+- Navigation dots and arrow buttons have accessible labels.
+
+### Consistency
+- Game cards on the Explore page use the same shared game card component used on the Dashboard, Console Detail, and other pages. No one-off card designs.
+- The visual language (spacing, typography, colors) matches the rest of the application.

--- a/design-proposals/explore-page-plan.md
+++ b/design-proposals/explore-page-plan.md
@@ -1,0 +1,590 @@
+# Explore Page — Implementation Plan
+
+## Vision
+
+Transform Spela from a "browse by console" library into a Netflix/Spotify-style discovery
+experience that scales to tens of thousands of games. Beautiful, personalized, and social.
+
+## Principles
+
+- **Each phase ships a working feature** — no half-built scaffolding
+- **One PR per phase** — reviewable, testable, revertable
+- **Art-first design** — leverage SteamGridDB hero banners, logos, and IGDB artworks everywhere
+- **Progressive enrichment** — early phases use existing data, later phases fetch new IGDB data
+- **Both web and player app** — every phase covers both platforms
+
+---
+
+## Phase 1: Foundation — The Explore Page Shell + Hero Carousel
+
+**Goal:** New "Explore" route/tab with a stunning hero carousel and basic curated rows.
+
+### Backend
+- [ ] New endpoint: `GET /api/explore/featured` — returns 5-8 featured games with hero art
+  - Initially: highest-rated games that have SteamGridDB hero art + logo
+  - Later: admin-curated featured items
+- [ ] New endpoint: `GET /api/explore/rows` — returns multiple curated rows in one call:
+  - "Top Rated" (cross-console, top 20 by IGDB rating)
+  - "Recently Added" (newest games in library by creation date)
+  - "Hidden Gems" (high IGDB rating + low play count across all server users)
+  - "Most Played on Your Server" (highest total play time across users)
+- [ ] Each row returns games with cover art, hero art, logo, console badge, rating
+
+### Web Frontend
+- [ ] New route: `/explore` — add to main navigation
+- [ ] Hero carousel component:
+  - Full-width SteamGridDB hero banner (1920x620)
+  - Game logo overlaid (bottom-left)
+  - Console badge, rating, genre chips
+  - "Play" / "Add to Queue" action buttons
+  - Auto-rotate every 8 seconds, pause on hover
+  - Smooth crossfade transitions
+  - Navigation dots + arrow buttons
+- [ ] Horizontal scrollable shelf component (reusable for all rows):
+  - Game cards with cover art, title, console badge, rating
+  - Hover: reveal hero art background, quick actions (favorite, queue)
+  - Scroll arrows on edges, smooth scroll
+- [ ] Page layout: Hero → shelf rows stacked vertically
+- [ ] Responsive: works at all viewport widths
+
+### Player App
+- [ ] New "Explore" tab in bottom navigation (or replace/augment existing home)
+- [ ] Hero carousel composable with SteamGridDB hero art + logo overlay
+- [ ] Horizontal LazyRow shelves with game cards
+- [ ] Smooth transitions and loading skeletons
+
+### Tests
+- [ ] Backend: unit tests for explore endpoints, hidden gems algorithm, row assembly
+- [ ] Web: E2E test — navigate to Explore, verify carousel renders, rows display games
+- [ ] Player: desktop E2E test — Explore tab renders, carousel shows, shelves scroll
+
+---
+
+## Phase 2: IGDB Enrichment — Themes, Keywords, Franchises
+
+**Goal:** Fetch and store richer IGDB metadata to power discovery features.
+
+### Backend
+- [ ] Extend IGDB client with new methods:
+  - `GetGameFull(igdbID) → themes, keywords, franchises, collections, player_perspectives, artworks`
+  - `GetCollection(collectionID) → name, games[]`
+  - `GetFranchise(franchiseID) → name, games[]`
+- [ ] New DB models:
+  - `GameTheme` (game_id, igdb_theme_id, name) — many-to-many
+  - `GameKeyword` (game_id, igdb_keyword_id, name) — many-to-many
+  - `GamePlayerPerspective` (game_id, perspective_name) — e.g., "Top-down", "First-person"
+  - `GameFranchise` (game_id, igdb_franchise_id, franchise_name)
+  - `GameCollection` rename consideration — IGDB "collections" = game series (e.g., "Super Mario"),
+    vs. our existing `GameCollection` = user-created collections. Use `GameSeries` for IGDB data.
+  - `GameSeries` (igdb_collection_id, name) + `GameSeriesEntry` (series_id, game_id, igdb_game_id)
+  - `GameArtworkImage` (game_id, igdb_image_id, url, width, height) — IGDB promotional art
+- [ ] Extend scraper to fetch themes, keywords, perspectives, franchise, collection, artworks
+  during game scraping (single enriched IGDB query per game)
+- [ ] Backfill endpoint: `POST /api/admin/enrich-metadata` — re-scrape all games for new fields
+- [ ] New API endpoints:
+  - `GET /api/themes` — list all themes with game counts
+  - `GET /api/themes/:id/games` — games for a theme
+  - `GET /api/keywords` — list popular keywords with game counts
+  - `GET /api/keywords/:id/games` — games for a keyword
+  - `GET /api/series` — list all game series in library
+  - `GET /api/series/:id` — series detail with all games (cross-console)
+  - `GET /api/franchises` — list all franchises
+  - `GET /api/franchises/:id` — franchise detail with all games
+- [ ] Extend `GET /api/games` filters: `theme`, `keyword`, `perspective` params
+
+### Web + Player
+- [ ] No new UI yet — this phase is data enrichment only
+- [ ] Verify new data appears correctly in API responses
+
+### Tests
+- [ ] Backend: unit tests for new IGDB client methods, enrichment scraping, new endpoints
+- [ ] Backend: test backfill endpoint with mock IGDB responses
+
+---
+
+## Phase 3: Theme & Keyword Browsing
+
+**Goal:** Browse games by theme (Sci-Fi, Horror, Fantasy) and keyword (time travel, zombies).
+
+### Backend
+- [ ] `GET /api/explore/themes` — top themes with representative hero art (pick highest-rated game
+  per theme that has hero art)
+- [ ] `GET /api/explore/keywords/popular` — popular keywords ranked by game count
+
+### Web Frontend
+- [ ] Theme grid section on Explore page:
+  - Visual cards: theme name over hero art from the best game in that theme
+  - E.g., "Sci-Fi" card shows a hero banner from a top sci-fi game with the theme name overlaid
+  - Tap → theme detail page with all games, filterable and sortable
+- [ ] Keyword tag cloud or keyword chips section:
+  - Tappable keyword chips: "Time Travel", "Post-Apocalyptic", "Steampunk"
+  - Tap → filtered game list
+- [ ] Theme detail page: `/explore/themes/:id`
+  - Hero banner from top game in theme
+  - Grid of all games in theme with cover art
+  - Sort: rating, release date, title
+
+### Player App
+- [ ] Theme grid section on Explore screen
+- [ ] Keyword chips row (horizontal scroll)
+- [ ] Theme detail screen with game grid
+
+### Tests
+- [ ] Web: E2E test — browse themes, tap theme, see correct games
+- [ ] Player: desktop E2E test — theme grid renders, navigation works
+
+---
+
+## Phase 4: Franchise & Series Pages
+
+**Goal:** Cross-console franchise browsing — "The Complete Zelda", "Every Final Fantasy".
+
+### Backend
+- [ ] `GET /api/series/:id` already exists from Phase 2
+- [ ] Extend to return: timeline data (release dates sorted), console grouping, games in library
+  vs. not in library, hero art for header
+- [ ] `GET /api/explore/series/featured` — series with most games in library, for Explore page shelf
+
+### Web Frontend
+- [ ] "Franchise Collections" shelf on Explore page:
+  - Horizontal row of franchise cards (e.g., "Mario — 12 games across 5 consoles")
+  - Card shows montage or best hero art
+- [ ] Franchise detail page: `/explore/series/:id`
+  - Hero banner (best game's SteamGridDB art)
+  - Visual timeline: games ordered by release date
+  - Each game shows: cover art, title, console badge, release year, rating
+  - Games in your library: full color. Not in library: dimmed/greyed.
+  - "You own 8 of 15 games" progress indicator
+- [ ] Link from game detail page: "Part of the [Franchise] series" → links to franchise page
+
+### Player App
+- [ ] Franchise shelf on Explore screen
+- [ ] Franchise detail screen with timeline view
+- [ ] "Part of [Series]" link on game detail screen
+
+### Tests
+- [ ] Web: E2E test — franchise shelf visible, tap into franchise, timeline renders correctly
+- [ ] Player: desktop E2E test — franchise screen renders, games displayed
+
+---
+
+## Phase 5: Mood Picker & Contextual Entry Points
+
+**Goal:** "What are you in the mood for?" quick-start cards.
+
+### Backend
+- [ ] `GET /api/explore/mood/:mood` — returns game list for each mood
+- [ ] Mood definitions (server-side mapping):
+  - "chill" → themes: fantasy, comedy; genres: puzzle, simulation; keywords: relaxing
+  - "challenge" → keywords: difficult, hardcore; low achievement completion rates
+  - "nostalgia" → user's most-played + era-matched games
+  - "something-new" → unplayed games in library, sorted by rating
+  - "quick" → games with avg session < 15 min (from play history)
+  - "together" → game_modes: multiplayer, co-op, split-screen
+  - "surprise" → random high-rated game
+
+### Web Frontend
+- [ ] Mood picker section on Explore page (below hero carousel):
+  - Large, visually distinct cards with icons/illustrations
+  - Each card has evocative background (subtle hero art collage)
+  - Tap → dedicated results page or filtered game grid
+- [ ] "Surprise Me" button with slot-machine animation:
+  - Spins through cover art, lands on one
+  - "Play Now" + "Try Another" buttons
+
+### Player App
+- [ ] Mood picker cards (horizontal scroll or 2-column grid)
+- [ ] Surprise Me with animation
+- [ ] Quick session: "15 minutes" → launch directly into a short-session game
+
+### Tests
+- [ ] Backend: unit test mood-to-filter mapping, each mood returns appropriate games
+- [ ] Web: E2E test — mood cards visible, tap each mood, results make sense
+- [ ] Player: desktop E2E test — mood picker renders, surprise me works
+
+---
+
+## Phase 6: Personalized Recommendations — "For You"
+
+**Goal:** Personalized rows based on play history, favorites, and ratings.
+
+### Backend
+- [ ] `GET /api/explore/for-you` — returns personalized rows:
+  - "Because you played [Game]" — IGDB similar games (already have this data)
+  - "More [Genre] for you" — top-rated unplayed games in user's most-played genre
+  - "Continue your [Developer] marathon" — if 3+ games from same developer played
+  - "Your unfinished business" — played < 30 min, abandoned > 7 days ago
+  - "Expand your horizons" — best games in genres user has never played
+- [ ] `GET /api/user/taste-profile` — genre/theme breakdown of user's play history
+  - Returns: `{ genres: [{ name: "RPG", percentage: 45, hoursPlayed: 120 }, ...], themes: [...] }`
+- [ ] Collaborative filtering: `GET /api/explore/players-like-you`
+  - Find users with most overlapping favorites, recommend their non-overlapping favorites
+  - Simple approach: Jaccard similarity on favorites sets
+
+### Web Frontend
+- [ ] "For You" section on Explore page with personalized rows
+- [ ] Each row labeled contextually: "Because you played Chrono Trigger" with that game's
+  cover art as the row icon
+- [ ] Taste profile visualization (optional — could be a separate "Profile" section):
+  - Pie/donut chart or bar chart of genre breakdown
+  - Tap genre segment → browse that genre
+- [ ] "Expand Your Horizons" callout: "You've never tried a racing game. Here are the best ones."
+
+### Player App
+- [ ] "For You" section on Explore screen with same personalized rows
+- [ ] Taste profile card on profile/stats screen
+- [ ] "Expand Your Horizons" nudge
+
+### Tests
+- [ ] Backend: unit tests for recommendation algorithms, taste profile calculation
+- [ ] Web: E2E test — for-you rows render, contextual labels correct
+- [ ] Player: desktop E2E test — personalized rows render with fake play history
+
+---
+
+## Phase 7: Developer & Publisher Spotlight Pages
+
+**Goal:** Tap any developer/publisher name → see their full catalog across all consoles.
+
+### Backend
+- [ ] `GET /api/developers` — list developers with game count, avg rating, consoles
+- [ ] `GET /api/developers/:name/games` — all games by developer, cross-console
+- [ ] `GET /api/publishers/:name/games` — all games by publisher
+- [ ] `GET /api/explore/developers/spotlight` — featured developer (rotating weekly or admin-picked)
+- [ ] Extend IGDB: optionally fetch company logos from `/companies` endpoint
+
+### Web Frontend
+- [ ] Developer detail page: `/explore/developers/:name`
+  - Header with developer name (+ logo if available)
+  - Stats: total games, avg rating, active years, consoles
+  - Timeline of releases
+  - Games grid sorted by rating
+  - "Best of [Developer]" shelf
+- [ ] Publisher detail page: same structure
+- [ ] "Developer Spotlight" section on Explore page:
+  - Featured studio with hero treatment
+  - "Studios That Defined [Console]" shelf per console showcase
+- [ ] Make all developer/publisher names clickable throughout the app
+
+### Player App
+- [ ] Developer detail screen
+- [ ] Developer spotlight section on Explore
+- [ ] Clickable developer/publisher names on game detail
+
+### Tests
+- [ ] Backend: unit tests for developer aggregation, spotlight selection
+- [ ] Web: E2E test — developer page renders, games listed correctly
+- [ ] Player: desktop E2E test — developer screen renders
+
+---
+
+## Phase 8: Console Showcase Pages
+
+**Goal:** Premium landing page per console with its color theme and rich content.
+
+### Backend
+- [ ] `GET /api/consoles/:id/showcase` — aggregated console data:
+  - Top-rated games (existing)
+  - Hidden gems
+  - Genre breakdown (game counts per genre for this console)
+  - Top developers for this console
+  - Recently played on this console (personal)
+  - Era info (launch year, generation)
+
+### Web Frontend
+- [ ] Console showcase page: `/explore/consoles/:id`
+  - Console color theme applied to page (existing color data)
+  - Hero carousel of top games for this console
+  - "Essentials" shelf — the must-plays
+  - "Hidden Gems" shelf
+  - Genre breakdown with visual cards
+  - "Studios That Defined This Console" section
+  - "Recently Played" personal shelf
+- [ ] Console quick-jump row on Explore page:
+  - Horizontal row of console icons/logos
+  - Tap → console showcase page
+
+### Player App
+- [ ] Console showcase screen (or enhanced console detail screen)
+- [ ] Console quick-jump on Explore screen
+
+### Tests
+- [ ] Web: E2E test — console showcase renders, shelves populated
+- [ ] Player: desktop E2E test — console showcase renders
+
+---
+
+## Phase 9: Visual Browsing — Gallery & Art Modes
+
+**Goal:** Discover games by how they look — screenshot gallery, box art wall, artwork showcase.
+
+### Backend
+- [ ] `GET /api/explore/screenshots` — paginated stream of screenshots with game metadata
+  - Filters: console, genre, theme
+- [ ] `GET /api/explore/artwork` — IGDB promotional artwork (from Phase 2 enrichment)
+- [ ] `GET /api/explore/covers` — dense cover art feed with minimal metadata
+
+### Web Frontend
+- [ ] Screenshot Gallery page: `/explore/gallery`
+  - Pinterest-style masonry grid of screenshots
+  - No titles visible initially — pure visual
+  - Hover: game title + console badge overlay
+  - Click: navigate to game detail
+  - Infinite scroll
+  - Filter bar: console, genre, theme
+- [ ] Box Art Wall: `/explore/covers`
+  - Dense grid of cover art thumbnails
+  - Zoom controls (small/medium/large)
+  - Click → game detail
+- [ ] Artwork Showcase section on Explore page:
+  - Curated row of the most beautiful IGDB promotional artwork
+  - Full-width art with game info overlay
+
+### Player App
+- [ ] Gallery mode as a section on Explore screen (or dedicated sub-screen)
+- [ ] Artwork showcase row
+
+### Tests
+- [ ] Web: E2E test — gallery renders, hover reveals info, click navigates
+- [ ] Player: desktop E2E test — gallery section renders
+
+---
+
+## Phase 10: Social & Community Discovery
+
+**Goal:** See what your server community is playing, trending games, community ratings.
+
+### Backend
+- [ ] `GET /api/explore/trending` — games with biggest play-count increase in last 7 days
+- [ ] `GET /api/explore/community-top` — highest user-rated games on server
+- [ ] `GET /api/explore/cult-classics` — high user rating but moderate IGDB rating
+- [ ] `GET /api/explore/recently-reviewed` — games with recent user reviews
+- [ ] `GET /api/explore/active-now` — games with active shared sessions or challenges
+
+### Web Frontend
+- [ ] "Trending on Your Server" shelf on Explore page
+  - Game cards with "played by X people this week" badge
+- [ ] "Community Favorites" shelf — distinct from IGDB ratings
+- [ ] "Cult Classics" shelf — "Your community rates these higher than the critics"
+- [ ] "Active Right Now" shelf — live sessions and challenges
+- [ ] "Recently Reviewed" shelf — latest user reviews
+
+### Player App
+- [ ] Same shelves on Explore screen
+- [ ] "Active Now" with join buttons for shared sessions
+
+### Tests
+- [ ] Backend: unit tests for trending algorithm, cult classics detection
+- [ ] Web: E2E test — social shelves render with seeded data
+- [ ] Player: desktop E2E test — social sections render
+
+---
+
+## Phase 11: Temporal Discovery
+
+**Goal:** "On This Day", "Best of [Year]", gaming anniversary features.
+
+### Backend
+- [ ] `GET /api/explore/on-this-day` — games released on today's date across all years
+- [ ] `GET /api/explore/best-of-year/:year` — top-rated games from a specific year
+- [ ] `GET /api/explore/your-anniversaries` — personal milestones ("1 year ago you played...")
+- [ ] `GET /api/explore/decades/:decade` — best games of a decade (80s, 90s, 00s)
+
+### Web Frontend
+- [ ] "On This Day in Gaming" shelf on Explore page
+  - "March 9: [games released on this date]"
+  - Day/month matching on release dates
+- [ ] "Best of [Year]" browsable section
+  - Year selector (slider or dropdown spanning 1985–2005)
+  - Grid of top games for selected year
+- [ ] "Your Gaming Anniversaries" personal row
+- [ ] "Decade Spotlight" section with era-appropriate styling
+
+### Player App
+- [ ] "On This Day" section on Explore screen
+- [ ] Year browser
+- [ ] Personal anniversaries
+
+### Tests
+- [ ] Backend: unit tests for on-this-day date matching, year filtering
+- [ ] Web: E2E test — on-this-day renders, year browser works
+- [ ] Player: desktop E2E test — temporal sections render
+
+---
+
+## Phase 12: Achievement & Challenge-Driven Discovery
+
+**Goal:** Discover games through achievements and challenges.
+
+### Backend
+- [ ] `GET /api/explore/easy-to-complete` — high achievement completion rates
+- [ ] `GET /api/explore/hardest-games` — low achievement completion rates
+- [ ] `GET /api/explore/almost-done` — user's games at 80%+ achievement completion
+- [ ] `GET /api/explore/fresh-challenges` — games with achievements user hasn't started
+- [ ] `GET /api/explore/active-challenges` — currently open challenges
+
+### Web Frontend
+- [ ] Achievement-driven shelves on Explore page
+- [ ] "Easy to 100%" and "Mount Everest" rows
+- [ ] Personal "Almost Done" and "Fresh Challenges" rows
+- [ ] Active challenges callout with join buttons
+
+### Player App
+- [ ] Same achievement shelves
+- [ ] Direct navigation to game + achievement tracking
+
+### Tests
+- [ ] Backend: unit tests for completion rate calculations
+- [ ] Web: E2E test — achievement rows render
+- [ ] Player: desktop E2E test — achievement sections render
+
+---
+
+## Phase 13: Advanced Search & Multi-Faceted Filtering
+
+**Goal:** Power-user search with combinable filters across all metadata dimensions.
+
+### Backend
+- [ ] Extend `GET /api/games` with all new filter dimensions:
+  - `themes[]` (multi-select)
+  - `keywords[]` (multi-select)
+  - `perspectives[]` (multi-select)
+  - `yearMin`, `yearMax` (range)
+  - `ratingMin`, `ratingMax` (range)
+  - `gameModes[]` (single-player, co-op, multiplayer)
+  - `playStatus` (unplayed, played, favorited, queued)
+  - `developer`, `publisher`
+  - `ageRating`
+  - `consoles[]` (multi-select)
+  - `genres[]` (multi-select)
+- [ ] `POST /api/user/saved-searches` — save filter combos
+- [ ] `GET /api/user/saved-searches` — list saved searches
+- [ ] `DELETE /api/user/saved-searches/:id`
+
+### Web Frontend
+- [ ] Advanced filter panel (collapsible sidebar or modal):
+  - Multi-select dropdowns for genres, themes, consoles
+  - Keyword search with autocomplete
+  - Range sliders for year and rating
+  - Toggle chips for play status and game modes
+  - "X games match" live count
+  - "Save this search" button
+- [ ] Saved searches as dynamic collections on Explore page
+- [ ] URL-based filter state (shareable links)
+
+### Player App
+- [ ] Filter panel (bottom sheet or dedicated filter screen)
+- [ ] Saved searches in Explore
+- [ ] Quick filter chips at top of game lists
+
+### Tests
+- [ ] Backend: unit tests for combined filtering, saved search CRUD
+- [ ] Web: E2E test — apply multiple filters, results update, save search
+- [ ] Player: desktop E2E test — filter panel works
+
+---
+
+## Phase 14: Wild Features — Surprise, Wizard, Gamification
+
+**Goal:** Delight features that make discovery fun and addictive.
+
+### Backend
+- [ ] `GET /api/explore/random?console=&genre=&minRating=` — random game with optional constraints
+- [ ] `GET /api/explore/wizard` — decision wizard flow (mood → era → vibe → results)
+- [ ] `GET /api/user/explorer-badges` — badge system for breadth of play
+  - "Played every console"
+  - "Played 10 genres"
+  - "Played games from 5 decades"
+  - "100 games played"
+- [ ] `GET /api/user/completionist-map` — per-console completion stats
+  - `{ consoles: [{ id, name, totalGames, playedGames, percentage }, ...] }`
+
+### Web Frontend
+- [ ] "I'm Feeling Lucky" button with slot-machine animation
+  - Cover art spins, lands on a game
+  - "Play Now" / "Spin Again" buttons
+- [ ] Decision Wizard: `/explore/wizard`
+  - Step 1: mood cards
+  - Step 2: era selection (decade cards with period artwork)
+  - Step 3: vibe refinement (theme/keyword chips)
+  - Result: 5 personalized recommendations with hero art
+- [ ] Explorer Badges on profile page
+  - Visual badge gallery
+  - Progress bars for incomplete badges
+  - "Next badge: Play a [Console] game" nudges
+- [ ] Completionist's Map on profile/stats page
+  - Visual map of consoles with fill percentage
+  - Tap console → see which games you've played / haven't
+
+### Player App
+- [ ] Same features adapted for native UI
+- [ ] "Feeling Lucky" with haptic feedback on landing
+- [ ] Badge unlock celebrations (confetti/animation)
+
+### Tests
+- [ ] Backend: unit tests for random selection, badge calculation, wizard logic
+- [ ] Web: E2E test — wizard flow works end to end, badges render
+- [ ] Player: desktop E2E test — wizard and badges render
+
+---
+
+## Phase 15: Polish & Integration
+
+**Goal:** Final integration pass — connect everything, optimize performance, refine UX.
+
+### Tasks
+- [ ] Explore page section ordering based on user engagement (most-clicked sections rise)
+- [ ] Performance: lazy-load below-the-fold sections, image optimization, API response caching
+- [ ] Skeleton loading states for every section
+- [ ] Empty states: helpful messages when no data (e.g., "Play some games to get recommendations!")
+- [ ] Deep linking: every Explore section has a shareable URL
+- [ ] Admin panel: ability to feature/pin games, curate the hero carousel, set developer spotlight
+- [ ] Analytics: track which Explore sections get most engagement (server-side, privacy-respecting)
+- [ ] Accessibility pass: keyboard navigation, screen reader support, focus management
+- [ ] Cross-link everything: game detail → franchise, developer, theme, similar;
+  developer page → games → franchise; etc.
+
+### Tests
+- [ ] Full E2E regression suite for all Explore features
+- [ ] Performance benchmarks: page load time, API response times
+- [ ] Accessibility audit
+
+---
+
+## Data Dependencies Summary
+
+| Phase | IGDB Data Needed | SteamGridDB Data Needed | New DB Models |
+|-------|-----------------|------------------------|---------------|
+| 1 | None (existing) | None (existing) | None |
+| 2 | themes, keywords, collections, franchises, perspectives, artworks | None | GameTheme, GameKeyword, GamePlayerPerspective, GameSeries, GameSeriesEntry, GameArtworkImage |
+| 3 | From Phase 2 | None | None |
+| 4 | From Phase 2 | None | None |
+| 5 | From Phase 2 | None | MoodDefinition (or config) |
+| 6 | Similar games (existing) | None | TasteProfile (computed), SavedRecommendation (cache) |
+| 7 | Companies (new) | None | None (uses existing developer/publisher fields) |
+| 8 | None | None | None |
+| 9 | Artworks (from Phase 2) | None | None |
+| 10 | None | None | None (uses existing play history, ratings) |
+| 11 | None | None | None (uses existing release dates) |
+| 12 | None | None | None (uses existing achievements) |
+| 13 | From Phase 2 | None | SavedSearch |
+| 14 | None | None | ExplorerBadge, UserBadge |
+| 15 | None | None | ExploreAnalytics (optional) |
+
+---
+
+## Estimated Scope
+
+- **15 phases** — each is a self-contained PR
+- **Backend:** ~15 new endpoints, ~6 new DB models, IGDB client extensions
+- **Web:** New Explore page with ~15 sections, 5+ sub-pages, advanced filter panel
+- **Player:** New Explore tab with matching sections and screens
+- **Tests:** Full coverage per phase — unit + E2E for backend, web, and player
+
+## Open Questions
+
+- [ ] Should Explore replace the current Dashboard/Home, or live alongside it?
+- [ ] Should we gate the Explore page behind a minimum library size? (e.g., only show when >100 games)
+- [ ] Admin curation: how much control should the admin have over featured content?
+- [ ] IGDB rate limiting: do we need to batch/throttle the Phase 2 enrichment backfill?
+- [ ] Should franchise pages show games NOT in the library (as "missing from your collection")?

--- a/design-proposals/explore-page-plan.md
+++ b/design-proposals/explore-page-plan.md
@@ -581,10 +581,30 @@ experience that scales to tens of thousands of games. Beautiful, personalized, a
 - **Player:** New Explore tab with matching sections and screens
 - **Tests:** Full coverage per phase — unit + E2E for backend, web, and player
 
-## Open Questions
+## Decisions
 
-- [ ] Should Explore replace the current Dashboard/Home, or live alongside it?
-- [ ] Should we gate the Explore page behind a minimum library size? (e.g., only show when >100 games)
-- [ ] Admin curation: how much control should the admin have over featured content?
-- [ ] IGDB rate limiting: do we need to batch/throttle the Phase 2 enrichment backfill?
-- [ ] Should franchise pages show games NOT in the library (as "missing from your collection")?
+1. **Explore lives alongside Dashboard/Home.** Keep the existing Dashboard for now. We'll likely
+   replace it later, but for now Explore is a new tab/route.
+
+2. **No library size gate.** Explore is available to everyone regardless of library size. We may
+   revisit this later, but for now keep it open.
+
+3. **No admin curation.** Zero admin burden — the Explore page is fully algorithmic. Set up the
+   server and it just works. Featured content is auto-selected (highest-rated with hero art, etc.).
+
+4. **Respect IGDB/SteamGridDB rate limits. Cache everything locally.** The enrichment backfill
+   (Phase 2) must be throttled to stay within IGDB's 4 req/sec limit. All IGDB and SteamGridDB
+   data must be stored locally so the Explore page works even when external APIs are down. Data
+   may be stale, but the feature must never break due to an external service outage.
+
+5. **Always show games not in the library, but clearly indicate them.** Franchise pages, top-rated
+   lists, and similar-games rows should include games the user doesn't own. These must be visually
+   distinct — use a consistent design system approach:
+   - **Web:** A shared component prop (e.g., `missingInLibrary`) that the design system uses to
+     render the distinction (dimmed art, overlay icon, badge — the design system decides how).
+   - **Player app:** An equivalent `Sp*` component parameter.
+   - **Consistency is key:** The same visual treatment everywhere, decided by the shared component
+     library, not by individual features or screens.
+   - The existing "top rated" list on the console screen already dims missing games — we should
+     unify this with the new shared approach and make it clearer to users what "missing" means
+     (e.g., a small icon overlay or "Not in library" label).

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreScreenTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreScreenTest.kt
@@ -1,0 +1,252 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.ExploreRow
+import com.spela.player.domain.model.FeaturedGame
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for the Explore screen.
+ *
+ * Covers:
+ * - Screen renders with featured games and shelf rows
+ * - Hero carousel displays featured games
+ * - Shelf rows display games
+ * - Empty state when no data
+ * - Navigation to game detail from carousel
+ * - Navigation to game detail from shelf
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ExploreScreenTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private val sampleFeatured = listOf(
+        FeaturedGame(
+            gameId = "1",
+            title = "Super Mario World",
+            heroUrl = null,
+            logoUrl = null,
+            consoleAbbreviation = "SNES",
+            consoleColor = "#7B2D8E",
+            rating = 92.5,
+            genre = "Platformer",
+            isFavorite = false,
+            isPlayLater = false,
+        ),
+        FeaturedGame(
+            gameId = "2",
+            title = "Chrono Trigger",
+            heroUrl = null,
+            logoUrl = null,
+            consoleAbbreviation = "SNES",
+            consoleColor = "#7B2D8E",
+            rating = 95.0,
+            genre = "RPG",
+            isFavorite = true,
+            isPlayLater = false,
+        ),
+    )
+
+    private val sampleGames = listOf(
+        Game(
+            id = "10",
+            title = "Mega Man X",
+            consoleName = "SNES",
+            consoleId = "snes",
+            coverUrl = null,
+            rating = 88.0,
+        ),
+        Game(
+            id = "11",
+            title = "Final Fantasy VI",
+            consoleName = "SNES",
+            consoleId = "snes",
+            coverUrl = null,
+            rating = 94.0,
+        ),
+        Game(
+            id = "12",
+            title = "Donkey Kong Country",
+            consoleName = "SNES",
+            consoleId = "snes",
+            coverUrl = null,
+            rating = 85.0,
+        ),
+    )
+
+    private val sampleRows = listOf(
+        ExploreRow(
+            id = "recently-added",
+            title = "Recently Added",
+            games = sampleGames,
+        ),
+        ExploreRow(
+            id = "top-rated",
+            title = "Top Rated",
+            games = listOf(
+                Game(
+                    id = "20",
+                    title = "A Link to the Past",
+                    consoleName = "SNES",
+                    consoleId = "snes",
+                    coverUrl = null,
+                    rating = 96.0,
+                ),
+            ),
+        ),
+    )
+
+    @Test
+    fun exploreScreenRenders() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredGames = sampleFeatured
+        harness.exploreRepo.exploreRows = sampleRows
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+    }
+
+    @Test
+    fun heroCarouselDisplaysFeaturedGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredGames = sampleFeatured
+        harness.exploreRepo.exploreRows = sampleRows
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("hero_carousel").assertIsDisplayed()
+        // The first featured game should be visible
+        onNodeWithText("Super Mario World").assertExists()
+    }
+
+    @Test
+    fun heroCarouselShowsConsoleChipAndGenre() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredGames = sampleFeatured
+        harness.exploreRepo.exploreRows = emptyList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        // Console abbreviation chip and genre chip should be visible for the active slide
+        onNodeWithText("SNES").assertExists()
+        onNodeWithText("Platformer").assertExists()
+    }
+
+    @Test
+    fun heroCarouselShowsViewGameButton() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredGames = sampleFeatured
+        harness.exploreRepo.exploreRows = emptyList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithText("View Game").assertExists()
+    }
+
+    @Test
+    fun shelfRowsDisplayGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredGames = emptyList()
+        harness.exploreRepo.exploreRows = sampleRows
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        // Row titles
+        onNodeWithText("Recently Added").assertIsDisplayed()
+        onNodeWithText("Top Rated").assertIsDisplayed()
+
+        // Game titles from the rows
+        onNodeWithText("Mega Man X").assertExists()
+        onNodeWithText("Final Fantasy VI").assertExists()
+        onNodeWithText("A Link to the Past").assertExists()
+    }
+
+    @Test
+    fun emptyStateWhenNoGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredGames = emptyList()
+        harness.exploreRepo.exploreRows = emptyList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_empty_state").assertIsDisplayed()
+        onNodeWithText("Nothing to explore yet").assertIsDisplayed()
+    }
+
+    @Test
+    fun navigationToGameDetailFromShelf() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredGames = emptyList()
+        harness.exploreRepo.exploreRows = sampleRows
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        // Click a game card in the shelf
+        onNodeWithTag("explore_game_card_10").performClick()
+        advance(harness)
+
+        // Should navigate to game detail
+        val navState = harness.navigationViewModel.state.value
+        assertEquals(SpScreen.GameDetail("10"), navState.currentScreen)
+    }
+
+    @Test
+    fun navigationToGameDetailFromCarousel() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredGames = sampleFeatured
+        harness.exploreRepo.exploreRows = emptyList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        // Click the "View Game" button on the hero carousel
+        onNodeWithText("View Game").performClick()
+        advance(harness)
+
+        // Should navigate to game detail for the first featured game
+        val navState = harness.navigationViewModel.state.value
+        assertEquals(SpScreen.GameDetail("1"), navState.currentScreen)
+    }
+
+    @Test
+    fun shelfRowsShowGameConsoleNames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredGames = emptyList()
+        harness.exploreRepo.exploreRows = sampleRows
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        // Console name should appear as subtitle under game cards
+        onAllNodesWithText("SNES").assertCountEquals(4) // 3 games in first row + 1 in second row
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -340,6 +340,14 @@ class SpelaTestHarness(
         scope = scope,
     )
 
+    val exploreRepo = FakeExploreRepository()
+
+    val exploreViewModel = ExploreViewModel(
+        exploreRepository = exploreRepo,
+        dispatchers = dispatchers,
+        scope = scope,
+    )
+
     @Composable
     fun App() {
         androidx.compose.runtime.CompositionLocalProvider(
@@ -371,6 +379,7 @@ class SpelaTestHarness(
             connectivityMonitor = connectivityMonitor,
             sessionDetailViewModel = sessionDetailViewModel,
             topListsViewModel = topListsViewModel,
+            exploreViewModel = exploreViewModel,
             gamepadPortManager = gamepadPortManager,
         )
         }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1318,6 +1318,20 @@ class FakeSessionRepository : SessionRepository {
     fun getLastCheatConfig(sessionId: String): SessionCheatConfig? = sessionCheats[sessionId]
 }
 
+class FakeExploreRepository : ExploreRepository {
+    var featuredGames: List<FeaturedGame> = emptyList()
+    var exploreRows: List<ExploreRow> = emptyList()
+    var shouldFail: Boolean = false
+
+    override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> =
+        if (shouldFail) Result.failure(Exception("Failed to load featured games"))
+        else Result.success(featuredGames)
+
+    override suspend fun getExploreRows(): Result<List<ExploreRow>> =
+        if (shouldFail) Result.failure(Exception("Failed to load explore rows"))
+        else Result.success(exploreRows)
+}
+
 class FakeCheatRepository : CheatRepository {
     var cheats: MutableList<Cheat> = mutableListOf()
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -235,6 +235,17 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/games/$gameId/developer-games").body()
     }
 
+    /** Returns featured games for the Explore page hero carousel */
+    suspend fun getExploreFeatured(): List<FeaturedGameDto> {
+        return client.get("$baseUrl/api/explore/featured").body()
+    }
+
+    /** Returns curated rows for the Explore page (Top Rated, Recently Added, etc.) */
+    suspend fun getExploreRows(): List<ExploreRowDto> {
+        val response: ExploreRowsResponseDto = client.get("$baseUrl/api/explore/rows").body()
+        return response.rows
+    }
+
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
     suspend fun getRecentGames(): List<GameDto> {
         return client.get("$baseUrl/api/user/recent").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -545,3 +545,24 @@ fun SessionCheatConfigDto.toDomain() = SessionCheatConfig(
     cheatsEnabled = cheatsEnabled,
     enabledIndices = enabledIndices,
 )
+
+// Explore mappers
+
+fun FeaturedGameDto.toDomain(): FeaturedGame = FeaturedGame(
+    gameId = gameId,
+    title = title,
+    heroUrl = heroUrl,
+    logoUrl = logoUrl,
+    consoleAbbreviation = consoleAbbreviation,
+    consoleColor = consoleColor,
+    rating = rating,
+    genre = genre,
+    isFavorite = isFavorite,
+    isPlayLater = isPlayLater,
+)
+
+fun ExploreRowDto.toDomain(): ExploreRow = ExploreRow(
+    id = id,
+    title = title,
+    games = games.map { it.toDomain() },
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1003,3 +1003,31 @@ data class CheatDto(
     val description: String = "",
     val code: String = "",
 )
+
+// Explore
+
+@Serializable
+data class FeaturedGameDto(
+    val gameId: String,
+    val title: String,
+    val heroUrl: String? = null,
+    val logoUrl: String? = null,
+    val consoleAbbreviation: String = "",
+    val consoleColor: String = "",
+    val rating: Double = 0.0,
+    val genre: String = "",
+    val isFavorite: Boolean = false,
+    val isPlayLater: Boolean = false,
+)
+
+@Serializable
+data class ExploreRowDto(
+    val id: String,
+    val title: String,
+    val games: List<GameDto>,
+)
+
+@Serializable
+data class ExploreRowsResponseDto(
+    val rows: List<ExploreRowDto>,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -1,0 +1,35 @@
+package com.spela.player.data.repository
+
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.dto.toDomain
+import com.spela.player.domain.model.ExploreRow
+import com.spela.player.domain.model.FeaturedGame
+import com.spela.player.domain.repository.ExploreRepository
+
+class ExploreRepositoryImpl(
+    private val apiClient: SpelaApiClient,
+) : ExploreRepository {
+
+    override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> = runCatching {
+        apiClient.getExploreFeatured().map { dto ->
+            dto.toDomain().copy(
+                heroUrl = apiClient.resolveUrl(dto.heroUrl),
+                logoUrl = apiClient.resolveUrl(dto.logoUrl),
+            )
+        }
+    }
+
+    override suspend fun getExploreRows(): Result<List<ExploreRow>> = runCatching {
+        apiClient.getExploreRows().map { dto ->
+            dto.toDomain().copy(
+                games = dto.games.map { gameDto ->
+                    gameDto.toDomain().copy(
+                        coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                        heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+                        logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+                    )
+                },
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -69,6 +69,7 @@ val commonModule = module {
     single<GameStatsRepository> { GameStatsRepositoryImpl(get()) }
     single<CheatRepository> { CheatRepositoryImpl(get(), get()) }
     single<SessionRepository> { SessionRepositoryImpl(get()) }
+    single<ExploreRepository> { ExploreRepositoryImpl(get()) }
     single { BiosRepository(get(), get()) }
     single { GamepadPortManager(get()) }
 
@@ -322,6 +323,14 @@ val commonModule = module {
     factory {
         TopListsViewModel(
             gameRepository = get(),
+            dispatchers = get(),
+            scope = get(),
+        )
+    }
+
+    factory {
+        ExploreViewModel(
+            exploreRepository = get(),
             dispatchers = get(),
             scope = get(),
         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -1,0 +1,20 @@
+package com.spela.player.domain.model
+
+data class FeaturedGame(
+    val gameId: String,
+    val title: String,
+    val heroUrl: String?,
+    val logoUrl: String?,
+    val consoleAbbreviation: String,
+    val consoleColor: String,
+    val rating: Double,
+    val genre: String,
+    val isFavorite: Boolean,
+    val isPlayLater: Boolean,
+)
+
+data class ExploreRow(
+    val id: String,
+    val title: String,
+    val games: List<Game>,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -1,0 +1,9 @@
+package com.spela.player.domain.repository
+
+import com.spela.player.domain.model.ExploreRow
+import com.spela.player.domain.model.FeaturedGame
+
+interface ExploreRepository {
+    suspend fun getFeaturedGames(): Result<List<FeaturedGame>>
+    suspend fun getExploreRows(): Result<List<ExploreRow>>
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
@@ -29,7 +29,7 @@ class NavigationViewModel(
     val state: StateFlow<NavigationState> = _state.asStateFlow()
 
     private val sections = listOf(
-        SpScreen.Home, SpScreen.Consoles, SpScreen.Collections, SpScreen.Activity, SpScreen.Settings
+        SpScreen.Home, SpScreen.Explore, SpScreen.Consoles, SpScreen.Collections, SpScreen.Activity, SpScreen.Settings
     )
 
     init {
@@ -78,6 +78,7 @@ class NavigationViewModel(
                         )
                     } else if (current.currentScreen is SpScreen.Settings ||
                         current.currentScreen is SpScreen.Downloads ||
+                        current.currentScreen is SpScreen.Explore ||
                         current.currentScreen is SpScreen.Consoles ||
                         current.currentScreen is SpScreen.Collections ||
                         current.currentScreen is SpScreen.Activity
@@ -186,6 +187,7 @@ class NavigationViewModel(
 
     companion object {
         fun activeTabForScreen(screen: SpScreen): BottomNavTab = when (screen) {
+            is SpScreen.Explore -> BottomNavTab.EXPLORE
             is SpScreen.Consoles, is SpScreen.Console -> BottomNavTab.CONSOLES
             is SpScreen.Collections, is SpScreen.CollectionDetail -> BottomNavTab.COLLECTIONS
             is SpScreen.Activity, is SpScreen.Stats -> BottomNavTab.ACTIVITY

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -4,6 +4,7 @@ sealed class SpScreen(val route: String) {
     data object ServerConnection : SpScreen("server_connection")
     data object Login : SpScreen("login")
     data object Home : SpScreen("home")
+    data object Explore : SpScreen("explore")
     data object Consoles : SpScreen("consoles")
     data object AllGames : SpScreen("all_games")
     data object Favorites : SpScreen("favorites")

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -92,6 +92,7 @@ import com.spela.player.presentation.ui.screen.ChallengeDetailScreen
 import com.spela.player.presentation.ui.screen.ChallengeListScreen
 import com.spela.player.presentation.ui.screen.GlobalChallengesScreen
 import com.spela.player.presentation.ui.screen.StatsScreen
+import com.spela.player.presentation.ui.screen.ExploreScreen
 import com.spela.player.presentation.ui.screen.TopListsScreen
 import com.spela.player.presentation.ui.screen.UserProfileScreen
 import com.spela.player.presentation.ui.theme.SpColor
@@ -118,6 +119,7 @@ import com.spela.player.presentation.viewmodel.NetplayLobbyViewModel
 import com.spela.player.presentation.viewmodel.NetplayViewModel
 import com.spela.player.presentation.viewmodel.ChallengeDetailViewModel
 import com.spela.player.presentation.viewmodel.ChallengeListViewModel
+import com.spela.player.presentation.viewmodel.ExploreViewModel
 import com.spela.player.presentation.viewmodel.CollectionsViewModel
 import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
 import com.spela.player.presentation.viewmodel.SocialViewModel
@@ -153,6 +155,7 @@ fun SpelaApp(
     connectivityMonitor: ConnectivityMonitor,
     sessionDetailViewModel: SessionDetailViewModel? = null,
     topListsViewModel: TopListsViewModel? = null,
+    exploreViewModel: ExploreViewModel? = null,
     navigationEventBus: NavigationEventBus? = null,
     gamepadPortManager: GamepadPortManager? = null,
 ) {
@@ -438,6 +441,19 @@ fun SpelaApp(
                                     hasActiveDownloads = downloadsState.activeDownloads.isNotEmpty(),
                                     activeNetplaySessions = activeNetplaySessions,
                                 )
+                            }
+
+                            is SpScreen.Explore -> {
+                                if (exploreViewModel != null) {
+                                    ExploreScreen(
+                                        viewModel = exploreViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                    )
+                                }
                             }
 
                             is SpScreen.Console -> {
@@ -1079,6 +1095,7 @@ fun SpelaApp(
                         onTabSelected = { tab ->
                             val targetScreen = when (tab) {
                                 BottomNavTab.HOME -> SpScreen.Home
+                                BottomNavTab.EXPLORE -> SpScreen.Explore
                                 BottomNavTab.CONSOLES -> SpScreen.Consoles
                                 BottomNavTab.COLLECTIONS -> SpScreen.Collections
                                 BottomNavTab.ACTIVITY -> SpScreen.Activity

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpBottomNavBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpBottomNavBar.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.windowInsetsBottomHeight
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CollectionsBookmark
+import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Notifications
 import androidx.compose.material.icons.filled.Settings
@@ -47,6 +48,7 @@ enum class BottomNavTab(
     val icon: ImageVector,
 ) {
     HOME("Home", Icons.Filled.Home),
+    EXPLORE("Explore", Icons.Filled.Explore),
     CONSOLES("Consoles", Icons.Filled.SportsEsports),
     COLLECTIONS("Collections", Icons.Filled.CollectionsBookmark),
     ACTIVITY("Activity", Icons.Filled.Notifications),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
@@ -1,0 +1,170 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.WatchLater
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.formatRating
+
+@Composable
+fun GameShelf(
+    games: List<Game>,
+    onGameSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("game_shelf"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(games, key = { it.id }) { game ->
+            ExploreGameCard(
+                game = game,
+                onClick = { onGameSelected(game.id) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ExploreGameCard(
+    game: Game,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        modifier = Modifier
+            .width(SpSpacing.CoverMediumWidth)
+            .testTag("explore_game_card_${game.id}")
+            .semantics {
+                contentDescription = "${game.title}, ${game.consoleName}"
+                role = Role.Button
+            },
+        onClick = onClick,
+        onGradient = true,
+    ) {
+        Column {
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.title} cover art",
+                modifier = Modifier.fillMaxWidth(),
+                aspectRatio = game.coverAspectRatio,
+            )
+            Column(
+                modifier = Modifier.padding(
+                    horizontal = SpSpacing.Small,
+                    vertical = SpSpacing.Small,
+                ),
+            ) {
+                Text(
+                    text = game.title,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+
+                // Console badge
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                ) {
+                    Text(
+                        text = game.consoleName,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                        maxLines = 1,
+                    )
+
+                    // Rating
+                    if (game.rating > 0) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(10.dp),
+                        )
+                        Text(
+                            text = formatRating(game.rating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+
+                // Favorite / Play Later indicators
+                if (game.isFavorite || game.isInPlayLater) {
+                    Row(
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                    ) {
+                        if (game.isFavorite) {
+                            Icon(
+                                imageVector = Icons.Filled.Favorite,
+                                contentDescription = "Favorited",
+                                tint = SpColor.Favorite,
+                                modifier = Modifier.size(12.dp),
+                            )
+                        }
+                        if (game.isInPlayLater) {
+                            Icon(
+                                imageVector = Icons.Filled.WatchLater,
+                                contentDescription = "In Play Later",
+                                tint = SpColor.OnBackgroundTertiary,
+                                modifier = Modifier.size(12.dp),
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun GameShelfSkeleton(
+    modifier: Modifier = Modifier,
+    count: Int = 5,
+) {
+    LazyRow(
+        modifier = modifier.testTag("game_shelf_skeleton"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(count) {
+            SpGameCardSkeleton(modifier = Modifier.width(SpSpacing.CoverMediumWidth))
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/HeroCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/HeroCarousel.kt
@@ -1,0 +1,352 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.material3.ripple
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import com.spela.player.domain.model.FeaturedGame
+import com.spela.player.presentation.ui.components.LocalAnimationsEnabled
+import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpShimmer
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.formatRating
+import com.spela.player.util.parseHexColor
+import kotlinx.coroutines.delay
+
+private val HERO_HEIGHT = 320.dp
+private const val AUTO_ADVANCE_DELAY_MS = 8_000L
+
+@Composable
+fun HeroCarousel(
+    featuredGames: List<FeaturedGame>,
+    onGameSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (featuredGames.isEmpty()) return
+
+    var currentIndex by remember { mutableStateOf(0) }
+    var isPaused by remember { mutableStateOf(false) }
+    var dotTapKey by remember { mutableStateOf(0) }
+    val animationsEnabled = LocalAnimationsEnabled.current
+
+    // Auto-advance
+    LaunchedEffect(currentIndex, isPaused) {
+        if (!isPaused && animationsEnabled) {
+            delay(AUTO_ADVANCE_DELAY_MS)
+            currentIndex = (currentIndex + 1) % featuredGames.size
+        }
+    }
+
+    // Resume auto-advance after dot tap pause
+    LaunchedEffect(dotTapKey) {
+        if (dotTapKey > 0) {
+            delay(AUTO_ADVANCE_DELAY_MS)
+            isPaused = false
+        }
+    }
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(HERO_HEIGHT)
+            .clip(RoundedCornerShape(SpSpacing.CardCornerRadius))
+            .testTag("hero_carousel")
+            .pointerInput(featuredGames.size) {
+                var dragConsumed = false
+                detectHorizontalDragGestures(
+                    onDragStart = {
+                        isPaused = true
+                        dragConsumed = false
+                    },
+                    onDragEnd = {
+                        isPaused = false
+                        dragConsumed = false
+                    },
+                ) { _, dragAmount ->
+                    if (dragConsumed) return@detectHorizontalDragGestures
+                    if (dragAmount < -40f) {
+                        currentIndex = (currentIndex + 1) % featuredGames.size
+                        dragConsumed = true
+                    } else if (dragAmount > 40f) {
+                        currentIndex = (currentIndex - 1 + featuredGames.size) % featuredGames.size
+                        dragConsumed = true
+                    }
+                }
+            },
+    ) {
+        // Hero image with crossfade
+        AnimatedContent(
+            targetState = currentIndex,
+            transitionSpec = {
+                fadeIn() togetherWith fadeOut()
+            },
+            label = "heroCarousel",
+        ) { index ->
+            val game = featuredGames[index]
+            HeroSlide(
+                game = game,
+                onGameSelected = { onGameSelected(game.gameId) },
+            )
+        }
+
+        // Navigation dots at bottom center
+        if (featuredGames.size > 1) {
+            Row(
+                modifier = Modifier
+                    .align(Alignment.BottomCenter)
+                    .padding(bottom = SpSpacing.Medium),
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            ) {
+                featuredGames.forEachIndexed { index, _ ->
+                    val isActive = index == currentIndex
+                    Box(
+                        modifier = Modifier
+                            .size(if (isActive) 10.dp else 8.dp)
+                            .clip(CircleShape)
+                            .background(
+                                if (isActive) SpColor.Primary
+                                else SpColor.OnBackground.copy(alpha = 0.4f),
+                            )
+                            .clickable(
+                                interactionSource = remember { MutableInteractionSource() },
+                                indication = ripple(bounded = false, radius = 12.dp),
+                            ) {
+                                currentIndex = index
+                                isPaused = true
+                                dotTapKey++
+                            }
+                            .semantics {
+                                contentDescription = "Slide ${index + 1} of ${featuredGames.size}"
+                                role = Role.Button
+                            },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HeroSlide(
+    game: FeaturedGame,
+    onGameSelected: () -> Unit,
+) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("hero_slide_${game.gameId}")
+            .semantics {
+                contentDescription = "Featured: ${game.title}"
+            },
+    ) {
+        // Hero art background
+        if (game.heroUrl != null) {
+            SubcomposeAsyncImage(
+                model = game.heroUrl,
+                contentDescription = "Hero art for ${game.title}",
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+                loading = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(SpColor.SurfaceVariant),
+                    )
+                },
+                error = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .background(SpColor.SurfaceVariant),
+                    )
+                },
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(SpColor.SurfaceVariant),
+            )
+        }
+
+        // Gradient overlay for text readability
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(
+                    Brush.verticalGradient(
+                        colors = listOf(
+                            Color.Transparent,
+                            SpColor.Background.copy(alpha = 0.3f),
+                            SpColor.Background.copy(alpha = 0.85f),
+                            SpColor.Background,
+                        ),
+                    ),
+                ),
+        )
+
+        // Content overlay (bottom-left)
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(SpSpacing.XLarge)
+                .padding(bottom = SpSpacing.XLarge),
+        ) {
+            // Logo or title text fallback
+            if (game.logoUrl != null) {
+                SubcomposeAsyncImage(
+                    model = game.logoUrl,
+                    contentDescription = "${game.title} logo",
+                    modifier = Modifier
+                        .height(60.dp)
+                        .fillMaxWidth(0.5f),
+                    contentScale = ContentScale.Fit,
+                    loading = {
+                        Text(
+                            text = game.title,
+                            style = SpTypography.DisplaySmall,
+                            color = SpColor.OnBackground,
+                        )
+                    },
+                    error = {
+                        Text(
+                            text = game.title,
+                            style = SpTypography.DisplaySmall,
+                            color = SpColor.OnBackground,
+                        )
+                    },
+                )
+            } else {
+                Text(
+                    text = game.title,
+                    style = SpTypography.DisplaySmall,
+                    color = SpColor.OnBackground,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+
+            Spacer(Modifier.height(SpSpacing.Small))
+
+            // Metadata row: console badge, rating, genre
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            ) {
+                // Console badge
+                val consoleColor = parseHexColor(game.consoleColor, SpColor.Primary)
+                SpChip(
+                    text = game.consoleAbbreviation,
+                    color = consoleColor,
+                    isSelected = true,
+                )
+
+                // Rating
+                if (game.rating > 0) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(SpSpacing.IconSmall),
+                        )
+                        Text(
+                            text = formatRating(game.rating),
+                            style = SpTypography.LabelMedium,
+                            color = SpColor.OnBackground,
+                        )
+                    }
+                }
+
+                // Genre
+                if (game.genre.isNotEmpty()) {
+                    SpChip(text = game.genre)
+                }
+            }
+
+            Spacer(Modifier.height(SpSpacing.Medium))
+
+            // Action button
+            SpButton(
+                text = "View Game",
+                onClick = onGameSelected,
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Filled.PlayArrow,
+                        contentDescription = null,
+                        modifier = Modifier.size(SpSpacing.IconDefault),
+                    )
+                },
+            )
+        }
+    }
+}
+
+@Composable
+fun HeroCarouselSkeleton(
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(HERO_HEIGHT)
+            .clip(RoundedCornerShape(SpSpacing.CardCornerRadius))
+            .testTag("hero_carousel_skeleton"),
+    ) {
+        SpShimmer(
+            modifier = Modifier.fillMaxSize(),
+            width = 400.dp,
+            height = HERO_HEIGHT,
+        )
+    }
+}
+

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -1,0 +1,152 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Explore
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.feature.explore.GameShelf
+import com.spela.player.presentation.ui.feature.explore.GameShelfSkeleton
+import com.spela.player.presentation.ui.feature.explore.HeroCarousel
+import com.spela.player.presentation.ui.feature.explore.HeroCarouselSkeleton
+import com.spela.player.presentation.ui.theme.LocalTitleBarInset
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+
+@Composable
+fun ExploreScreen(
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.load()
+    }
+
+    val titleBarInset = LocalTitleBarInset.current
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("explore_screen"),
+    ) {
+        when {
+            // Empty library: no data at all and not loading
+            state.isEmpty && !state.isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    SpEmptyState(
+                        icon = Icons.Filled.Explore,
+                        title = "Nothing to explore yet",
+                        message = "Games need to be added to the library before you can explore. Contact your server admin to add games.",
+                        modifier = Modifier.testTag("explore_empty_state"),
+                    )
+                }
+            }
+
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxSize(),
+                    contentPadding = PaddingValues(
+                        top = titleBarInset,
+                        bottom = SpSpacing.XLarge,
+                    ),
+                ) {
+                    // Hero carousel
+                    item {
+                        if (state.isLoadingFeatured && state.featuredGames.isEmpty()) {
+                            HeroCarouselSkeleton(
+                                modifier = Modifier.padding(
+                                    horizontal = SpSpacing.ScreenHorizontal,
+                                    vertical = SpSpacing.Default,
+                                ),
+                            )
+                        } else if (state.featuredGames.isNotEmpty()) {
+                            HeroCarousel(
+                                featuredGames = state.featuredGames,
+                                onGameSelected = onGameSelected,
+                                modifier = Modifier.padding(
+                                    horizontal = SpSpacing.ScreenHorizontal,
+                                    vertical = SpSpacing.Default,
+                                ),
+                            )
+                        }
+                    }
+
+                    // Shelf rows
+                    if (state.isLoadingRows && state.rows.isEmpty()) {
+                        // Loading skeletons for rows
+                        val skeletonTitles = listOf("Top Rated", "Recently Added", "Hidden Gems")
+                        items(skeletonTitles.size) { index ->
+                            SpTitledSection(
+                                title = skeletonTitles[index],
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                GameShelfSkeleton()
+                            }
+                        }
+                    } else {
+                        items(
+                            items = state.rows,
+                            key = { it.id },
+                        ) { row ->
+                            if (row.games.isNotEmpty()) {
+                                SpTitledSection(
+                                    title = row.title,
+                                    edgeToEdgeContent = true,
+                                    modifier = Modifier
+                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                        .testTag("explore_row_${row.id}"),
+                                ) {
+                                    GameShelf(
+                                        games = row.games,
+                                        onGameSelected = onGameSelected,
+                                    )
+                                }
+                            }
+                        }
+                    }
+
+                    // Bottom spacer
+                    item { Spacer(Modifier.height(SpSpacing.XLarge)) }
+                }
+            }
+        }
+
+        // Error snackbar
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.dismissError() },
+                )
+            },
+            onDismiss = { viewModel.dismissError() },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -1,0 +1,75 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.domain.model.ExploreRow
+import com.spela.player.domain.model.FeaturedGame
+import com.spela.player.domain.repository.ExploreRepository
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class ExploreState(
+    val featuredGames: List<FeaturedGame> = emptyList(),
+    val rows: List<ExploreRow> = emptyList(),
+    val isLoadingFeatured: Boolean = false,
+    val isLoadingRows: Boolean = false,
+    val error: String? = null,
+) {
+    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows
+    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && !isLoading
+}
+
+class ExploreViewModel(
+    private val exploreRepository: ExploreRepository,
+    private val dispatchers: DispatcherProvider,
+    private val scope: CoroutineScope,
+) {
+    private val _state = MutableStateFlow(ExploreState())
+    val state: StateFlow<ExploreState> = _state.asStateFlow()
+
+    private var featuredJob: Job? = null
+    private var rowsJob: Job? = null
+
+    fun load() {
+        loadFeatured()
+        loadRows()
+    }
+
+    fun dismissError() {
+        _state.update { it.copy(error = null) }
+    }
+
+    private fun loadFeatured() {
+        if (featuredJob?.isActive == true) return
+        _state.update { it.copy(isLoadingFeatured = true) }
+        featuredJob = scope.launch(dispatchers.io) {
+            exploreRepository.getFeaturedGames().fold(
+                onSuccess = { featured ->
+                    _state.update { it.copy(featuredGames = featured, isLoadingFeatured = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoadingFeatured = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun loadRows() {
+        if (rowsJob?.isActive == true) return
+        _state.update { it.copy(isLoadingRows = true) }
+        rowsJob = scope.launch(dispatchers.io) {
+            exploreRepository.getExploreRows().fold(
+                onSuccess = { rows ->
+                    _state.update { it.copy(rows = rows, isLoadingRows = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoadingRows = false, error = error.message) }
+                },
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/FormatUtils.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/FormatUtils.kt
@@ -11,6 +11,19 @@ fun formatPlayTime(seconds: Long): String {
 }
 
 /**
+ * Formats a rating like 92.5 for display. Avoids platform-specific String.format.
+ * Always shows one decimal place (e.g., "92.5", "95.0").
+ */
+fun formatRating(rating: Double): String {
+    val rounded = (rating * 10).toLong() / 10.0
+    return if (rounded == rounded.toLong().toDouble()) {
+        "${rounded.toLong()}.0"
+    } else {
+        rounded.toString()
+    }
+}
+
+/**
  * Formats a byte count into a human-readable string (e.g., "1.5 KB", "3.2 MB").
  */
 fun formatBytes(bytes: Long): String {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -182,6 +182,9 @@ class NavigationViewModelTest {
         assertEquals(SpScreen.Home, vm.state.value.currentScreen)
 
         vm.onIntent(NavigationIntent.NextSection)
+        assertEquals(SpScreen.Explore, vm.state.value.currentScreen)
+
+        vm.onIntent(NavigationIntent.NextSection)
         assertEquals(SpScreen.Consoles, vm.state.value.currentScreen)
 
         vm.onIntent(NavigationIntent.NextSection)
@@ -250,6 +253,7 @@ class NavigationViewModelTest {
 
         // Navigate to Collections via section cycling (empty backstack)
         vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        vm.onIntent(NavigationIntent.NextSection) // Explore
         vm.onIntent(NavigationIntent.NextSection) // Consoles
         vm.onIntent(NavigationIntent.NextSection) // Collections
         assertEquals(SpScreen.Collections, vm.state.value.currentScreen)

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -1,0 +1,355 @@
+package api
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// ExploreHandler handles explore page endpoints.
+type ExploreHandler struct {
+	DB *gorm.DB
+}
+
+// FeaturedGameResponse is the API response for a featured game in the hero carousel.
+type FeaturedGameResponse struct {
+	GameID              string  `json:"gameId"`
+	Title               string  `json:"title"`
+	HeroURL             string  `json:"heroUrl"`
+	LogoURL             string  `json:"logoUrl"`
+	ConsoleID           string  `json:"consoleId"`
+	ConsoleName         string  `json:"consoleName"`
+	ConsoleAbbreviation string  `json:"consoleAbbreviation"`
+	ConsoleColor        string  `json:"consoleColor"`
+	Rating              float64 `json:"rating"`
+	Genre               string  `json:"genre"`
+	IsFavorite          bool    `json:"isFavorite"`
+	IsPlayLater         bool    `json:"isPlayLater"`
+}
+
+// ExploreRowResponse is the API response for a single curated row on the explore page.
+type ExploreRowResponse struct {
+	ID    string         `json:"id"`
+	Title string         `json:"title"`
+	Games []GameResponse `json:"games"`
+}
+
+// ExploreRowsResponse is the API response for all explore rows.
+type ExploreRowsResponse struct {
+	Rows []ExploreRowResponse `json:"rows"`
+}
+
+// GetExploreFeatured returns featured games for the hero carousel.
+// Games must have both hero art and logo art from SteamGridDB, sorted by IGDB rating descending.
+func (h *ExploreHandler) GetExploreFeatured(c *gin.Context) {
+	userID := getUserID(c)
+
+	// Find games that have hero art AND logo art, sorted by rating desc, limit 8
+	type featuredRow struct {
+		GameID    uint
+		Title     string
+		HeroURL   string
+		LogoURL   string
+		Rating    float64
+		Genre     string
+		ConsoleID uint
+	}
+
+	var rows []featuredRow
+	err := h.DB.
+		Table("games").
+		Select("games.id AS game_id, games.title, game_artworks.hero_url, game_artworks.logo_url, games.rating, games.genre, games.console_id").
+		Joins("JOIN game_artworks ON game_artworks.game_id = games.id").
+		Where("games.deleted_at IS NULL").
+		Where("game_artworks.hero_url != '' AND game_artworks.logo_url != ''").
+		Order("games.rating DESC").
+		Limit(8).
+		Scan(&rows).Error
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch featured games"})
+		return
+	}
+
+	if len(rows) == 0 {
+		c.JSON(http.StatusOK, []FeaturedGameResponse{})
+		return
+	}
+
+	// Batch-load console data for these games
+	consoleIDs := make([]uint, 0, len(rows))
+	for _, r := range rows {
+		consoleIDs = append(consoleIDs, r.ConsoleID)
+	}
+	var consoles []db.Console
+	if err := h.DB.Where("id IN ?", consoleIDs).Find(&consoles).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch console data"})
+		return
+	}
+	consoleMap := make(map[uint]db.Console, len(consoles))
+	for _, con := range consoles {
+		consoleMap[con.ID] = con
+	}
+
+	// Batch-load user data (favorites, play later)
+	gameIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		gameIDs[i] = r.GameID
+	}
+	favorites := make(map[uint]bool)
+	playLater := make(map[uint]bool)
+	if userID > 0 {
+		var favs []db.Favorite
+		if err := h.DB.Where("user_id = ? AND game_id IN ?", userID, gameIDs).Find(&favs).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch favorites"})
+			return
+		}
+		for _, f := range favs {
+			favorites[f.GameID] = true
+		}
+		var plItems []db.PlayLaterItem
+		if err := h.DB.Where("user_id = ? AND game_id IN ?", userID, gameIDs).Find(&plItems).Error; err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch play later items"})
+			return
+		}
+		for _, item := range plItems {
+			playLater[item.GameID] = true
+		}
+	}
+
+	result := make([]FeaturedGameResponse, len(rows))
+	for i, r := range rows {
+		con := consoleMap[r.ConsoleID]
+		abbr := strings.ToLower(con.Abbreviation)
+		result[i] = FeaturedGameResponse{
+			GameID:              strconv.FormatUint(uint64(r.GameID), 10),
+			Title:               r.Title,
+			HeroURL:             r.HeroURL,
+			LogoURL:             r.LogoURL,
+			ConsoleID:           abbr,
+			ConsoleName:         con.Name,
+			ConsoleAbbreviation: abbr,
+			ConsoleColor:        con.ColorTheme,
+			Rating:              r.Rating,
+			Genre:               r.Genre,
+			IsFavorite:          favorites[r.GameID],
+			IsPlayLater:         playLater[r.GameID],
+		}
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// GetExploreRows returns all curated shelf rows for the explore page.
+// Empty rows are omitted from the response.
+func (h *ExploreHandler) GetExploreRows(c *gin.Context) {
+	userID := getUserID(c)
+
+	rows := []ExploreRowResponse{}
+
+	// Top Rated: top 20 games by IGDB rating, rating > 0
+	if row, err := h.buildTopRatedRow(userID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build top-rated row"})
+		return
+	} else if row != nil {
+		rows = append(rows, *row)
+	}
+
+	// Recently Added: top 20 games by created_at DESC
+	if row, err := h.buildRecentlyAddedRow(userID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build recently-added row"})
+		return
+	} else if row != nil {
+		rows = append(rows, *row)
+	}
+
+	// Hidden Gems: high rating + low play time across all users
+	if row, err := h.buildHiddenGemsRow(userID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build hidden-gems row"})
+		return
+	} else if row != nil {
+		rows = append(rows, *row)
+	}
+
+	// Most Played on Your Server: top 20 by total play time across all users
+	if row, err := h.buildMostPlayedRow(userID); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build most-played row"})
+		return
+	} else if row != nil {
+		rows = append(rows, *row)
+	}
+
+	c.JSON(http.StatusOK, ExploreRowsResponse{Rows: rows})
+}
+
+// buildTopRatedRow returns the top 20 games by IGDB rating, cross-console.
+func (h *ExploreHandler) buildTopRatedRow(userID uint) (*ExploreRowResponse, error) {
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("rating > 0").
+		Order("rating DESC").
+		Limit(20).
+		Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	if len(games) == 0 {
+		return nil, nil
+	}
+
+	return &ExploreRowResponse{
+		ID:    "top-rated",
+		Title: "Top Rated",
+		Games: ToGameResponses(games, h.DB, userID),
+	}, nil
+}
+
+// buildRecentlyAddedRow returns the 20 most recently added games.
+func (h *ExploreHandler) buildRecentlyAddedRow(userID uint) (*ExploreRowResponse, error) {
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Order("created_at DESC").
+		Limit(20).
+		Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	if len(games) == 0 {
+		return nil, nil
+	}
+
+	return &ExploreRowResponse{
+		ID:    "recently-added",
+		Title: "Recently Added",
+		Games: ToGameResponses(games, h.DB, userID),
+	}, nil
+}
+
+// buildHiddenGemsRow returns games with high IGDB rating but low total play time
+// across all users. Uses SQL to compute the play-time threshold and filter in a
+// single bounded query instead of loading all games/play history into memory.
+func (h *ExploreHandler) buildHiddenGemsRow(userID uint) (*ExploreRowResponse, error) {
+	// First, check if there are at least 5 games total (per acceptance criteria,
+	// hidden gems section is hidden when library is tiny)
+	var totalGames int64
+	if err := h.DB.Model(&db.Game{}).Count(&totalGames).Error; err != nil {
+		return nil, err
+	}
+	if totalGames < 5 {
+		return nil, nil
+	}
+
+	// Calculate the play-time threshold (25th percentile) in SQL.
+	// We only need the count of games with play time > 0 and the threshold value.
+	type thresholdRow struct {
+		TotalPlayTime int64
+	}
+	var playTimes []thresholdRow
+	if err := h.DB.Model(&db.PlayHistory{}).
+		Select("COALESCE(SUM(play_time), 0) as total_play_time").
+		Group("game_id").
+		Having("total_play_time > 0").
+		Order("total_play_time ASC").
+		Scan(&playTimes).Error; err != nil {
+		return nil, err
+	}
+
+	var threshold int64
+	if len(playTimes) > 0 {
+		idx := len(playTimes) / 4
+		threshold = playTimes[idx].TotalPlayTime
+		if threshold == 0 {
+			threshold = 1
+		}
+	}
+	// If threshold is 0 (no play history at all), all rated games qualify
+
+	// Query games with rating >= 75 and low/zero play time in a single bounded query.
+	// LEFT JOIN aggregated play history, filter where total play time <= threshold or NULL.
+	var games []db.Game
+	query := h.DB.Preload("Console").
+		Joins("LEFT JOIN (SELECT game_id, COALESCE(SUM(play_time), 0) as total_play_time FROM play_histories GROUP BY game_id) ph ON ph.game_id = games.id").
+		Where("games.rating >= 75").
+		Where("games.deleted_at IS NULL")
+
+	if threshold > 0 {
+		query = query.Where("ph.total_play_time IS NULL OR ph.total_play_time <= ?", threshold)
+	}
+
+	if err := query.
+		Order("games.rating DESC").
+		Limit(20).
+		Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	if len(games) == 0 {
+		return nil, nil
+	}
+
+	return &ExploreRowResponse{
+		ID:    "hidden-gems",
+		Title: "Hidden Gems",
+		Games: ToGameResponses(games, h.DB, userID),
+	}, nil
+}
+
+// buildMostPlayedRow returns the top 20 games by total play time across all users.
+func (h *ExploreHandler) buildMostPlayedRow(userID uint) (*ExploreRowResponse, error) {
+	// Aggregate play time per game across all users, bounded to top 20
+	type playTimeRow struct {
+		GameID        uint
+		TotalPlayTime int64
+	}
+	var playTimeRows []playTimeRow
+	if err := h.DB.Model(&db.PlayHistory{}).
+		Select("game_id, COALESCE(SUM(play_time), 0) as total_play_time").
+		Group("game_id").
+		Having("total_play_time > 0").
+		Order("total_play_time DESC").
+		Limit(20).
+		Scan(&playTimeRows).Error; err != nil {
+		return nil, err
+	}
+
+	if len(playTimeRows) == 0 {
+		return nil, nil
+	}
+
+	// Load the game objects (scoped to only the game IDs we need)
+	gameIDs := make([]uint, len(playTimeRows))
+	for i, r := range playTimeRows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	if len(games) == 0 {
+		return nil, nil
+	}
+
+	// Re-sort games by total play time (the IN query may not preserve order)
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+	sortedGames := make([]db.Game, 0, len(playTimeRows))
+	for _, r := range playTimeRows {
+		if g, ok := gameMap[r.GameID]; ok {
+			sortedGames = append(sortedGames, g)
+		}
+	}
+
+	return &ExploreRowResponse{
+		ID:    "most-played",
+		Title: "Most Played on Your Server",
+		Games: ToGameResponses(sortedGames, h.DB, userID),
+	}, nil
+}
+

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -1,0 +1,834 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// exploreTestEnv holds shared test fixtures for explore handler tests.
+type exploreTestEnv struct {
+	database *gorm.DB
+	router   http.Handler
+	token    string
+}
+
+func setupExploreTestEnv(t *testing.T) *exploreTestEnv {
+	t.Helper()
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+	return &exploreTestEnv{
+		database: database,
+		router:   router,
+		token:    token,
+	}
+}
+
+// createExploreGame creates a game with the given properties for testing.
+func createExploreGame(t *testing.T, database *gorm.DB, consoleAbbr, title string, rating float64) db.Game {
+	t.Helper()
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", consoleAbbr).First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     title,
+		FileName:  title + ".rom",
+		FilePath:  consoleAbbr + "/" + title + ".rom",
+		Rating:    rating,
+		Genre:     "Action",
+	}
+	require.NoError(t, database.Create(&game).Error)
+	return game
+}
+
+// createExploreGameWithTime creates a game with a specific created_at time.
+func createExploreGameWithTime(t *testing.T, database *gorm.DB, consoleAbbr, title string, rating float64, createdAt time.Time) db.Game {
+	t.Helper()
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", consoleAbbr).First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     title,
+		FileName:  title + ".rom",
+		FilePath:  consoleAbbr + "/" + title + ".rom",
+		Rating:    rating,
+		Genre:     "Action",
+	}
+	require.NoError(t, database.Create(&game).Error)
+	// Update created_at directly
+	database.Model(&game).Update("created_at", createdAt)
+	game.CreatedAt = createdAt
+	return game
+}
+
+// --- Featured endpoint tests ---
+
+func TestGetExploreFeatured_NoHeroArt(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create a game without hero art
+	createExploreGame(t, env.database, "NES", "Super Mario Bros", 90.0)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/featured", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []FeaturedGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp)
+}
+
+func TestGetExploreFeatured_WithHeroArt(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create games with different ratings
+	game1 := createExploreGame(t, env.database, "SNES", "Chrono Trigger", 95.0)
+	game2 := createExploreGame(t, env.database, "NES", "Super Mario Bros 3", 90.0)
+	game3 := createExploreGame(t, env.database, "GBA", "Metroid Fusion", 85.0)
+
+	// Only game1 and game2 have both hero and logo art
+	env.database.Create(&db.GameArtwork{
+		GameID:  game1.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/chrono.png",
+		LogoURL: "https://cdn.steamgriddb.com/logo/chrono.png",
+	})
+	env.database.Create(&db.GameArtwork{
+		GameID:  game2.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/smb3.png",
+		LogoURL: "https://cdn.steamgriddb.com/logo/smb3.png",
+	})
+	// game3 has hero but no logo — should NOT appear
+	env.database.Create(&db.GameArtwork{
+		GameID:  game3.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/metroid.png",
+		LogoURL: "",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/featured", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []FeaturedGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp, 2)
+
+	// Should be sorted by rating DESC
+	assert.Equal(t, "Chrono Trigger", resp[0].Title)
+	assert.Equal(t, 95.0, resp[0].Rating)
+	assert.Equal(t, "https://cdn.steamgriddb.com/hero/chrono.png", resp[0].HeroURL)
+	assert.Equal(t, "https://cdn.steamgriddb.com/logo/chrono.png", resp[0].LogoURL)
+	assert.Equal(t, "Action", resp[0].Genre)
+
+	assert.Equal(t, "Super Mario Bros 3", resp[1].Title)
+	assert.Equal(t, 90.0, resp[1].Rating)
+}
+
+func TestGetExploreFeatured_ConsoleInfo(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game := createExploreGame(t, env.database, "SNES", "Super Mario World", 95.0)
+	env.database.Create(&db.GameArtwork{
+		GameID:  game.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/smw.png",
+		LogoURL: "https://cdn.steamgriddb.com/logo/smw.png",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/featured", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []FeaturedGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+
+	assert.Equal(t, "snes", resp[0].ConsoleAbbreviation)
+	assert.Equal(t, "snes", resp[0].ConsoleID)
+	assert.Equal(t, "Super Nintendo", resp[0].ConsoleName)
+	assert.NotEmpty(t, resp[0].ConsoleColor)
+	assert.NotEmpty(t, resp[0].GameID)
+}
+
+func TestGetExploreFeatured_FavoriteAndPlayLater(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game := createExploreGame(t, env.database, "SNES", "Super Mario World", 95.0)
+	env.database.Create(&db.GameArtwork{
+		GameID:  game.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/smw.png",
+		LogoURL: "https://cdn.steamgriddb.com/logo/smw.png",
+	})
+
+	// Get the user ID from the token
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Add to favorites
+	env.database.Create(&db.Favorite{UserID: user.ID, GameID: game.ID})
+	// Add to play later
+	env.database.Create(&db.PlayLaterItem{UserID: user.ID, GameID: game.ID})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/featured", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []FeaturedGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.True(t, resp[0].IsFavorite)
+	assert.True(t, resp[0].IsPlayLater)
+}
+
+func TestGetExploreFeatured_Limit8(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create 10 games with hero art — should only return 8
+	for i := 0; i < 10; i++ {
+		game := createExploreGame(t, env.database, "NES", fmt.Sprintf("Game %d", i), float64(90-i))
+		env.database.Create(&db.GameArtwork{
+			GameID:  game.ID,
+			HeroURL: fmt.Sprintf("https://cdn.steamgriddb.com/hero/game%d.png", i),
+			LogoURL: fmt.Sprintf("https://cdn.steamgriddb.com/logo/game%d.png", i),
+		})
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/featured", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []FeaturedGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp, 8)
+}
+
+// --- Rows endpoint tests ---
+
+func TestGetExploreRows_EmptyLibrary(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Rows)
+
+	// Verify the JSON contains an empty array "[]", not "null" for rows
+	assert.Contains(t, w.Body.String(), `"rows":[]`)
+}
+
+func TestGetExploreRows_TopRated(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGame(t, env.database, "SNES", "Top Game", 95.0)
+	createExploreGame(t, env.database, "NES", "Good Game", 80.0)
+	createExploreGame(t, env.database, "GBA", "Average Game", 60.0)
+	// Game with no rating should not appear in top-rated
+	createExploreGame(t, env.database, "NES", "Unrated Game", 0)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Find the top-rated row
+	var topRated *ExploreRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].ID == "top-rated" {
+			topRated = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, topRated, "top-rated row should exist")
+	assert.Equal(t, "Top Rated", topRated.Title)
+
+	// Should have 3 rated games, sorted by rating DESC
+	assert.Len(t, topRated.Games, 3)
+	assert.Equal(t, "Top Game", topRated.Games[0].Title)
+	assert.Equal(t, 95.0, topRated.Games[0].Rating)
+	assert.Equal(t, "Good Game", topRated.Games[1].Title)
+	assert.Equal(t, "Average Game", topRated.Games[2].Title)
+}
+
+func TestGetExploreRows_RecentlyAdded(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	now := time.Now()
+	createExploreGameWithTime(t, env.database, "SNES", "Oldest Game", 80.0, now.Add(-72*time.Hour))
+	createExploreGameWithTime(t, env.database, "NES", "Middle Game", 75.0, now.Add(-24*time.Hour))
+	createExploreGameWithTime(t, env.database, "GBA", "Newest Game", 70.0, now)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var recentlyAdded *ExploreRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].ID == "recently-added" {
+			recentlyAdded = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, recentlyAdded, "recently-added row should exist")
+	assert.Equal(t, "Recently Added", recentlyAdded.Title)
+
+	// Should be sorted by created_at DESC (newest first)
+	require.Len(t, recentlyAdded.Games, 3)
+	assert.Equal(t, "Newest Game", recentlyAdded.Games[0].Title)
+	assert.Equal(t, "Middle Game", recentlyAdded.Games[1].Title)
+	assert.Equal(t, "Oldest Game", recentlyAdded.Games[2].Title)
+}
+
+func TestGetExploreRows_HiddenGems(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Need at least 5 games for hidden gems to appear
+	highRatedUnplayed := createExploreGame(t, env.database, "SNES", "Hidden Gem 1", 85.0)
+	createExploreGame(t, env.database, "NES", "Hidden Gem 2", 80.0)
+	highRatedPlayed := createExploreGame(t, env.database, "GBA", "Popular Game", 90.0)
+	createExploreGame(t, env.database, "NES", "Filler 1", 50.0)
+	createExploreGame(t, env.database, "NES", "Filler 2", 40.0)
+
+	// Create a user to add play history
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Give "Popular Game" significant play time
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     highRatedPlayed.ID,
+		PlayTime:   10000,
+		LastPlayed: time.Now(),
+	})
+	// Give "Hidden Gem 1" zero play time (no entry = zero)
+	_ = highRatedUnplayed
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var hiddenGems *ExploreRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].ID == "hidden-gems" {
+			hiddenGems = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, hiddenGems, "hidden-gems row should exist")
+	assert.Equal(t, "Hidden Gems", hiddenGems.Title)
+
+	// Hidden Gem 1 and Hidden Gem 2 should appear (high rating, low/no play time)
+	// Popular Game has high play time, so depending on threshold it might be excluded
+	foundGem1 := false
+	foundGem2 := false
+	for _, g := range hiddenGems.Games {
+		if g.Title == "Hidden Gem 1" {
+			foundGem1 = true
+		}
+		if g.Title == "Hidden Gem 2" {
+			foundGem2 = true
+		}
+	}
+	assert.True(t, foundGem1, "Hidden Gem 1 should be in hidden gems (no play time)")
+	assert.True(t, foundGem2, "Hidden Gem 2 should be in hidden gems (no play time)")
+}
+
+func TestGetExploreRows_HiddenGems_NotShownForSmallLibrary(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create only 3 games (< 5 threshold)
+	createExploreGame(t, env.database, "SNES", "Game 1", 90.0)
+	createExploreGame(t, env.database, "NES", "Game 2", 85.0)
+	createExploreGame(t, env.database, "GBA", "Game 3", 80.0)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	for _, row := range resp.Rows {
+		assert.NotEqual(t, "hidden-gems", row.ID, "hidden gems should not appear for < 5 games")
+	}
+}
+
+func TestGetExploreRows_HiddenGems_NoPlayHistory(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create 6 games with high ratings, no play history at all
+	for i := 0; i < 6; i++ {
+		createExploreGame(t, env.database, "NES", fmt.Sprintf("Gem %d", i), float64(90-i))
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var hiddenGems *ExploreRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].ID == "hidden-gems" {
+			hiddenGems = &resp.Rows[i]
+			break
+		}
+	}
+	// With no play history and all games >= 75 rating, all qualify as hidden gems
+	require.NotNil(t, hiddenGems, "hidden gems should appear when no play history exists")
+	assert.Greater(t, len(hiddenGems.Games), 0)
+}
+
+func TestGetExploreRows_MostPlayed(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "SNES", "Most Played", 80.0)
+	game2 := createExploreGame(t, env.database, "NES", "Second Most Played", 75.0)
+	createExploreGame(t, env.database, "GBA", "Never Played", 70.0)
+
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Add play history
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game1.ID,
+		PlayTime:   5000,
+		LastPlayed: time.Now(),
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game2.ID,
+		PlayTime:   2000,
+		LastPlayed: time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var mostPlayed *ExploreRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].ID == "most-played" {
+			mostPlayed = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, mostPlayed, "most-played row should exist when play history exists")
+	assert.Equal(t, "Most Played on Your Server", mostPlayed.Title)
+
+	// Should be sorted by total play time DESC
+	require.Len(t, mostPlayed.Games, 2)
+	assert.Equal(t, "Most Played", mostPlayed.Games[0].Title)
+	assert.Equal(t, "Second Most Played", mostPlayed.Games[1].Title)
+}
+
+func TestGetExploreRows_MostPlayed_AggregatesAcrossUsers(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "SNES", "Community Favorite", 80.0)
+	game2 := createExploreGame(t, env.database, "NES", "Single User Game", 75.0)
+
+	// Get owner user
+	var user1 db.User
+	require.NoError(t, env.database.First(&user1).Error)
+
+	// Create a second user
+	ownerToken := env.token
+	user2Token := createNonOwnerUser(t, env.router, ownerToken, "player2", "player2@example.com", "password123")
+	_ = user2Token
+	var user2 db.User
+	require.NoError(t, env.database.Where("username = ?", "player2").First(&user2).Error)
+
+	// Both users play game1
+	env.database.Create(&db.PlayHistory{
+		UserID:     user1.ID,
+		GameID:     game1.ID,
+		PlayTime:   3000,
+		LastPlayed: time.Now(),
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user2.ID,
+		GameID:     game1.ID,
+		PlayTime:   3000,
+		LastPlayed: time.Now(),
+	})
+	// Only user1 plays game2 with more time
+	env.database.Create(&db.PlayHistory{
+		UserID:     user1.ID,
+		GameID:     game2.ID,
+		PlayTime:   5000,
+		LastPlayed: time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var mostPlayed *ExploreRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].ID == "most-played" {
+			mostPlayed = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, mostPlayed)
+
+	// game1 has 6000 total (3000+3000), game2 has 5000 total
+	// game1 should be first
+	require.Len(t, mostPlayed.Games, 2)
+	assert.Equal(t, "Community Favorite", mostPlayed.Games[0].Title)
+	assert.Equal(t, "Single User Game", mostPlayed.Games[1].Title)
+}
+
+func TestGetExploreRows_MostPlayed_OmittedWhenNoPlayHistory(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGame(t, env.database, "SNES", "Some Game", 80.0)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	for _, row := range resp.Rows {
+		assert.NotEqual(t, "most-played", row.ID, "most-played row should be omitted when no play history")
+	}
+}
+
+func TestGetExploreRows_AllFourRows(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create enough games for all rows to appear
+	// Need at least 5 games, some with rating >= 75, and play history
+	var games []db.Game
+	for i := 0; i < 6; i++ {
+		game := createExploreGame(t, env.database, "NES", fmt.Sprintf("Game %d", i), float64(90-i*5))
+		games = append(games, game)
+	}
+
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Add play history to some games (not all, so hidden gems can work)
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     games[0].ID,
+		PlayTime:   10000,
+		LastPlayed: time.Now(),
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     games[1].ID,
+		PlayTime:   5000,
+		LastPlayed: time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// All 4 row types should be present
+	rowIDs := make(map[string]bool)
+	for _, row := range resp.Rows {
+		rowIDs[row.ID] = true
+	}
+	assert.True(t, rowIDs["top-rated"], "top-rated row should exist")
+	assert.True(t, rowIDs["recently-added"], "recently-added row should exist")
+	assert.True(t, rowIDs["hidden-gems"], "hidden-gems row should exist")
+	assert.True(t, rowIDs["most-played"], "most-played row should exist")
+
+	// Verify ordering: top-rated, recently-added, hidden-gems, most-played
+	require.Len(t, resp.Rows, 4)
+	assert.Equal(t, "top-rated", resp.Rows[0].ID)
+	assert.Equal(t, "recently-added", resp.Rows[1].ID)
+	assert.Equal(t, "hidden-gems", resp.Rows[2].ID)
+	assert.Equal(t, "most-played", resp.Rows[3].ID)
+}
+
+func TestGetExploreRows_UserFavoriteStatus(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game := createExploreGame(t, env.database, "NES", "Favorited Game", 90.0)
+
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Favorite this game
+	env.database.Create(&db.Favorite{UserID: user.ID, GameID: game.ID})
+	// Add to play later
+	env.database.Create(&db.PlayLaterItem{UserID: user.ID, GameID: game.ID})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Find top-rated row and check the game
+	var topRated *ExploreRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].ID == "top-rated" {
+			topRated = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, topRated)
+	require.Len(t, topRated.Games, 1)
+	assert.True(t, topRated.Games[0].IsFavorite, "game should be marked as favorite")
+	assert.True(t, topRated.Games[0].IsInPlayLater, "game should be marked as play later")
+}
+
+func TestGetExploreRows_GamesIncludeConsoleInfo(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGame(t, env.database, "SNES", "SNES Game", 90.0)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var topRated *ExploreRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].ID == "top-rated" {
+			topRated = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, topRated)
+	require.Len(t, topRated.Games, 1)
+
+	game := topRated.Games[0]
+	assert.Equal(t, "snes", game.ConsoleID)
+	assert.NotEmpty(t, game.ConsoleName)
+	assert.NotEmpty(t, game.ID)
+	assert.Equal(t, "SNES Game", game.Title)
+	assert.Equal(t, 90.0, game.Rating)
+}
+
+func TestGetExploreRows_TopRated_CrossConsole(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGame(t, env.database, "SNES", "Best SNES", 95.0)
+	createExploreGame(t, env.database, "NES", "Best NES", 90.0)
+	createExploreGame(t, env.database, "GBA", "Best GBA", 85.0)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var topRated *ExploreRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].ID == "top-rated" {
+			topRated = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, topRated)
+	require.Len(t, topRated.Games, 3)
+
+	// Games from different consoles should be mixed together
+	consoles := make(map[string]bool)
+	for _, g := range topRated.Games {
+		consoles[g.ConsoleID] = true
+	}
+	assert.Len(t, consoles, 3, "top-rated should include games from multiple consoles")
+}
+
+func TestGetExploreRows_EmptyRowsOmitted(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create only unrated games (no games with rating > 0)
+	createExploreGame(t, env.database, "NES", "Unrated", 0)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// top-rated should not appear (no rated games)
+	for _, row := range resp.Rows {
+		assert.NotEqual(t, "top-rated", row.ID, "top-rated row should be omitted when no games have rating > 0")
+	}
+
+	// recently-added SHOULD appear (we have 1 game)
+	found := false
+	for _, row := range resp.Rows {
+		if row.ID == "recently-added" {
+			found = true
+			break
+		}
+	}
+	assert.True(t, found, "recently-added should appear even with unrated games")
+}
+
+func TestGetExploreRows_HiddenGems_OnlyHighRated(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create 5 games but none with rating >= 75
+	for i := 0; i < 5; i++ {
+		createExploreGame(t, env.database, "NES", fmt.Sprintf("Low Rated %d", i), float64(50+i))
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	for _, row := range resp.Rows {
+		assert.NotEqual(t, "hidden-gems", row.ID, "hidden gems should not appear when no games have rating >= 75")
+	}
+}
+
+func TestGetExploreRows_TopRated_Max20(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create 25 rated games
+	for i := 0; i < 25; i++ {
+		createExploreGame(t, env.database, "NES", fmt.Sprintf("Rated Game %d", i), float64(95-i))
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ExploreRowsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var topRated *ExploreRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].ID == "top-rated" {
+			topRated = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, topRated)
+	assert.Len(t, topRated.Games, 20, "top-rated should be limited to 20 games")
+}
+
+func TestGetExploreRows_RequiresAuth(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/rows", nil)
+	// No auth header
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestGetExploreFeatured_RequiresAuth(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/featured", nil)
+	// No auth header
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -172,6 +172,7 @@ func NewRouter(cfg Config) *gin.Engine {
 	challengeHandler.AttemptRateLimitSeconds = cfg.ChallengeAttemptRateLimitSec
 	sessionHandler := &SessionHandler{DB: cfg.DB, Storage: cfg.Storage}
 	artworkHandler := &ArtworkHandler{DB: cfg.DB}
+	exploreHandler := &ExploreHandler{DB: cfg.DB}
 	discoveryHandler := &GameDiscoveryHandler{DB: cfg.DB, Scraper: cfg.Scraper}
 	setupHandler := &SetupHandler{
 		DB:            cfg.DB,
@@ -231,6 +232,13 @@ func NewRouter(cfg Config) *gin.Engine {
 
 		// Top Lists
 		api.GET("/top-lists/top-rated", consoleHandler.GetTopListAvailable)
+
+		// Explore
+		explore := api.Group("/explore")
+		{
+			explore.GET("/featured", exploreHandler.GetExploreFeatured)
+			explore.GET("/rows", exploreHandler.GetExploreRows)
+		}
 
 		// Games
 		api.GET("/games", gameHandler.ListGames)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -35,6 +35,7 @@ import { NetplaySessionPage } from "@/pages/netplay-session-page";
 import { LicensesPage } from "@/pages/licenses-page";
 import { ChallengesPage } from "@/pages/challenges-page";
 import { TopListsPage } from "@/pages/top-lists-page";
+import { ExplorePage } from "@/pages/explore-page";
 import { ChallengeDetailPage } from "@/pages/challenge-detail-page";
 import { SessionDetailPage } from "@/pages/session-detail-page";
 import { SetupWizardPage } from "@/pages/setup-wizard-page";
@@ -82,6 +83,7 @@ export function App() {
                     }
                   >
                     <Route index element={<DashboardPage />} />
+                    <Route path="explore" element={<ExplorePage />} />
                     <Route element={<LibraryLayout />}>
                       <Route path="consoles" element={<ConsolesPage />} />
                       <Route path="games" element={<GamesPage />} />

--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from "react";
 import { Outlet, useNavigate, useLocation } from "react-router-dom";
 import {
   LayoutDashboard,
+  Compass,
   Library,
   BarChart3,
   Activity,
@@ -61,6 +62,7 @@ export function AppLayout() {
       section: undefined,
       items: [
         { to: "/", icon: LayoutDashboard, label: "Dashboard" },
+        { to: "/explore", icon: Compass, label: "Explore" },
         {
           to: "/consoles",
           icon: Library,

--- a/web/src/components/game-card.tsx
+++ b/web/src/components/game-card.tsx
@@ -8,6 +8,7 @@ import type { Game } from "@/types/api";
 interface GameCardProps {
   game: Game;
   aspectRatio?: number;
+  showConsoleBadge?: boolean;
   onToggleFavorite?: (game: Game) => void;
   onTogglePlayLater?: (game: Game) => void;
 }
@@ -15,6 +16,7 @@ interface GameCardProps {
 export function GameCard({
   game,
   aspectRatio,
+  showConsoleBadge,
   onToggleFavorite,
   onTogglePlayLater,
 }: GameCardProps) {
@@ -97,7 +99,10 @@ export function GameCard({
 
         {/* Console badge */}
         {game.consoleName && (
-          <div className="absolute bottom-2.5 left-2.5 opacity-0 group-hover:opacity-100 transition-opacity duration-300">
+          <div className={cn(
+            "absolute bottom-2.5 left-2.5 transition-opacity duration-300",
+            showConsoleBadge ? "opacity-100" : "opacity-0 group-hover:opacity-100",
+          )}>
             <Badge variant="brand">{game.consoleName}</Badge>
           </div>
         )}

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -1,0 +1,262 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { ExplorePage } from "@/pages/explore-page";
+import type { FeaturedGame, Game, ExploreRowsResponse } from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-explore", () => ({
+  useExploreFeatured: vi.fn(),
+  useExploreRows: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-games", () => ({
+  useToggleFavorite: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-play-later", () => ({
+  useTogglePlayLater: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ user: { username: "testuser", role: "admin" }, isAdmin: true }),
+}));
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+import { useExploreFeatured, useExploreRows } from "@/hooks/use-explore";
+
+const mockUseExploreFeatured = useExploreFeatured as ReturnType<typeof vi.fn>;
+const mockUseExploreRows = useExploreRows as ReturnType<typeof vi.fn>;
+
+function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
+  return {
+    gameId: "1",
+    title: "Featured Game",
+    heroUrl: "/hero/test.jpg",
+    logoUrl: "/logo/test.png",
+    consoleAbbreviation: "snes",
+    consoleColor: "#805ad5",
+    rating: 92.5,
+    genre: "RPG",
+    isFavorite: false,
+    isPlayLater: false,
+    ...overrides,
+  };
+}
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "nes",
+    consoleName: "NES",
+    fileName: "test.nes",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const mockFeatured: FeaturedGame[] = [
+  makeFeaturedGame({ gameId: "1", title: "Hero Game One" }),
+  makeFeaturedGame({ gameId: "2", title: "Hero Game Two" }),
+];
+
+const mockRows: ExploreRowsResponse = {
+  rows: [
+    {
+      id: "top-rated",
+      title: "Top Rated",
+      games: [
+        makeGame({ id: "10", title: "Top Game A" }),
+        makeGame({ id: "11", title: "Top Game B" }),
+      ],
+    },
+    {
+      id: "recently-added",
+      title: "Recently Added",
+      games: [
+        makeGame({ id: "20", title: "New Game A" }),
+      ],
+    },
+    {
+      id: "hidden-gems",
+      title: "Hidden Gems",
+      games: [
+        makeGame({ id: "30", title: "Gem Game" }),
+      ],
+    },
+  ],
+};
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <ExplorePage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ExplorePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // Mock matchMedia for prefers-reduced-motion
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+
+    mockUseExploreFeatured.mockReturnValue({
+      data: mockFeatured,
+      isLoading: false,
+    });
+    mockUseExploreRows.mockReturnValue({
+      data: mockRows,
+      isLoading: false,
+    });
+  });
+
+  it("renders the page heading", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: "Explore", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders the hero carousel", () => {
+    renderPage();
+    expect(screen.getByTestId("hero-carousel")).toBeInTheDocument();
+  });
+
+  it("renders all shelf rows", () => {
+    renderPage();
+    expect(screen.getByTestId("shelf-Top Rated")).toBeInTheDocument();
+    expect(screen.getByTestId("shelf-Recently Added")).toBeInTheDocument();
+    expect(screen.getByTestId("shelf-Hidden Gems")).toBeInTheDocument();
+  });
+
+  it("renders games in shelf rows", () => {
+    renderPage();
+    expect(screen.getByText("Top Game A")).toBeInTheDocument();
+    expect(screen.getByText("Top Game B")).toBeInTheDocument();
+    expect(screen.getByText("New Game A")).toBeInTheDocument();
+    expect(screen.getByText("Gem Game")).toBeInTheDocument();
+  });
+
+  it("shows empty library state when no data", () => {
+    mockUseExploreFeatured.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    mockUseExploreRows.mockReturnValue({
+      data: { rows: [] },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("Nothing to explore yet")).toBeInTheDocument();
+  });
+
+  it("shows admin scan link in empty state for admins", () => {
+    mockUseExploreFeatured.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    mockUseExploreRows.mockReturnValue({
+      data: { rows: [] },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("Scan Library")).toBeInTheDocument();
+  });
+
+  it("shows loading skeletons while data is loading", () => {
+    mockUseExploreFeatured.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    mockUseExploreRows.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByTestId("hero-carousel-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("shelf-skeleton-Top Rated")).toBeInTheDocument();
+    expect(screen.getByTestId("shelf-skeleton-Recently Added")).toBeInTheDocument();
+  });
+
+  it("renders hero carousel and rows independently when one loads first", () => {
+    mockUseExploreFeatured.mockReturnValue({
+      data: mockFeatured,
+      isLoading: false,
+    });
+    mockUseExploreRows.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    // Carousel should render
+    expect(screen.getByTestId("hero-carousel")).toBeInTheDocument();
+    // Rows should show skeleton
+    expect(screen.getByTestId("shelf-skeleton-Top Rated")).toBeInTheDocument();
+  });
+
+  it("does not render carousel when featured games empty but rows exist", () => {
+    mockUseExploreFeatured.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("hero-carousel")).not.toBeInTheDocument();
+    // Rows should still render
+    expect(screen.getByTestId("shelf-Top Rated")).toBeInTheDocument();
+  });
+
+  it("omits shelf rows with empty games arrays", () => {
+    mockUseExploreRows.mockReturnValue({
+      data: {
+        rows: [
+          { id: "top-rated", title: "Top Rated", games: [] },
+          {
+            id: "recently-added",
+            title: "Recently Added",
+            games: [makeGame({ id: "20", title: "New Game A" })],
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("shelf-Top Rated")).not.toBeInTheDocument();
+    expect(screen.getByTestId("shelf-Recently Added")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/explore/components/__tests__/game-shelf.test.tsx
+++ b/web/src/features/explore/components/__tests__/game-shelf.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { GameShelf } from "../game-shelf";
+import type { Game } from "@/types/api";
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "nes",
+    consoleName: "NES",
+    fileName: "test.nes",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const mockGames: Game[] = [
+  makeGame({ id: "1", title: "Super Mario World", consoleName: "SNES" }),
+  makeGame({ id: "2", title: "Chrono Trigger", consoleName: "SNES" }),
+  makeGame({ id: "3", title: "Zelda", consoleName: "NES" }),
+];
+
+function renderShelf(
+  props: {
+    title?: string;
+    games?: Game[] | undefined;
+    isLoading?: boolean;
+  } = {},
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const games = "games" in props ? props.games : mockGames;
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <GameShelf
+          title={props.title ?? "Top Rated"}
+          games={games}
+          isLoading={props.isLoading ?? false}
+        />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("GameShelf", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders section with title", () => {
+    renderShelf();
+    expect(
+      screen.getByRole("heading", { name: "Top Rated", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders games in a list", () => {
+    renderShelf();
+    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+    expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
+    expect(screen.getByText("Zelda")).toBeInTheDocument();
+  });
+
+  it("renders game cards as list items", () => {
+    renderShelf();
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(3);
+  });
+
+  it("renders the scrollable list with title as label", () => {
+    renderShelf();
+    expect(screen.getByRole("list", { name: "Top Rated" })).toBeInTheDocument();
+  });
+
+  it("renders nothing when games array is empty", () => {
+    const { container } = renderShelf({ games: [] });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when games is undefined and not loading", () => {
+    const { container } = renderShelf({ games: undefined, isLoading: false });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders loading skeleton when loading", () => {
+    renderShelf({ isLoading: true, games: undefined });
+    expect(
+      screen.getByTestId("shelf-skeleton-Top Rated"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Top Rated", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton with shimmer animation", () => {
+    const { container } = renderShelf({ isLoading: true, games: undefined });
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders different section titles", () => {
+    renderShelf({ title: "Hidden Gems" });
+    expect(
+      screen.getByRole("heading", { name: "Hidden Gems", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("links game cards to game detail pages", () => {
+    renderShelf();
+    const links = screen.getAllByRole("link");
+    const hrefs = links.map((l) => l.getAttribute("href"));
+    expect(hrefs).toContain("/games/1");
+    expect(hrefs).toContain("/games/2");
+    expect(hrefs).toContain("/games/3");
+  });
+});

--- a/web/src/features/explore/components/__tests__/hero-carousel.test.tsx
+++ b/web/src/features/explore/components/__tests__/hero-carousel.test.tsx
@@ -1,0 +1,249 @@
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { HeroCarousel } from "../hero-carousel";
+import type { FeaturedGame } from "@/types/api";
+
+function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
+  return {
+    gameId: "1",
+    title: "Test Game",
+    heroUrl: "/hero/test.jpg",
+    logoUrl: "/logo/test.png",
+    consoleAbbreviation: "snes",
+    consoleColor: "#805ad5",
+    rating: 92.5,
+    genre: "RPG",
+    isFavorite: false,
+    isPlayLater: false,
+    ...overrides,
+  };
+}
+
+const mockGames: FeaturedGame[] = [
+  makeFeaturedGame({ gameId: "1", title: "Game One" }),
+  makeFeaturedGame({ gameId: "2", title: "Game Two", logoUrl: null }),
+  makeFeaturedGame({ gameId: "3", title: "Game Three" }),
+];
+
+function renderCarousel(
+  props: { games?: FeaturedGame[] | undefined; isLoading?: boolean } = {},
+) {
+  const games = "games" in props ? props.games : mockGames;
+  return render(
+    <MemoryRouter>
+      <HeroCarousel
+        games={games}
+        isLoading={props.isLoading ?? false}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("HeroCarousel", () => {
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // Mock matchMedia for prefers-reduced-motion
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: false,
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("renders featured games", () => {
+    renderCarousel();
+    expect(screen.getByTestId("hero-carousel")).toBeInTheDocument();
+    expect(screen.getByTestId("hero-slide-1")).toBeInTheDocument();
+    expect(screen.getByTestId("hero-slide-2")).toBeInTheDocument();
+    expect(screen.getByTestId("hero-slide-3")).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton when loading", () => {
+    renderCarousel({ isLoading: true, games: undefined });
+    expect(screen.getByTestId("hero-carousel-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("hero-carousel")).not.toBeInTheDocument();
+  });
+
+  it("renders nothing when no games", () => {
+    const { container } = renderCarousel({ games: [] });
+    expect(screen.queryByTestId("hero-carousel")).not.toBeInTheDocument();
+    expect(screen.queryByTestId("hero-carousel-skeleton")).not.toBeInTheDocument();
+    // Check there's no output at all
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when games is undefined and not loading", () => {
+    const { container } = renderCarousel({ games: undefined, isLoading: false });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows logo image when logoUrl is available", () => {
+    renderCarousel({
+      games: [makeFeaturedGame({ gameId: "1", logoUrl: "/logo/test.png" })],
+    });
+    expect(screen.getByTestId("hero-logo-1")).toBeInTheDocument();
+  });
+
+  it("falls back to text title when logoUrl is null", () => {
+    renderCarousel({
+      games: [makeFeaturedGame({ gameId: "2", title: "No Logo Game", logoUrl: null })],
+    });
+    expect(screen.getByTestId("hero-title-text-2")).toBeInTheDocument();
+    expect(screen.getByText("No Logo Game")).toBeInTheDocument();
+  });
+
+  it("renders console badge", () => {
+    renderCarousel({
+      games: [makeFeaturedGame({ consoleAbbreviation: "snes" })],
+    });
+    expect(screen.getByText("SNES")).toBeInTheDocument();
+  });
+
+  it("renders rating", () => {
+    renderCarousel({
+      games: [makeFeaturedGame({ rating: 92.5 })],
+    });
+    expect(screen.getByText("92.5")).toBeInTheDocument();
+  });
+
+  it("renders genre chip", () => {
+    renderCarousel({
+      games: [makeFeaturedGame({ genre: "RPG" })],
+    });
+    expect(screen.getByText("RPG")).toBeInTheDocument();
+  });
+
+  it("renders View Game button linking to game detail", () => {
+    renderCarousel({
+      games: [makeFeaturedGame({ gameId: "42" })],
+    });
+    const link = screen.getByTestId("hero-view-game-42");
+    expect(link).toHaveAttribute("href", "/games/42");
+  });
+
+  it("renders navigation dots for multiple games", () => {
+    renderCarousel();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs).toHaveLength(3);
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+    expect(tabs[1]).toHaveAttribute("aria-selected", "false");
+  });
+
+  it("does not render navigation dots for single game", () => {
+    renderCarousel({
+      games: [makeFeaturedGame()],
+    });
+    expect(screen.queryByRole("tab")).not.toBeInTheDocument();
+  });
+
+  it("renders arrow buttons for multiple games", () => {
+    renderCarousel();
+    expect(screen.getByLabelText("Previous slide")).toBeInTheDocument();
+    expect(screen.getByLabelText("Next slide")).toBeInTheDocument();
+  });
+
+  it("does not render arrow buttons for single game", () => {
+    renderCarousel({ games: [makeFeaturedGame()] });
+    expect(screen.queryByLabelText("Previous slide")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("Next slide")).not.toBeInTheDocument();
+  });
+
+  it("auto-rotates after 8 seconds", () => {
+    renderCarousel();
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    const tabsAfter = screen.getAllByRole("tab");
+    expect(tabsAfter[0]).toHaveAttribute("aria-selected", "false");
+    expect(tabsAfter[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("pauses auto-rotation on hover", async () => {
+    renderCarousel();
+    const carousel = screen.getByTestId("hero-carousel");
+
+    // Hover to pause
+    await userEvent.hover(carousel);
+
+    act(() => {
+      vi.advanceTimersByTime(16000);
+    });
+
+    // Should still be on first slide
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[0]).toHaveAttribute("aria-selected", "true");
+
+    // Unhover to resume
+    await userEvent.unhover(carousel);
+
+    act(() => {
+      vi.advanceTimersByTime(8000);
+    });
+
+    const tabsAfter = screen.getAllByRole("tab");
+    expect(tabsAfter[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("clicking navigation dot changes slide", async () => {
+    renderCarousel();
+    const tabs = screen.getAllByRole("tab");
+
+    await userEvent.click(tabs[2]);
+
+    const tabsAfter = screen.getAllByRole("tab");
+    expect(tabsAfter[2]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("clicking next arrow advances to next slide", async () => {
+    renderCarousel();
+    const nextBtn = screen.getByLabelText("Next slide");
+
+    await userEvent.click(nextBtn);
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[1]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("clicking prev arrow goes to previous slide (wraps)", async () => {
+    renderCarousel();
+    const prevBtn = screen.getByLabelText("Previous slide");
+
+    await userEvent.click(prevBtn);
+
+    const tabs = screen.getAllByRole("tab");
+    expect(tabs[2]).toHaveAttribute("aria-selected", "true");
+  });
+
+  it("has accessible region label", () => {
+    renderCarousel();
+    const region = screen.getByRole("region", {
+      name: "Featured games carousel",
+    });
+    expect(region).toBeInTheDocument();
+  });
+
+  it("has accessible labels on navigation dots", () => {
+    renderCarousel();
+    expect(screen.getByLabelText("Go to slide 1")).toBeInTheDocument();
+    expect(screen.getByLabelText("Go to slide 2")).toBeInTheDocument();
+    expect(screen.getByLabelText("Go to slide 3")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/explore/components/game-shelf.tsx
+++ b/web/src/features/explore/components/game-shelf.tsx
@@ -1,0 +1,132 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton } from "@/components/ui";
+import type { Game } from "@/types/api";
+
+interface GameShelfProps {
+  title: string;
+  games: Game[] | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+function GameShelfSkeleton({ title }: { title: string }) {
+  return (
+    <section data-testid={`shelf-skeleton-${title}`}>
+      <h2 className="text-xl font-bold text-surface-100 mb-5">{title}</h2>
+      <div className="flex gap-5 overflow-hidden">
+        {Array.from({ length: 6 }, (_, i) => (
+          <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+            <GameCardSkeleton />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function GameShelf({
+  title,
+  games,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: GameShelfProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(
+      el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
+    );
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, games]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return <GameShelfSkeleton title={title} />;
+  }
+
+  if (!games || games.length === 0) {
+    return null;
+  }
+
+  return (
+    <section data-testid={`shelf-${title}`} className="group/shelf relative">
+      <h2 className="text-xl font-bold text-surface-100 mb-5">{title}</h2>
+
+      <div className="relative">
+        {/* Scroll arrows */}
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label={`Scroll ${title} left`}
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label={`Scroll ${title} right`}
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        {/* Scrollable row */}
+        <div
+          ref={scrollRef}
+          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label={title}
+        >
+          {games.map((game) => (
+            <div
+              key={game.id}
+              className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+              role="listitem"
+            >
+              <GameCard
+                game={game}
+                showConsoleBadge
+                onToggleFavorite={onToggleFavorite}
+                onTogglePlayLater={onTogglePlayLater}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/features/explore/components/hero-carousel.tsx
+++ b/web/src/features/explore/components/hero-carousel.tsx
@@ -1,0 +1,284 @@
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Link } from "react-router-dom";
+import { ChevronLeft, ChevronRight, Star } from "lucide-react";
+import { Badge, Skeleton } from "@/components/ui";
+import { cn } from "@/lib/cn";
+import type { FeaturedGame } from "@/types/api";
+
+interface HeroCarouselProps {
+  games: FeaturedGame[] | undefined;
+  isLoading: boolean;
+}
+
+function HeroCarouselSkeleton() {
+  return (
+    <div
+      className="relative w-full overflow-hidden rounded-2xl"
+      data-testid="hero-carousel-skeleton"
+    >
+      <Skeleton className="w-full rounded-2xl" style={{ aspectRatio: "21/9" }} />
+    </div>
+  );
+}
+
+function NavigationDots({
+  count,
+  activeIndex,
+  onSelect,
+}: {
+  count: number;
+  activeIndex: number;
+  onSelect: (index: number) => void;
+}) {
+  return (
+    <div
+      className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 z-10"
+      role="tablist"
+      aria-label="Carousel navigation"
+    >
+      {Array.from({ length: count }, (_, i) => (
+        <button
+          key={i}
+          role="tab"
+          aria-selected={i === activeIndex}
+          aria-label={`Go to slide ${i + 1}`}
+          onClick={() => onSelect(i)}
+          className={cn(
+            "h-2 rounded-full transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+            i === activeIndex
+              ? "w-6 bg-white"
+              : "w-2 bg-white/40 hover:bg-white/60",
+          )}
+        />
+      ))}
+    </div>
+  );
+}
+
+function HeroSlide({
+  game,
+  isActive,
+}: {
+  game: FeaturedGame;
+  isActive: boolean;
+}) {
+  const [imageError, setImageError] = useState(false);
+
+  return (
+    <div
+      className={cn(
+        "absolute inset-0 transition-opacity duration-700 ease-in-out",
+        isActive ? "opacity-100 z-[1]" : "opacity-0 z-0",
+      )}
+      aria-hidden={!isActive}
+      data-testid={`hero-slide-${game.gameId}`}
+    >
+      {/* Hero background image */}
+      {!imageError ? (
+        <img
+          src={game.heroUrl}
+          alt={`Hero art for ${game.title}`}
+          className="absolute inset-0 w-full h-full object-cover"
+          onError={() => setImageError(true)}
+          loading={isActive ? "eager" : "lazy"}
+        />
+      ) : (
+        <div className="absolute inset-0 bg-gradient-to-br from-surface-800 to-surface-950" />
+      )}
+
+      {/* Gradient overlays for readability */}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/30 to-transparent" />
+      <div className="absolute inset-0 bg-gradient-to-r from-black/50 via-transparent to-transparent" />
+
+      {/* Content overlay */}
+      <div className="absolute inset-0 flex flex-col justify-end p-6 sm:p-8 lg:p-10">
+        <div className="max-w-2xl space-y-4">
+          {/* Game logo or title */}
+          {game.logoUrl ? (
+            <img
+              src={game.logoUrl}
+              alt={game.title}
+              className="max-h-20 sm:max-h-24 lg:max-h-28 max-w-[60%] object-contain drop-shadow-lg"
+              data-testid={`hero-logo-${game.gameId}`}
+            />
+          ) : (
+            <h2
+              className="text-3xl sm:text-4xl lg:text-5xl font-bold text-white drop-shadow-lg"
+              data-testid={`hero-title-text-${game.gameId}`}
+            >
+              {game.title}
+            </h2>
+          )}
+
+          {/* Metadata badges */}
+          <div className="flex flex-wrap items-center gap-2">
+            {game.consoleAbbreviation && (
+              <Badge
+                variant="brand"
+                style={
+                  game.consoleColor
+                    ? ({
+                        "--badge-color": game.consoleColor,
+                        backgroundColor: `${game.consoleColor}20`,
+                        borderColor: `${game.consoleColor}50`,
+                        color: game.consoleColor,
+                      } as React.CSSProperties)
+                    : undefined
+                }
+              >
+                {game.consoleAbbreviation.toUpperCase()}
+              </Badge>
+            )}
+            {game.rating > 0 && (
+              <span className="inline-flex items-center gap-1 text-sm font-medium text-amber-400">
+                <Star className="h-3.5 w-3.5 fill-amber-400" />
+                {game.rating.toFixed(1)}
+              </span>
+            )}
+            {game.genre && (
+              <Badge variant="default">{game.genre}</Badge>
+            )}
+          </div>
+
+          {/* Action button */}
+          <div>
+            <Link
+              to={`/games/${game.gameId}`}
+              className="inline-flex items-center gap-2 px-5 py-2.5 rounded-xl bg-brand-600 text-white font-medium text-sm hover:bg-brand-500 transition-colors shadow-lg shadow-brand-600/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950"
+              tabIndex={isActive ? 0 : -1}
+              data-testid={`hero-view-game-${game.gameId}`}
+            >
+              View Game
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function HeroCarousel({ games, isLoading }: HeroCarouselProps) {
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [isPaused, setIsPaused] = useState(false);
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  // Check for prefers-reduced-motion
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReducedMotion(mq.matches);
+    const handler = (e: MediaQueryListEvent) =>
+      setPrefersReducedMotion(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  const slideCount = games?.length ?? 0;
+
+  const goToNext = useCallback(() => {
+    if (slideCount <= 1) return;
+    setActiveIndex((prev) => (prev + 1) % slideCount);
+  }, [slideCount]);
+
+  const goToPrev = useCallback(() => {
+    if (slideCount <= 1) return;
+    setActiveIndex((prev) => (prev - 1 + slideCount) % slideCount);
+  }, [slideCount]);
+
+  const goToSlide = useCallback((index: number) => {
+    setActiveIndex(index);
+  }, []);
+
+  // Auto-rotation
+  useEffect(() => {
+    if (
+      prefersReducedMotion ||
+      isPaused ||
+      slideCount <= 1
+    ) {
+      return;
+    }
+
+    const timer = setInterval(goToNext, 8000);
+    return () => clearInterval(timer);
+  }, [prefersReducedMotion, isPaused, slideCount, goToNext]);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        goToPrev();
+      } else if (e.key === "ArrowRight") {
+        e.preventDefault();
+        goToNext();
+      }
+    };
+
+    container.addEventListener("keydown", handler);
+    return () => container.removeEventListener("keydown", handler);
+  }, [goToNext, goToPrev]);
+
+  if (isLoading) {
+    return <HeroCarouselSkeleton />;
+  }
+
+  if (!games || games.length === 0) {
+    return null;
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="relative w-full overflow-hidden rounded-2xl group aspect-[21/9]"
+      onMouseEnter={() => setIsPaused(true)}
+      onMouseLeave={() => setIsPaused(false)}
+      tabIndex={0}
+      role="region"
+      aria-label="Featured games carousel"
+      aria-roledescription="carousel"
+      data-testid="hero-carousel"
+    >
+      {/* Slides */}
+      {games.map((game, index) => (
+        <HeroSlide
+          key={game.gameId}
+          game={game}
+          isActive={index === activeIndex}
+        />
+      ))}
+
+      {/* Arrow buttons */}
+      {slideCount > 1 && (
+        <>
+          <button
+            onClick={goToPrev}
+            className="absolute left-3 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-black/40 text-white/70 hover:text-white hover:bg-black/60 opacity-0 group-hover:opacity-100 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label="Previous slide"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+          <button
+            onClick={goToNext}
+            className="absolute right-3 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-black/40 text-white/70 hover:text-white hover:bg-black/60 opacity-0 group-hover:opacity-100 transition-all duration-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label="Next slide"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        </>
+      )}
+
+      {/* Navigation dots */}
+      {slideCount > 1 && (
+        <NavigationDots
+          count={slideCount}
+          activeIndex={activeIndex}
+          onSelect={goToSlide}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/hooks/use-explore.ts
+++ b/web/src/hooks/use-explore.ts
@@ -1,0 +1,17 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type { FeaturedGame, ExploreRowsResponse } from "@/types/api";
+
+export function useExploreFeatured() {
+  return useQuery({
+    queryKey: ["explore", "featured"],
+    queryFn: () => api.get<FeaturedGame[]>("/explore/featured"),
+  });
+}
+
+export function useExploreRows() {
+  return useQuery({
+    queryKey: ["explore", "rows"],
+    queryFn: () => api.get<ExploreRowsResponse>("/explore/rows"),
+  });
+}

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -17,6 +17,10 @@ export type ApiGetPath = WithQuery<
   // Auth
   | "/auth/setup-status"
 
+  // Explore
+  | "/explore/featured"
+  | "/explore/rows"
+
   // Consoles
   | "/consoles"
   | `/consoles/${string}/games`

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -1,0 +1,101 @@
+import { Library } from "lucide-react";
+import { Link } from "react-router-dom";
+import { EmptyState, Button } from "@/components/ui";
+import { HeroCarousel } from "@/features/explore/components/hero-carousel";
+import { GameShelf } from "@/features/explore/components/game-shelf";
+import { useExploreFeatured, useExploreRows } from "@/hooks/use-explore";
+import { useToggleFavorite } from "@/hooks/use-games";
+import { useTogglePlayLater } from "@/hooks/use-play-later";
+import { useAuth } from "@/hooks/use-auth";
+
+export function ExplorePage() {
+  const { isAdmin } = useAuth();
+  const {
+    data: featuredGames,
+    isLoading: isFeaturedLoading,
+  } = useExploreFeatured();
+  const {
+    data: rowsData,
+    isLoading: isRowsLoading,
+  } = useExploreRows();
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+
+  const rows = rowsData?.rows ?? [];
+  const isInitialLoading = isFeaturedLoading && isRowsLoading;
+  const hasNoData =
+    !isInitialLoading &&
+    (!featuredGames || featuredGames.length === 0) &&
+    rows.length === 0;
+
+  // Empty library state
+  if (hasNoData && !isFeaturedLoading && !isRowsLoading) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-3xl font-bold text-surface-100">Explore</h1>
+          <p className="mt-1 text-surface-400">
+            Discover games in your library.
+          </p>
+        </div>
+        <EmptyState
+          icon={Library}
+          title="Nothing to explore yet"
+          description={
+            isAdmin
+              ? "Your library is empty. Scan for games to start building your collection."
+              : "No games have been added to the library yet. Contact an admin to get started."
+          }
+          action={
+            isAdmin ? (
+              <Link to="/admin/scan">
+                <Button variant="primary">Scan Library</Button>
+              </Link>
+            ) : undefined
+          }
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-10" data-testid="explore-page">
+      <div>
+        <h1 className="text-3xl font-bold text-surface-100">Explore</h1>
+        <p className="mt-1 text-surface-400">
+          Discover games in your library.
+        </p>
+      </div>
+
+      {/* Hero Carousel */}
+      <HeroCarousel games={featuredGames} isLoading={isFeaturedLoading} />
+
+      {/* Shelf rows */}
+      {isRowsLoading ? (
+        <>
+          <GameShelf
+            title="Top Rated"
+            games={undefined}
+            isLoading={true}
+          />
+          <GameShelf
+            title="Recently Added"
+            games={undefined}
+            isLoading={true}
+          />
+        </>
+      ) : (
+        rows.map((row) => (
+          <GameShelf
+            key={row.id}
+            title={row.title}
+            games={row.games}
+            isLoading={false}
+            onToggleFavorite={handleToggleFavorite}
+            onTogglePlayLater={handleTogglePlayLater}
+          />
+        ))
+      )}
+    </div>
+  );
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -815,6 +815,31 @@ export interface PossibleConsole {
   name: string;
 }
 
+// --- Explore ---
+
+export interface FeaturedGame {
+  gameId: string;
+  title: string;
+  heroUrl: string;
+  logoUrl: string | null;
+  consoleAbbreviation: string;
+  consoleColor: string;
+  rating: number;
+  genre: string;
+  isFavorite: boolean;
+  isPlayLater: boolean;
+}
+
+export interface ExploreRow {
+  id: string;
+  title: string;
+  games: Game[];
+}
+
+export interface ExploreRowsResponse {
+  rows: ExploreRow[];
+}
+
 export interface StagedUpload {
   id: string;
   fileName: string;


### PR DESCRIPTION
## Summary

Phase 1 of the Explore page feature — a Netflix-style game discovery experience for large libraries.

- **Backend:** Two new endpoints (`/api/explore/featured`, `/api/explore/rows`) serving hero carousel games and curated shelves (Top Rated, Recently Added, Hidden Gems, Most Played)
- **Web:** New `/explore` route with full-width SteamGridDB hero carousel, horizontal game shelves, keyboard accessibility, and `focus-visible` on all interactive elements
- **Player app:** New Explore tab in bottom nav with hero carousel (auto-advance, swipe, dot navigation) and game shelves via Compose Multiplatform shared code

### Key design decisions
- Fully algorithmic — no admin curation needed
- All data served from local DB (works when IGDB/SteamGridDB are down)
- Hidden gems algorithm uses SQL-optimized query (high IGDB rating + low play count)
- `showConsoleBadge` prop on `GameCard` for always-visible console badges in cross-console views

### What's next
This is Phase 1 of 15. See `design-proposals/explore-page-plan.md` for the full roadmap. Phase 2 will enrich IGDB metadata (themes, keywords, franchises).

## Test plan
- [x] Server: 20 unit tests for explore endpoints (hidden gems algorithm, featured selection, row assembly, error handling, auth)
- [x] Web: 41 unit tests (hero carousel rendering/rotation/accessibility, game shelf scroll/empty states, explore page integration)
- [x] Player: 9 desktop E2E tests (explore screen rendering, carousel, shelves, navigation)
- [x] All existing tests pass — zero regressions (762 web tests, full Go suite)
- [ ] Manual: navigate to Explore in web, verify carousel auto-rotates with hero art
- [ ] Manual: navigate to Explore in player app, verify carousel and shelves render