### PR TITLE
feat: IGDB enrichment — themes, keywords, franchises, series

### DIFF
--- a/design-proposals/explore-page-phase2-stories.md
+++ b/design-proposals/explore-page-phase2-stories.md
@@ -1,0 +1,434 @@
+# Explore Page -- Phase 2 User Stories
+
+## Context
+
+Phase 2 is a **data-layer phase** -- there is no new UI. The goal is to enrich every game in the library with richer IGDB metadata (themes, keywords, player perspectives, franchises, series, and promotional artwork) so that later phases (3-4) can build browsing and filtering UIs on top of this data.
+
+The existing IGDB client (`server/internal/igdb/client.go`) fetches basic game metadata: name, summary, cover, screenshots, genres, involved companies, release date, rating, and game modes. The existing scraper (`server/internal/scraper/scraper.go`) calls this during `ScrapeGame` and stores the result in the `Game` model. This phase extends both the IGDB client and the scraper to fetch additional fields, introduces new DB models for the many-to-many relationships, adds a backfill admin endpoint, and exposes the new data through read-only API endpoints.
+
+### Key constraints (from the plan's Decisions section)
+
+- **All IGDB data is cached locally.** The Explore features must work when IGDB is unreachable. Stale data is acceptable; broken features are not.
+- **IGDB rate limit: 4 requests/second.** The existing client already enforces this via a 250ms rate ticker. The backfill must respect this limit.
+- **IGDB "collections" = game series.** The existing `GameCollection` model is user-created collections. IGDB collections (e.g., "Super Mario") are stored as `GameSeries` / `GameSeriesEntry` to avoid confusion.
+
+### Naming conventions
+
+| IGDB concept | Spela DB model | Rationale |
+|---|---|---|
+| Theme | `GameTheme` | Direct mapping |
+| Keyword | `GameKeyword` | Direct mapping |
+| Player Perspective | `GamePlayerPerspective` | Direct mapping |
+| Franchise | `GameFranchise` | Direct mapping |
+| Collection | `GameSeries` + `GameSeriesEntry` | Avoids collision with user `GameCollection` |
+| Artwork | `GameArtworkImage` | Avoids collision with SteamGridDB `GameArtwork` |
+
+---
+
+## Story 1: Extend IGDB client to fetch enriched game data
+
+**As a** developer implementing later Explore phases,
+**I want** the IGDB client to fetch themes, keywords, player perspectives, franchises, collections (series), and artwork for a game,
+**so that** this data can be stored locally and used for discovery features.
+
+### Acceptance Criteria
+
+#### New client method: `GetGameFull`
+- A new method `GetGameFull(igdbID int)` is added to the IGDB client.
+- It queries the IGDB `/games` endpoint for a single game by ID and requests the following fields (in addition to the fields already fetched by `SearchGame`):
+  - `themes.name` -- e.g., "Sci-Fi", "Horror", "Fantasy"
+  - `keywords.name` -- e.g., "time travel", "zombies", "procedural generation"
+  - `player_perspectives.name` -- e.g., "First person", "Bird view", "Side view"
+  - `franchises` (ID array) -- links to franchise entities
+  - `collection` (single ID) -- the primary IGDB collection (series) the game belongs to
+  - `artworks.image_id`, `artworks.width`, `artworks.height` -- promotional artwork
+- It returns a struct containing all of the above in parsed form (not raw JSON).
+- The method respects the existing rate limiter (waits on `rateLimiter` before each request).
+- The method uses the same authentication flow as existing methods.
+- If the game is not found (empty response), it returns `nil, nil`.
+
+#### New client method: `GetCollection`
+- A new method `GetCollection(collectionID int)` queries the IGDB `/collections` endpoint.
+- It returns the collection name and the list of game IDs in the collection.
+- It respects the rate limiter.
+
+#### New client method: `GetFranchise`
+- A new method `GetFranchise(franchiseID int)` queries the IGDB `/franchises` endpoint.
+- It returns the franchise name and the list of game IDs in the franchise.
+- It respects the rate limiter.
+
+#### Error handling
+- All new methods follow the same error wrapping convention as existing methods: `fmt.Errorf("doing thing: %w", err)`.
+- Authentication failures, HTTP errors, and JSON decoding errors produce descriptive wrapped errors.
+- IGDB returning an empty result set is not an error -- the method returns nil or empty slices as appropriate.
+
+#### Tests
+- Unit tests using an HTTP test server that returns canned IGDB JSON responses.
+- Tests cover: successful fetch, empty result, HTTP error, malformed JSON.
+- Tests verify rate limiter is consumed (the test should observe the expected delay or verify the channel was read).
+
+---
+
+## Story 2: New DB models for enriched metadata
+
+**As a** developer,
+**I want** new database models to store themes, keywords, player perspectives, franchises, series, and artwork images,
+**so that** this data persists locally and can be queried efficiently.
+
+### Acceptance Criteria
+
+#### GameTheme
+- Fields: `ID`, `CreatedAt`, `GameID` (indexed, not null), `IGDBThemeID` (int, not null), `Name` (string, not null).
+- Unique constraint on `(game_id, igdb_theme_id)` to prevent duplicates.
+- A game can have multiple themes (many-to-many via this join model).
+
+#### GameKeyword
+- Fields: `ID`, `CreatedAt`, `GameID` (indexed, not null), `IGDBKeywordID` (int, not null), `Name` (string, not null).
+- Unique constraint on `(game_id, igdb_keyword_id)`.
+- A game can have multiple keywords.
+
+#### GamePlayerPerspective
+- Fields: `ID`, `CreatedAt`, `GameID` (indexed, not null), `IGDBPerspectiveID` (int, not null), `Name` (string, not null).
+- Unique constraint on `(game_id, igdb_perspective_id)`.
+- A game can have multiple player perspectives.
+
+#### GameFranchise
+- Fields: `ID`, `CreatedAt`, `GameID` (indexed, not null), `IGDBFranchiseID` (int, not null), `FranchiseName` (string, not null).
+- Unique constraint on `(game_id, igdb_franchise_id)`.
+- A game can belong to multiple franchises.
+
+#### GameSeries
+- Fields: `ID`, `CreatedAt`, `UpdatedAt`, `IGDBCollectionID` (int, unique index, not null), `Name` (string, not null).
+- Represents an IGDB collection (game series like "Super Mario", "The Legend of Zelda").
+
+#### GameSeriesEntry
+- Fields: `ID`, `CreatedAt`, `SeriesID` (foreign key to `GameSeries`, indexed, not null), `GameID` (foreign key to `Game`, nullable -- null means the game is in the series but not in the local library), `IGDBGameID` (int, not null).
+- Unique constraint on `(series_id, igdb_game_id)`.
+- `GameID` is nullable because a series may include IGDB games that are not in the local library. This is needed for Phase 4's "You own 8 of 15 games" display.
+
+#### GameArtworkImage
+- Fields: `ID`, `CreatedAt`, `GameID` (indexed, not null), `IGDBImageID` (string, not null), `Width` (int), `Height` (int).
+- Unique constraint on `(game_id, igdb_image_id)`.
+- Stores IGDB promotional artwork (distinct from SteamGridDB `GameArtwork` which stores hero/grid/logo/icon).
+- The image URL is constructed at query time using the existing `igdb.ImageURL()` helper, not stored.
+
+#### Auto-migration
+- All new models are added to the GORM auto-migration list in `server/internal/db/database.go`.
+- Migrating an existing database with no new tables creates them without errors.
+- Migrating a database that already has these tables (idempotent re-run) completes without errors.
+
+#### Tests
+- Unit tests verify that records can be created, queried, and that unique constraints are enforced (duplicate insert returns an error or is handled via upsert).
+
+---
+
+## Story 3: Extend scraper to fetch and store enriched metadata during game scraping
+
+**As a** server admin running a scrape,
+**I want** the scraper to automatically fetch and store themes, keywords, perspectives, franchises, series membership, and artwork for each game,
+**so that** my library is enriched without any extra manual steps.
+
+### Acceptance Criteria
+
+#### Scraper integration
+- When `ScrapeGame` runs for a game that has an IGDB match (i.e., `ScraperID` starts with `igdb:`), it calls `GetGameFull` with the IGDB game ID after the initial search/match.
+- This is a single additional IGDB API call per game (the enriched query fetches all new fields at once).
+- The scraper stores the returned data in the new DB models (GameTheme, GameKeyword, GamePlayerPerspective, GameFranchise, GameSeries, GameSeriesEntry, GameArtworkImage).
+
+#### Upsert behavior
+- On re-scrape (`ScrapeAttempts > 0`), old enrichment data for the game is replaced:
+  - Existing GameTheme, GameKeyword, GamePlayerPerspective, GameFranchise, GameArtworkImage rows for the game are deleted and re-created from the fresh IGDB response.
+  - GameSeriesEntry rows are upserted (insert or update); stale entries for this game are removed.
+- This ensures re-scraping never produces duplicate rows.
+
+#### Series handling
+- When a game belongs to an IGDB collection, the scraper:
+  1. Checks if a `GameSeries` row with that `IGDBCollectionID` already exists.
+  2. If not, calls `GetCollection` to fetch the series name and creates the `GameSeries` row.
+  3. Creates a `GameSeriesEntry` linking the series to the local game.
+  4. Does NOT eagerly fetch all other games in the series (this would be too many API calls). Series membership for non-library games is populated by the backfill endpoint (Story 4).
+
+#### Franchise handling
+- When a game has franchise IDs, the scraper stores a `GameFranchise` row for each one.
+- The franchise name is fetched via `GetFranchise` for each unique franchise ID not already cached in the DB. If the name was already fetched for a different game, it is reused from the existing `GameFranchise` rows (query by `igdb_franchise_id`) to avoid redundant API calls.
+
+#### Graceful degradation
+- If `GetGameFull` fails (IGDB down, rate limit hit, network error), the scraper logs a warning and continues. The basic metadata (title, description, cover, screenshots, etc.) from the initial search is still saved.
+- The game is not marked as failed. The enrichment data simply remains empty for this game until the next scrape or backfill.
+- This matches the existing pattern where IGDB failures fall back to LibRetro data.
+
+#### `ScrapeGameWithIGDBMatch` also enriches
+- The admin "re-scrape with specific IGDB match" flow (`ScrapeGameWithIGDBMatch`) also calls the enrichment logic, so manually matched games get the same rich metadata.
+
+#### Tests
+- Unit tests with a mock IGDB HTTP server verify:
+  - Themes, keywords, perspectives, franchises, and artwork are stored correctly after scraping.
+  - Re-scraping replaces old enrichment data without duplicates.
+  - IGDB enrichment failure does not prevent basic metadata from being saved.
+  - Series is created on first encounter and reused on subsequent games in the same series.
+
+---
+
+## Story 4: Admin backfill endpoint for enriching existing games
+
+**As a** server admin,
+**I want** a backfill endpoint that enriches all existing games with the new IGDB metadata,
+**so that** games scraped before this feature was added also get themes, keywords, franchises, etc.
+
+### Acceptance Criteria
+
+#### Endpoint: `POST /api/admin/enrich-metadata`
+- Available only to admin and owner roles (behind `AdminMiddleware`).
+- Accepts an optional query parameter `mode`:
+  - `"missing"` (default): only enrich games that have an IGDB match (`ScraperID` starts with `igdb:`) but have zero `GameTheme` rows (i.e., never been enriched).
+  - `"all"`: re-enrich every game that has an IGDB match, replacing existing enrichment data.
+- Returns `202 Accepted` immediately with `{ "message": "enrichment started in background", "total": <count> }`.
+- Returns `409 Conflict` if an enrichment or scrape operation is already in progress.
+
+#### Execution behavior
+- The backfill runs in a background goroutine (same pattern as `TriggerScrape`).
+- It iterates over matching games and calls `GetGameFull` + stores results for each one.
+- It respects the IGDB rate limiter (4 req/sec). For a library of 1000 games, the backfill takes ~4-5 minutes at minimum.
+- It does NOT re-run the full scrape (no re-downloading of cover art, screenshots, etc.). It only fetches and stores the new enrichment fields.
+
+#### Progress tracking
+- Progress is broadcast via WebSocket events, following the same pattern as scrape progress:
+  - `enrich_started` when the backfill begins.
+  - `enrich_progress` with `{ current, total, gameName, successes, failures }` after each game.
+  - `enrich_complete` with `{ enriched, total }` when finished.
+  - `enrich_error` if the entire operation fails.
+- A status endpoint `GET /api/admin/enrich-metadata/status` returns whether an enrichment is active and current progress (same pattern as `GET /api/admin/scrape/status`).
+
+#### Error resilience
+- If enrichment fails for an individual game (IGDB timeout, auth error, malformed response), the backfill logs a warning, increments the failure counter, and continues to the next game.
+- The backfill does not abort on individual failures.
+- If the IGDB client is not configured (no credentials), the endpoint returns `400 Bad Request` with `{ "error": "IGDB credentials not configured" }`.
+
+#### Series population during backfill
+- During backfill, when a `GameSeries` is encountered for the first time, the backfill also calls `GetCollection` to fetch the full list of game IDs in that series and populates `GameSeriesEntry` rows for all of them (with `GameID` null for games not in the local library).
+- This is what powers the "You own 8 of 15 games" display in Phase 4.
+- For series already fully populated (all `GameSeriesEntry` rows exist), the backfill skips the `GetCollection` call.
+
+#### Tests
+- Unit tests with mock IGDB responses verify:
+  - The endpoint returns 202 and starts a background job.
+  - The `"missing"` mode skips already-enriched games.
+  - The `"all"` mode re-enriches all games.
+  - Individual game failures do not abort the backfill.
+  - The endpoint returns 409 if a job is already running.
+  - The endpoint returns 400 if IGDB is not configured.
+  - Progress events are broadcast via WebSocket.
+
+---
+
+## Story 5: API endpoint -- list themes with game counts
+
+**As a** future Explore page UI (Phase 3),
+**I want** an endpoint that lists all themes present in the library with the number of games per theme,
+**so that** I can display theme browsing cards with meaningful counts.
+
+### Acceptance Criteria
+
+#### Endpoint: `GET /api/themes`
+- Requires authentication (standard user or admin).
+- Returns a JSON array of themes, each with:
+  - `id` (string) -- the IGDB theme ID.
+  - `name` (string) -- e.g., "Science fiction", "Horror", "Fantasy".
+  - `gameCount` (int) -- number of games in the local library tagged with this theme.
+- Themes are sorted by `gameCount` descending (most popular themes first).
+- Themes with zero games in the library are excluded.
+- Response example:
+  ```json
+  [
+    { "id": "17", "name": "Fantasy", "gameCount": 42 },
+    { "id": "18", "name": "Science fiction", "gameCount": 35 },
+    { "id": "19", "name": "Horror", "gameCount": 12 }
+  ]
+  ```
+
+#### Endpoint: `GET /api/themes/:id/games`
+- Returns a paginated list of games tagged with the given theme.
+- Uses the existing `GameResponse` format for game objects.
+- Supports `?page=1&pageSize=20` query parameters (defaults: page 1, pageSize 20).
+- Games are sorted by rating descending.
+- Returns 404 if no theme with the given ID exists in the library.
+
+#### Tests
+- Unit tests verify correct game counts, sorting, pagination, and 404 for unknown theme.
+
+---
+
+## Story 6: API endpoint -- list keywords with game counts
+
+**As a** future Explore page UI (Phase 3),
+**I want** an endpoint that lists popular keywords in the library,
+**so that** I can display keyword chips for browsing.
+
+### Acceptance Criteria
+
+#### Endpoint: `GET /api/keywords`
+- Requires authentication.
+- Returns a JSON array of keywords, each with `id`, `name`, `gameCount`.
+- Sorted by `gameCount` descending.
+- By default, returns the top 50 keywords (to avoid returning hundreds of obscure keywords).
+- Supports `?limit=N` to override the default (max 200).
+- Keywords with zero games are excluded.
+
+#### Endpoint: `GET /api/keywords/:id/games`
+- Returns a paginated list of games tagged with the given keyword.
+- Uses `GameResponse` format, sorted by rating descending.
+- Supports `?page=1&pageSize=20`.
+- Returns 404 if the keyword is not found.
+
+#### Tests
+- Unit tests verify default limit of 50, custom limit, correct counts, pagination.
+
+---
+
+## Story 7: API endpoint -- list series (IGDB collections) in the library
+
+**As a** future Franchise page UI (Phase 4),
+**I want** an endpoint that lists all game series present in the library,
+**so that** I can display franchise browsing cards.
+
+### Acceptance Criteria
+
+#### Endpoint: `GET /api/series`
+- Requires authentication.
+- Returns a JSON array of game series that have at least one game in the local library.
+- Each entry includes:
+  - `id` (string) -- the `GameSeries.ID`.
+  - `igdbCollectionId` (int) -- the IGDB collection ID.
+  - `name` (string) -- e.g., "Super Mario", "The Legend of Zelda".
+  - `totalGames` (int) -- total number of games in the series (from `GameSeriesEntry` rows, including those not in the library).
+  - `libraryGames` (int) -- number of series games that are in the local library.
+- Sorted by `libraryGames` descending (series with the most local games first).
+
+#### Endpoint: `GET /api/series/:id`
+- Returns the series detail with all games.
+- Response includes:
+  - `id`, `name`, `igdbCollectionId`.
+  - `games` -- array of all games in the series, each with:
+    - `igdbGameId` (int).
+    - `name` (string) -- the IGDB game name (fetched during series population).
+    - `inLibrary` (bool) -- whether the game exists in the local library.
+    - `localGameId` (string, nullable) -- the local game ID if `inLibrary` is true.
+    - `coverUrl` (string, nullable) -- local cover art URL if in library.
+- Games are sorted by release date (if available) or alphabetically.
+- Returns 404 if the series is not found.
+
+#### Tests
+- Unit tests verify: series list only includes series with local games, counts are correct, detail endpoint returns both local and non-local entries.
+
+---
+
+## Story 8: API endpoint -- list franchises in the library
+
+**As a** future Franchise page UI (Phase 4),
+**I want** an endpoint that lists all franchises present in the library,
+**so that** I can display franchise browsing.
+
+### Acceptance Criteria
+
+#### Endpoint: `GET /api/franchises`
+- Requires authentication.
+- Returns a JSON array of franchises that have at least one game in the local library.
+- Each entry includes:
+  - `id` (string) -- the IGDB franchise ID.
+  - `name` (string) -- e.g., "Mario", "Zelda".
+  - `gameCount` (int) -- number of games in the local library in this franchise.
+- Sorted by `gameCount` descending.
+
+#### Endpoint: `GET /api/franchises/:id`
+- Returns the franchise detail with all local games.
+- Response includes:
+  - `id`, `name`.
+  - `games` -- array of local games in this franchise, using the `GameResponse` format.
+- Games sorted by release date (if available) or alphabetically.
+- Returns 404 if no franchise with the given ID exists in the library.
+
+#### Tests
+- Unit tests verify: correct game counts, sorting, detail includes all matching games, 404 for unknown franchise.
+
+---
+
+## Story 9: Extend `GET /api/games` with new filter parameters
+
+**As a** developer building filtering UIs in later phases,
+**I want** the existing games list endpoint to support filtering by theme, keyword, and player perspective,
+**so that** the same endpoint can power both the current library view and future filtered views.
+
+### Acceptance Criteria
+
+#### New query parameters on `GET /api/games`
+- `theme` (string) -- IGDB theme ID. When provided, only games tagged with this theme are returned.
+- `keyword` (string) -- IGDB keyword ID. When provided, only games tagged with this keyword are returned.
+- `perspective` (string) -- IGDB perspective ID. When provided, only games tagged with this perspective are returned.
+- Multiple filters can be combined (AND logic): `?theme=17&perspective=4` returns games that are Fantasy AND First person.
+- Existing filters (console, genre, search) continue to work and can be combined with the new filters.
+- When no new filters are provided, the endpoint behaves identically to today (no regression).
+
+#### Performance
+- Filters use JOIN queries against the new tables rather than loading all games into memory and filtering in Go.
+- The queries are bounded by the existing pagination (page/pageSize).
+
+#### Tests
+- Unit tests verify:
+  - Filtering by a single theme returns correct games.
+  - Filtering by a single keyword returns correct games.
+  - Combining theme + perspective filters returns the intersection.
+  - Combining new filters with existing console filter works.
+  - No regression: calling without new filters returns the same results as before.
+
+---
+
+## Story 10: IGDB unavailability does not break existing features
+
+**As a** server admin,
+**I want** the enrichment to be resilient to IGDB outages,
+**so that** existing scraping, game browsing, and the Explore page continue to work when IGDB is down.
+
+### Acceptance Criteria
+
+#### During normal scraping
+- If `GetGameFull` fails during `ScrapeGame`, the game is still scraped successfully with basic metadata (title, description, cover, screenshots from the initial IGDB search + LibRetro).
+- The scrape is counted as a success, not a failure, in the progress counters.
+- A warning is logged with the game name and error.
+
+#### During backfill
+- If `GetGameFull` fails for a specific game during the backfill, that game is skipped and counted as a failure in the progress.
+- The backfill continues to the next game.
+- If IGDB returns repeated auth failures (e.g., expired token), the client re-authenticates automatically (existing behavior in `authenticate()`).
+
+#### API endpoints
+- The new read endpoints (`/api/themes`, `/api/keywords`, `/api/series`, `/api/franchises`) always read from the local database. They never make live IGDB calls.
+- If no enrichment data exists (e.g., IGDB was never configured), these endpoints return empty arrays, not errors.
+- The game filter parameters (`theme`, `keyword`, `perspective`) on `GET /api/games` return empty results when no enrichment data exists, not errors.
+
+#### Tests
+- Unit tests with a mock IGDB server that returns errors verify:
+  - Scrape completes successfully despite enrichment failure.
+  - Backfill skips failed games and completes.
+  - Read endpoints return empty arrays when no enrichment data exists.
+
+---
+
+## Non-functional requirements
+
+### Rate limiting
+- The enrichment backfill must not exceed IGDB's 4 requests/second limit. The existing rate ticker in the IGDB client enforces this; no additional throttling is needed, but the backfill must use the same client instance (not create a new one that bypasses the limiter).
+- For games that require multiple IGDB calls (game data + collection lookup + franchise lookup), each call independently waits on the rate limiter. A game that needs 3 calls uses 3 rate slots (750ms minimum).
+
+### Database performance
+- New tables have appropriate indexes on foreign keys and columns used in WHERE/JOIN clauses (as specified in the unique constraints above).
+- The `GET /api/themes` and `GET /api/keywords` endpoints use aggregate SQL queries (GROUP BY + COUNT) rather than loading all rows into memory.
+
+### Backward compatibility
+- Existing API responses are unchanged. No existing field is removed or renamed.
+- The `GameResponse` struct is not modified in this phase. Enrichment data is only available via the new dedicated endpoints.
+- Existing scrape functionality (ScrapeGame, ScrapeAll, ScrapeGameWithIGDBMatch) continues to work identically for users who have not configured IGDB credentials -- the enrichment steps are simply skipped.
+
+### Observability
+- All new IGDB API calls are logged at INFO level with the game name and IGDB ID (following the existing logging pattern in `client.go`).
+- Enrichment failures are logged at WARN level.
+- The backfill logs a summary at completion: total games, successes, failures, duration.

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -71,6 +71,13 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.SessionCheatSetting{},
 		&db.DailyPlayActivity{},
 		&db.GameArtwork{},
+		&db.GameTheme{},
+		&db.GameKeyword{},
+		&db.GamePlayerPerspective{},
+		&db.GameFranchise{},
+		&db.GameSeries{},
+		&db.GameSeriesEntry{},
+		&db.GameArtworkImage{},
 	)
 	require.NoError(t, err)
 	err = db.SeedConsoles(database)

--- a/server/internal/api/enrichment_handler.go
+++ b/server/internal/api/enrichment_handler.go
@@ -1,0 +1,505 @@
+package api
+
+import (
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/scraper"
+	ws "github.com/spela/server/internal/websocket"
+	"gorm.io/gorm"
+)
+
+// EnrichmentHandler handles enrichment-related API endpoints.
+type EnrichmentHandler struct {
+	DB      *gorm.DB
+	Scraper *scraper.Scraper
+	Hub     *ws.Hub
+}
+
+// --- Theme endpoints ---
+
+// ThemeResponse is the API response for a theme with game count.
+type ThemeResponse struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	GameCount int    `json:"gameCount"`
+}
+
+// ListThemes returns all themes with game counts, sorted by count DESC.
+// GET /api/themes
+func (h *EnrichmentHandler) ListThemes(c *gin.Context) {
+	type themeRow struct {
+		IGDBThemeID int
+		Name        string
+		GameCount   int
+	}
+
+	var rows []themeRow
+	if err := h.DB.Model(&db.GameTheme{}).
+		Joins("JOIN games ON games.id = game_themes.game_id AND games.deleted_at IS NULL").
+		Select("igdb_theme_id, game_themes.name, COUNT(DISTINCT game_themes.game_id) as game_count").
+		Group("igdb_theme_id, game_themes.name").
+		Having("game_count > 0").
+		Order("game_count DESC").
+		Scan(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch themes"})
+		return
+	}
+
+	result := make([]ThemeResponse, len(rows))
+	for i, r := range rows {
+		result[i] = ThemeResponse{
+			ID:        strconv.Itoa(r.IGDBThemeID),
+			Name:      r.Name,
+			GameCount: r.GameCount,
+		}
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// ListThemeGames returns paginated games for a theme.
+// GET /api/themes/:id/games
+func (h *EnrichmentHandler) ListThemeGames(c *gin.Context) {
+	themeID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid theme ID"})
+		return
+	}
+
+	// Check theme exists
+	var count int64
+	h.DB.Model(&db.GameTheme{}).Where("igdb_theme_id = ?", themeID).Count(&count)
+	if count == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "theme not found"})
+		return
+	}
+
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("pageSize", "20"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 20
+	}
+
+	// Count total matching games
+	var total int64
+	h.DB.Model(&db.Game{}).
+		Joins("JOIN game_themes ON game_themes.game_id = games.id").
+		Where("game_themes.igdb_theme_id = ?", themeID).
+		Where("games.deleted_at IS NULL").
+		Count(&total)
+
+	// Fetch games
+	var games []db.Game
+	offset := (page - 1) * pageSize
+	if err := h.DB.Preload("Console").Preload("Screenshots").
+		Joins("JOIN game_themes ON game_themes.game_id = games.id").
+		Where("game_themes.igdb_theme_id = ?", themeID).
+		Where("games.deleted_at IS NULL").
+		Order("games.rating DESC").
+		Offset(offset).Limit(pageSize).
+		Find(&games).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch theme games"})
+		return
+	}
+
+	userID := getUserID(c)
+	c.JSON(http.StatusOK, PaginatedResponse{
+		Data:     ToGameResponses(games, h.DB, userID),
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+	})
+}
+
+// --- Keyword endpoints ---
+
+// KeywordResponse is the API response for a keyword with game count.
+type KeywordResponse struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	GameCount int    `json:"gameCount"`
+}
+
+// ListKeywords returns top keywords by game count.
+// GET /api/keywords?limit=50
+func (h *EnrichmentHandler) ListKeywords(c *gin.Context) {
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "50"))
+	if limit < 1 || limit > 200 {
+		limit = 50
+	}
+
+	type keywordRow struct {
+		IGDBKeywordID int
+		Name          string
+		GameCount     int
+	}
+
+	var rows []keywordRow
+	if err := h.DB.Model(&db.GameKeyword{}).
+		Joins("JOIN games ON games.id = game_keywords.game_id AND games.deleted_at IS NULL").
+		Select("igdb_keyword_id, game_keywords.name, COUNT(DISTINCT game_keywords.game_id) as game_count").
+		Group("igdb_keyword_id, game_keywords.name").
+		Having("game_count > 0").
+		Order("game_count DESC").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch keywords"})
+		return
+	}
+
+	result := make([]KeywordResponse, len(rows))
+	for i, r := range rows {
+		result[i] = KeywordResponse{
+			ID:        strconv.Itoa(r.IGDBKeywordID),
+			Name:      r.Name,
+			GameCount: r.GameCount,
+		}
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// ListKeywordGames returns paginated games for a keyword.
+// GET /api/keywords/:id/games
+func (h *EnrichmentHandler) ListKeywordGames(c *gin.Context) {
+	keywordID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid keyword ID"})
+		return
+	}
+
+	var count int64
+	h.DB.Model(&db.GameKeyword{}).Where("igdb_keyword_id = ?", keywordID).Count(&count)
+	if count == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "keyword not found"})
+		return
+	}
+
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("pageSize", "20"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 20
+	}
+
+	var total int64
+	h.DB.Model(&db.Game{}).
+		Joins("JOIN game_keywords ON game_keywords.game_id = games.id").
+		Where("game_keywords.igdb_keyword_id = ?", keywordID).
+		Where("games.deleted_at IS NULL").
+		Count(&total)
+
+	var games []db.Game
+	offset := (page - 1) * pageSize
+	if err := h.DB.Preload("Console").Preload("Screenshots").
+		Joins("JOIN game_keywords ON game_keywords.game_id = games.id").
+		Where("game_keywords.igdb_keyword_id = ?", keywordID).
+		Where("games.deleted_at IS NULL").
+		Order("games.rating DESC").
+		Offset(offset).Limit(pageSize).
+		Find(&games).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch keyword games"})
+		return
+	}
+
+	userID := getUserID(c)
+	c.JSON(http.StatusOK, PaginatedResponse{
+		Data:     ToGameResponses(games, h.DB, userID),
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+	})
+}
+
+// --- Series endpoints ---
+
+// SeriesListResponse is the API response for a series in the list view.
+type SeriesListResponse struct {
+	ID               string `json:"id"`
+	IGDBCollectionID int    `json:"igdbCollectionId"`
+	Name             string `json:"name"`
+	TotalGames       int    `json:"totalGames"`
+	LibraryGames     int    `json:"libraryGames"`
+}
+
+// ListSeries returns all series with at least one local game, sorted by library count.
+// GET /api/series
+func (h *EnrichmentHandler) ListSeries(c *gin.Context) {
+	type seriesRow struct {
+		ID               uint
+		IGDBCollectionID int
+		Name             string
+		TotalGames       int
+		LibraryGames     int
+	}
+
+	var rows []seriesRow
+	if err := h.DB.
+		Table("game_series").
+		Select(`game_series.id, game_series.igdb_collection_id, game_series.name,
+			COUNT(game_series_entries.id) as total_games,
+			COUNT(game_series_entries.game_id) as library_games`).
+		Joins("JOIN game_series_entries ON game_series_entries.series_id = game_series.id").
+		Group("game_series.id").
+		Having("library_games > 0").
+		Order("library_games DESC").
+		Scan(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch series"})
+		return
+	}
+
+	result := make([]SeriesListResponse, len(rows))
+	for i, r := range rows {
+		result[i] = SeriesListResponse{
+			ID:               strconv.FormatUint(uint64(r.ID), 10),
+			IGDBCollectionID: r.IGDBCollectionID,
+			Name:             r.Name,
+			TotalGames:       r.TotalGames,
+			LibraryGames:     r.LibraryGames,
+		}
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// SeriesDetailResponse is the API response for a series detail view.
+type SeriesDetailResponse struct {
+	ID               string              `json:"id"`
+	IGDBCollectionID int                 `json:"igdbCollectionId"`
+	Name             string              `json:"name"`
+	Games            []SeriesGameResponse `json:"games"`
+}
+
+// SeriesGameResponse is the API response for a game within a series.
+type SeriesGameResponse struct {
+	IGDBGameID  int     `json:"igdbGameId"`
+	Name        string  `json:"name"`
+	InLibrary   bool    `json:"inLibrary"`
+	LocalGameID *string `json:"localGameId"`
+	CoverURL    *string `json:"coverUrl"`
+}
+
+// GetSeriesDetail returns a series with all its games (local and non-local).
+// GET /api/series/:id
+func (h *EnrichmentHandler) GetSeriesDetail(c *gin.Context) {
+	id := c.Param("id")
+	var series db.GameSeries
+	if err := h.DB.Preload("Entries").First(&series, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "series not found"})
+		return
+	}
+
+	games := make([]SeriesGameResponse, len(series.Entries))
+	for i, entry := range series.Entries {
+		gameResp := SeriesGameResponse{
+			IGDBGameID: entry.IGDBGameID,
+			Name:       entry.Name,
+			InLibrary:  entry.GameID != nil,
+		}
+		if entry.GameID != nil {
+			localID := strconv.FormatUint(uint64(*entry.GameID), 10)
+			gameResp.LocalGameID = &localID
+
+			// Load local game cover
+			var game db.Game
+			if err := h.DB.Select("cover_url").First(&game, *entry.GameID).Error; err == nil && game.CoverURL != "" {
+				coverURL := resolveImageURL(game.CoverURL)
+				gameResp.CoverURL = &coverURL
+			}
+		}
+		games[i] = gameResp
+	}
+
+	c.JSON(http.StatusOK, SeriesDetailResponse{
+		ID:               strconv.FormatUint(uint64(series.ID), 10),
+		IGDBCollectionID: series.IGDBCollectionID,
+		Name:             series.Name,
+		Games:            games,
+	})
+}
+
+// --- Franchise endpoints ---
+
+// FranchiseResponse is the API response for a franchise with game count.
+type FranchiseResponse struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	GameCount int    `json:"gameCount"`
+}
+
+// ListFranchises returns all franchises with at least one game in the library.
+// GET /api/franchises
+func (h *EnrichmentHandler) ListFranchises(c *gin.Context) {
+	type franchiseRow struct {
+		IGDBFranchiseID int
+		FranchiseName   string
+		GameCount       int
+	}
+
+	var rows []franchiseRow
+	if err := h.DB.Model(&db.GameFranchise{}).
+		Joins("JOIN games ON games.id = game_franchises.game_id AND games.deleted_at IS NULL").
+		Select("igdb_franchise_id, franchise_name, COUNT(DISTINCT game_franchises.game_id) as game_count").
+		Group("igdb_franchise_id, franchise_name").
+		Having("game_count > 0").
+		Order("game_count DESC").
+		Scan(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch franchises"})
+		return
+	}
+
+	result := make([]FranchiseResponse, len(rows))
+	for i, r := range rows {
+		result[i] = FranchiseResponse{
+			ID:        strconv.Itoa(r.IGDBFranchiseID),
+			Name:      r.FranchiseName,
+			GameCount: r.GameCount,
+		}
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// ListFranchiseGames returns paginated games in a franchise.
+// GET /api/franchises/:id/games
+func (h *EnrichmentHandler) ListFranchiseGames(c *gin.Context) {
+	franchiseID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid franchise ID"})
+		return
+	}
+
+	var count int64
+	h.DB.Model(&db.GameFranchise{}).Where("igdb_franchise_id = ?", franchiseID).Count(&count)
+	if count == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "franchise not found"})
+		return
+	}
+
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("pageSize", "20"))
+	if page < 1 {
+		page = 1
+	}
+	if pageSize < 1 || pageSize > 100 {
+		pageSize = 20
+	}
+
+	// Count total matching games
+	var total int64
+	h.DB.Model(&db.Game{}).
+		Joins("JOIN game_franchises ON game_franchises.game_id = games.id").
+		Where("game_franchises.igdb_franchise_id = ?", franchiseID).
+		Where("games.deleted_at IS NULL").
+		Count(&total)
+
+	// Fetch games
+	var games []db.Game
+	offset := (page - 1) * pageSize
+	if err := h.DB.Preload("Console").Preload("Screenshots").
+		Joins("JOIN game_franchises ON game_franchises.game_id = games.id").
+		Where("game_franchises.igdb_franchise_id = ?", franchiseID).
+		Where("games.deleted_at IS NULL").
+		Order("games.release_date ASC, games.title ASC").
+		Offset(offset).Limit(pageSize).
+		Find(&games).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch franchise games"})
+		return
+	}
+
+	userID := getUserID(c)
+	c.JSON(http.StatusOK, PaginatedResponse{
+		Data:     ToGameResponses(games, h.DB, userID),
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+	})
+}
+
+// --- Admin backfill endpoint ---
+
+// TriggerEnrichMetadata starts a background IGDB metadata enrichment.
+// POST /api/admin/enrich-metadata?mode=missing|all
+func (h *EnrichmentHandler) TriggerEnrichMetadata(c *gin.Context) {
+	if h.Scraper.IGDBClient == nil || !h.Scraper.IGDBClient.IsConfigured() {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "IGDB credentials not configured"})
+		return
+	}
+
+	mode := c.DefaultQuery("mode", "missing")
+
+	if !h.Scraper.TryStartEnrich() {
+		c.JSON(http.StatusConflict, gin.H{"error": "an enrichment or scrape operation is already in progress"})
+		return
+	}
+
+	// Count matching games
+	var total int64
+	switch mode {
+	case "all":
+		h.DB.Model(&db.Game{}).Where("scraper_id LIKE 'igdb:%'").Count(&total)
+	default:
+		h.DB.Model(&db.Game{}).Where("scraper_id LIKE 'igdb:%'").
+			Where("id NOT IN (SELECT DISTINCT game_id FROM game_themes)").
+			Count(&total)
+	}
+
+	if h.Hub != nil {
+		h.Hub.Broadcast(ws.Event{Type: "enrich_started", Payload: gin.H{"total": total}})
+	}
+
+	go func() {
+		defer h.Scraper.FinishEnrich()
+
+		count, enrichTotal, err := h.Scraper.EnrichAll(mode, func(p scraper.EnrichProgress) {
+			h.Scraper.SetEnrichProgress(&p)
+			if h.Hub != nil {
+				h.Hub.Broadcast(ws.Event{Type: "enrich_progress", Payload: p})
+			}
+		})
+		if err != nil {
+			slog.Error("metadata enrichment failed", "error", err)
+			if h.Hub != nil {
+				h.Hub.Broadcast(ws.Event{Type: "enrich_error", Payload: gin.H{"error": "enrichment failed"}})
+			}
+			return
+		}
+		slog.Info("metadata enrichment complete", "enriched", count, "total", enrichTotal)
+		if h.Hub != nil {
+			h.Hub.Broadcast(ws.Event{Type: "enrich_complete", Payload: gin.H{"enriched": count, "total": enrichTotal}})
+		}
+	}()
+
+	adminID, _ := c.Get("userId")
+	slog.Info("audit: admin triggered enrichment", "admin_id", adminID, "mode", mode)
+	c.JSON(http.StatusAccepted, gin.H{"message": "enrichment started in background", "total": total})
+}
+
+// EnrichMetadataStatus returns the current enrichment status.
+// GET /api/admin/enrich-metadata/status
+func (h *EnrichmentHandler) EnrichMetadataStatus(c *gin.Context) {
+	active, progress := h.Scraper.GetEnrichStatus()
+
+	if !active || progress == nil {
+		c.JSON(http.StatusOK, gin.H{"active": false})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{
+		"active":    true,
+		"current":   progress.Current,
+		"total":     progress.Total,
+		"gameName":  progress.GameName,
+		"successes": progress.Successes,
+		"failures":  progress.Failures,
+	})
+}

--- a/server/internal/api/enrichment_handler_test.go
+++ b/server/internal/api/enrichment_handler_test.go
@@ -1,0 +1,519 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// enrichTestEnv holds shared test fixtures for enrichment handler tests.
+type enrichTestEnv struct {
+	database *gorm.DB
+	router   http.Handler
+	token    string
+}
+
+func setupEnrichTestEnv(t *testing.T) *enrichTestEnv {
+	t.Helper()
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+	return &enrichTestEnv{
+		database: database,
+		router:   router,
+		token:    token,
+	}
+}
+
+// createEnrichTestGame creates a game in the NES console with the given title and rating.
+func createEnrichTestGame(t *testing.T, database *gorm.DB, title string, rating float64) db.Game {
+	t.Helper()
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     title,
+		FileName:  title + ".nes",
+		FilePath:  "NES/" + title + ".nes",
+		Rating:    rating,
+		ScraperID: fmt.Sprintf("igdb:%d", 1000+int(rating)),
+	}
+	require.NoError(t, database.Create(&game).Error)
+	return game
+}
+
+// --- Theme endpoint tests ---
+
+func TestListThemes_Empty(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/themes", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var themes []ThemeResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &themes))
+	assert.Empty(t, themes)
+}
+
+func TestListThemes_WithData(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda", 90)
+	game2 := createEnrichTestGame(t, env.database, "Mario", 85)
+
+	// Create themes
+	env.database.Create(&db.GameTheme{GameID: game1.ID, IGDBThemeID: 1, Name: "Fantasy"})
+	env.database.Create(&db.GameTheme{GameID: game2.ID, IGDBThemeID: 1, Name: "Fantasy"})
+	env.database.Create(&db.GameTheme{GameID: game1.ID, IGDBThemeID: 17, Name: "Sci-Fi"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/themes", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var themes []ThemeResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &themes))
+	require.Len(t, themes, 2)
+
+	// Sorted by game count DESC
+	assert.Equal(t, "1", themes[0].ID)
+	assert.Equal(t, "Fantasy", themes[0].Name)
+	assert.Equal(t, 2, themes[0].GameCount)
+
+	assert.Equal(t, "17", themes[1].ID)
+	assert.Equal(t, "Sci-Fi", themes[1].Name)
+	assert.Equal(t, 1, themes[1].GameCount)
+}
+
+func TestListThemeGames_Success(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda", 90)
+	game2 := createEnrichTestGame(t, env.database, "Mario", 85)
+	_ = createEnrichTestGame(t, env.database, "Metroid", 80) // no theme
+
+	env.database.Create(&db.GameTheme{GameID: game1.ID, IGDBThemeID: 1, Name: "Fantasy"})
+	env.database.Create(&db.GameTheme{GameID: game2.ID, IGDBThemeID: 1, Name: "Fantasy"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/themes/1/games", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PaginatedResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(2), resp.Total)
+	assert.Equal(t, 1, resp.Page)
+}
+
+func TestListThemeGames_NotFound(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/themes/99999/games", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestListThemeGames_InvalidID(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/themes/abc/games", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Keyword endpoint tests ---
+
+func TestListKeywords_Empty(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/keywords", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var keywords []KeywordResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &keywords))
+	assert.Empty(t, keywords)
+}
+
+func TestListKeywords_WithData(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda", 90)
+	game2 := createEnrichTestGame(t, env.database, "Mario", 85)
+
+	env.database.Create(&db.GameKeyword{GameID: game1.ID, IGDBKeywordID: 100, Name: "open world"})
+	env.database.Create(&db.GameKeyword{GameID: game2.ID, IGDBKeywordID: 100, Name: "open world"})
+	env.database.Create(&db.GameKeyword{GameID: game1.ID, IGDBKeywordID: 200, Name: "puzzle"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/keywords", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var keywords []KeywordResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &keywords))
+	require.Len(t, keywords, 2)
+	assert.Equal(t, "100", keywords[0].ID)
+	assert.Equal(t, "open world", keywords[0].Name)
+	assert.Equal(t, 2, keywords[0].GameCount)
+}
+
+func TestListKeywords_WithLimit(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game := createEnrichTestGame(t, env.database, "Zelda", 90)
+	env.database.Create(&db.GameKeyword{GameID: game.ID, IGDBKeywordID: 100, Name: "keyword1"})
+	env.database.Create(&db.GameKeyword{GameID: game.ID, IGDBKeywordID: 200, Name: "keyword2"})
+	env.database.Create(&db.GameKeyword{GameID: game.ID, IGDBKeywordID: 300, Name: "keyword3"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/keywords?limit=2", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var keywords []KeywordResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &keywords))
+	assert.Len(t, keywords, 2)
+}
+
+func TestListKeywordGames_Success(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game := createEnrichTestGame(t, env.database, "Zelda", 90)
+	env.database.Create(&db.GameKeyword{GameID: game.ID, IGDBKeywordID: 100, Name: "open world"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/keywords/100/games", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PaginatedResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(1), resp.Total)
+}
+
+func TestListKeywordGames_NotFound(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/keywords/99999/games", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Franchise endpoint tests ---
+
+func TestListFranchises_Empty(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/franchises", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var franchises []FranchiseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &franchises))
+	assert.Empty(t, franchises)
+}
+
+func TestListFranchises_WithData(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda1", 90)
+	game2 := createEnrichTestGame(t, env.database, "Zelda2", 85)
+	game3 := createEnrichTestGame(t, env.database, "Mario1", 80)
+
+	env.database.Create(&db.GameFranchise{GameID: game1.ID, IGDBFranchiseID: 100, FranchiseName: "The Legend of Zelda"})
+	env.database.Create(&db.GameFranchise{GameID: game2.ID, IGDBFranchiseID: 100, FranchiseName: "The Legend of Zelda"})
+	env.database.Create(&db.GameFranchise{GameID: game3.ID, IGDBFranchiseID: 200, FranchiseName: "Mario"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/franchises", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var franchises []FranchiseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &franchises))
+	require.Len(t, franchises, 2)
+
+	// Sorted by game count DESC
+	assert.Equal(t, "100", franchises[0].ID)
+	assert.Equal(t, "The Legend of Zelda", franchises[0].Name)
+	assert.Equal(t, 2, franchises[0].GameCount)
+
+	assert.Equal(t, "200", franchises[1].ID)
+	assert.Equal(t, "Mario", franchises[1].Name)
+	assert.Equal(t, 1, franchises[1].GameCount)
+}
+
+func TestListFranchiseGames_Success(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda1", 90)
+	game2 := createEnrichTestGame(t, env.database, "Zelda2", 85)
+
+	env.database.Create(&db.GameFranchise{GameID: game1.ID, IGDBFranchiseID: 100, FranchiseName: "Zelda"})
+	env.database.Create(&db.GameFranchise{GameID: game2.ID, IGDBFranchiseID: 100, FranchiseName: "Zelda"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/franchises/100/games", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PaginatedResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(2), resp.Total)
+	assert.Equal(t, 1, resp.Page)
+}
+
+func TestListFranchiseGames_NotFound(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/franchises/99999/games", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Series endpoint tests ---
+
+func TestListSeries_Empty(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/series", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var series []SeriesListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &series))
+	assert.Empty(t, series)
+}
+
+func TestListSeries_WithData(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Mario1", 90)
+	game2 := createEnrichTestGame(t, env.database, "Mario2", 85)
+
+	series := db.GameSeries{
+		IGDBCollectionID: 789,
+		Name:             "Super Mario",
+	}
+	require.NoError(t, env.database.Create(&series).Error)
+
+	// Add entries (two local, one non-local)
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game1.ID, IGDBGameID: 100, Name: "Super Mario Bros.",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game2.ID, IGDBGameID: 200, Name: "Super Mario Bros. 2",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: nil, IGDBGameID: 300, Name: "Super Mario Bros. 3",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/series", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []SeriesListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.Len(t, result, 1)
+
+	assert.Equal(t, "Super Mario", result[0].Name)
+	assert.Equal(t, 789, result[0].IGDBCollectionID)
+	assert.Equal(t, 3, result[0].TotalGames)
+	assert.Equal(t, 2, result[0].LibraryGames)
+}
+
+func TestGetSeriesDetail_Success(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game := createEnrichTestGame(t, env.database, "Mario1", 90)
+
+	series := db.GameSeries{
+		IGDBCollectionID: 789,
+		Name:             "Super Mario",
+	}
+	require.NoError(t, env.database.Create(&series).Error)
+
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game.ID, IGDBGameID: 100, Name: "Super Mario Bros.",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: nil, IGDBGameID: 200, Name: "Super Mario Bros. 2",
+	})
+
+	url := fmt.Sprintf("/api/series/%d", series.ID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var detail SeriesDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &detail))
+	assert.Equal(t, "Super Mario", detail.Name)
+	assert.Equal(t, 789, detail.IGDBCollectionID)
+	require.Len(t, detail.Games, 2)
+
+	// The local game
+	assert.Equal(t, 100, detail.Games[0].IGDBGameID)
+	assert.Equal(t, "Super Mario Bros.", detail.Games[0].Name)
+	assert.True(t, detail.Games[0].InLibrary)
+	assert.NotNil(t, detail.Games[0].LocalGameID)
+
+	// The non-local game
+	assert.Equal(t, 200, detail.Games[1].IGDBGameID)
+	assert.Equal(t, "Super Mario Bros. 2", detail.Games[1].Name)
+	assert.False(t, detail.Games[1].InLibrary)
+	assert.Nil(t, detail.Games[1].LocalGameID)
+}
+
+func TestGetSeriesDetail_NotFound(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/series/99999", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// --- Game filter enrichment tests ---
+
+func TestListGames_FilterByTheme(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda", 90)
+	_ = createEnrichTestGame(t, env.database, "Tetris", 80)
+
+	env.database.Create(&db.GameTheme{GameID: game1.ID, IGDBThemeID: 1, Name: "Fantasy"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games?theme=1", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PaginatedResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(1), resp.Total)
+}
+
+func TestListGames_FilterByKeyword(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda", 90)
+	_ = createEnrichTestGame(t, env.database, "Tetris", 80)
+
+	env.database.Create(&db.GameKeyword{GameID: game1.ID, IGDBKeywordID: 100, Name: "open world"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games?keyword=100", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PaginatedResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(1), resp.Total)
+}
+
+func TestListGames_FilterByPerspective(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda", 90)
+	_ = createEnrichTestGame(t, env.database, "Tetris", 80)
+
+	env.database.Create(&db.GamePlayerPerspective{GameID: game1.ID, IGDBPerspectiveID: 3, Name: "Side view"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games?perspective=3", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PaginatedResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(1), resp.Total)
+}
+
+// --- Admin enrichment endpoint tests ---
+
+func TestEnrichMetadataStatus_NoActiveEnrichment(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	// The first registered user is the owner, so the token is admin/owner
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/enrich-metadata/status", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, false, resp["active"])
+}
+
+func TestTriggerEnrichMetadata_NoIGDBConfig(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	// Scraper has no IGDB client configured by default in tests
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/admin/enrich-metadata", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Authentication tests ---
+
+func TestEnrichmentEndpoints_RequireAuth(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	endpoints := []string{
+		"/api/themes",
+		"/api/keywords",
+		"/api/series",
+		"/api/franchises",
+	}
+
+	for _, endpoint := range endpoints {
+		t.Run(endpoint, func(t *testing.T) {
+			w := httptest.NewRecorder()
+			req := httptest.NewRequest("GET", endpoint, nil)
+			env.router.ServeHTTP(w, req)
+			assert.Equal(t, http.StatusUnauthorized, w.Code)
+		})
+	}
+}

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -54,6 +54,20 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 		query = query.Where("genre = ?", genre)
 	}
 
+	// Phase 2 Explore: enrichment-based filters (JOIN against enrichment tables)
+	if themeID := c.Query("theme"); themeID != "" {
+		query = query.Joins("JOIN game_themes ON game_themes.game_id = games.id").
+			Where("game_themes.igdb_theme_id = ?", themeID)
+	}
+	if keywordID := c.Query("keyword"); keywordID != "" {
+		query = query.Joins("JOIN game_keywords ON game_keywords.game_id = games.id").
+			Where("game_keywords.igdb_keyword_id = ?", keywordID)
+	}
+	if perspectiveID := c.Query("perspective"); perspectiveID != "" {
+		query = query.Joins("JOIN game_player_perspectives ON game_player_perspectives.game_id = games.id").
+			Where("game_player_perspectives.igdb_perspective_id = ?", perspectiveID)
+	}
+
 	// Sorting - whitelist both column and direction to prevent SQL injection
 	sort := c.DefaultQuery("sort", "title")
 	if s := c.Query("sortBy"); s != "" {
@@ -100,6 +114,19 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 	}
 	if genre := c.Query("genre"); genre != "" {
 		countQuery = countQuery.Where("genre = ?", genre)
+	}
+	// Phase 2 Explore: enrichment-based filters for count query
+	if themeID := c.Query("theme"); themeID != "" {
+		countQuery = countQuery.Joins("JOIN game_themes ON game_themes.game_id = games.id").
+			Where("game_themes.igdb_theme_id = ?", themeID)
+	}
+	if keywordID := c.Query("keyword"); keywordID != "" {
+		countQuery = countQuery.Joins("JOIN game_keywords ON game_keywords.game_id = games.id").
+			Where("game_keywords.igdb_keyword_id = ?", keywordID)
+	}
+	if perspectiveID := c.Query("perspective"); perspectiveID != "" {
+		countQuery = countQuery.Joins("JOIN game_player_perspectives ON game_player_perspectives.game_id = games.id").
+			Where("game_player_perspectives.igdb_perspective_id = ?", perspectiveID)
 	}
 	countQuery.Count(&total)
 

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -173,6 +173,7 @@ func NewRouter(cfg Config) *gin.Engine {
 	sessionHandler := &SessionHandler{DB: cfg.DB, Storage: cfg.Storage}
 	artworkHandler := &ArtworkHandler{DB: cfg.DB}
 	exploreHandler := &ExploreHandler{DB: cfg.DB}
+	enrichmentHandler := &EnrichmentHandler{DB: cfg.DB, Scraper: cfg.Scraper, Hub: cfg.Hub}
 	discoveryHandler := &GameDiscoveryHandler{DB: cfg.DB, Scraper: cfg.Scraper}
 	setupHandler := &SetupHandler{
 		DB:            cfg.DB,
@@ -416,6 +417,16 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/games/:id/challenges", challengeHandler.ListGameChallenges)
 		api.GET("/user/challenges", challengeHandler.ListMyChallenges)
 
+		// Enrichment: Themes, Keywords, Series, Franchises
+		api.GET("/themes", enrichmentHandler.ListThemes)
+		api.GET("/themes/:id/games", enrichmentHandler.ListThemeGames)
+		api.GET("/keywords", enrichmentHandler.ListKeywords)
+		api.GET("/keywords/:id/games", enrichmentHandler.ListKeywordGames)
+		api.GET("/series", enrichmentHandler.ListSeries)
+		api.GET("/series/:id", enrichmentHandler.GetSeriesDetail)
+		api.GET("/franchises", enrichmentHandler.ListFranchises)
+		api.GET("/franchises/:id/games", enrichmentHandler.ListFranchiseGames)
+
 		// RetroAchievements
 		api.POST("/user/ra/link", raHandler.LinkAccount)
 		api.DELETE("/user/ra/link", raHandler.UnlinkAccount)
@@ -463,6 +474,10 @@ func NewRouter(cfg Config) *gin.Engine {
 			admin.POST("/cheats/import", adminHandler.TriggerCheatImport)
 			admin.GET("/cheats/stats", adminHandler.GetCheatStats)
 			admin.GET("/core-compatibility", adminHandler.GetCoreCompatibility)
+
+			// Enrichment backfill
+			admin.POST("/enrich-metadata", enrichmentHandler.TriggerEnrichMetadata)
+			admin.GET("/enrich-metadata/status", enrichmentHandler.EnrichMetadataStatus)
 
 			// ROM uploads
 			admin.POST("/uploads", uploadHandler.UploadROMs)

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -154,6 +154,14 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&SessionCheatSetting{},
 		&DailyPlayActivity{},
 		&GameArtwork{},
+		// Phase 2 Explore: IGDB enrichment
+		&GameTheme{},
+		&GameKeyword{},
+		&GamePlayerPerspective{},
+		&GameFranchise{},
+		&GameSeries{},
+		&GameSeriesEntry{},
+		&GameArtworkImage{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)
@@ -450,6 +458,76 @@ func mergeGameData(database *gorm.DB, keeperID, dupID uint) {
 			database.Unscoped().Delete(&ci)
 		}
 	}
+
+	// --- Phase 2 Enrichment tables ---
+
+	// GameTheme — move, skip if keeper already has same theme
+	var dupThemes []GameTheme
+	database.Where("game_id = ?", dupID).Find(&dupThemes)
+	for _, t := range dupThemes {
+		var count int64
+		database.Model(&GameTheme{}).Where("game_id = ? AND igdb_theme_id = ?", keeperID, t.IGDBThemeID).Count(&count)
+		if count == 0 {
+			database.Model(&t).Update("game_id", keeperID)
+		} else {
+			database.Unscoped().Delete(&t)
+		}
+	}
+
+	// GameKeyword — move, skip if keeper already has same keyword
+	var dupKeywords []GameKeyword
+	database.Where("game_id = ?", dupID).Find(&dupKeywords)
+	for _, k := range dupKeywords {
+		var count int64
+		database.Model(&GameKeyword{}).Where("game_id = ? AND igdb_keyword_id = ?", keeperID, k.IGDBKeywordID).Count(&count)
+		if count == 0 {
+			database.Model(&k).Update("game_id", keeperID)
+		} else {
+			database.Unscoped().Delete(&k)
+		}
+	}
+
+	// GamePlayerPerspective — move, skip if keeper already has same perspective
+	var dupPerspectives []GamePlayerPerspective
+	database.Where("game_id = ?", dupID).Find(&dupPerspectives)
+	for _, p := range dupPerspectives {
+		var count int64
+		database.Model(&GamePlayerPerspective{}).Where("game_id = ? AND igdb_perspective_id = ?", keeperID, p.IGDBPerspectiveID).Count(&count)
+		if count == 0 {
+			database.Model(&p).Update("game_id", keeperID)
+		} else {
+			database.Unscoped().Delete(&p)
+		}
+	}
+
+	// GameFranchise — move, skip if keeper already has same franchise
+	var dupFranchises []GameFranchise
+	database.Where("game_id = ?", dupID).Find(&dupFranchises)
+	for _, f := range dupFranchises {
+		var count int64
+		database.Model(&GameFranchise{}).Where("game_id = ? AND igdb_franchise_id = ?", keeperID, f.IGDBFranchiseID).Count(&count)
+		if count == 0 {
+			database.Model(&f).Update("game_id", keeperID)
+		} else {
+			database.Unscoped().Delete(&f)
+		}
+	}
+
+	// GameArtworkImage — move, skip if keeper already has same image
+	var dupArtworks []GameArtworkImage
+	database.Where("game_id = ?", dupID).Find(&dupArtworks)
+	for _, a := range dupArtworks {
+		var count int64
+		database.Model(&GameArtworkImage{}).Where("game_id = ? AND igdb_image_id = ?", keeperID, a.IGDBImageID).Count(&count)
+		if count == 0 {
+			database.Model(&a).Update("game_id", keeperID)
+		} else {
+			database.Unscoped().Delete(&a)
+		}
+	}
+
+	// GameSeriesEntry — update any entries pointing to the duplicate game
+	database.Model(&GameSeriesEntry{}).Where("game_id = ?", dupID).Update("game_id", keeperID)
 
 	// PlayHistory — merge: keep highest play time and latest timestamp per user
 	var dupPH []PlayHistory

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -636,6 +636,77 @@ type GameArtwork struct {
 	UpdatedAt     time.Time `json:"updatedAt"`
 }
 
+// --- Phase 2 Explore: IGDB Enrichment models ---
+
+// GameTheme stores an IGDB theme associated with a game (e.g., "Fantasy", "Sci-Fi").
+type GameTheme struct {
+	ID          uint      `gorm:"primarykey" json:"id"`
+	CreatedAt   time.Time `json:"createdAt"`
+	GameID      uint      `gorm:"uniqueIndex:idx_game_theme;not null" json:"gameId"`
+	IGDBThemeID int       `gorm:"uniqueIndex:idx_game_theme;not null" json:"igdbThemeId"`
+	Name        string    `gorm:"size:255;not null" json:"name"`
+}
+
+// GameKeyword stores an IGDB keyword associated with a game (e.g., "time travel", "zombies").
+type GameKeyword struct {
+	ID            uint      `gorm:"primarykey" json:"id"`
+	CreatedAt     time.Time `json:"createdAt"`
+	GameID        uint      `gorm:"uniqueIndex:idx_game_keyword;not null" json:"gameId"`
+	IGDBKeywordID int       `gorm:"uniqueIndex:idx_game_keyword;not null" json:"igdbKeywordId"`
+	Name          string    `gorm:"size:255;not null" json:"name"`
+}
+
+// GamePlayerPerspective stores a player perspective for a game (e.g., "First person", "Side view").
+type GamePlayerPerspective struct {
+	ID                uint      `gorm:"primarykey" json:"id"`
+	CreatedAt         time.Time `json:"createdAt"`
+	GameID            uint      `gorm:"uniqueIndex:idx_game_perspective;not null" json:"gameId"`
+	IGDBPerspectiveID int       `gorm:"uniqueIndex:idx_game_perspective;not null" json:"igdbPerspectiveId"`
+	Name              string    `gorm:"size:255;not null" json:"name"`
+}
+
+// GameFranchise stores a franchise association for a game (e.g., "Mario", "Zelda").
+type GameFranchise struct {
+	ID              uint      `gorm:"primarykey" json:"id"`
+	CreatedAt       time.Time `json:"createdAt"`
+	GameID          uint      `gorm:"uniqueIndex:idx_game_franchise;not null" json:"gameId"`
+	IGDBFranchiseID int       `gorm:"uniqueIndex:idx_game_franchise;not null" json:"igdbFranchiseId"`
+	FranchiseName   string    `gorm:"size:255;not null" json:"franchiseName"`
+}
+
+// GameSeries represents an IGDB collection (game series like "Super Mario", "The Legend of Zelda").
+// Named "Series" to avoid collision with user-created GameCollection.
+type GameSeries struct {
+	ID               uint              `gorm:"primarykey" json:"id"`
+	CreatedAt        time.Time         `json:"createdAt"`
+	UpdatedAt        time.Time         `json:"updatedAt"`
+	IGDBCollectionID int               `gorm:"uniqueIndex;not null" json:"igdbCollectionId"`
+	Name             string            `gorm:"size:255;not null" json:"name"`
+	Entries          []GameSeriesEntry `gorm:"foreignKey:SeriesID" json:"entries,omitempty"`
+}
+
+// GameSeriesEntry represents a game within a series. GameID is nullable because the
+// game may not be in the local library (supports "You own 8 of 15 games" display).
+type GameSeriesEntry struct {
+	ID           uint      `gorm:"primarykey" json:"id"`
+	CreatedAt    time.Time `json:"createdAt"`
+	SeriesID     uint      `gorm:"uniqueIndex:idx_series_igdb_game;not null" json:"seriesId"`
+	GameID       *uint     `gorm:"index" json:"gameId"`
+	IGDBGameID   int       `gorm:"uniqueIndex:idx_series_igdb_game;not null" json:"igdbGameId"`
+	Name         string    `gorm:"size:255;not null" json:"name"`
+	CoverImageID string    `gorm:"size:255" json:"coverImageId"`
+}
+
+// GameArtworkImage stores IGDB promotional artwork (distinct from SteamGridDB GameArtwork).
+type GameArtworkImage struct {
+	ID          uint      `gorm:"primarykey" json:"id"`
+	CreatedAt   time.Time `json:"createdAt"`
+	GameID      uint      `gorm:"uniqueIndex:idx_game_artwork_image;not null" json:"gameId"`
+	IGDBImageID string    `gorm:"uniqueIndex:idx_game_artwork_image;size:255;not null" json:"igdbImageId"`
+	Width       int       `json:"width"`
+	Height      int       `json:"height"`
+}
+
 // StagedUpload represents a ROM file uploaded to the staging area pending admin review.
 type StagedUpload struct {
 	ID               uint           `gorm:"primarykey" json:"id"`

--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -590,6 +590,342 @@ func (c *Client) GetSimilarGames(igdbGameID int) ([]SimilarGame, error) {
 	return games, nil
 }
 
+// --- Enrichment types for Phase 2 Explore ---
+
+// GameEnrichment holds extended metadata fetched from IGDB for a single game.
+type GameEnrichment struct {
+	Themes             []EnrichmentNamedItem `json:"themes"`
+	Keywords           []EnrichmentNamedItem `json:"keywords"`
+	PlayerPerspectives []EnrichmentNamedItem `json:"player_perspectives"`
+	Franchises         []int                 `json:"franchises"`       // raw franchise IDs
+	CollectionID       *int                  `json:"collection_id"`    // IGDB collection (series) ID, nil if none
+	Artworks           []ArtworkData         `json:"artworks"`
+}
+
+// EnrichmentNamedItem holds an IGDB entity with an ID and name.
+type EnrichmentNamedItem struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// ArtworkData holds IGDB artwork image metadata.
+type ArtworkData struct {
+	ImageID string `json:"image_id"`
+	Width   int    `json:"width"`
+	Height  int    `json:"height"`
+}
+
+// FranchiseData holds IGDB franchise details.
+type FranchiseData struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	GameIDs []int  `json:"games"`
+}
+
+// CollectionData holds IGDB collection (series) details.
+type CollectionData struct {
+	ID      int    `json:"id"`
+	Name    string `json:"name"`
+	GameIDs []int  `json:"games"`
+}
+
+// CollectionGameInfo holds basic info about a game within a collection.
+type CollectionGameInfo struct {
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	CoverImageID string `json:"cover_image_id"`
+}
+
+// GetGameEnrichment fetches extended metadata for a game: themes, keywords,
+// player perspectives, franchise IDs, collection ID, and artworks.
+// Returns nil, nil if the game is not found.
+func (c *Client) GetGameEnrichment(igdbID int) (*GameEnrichment, error) {
+	if err := c.authenticate(); err != nil {
+		return nil, fmt.Errorf("IGDB authentication: %w", err)
+	}
+
+	<-c.rateLimiter
+
+	query := fmt.Sprintf(
+		`fields themes.name,keywords.name,player_perspectives.name,franchises,collection,artworks.image_id,artworks.width,artworks.height; where id = %d; limit 1;`,
+		igdbID,
+	)
+
+	slog.Info("IGDB get game enrichment request", "igdbID", igdbID)
+
+	c.mu.Lock()
+	token := c.token.AccessToken
+	c.mu.Unlock()
+
+	req, err := http.NewRequest("POST", igdbAPIBase+"/games", strings.NewReader(query))
+	if err != nil {
+		return nil, fmt.Errorf("creating IGDB enrichment request: %w", err)
+	}
+	req.Header.Set("Client-ID", c.ClientID)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling IGDB API for enrichment: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading IGDB enrichment response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var results []struct {
+		Themes             []EnrichmentNamedItem `json:"themes"`
+		Keywords           []EnrichmentNamedItem `json:"keywords"`
+		PlayerPerspectives []EnrichmentNamedItem `json:"player_perspectives"`
+		Franchises         []int                 `json:"franchises"`
+		Collection         *int                  `json:"collection"`
+		Artworks           []struct {
+			ImageID string `json:"image_id"`
+			Width   int    `json:"width"`
+			Height  int    `json:"height"`
+		} `json:"artworks"`
+	}
+	if err := json.Unmarshal(body, &results); err != nil {
+		return nil, fmt.Errorf("decoding IGDB enrichment response: %w", err)
+	}
+
+	if len(results) == 0 {
+		slog.Info("IGDB get game enrichment: not found", "igdbID", igdbID)
+		return nil, nil
+	}
+
+	r := results[0]
+	enrichment := &GameEnrichment{
+		Themes:             r.Themes,
+		Keywords:           r.Keywords,
+		PlayerPerspectives: r.PlayerPerspectives,
+		Franchises:         r.Franchises,
+		CollectionID:       r.Collection,
+	}
+
+	for _, a := range r.Artworks {
+		enrichment.Artworks = append(enrichment.Artworks, ArtworkData{
+			ImageID: a.ImageID,
+			Width:   a.Width,
+			Height:  a.Height,
+		})
+	}
+
+	slog.Info("IGDB get game enrichment response", "igdbID", igdbID,
+		"themes", len(enrichment.Themes), "keywords", len(enrichment.Keywords),
+		"perspectives", len(enrichment.PlayerPerspectives),
+		"franchises", len(enrichment.Franchises),
+		"artworks", len(enrichment.Artworks))
+
+	return enrichment, nil
+}
+
+// GetCollection fetches an IGDB collection (series) by ID.
+// Returns the collection name and the list of game IDs.
+// Returns nil, nil if the collection is not found.
+func (c *Client) GetCollection(collectionID int) (*CollectionData, error) {
+	if err := c.authenticate(); err != nil {
+		return nil, fmt.Errorf("IGDB authentication: %w", err)
+	}
+
+	<-c.rateLimiter
+
+	query := fmt.Sprintf(
+		`fields name,games; where id = %d; limit 1;`,
+		collectionID,
+	)
+
+	slog.Info("IGDB get collection request", "collectionID", collectionID)
+
+	c.mu.Lock()
+	token := c.token.AccessToken
+	c.mu.Unlock()
+
+	req, err := http.NewRequest("POST", igdbAPIBase+"/collections", strings.NewReader(query))
+	if err != nil {
+		return nil, fmt.Errorf("creating IGDB collection request: %w", err)
+	}
+	req.Header.Set("Client-ID", c.ClientID)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling IGDB API for collection: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading IGDB collection response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var results []CollectionData
+	if err := json.Unmarshal(body, &results); err != nil {
+		return nil, fmt.Errorf("decoding IGDB collection response: %w", err)
+	}
+
+	if len(results) == 0 {
+		slog.Info("IGDB get collection: not found", "collectionID", collectionID)
+		return nil, nil
+	}
+
+	slog.Info("IGDB get collection response", "collectionID", collectionID,
+		"name", results[0].Name, "games", len(results[0].GameIDs))
+
+	return &results[0], nil
+}
+
+// GetFranchise fetches an IGDB franchise by ID.
+// Returns the franchise name and the list of game IDs.
+// Returns nil, nil if the franchise is not found.
+func (c *Client) GetFranchise(franchiseID int) (*FranchiseData, error) {
+	if err := c.authenticate(); err != nil {
+		return nil, fmt.Errorf("IGDB authentication: %w", err)
+	}
+
+	<-c.rateLimiter
+
+	query := fmt.Sprintf(
+		`fields name,games; where id = %d; limit 1;`,
+		franchiseID,
+	)
+
+	slog.Info("IGDB get franchise request", "franchiseID", franchiseID)
+
+	c.mu.Lock()
+	token := c.token.AccessToken
+	c.mu.Unlock()
+
+	req, err := http.NewRequest("POST", igdbAPIBase+"/franchises", strings.NewReader(query))
+	if err != nil {
+		return nil, fmt.Errorf("creating IGDB franchise request: %w", err)
+	}
+	req.Header.Set("Client-ID", c.ClientID)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling IGDB API for franchise: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading IGDB franchise response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var results []FranchiseData
+	if err := json.Unmarshal(body, &results); err != nil {
+		return nil, fmt.Errorf("decoding IGDB franchise response: %w", err)
+	}
+
+	if len(results) == 0 {
+		slog.Info("IGDB get franchise: not found", "franchiseID", franchiseID)
+		return nil, nil
+	}
+
+	slog.Info("IGDB get franchise response", "franchiseID", franchiseID,
+		"name", results[0].Name, "games", len(results[0].GameIDs))
+
+	return &results[0], nil
+}
+
+// GetCollectionGames fetches basic info for games within a collection.
+// Returns name and cover for each game ID provided.
+func (c *Client) GetCollectionGames(gameIDs []int) ([]CollectionGameInfo, error) {
+	if len(gameIDs) == 0 {
+		return nil, nil
+	}
+
+	if err := c.authenticate(); err != nil {
+		return nil, fmt.Errorf("IGDB authentication: %w", err)
+	}
+
+	// Process in batches of 50 (IGDB limit)
+	var allGames []CollectionGameInfo
+	for i := 0; i < len(gameIDs); i += 50 {
+		end := i + 50
+		if end > len(gameIDs) {
+			end = len(gameIDs)
+		}
+		batch := gameIDs[i:end]
+
+		<-c.rateLimiter
+
+		idStrs := make([]string, len(batch))
+		for j, id := range batch {
+			idStrs[j] = fmt.Sprintf("%d", id)
+		}
+
+		query := fmt.Sprintf(
+			`fields name,cover.image_id; where id = (%s); limit %d;`,
+			strings.Join(idStrs, ","), len(batch),
+		)
+
+		c.mu.Lock()
+		token := c.token.AccessToken
+		c.mu.Unlock()
+
+		req, err := http.NewRequest("POST", igdbAPIBase+"/games", strings.NewReader(query))
+		if err != nil {
+			return nil, fmt.Errorf("creating IGDB collection games request: %w", err)
+		}
+		req.Header.Set("Client-ID", c.ClientID)
+		req.Header.Set("Authorization", "Bearer "+token)
+
+		resp, err := c.HTTPClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("calling IGDB API for collection games: %w", err)
+		}
+
+		body, err := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if err != nil {
+			return nil, fmt.Errorf("reading IGDB collection games response: %w", err)
+		}
+
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
+		}
+
+		var games []struct {
+			ID    int    `json:"id"`
+			Name  string `json:"name"`
+			Cover *Image `json:"cover"`
+		}
+		if err := json.Unmarshal(body, &games); err != nil {
+			return nil, fmt.Errorf("decoding IGDB collection games response: %w", err)
+		}
+
+		for _, g := range games {
+			info := CollectionGameInfo{
+				ID:   g.ID,
+				Name: g.Name,
+			}
+			if g.Cover != nil {
+				info.CoverImageID = g.Cover.ImageID
+			}
+			allGames = append(allGames, info)
+		}
+	}
+
+	return allGames, nil
+}
+
 // escapeQuery sanitizes user input for IGDB Apicalypse queries.
 // Escapes double quotes and removes semicolons to prevent query injection.
 func escapeQuery(s string) string {

--- a/server/internal/igdb/enrichment_test.go
+++ b/server/internal/igdb/enrichment_test.go
@@ -1,0 +1,440 @@
+package igdb
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetGameEnrichment_Success(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/v4/games", r.URL.Path)
+
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{
+				"themes": []map[string]interface{}{
+					{"id": 1, "name": "Fantasy"},
+					{"id": 17, "name": "Sci-Fi"},
+				},
+				"keywords": []map[string]interface{}{
+					{"id": 100, "name": "time travel"},
+				},
+				"player_perspectives": []map[string]interface{}{
+					{"id": 3, "name": "Side view"},
+				},
+				"franchises": []int{123, 456},
+				"collection": 789,
+				"artworks": []map[string]interface{}{
+					{"image_id": "ar1234", "width": 1920, "height": 1080},
+					{"image_id": "ar5678", "width": 3840, "height": 2160},
+				},
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	enrichment, err := c.GetGameEnrichment(1234)
+	require.NoError(t, err)
+	require.NotNil(t, enrichment)
+
+	assert.Len(t, enrichment.Themes, 2)
+	assert.Equal(t, 1, enrichment.Themes[0].ID)
+	assert.Equal(t, "Fantasy", enrichment.Themes[0].Name)
+	assert.Equal(t, 17, enrichment.Themes[1].ID)
+	assert.Equal(t, "Sci-Fi", enrichment.Themes[1].Name)
+
+	assert.Len(t, enrichment.Keywords, 1)
+	assert.Equal(t, 100, enrichment.Keywords[0].ID)
+	assert.Equal(t, "time travel", enrichment.Keywords[0].Name)
+
+	assert.Len(t, enrichment.PlayerPerspectives, 1)
+	assert.Equal(t, 3, enrichment.PlayerPerspectives[0].ID)
+	assert.Equal(t, "Side view", enrichment.PlayerPerspectives[0].Name)
+
+	assert.Equal(t, []int{123, 456}, enrichment.Franchises)
+
+	require.NotNil(t, enrichment.CollectionID)
+	assert.Equal(t, 789, *enrichment.CollectionID)
+
+	assert.Len(t, enrichment.Artworks, 2)
+	assert.Equal(t, "ar1234", enrichment.Artworks[0].ImageID)
+	assert.Equal(t, 1920, enrichment.Artworks[0].Width)
+	assert.Equal(t, 1080, enrichment.Artworks[0].Height)
+}
+
+func TestGetGameEnrichment_NotFound(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	enrichment, err := c.GetGameEnrichment(99999)
+	require.NoError(t, err)
+	assert.Nil(t, enrichment)
+}
+
+func TestGetGameEnrichment_APIError(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	_, err := c.GetGameEnrichment(1234)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestGetGameEnrichment_NoCollection(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{
+				"themes": []map[string]interface{}{
+					{"id": 1, "name": "Fantasy"},
+				},
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	enrichment, err := c.GetGameEnrichment(1234)
+	require.NoError(t, err)
+	require.NotNil(t, enrichment)
+
+	assert.Len(t, enrichment.Themes, 1)
+	assert.Nil(t, enrichment.CollectionID)
+	assert.Empty(t, enrichment.Franchises)
+	assert.Empty(t, enrichment.Artworks)
+}
+
+func TestGetCollection_Success(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v4/collections", r.URL.Path)
+		json.NewEncoder(w).Encode([]CollectionData{
+			{ID: 789, Name: "Super Mario", GameIDs: []int{100, 200, 300}},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	collection, err := c.GetCollection(789)
+	require.NoError(t, err)
+	require.NotNil(t, collection)
+
+	assert.Equal(t, 789, collection.ID)
+	assert.Equal(t, "Super Mario", collection.Name)
+	assert.Equal(t, []int{100, 200, 300}, collection.GameIDs)
+}
+
+func TestGetCollection_NotFound(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]CollectionData{})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	collection, err := c.GetCollection(99999)
+	require.NoError(t, err)
+	assert.Nil(t, collection)
+}
+
+func TestGetFranchise_Success(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v4/franchises", r.URL.Path)
+		json.NewEncoder(w).Encode([]FranchiseData{
+			{ID: 123, Name: "The Legend of Zelda", GameIDs: []int{10, 20, 30, 40}},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	franchise, err := c.GetFranchise(123)
+	require.NoError(t, err)
+	require.NotNil(t, franchise)
+
+	assert.Equal(t, 123, franchise.ID)
+	assert.Equal(t, "The Legend of Zelda", franchise.Name)
+	assert.Equal(t, []int{10, 20, 30, 40}, franchise.GameIDs)
+}
+
+func TestGetFranchise_NotFound(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]FranchiseData{})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	franchise, err := c.GetFranchise(99999)
+	require.NoError(t, err)
+	assert.Nil(t, franchise)
+}
+
+func TestGetCollectionGames_Success(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{"id": 100, "name": "Super Mario Bros.", "cover": map[string]interface{}{"image_id": "co1111"}},
+			{"id": 200, "name": "Super Mario Bros. 2", "cover": map[string]interface{}{"image_id": "co2222"}},
+			{"id": 300, "name": "Super Mario Bros. 3"},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	games, err := c.GetCollectionGames([]int{100, 200, 300})
+	require.NoError(t, err)
+	require.Len(t, games, 3)
+
+	assert.Equal(t, 100, games[0].ID)
+	assert.Equal(t, "Super Mario Bros.", games[0].Name)
+	assert.Equal(t, "co1111", games[0].CoverImageID)
+
+	assert.Equal(t, 200, games[1].ID)
+	assert.Equal(t, "co2222", games[1].CoverImageID)
+
+	// Game without cover
+	assert.Equal(t, 300, games[2].ID)
+	assert.Equal(t, "", games[2].CoverImageID)
+}
+
+func TestGetCollectionGames_EmptyInput(t *testing.T) {
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	games, err := c.GetCollectionGames(nil)
+	require.NoError(t, err)
+	assert.Nil(t, games)
+
+	games, err = c.GetCollectionGames([]int{})
+	require.NoError(t, err)
+	assert.Nil(t, games)
+}

--- a/server/internal/scraper/crc_integration_test.go
+++ b/server/internal/scraper/crc_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -35,8 +36,8 @@ func TestScrapeIGDB_CRCMatch_RenamesAndUsesCanonicalName(t *testing.T) {
 `
 	require.NoError(t, os.WriteFile(datPath, []byte(datContent), 0o644))
 
-	// Set up IGDB mock that records the search query
-	var searchQuery string
+	// Set up IGDB mock that records all request queries
+	var searchQueries []string
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]interface{}{
 			"access_token": "test-token",
@@ -50,7 +51,7 @@ func TestScrapeIGDB_CRCMatch_RenamesAndUsesCanonicalName(t *testing.T) {
 		// Parse the search query from the IGDB request body
 		body := make([]byte, 4096)
 		n, _ := r.Body.Read(body)
-		searchQuery = string(body[:n])
+		searchQueries = append(searchQueries, string(body[:n]))
 
 		json.NewEncoder(w).Encode([]igdb.Game{
 			{ID: 1, Name: "Castlevania"},
@@ -112,7 +113,14 @@ func TestScrapeIGDB_CRCMatch_RenamesAndUsesCanonicalName(t *testing.T) {
 	assert.True(t, os.IsNotExist(err))
 
 	// Verify IGDB was searched with the canonical name (cleaned from "Castlevania (USA).nes")
-	assert.Contains(t, searchQuery, "Castlevania")
+	foundCastlevania := false
+	for _, q := range searchQueries {
+		if strings.Contains(q, "Castlevania") {
+			foundCastlevania = true
+			break
+		}
+	}
+	assert.True(t, foundCastlevania, "expected at least one IGDB query to contain 'Castlevania', got: %v", searchQueries)
 
 	// Verify the game got metadata from IGDB
 	assert.Equal(t, "Castlevania", game.Title)

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -34,6 +34,11 @@ type Scraper struct {
 	scrapeMu       sync.Mutex
 	scraping       bool
 	scrapeProgress *ScrapeProgress
+
+	// Enrichment state tracking
+	enrichMu       sync.Mutex
+	enriching      bool
+	enrichProgress *EnrichProgress
 }
 
 // NewScraper creates a new metadata scraper instance.
@@ -58,10 +63,13 @@ func (s *Scraper) IsIGDBConfigured() bool {
 
 // TryStartScrape attempts to acquire the scrape lock.
 // Returns true if the lock was acquired (caller must call FinishScrape when done).
+// Also checks the enrichment lock — scraping and enrichment are mutually exclusive.
 func (s *Scraper) TryStartScrape() bool {
 	s.scrapeMu.Lock()
 	defer s.scrapeMu.Unlock()
-	if s.scraping {
+	s.enrichMu.Lock()
+	defer s.enrichMu.Unlock()
+	if s.scraping || s.enriching {
 		return false
 	}
 	s.scraping = true
@@ -92,6 +100,47 @@ func (s *Scraper) GetScrapeStatus() (bool, *ScrapeProgress) {
 	}
 	p := *s.scrapeProgress
 	return s.scraping, &p
+}
+
+// TryStartEnrich attempts to acquire the enrichment lock.
+// Returns true if the lock was acquired (caller must call FinishEnrich when done).
+// Also checks the scrape lock — enrichment and scraping are mutually exclusive.
+func (s *Scraper) TryStartEnrich() bool {
+	s.scrapeMu.Lock()
+	defer s.scrapeMu.Unlock()
+	s.enrichMu.Lock()
+	defer s.enrichMu.Unlock()
+	if s.scraping || s.enriching {
+		return false
+	}
+	s.enriching = true
+	return true
+}
+
+// FinishEnrich releases the enrichment lock and clears progress.
+func (s *Scraper) FinishEnrich() {
+	s.enrichMu.Lock()
+	s.enriching = false
+	s.enrichProgress = nil
+	s.enrichMu.Unlock()
+}
+
+// SetEnrichProgress updates the current enrichment progress.
+func (s *Scraper) SetEnrichProgress(p *EnrichProgress) {
+	s.enrichMu.Lock()
+	s.enrichProgress = p
+	s.enrichMu.Unlock()
+}
+
+// GetEnrichStatus returns whether an enrichment is active and the current progress.
+func (s *Scraper) GetEnrichStatus() (bool, *EnrichProgress) {
+	s.enrichMu.Lock()
+	defer s.enrichMu.Unlock()
+	if s.enrichProgress == nil {
+		return s.enriching, nil
+	}
+	p := *s.enrichProgress
+	return s.enriching, &p
 }
 
 // AbbreviationToLibRetro maps console abbreviations to LibRetro system names.
@@ -443,6 +492,10 @@ func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string
 	s.applyIGDBMatch(game, console, match, gameIDStr, forceTitle)
 
 	slog.Info("IGDB match found", "game", searchName, "matched", match.Name, "igdbId", match.ID)
+
+	// Enrichment: fetch themes, keywords, perspectives, franchises, artworks
+	s.enrichGameMetadata(game, match.ID)
+
 	return nil
 }
 
@@ -644,8 +697,334 @@ func (s *Scraper) ScrapeGameWithIGDBMatch(game *db.Game, igdbID int) error {
 		return fmt.Errorf("saving scraped metadata: %w", err)
 	}
 
+	// Enrichment: fetch themes, keywords, perspectives, franchises, artworks
+	s.enrichGameMetadata(game, igdbID)
+
 	slog.Info("re-scraped with manual IGDB match", "game", game.Title, "igdbId", igdbID, "scraperId", game.ScraperID)
 	return nil
+}
+
+// enrichGameMetadata fetches extended IGDB metadata (themes, keywords, perspectives,
+// franchises, artworks) and stores them in the database. Errors are logged but do not
+// fail the overall scrape — the game will simply lack enrichment data.
+func (s *Scraper) enrichGameMetadata(game *db.Game, igdbGameID int) {
+	if s.IGDBClient == nil || !s.IGDBClient.IsConfigured() {
+		return
+	}
+
+	enrichment, err := s.IGDBClient.GetGameEnrichment(igdbGameID)
+	if err != nil {
+		slog.Warn("IGDB enrichment failed, skipping", "game", game.Title, "igdbId", igdbGameID, "error", err)
+		return
+	}
+	if enrichment == nil {
+		return
+	}
+
+	s.storeEnrichmentData(game, enrichment, igdbGameID)
+}
+
+// storeEnrichmentData persists enrichment data to the DB, replacing any existing data.
+func (s *Scraper) storeEnrichmentData(game *db.Game, enrichment *igdb.GameEnrichment, igdbGameID int) {
+	// Delete old enrichment data to prevent duplicates on re-scrape
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameTheme{})
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameKeyword{})
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GamePlayerPerspective{})
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameFranchise{})
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameArtworkImage{})
+
+	// Store themes
+	for _, t := range enrichment.Themes {
+		s.DB.Create(&db.GameTheme{
+			GameID:      game.ID,
+			IGDBThemeID: t.ID,
+			Name:        t.Name,
+		})
+	}
+
+	// Store keywords
+	for _, k := range enrichment.Keywords {
+		s.DB.Create(&db.GameKeyword{
+			GameID:        game.ID,
+			IGDBKeywordID: k.ID,
+			Name:          k.Name,
+		})
+	}
+
+	// Store player perspectives
+	for _, p := range enrichment.PlayerPerspectives {
+		s.DB.Create(&db.GamePlayerPerspective{
+			GameID:            game.ID,
+			IGDBPerspectiveID: p.ID,
+			Name:              p.Name,
+		})
+	}
+
+	// Store franchises (reuse name from existing DB entries when possible)
+	for _, fID := range enrichment.Franchises {
+		var existing db.GameFranchise
+		if err := s.DB.Where("igdb_franchise_id = ?", fID).First(&existing).Error; err == nil {
+			// Reuse the cached franchise name
+			s.DB.Create(&db.GameFranchise{
+				GameID:          game.ID,
+				IGDBFranchiseID: fID,
+				FranchiseName:   existing.FranchiseName,
+			})
+		} else if s.IGDBClient != nil {
+			// Fetch franchise name from IGDB
+			franchise, fetchErr := s.IGDBClient.GetFranchise(fID)
+			if fetchErr != nil {
+				slog.Warn("failed to fetch franchise from IGDB", "franchiseId", fID, "error", fetchErr)
+				continue
+			}
+			if franchise != nil {
+				s.DB.Create(&db.GameFranchise{
+					GameID:          game.ID,
+					IGDBFranchiseID: fID,
+					FranchiseName:   franchise.Name,
+				})
+			}
+		}
+	}
+
+	// Store artworks
+	for _, a := range enrichment.Artworks {
+		if a.ImageID == "" {
+			continue
+		}
+		s.DB.Create(&db.GameArtworkImage{
+			GameID:      game.ID,
+			IGDBImageID: a.ImageID,
+			Width:       a.Width,
+			Height:      a.Height,
+		})
+	}
+
+	// Handle series (IGDB collection)
+	if enrichment.CollectionID != nil {
+		s.handleSeriesForGame(game, *enrichment.CollectionID)
+	}
+}
+
+// handleSeriesForGame creates or reuses a GameSeries for the IGDB collection
+// and links the current game to it via GameSeriesEntry.
+func (s *Scraper) handleSeriesForGame(game *db.Game, igdbCollectionID int) {
+	var series db.GameSeries
+	if err := s.DB.Where("igdb_collection_id = ?", igdbCollectionID).First(&series).Error; err != nil {
+		// Series doesn't exist yet — fetch from IGDB
+		if s.IGDBClient == nil {
+			return
+		}
+		collectionData, fetchErr := s.IGDBClient.GetCollection(igdbCollectionID)
+		if fetchErr != nil {
+			slog.Warn("failed to fetch collection from IGDB", "collectionId", igdbCollectionID, "error", fetchErr)
+			return
+		}
+		if collectionData == nil {
+			return
+		}
+		series = db.GameSeries{
+			IGDBCollectionID: igdbCollectionID,
+			Name:             collectionData.Name,
+		}
+		if err := s.DB.Create(&series).Error; err != nil {
+			slog.Warn("failed to create game series", "name", collectionData.Name, "error", err)
+			return
+		}
+	}
+
+	// Create/update the entry for this local game
+	igdbID := 0
+	if _, parseErr := fmt.Sscanf(game.ScraperID, "igdb:%d", &igdbID); parseErr != nil || igdbID == 0 {
+		return
+	}
+
+	var entry db.GameSeriesEntry
+	result := s.DB.Where("series_id = ? AND igdb_game_id = ?", series.ID, igdbID).First(&entry)
+	if result.Error != nil {
+		// Create new entry
+		gameID := game.ID
+		s.DB.Create(&db.GameSeriesEntry{
+			SeriesID:   series.ID,
+			GameID:     &gameID,
+			IGDBGameID: igdbID,
+			Name:       game.Title,
+		})
+	} else {
+		// Update existing entry to link to local game
+		if entry.GameID == nil {
+			gameID := game.ID
+			s.DB.Model(&entry).Update("game_id", &gameID)
+		}
+	}
+}
+
+// EnrichGameOnly fetches and stores enrichment data for a game that already has
+// an IGDB match. Unlike ScrapeGame, it does NOT re-download cover art, screenshots,
+// or any other basic metadata. Used by the backfill endpoint.
+func (s *Scraper) EnrichGameOnly(game *db.Game) error {
+	if s.IGDBClient == nil || !s.IGDBClient.IsConfigured() {
+		return fmt.Errorf("IGDB client is not configured")
+	}
+
+	// Extract IGDB ID from scraper ID
+	var igdbID int
+	if _, err := fmt.Sscanf(game.ScraperID, "igdb:%d", &igdbID); err != nil || igdbID == 0 {
+		return fmt.Errorf("game %q has no valid IGDB scraper ID: %s", game.Title, game.ScraperID)
+	}
+
+	enrichment, err := s.IGDBClient.GetGameEnrichment(igdbID)
+	if err != nil {
+		return fmt.Errorf("fetching enrichment for %q (igdb:%d): %w", game.Title, igdbID, err)
+	}
+	if enrichment == nil {
+		return nil // game not found on IGDB — not an error
+	}
+
+	s.storeEnrichmentData(game, enrichment, igdbID)
+	return nil
+}
+
+// PopulateSeriesEntries fetches all games in a series from IGDB and populates
+// GameSeriesEntry rows (with GameID null for non-library games).
+// This is called during backfill to power "You own 8 of 15 games" displays.
+func (s *Scraper) PopulateSeriesEntries(series *db.GameSeries) error {
+	if s.IGDBClient == nil || !s.IGDBClient.IsConfigured() {
+		return fmt.Errorf("IGDB client is not configured")
+	}
+
+	collectionData, err := s.IGDBClient.GetCollection(series.IGDBCollectionID)
+	if err != nil {
+		return fmt.Errorf("fetching collection %d: %w", series.IGDBCollectionID, err)
+	}
+	if collectionData == nil || len(collectionData.GameIDs) == 0 {
+		return nil
+	}
+
+	// Fetch game names and covers from IGDB
+	gameInfos, err := s.IGDBClient.GetCollectionGames(collectionData.GameIDs)
+	if err != nil {
+		return fmt.Errorf("fetching collection game details: %w", err)
+	}
+
+	// Build a map of IGDB game ID -> local game ID
+	var localGames []db.Game
+	s.DB.Select("id, scraper_id").Where("scraper_id LIKE 'igdb:%'").Find(&localGames)
+	localMap := make(map[int]uint) // igdbID -> local game ID
+	for _, g := range localGames {
+		var igdbID int
+		if _, parseErr := fmt.Sscanf(g.ScraperID, "igdb:%d", &igdbID); parseErr == nil && igdbID > 0 {
+			localMap[igdbID] = g.ID
+		}
+	}
+
+	// Upsert entries
+	for _, info := range gameInfos {
+		var entry db.GameSeriesEntry
+		result := s.DB.Where("series_id = ? AND igdb_game_id = ?", series.ID, info.ID).First(&entry)
+		if result.Error != nil {
+			// Create new entry
+			newEntry := db.GameSeriesEntry{
+				SeriesID:     series.ID,
+				IGDBGameID:   info.ID,
+				Name:         info.Name,
+				CoverImageID: info.CoverImageID,
+			}
+			if localID, ok := localMap[info.ID]; ok {
+				newEntry.GameID = &localID
+			}
+			s.DB.Create(&newEntry)
+		} else {
+			// Update existing entry
+			updates := map[string]interface{}{
+				"name":           info.Name,
+				"cover_image_id": info.CoverImageID,
+			}
+			if localID, ok := localMap[info.ID]; ok {
+				updates["game_id"] = localID
+			}
+			s.DB.Model(&entry).Updates(updates)
+		}
+	}
+
+	return nil
+}
+
+// EnrichProgress holds progress information for a metadata enrichment operation.
+type EnrichProgress struct {
+	Current   int    `json:"current"`
+	Total     int    `json:"total"`
+	GameName  string `json:"gameName"`
+	Successes int    `json:"successes"`
+	Failures  int    `json:"failures"`
+}
+
+// EnrichAll enriches games with IGDB metadata.
+// Mode "missing" (default) only enriches games without themes; "all" re-enriches everything.
+// If onProgress is non-nil, it is called after each game.
+func (s *Scraper) EnrichAll(mode string, onProgress func(EnrichProgress)) (int, int, error) {
+	var games []db.Game
+	switch mode {
+	case "all":
+		if err := s.DB.Where("scraper_id LIKE 'igdb:%'").Find(&games).Error; err != nil {
+			return 0, 0, fmt.Errorf("loading IGDB-matched games: %w", err)
+		}
+	default: // "missing"
+		// Games with IGDB match but no themes (never enriched)
+		if err := s.DB.Where("scraper_id LIKE 'igdb:%'").
+			Where("id NOT IN (SELECT DISTINCT game_id FROM game_themes)").
+			Find(&games).Error; err != nil {
+			return 0, 0, fmt.Errorf("loading unenriched games: %w", err)
+		}
+	}
+
+	total := len(games)
+	successes := 0
+	failures := 0
+
+	// Track series we've populated to avoid redundant GetCollection calls
+	populatedSeries := make(map[uint]bool)
+
+	for i := range games {
+		if err := s.EnrichGameOnly(&games[i]); err != nil {
+			slog.Warn("enrichment failed for game", "game", games[i].Title, "error", err)
+			failures++
+		} else {
+			successes++
+
+			// Check if this game's series needs full population
+			var entries []db.GameSeriesEntry
+			s.DB.Where("game_id = ?", games[i].ID).Find(&entries)
+			for _, entry := range entries {
+				if !populatedSeries[entry.SeriesID] {
+					var series db.GameSeries
+					if err := s.DB.First(&series, entry.SeriesID).Error; err == nil {
+						// Only populate if series has few entries (likely not yet populated)
+						var entryCount int64
+						s.DB.Model(&db.GameSeriesEntry{}).Where("series_id = ?", series.ID).Count(&entryCount)
+						if entryCount <= 1 {
+							if popErr := s.PopulateSeriesEntries(&series); popErr != nil {
+								slog.Warn("failed to populate series entries", "series", series.Name, "error", popErr)
+							}
+						}
+						populatedSeries[entry.SeriesID] = true
+					}
+				}
+			}
+		}
+
+		if onProgress != nil {
+			onProgress(EnrichProgress{
+				Current:   i + 1,
+				Total:     total,
+				GameName:  games[i].Title,
+				Successes: successes,
+				Failures:  failures,
+			})
+		}
+	}
+
+	return successes, total, nil
 }
 
 // downloadExternalImage downloads an image from an external URL and saves it locally.

--- a/server/internal/scraper/scraper_igdb_test.go
+++ b/server/internal/scraper/scraper_igdb_test.go
@@ -29,7 +29,12 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	require.NoError(t, err)
-	require.NoError(t, database.AutoMigrate(&db.Console{}, &db.Game{}, &db.GameScreenshot{}))
+	require.NoError(t, database.AutoMigrate(
+		&db.Console{}, &db.Game{}, &db.GameScreenshot{},
+		&db.GameTheme{}, &db.GameKeyword{}, &db.GamePlayerPerspective{},
+		&db.GameFranchise{}, &db.GameSeries{}, &db.GameSeriesEntry{},
+		&db.GameArtworkImage{},
+	))
 	return database
 }
 


### PR DESCRIPTION
## Summary

Phase 2 of the Explore page — extends the IGDB integration to fetch richer metadata for game discovery features.

- **IGDB client:** New methods for game enrichment (themes, keywords, perspectives, franchises, collections, artworks) and series data
- **7 new DB models:** `GameTheme`, `GameKeyword`, `GamePlayerPerspective`, `GameFranchise`, `GameSeries`, `GameSeriesEntry`, `GameArtworkImage`
- **Scraper enrichment:** Automatic during normal scraping with graceful degradation; admin backfill endpoint for existing libraries
- **8 new API endpoints:** Browse by theme, keyword, series, franchise
- **Extended game filters:** Filter by theme, keyword, and player perspective

### Key design decisions
- All data cached locally — read endpoints never hit IGDB live
- `GameSeries`/`GameSeriesEntry` avoids name collision with user-created `GameCollection`
- `GameSeriesEntry.GameID` is nullable for tracking series members not in the library
- Enrichment and scraping are mutually exclusive (thread-safe locking)
- Enrichment counts exclude soft-deleted games
- Game deduplication handles all enrichment tables

### What's next
Phase 3 will add theme & keyword browsing UI using this enriched data.

## Test plan
- [x] IGDB client: 10 tests for enrichment, collection, franchise methods
- [x] API endpoints: 21 tests for themes, keywords, series, franchises, filters, auth
- [x] All existing tests pass — zero regressions
- [ ] Manual: run admin backfill against a real IGDB-configured server