### PR TITLE
feat: Theme & keyword browsing on Explore page

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreThemeKeywordTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreThemeKeywordTest.kt
@@ -1,0 +1,263 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.Keyword
+import com.spela.player.domain.model.Theme
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for Phase 3: Theme & Keyword Browsing.
+ *
+ * Covers:
+ * - Theme grid renders on Explore screen
+ * - Keyword chips render on Explore screen
+ * - Navigation to theme detail works
+ * - Theme detail shows games
+ * - Navigation to keyword detail works
+ * - Keyword detail shows games
+ * - Sections hidden when no data
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ExploreThemeKeywordTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private val sampleThemes = listOf(
+        Theme(id = "17", name = "Sci-Fi", gameCount = 25),
+        Theme(id = "18", name = "Horror", gameCount = 12),
+        Theme(id = "21", name = "Fantasy", gameCount = 30),
+    )
+
+    private val sampleKeywords = listOf(
+        Keyword(id = "100", name = "Time Travel", gameCount = 8),
+        Keyword(id = "101", name = "Zombies", gameCount = 15),
+        Keyword(id = "102", name = "Steampunk", gameCount = 5),
+    )
+
+    private val sampleThemeGames = listOf(
+        Game(
+            id = "50",
+            title = "Metroid Prime",
+            consoleName = "GC",
+            consoleId = "gc",
+            coverUrl = null,
+            rating = 96.0,
+        ),
+        Game(
+            id = "51",
+            title = "Mega Man X",
+            consoleName = "SNES",
+            consoleId = "snes",
+            coverUrl = null,
+            rating = 88.0,
+        ),
+    )
+
+    private val sampleKeywordGames = listOf(
+        Game(
+            id = "60",
+            title = "Chrono Trigger",
+            consoleName = "SNES",
+            consoleId = "snes",
+            coverUrl = null,
+            rating = 95.0,
+        ),
+    )
+
+    @Test
+    fun themeGridRendersOnExploreScreen() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.themes = sampleThemes
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_themes_section").assertIsDisplayed()
+        onNodeWithText("Browse by Theme").assertIsDisplayed()
+        onNodeWithTag("theme_grid").assertIsDisplayed()
+    }
+
+    @Test
+    fun themeCardsShowThemeNames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.themes = sampleThemes
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithText("Sci-Fi").assertExists()
+        onNodeWithText("Horror").assertExists()
+        onNodeWithText("Fantasy").assertExists()
+    }
+
+    @Test
+    fun themeCardsShowGameCounts() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.themes = sampleThemes
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithText("25 games").assertExists()
+        onNodeWithText("12 games").assertExists()
+        onNodeWithText("30 games").assertExists()
+    }
+
+    @Test
+    fun keywordChipsRenderOnExploreScreen() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.keywords = sampleKeywords
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_keywords_section").assertIsDisplayed()
+        onNodeWithText("Popular Keywords").assertIsDisplayed()
+        onNodeWithTag("keyword_chips").assertIsDisplayed()
+    }
+
+    @Test
+    fun keywordChipsShowNamesAndCounts() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.keywords = sampleKeywords
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithText("Time Travel (8)").assertExists()
+        onNodeWithText("Zombies (15)").assertExists()
+        onNodeWithText("Steampunk (5)").assertExists()
+    }
+
+    @Test
+    fun navigationToThemeDetailWorks() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.themes = sampleThemes
+        harness.exploreRepo.themeGames = mapOf("17" to sampleThemeGames)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        // Click the Sci-Fi theme card
+        onNodeWithTag("theme_card_17").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("explore_theme/17", navState.currentScreen.route)
+    }
+
+    @Test
+    fun themeDetailShowsGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.themeGames = mapOf("17" to sampleThemeGames)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreTheme("17", "Sci-Fi"))
+        )
+        advance(harness)
+
+        onNodeWithTag("explore_theme_screen").assertIsDisplayed()
+        onNodeWithText("Sci-Fi").assertIsDisplayed()
+        onNodeWithText("Metroid Prime").assertExists()
+        onNodeWithText("Mega Man X").assertExists()
+    }
+
+    @Test
+    fun themeDetailNavigatesToGameDetail() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.themeGames = mapOf("17" to sampleThemeGames)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreTheme("17", "Sci-Fi"))
+        )
+        advance(harness)
+
+        onNodeWithTag("theme_game_card_50").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals(SpScreen.GameDetail("50"), navState.currentScreen)
+    }
+
+    @Test
+    fun navigationToKeywordDetailWorks() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.keywords = sampleKeywords
+        harness.exploreRepo.keywordGames = mapOf("100" to sampleKeywordGames)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        // Click the "Time Travel" keyword chip
+        onNodeWithTag("keyword_chip_100").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("explore_keyword/100", navState.currentScreen.route)
+    }
+
+    @Test
+    fun keywordDetailShowsGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.keywordGames = mapOf("100" to sampleKeywordGames)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreKeyword("100", "Time Travel"))
+        )
+        advance(harness)
+
+        onNodeWithTag("explore_keyword_screen").assertIsDisplayed()
+        onNodeWithText("Time Travel").assertIsDisplayed()
+        onNodeWithText("Chrono Trigger").assertExists()
+    }
+
+    @Test
+    fun themeSectionHiddenWhenNoThemes() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.themes = emptyList()
+        harness.exploreRepo.keywords = sampleKeywords
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_themes_section").assertDoesNotExist()
+    }
+
+    @Test
+    fun keywordSectionHiddenWhenNoKeywords() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.themes = sampleThemes
+        harness.exploreRepo.keywords = emptyList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_keywords_section").assertDoesNotExist()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1321,6 +1321,10 @@ class FakeSessionRepository : SessionRepository {
 class FakeExploreRepository : ExploreRepository {
     var featuredGames: List<FeaturedGame> = emptyList()
     var exploreRows: List<ExploreRow> = emptyList()
+    var themes: List<Theme> = emptyList()
+    var keywords: List<Keyword> = emptyList()
+    var themeGames: Map<String, List<Game>> = emptyMap()
+    var keywordGames: Map<String, List<Game>> = emptyMap()
     var shouldFail: Boolean = false
 
     override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> =
@@ -1330,6 +1334,22 @@ class FakeExploreRepository : ExploreRepository {
     override suspend fun getExploreRows(): Result<List<ExploreRow>> =
         if (shouldFail) Result.failure(Exception("Failed to load explore rows"))
         else Result.success(exploreRows)
+
+    override suspend fun getThemes(): Result<List<Theme>> =
+        if (shouldFail) Result.failure(Exception("Failed to load themes"))
+        else Result.success(themes)
+
+    override suspend fun getThemeGames(themeId: String, page: Int, pageSize: Int): Result<List<Game>> =
+        if (shouldFail) Result.failure(Exception("Failed to load theme games"))
+        else Result.success(themeGames[themeId] ?: emptyList())
+
+    override suspend fun getKeywords(limit: Int): Result<List<Keyword>> =
+        if (shouldFail) Result.failure(Exception("Failed to load keywords"))
+        else Result.success(keywords)
+
+    override suspend fun getKeywordGames(keywordId: String, page: Int, pageSize: Int): Result<List<Game>> =
+        if (shouldFail) Result.failure(Exception("Failed to load keyword games"))
+        else Result.success(keywordGames[keywordId] ?: emptyList())
 }
 
 class FakeCheatRepository : CheatRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -246,6 +246,34 @@ class SpelaApiClient(
         return response.rows
     }
 
+    /** Returns all themes with game counts, sorted by count DESC */
+    suspend fun getThemes(): List<ThemeDto> {
+        return client.get("$baseUrl/api/themes").body()
+    }
+
+    /** Returns paginated games for a theme */
+    suspend fun getThemeGames(themeId: String, page: Int = 1, pageSize: Int = 20): GameListResponse {
+        return client.get("$baseUrl/api/themes/$themeId/games") {
+            parameter("page", page)
+            parameter("pageSize", pageSize)
+        }.body()
+    }
+
+    /** Returns top keywords by game count */
+    suspend fun getKeywords(limit: Int = 50): List<KeywordDto> {
+        return client.get("$baseUrl/api/keywords") {
+            parameter("limit", limit)
+        }.body()
+    }
+
+    /** Returns paginated games for a keyword */
+    suspend fun getKeywordGames(keywordId: String, page: Int = 1, pageSize: Int = 20): GameListResponse {
+        return client.get("$baseUrl/api/keywords/$keywordId/games") {
+            parameter("page", page)
+            parameter("pageSize", pageSize)
+        }.body()
+    }
+
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
     suspend fun getRecentGames(): List<GameDto> {
         return client.get("$baseUrl/api/user/recent").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -566,3 +566,15 @@ fun ExploreRowDto.toDomain(): ExploreRow = ExploreRow(
     title = title,
     games = games.map { it.toDomain() },
 )
+
+fun ThemeDto.toDomain(): Theme = Theme(
+    id = id,
+    name = name,
+    gameCount = gameCount,
+)
+
+fun KeywordDto.toDomain(): Keyword = Keyword(
+    id = id,
+    name = name,
+    gameCount = gameCount,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1031,3 +1031,19 @@ data class ExploreRowDto(
 data class ExploreRowsResponseDto(
     val rows: List<ExploreRowDto>,
 )
+
+// Themes & Keywords
+
+@Serializable
+data class ThemeDto(
+    val id: String,
+    val name: String,
+    val gameCount: Int = 0,
+)
+
+@Serializable
+data class KeywordDto(
+    val id: String,
+    val name: String,
+    val gameCount: Int = 0,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -4,6 +4,9 @@ import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
+import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.Keyword
+import com.spela.player.domain.model.Theme
 import com.spela.player.domain.repository.ExploreRepository
 
 class ExploreRepositoryImpl(
@@ -29,6 +32,34 @@ class ExploreRepositoryImpl(
                         logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
                     )
                 },
+            )
+        }
+    }
+
+    override suspend fun getThemes(): Result<List<Theme>> = runCatching {
+        apiClient.getThemes().map { it.toDomain() }
+    }
+
+    override suspend fun getThemeGames(themeId: String, page: Int, pageSize: Int): Result<List<Game>> = runCatching {
+        apiClient.getThemeGames(themeId, page, pageSize).data.map { gameDto ->
+            gameDto.toDomain().copy(
+                coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+                logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+            )
+        }
+    }
+
+    override suspend fun getKeywords(limit: Int): Result<List<Keyword>> = runCatching {
+        apiClient.getKeywords(limit).map { it.toDomain() }
+    }
+
+    override suspend fun getKeywordGames(keywordId: String, page: Int, pageSize: Int): Result<List<Game>> = runCatching {
+        apiClient.getKeywordGames(keywordId, page, pageSize).data.map { gameDto ->
+            gameDto.toDomain().copy(
+                coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+                logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
             )
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -18,3 +18,15 @@ data class ExploreRow(
     val title: String,
     val games: List<Game>,
 )
+
+data class Theme(
+    val id: String,
+    val name: String,
+    val gameCount: Int,
+)
+
+data class Keyword(
+    val id: String,
+    val name: String,
+    val gameCount: Int,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -2,8 +2,15 @@ package com.spela.player.domain.repository
 
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
+import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.Keyword
+import com.spela.player.domain.model.Theme
 
 interface ExploreRepository {
     suspend fun getFeaturedGames(): Result<List<FeaturedGame>>
     suspend fun getExploreRows(): Result<List<ExploreRow>>
+    suspend fun getThemes(): Result<List<Theme>>
+    suspend fun getThemeGames(themeId: String, page: Int = 1, pageSize: Int = 20): Result<List<Game>>
+    suspend fun getKeywords(limit: Int = 50): Result<List<Keyword>>
+    suspend fun getKeywordGames(keywordId: String, page: Int = 1, pageSize: Int = 20): Result<List<Game>>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -29,6 +29,8 @@ sealed class SpScreen(val route: String) {
     data class ChallengeDetail(val challengeId: String) : SpScreen("challenge/$challengeId")
     data class SessionDetail(val sessionId: String) : SpScreen("sessions/$sessionId")
     data object TopLists : SpScreen("top_lists")
+    data class ExploreTheme(val themeId: String, val themeName: String) : SpScreen("explore_theme/$themeId")
+    data class ExploreKeyword(val keywordId: String, val keywordName: String) : SpScreen("explore_keyword/$keywordId")
 }
 
 data class NavigationState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -92,7 +92,9 @@ import com.spela.player.presentation.ui.screen.ChallengeDetailScreen
 import com.spela.player.presentation.ui.screen.ChallengeListScreen
 import com.spela.player.presentation.ui.screen.GlobalChallengesScreen
 import com.spela.player.presentation.ui.screen.StatsScreen
+import com.spela.player.presentation.ui.screen.ExploreKeywordScreen
 import com.spela.player.presentation.ui.screen.ExploreScreen
+import com.spela.player.presentation.ui.screen.ExploreThemeScreen
 import com.spela.player.presentation.ui.screen.TopListsScreen
 import com.spela.player.presentation.ui.screen.UserProfileScreen
 import com.spela.player.presentation.ui.theme.SpColor
@@ -451,6 +453,52 @@ fun SpelaApp(
                                             navigationViewModel.onIntent(
                                                 NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
                                             )
+                                        },
+                                        onThemeSelected = { themeId, themeName ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreTheme(themeId, themeName))
+                                            )
+                                        },
+                                        onKeywordSelected = { keywordId, keywordName ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreKeyword(keywordId, keywordName))
+                                            )
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.ExploreTheme -> {
+                                if (exploreViewModel != null) {
+                                    ExploreThemeScreen(
+                                        themeId = screen.themeId,
+                                        themeName = screen.themeName,
+                                        viewModel = exploreViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.ExploreKeyword -> {
+                                if (exploreViewModel != null) {
+                                    ExploreKeywordScreen(
+                                        keywordId = screen.keywordId,
+                                        keywordName = screen.keywordName,
+                                        viewModel = exploreViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
                                         },
                                     )
                                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/KeywordChips.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/KeywordChips.kt
@@ -1,0 +1,54 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.Keyword
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpShimmer
+import com.spela.player.presentation.ui.theme.SpSpacing
+
+@Composable
+fun KeywordChips(
+    keywords: List<Keyword>,
+    onKeywordSelected: (keywordId: String, keywordName: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("keyword_chips"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        items(keywords, key = { it.id }) { keyword ->
+            SpChip(
+                text = "${keyword.name} (${keyword.gameCount})",
+                onClick = { onKeywordSelected(keyword.id, keyword.name) },
+                modifier = Modifier.testTag("keyword_chip_${keyword.id}"),
+            )
+        }
+    }
+}
+
+@Composable
+fun KeywordChipsSkeleton(
+    modifier: Modifier = Modifier,
+    count: Int = 6,
+) {
+    LazyRow(
+        modifier = modifier.testTag("keyword_chips_skeleton"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        items(count) {
+            SpShimmer(
+                width = 100.dp,
+                height = 32.dp,
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ThemeGrid.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ThemeGrid.kt
@@ -1,0 +1,142 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.Theme
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Theme gradient colors — each theme gets a distinctive gradient based on its index.
+ */
+private val themeGradients = listOf(
+    listOf(Color(0xFF6C5CE7), Color(0xFF4834D4)),  // Indigo
+    listOf(Color(0xFFFF6B81), Color(0xFFE84563)),  // Rose
+    listOf(Color(0xFF00D2FF), Color(0xFF009FCC)),  // Cyan
+    listOf(Color(0xFF00C853), Color(0xFF009624)),  // Green
+    listOf(Color(0xFFFF6F00), Color(0xFFE65100)),  // Orange
+    listOf(Color(0xFFAA00FF), Color(0xFF7B1FA2)),  // Purple
+    listOf(Color(0xFF304FFE), Color(0xFF1A237E)),  // Deep blue
+    listOf(Color(0xFFFFD600), Color(0xFFC8A200)),  // Gold
+)
+
+@Composable
+fun ThemeGrid(
+    themes: List<Theme>,
+    onThemeSelected: (themeId: String, themeName: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("theme_grid"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(themes, key = { it.id }) { theme ->
+            val gradientIndex = themes.indexOf(theme) % themeGradients.size
+            ThemeCard(
+                theme = theme,
+                gradientColors = themeGradients[gradientIndex],
+                onClick = { onThemeSelected(theme.id, theme.name) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ThemeCard(
+    theme: Theme,
+    gradientColors: List<Color>,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
+
+    SpCard(
+        modifier = Modifier
+            .width(160.dp)
+            .height(90.dp)
+            .testTag("theme_card_${theme.id}")
+            .semantics {
+                contentDescription = "${theme.name}, ${theme.gameCount} games"
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(90.dp)
+                .clip(shape)
+                .background(Brush.linearGradient(gradientColors)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(SpSpacing.Medium),
+            ) {
+                Text(
+                    text = theme.name,
+                    style = SpTypography.TitleLarge,
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = "${theme.gameCount} games",
+                    style = SpTypography.LabelSmall,
+                    color = Color.White.copy(alpha = 0.75f),
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ThemeGridSkeleton(
+    modifier: Modifier = Modifier,
+    count: Int = 5,
+) {
+    LazyRow(
+        modifier = modifier.testTag("theme_grid_skeleton"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(count) {
+            com.spela.player.presentation.ui.components.SpShimmer(
+                modifier = Modifier
+                    .width(160.dp)
+                    .clip(RoundedCornerShape(SpSpacing.CardCornerRadius)),
+                width = 160.dp,
+                height = 90.dp,
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreKeywordScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreKeywordScreen.kt
@@ -1,0 +1,211 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Label
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+import com.spela.player.util.formatRating
+
+@Composable
+fun ExploreKeywordScreen(
+    keywordId: String,
+    keywordName: String,
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val state by viewModel.keywordDetailState.collectAsState()
+
+    LaunchedEffect(keywordId) {
+        viewModel.loadKeywordGames(keywordId, keywordName)
+    }
+
+    Box(modifier = Modifier.fillMaxSize().testTag("explore_keyword_screen")) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = keywordName,
+                showBack = true,
+                onBack = onBack,
+            )
+
+            when {
+                state.isLoading && state.games.isEmpty() -> {
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("keyword_games_loading"),
+                        contentPadding = PaddingValues(SpSpacing.ScreenHorizontal),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                    ) {
+                        items(8) {
+                            SpGameCardSkeleton()
+                        }
+                    }
+                }
+
+                state.games.isEmpty() && !state.isLoading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.Label,
+                            title = "No games found",
+                            message = "No games match this keyword yet.",
+                            modifier = Modifier.testTag("keyword_empty_state"),
+                        )
+                    }
+                }
+
+                else -> {
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("keyword_games_grid"),
+                        contentPadding = PaddingValues(SpSpacing.ScreenHorizontal),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                    ) {
+                        items(state.games, key = { it.id }) { game ->
+                            KeywordGameCard(
+                                game = game,
+                                onClick = { onGameSelected(game.id) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.dismissKeywordDetailError() },
+                )
+            },
+            onDismiss = { viewModel.dismissKeywordDetailError() },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@Composable
+private fun KeywordGameCard(
+    game: Game,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("keyword_game_card_${game.id}")
+            .semantics {
+                contentDescription = "${game.title}, ${game.consoleName}"
+                role = Role.Button
+            },
+        onClick = onClick,
+        onGradient = true,
+    ) {
+        Column {
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.title} cover art",
+                modifier = Modifier.fillMaxWidth(),
+                aspectRatio = game.coverAspectRatio,
+            )
+            Column(
+                modifier = Modifier.padding(
+                    horizontal = SpSpacing.Small,
+                    vertical = SpSpacing.Small,
+                ),
+            ) {
+                Text(
+                    text = game.title,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                ) {
+                    Text(
+                        text = game.consoleName,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                        maxLines = 1,
+                    )
+                    if (game.rating > 0) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(10.dp),
+                        )
+                        Text(
+                            text = formatRating(game.rating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Explore
-import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -27,6 +26,10 @@ import com.spela.player.presentation.ui.feature.explore.GameShelf
 import com.spela.player.presentation.ui.feature.explore.GameShelfSkeleton
 import com.spela.player.presentation.ui.feature.explore.HeroCarousel
 import com.spela.player.presentation.ui.feature.explore.HeroCarouselSkeleton
+import com.spela.player.presentation.ui.feature.explore.KeywordChips
+import com.spela.player.presentation.ui.feature.explore.KeywordChipsSkeleton
+import com.spela.player.presentation.ui.feature.explore.ThemeGrid
+import com.spela.player.presentation.ui.feature.explore.ThemeGridSkeleton
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.viewmodel.ExploreViewModel
@@ -35,6 +38,8 @@ import com.spela.player.presentation.viewmodel.ExploreViewModel
 fun ExploreScreen(
     viewModel: ExploreViewModel,
     onGameSelected: (String) -> Unit,
+    onThemeSelected: ((themeId: String, themeName: String) -> Unit)? = null,
+    onKeywordSelected: ((keywordId: String, keywordName: String) -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
 
@@ -91,6 +96,62 @@ fun ExploreScreen(
                                     vertical = SpSpacing.Default,
                                 ),
                             )
+                        }
+                    }
+
+                    // Theme grid section
+                    item {
+                        if (state.isLoadingThemes && state.themes.isEmpty()) {
+                            SpTitledSection(
+                                title = "Browse by Theme",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                ThemeGridSkeleton()
+                            }
+                        } else if (state.themes.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "Browse by Theme",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_themes_section"),
+                            ) {
+                                ThemeGrid(
+                                    themes = state.themes,
+                                    onThemeSelected = { themeId, themeName ->
+                                        onThemeSelected?.invoke(themeId, themeName)
+                                    },
+                                )
+                            }
+                        }
+                    }
+
+                    // Keyword chips section
+                    item {
+                        if (state.isLoadingKeywords && state.keywords.isEmpty()) {
+                            SpTitledSection(
+                                title = "Popular Keywords",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                KeywordChipsSkeleton()
+                            }
+                        } else if (state.keywords.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "Popular Keywords",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_keywords_section"),
+                            ) {
+                                KeywordChips(
+                                    keywords = state.keywords,
+                                    onKeywordSelected = { keywordId, keywordName ->
+                                        onKeywordSelected?.invoke(keywordId, keywordName)
+                                    },
+                                )
+                            }
                         }
                     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreThemeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreThemeScreen.kt
@@ -1,0 +1,212 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Category
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+import com.spela.player.util.formatRating
+
+@Composable
+fun ExploreThemeScreen(
+    themeId: String,
+    themeName: String,
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val state by viewModel.themeDetailState.collectAsState()
+
+    LaunchedEffect(themeId) {
+        viewModel.loadThemeGames(themeId, themeName)
+    }
+
+    Box(modifier = Modifier.fillMaxSize().testTag("explore_theme_screen")) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = themeName,
+                showBack = true,
+                onBack = onBack,
+            )
+
+            when {
+                state.isLoading && state.games.isEmpty() -> {
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("theme_games_loading"),
+                        contentPadding = PaddingValues(SpSpacing.ScreenHorizontal),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                    ) {
+                        items(8) {
+                            SpGameCardSkeleton()
+                        }
+                    }
+                }
+
+                state.games.isEmpty() && !state.isLoading -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.Category,
+                            title = "No games found",
+                            message = "No games match this theme yet.",
+                            modifier = Modifier.testTag("theme_empty_state"),
+                        )
+                    }
+                }
+
+                else -> {
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("theme_games_grid"),
+                        contentPadding = PaddingValues(SpSpacing.ScreenHorizontal),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                    ) {
+                        items(state.games, key = { it.id }) { game ->
+                            ThemeGameCard(
+                                game = game,
+                                onClick = { onGameSelected(game.id) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.dismissThemeDetailError() },
+                )
+            },
+            onDismiss = { viewModel.dismissThemeDetailError() },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@Composable
+private fun ThemeGameCard(
+    game: Game,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("theme_game_card_${game.id}")
+            .semantics {
+                contentDescription = "${game.title}, ${game.consoleName}"
+                role = Role.Button
+            },
+        onClick = onClick,
+        onGradient = true,
+    ) {
+        Column {
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.title} cover art",
+                modifier = Modifier.fillMaxWidth(),
+                aspectRatio = game.coverAspectRatio,
+            )
+            Column(
+                modifier = Modifier.padding(
+                    horizontal = SpSpacing.Small,
+                    vertical = SpSpacing.Small,
+                ),
+            ) {
+                Text(
+                    text = game.title,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                ) {
+                    Text(
+                        text = game.consoleName,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                        maxLines = 1,
+                    )
+                    if (game.rating > 0) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(10.dp),
+                        )
+                        Text(
+                            text = formatRating(game.rating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -2,6 +2,9 @@ package com.spela.player.presentation.viewmodel
 
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
+import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.Keyword
+import com.spela.player.domain.model.Theme
 import com.spela.player.domain.repository.ExploreRepository
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
@@ -15,13 +18,33 @@ import kotlinx.coroutines.launch
 data class ExploreState(
     val featuredGames: List<FeaturedGame> = emptyList(),
     val rows: List<ExploreRow> = emptyList(),
+    val themes: List<Theme> = emptyList(),
+    val keywords: List<Keyword> = emptyList(),
     val isLoadingFeatured: Boolean = false,
     val isLoadingRows: Boolean = false,
+    val isLoadingThemes: Boolean = false,
+    val isLoadingKeywords: Boolean = false,
     val error: String? = null,
 ) {
-    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows
-    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && !isLoading
+    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords
+    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && !isLoading
 }
+
+data class ThemeDetailState(
+    val themeId: String = "",
+    val themeName: String = "",
+    val games: List<Game> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+data class KeywordDetailState(
+    val keywordId: String = "",
+    val keywordName: String = "",
+    val games: List<Game> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
 
 class ExploreViewModel(
     private val exploreRepository: ExploreRepository,
@@ -31,16 +54,70 @@ class ExploreViewModel(
     private val _state = MutableStateFlow(ExploreState())
     val state: StateFlow<ExploreState> = _state.asStateFlow()
 
+    private val _themeDetailState = MutableStateFlow(ThemeDetailState())
+    val themeDetailState: StateFlow<ThemeDetailState> = _themeDetailState.asStateFlow()
+
+    private val _keywordDetailState = MutableStateFlow(KeywordDetailState())
+    val keywordDetailState: StateFlow<KeywordDetailState> = _keywordDetailState.asStateFlow()
+
     private var featuredJob: Job? = null
     private var rowsJob: Job? = null
+    private var themesJob: Job? = null
+    private var keywordsJob: Job? = null
+    private var themeDetailJob: Job? = null
+    private var keywordDetailJob: Job? = null
 
     fun load() {
         loadFeatured()
         loadRows()
+        loadThemes()
+        loadKeywords()
     }
 
     fun dismissError() {
         _state.update { it.copy(error = null) }
+    }
+
+    fun loadThemeGames(themeId: String, themeName: String) {
+        themeDetailJob?.cancel()
+        _themeDetailState.update {
+            ThemeDetailState(themeId = themeId, themeName = themeName, isLoading = true)
+        }
+        themeDetailJob = scope.launch(dispatchers.io) {
+            exploreRepository.getThemeGames(themeId, page = 1, pageSize = 50).fold(
+                onSuccess = { games ->
+                    _themeDetailState.update { it.copy(games = games, isLoading = false) }
+                },
+                onFailure = { error ->
+                    _themeDetailState.update { it.copy(isLoading = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun loadKeywordGames(keywordId: String, keywordName: String) {
+        keywordDetailJob?.cancel()
+        _keywordDetailState.update {
+            KeywordDetailState(keywordId = keywordId, keywordName = keywordName, isLoading = true)
+        }
+        keywordDetailJob = scope.launch(dispatchers.io) {
+            exploreRepository.getKeywordGames(keywordId, page = 1, pageSize = 50).fold(
+                onSuccess = { games ->
+                    _keywordDetailState.update { it.copy(games = games, isLoading = false) }
+                },
+                onFailure = { error ->
+                    _keywordDetailState.update { it.copy(isLoading = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun dismissThemeDetailError() {
+        _themeDetailState.update { it.copy(error = null) }
+    }
+
+    fun dismissKeywordDetailError() {
+        _keywordDetailState.update { it.copy(error = null) }
     }
 
     private fun loadFeatured() {
@@ -68,6 +145,36 @@ class ExploreViewModel(
                 },
                 onFailure = { error ->
                     _state.update { it.copy(isLoadingRows = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun loadThemes() {
+        if (themesJob?.isActive == true) return
+        _state.update { it.copy(isLoadingThemes = true) }
+        themesJob = scope.launch(dispatchers.io) {
+            exploreRepository.getThemes().fold(
+                onSuccess = { themes ->
+                    _state.update { it.copy(themes = themes, isLoadingThemes = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoadingThemes = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun loadKeywords() {
+        if (keywordsJob?.isActive == true) return
+        _state.update { it.copy(isLoadingKeywords = true) }
+        keywordsJob = scope.launch(dispatchers.io) {
+            exploreRepository.getKeywords().fold(
+                onSuccess = { keywords ->
+                    _state.update { it.copy(keywords = keywords, isLoadingKeywords = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoadingKeywords = false, error = error.message) }
                 },
             )
         }

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -3,12 +3,14 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { ExplorePage } from "@/pages/explore-page";
-import type { FeaturedGame, Game, ExploreRowsResponse } from "@/types/api";
+import type { FeaturedGame, Game, ExploreRowsResponse, Theme, Keyword } from "@/types/api";
 
 // Mock hooks
 vi.mock("@/hooks/use-explore", () => ({
   useExploreFeatured: vi.fn(),
   useExploreRows: vi.fn(),
+  useThemes: vi.fn(),
+  useKeywords: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-games", () => ({
@@ -27,10 +29,12 @@ vi.mock("@/hooks/use-auto-scrape", () => ({
   useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
 }));
 
-import { useExploreFeatured, useExploreRows } from "@/hooks/use-explore";
+import { useExploreFeatured, useExploreRows, useThemes, useKeywords } from "@/hooks/use-explore";
 
 const mockUseExploreFeatured = useExploreFeatured as ReturnType<typeof vi.fn>;
 const mockUseExploreRows = useExploreRows as ReturnType<typeof vi.fn>;
+const mockUseThemes = useThemes as ReturnType<typeof vi.fn>;
+const mockUseKeywords = useKeywords as ReturnType<typeof vi.fn>;
 
 function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
   return {
@@ -75,6 +79,16 @@ function makeGame(overrides: Partial<Game> = {}): Game {
 const mockFeatured: FeaturedGame[] = [
   makeFeaturedGame({ gameId: "1", title: "Hero Game One" }),
   makeFeaturedGame({ gameId: "2", title: "Hero Game Two" }),
+];
+
+const mockThemes: Theme[] = [
+  { id: "17", name: "Science Fiction", gameCount: 42 },
+  { id: "18", name: "Horror", gameCount: 28 },
+];
+
+const mockKeywords: Keyword[] = [
+  { id: "100", name: "Time Travel", gameCount: 15 },
+  { id: "101", name: "Post-Apocalyptic", gameCount: 12 },
 ];
 
 const mockRows: ExploreRowsResponse = {
@@ -142,6 +156,14 @@ describe("ExplorePage", () => {
     });
     mockUseExploreRows.mockReturnValue({
       data: mockRows,
+      isLoading: false,
+    });
+    mockUseThemes.mockReturnValue({
+      data: mockThemes,
+      isLoading: false,
+    });
+    mockUseKeywords.mockReturnValue({
+      data: mockKeywords,
       isLoading: false,
     });
   });
@@ -258,5 +280,55 @@ describe("ExplorePage", () => {
     renderPage();
     expect(screen.queryByTestId("shelf-Top Rated")).not.toBeInTheDocument();
     expect(screen.getByTestId("shelf-Recently Added")).toBeInTheDocument();
+  });
+
+  it("renders the theme grid section", () => {
+    renderPage();
+    expect(screen.getByTestId("theme-grid")).toBeInTheDocument();
+    expect(screen.getByText("Science Fiction")).toBeInTheDocument();
+    expect(screen.getByText("Horror")).toBeInTheDocument();
+  });
+
+  it("renders the keyword chips section", () => {
+    renderPage();
+    expect(screen.getByTestId("keyword-chips")).toBeInTheDocument();
+    expect(screen.getByText("Time Travel")).toBeInTheDocument();
+    expect(screen.getByText("Post-Apocalyptic")).toBeInTheDocument();
+  });
+
+  it("hides theme grid when no themes available", () => {
+    mockUseThemes.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("theme-grid")).not.toBeInTheDocument();
+  });
+
+  it("hides keyword chips when no keywords available", () => {
+    mockUseKeywords.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("keyword-chips")).not.toBeInTheDocument();
+  });
+
+  it("shows theme grid skeleton while loading", () => {
+    mockUseThemes.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByTestId("theme-grid-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows keyword chips skeleton while loading", () => {
+    mockUseKeywords.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByTestId("keyword-chips-skeleton")).toBeInTheDocument();
   });
 });

--- a/web/src/features/explore/components/__tests__/keyword-chips.test.tsx
+++ b/web/src/features/explore/components/__tests__/keyword-chips.test.tsx
@@ -1,0 +1,112 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { KeywordChips } from "../keyword-chips";
+import type { Keyword } from "@/types/api";
+
+function makeKeyword(overrides: Partial<Keyword> = {}): Keyword {
+  return {
+    id: "100",
+    name: "Time Travel",
+    gameCount: 15,
+    ...overrides,
+  };
+}
+
+const mockKeywords: Keyword[] = [
+  makeKeyword({ id: "100", name: "Time Travel", gameCount: 15 }),
+  makeKeyword({ id: "101", name: "Post-Apocalyptic", gameCount: 12 }),
+  makeKeyword({ id: "102", name: "Steampunk", gameCount: 8 }),
+];
+
+function renderChips(
+  props: { keywords?: Keyword[] | undefined; isLoading?: boolean } = {},
+) {
+  const keywords = "keywords" in props ? props.keywords : mockKeywords;
+  return render(
+    <MemoryRouter>
+      <KeywordChips keywords={keywords} isLoading={props.isLoading ?? false} />
+    </MemoryRouter>,
+  );
+}
+
+describe("KeywordChips", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders section with heading", () => {
+    renderChips();
+    expect(
+      screen.getByRole("heading", { name: "Popular Keywords", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders keyword chips", () => {
+    renderChips();
+    expect(screen.getByText("Time Travel")).toBeInTheDocument();
+    expect(screen.getByText("Post-Apocalyptic")).toBeInTheDocument();
+    expect(screen.getByText("Steampunk")).toBeInTheDocument();
+  });
+
+  it("shows game counts on chips", () => {
+    renderChips();
+    expect(screen.getByText("15")).toBeInTheDocument();
+    expect(screen.getByText("12")).toBeInTheDocument();
+    expect(screen.getByText("8")).toBeInTheDocument();
+  });
+
+  it("renders chips as list items", () => {
+    renderChips();
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(3);
+  });
+
+  it("renders the scrollable list with label", () => {
+    renderChips();
+    expect(
+      screen.getByRole("list", { name: "Popular Keywords" }),
+    ).toBeInTheDocument();
+  });
+
+  it("links keyword chips to keyword detail pages", () => {
+    renderChips();
+    const listItems = screen.getAllByRole("listitem");
+    const hrefs = listItems.map((l) => l.getAttribute("href"));
+    expect(hrefs).toContain("/explore/keywords/100");
+    expect(hrefs).toContain("/explore/keywords/101");
+    expect(hrefs).toContain("/explore/keywords/102");
+  });
+
+  it("renders nothing when keywords array is empty", () => {
+    const { container } = renderChips({ keywords: [] });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when keywords is undefined and not loading", () => {
+    const { container } = renderChips({
+      keywords: undefined,
+      isLoading: false,
+    });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders loading skeleton when loading", () => {
+    renderChips({ isLoading: true, keywords: undefined });
+    expect(
+      screen.getByTestId("keyword-chips-skeleton"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Popular Keywords", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton with shimmer animation", () => {
+    const { container } = renderChips({
+      isLoading: true,
+      keywords: undefined,
+    });
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/features/explore/components/__tests__/theme-grid.test.tsx
+++ b/web/src/features/explore/components/__tests__/theme-grid.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { ThemeGrid } from "../theme-grid";
+import type { Theme } from "@/types/api";
+
+function makeTheme(overrides: Partial<Theme> = {}): Theme {
+  return {
+    id: "1",
+    name: "Science Fiction",
+    gameCount: 42,
+    ...overrides,
+  };
+}
+
+const mockThemes: Theme[] = [
+  makeTheme({ id: "1", name: "Science Fiction", gameCount: 42 }),
+  makeTheme({ id: "2", name: "Horror", gameCount: 28 }),
+  makeTheme({ id: "3", name: "Fantasy", gameCount: 35 }),
+];
+
+function renderGrid(
+  props: { themes?: Theme[] | undefined; isLoading?: boolean } = {},
+) {
+  const themes = "themes" in props ? props.themes : mockThemes;
+  return render(
+    <MemoryRouter>
+      <ThemeGrid themes={themes} isLoading={props.isLoading ?? false} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ThemeGrid", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders section with heading", () => {
+    renderGrid();
+    expect(
+      screen.getByRole("heading", { name: "Browse by Theme", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders theme cards", () => {
+    renderGrid();
+    expect(screen.getByText("Science Fiction")).toBeInTheDocument();
+    expect(screen.getByText("Horror")).toBeInTheDocument();
+    expect(screen.getByText("Fantasy")).toBeInTheDocument();
+  });
+
+  it("shows game counts", () => {
+    renderGrid();
+    expect(screen.getByText("42 games")).toBeInTheDocument();
+    expect(screen.getByText("28 games")).toBeInTheDocument();
+    expect(screen.getByText("35 games")).toBeInTheDocument();
+  });
+
+  it("renders singular game count", () => {
+    renderGrid({ themes: [makeTheme({ id: "10", name: "Test", gameCount: 1 })] });
+    expect(screen.getByText("1 game")).toBeInTheDocument();
+  });
+
+  it("renders cards as list items", () => {
+    renderGrid();
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(3);
+  });
+
+  it("renders the scrollable list with label", () => {
+    renderGrid();
+    expect(
+      screen.getByRole("list", { name: "Browse by Theme" }),
+    ).toBeInTheDocument();
+  });
+
+  it("links theme cards to theme detail pages", () => {
+    renderGrid();
+    const listItems = screen.getAllByRole("listitem");
+    const hrefs = listItems.map((l) => l.getAttribute("href"));
+    expect(hrefs).toContain("/explore/themes/1");
+    expect(hrefs).toContain("/explore/themes/2");
+    expect(hrefs).toContain("/explore/themes/3");
+  });
+
+  it("renders nothing when themes array is empty", () => {
+    const { container } = renderGrid({ themes: [] });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when themes is undefined and not loading", () => {
+    const { container } = renderGrid({ themes: undefined, isLoading: false });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders loading skeleton when loading", () => {
+    renderGrid({ isLoading: true, themes: undefined });
+    expect(screen.getByTestId("theme-grid-skeleton")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Browse by Theme", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton with shimmer animation", () => {
+    const { container } = renderGrid({ isLoading: true, themes: undefined });
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/features/explore/components/keyword-chips.tsx
+++ b/web/src/features/explore/components/keyword-chips.tsx
@@ -1,0 +1,131 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import { ChevronLeft, ChevronRight, Tag } from "lucide-react";
+import { Skeleton } from "@/components/ui";
+import type { Keyword } from "@/types/api";
+
+interface KeywordChipsProps {
+  keywords: Keyword[] | undefined;
+  isLoading: boolean;
+}
+
+function KeywordChipsSkeleton() {
+  return (
+    <section data-testid="keyword-chips-skeleton">
+      <h2 className="text-xl font-bold text-surface-100 mb-5">
+        Popular Keywords
+      </h2>
+      <div className="flex gap-3 overflow-hidden flex-wrap">
+        {Array.from({ length: 12 }, (_, i) => (
+          <Skeleton
+            key={i}
+            className="h-9 rounded-full"
+            style={{ width: `${80 + Math.random() * 60}px` }}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function KeywordChips({ keywords, isLoading }: KeywordChipsProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, keywords]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return <KeywordChipsSkeleton />;
+  }
+
+  if (!keywords || keywords.length === 0) {
+    return null;
+  }
+
+  return (
+    <section data-testid="keyword-chips" className="group/keywords relative">
+      <h2 className="text-xl font-bold text-surface-100 mb-5">
+        Popular Keywords
+      </h2>
+
+      <div className="relative">
+        {/* Scroll arrows */}
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/keywords:opacity-100 transition-all duration-300 shadow-lg"
+            aria-label="Scroll keywords left"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/keywords:opacity-100 transition-all duration-300 shadow-lg"
+            aria-label="Scroll keywords right"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        {/* Scrollable row of chips */}
+        <div
+          ref={scrollRef}
+          className="flex gap-3 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label="Popular Keywords"
+        >
+          {keywords.map((keyword) => (
+            <Link
+              key={keyword.id}
+              to={`/explore/keywords/${keyword.id}`}
+              role="listitem"
+              className="flex-shrink-0"
+            >
+              <div className="flex items-center gap-2 px-4 py-2 rounded-full bg-surface-800/60 border border-surface-700/50 text-surface-200 hover:bg-surface-700/60 hover:border-surface-600/50 hover:text-surface-100 transition-all duration-200 group/chip">
+                <Tag className="h-3.5 w-3.5 text-surface-400 group-hover/chip:text-brand-400 transition-colors" />
+                <span className="text-sm font-medium whitespace-nowrap">
+                  {keyword.name}
+                </span>
+                <span className="text-xs text-surface-500 tabular-nums">
+                  {keyword.gameCount}
+                </span>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/features/explore/components/theme-grid.tsx
+++ b/web/src/features/explore/components/theme-grid.tsx
@@ -1,0 +1,183 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Skeleton } from "@/components/ui";
+import type { Theme } from "@/types/api";
+
+// Visual gradients for theme cards — mapped by theme name patterns
+const THEME_GRADIENTS: Record<string, string> = {
+  "science fiction": "from-cyan-900/80 via-blue-900/60 to-indigo-950/80",
+  "sci-fi": "from-cyan-900/80 via-blue-900/60 to-indigo-950/80",
+  horror: "from-red-950/80 via-rose-900/60 to-gray-950/80",
+  fantasy: "from-amber-900/80 via-orange-800/60 to-yellow-950/80",
+  thriller: "from-slate-900/80 via-gray-800/60 to-zinc-950/80",
+  comedy: "from-yellow-800/80 via-amber-700/60 to-orange-900/80",
+  action: "from-red-900/80 via-orange-900/60 to-amber-950/80",
+  drama: "from-purple-900/80 via-violet-800/60 to-indigo-950/80",
+  mystery: "from-indigo-950/80 via-purple-900/60 to-slate-900/80",
+  survival: "from-green-950/80 via-emerald-900/60 to-teal-950/80",
+  stealth: "from-gray-900/80 via-slate-800/60 to-zinc-950/80",
+  historical: "from-amber-950/80 via-yellow-900/60 to-orange-950/80",
+  warfare: "from-stone-900/80 via-neutral-800/60 to-gray-950/80",
+  romance: "from-pink-900/80 via-rose-800/60 to-fuchsia-950/80",
+  sandbox: "from-lime-900/80 via-green-800/60 to-emerald-950/80",
+  "open world": "from-sky-900/80 via-blue-800/60 to-cyan-950/80",
+  educational: "from-teal-900/80 via-cyan-800/60 to-blue-950/80",
+  "party game": "from-fuchsia-900/80 via-pink-800/60 to-rose-950/80",
+  erotic: "from-rose-950/80 via-pink-900/60 to-red-950/80",
+  business: "from-emerald-900/80 via-teal-800/60 to-cyan-950/80",
+  "4x (explore, expand, exploit, exterminate)":
+    "from-violet-900/80 via-indigo-800/60 to-blue-950/80",
+  "non-fiction": "from-stone-800/80 via-neutral-700/60 to-gray-900/80",
+};
+
+const FALLBACK_GRADIENTS = [
+  "from-violet-900/80 via-purple-800/60 to-indigo-950/80",
+  "from-teal-900/80 via-emerald-800/60 to-green-950/80",
+  "from-rose-900/80 via-pink-800/60 to-fuchsia-950/80",
+  "from-sky-900/80 via-blue-800/60 to-cyan-950/80",
+  "from-amber-900/80 via-yellow-800/60 to-orange-950/80",
+  "from-slate-800/80 via-gray-700/60 to-zinc-900/80",
+];
+
+function getGradient(themeName: string, index: number): string {
+  const lower = themeName.toLowerCase();
+  for (const [key, gradient] of Object.entries(THEME_GRADIENTS)) {
+    if (lower.includes(key) || key.includes(lower)) {
+      return gradient;
+    }
+  }
+  return FALLBACK_GRADIENTS[index % FALLBACK_GRADIENTS.length];
+}
+
+interface ThemeGridProps {
+  themes: Theme[] | undefined;
+  isLoading: boolean;
+}
+
+function ThemeGridSkeleton() {
+  return (
+    <section data-testid="theme-grid-skeleton">
+      <h2 className="text-xl font-bold text-surface-100 mb-5">
+        Browse by Theme
+      </h2>
+      <div className="flex gap-4 overflow-hidden">
+        {Array.from({ length: 6 }, (_, i) => (
+          <Skeleton
+            key={i}
+            className="w-44 sm:w-48 lg:w-52 h-28 flex-shrink-0 rounded-2xl"
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function ThemeGrid({ themes, isLoading }: ThemeGridProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, themes]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return <ThemeGridSkeleton />;
+  }
+
+  if (!themes || themes.length === 0) {
+    return null;
+  }
+
+  return (
+    <section data-testid="theme-grid" className="group/themes relative">
+      <h2 className="text-xl font-bold text-surface-100 mb-5">
+        Browse by Theme
+      </h2>
+
+      <div className="relative">
+        {/* Scroll arrows */}
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/themes:opacity-100 transition-all duration-300 shadow-lg"
+            aria-label="Scroll themes left"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/themes:opacity-100 transition-all duration-300 shadow-lg"
+            aria-label="Scroll themes right"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        {/* Scrollable row */}
+        <div
+          ref={scrollRef}
+          className="flex gap-4 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label="Browse by Theme"
+        >
+          {themes.map((theme, index) => (
+            <Link
+              key={theme.id}
+              to={`/explore/themes/${theme.id}`}
+              className="w-44 sm:w-48 lg:w-52 flex-shrink-0"
+              role="listitem"
+            >
+              <div
+                className={`relative h-28 rounded-2xl overflow-hidden bg-gradient-to-br ${getGradient(theme.name, index)} border border-white/[0.06] transition-all duration-300 hover:border-white/[0.12] hover:shadow-xl hover:shadow-black/30 hover:-translate-y-1 group/card`}
+              >
+                {/* Subtle texture overlay */}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-white/[0.04] pointer-events-none" />
+
+                {/* Content */}
+                <div className="relative flex flex-col justify-end h-full p-4">
+                  <h3 className="text-base font-bold text-white leading-tight group-hover/card:text-brand-300 transition-colors">
+                    {theme.name}
+                  </h3>
+                  <p className="text-xs text-white/60 mt-1">
+                    {theme.gameCount} {theme.gameCount === 1 ? "game" : "games"}
+                  </p>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/hooks/use-explore.ts
+++ b/web/src/hooks/use-explore.ts
@@ -1,6 +1,12 @@
 import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
-import type { FeaturedGame, ExploreRowsResponse } from "@/types/api";
+import type {
+  FeaturedGame,
+  ExploreRowsResponse,
+  Theme,
+  Keyword,
+  GamesResponse,
+} from "@/types/api";
 
 export function useExploreFeatured() {
   return useQuery({
@@ -13,5 +19,49 @@ export function useExploreRows() {
   return useQuery({
     queryKey: ["explore", "rows"],
     queryFn: () => api.get<ExploreRowsResponse>("/explore/rows"),
+  });
+}
+
+export function useThemes() {
+  return useQuery({
+    queryKey: ["themes"],
+    queryFn: () => api.get<Theme[]>("/themes"),
+  });
+}
+
+export function useThemeGames(
+  themeId: string | undefined,
+  page: number,
+  pageSize: number,
+) {
+  return useQuery({
+    queryKey: ["themes", themeId, "games", page, pageSize],
+    queryFn: () =>
+      api.get<GamesResponse>(
+        `/themes/${themeId}/games?page=${page}&pageSize=${pageSize}`,
+      ),
+    enabled: !!themeId,
+  });
+}
+
+export function useKeywords(limit = 30) {
+  return useQuery({
+    queryKey: ["keywords", limit],
+    queryFn: () => api.get<Keyword[]>(`/keywords?limit=${limit}`),
+  });
+}
+
+export function useKeywordGames(
+  keywordId: string | undefined,
+  page: number,
+  pageSize: number,
+) {
+  return useQuery({
+    queryKey: ["keywords", keywordId, "games", page, pageSize],
+    queryFn: () =>
+      api.get<GamesResponse>(
+        `/keywords/${keywordId}/games?page=${page}&pageSize=${pageSize}`,
+      ),
+    enabled: !!keywordId,
   });
 }

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -21,6 +21,12 @@ export type ApiGetPath = WithQuery<
   | "/explore/featured"
   | "/explore/rows"
 
+  // Themes & Keywords
+  | "/themes"
+  | `/themes/${string}/games`
+  | "/keywords"
+  | `/keywords/${string}/games`
+
   // Consoles
   | "/consoles"
   | `/consoles/${string}/games`

--- a/web/src/pages/__tests__/explore-keyword-page.test.tsx
+++ b/web/src/pages/__tests__/explore-keyword-page.test.tsx
@@ -1,0 +1,165 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ExploreKeywordPage } from "@/pages/explore-keyword-page";
+import type { Keyword, Game, GamesResponse } from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-explore", () => ({
+  useKeywords: vi.fn(),
+  useKeywordGames: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-games", () => ({
+  useToggleFavorite: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-play-later", () => ({
+  useTogglePlayLater: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+import { useKeywords, useKeywordGames } from "@/hooks/use-explore";
+
+const mockUseKeywords = useKeywords as ReturnType<typeof vi.fn>;
+const mockUseKeywordGames = useKeywordGames as ReturnType<typeof vi.fn>;
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "nes",
+    consoleName: "NES",
+    fileName: "test.nes",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const mockKeywords: Keyword[] = [
+  { id: "100", name: "Time Travel", gameCount: 15 },
+  { id: "101", name: "Post-Apocalyptic", gameCount: 12 },
+];
+
+const mockGamesResponse: GamesResponse = {
+  data: [
+    makeGame({ id: "1", title: "Chrono Trigger", rating: 95 }),
+    makeGame({ id: "2", title: "Chrono Cross", rating: 88 }),
+  ],
+  total: 2,
+  page: 1,
+  pageSize: 48,
+};
+
+function renderPage(keywordId = "100") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/explore/keywords/${keywordId}`]}>
+        <Routes>
+          <Route
+            path="/explore/keywords/:id"
+            element={<ExploreKeywordPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ExploreKeywordPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseKeywords.mockReturnValue({
+      data: mockKeywords,
+      isLoading: false,
+    });
+    mockUseKeywordGames.mockReturnValue({
+      data: mockGamesResponse,
+      isLoading: false,
+    });
+  });
+
+  it("renders the page with test id", () => {
+    renderPage();
+    expect(screen.getByTestId("keyword-detail-page")).toBeInTheDocument();
+  });
+
+  it("renders keyword name in heading", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: "Time Travel", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders game count", () => {
+    renderPage();
+    expect(screen.getByText("2 games")).toBeInTheDocument();
+  });
+
+  it("renders games in grid", () => {
+    renderPage();
+    expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
+    expect(screen.getByText("Chrono Cross")).toBeInTheDocument();
+  });
+
+  it("renders back button", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /back to explore/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders sort select", () => {
+    renderPage();
+    expect(screen.getByLabelText("Sort games")).toBeInTheDocument();
+  });
+
+  it("shows loading skeletons while loading", () => {
+    mockUseKeywordGames.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows empty state when no games", () => {
+    mockUseKeywordGames.mockReturnValue({
+      data: { data: [], total: 0, page: 1, pageSize: 48 },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No games found")).toBeInTheDocument();
+  });
+
+  it("renders fallback keyword name when keyword not found", () => {
+    mockUseKeywords.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderPage("999");
+    expect(
+      screen.getByRole("heading", { name: "Keyword", level: 1 }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/__tests__/explore-theme-page.test.tsx
+++ b/web/src/pages/__tests__/explore-theme-page.test.tsx
@@ -1,0 +1,174 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ExploreThemePage } from "@/pages/explore-theme-page";
+import type { Theme, Game, GamesResponse } from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-explore", () => ({
+  useThemes: vi.fn(),
+  useThemeGames: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-games", () => ({
+  useToggleFavorite: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-play-later", () => ({
+  useTogglePlayLater: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+import { useThemes, useThemeGames } from "@/hooks/use-explore";
+
+const mockUseThemes = useThemes as ReturnType<typeof vi.fn>;
+const mockUseThemeGames = useThemeGames as ReturnType<typeof vi.fn>;
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "nes",
+    consoleName: "NES",
+    fileName: "test.nes",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const mockThemes: Theme[] = [
+  { id: "17", name: "Science Fiction", gameCount: 42 },
+  { id: "18", name: "Horror", gameCount: 28 },
+];
+
+const mockGamesResponse: GamesResponse = {
+  data: [
+    makeGame({ id: "1", title: "Metroid", rating: 90 }),
+    makeGame({ id: "2", title: "Star Fox", rating: 85 }),
+    makeGame({ id: "3", title: "Mega Man X", rating: 88 }),
+  ],
+  total: 3,
+  page: 1,
+  pageSize: 48,
+};
+
+function renderPage(themeId = "17") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/explore/themes/${themeId}`]}>
+        <Routes>
+          <Route
+            path="/explore/themes/:id"
+            element={<ExploreThemePage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ExploreThemePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseThemes.mockReturnValue({
+      data: mockThemes,
+      isLoading: false,
+    });
+    mockUseThemeGames.mockReturnValue({
+      data: mockGamesResponse,
+      isLoading: false,
+    });
+  });
+
+  it("renders the page with test id", () => {
+    renderPage();
+    expect(screen.getByTestId("theme-detail-page")).toBeInTheDocument();
+  });
+
+  it("renders theme name in heading", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", {
+        name: "Science Fiction Games",
+        level: 1,
+      }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders game count", () => {
+    renderPage();
+    expect(screen.getByText("3 games")).toBeInTheDocument();
+  });
+
+  it("renders games in grid", () => {
+    renderPage();
+    expect(screen.getByText("Metroid")).toBeInTheDocument();
+    expect(screen.getByText("Star Fox")).toBeInTheDocument();
+    expect(screen.getByText("Mega Man X")).toBeInTheDocument();
+  });
+
+  it("renders back button", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /back to explore/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders sort select", () => {
+    renderPage();
+    expect(screen.getByLabelText("Sort games")).toBeInTheDocument();
+  });
+
+  it("shows loading skeletons while loading", () => {
+    mockUseThemeGames.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows empty state when no games", () => {
+    mockUseThemeGames.mockReturnValue({
+      data: { data: [], total: 0, page: 1, pageSize: 48 },
+      isLoading: false,
+    });
+    mockUseThemes.mockReturnValue({
+      data: mockThemes,
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No games found")).toBeInTheDocument();
+  });
+
+  it("renders fallback theme name when theme not found", () => {
+    mockUseThemes.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderPage("999");
+    expect(
+      screen.getByRole("heading", { name: "Theme Games", level: 1 }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/explore-keyword-page.tsx
+++ b/web/src/pages/explore-keyword-page.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Library } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameGrid } from "@/components/game-grid";
+import {
+  BackButton,
+  GameCardSkeleton,
+  EmptyState,
+  Select,
+} from "@/components/ui";
+import { Pagination } from "@/components/pagination";
+import { useKeywords, useKeywordGames } from "@/hooks/use-explore";
+import { useToggleFavorite } from "@/hooks/use-games";
+import { useTogglePlayLater } from "@/hooks/use-play-later";
+
+const PAGE_SIZE = 48;
+
+const SORT_OPTIONS = [
+  { value: "rating-desc", label: "Highest Rated" },
+  { value: "rating-asc", label: "Lowest Rated" },
+  { value: "title-asc", label: "Title A-Z" },
+  { value: "title-desc", label: "Title Z-A" },
+  { value: "release-desc", label: "Newest First" },
+  { value: "release-asc", label: "Oldest First" },
+];
+
+export function ExploreKeywordPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [sortBy, setSortBy] = useState("rating-desc");
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+
+  const { data: keywords } = useKeywords(200);
+  const { data, isLoading } = useKeywordGames(id, page, PAGE_SIZE);
+
+  const keyword = keywords?.find((k) => k.id === id);
+  const keywordName = keyword?.name ?? "Keyword";
+  const games = data?.data ?? [];
+  const totalGames = data?.total ?? keyword?.gameCount ?? 0;
+
+  // Client-side sort (the API returns by rating DESC by default)
+  const sortedGames = [...games].sort((a, b) => {
+    switch (sortBy) {
+      case "rating-desc":
+        return (b.rating ?? 0) - (a.rating ?? 0);
+      case "rating-asc":
+        return (a.rating ?? 0) - (b.rating ?? 0);
+      case "title-asc":
+        return a.title.localeCompare(b.title);
+      case "title-desc":
+        return b.title.localeCompare(a.title);
+      case "release-desc":
+        return (b.releaseDate ?? "").localeCompare(a.releaseDate ?? "");
+      case "release-asc":
+        return (a.releaseDate ?? "").localeCompare(b.releaseDate ?? "");
+      default:
+        return 0;
+    }
+  });
+
+  return (
+    <div className="space-y-6" data-testid="keyword-detail-page">
+      {/* Back button */}
+      <BackButton onClick={() => navigate("/explore")}>
+        Back to Explore
+      </BackButton>
+
+      {/* Page header */}
+      <div>
+        <h1 className="text-3xl font-bold text-surface-100">
+          {keywordName}
+        </h1>
+        <p className="mt-1 text-surface-400">
+          {totalGames} {totalGames === 1 ? "game" : "games"}
+        </p>
+      </div>
+
+      {/* Sort controls */}
+      <div className="flex items-center gap-4">
+        <Select
+          options={SORT_OPTIONS}
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value)}
+          className="w-48"
+          aria-label="Sort games"
+        />
+      </div>
+
+      {/* Games grid */}
+      {isLoading ? (
+        <GameGrid>
+          {Array.from({ length: 12 }, (_, i) => (
+            <GameCardSkeleton key={i} />
+          ))}
+        </GameGrid>
+      ) : sortedGames.length === 0 ? (
+        <EmptyState
+          icon={Library}
+          title="No games found"
+          description={`No games found for the "${keywordName}" keyword.`}
+        />
+      ) : (
+        <GameGrid>
+          {sortedGames.map((game) => (
+            <GameCard
+              key={game.id}
+              game={game}
+              showConsoleBadge
+              onToggleFavorite={handleToggleFavorite}
+              onTogglePlayLater={handleTogglePlayLater}
+            />
+          ))}
+        </GameGrid>
+      )}
+
+      {data && (
+        <Pagination
+          total={data.total}
+          pageSize={PAGE_SIZE}
+          currentPage={page}
+          onPageChange={setPage}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -3,7 +3,14 @@ import { Link } from "react-router-dom";
 import { EmptyState, Button } from "@/components/ui";
 import { HeroCarousel } from "@/features/explore/components/hero-carousel";
 import { GameShelf } from "@/features/explore/components/game-shelf";
-import { useExploreFeatured, useExploreRows } from "@/hooks/use-explore";
+import { ThemeGrid } from "@/features/explore/components/theme-grid";
+import { KeywordChips } from "@/features/explore/components/keyword-chips";
+import {
+  useExploreFeatured,
+  useExploreRows,
+  useThemes,
+  useKeywords,
+} from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
 import { useAuth } from "@/hooks/use-auth";
@@ -18,6 +25,14 @@ export function ExplorePage() {
     data: rowsData,
     isLoading: isRowsLoading,
   } = useExploreRows();
+  const {
+    data: themes,
+    isLoading: isThemesLoading,
+  } = useThemes();
+  const {
+    data: keywords,
+    isLoading: isKeywordsLoading,
+  } = useKeywords(30);
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
 
@@ -58,6 +73,10 @@ export function ExplorePage() {
     );
   }
 
+  // Split rows: show first row, then themes/keywords, then remaining rows
+  const firstRow = rows[0];
+  const remainingRows = rows.slice(1);
+
   return (
     <div className="space-y-10" data-testid="explore-page">
       <div>
@@ -70,22 +89,39 @@ export function ExplorePage() {
       {/* Hero Carousel */}
       <HeroCarousel games={featuredGames} isLoading={isFeaturedLoading} />
 
-      {/* Shelf rows */}
+      {/* First shelf row */}
       {isRowsLoading ? (
-        <>
-          <GameShelf
-            title="Top Rated"
-            games={undefined}
-            isLoading={true}
-          />
-          <GameShelf
-            title="Recently Added"
-            games={undefined}
-            isLoading={true}
-          />
-        </>
+        <GameShelf
+          title="Top Rated"
+          games={undefined}
+          isLoading={true}
+        />
+      ) : firstRow ? (
+        <GameShelf
+          key={firstRow.id}
+          title={firstRow.title}
+          games={firstRow.games}
+          isLoading={false}
+          onToggleFavorite={handleToggleFavorite}
+          onTogglePlayLater={handleTogglePlayLater}
+        />
+      ) : null}
+
+      {/* Theme Grid */}
+      <ThemeGrid themes={themes} isLoading={isThemesLoading} />
+
+      {/* Keyword Chips */}
+      <KeywordChips keywords={keywords} isLoading={isKeywordsLoading} />
+
+      {/* Remaining shelf rows */}
+      {isRowsLoading ? (
+        <GameShelf
+          title="Recently Added"
+          games={undefined}
+          isLoading={true}
+        />
       ) : (
-        rows.map((row) => (
+        remainingRows.map((row) => (
           <GameShelf
             key={row.id}
             title={row.title}

--- a/web/src/pages/explore-theme-page.tsx
+++ b/web/src/pages/explore-theme-page.tsx
@@ -1,0 +1,129 @@
+import { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { Library } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameGrid } from "@/components/game-grid";
+import {
+  BackButton,
+  GameCardSkeleton,
+  EmptyState,
+  Select,
+} from "@/components/ui";
+import { Pagination } from "@/components/pagination";
+import { useThemes, useThemeGames } from "@/hooks/use-explore";
+import { useToggleFavorite } from "@/hooks/use-games";
+import { useTogglePlayLater } from "@/hooks/use-play-later";
+
+const PAGE_SIZE = 48;
+
+const SORT_OPTIONS = [
+  { value: "rating-desc", label: "Highest Rated" },
+  { value: "rating-asc", label: "Lowest Rated" },
+  { value: "title-asc", label: "Title A-Z" },
+  { value: "title-desc", label: "Title Z-A" },
+  { value: "release-desc", label: "Newest First" },
+  { value: "release-asc", label: "Oldest First" },
+];
+
+export function ExploreThemePage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [sortBy, setSortBy] = useState("rating-desc");
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+
+  const { data: themes } = useThemes();
+  const { data, isLoading } = useThemeGames(id, page, PAGE_SIZE);
+
+  const theme = themes?.find((t) => t.id === id);
+  const themeName = theme?.name ?? "Theme";
+  const games = data?.data ?? [];
+  const totalGames = data?.total ?? theme?.gameCount ?? 0;
+
+  // Client-side sort (the API returns by rating DESC by default)
+  const sortedGames = [...games].sort((a, b) => {
+    switch (sortBy) {
+      case "rating-desc":
+        return (b.rating ?? 0) - (a.rating ?? 0);
+      case "rating-asc":
+        return (a.rating ?? 0) - (b.rating ?? 0);
+      case "title-asc":
+        return a.title.localeCompare(b.title);
+      case "title-desc":
+        return b.title.localeCompare(a.title);
+      case "release-desc":
+        return (b.releaseDate ?? "").localeCompare(a.releaseDate ?? "");
+      case "release-asc":
+        return (a.releaseDate ?? "").localeCompare(b.releaseDate ?? "");
+      default:
+        return 0;
+    }
+  });
+
+  return (
+    <div className="space-y-6" data-testid="theme-detail-page">
+      {/* Back button */}
+      <BackButton onClick={() => navigate("/explore")}>
+        Back to Explore
+      </BackButton>
+
+      {/* Page header */}
+      <div>
+        <h1 className="text-3xl font-bold text-surface-100">
+          {themeName} Games
+        </h1>
+        <p className="mt-1 text-surface-400">
+          {totalGames} {totalGames === 1 ? "game" : "games"}
+        </p>
+      </div>
+
+      {/* Sort controls */}
+      <div className="flex items-center gap-4">
+        <Select
+          options={SORT_OPTIONS}
+          value={sortBy}
+          onChange={(e) => setSortBy(e.target.value)}
+          className="w-48"
+          aria-label="Sort games"
+        />
+      </div>
+
+      {/* Games grid */}
+      {isLoading ? (
+        <GameGrid>
+          {Array.from({ length: 12 }, (_, i) => (
+            <GameCardSkeleton key={i} />
+          ))}
+        </GameGrid>
+      ) : sortedGames.length === 0 ? (
+        <EmptyState
+          icon={Library}
+          title="No games found"
+          description={`No games found for the "${themeName}" theme.`}
+        />
+      ) : (
+        <GameGrid>
+          {sortedGames.map((game) => (
+            <GameCard
+              key={game.id}
+              game={game}
+              showConsoleBadge
+              onToggleFavorite={handleToggleFavorite}
+              onTogglePlayLater={handleTogglePlayLater}
+            />
+          ))}
+        </GameGrid>
+      )}
+
+      {data && (
+        <Pagination
+          total={data.total}
+          pageSize={PAGE_SIZE}
+          currentPage={page}
+          onPageChange={setPage}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -815,6 +815,20 @@ export interface PossibleConsole {
   name: string;
 }
 
+// --- Themes & Keywords ---
+
+export interface Theme {
+  id: string;
+  name: string;
+  gameCount: number;
+}
+
+export interface Keyword {
+  id: string;
+  name: string;
+  gameCount: number;
+}
+
 // --- Explore ---
 
 export interface FeaturedGame {


### PR DESCRIPTION
## Summary

Phase 3 of the Explore page — browse games by IGDB themes and keywords.

- **Web:** Theme grid with gradient cards, keyword chips row, detail pages with game grids/sorting/pagination
- **Player app:** Theme grid and keyword chips on Explore screen, detail screens with game grids

Both platforms hide sections when no enrichment data is available and show loading skeletons while fetching.

### What's next
Phase 4: Franchise & series pages with cross-console timelines.

## Test plan
- [x] Web: 40 new tests (theme grid, keyword chips, detail pages, explore page integration) — 807 total
- [x] Player: 12 new desktop E2E tests for themes, keywords, navigation, detail screens
- [x] All existing tests pass — zero regressions
- [ ] Manual: verify theme cards display on Explore page with enriched data
- [ ] Manual: verify keyword chips render and link to detail pages