### PR TITLE
feat: Explore page — Phase 4: franchise & series pages

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreSeriesTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreSeriesTest.kt
@@ -1,0 +1,311 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.FeaturedSeries
+import com.spela.player.domain.model.GameSeriesLink
+import com.spela.player.domain.model.SeriesConsole
+import com.spela.player.domain.model.SeriesDetail
+import com.spela.player.domain.model.SeriesGame
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for Phase 4: Franchise & Series Pages.
+ *
+ * Covers:
+ * - Series shelf renders on Explore screen
+ * - Series shelf cards show correct info
+ * - Navigate to series detail screen
+ * - Series detail shows games in timeline
+ * - Ownership progress shows correct counts
+ * - Console filter works
+ * - Dimmed treatment for non-library games
+ * - "Part of [Series]" link on game detail screen
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ExploreSeriesTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private val sampleFeaturedSeries = listOf(
+        FeaturedSeries(
+            id = "s1",
+            name = "Super Mario",
+            libraryGames = 5,
+            totalGames = 12,
+            consoleCount = 3,
+            heroUrl = null,
+        ),
+        FeaturedSeries(
+            id = "s2",
+            name = "The Legend of Zelda",
+            libraryGames = 3,
+            totalGames = 8,
+            consoleCount = 4,
+            heroUrl = null,
+        ),
+    )
+
+    private val sampleSeriesGames = listOf(
+        SeriesGame(
+            igdbGameId = 1001,
+            name = "Super Mario Bros.",
+            inLibrary = true,
+            localGameId = "game-1",
+            coverUrl = null,
+            releaseDate = "1985-09-13",
+            rating = 85.0,
+            consoleAbbreviation = "NES",
+            consoleName = "NES",
+            consoleColor = "#dc2626",
+        ),
+        SeriesGame(
+            igdbGameId = 1002,
+            name = "Super Mario World",
+            inLibrary = true,
+            localGameId = "game-2",
+            coverUrl = null,
+            releaseDate = "1990-11-21",
+            rating = 94.0,
+            consoleAbbreviation = "SNES",
+            consoleName = "SNES",
+            consoleColor = "#9333ea",
+        ),
+        SeriesGame(
+            igdbGameId = 1003,
+            name = "Super Mario 64",
+            inLibrary = false,
+            localGameId = null,
+            coverUrl = null,
+            releaseDate = "1996-06-23",
+            rating = 96.0,
+            consoleAbbreviation = "N64",
+            consoleName = "N64",
+            consoleColor = "#22c55e",
+        ),
+    )
+
+    private val sampleSeriesConsoles = listOf(
+        SeriesConsole(abbreviation = "NES", name = "Nintendo Entertainment System", color = "#dc2626", gameCount = 1),
+        SeriesConsole(abbreviation = "SNES", name = "Super Nintendo", color = "#9333ea", gameCount = 1),
+        SeriesConsole(abbreviation = "N64", name = "Nintendo 64", color = "#22c55e", gameCount = 1),
+    )
+
+    private val sampleSeriesDetail = SeriesDetail(
+        id = "s1",
+        name = "Super Mario",
+        heroUrl = null,
+        consoles = sampleSeriesConsoles,
+        libraryGames = 2,
+        totalGames = 3,
+        games = sampleSeriesGames,
+    )
+
+    // --- Series shelf on Explore screen ---
+
+    @Test
+    fun seriesShelfRendersOnExploreScreen() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredSeriesList = sampleFeaturedSeries
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_series_section").assertIsDisplayed()
+        onNodeWithText("Browse by Series").assertIsDisplayed()
+        onNodeWithTag("series_shelf").assertIsDisplayed()
+    }
+
+    @Test
+    fun seriesCardsShowCorrectInfo() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredSeriesList = sampleFeaturedSeries
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithText("Super Mario").assertExists()
+        onNodeWithText("5/12 games").assertExists()
+        onNodeWithText("across 3 consoles").assertExists()
+        onNodeWithText("The Legend of Zelda").assertExists()
+        onNodeWithText("3/8 games").assertExists()
+    }
+
+    @Test
+    fun seriesShelfHiddenWhenNoSeries() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredSeriesList = emptyList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_series_section").assertDoesNotExist()
+    }
+
+    // --- Navigation to series detail ---
+
+    @Test
+    fun navigationToSeriesDetailWorks() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredSeriesList = sampleFeaturedSeries
+        harness.exploreRepo.seriesDetails = mapOf("s1" to sampleSeriesDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("series_card_s1").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("explore_series/s1", navState.currentScreen.route)
+    }
+
+    // --- Series detail screen ---
+
+    @Test
+    fun seriesDetailShowsGamesInTimeline() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.seriesDetails = mapOf("s1" to sampleSeriesDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreSeries("s1", "Super Mario"))
+        )
+        advance(harness)
+
+        onNodeWithTag("explore_series_screen").assertIsDisplayed()
+        // "Super Mario" appears in both the top bar and the hero banner
+        onAllNodesWithText("Super Mario").fetchSemanticsNodes().let {
+            assert(it.isNotEmpty()) { "Expected at least one 'Super Mario' text node" }
+        }
+        onNodeWithText("Super Mario Bros.").assertExists()
+        onNodeWithText("Super Mario World").assertExists()
+        onNodeWithText("Super Mario 64").assertExists()
+    }
+
+    @Test
+    fun ownershipProgressShowsCorrectCounts() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.seriesDetails = mapOf("s1" to sampleSeriesDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreSeries("s1", "Super Mario"))
+        )
+        advance(harness)
+
+        onNodeWithTag("series_ownership_text").assertIsDisplayed()
+        onNodeWithText("You own 2 of 3 games").assertExists()
+    }
+
+    @Test
+    fun consoleFilterWorks() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.seriesDetails = mapOf("s1" to sampleSeriesDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreSeries("s1", "Super Mario"))
+        )
+        advance(harness)
+
+        // All 3 games visible initially
+        onNodeWithTag("series_game_1001").assertExists()
+        onNodeWithTag("series_game_1002").assertExists()
+        onNodeWithTag("series_game_1003").assertExists()
+
+        // Click NES filter
+        onNodeWithTag("series_console_chip_NES").performClick()
+        advanceQuick(harness)
+
+        // Only NES game visible
+        onNodeWithTag("series_game_1001").assertExists()
+        onNodeWithTag("series_game_1002").assertDoesNotExist()
+        onNodeWithTag("series_game_1003").assertDoesNotExist()
+
+        // Click NES again to clear filter
+        onNodeWithTag("series_console_chip_NES").performClick()
+        advanceQuick(harness)
+
+        // All games visible again
+        onNodeWithTag("series_game_1001").assertExists()
+        onNodeWithTag("series_game_1002").assertExists()
+        onNodeWithTag("series_game_1003").assertExists()
+    }
+
+    @Test
+    fun dimmedTreatmentForNonLibraryGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.seriesDetails = mapOf("s1" to sampleSeriesDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreSeries("s1", "Super Mario"))
+        )
+        advance(harness)
+
+        // In-library game should exist
+        val inLibraryNode = onNodeWithTag("series_game_1001")
+        inLibraryNode.assertExists()
+
+        // Not-in-library game should exist (dimmed via alpha)
+        val notInLibraryNode = onNodeWithTag("series_game_1003")
+        notInLibraryNode.assertExists()
+
+        // The semantics should indicate non-library status
+        notInLibraryNode.assertContentDescriptionContains("not in library", substring = true)
+    }
+
+    // --- "Part of [Series]" on game detail screen ---
+
+    @Test
+    fun seriesLinkShowsOnGameDetailScreen() = runComposeUiTest {
+        val harness = createHarness()
+
+        // Game "1" (Castlevania) already exists in FakeGameRepository
+        // Add series links for it
+        harness.exploreRepo.gameSeriesLinks = mapOf(
+            "1" to listOf(
+                GameSeriesLink(
+                    id = "s1",
+                    name = "Super Mario",
+                    totalGames = 12,
+                    libraryGames = 5,
+                ),
+            ),
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Verify the series link chip is displayed
+        onNodeWithTag("series_franchise_section").assertExists()
+        onNodeWithText("Part of Super Mario (5/12)", substring = true).assertExists()
+    }
+
+    @Test
+    fun seriesSectionHiddenWhenNoLinks() = runComposeUiTest {
+        val harness = createHarness()
+
+        // Game "1" (Castlevania) exists but no series/franchise links
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        onNodeWithTag("series_franchise_section").assertDoesNotExist()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -106,6 +106,7 @@ class SpelaTestHarness(
     val biosRepo = FakeBiosRepository(fakeApiClient, FakeFileStorage())
     val cheatRepo = FakeCheatRepository()
     val sessionRepo = FakeSessionRepository()
+    val exploreRepo = FakeExploreRepository()
 
     private val scrapeService = com.spela.player.data.remote.ScrapeService(fakeApiClient, dispatchers, scope)
 
@@ -150,6 +151,7 @@ class SpelaTestHarness(
         biosRepository = biosRepo,
         cheatRepository = cheatRepo,
         sessionRepository = sessionRepo,
+        exploreRepository = exploreRepo,
     )
 
     private val stubEngineFactory = object : HttpClientEngineFactory<HttpClientEngineConfig> {
@@ -339,8 +341,6 @@ class SpelaTestHarness(
         dispatchers = dispatchers,
         scope = scope,
     )
-
-    val exploreRepo = FakeExploreRepository()
 
     val exploreViewModel = ExploreViewModel(
         exploreRepository = exploreRepo,

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1325,6 +1325,10 @@ class FakeExploreRepository : ExploreRepository {
     var keywords: List<Keyword> = emptyList()
     var themeGames: Map<String, List<Game>> = emptyMap()
     var keywordGames: Map<String, List<Game>> = emptyMap()
+    var featuredSeriesList: List<FeaturedSeries> = emptyList()
+    var seriesDetails: Map<String, SeriesDetail> = emptyMap()
+    var gameSeriesLinks: Map<String, List<GameSeriesLink>> = emptyMap()
+    var gameFranchiseLinks: Map<String, List<GameFranchiseLink>> = emptyMap()
     var shouldFail: Boolean = false
 
     override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> =
@@ -1350,6 +1354,26 @@ class FakeExploreRepository : ExploreRepository {
     override suspend fun getKeywordGames(keywordId: String, page: Int, pageSize: Int): Result<List<Game>> =
         if (shouldFail) Result.failure(Exception("Failed to load keyword games"))
         else Result.success(keywordGames[keywordId] ?: emptyList())
+
+    override suspend fun getFeaturedSeries(): Result<List<FeaturedSeries>> =
+        if (shouldFail) Result.failure(Exception("Failed to load featured series"))
+        else Result.success(featuredSeriesList)
+
+    override suspend fun getSeriesDetail(id: String): Result<SeriesDetail> =
+        if (shouldFail) Result.failure(Exception("Failed to load series detail"))
+        else {
+            val detail = seriesDetails[id]
+            if (detail != null) Result.success(detail)
+            else Result.failure(Exception("Series not found"))
+        }
+
+    override suspend fun getGameSeries(gameId: String): Result<List<GameSeriesLink>> =
+        if (shouldFail) Result.failure(Exception("Failed to load game series"))
+        else Result.success(gameSeriesLinks[gameId] ?: emptyList())
+
+    override suspend fun getGameFranchises(gameId: String): Result<List<GameFranchiseLink>> =
+        if (shouldFail) Result.failure(Exception("Failed to load game franchises"))
+        else Result.success(gameFranchiseLinks[gameId] ?: emptyList())
 }
 
 class FakeCheatRepository : CheatRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -274,6 +274,26 @@ class SpelaApiClient(
         }.body()
     }
 
+    /** Returns featured series for the Explore page */
+    suspend fun getFeaturedSeries(): List<FeaturedSeriesDto> {
+        return client.get("$baseUrl/api/explore/series/featured").body()
+    }
+
+    /** Returns detail for a specific series */
+    suspend fun getSeriesDetail(id: String): SeriesDetailDto {
+        return client.get("$baseUrl/api/series/$id").body()
+    }
+
+    /** Returns series links for a game */
+    suspend fun getGameSeries(gameId: String): List<GameSeriesLinkDto> {
+        return client.get("$baseUrl/api/games/$gameId/series").body()
+    }
+
+    /** Returns franchise links for a game */
+    suspend fun getGameFranchises(gameId: String): List<GameFranchiseLinkDto> {
+        return client.get("$baseUrl/api/games/$gameId/franchises").body()
+    }
+
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
     suspend fun getRecentGames(): List<GameDto> {
         return client.get("$baseUrl/api/user/recent").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -578,3 +578,55 @@ fun KeywordDto.toDomain(): Keyword = Keyword(
     name = name,
     gameCount = gameCount,
 )
+
+fun FeaturedSeriesDto.toDomain(): FeaturedSeries = FeaturedSeries(
+    id = id,
+    name = name,
+    libraryGames = libraryGames,
+    totalGames = totalGames,
+    consoleCount = consoleCount,
+    heroUrl = heroUrl,
+)
+
+fun SeriesDetailDto.toDomain(): SeriesDetail = SeriesDetail(
+    id = id,
+    name = name,
+    heroUrl = heroUrl,
+    consoles = consoles.map { it.toDomain() },
+    libraryGames = libraryGames,
+    totalGames = totalGames,
+    games = games.map { it.toDomain() },
+)
+
+fun SeriesConsoleDto.toDomain(): SeriesConsole = SeriesConsole(
+    abbreviation = abbreviation,
+    name = name,
+    color = color,
+    gameCount = gameCount,
+)
+
+fun SeriesGameDto.toDomain(): SeriesGame = SeriesGame(
+    igdbGameId = igdbGameId,
+    name = name,
+    inLibrary = inLibrary,
+    localGameId = localGameId,
+    coverUrl = coverUrl,
+    releaseDate = releaseDate,
+    rating = rating,
+    consoleAbbreviation = consoleAbbreviation,
+    consoleName = consoleName,
+    consoleColor = consoleColor,
+)
+
+fun GameSeriesLinkDto.toDomain(): GameSeriesLink = GameSeriesLink(
+    id = id,
+    name = name,
+    totalGames = totalGames,
+    libraryGames = libraryGames,
+)
+
+fun GameFranchiseLinkDto.toDomain(): GameFranchiseLink = GameFranchiseLink(
+    id = id,
+    name = name,
+    gameCount = gameCount,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1047,3 +1047,63 @@ data class KeywordDto(
     val name: String,
     val gameCount: Int = 0,
 )
+
+// Series & Franchise
+
+@Serializable
+data class FeaturedSeriesDto(
+    val id: String,
+    val name: String,
+    val libraryGames: Int = 0,
+    val totalGames: Int = 0,
+    val consoleCount: Int = 0,
+    val heroUrl: String? = null,
+)
+
+@Serializable
+data class SeriesDetailDto(
+    val id: String,
+    val name: String,
+    val heroUrl: String? = null,
+    val consoles: List<SeriesConsoleDto> = emptyList(),
+    val libraryGames: Int = 0,
+    val totalGames: Int = 0,
+    val games: List<SeriesGameDto> = emptyList(),
+)
+
+@Serializable
+data class SeriesConsoleDto(
+    val abbreviation: String,
+    val name: String,
+    val color: String = "#6366f1",
+    val gameCount: Int = 0,
+)
+
+@Serializable
+data class SeriesGameDto(
+    val igdbGameId: Int,
+    val name: String,
+    val inLibrary: Boolean = false,
+    val localGameId: String? = null,
+    val coverUrl: String? = null,
+    val releaseDate: String? = null,
+    val rating: Double = 0.0,
+    val consoleAbbreviation: String? = null,
+    val consoleName: String? = null,
+    val consoleColor: String? = null,
+)
+
+@Serializable
+data class GameSeriesLinkDto(
+    val id: String,
+    val name: String,
+    val totalGames: Int = 0,
+    val libraryGames: Int = 0,
+)
+
+@Serializable
+data class GameFranchiseLinkDto(
+    val id: String,
+    val name: String,
+    val gameCount: Int = 0,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -4,8 +4,12 @@ import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
+import com.spela.player.domain.model.FeaturedSeries
 import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.GameFranchiseLink
+import com.spela.player.domain.model.GameSeriesLink
 import com.spela.player.domain.model.Keyword
+import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.Theme
 import com.spela.player.domain.repository.ExploreRepository
 
@@ -62,5 +66,33 @@ class ExploreRepositoryImpl(
                 logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
             )
         }
+    }
+
+    override suspend fun getFeaturedSeries(): Result<List<FeaturedSeries>> = runCatching {
+        apiClient.getFeaturedSeries().map { dto ->
+            dto.toDomain().copy(
+                heroUrl = apiClient.resolveUrl(dto.heroUrl),
+            )
+        }
+    }
+
+    override suspend fun getSeriesDetail(id: String): Result<SeriesDetail> = runCatching {
+        val dto = apiClient.getSeriesDetail(id)
+        dto.toDomain().copy(
+            heroUrl = apiClient.resolveUrl(dto.heroUrl),
+            games = dto.games.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                )
+            },
+        )
+    }
+
+    override suspend fun getGameSeries(gameId: String): Result<List<GameSeriesLink>> = runCatching {
+        apiClient.getGameSeries(gameId).map { it.toDomain() }
+    }
+
+    override suspend fun getGameFranchises(gameId: String): Result<List<GameFranchiseLink>> = runCatching {
+        apiClient.getGameFranchises(gameId).map { it.toDomain() }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -30,3 +30,55 @@ data class Keyword(
     val name: String,
     val gameCount: Int,
 )
+
+data class FeaturedSeries(
+    val id: String,
+    val name: String,
+    val libraryGames: Int,
+    val totalGames: Int,
+    val consoleCount: Int,
+    val heroUrl: String?,
+)
+
+data class SeriesDetail(
+    val id: String,
+    val name: String,
+    val heroUrl: String?,
+    val consoles: List<SeriesConsole>,
+    val libraryGames: Int,
+    val totalGames: Int,
+    val games: List<SeriesGame>,
+)
+
+data class SeriesConsole(
+    val abbreviation: String,
+    val name: String,
+    val color: String,
+    val gameCount: Int,
+)
+
+data class SeriesGame(
+    val igdbGameId: Int,
+    val name: String,
+    val inLibrary: Boolean,
+    val localGameId: String?,
+    val coverUrl: String?,
+    val releaseDate: String?,
+    val rating: Double,
+    val consoleAbbreviation: String?,
+    val consoleName: String?,
+    val consoleColor: String?,
+)
+
+data class GameSeriesLink(
+    val id: String,
+    val name: String,
+    val totalGames: Int,
+    val libraryGames: Int,
+)
+
+data class GameFranchiseLink(
+    val id: String,
+    val name: String,
+    val gameCount: Int,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -2,8 +2,12 @@ package com.spela.player.domain.repository
 
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
+import com.spela.player.domain.model.FeaturedSeries
 import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.GameFranchiseLink
+import com.spela.player.domain.model.GameSeriesLink
 import com.spela.player.domain.model.Keyword
+import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.Theme
 
 interface ExploreRepository {
@@ -13,4 +17,8 @@ interface ExploreRepository {
     suspend fun getThemeGames(themeId: String, page: Int = 1, pageSize: Int = 20): Result<List<Game>>
     suspend fun getKeywords(limit: Int = 50): Result<List<Keyword>>
     suspend fun getKeywordGames(keywordId: String, page: Int = 1, pageSize: Int = 20): Result<List<Game>>
+    suspend fun getFeaturedSeries(): Result<List<FeaturedSeries>>
+    suspend fun getSeriesDetail(id: String): Result<SeriesDetail>
+    suspend fun getGameSeries(gameId: String): Result<List<GameSeriesLink>>
+    suspend fun getGameFranchises(gameId: String): Result<List<GameFranchiseLink>>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -31,6 +31,7 @@ sealed class SpScreen(val route: String) {
     data object TopLists : SpScreen("top_lists")
     data class ExploreTheme(val themeId: String, val themeName: String) : SpScreen("explore_theme/$themeId")
     data class ExploreKeyword(val keywordId: String, val keywordName: String) : SpScreen("explore_keyword/$keywordId")
+    data class ExploreSeries(val seriesId: String, val seriesName: String) : SpScreen("explore_series/$seriesId")
 }
 
 data class NavigationState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
@@ -9,7 +9,9 @@ import com.spela.player.domain.model.DownloadProgress
 import com.spela.player.domain.model.GameAchievement
 import com.spela.player.domain.model.GameCollection
 import com.spela.player.domain.model.GameDetail
+import com.spela.player.domain.model.GameFranchiseLink
 import com.spela.player.domain.model.GameRating
+import com.spela.player.domain.model.GameSeriesLink
 import com.spela.player.domain.model.GameStats
 import com.spela.player.domain.model.RatingSummary
 import com.spela.player.domain.model.SharedSession
@@ -80,4 +82,8 @@ data class GameDetailState(
     val isLoadingSessions: Boolean = false,
     val isPlayingFromSharedSave: Boolean = false,
     val playFromSharedSaveSessionId: String? = null,
+
+    // Series & Franchise links
+    val gameSeries: List<GameSeriesLink> = emptyList(),
+    val gameFranchises: List<GameFranchiseLink> = emptyList(),
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -94,6 +94,7 @@ import com.spela.player.presentation.ui.screen.GlobalChallengesScreen
 import com.spela.player.presentation.ui.screen.StatsScreen
 import com.spela.player.presentation.ui.screen.ExploreKeywordScreen
 import com.spela.player.presentation.ui.screen.ExploreScreen
+import com.spela.player.presentation.ui.screen.ExploreSeriesScreen
 import com.spela.player.presentation.ui.screen.ExploreThemeScreen
 import com.spela.player.presentation.ui.screen.TopListsScreen
 import com.spela.player.presentation.ui.screen.UserProfileScreen
@@ -464,6 +465,11 @@ fun SpelaApp(
                                                 NavigationIntent.NavigateTo(SpScreen.ExploreKeyword(keywordId, keywordName))
                                             )
                                         },
+                                        onSeriesSelected = { seriesId, seriesName ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreSeries(seriesId, seriesName))
+                                            )
+                                        },
                                     )
                                 }
                             }
@@ -491,6 +497,24 @@ fun SpelaApp(
                                     ExploreKeywordScreen(
                                         keywordId = screen.keywordId,
                                         keywordName = screen.keywordName,
+                                        viewModel = exploreViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.ExploreSeries -> {
+                                if (exploreViewModel != null) {
+                                    ExploreSeriesScreen(
+                                        seriesId = screen.seriesId,
+                                        seriesName = screen.seriesName,
                                         viewModel = exploreViewModel,
                                         onGameSelected = { gameId ->
                                             navigationViewModel.onIntent(
@@ -611,6 +635,11 @@ fun SpelaApp(
                                     onNavigateToUser = { userId ->
                                         navigationViewModel.onIntent(
                                             NavigationIntent.NavigateTo(SpScreen.UserProfile(userId))
+                                        )
+                                    },
+                                    onNavigateToSeries = { seriesId, seriesName ->
+                                        navigationViewModel.onIntent(
+                                            NavigationIntent.NavigateTo(SpScreen.ExploreSeries(seriesId, seriesName))
                                         )
                                     },
                                 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SeriesShelf.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SeriesShelf.kt
@@ -1,0 +1,150 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.FeaturedSeries
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Series gradient colors -- each series gets a distinctive gradient.
+ */
+private val seriesGradients = listOf(
+    listOf(Color(0xFF1B5E20), Color(0xFF2E7D32)),  // Forest green
+    listOf(Color(0xFF0D47A1), Color(0xFF1565C0)),  // Deep blue
+    listOf(Color(0xFF4A148C), Color(0xFF6A1B9A)),  // Deep purple
+    listOf(Color(0xFFBF360C), Color(0xFFD84315)),  // Deep orange
+    listOf(Color(0xFF006064), Color(0xFF00838F)),  // Teal
+    listOf(Color(0xFF880E4F), Color(0xFFAD1457)),  // Pink
+    listOf(Color(0xFF1A237E), Color(0xFF283593)),  // Indigo
+    listOf(Color(0xFFE65100), Color(0xFFEF6C00)),  // Orange
+)
+
+@Composable
+fun SeriesShelf(
+    series: List<FeaturedSeries>,
+    onSeriesSelected: (seriesId: String, seriesName: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("series_shelf"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        itemsIndexed(series, key = { _, item -> item.id }) { index, item ->
+            val gradientIndex = index % seriesGradients.size
+            SeriesCard(
+                series = item,
+                gradientColors = seriesGradients[gradientIndex],
+                onClick = { onSeriesSelected(item.id, item.name) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SeriesCard(
+    series: FeaturedSeries,
+    gradientColors: List<Color>,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
+
+    SpCard(
+        modifier = Modifier
+            .width(200.dp)
+            .height(100.dp)
+            .testTag("series_card_${series.id}")
+            .semantics {
+                contentDescription = "${series.name}, ${series.libraryGames} of ${series.totalGames} games across ${series.consoleCount} consoles"
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(100.dp)
+                .clip(shape)
+                .background(Brush.linearGradient(gradientColors)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(SpSpacing.Medium),
+            ) {
+                Text(
+                    text = series.name,
+                    style = SpTypography.TitleLarge,
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = "${series.libraryGames}/${series.totalGames} games",
+                    style = SpTypography.LabelSmall,
+                    color = Color.White.copy(alpha = 0.85f),
+                    textAlign = TextAlign.Center,
+                )
+                if (series.consoleCount > 0) {
+                    Text(
+                        text = "across ${series.consoleCount} consoles",
+                        style = SpTypography.LabelSmall,
+                        color = Color.White.copy(alpha = 0.65f),
+                        textAlign = TextAlign.Center,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun SeriesShelfSkeleton(
+    modifier: Modifier = Modifier,
+    count: Int = 4,
+) {
+    LazyRow(
+        modifier = modifier.testTag("series_shelf_skeleton"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(count) {
+            com.spela.player.presentation.ui.components.SpShimmer(
+                modifier = Modifier
+                    .width(200.dp)
+                    .clip(RoundedCornerShape(SpSpacing.CardCornerRadius)),
+                width = 200.dp,
+                height = 100.dp,
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SeriesFranchiseSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SeriesFranchiseSection.kt
@@ -1,0 +1,65 @@
+package com.spela.player.presentation.ui.feature.gamedetail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.spela.player.domain.model.GameFranchiseLink
+import com.spela.player.domain.model.GameSeriesLink
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+
+/**
+ * Shows "Part of [Series]" and "Part of [Franchise]" links on the game detail screen.
+ * Only renders when series or franchise data is available.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun SeriesFranchiseSection(
+    series: List<GameSeriesLink>,
+    franchises: List<GameFranchiseLink>,
+    onSeriesSelected: ((seriesId: String, seriesName: String) -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    if (series.isEmpty() && franchises.isEmpty()) return
+
+    SpTitledSection(
+        title = "Series & Franchises",
+        icon = Icons.AutoMirrored.Filled.List,
+        modifier = modifier.testTag("series_franchise_section"),
+    ) {
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            series.forEach { seriesLink ->
+                SpChip(
+                    text = "Part of ${seriesLink.name} (${seriesLink.libraryGames}/${seriesLink.totalGames})",
+                    onClick = if (onSeriesSelected != null) {
+                        { onSeriesSelected(seriesLink.id, seriesLink.name) }
+                    } else null,
+                    color = SpColor.Primary,
+                    onGradient = true,
+                    modifier = Modifier.testTag("series_link_${seriesLink.id}"),
+                )
+            }
+            franchises.forEach { franchiseLink ->
+                SpChip(
+                    text = "Part of ${franchiseLink.name} (${franchiseLink.gameCount} games)",
+                    color = SpColor.Accent,
+                    onGradient = true,
+                    modifier = Modifier.testTag("franchise_link_${franchiseLink.id}"),
+                )
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Medium))
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -28,6 +28,8 @@ import com.spela.player.presentation.ui.feature.explore.HeroCarousel
 import com.spela.player.presentation.ui.feature.explore.HeroCarouselSkeleton
 import com.spela.player.presentation.ui.feature.explore.KeywordChips
 import com.spela.player.presentation.ui.feature.explore.KeywordChipsSkeleton
+import com.spela.player.presentation.ui.feature.explore.SeriesShelf
+import com.spela.player.presentation.ui.feature.explore.SeriesShelfSkeleton
 import com.spela.player.presentation.ui.feature.explore.ThemeGrid
 import com.spela.player.presentation.ui.feature.explore.ThemeGridSkeleton
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
@@ -40,6 +42,7 @@ fun ExploreScreen(
     onGameSelected: (String) -> Unit,
     onThemeSelected: ((themeId: String, themeName: String) -> Unit)? = null,
     onKeywordSelected: ((keywordId: String, keywordName: String) -> Unit)? = null,
+    onSeriesSelected: ((seriesId: String, seriesName: String) -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
 
@@ -149,6 +152,34 @@ fun ExploreScreen(
                                     keywords = state.keywords,
                                     onKeywordSelected = { keywordId, keywordName ->
                                         onKeywordSelected?.invoke(keywordId, keywordName)
+                                    },
+                                )
+                            }
+                        }
+                    }
+
+                    // Series shelf section
+                    item {
+                        if (state.isLoadingFeaturedSeries && state.featuredSeries.isEmpty()) {
+                            SpTitledSection(
+                                title = "Browse by Series",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                SeriesShelfSkeleton()
+                            }
+                        } else if (state.featuredSeries.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "Browse by Series",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_series_section"),
+                            ) {
+                                SeriesShelf(
+                                    series = state.featuredSeries,
+                                    onSeriesSelected = { seriesId, seriesName ->
+                                        onSeriesSelected?.invoke(seriesId, seriesName)
                                     },
                                 )
                             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreSeriesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreSeriesScreen.kt
@@ -1,0 +1,403 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.VideoLibrary
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.SeriesConsole
+import com.spela.player.domain.model.SeriesGame
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpProgressBar
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+import com.spela.player.util.formatRating
+
+@Composable
+fun ExploreSeriesScreen(
+    seriesId: String,
+    seriesName: String,
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val state by viewModel.seriesDetailState.collectAsState()
+
+    LaunchedEffect(seriesId) {
+        viewModel.loadSeriesDetail(seriesId, seriesName)
+    }
+
+    Box(modifier = Modifier.fillMaxSize().testTag("explore_series_screen")) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = seriesName,
+                showBack = true,
+                onBack = onBack,
+            )
+
+            when {
+                state.isLoading && state.detail == null -> {
+                    // Loading skeleton
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(SpSpacing.ScreenHorizontal)
+                            .testTag("series_detail_loading"),
+                    ) {
+                        Spacer(Modifier.height(SpSpacing.Large))
+                        repeat(4) {
+                            SpGameCardSkeleton(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(bottom = SpSpacing.Medium),
+                            )
+                        }
+                    }
+                }
+
+                state.detail != null -> {
+                    val detail = state.detail!!
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = SpSpacing.XXLarge),
+                    ) {
+                        // Hero banner with gradient
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(160.dp)
+                                    .background(
+                                        Brush.verticalGradient(
+                                            listOf(
+                                                SpColor.Primary.copy(alpha = 0.3f),
+                                                SpColor.Background,
+                                            ),
+                                        ),
+                                    )
+                                    .testTag("series_hero_banner"),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = detail.name,
+                                    style = SpTypography.DisplaySmall,
+                                    color = SpColor.OnBackground,
+                                )
+                            }
+                        }
+
+                        // Ownership progress
+                        item {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("series_ownership_progress"),
+                            ) {
+                                val progress = if (detail.totalGames > 0) {
+                                    detail.libraryGames.toFloat() / detail.totalGames.toFloat()
+                                } else 0f
+
+                                Text(
+                                    text = "You own ${detail.libraryGames} of ${detail.totalGames} games",
+                                    style = SpTypography.BodyMedium,
+                                    color = SpColor.OnBackgroundSecondary,
+                                    modifier = Modifier.testTag("series_ownership_text"),
+                                )
+                                Spacer(Modifier.height(SpSpacing.Small))
+                                SpProgressBar(
+                                    progress = progress,
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                                Spacer(Modifier.height(SpSpacing.Large))
+                            }
+                        }
+
+                        // Console filter badges
+                        if (detail.consoles.isNotEmpty()) {
+                            item {
+                                ConsoleFilterRow(
+                                    consoles = detail.consoles,
+                                    totalGames = detail.totalGames,
+                                    selectedAbbreviation = state.consoleFilter,
+                                    onConsoleSelected = { abbreviation ->
+                                        viewModel.setSeriesConsoleFilter(
+                                            if (abbreviation != null && state.consoleFilter == abbreviation) null else abbreviation,
+                                        )
+                                    },
+                                    modifier = Modifier
+                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                        .testTag("series_console_filters"),
+                                )
+                                Spacer(Modifier.height(SpSpacing.Large))
+                            }
+                        }
+
+                        // Timeline of games
+                        val filteredGames = state.filteredGames
+                        if (filteredGames.isEmpty() && !state.isLoading) {
+                            item {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(SpSpacing.XXLarge),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    SpEmptyState(
+                                        icon = Icons.Filled.VideoLibrary,
+                                        title = "No games found",
+                                        message = "No games match the selected filter.",
+                                        modifier = Modifier.testTag("series_empty_state"),
+                                    )
+                                }
+                            }
+                        } else {
+                            items(
+                                items = filteredGames,
+                                key = { it.igdbGameId },
+                            ) { game ->
+                                SeriesTimelineItem(
+                                    game = game,
+                                    onClick = if (game.inLibrary && game.localGameId != null) {
+                                        { onGameSelected(game.localGameId) }
+                                    } else null,
+                                )
+                            }
+                        }
+                    }
+                }
+
+                else -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.VideoLibrary,
+                            title = "Series not found",
+                            message = "Could not load series details.",
+                            modifier = Modifier.testTag("series_error_state"),
+                        )
+                    }
+                }
+            }
+        }
+
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.dismissSeriesDetailError() },
+                )
+            },
+            onDismiss = { viewModel.dismissSeriesDetailError() },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun ConsoleFilterRow(
+    consoles: List<SeriesConsole>,
+    totalGames: Int,
+    selectedAbbreviation: String?,
+    onConsoleSelected: (String?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        // "All" chip
+        SpChip(
+            text = "All ($totalGames)",
+            onClick = { onConsoleSelected(null) },
+            isSelected = selectedAbbreviation == null,
+            modifier = Modifier
+                .testTag("series_console_chip_all")
+                .semantics {
+                    contentDescription = "All, $totalGames games"
+                    role = Role.Button
+                },
+        )
+
+        consoles.forEach { console ->
+            val isSelected = console.abbreviation == selectedAbbreviation
+
+            SpChip(
+                text = "${console.name} (${console.gameCount})",
+                onClick = { onConsoleSelected(console.abbreviation) },
+                isSelected = isSelected,
+                modifier = Modifier
+                    .testTag("series_console_chip_${console.abbreviation}")
+                    .semantics {
+                        contentDescription = "${console.name}, ${console.gameCount} games"
+                        role = Role.Button
+                    },
+            )
+        }
+    }
+}
+
+@Composable
+private fun SeriesTimelineItem(
+    game: SeriesGame,
+    onClick: (() -> Unit)?,
+) {
+    val itemAlpha = if (game.inLibrary) 1f else 0.5f
+
+    SpCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.XSmall,
+            )
+            .alpha(itemAlpha)
+            .testTag("series_game_${game.igdbGameId}")
+            .semantics {
+                contentDescription = buildString {
+                    append(game.name)
+                    game.consoleName?.let { append(", $it") }
+                    game.releaseDate?.let { append(", $it") }
+                    if (!game.inLibrary) append(", not in library")
+                }
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SpSpacing.Medium),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+        ) {
+            // Cover art
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.name} cover art",
+                modifier = Modifier
+                    .width(48.dp)
+                    .height(64.dp)
+                    .clip(RoundedCornerShape(SpSpacing.RadiusSmall)),
+                aspectRatio = 0.75f,
+            )
+
+            // Game info
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = game.name,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    game.consoleName?.let { consoleName ->
+                        Text(
+                            text = consoleName,
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+
+                    game.releaseDate?.take(4)?.let { year ->
+                        Text(
+                            text = year,
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+
+                    if (game.rating > 0) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(10.dp),
+                        )
+                        Text(
+                            text = formatRating(game.rating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+
+                if (!game.inLibrary) {
+                    Spacer(Modifier.height(SpSpacing.XXSmall))
+                    Text(
+                        text = "Not in library",
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -66,6 +66,7 @@ import com.spela.player.presentation.ui.feature.gamedetail.GameControlsSection
 import com.spela.player.presentation.ui.feature.gamedetail.GameCommunityStatsSection
 import com.spela.player.presentation.ui.feature.gamedetail.DeveloperGamesSection
 import com.spela.player.presentation.ui.feature.gamedetail.GameSharedSessionsSection
+import com.spela.player.presentation.ui.feature.gamedetail.SeriesFranchiseSection
 import com.spela.player.presentation.ui.feature.gamedetail.GameReviewsSection
 import com.spela.player.presentation.ui.feature.gamedetail.SessionsSection
 import com.spela.player.presentation.ui.feature.gamedetail.ScreenshotsSection
@@ -112,6 +113,7 @@ fun GameDetailScreen(
     onNavigateToSharedSession: ((sharedSessionId: String) -> Unit)? = null,
     onNavigateToGame: ((gameId: String) -> Unit)? = null,
     onNavigateToUser: ((userId: String) -> Unit)? = null,
+    onNavigateToSeries: ((seriesId: String, seriesName: String) -> Unit)? = null,
     syncState: GameSyncState? = null,
     onPlayWithLocalSave: () -> Unit = {},
     onCancelLaunch: () -> Unit = {},
@@ -217,6 +219,15 @@ fun GameDetailScreen(
                         onPlayWithLocalSave = onPlayWithLocalSave,
                         onCancelLaunch = onCancelLaunch,
                     )
+
+                    // Series & Franchise links
+                    if (state.gameSeries.isNotEmpty() || state.gameFranchises.isNotEmpty()) {
+                        SeriesFranchiseSection(
+                            series = state.gameSeries,
+                            franchises = state.gameFranchises,
+                            onSeriesSelected = onNavigateToSeries,
+                        )
+                    }
                 }
 
             },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -2,8 +2,10 @@ package com.spela.player.presentation.viewmodel
 
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
+import com.spela.player.domain.model.FeaturedSeries
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.Keyword
+import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.Theme
 import com.spela.player.domain.repository.ExploreRepository
 import com.spela.player.util.DispatcherProvider
@@ -20,14 +22,16 @@ data class ExploreState(
     val rows: List<ExploreRow> = emptyList(),
     val themes: List<Theme> = emptyList(),
     val keywords: List<Keyword> = emptyList(),
+    val featuredSeries: List<FeaturedSeries> = emptyList(),
     val isLoadingFeatured: Boolean = false,
     val isLoadingRows: Boolean = false,
     val isLoadingThemes: Boolean = false,
     val isLoadingKeywords: Boolean = false,
+    val isLoadingFeaturedSeries: Boolean = false,
     val error: String? = null,
 ) {
-    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords
-    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && !isLoading
+    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries
+    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && !isLoading
 }
 
 data class ThemeDetailState(
@@ -46,6 +50,26 @@ data class KeywordDetailState(
     val error: String? = null,
 )
 
+data class SeriesDetailState(
+    val seriesId: String = "",
+    val seriesName: String = "",
+    val detail: SeriesDetail? = null,
+    val consoleFilter: String? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+) {
+    val filteredGames: List<com.spela.player.domain.model.SeriesGame>
+        get() {
+            val games = detail?.games ?: return emptyList()
+            val filtered = if (consoleFilter != null) {
+                games.filter { it.consoleAbbreviation == consoleFilter }
+            } else {
+                games
+            }
+            return filtered.sortedWith(compareBy(nullsLast()) { it.releaseDate })
+        }
+}
+
 class ExploreViewModel(
     private val exploreRepository: ExploreRepository,
     private val dispatchers: DispatcherProvider,
@@ -60,18 +84,24 @@ class ExploreViewModel(
     private val _keywordDetailState = MutableStateFlow(KeywordDetailState())
     val keywordDetailState: StateFlow<KeywordDetailState> = _keywordDetailState.asStateFlow()
 
+    private val _seriesDetailState = MutableStateFlow(SeriesDetailState())
+    val seriesDetailState: StateFlow<SeriesDetailState> = _seriesDetailState.asStateFlow()
+
     private var featuredJob: Job? = null
     private var rowsJob: Job? = null
     private var themesJob: Job? = null
     private var keywordsJob: Job? = null
     private var themeDetailJob: Job? = null
     private var keywordDetailJob: Job? = null
+    private var featuredSeriesJob: Job? = null
+    private var seriesDetailJob: Job? = null
 
     fun load() {
         loadFeatured()
         loadRows()
         loadThemes()
         loadKeywords()
+        loadFeaturedSeries()
     }
 
     fun dismissError() {
@@ -118,6 +148,31 @@ class ExploreViewModel(
 
     fun dismissKeywordDetailError() {
         _keywordDetailState.update { it.copy(error = null) }
+    }
+
+    fun loadSeriesDetail(seriesId: String, seriesName: String) {
+        seriesDetailJob?.cancel()
+        _seriesDetailState.update {
+            SeriesDetailState(seriesId = seriesId, seriesName = seriesName, isLoading = true)
+        }
+        seriesDetailJob = scope.launch(dispatchers.io) {
+            exploreRepository.getSeriesDetail(seriesId).fold(
+                onSuccess = { detail ->
+                    _seriesDetailState.update { it.copy(detail = detail, isLoading = false) }
+                },
+                onFailure = { error ->
+                    _seriesDetailState.update { it.copy(isLoading = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun setSeriesConsoleFilter(abbreviation: String?) {
+        _seriesDetailState.update { it.copy(consoleFilter = abbreviation) }
+    }
+
+    fun dismissSeriesDetailError() {
+        _seriesDetailState.update { it.copy(error = null) }
     }
 
     private fun loadFeatured() {
@@ -175,6 +230,21 @@ class ExploreViewModel(
                 },
                 onFailure = { error ->
                     _state.update { it.copy(isLoadingKeywords = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun loadFeaturedSeries() {
+        if (featuredSeriesJob?.isActive == true) return
+        _state.update { it.copy(isLoadingFeaturedSeries = true) }
+        featuredSeriesJob = scope.launch(dispatchers.io) {
+            exploreRepository.getFeaturedSeries().fold(
+                onSuccess = { series ->
+                    _state.update { it.copy(featuredSeries = series, isLoadingFeaturedSeries = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoadingFeaturedSeries = false, error = error.message) }
                 },
             )
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -12,6 +12,7 @@ import com.spela.player.domain.usecase.TogglePlayLaterUseCase
 import com.spela.player.domain.repository.ChallengeRepository
 import com.spela.player.domain.repository.DownloadRepository
 import com.spela.player.domain.repository.CheatRepository
+import com.spela.player.domain.repository.ExploreRepository
 import com.spela.player.domain.repository.GameRepository
 import com.spela.player.domain.repository.RatingRepository
 import com.spela.player.domain.repository.SharedSessionRepository
@@ -51,6 +52,7 @@ class GameDetailViewModel(
     private val biosRepository: BiosRepository? = null,
     private val cheatRepository: CheatRepository? = null,
     private val sessionRepository: SessionRepository? = null,
+    private val exploreRepository: ExploreRepository? = null,
 ) {
     private val _state = MutableStateFlow(GameDetailState())
     val state: StateFlow<GameDetailState> = _state.asStateFlow()
@@ -167,6 +169,8 @@ class GameDetailViewModel(
         loadReviews(gameId)
         loadSimilarGames(gameId)
         loadDeveloperGames(gameId)
+        loadGameSeriesLinks(gameId)
+        loadGameFranchiseLinks(gameId)
     }
 
     private fun loadBiosStatus() {
@@ -676,6 +680,30 @@ class GameDetailViewModel(
                 onFailure = {
                     _state.update { it.copy(isLoadingDeveloperGames = false) }
                 },
+            )
+        }
+    }
+
+    private fun loadGameSeriesLinks(gameId: String) {
+        val repo = exploreRepository ?: return
+        scope.launch(dispatchers.io) {
+            repo.getGameSeries(gameId).fold(
+                onSuccess = { series ->
+                    _state.update { it.copy(gameSeries = series) }
+                },
+                onFailure = { /* silently ignore — series links are optional */ },
+            )
+        }
+    }
+
+    private fun loadGameFranchiseLinks(gameId: String) {
+        val repo = exploreRepository ?: return
+        scope.launch(dispatchers.io) {
+            repo.getGameFranchises(gameId).fold(
+                onSuccess = { franchises ->
+                    _state.update { it.copy(gameFranchises = franchises) }
+                },
+                onFailure = { /* silently ignore — franchise links are optional */ },
             )
         }
     }

--- a/server/internal/api/enrichment_handler.go
+++ b/server/internal/api/enrichment_handler.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/db"
@@ -247,8 +248,9 @@ func (h *EnrichmentHandler) ListSeries(c *gin.Context) {
 		Table("game_series").
 		Select(`game_series.id, game_series.igdb_collection_id, game_series.name,
 			COUNT(game_series_entries.id) as total_games,
-			COUNT(game_series_entries.game_id) as library_games`).
+			COUNT(CASE WHEN games.id IS NOT NULL AND games.deleted_at IS NULL THEN 1 END) as library_games`).
 		Joins("JOIN game_series_entries ON game_series_entries.series_id = game_series.id").
+		Joins("LEFT JOIN games ON games.id = game_series_entries.game_id").
 		Group("game_series.id").
 		Having("library_games > 0").
 		Order("library_games DESC").
@@ -273,19 +275,36 @@ func (h *EnrichmentHandler) ListSeries(c *gin.Context) {
 
 // SeriesDetailResponse is the API response for a series detail view.
 type SeriesDetailResponse struct {
-	ID               string              `json:"id"`
-	IGDBCollectionID int                 `json:"igdbCollectionId"`
-	Name             string              `json:"name"`
-	Games            []SeriesGameResponse `json:"games"`
+	ID               string                `json:"id"`
+	IGDBCollectionID int                   `json:"igdbCollectionId"`
+	Name             string                `json:"name"`
+	HeroURL          string                `json:"heroUrl,omitempty"`
+	LibraryGames     int                   `json:"libraryGames"`
+	TotalGames       int                   `json:"totalGames"`
+	Consoles         []SeriesConsoleInfo   `json:"consoles"`
+	Games            []SeriesGameResponse  `json:"games"`
+}
+
+// SeriesConsoleInfo represents a console with game count in a series.
+type SeriesConsoleInfo struct {
+	Abbreviation string `json:"abbreviation"`
+	Name         string `json:"name"`
+	Color        string `json:"color"`
+	GameCount    int    `json:"gameCount"`
 }
 
 // SeriesGameResponse is the API response for a game within a series.
 type SeriesGameResponse struct {
-	IGDBGameID  int     `json:"igdbGameId"`
-	Name        string  `json:"name"`
-	InLibrary   bool    `json:"inLibrary"`
-	LocalGameID *string `json:"localGameId"`
-	CoverURL    *string `json:"coverUrl"`
+	IGDBGameID        int     `json:"igdbGameId"`
+	Name              string  `json:"name"`
+	InLibrary         bool    `json:"inLibrary"`
+	LocalGameID       *string `json:"localGameId"`
+	CoverURL          *string `json:"coverUrl"`
+	ReleaseDate       string  `json:"releaseDate,omitempty"`
+	Rating            float64 `json:"rating"`
+	ConsoleAbbreviation string `json:"consoleAbbreviation,omitempty"`
+	ConsoleName       string  `json:"consoleName,omitempty"`
+	ConsoleColor      string  `json:"consoleColor,omitempty"`
 }
 
 // GetSeriesDetail returns a series with all its games (local and non-local).
@@ -298,6 +317,43 @@ func (h *EnrichmentHandler) GetSeriesDetail(c *gin.Context) {
 		return
 	}
 
+	// Collect local game IDs for batch loading
+	var localGameIDs []uint
+	for _, entry := range series.Entries {
+		if entry.GameID != nil {
+			localGameIDs = append(localGameIDs, *entry.GameID)
+		}
+	}
+
+	// Batch-load local games with console data
+	gameMap := make(map[uint]db.Game)
+	if len(localGameIDs) > 0 {
+		var localGames []db.Game
+		h.DB.Preload("Console").Where("id IN ?", localGameIDs).Find(&localGames)
+		for _, g := range localGames {
+			gameMap[g.ID] = g
+		}
+	}
+
+	// Batch-load hero artwork for local games
+	artworkMap := make(map[uint]db.GameArtwork)
+	if len(localGameIDs) > 0 {
+		var artworks []db.GameArtwork
+		h.DB.Where("game_id IN ? AND hero_url != ''", localGameIDs).Find(&artworks)
+		for _, a := range artworks {
+			artworkMap[a.GameID] = a
+		}
+	}
+
+	// Build per-game responses and track consoles
+	consoleCountMap := make(map[uint]int)       // consoleID -> count
+	consoleInfoMap := make(map[uint]db.Console)  // consoleID -> Console
+	libraryGames := 0
+
+	// Track the best game for hero art (highest rated with hero art)
+	var bestHeroURL string
+	var bestHeroRating float64 = -1
+
 	games := make([]SeriesGameResponse, len(series.Entries))
 	for i, entry := range series.Entries {
 		gameResp := SeriesGameResponse{
@@ -309,20 +365,63 @@ func (h *EnrichmentHandler) GetSeriesDetail(c *gin.Context) {
 			localID := strconv.FormatUint(uint64(*entry.GameID), 10)
 			gameResp.LocalGameID = &localID
 
-			// Load local game cover
-			var game db.Game
-			if err := h.DB.Select("cover_url").First(&game, *entry.GameID).Error; err == nil && game.CoverURL != "" {
-				coverURL := resolveImageURL(game.CoverURL)
-				gameResp.CoverURL = &coverURL
+			if g, ok := gameMap[*entry.GameID]; ok {
+				// Check soft-delete
+				if g.DeletedAt.Valid {
+					gameResp.InLibrary = false
+					gameResp.LocalGameID = nil
+				} else {
+					libraryGames++
+
+					if g.CoverURL != "" {
+						coverURL := resolveImageURL(g.CoverURL)
+						gameResp.CoverURL = &coverURL
+					}
+					gameResp.ReleaseDate = g.ReleaseDate
+					gameResp.Rating = g.Rating
+
+					if g.Console.ID != 0 {
+						abbr := strings.ToLower(g.Console.Abbreviation)
+						gameResp.ConsoleAbbreviation = abbr
+						gameResp.ConsoleName = g.Console.Name
+						gameResp.ConsoleColor = g.Console.ColorTheme
+						consoleCountMap[g.Console.ID]++
+						consoleInfoMap[g.Console.ID] = g.Console
+					}
+
+					// Track best hero art
+					if artwork, ok := artworkMap[*entry.GameID]; ok {
+						if g.Rating > bestHeroRating {
+							bestHeroRating = g.Rating
+							bestHeroURL = artwork.HeroURL
+						}
+					}
+				}
 			}
 		}
 		games[i] = gameResp
+	}
+
+	// Build console info list
+	consoles := make([]SeriesConsoleInfo, 0, len(consoleCountMap))
+	for consoleID, count := range consoleCountMap {
+		con := consoleInfoMap[consoleID]
+		consoles = append(consoles, SeriesConsoleInfo{
+			Abbreviation: strings.ToLower(con.Abbreviation),
+			Name:         con.Name,
+			Color:        con.ColorTheme,
+			GameCount:    count,
+		})
 	}
 
 	c.JSON(http.StatusOK, SeriesDetailResponse{
 		ID:               strconv.FormatUint(uint64(series.ID), 10),
 		IGDBCollectionID: series.IGDBCollectionID,
 		Name:             series.Name,
+		HeroURL:          bestHeroURL,
+		LibraryGames:     libraryGames,
+		TotalGames:       len(series.Entries),
+		Consoles:         consoles,
 		Games:            games,
 	})
 }
@@ -423,6 +522,166 @@ func (h *EnrichmentHandler) ListFranchiseGames(c *gin.Context) {
 		Page:     page,
 		PageSize: pageSize,
 	})
+}
+
+// --- Per-game series/franchise endpoints ---
+
+// GameSeriesResponse is the API response for a series that a game belongs to.
+type GameSeriesResponse struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	TotalGames   int    `json:"totalGames"`
+	LibraryGames int    `json:"libraryGames"`
+}
+
+// GetGameSeries returns the series that a game belongs to.
+// GET /api/games/:id/series
+func (h *EnrichmentHandler) GetGameSeries(c *gin.Context) {
+	gameID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid game ID"})
+		return
+	}
+
+	// Check game exists
+	var game db.Game
+	if err := h.DB.First(&game, gameID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "game not found"})
+		return
+	}
+
+	// Find series entries for this game, then load the full series with counts
+	var entries []db.GameSeriesEntry
+	if err := h.DB.Where("game_id = ?", gameID).Find(&entries).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch series"})
+		return
+	}
+
+	if len(entries) == 0 {
+		c.JSON(http.StatusOK, []GameSeriesResponse{})
+		return
+	}
+
+	// Collect unique series IDs
+	seriesIDs := make([]uint, 0, len(entries))
+	seen := make(map[uint]bool)
+	for _, e := range entries {
+		if !seen[e.SeriesID] {
+			seriesIDs = append(seriesIDs, e.SeriesID)
+			seen[e.SeriesID] = true
+		}
+	}
+
+	// Query series with counts
+	type seriesRow struct {
+		ID           uint
+		Name         string
+		TotalGames   int
+		LibraryGames int
+	}
+
+	var rows []seriesRow
+	if err := h.DB.
+		Table("game_series").
+		Select(`game_series.id, game_series.name,
+			COUNT(game_series_entries.id) as total_games,
+			COUNT(CASE WHEN games.id IS NOT NULL AND games.deleted_at IS NULL THEN 1 END) as library_games`).
+		Joins("JOIN game_series_entries ON game_series_entries.series_id = game_series.id").
+		Joins("LEFT JOIN games ON games.id = game_series_entries.game_id").
+		Where("game_series.id IN ?", seriesIDs).
+		Group("game_series.id").
+		Scan(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch series details"})
+		return
+	}
+
+	result := make([]GameSeriesResponse, len(rows))
+	for i, r := range rows {
+		result[i] = GameSeriesResponse{
+			ID:           strconv.FormatUint(uint64(r.ID), 10),
+			Name:         r.Name,
+			TotalGames:   r.TotalGames,
+			LibraryGames: r.LibraryGames,
+		}
+	}
+
+	c.JSON(http.StatusOK, result)
+}
+
+// GameFranchiseResponse is the API response for a franchise that a game belongs to.
+type GameFranchiseResponse struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	GameCount int    `json:"gameCount"`
+}
+
+// GetGameFranchises returns the franchises that a game belongs to.
+// GET /api/games/:id/franchises
+func (h *EnrichmentHandler) GetGameFranchises(c *gin.Context) {
+	gameID, err := strconv.Atoi(c.Param("id"))
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid game ID"})
+		return
+	}
+
+	// Check game exists
+	var game db.Game
+	if err := h.DB.First(&game, gameID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "game not found"})
+		return
+	}
+
+	// Find franchise associations for this game
+	var franchises []db.GameFranchise
+	if err := h.DB.Where("game_id = ?", gameID).Find(&franchises).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch franchises"})
+		return
+	}
+
+	if len(franchises) == 0 {
+		c.JSON(http.StatusOK, []GameFranchiseResponse{})
+		return
+	}
+
+	// Collect unique franchise IDs
+	franchiseIDs := make([]int, 0, len(franchises))
+	seen := make(map[int]bool)
+	franchiseNames := make(map[int]string)
+	for _, f := range franchises {
+		if !seen[f.IGDBFranchiseID] {
+			franchiseIDs = append(franchiseIDs, f.IGDBFranchiseID)
+			seen[f.IGDBFranchiseID] = true
+		}
+		franchiseNames[f.IGDBFranchiseID] = f.FranchiseName
+	}
+
+	// Query game counts per franchise
+	type franchiseRow struct {
+		IGDBFranchiseID int
+		GameCount       int
+	}
+
+	var rows []franchiseRow
+	if err := h.DB.Model(&db.GameFranchise{}).
+		Joins("JOIN games ON games.id = game_franchises.game_id AND games.deleted_at IS NULL").
+		Select("igdb_franchise_id, COUNT(DISTINCT game_franchises.game_id) as game_count").
+		Where("igdb_franchise_id IN ?", franchiseIDs).
+		Group("igdb_franchise_id").
+		Scan(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch franchise counts"})
+		return
+	}
+
+	result := make([]GameFranchiseResponse, len(rows))
+	for i, r := range rows {
+		result[i] = GameFranchiseResponse{
+			ID:        strconv.Itoa(r.IGDBFranchiseID),
+			Name:      franchiseNames[r.IGDBFranchiseID],
+			GameCount: r.GameCount,
+		}
+	}
+
+	c.JSON(http.StatusOK, result)
 }
 
 // --- Admin backfill endpoint ---

--- a/server/internal/api/enrichment_handler_test.go
+++ b/server/internal/api/enrichment_handler_test.go
@@ -355,6 +355,118 @@ func TestListSeries_WithData(t *testing.T) {
 	assert.Equal(t, 2, result[0].LibraryGames)
 }
 
+func TestListSeries_ExcludesSoftDeletedGames(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Mario1", 90)
+	game2 := createEnrichTestGame(t, env.database, "Mario2", 85)
+
+	series := db.GameSeries{
+		IGDBCollectionID: 789,
+		Name:             "Super Mario",
+	}
+	require.NoError(t, env.database.Create(&series).Error)
+
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game1.ID, IGDBGameID: 100, Name: "Super Mario Bros.",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game2.ID, IGDBGameID: 200, Name: "Super Mario Bros. 2",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: nil, IGDBGameID: 300, Name: "Super Mario Bros. 3",
+	})
+
+	// Soft-delete game2
+	env.database.Delete(&game2)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/series", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []SeriesListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.Len(t, result, 1)
+
+	assert.Equal(t, "Super Mario", result[0].Name)
+	assert.Equal(t, 3, result[0].TotalGames)
+	assert.Equal(t, 1, result[0].LibraryGames) // Only game1, game2 is soft-deleted
+}
+
+func TestListThemes_ExcludesSoftDeletedGames(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda", 90)
+	game2 := createEnrichTestGame(t, env.database, "Mario", 85)
+
+	env.database.Create(&db.GameTheme{GameID: game1.ID, IGDBThemeID: 1, Name: "Fantasy"})
+	env.database.Create(&db.GameTheme{GameID: game2.ID, IGDBThemeID: 1, Name: "Fantasy"})
+
+	// Soft-delete game2
+	env.database.Delete(&game2)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/themes", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var themes []ThemeResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &themes))
+	require.Len(t, themes, 1)
+	assert.Equal(t, 1, themes[0].GameCount) // Only game1
+}
+
+func TestListKeywords_ExcludesSoftDeletedGames(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda", 90)
+	game2 := createEnrichTestGame(t, env.database, "Mario", 85)
+
+	env.database.Create(&db.GameKeyword{GameID: game1.ID, IGDBKeywordID: 100, Name: "open world"})
+	env.database.Create(&db.GameKeyword{GameID: game2.ID, IGDBKeywordID: 100, Name: "open world"})
+
+	// Soft-delete game2
+	env.database.Delete(&game2)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/keywords", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var keywords []KeywordResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &keywords))
+	require.Len(t, keywords, 1)
+	assert.Equal(t, 1, keywords[0].GameCount) // Only game1
+}
+
+func TestListFranchises_ExcludesSoftDeletedGames(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda1", 90)
+	game2 := createEnrichTestGame(t, env.database, "Zelda2", 85)
+
+	env.database.Create(&db.GameFranchise{GameID: game1.ID, IGDBFranchiseID: 100, FranchiseName: "The Legend of Zelda"})
+	env.database.Create(&db.GameFranchise{GameID: game2.ID, IGDBFranchiseID: 100, FranchiseName: "The Legend of Zelda"})
+
+	// Soft-delete game2
+	env.database.Delete(&game2)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/franchises", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var franchises []FranchiseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &franchises))
+	require.Len(t, franchises, 1)
+	assert.Equal(t, 1, franchises[0].GameCount) // Only game1
+}
+
 func TestGetSeriesDetail_Success(t *testing.T) {
 	env := setupEnrichTestEnv(t)
 
@@ -494,6 +606,392 @@ func TestTriggerEnrichMetadata_NoIGDBConfig(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+env.token)
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+// --- Extended Series Detail tests ---
+
+func TestGetSeriesDetail_ExtendedFields(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	// Create a game on NES console
+	game1 := createEnrichTestGame(t, env.database, "Zelda1", 90)
+	// Update with more fields
+	env.database.Model(&game1).Updates(map[string]interface{}{
+		"release_date": "1986-02-21",
+	})
+
+	// Create second game on SNES console
+	var snesConsole db.Console
+	require.NoError(t, env.database.Where("abbreviation = ?", "SNES").First(&snesConsole).Error)
+	game2 := db.Game{
+		ConsoleID:   snesConsole.ID,
+		Title:       "Zelda2",
+		FileName:    "Zelda2.sfc",
+		FilePath:    "SNES/Zelda2.sfc",
+		Rating:      95,
+		ReleaseDate: "1991-11-21",
+		ScraperID:   "igdb:2000",
+	}
+	require.NoError(t, env.database.Create(&game2).Error)
+
+	// Create hero artwork for game2 (highest rated)
+	env.database.Create(&db.GameArtwork{
+		GameID:  game2.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/zelda2.png",
+	})
+
+	series := db.GameSeries{
+		IGDBCollectionID: 100,
+		Name:             "The Legend of Zelda",
+	}
+	require.NoError(t, env.database.Create(&series).Error)
+
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game1.ID, IGDBGameID: 100, Name: "Zelda 1",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game2.ID, IGDBGameID: 200, Name: "Zelda 2",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: nil, IGDBGameID: 300, Name: "Zelda 3",
+	})
+
+	url := fmt.Sprintf("/api/series/%d", series.ID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var detail SeriesDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &detail))
+
+	// Top-level extended fields
+	assert.Equal(t, "The Legend of Zelda", detail.Name)
+	assert.Equal(t, 2, detail.LibraryGames)
+	assert.Equal(t, 3, detail.TotalGames)
+	assert.Equal(t, "https://cdn.steamgriddb.com/hero/zelda2.png", detail.HeroURL)
+
+	// Consoles list
+	require.Len(t, detail.Consoles, 2)
+	consoleMap := make(map[string]SeriesConsoleInfo)
+	for _, c := range detail.Consoles {
+		consoleMap[c.Abbreviation] = c
+	}
+	assert.Equal(t, 1, consoleMap["nes"].GameCount)
+	assert.Equal(t, 1, consoleMap["snes"].GameCount)
+
+	// Per-game fields
+	require.Len(t, detail.Games, 3)
+
+	// Find game1 (Zelda 1) in the response
+	var zelda1, zelda2 *SeriesGameResponse
+	for i := range detail.Games {
+		if detail.Games[i].IGDBGameID == 100 {
+			zelda1 = &detail.Games[i]
+		}
+		if detail.Games[i].IGDBGameID == 200 {
+			zelda2 = &detail.Games[i]
+		}
+	}
+	require.NotNil(t, zelda1)
+	require.NotNil(t, zelda2)
+
+	assert.True(t, zelda1.InLibrary)
+	assert.Equal(t, "1986-02-21", zelda1.ReleaseDate)
+	assert.Equal(t, 90.0, zelda1.Rating)
+	assert.Equal(t, "nes", zelda1.ConsoleAbbreviation)
+	assert.NotEmpty(t, zelda1.ConsoleName)
+
+	assert.True(t, zelda2.InLibrary)
+	assert.Equal(t, "1991-11-21", zelda2.ReleaseDate)
+	assert.Equal(t, 95.0, zelda2.Rating)
+	assert.Equal(t, "snes", zelda2.ConsoleAbbreviation)
+
+	// Non-local game should have no per-game fields
+	var zelda3 *SeriesGameResponse
+	for i := range detail.Games {
+		if detail.Games[i].IGDBGameID == 300 {
+			zelda3 = &detail.Games[i]
+		}
+	}
+	require.NotNil(t, zelda3)
+	assert.False(t, zelda3.InLibrary)
+	assert.Empty(t, zelda3.ReleaseDate)
+	assert.Equal(t, 0.0, zelda3.Rating)
+	assert.Empty(t, zelda3.ConsoleAbbreviation)
+}
+
+func TestGetSeriesDetail_HeroFromBestRatedGame(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	// Create two games: lower rated has hero, higher rated does not
+	game1 := createEnrichTestGame(t, env.database, "LowRated", 50)
+	game2 := createEnrichTestGame(t, env.database, "HighRated", 99)
+
+	env.database.Create(&db.GameArtwork{
+		GameID:  game1.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/low.png",
+	})
+	env.database.Create(&db.GameArtwork{
+		GameID:  game2.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/high.png",
+	})
+
+	series := db.GameSeries{IGDBCollectionID: 200, Name: "Test Series"}
+	require.NoError(t, env.database.Create(&series).Error)
+
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game1.ID, IGDBGameID: 100, Name: "Low",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game2.ID, IGDBGameID: 200, Name: "High",
+	})
+
+	url := fmt.Sprintf("/api/series/%d", series.ID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var detail SeriesDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &detail))
+
+	// Hero should come from the highest-rated game
+	assert.Equal(t, "https://cdn.steamgriddb.com/hero/high.png", detail.HeroURL)
+}
+
+func TestGetSeriesDetail_NoHeroArt(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game := createEnrichTestGame(t, env.database, "NoArt", 80)
+	series := db.GameSeries{IGDBCollectionID: 300, Name: "No Art Series"}
+	require.NoError(t, env.database.Create(&series).Error)
+
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game.ID, IGDBGameID: 100, Name: "NoArt",
+	})
+
+	url := fmt.Sprintf("/api/series/%d", series.ID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var detail SeriesDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &detail))
+
+	assert.Empty(t, detail.HeroURL)
+}
+
+// --- GetGameSeries tests ---
+
+func TestGetGameSeries_Empty(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+	game := createEnrichTestGame(t, env.database, "Lonely Game", 80)
+
+	url := fmt.Sprintf("/api/games/%d/series", game.ID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []GameSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	assert.Empty(t, result)
+}
+
+func TestGetGameSeries_WithData(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Mario1", 90)
+	game2 := createEnrichTestGame(t, env.database, "Mario2", 85)
+
+	series := db.GameSeries{IGDBCollectionID: 789, Name: "Super Mario"}
+	require.NoError(t, env.database.Create(&series).Error)
+
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game1.ID, IGDBGameID: 100, Name: "Mario 1",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game2.ID, IGDBGameID: 200, Name: "Mario 2",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: nil, IGDBGameID: 300, Name: "Mario 3",
+	})
+
+	url := fmt.Sprintf("/api/games/%d/series", game1.ID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []GameSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.Len(t, result, 1)
+	assert.Equal(t, "Super Mario", result[0].Name)
+	assert.Equal(t, 3, result[0].TotalGames)
+	assert.Equal(t, 2, result[0].LibraryGames)
+}
+
+func TestGetGameSeries_GameNotFound(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/99999/series", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGetGameSeries_InvalidID(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/abc/series", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetGameSeries_MultipleSeries(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game := createEnrichTestGame(t, env.database, "CrossoverGame", 90)
+
+	series1 := db.GameSeries{IGDBCollectionID: 100, Name: "Series A"}
+	series2 := db.GameSeries{IGDBCollectionID: 200, Name: "Series B"}
+	require.NoError(t, env.database.Create(&series1).Error)
+	require.NoError(t, env.database.Create(&series2).Error)
+
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series1.ID, GameID: &game.ID, IGDBGameID: 100, Name: "Game",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series2.ID, GameID: &game.ID, IGDBGameID: 100, Name: "Game",
+	})
+
+	url := fmt.Sprintf("/api/games/%d/series", game.ID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []GameSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	assert.Len(t, result, 2)
+}
+
+// --- GetGameFranchises tests ---
+
+func TestGetGameFranchises_Empty(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+	game := createEnrichTestGame(t, env.database, "NoFranchise", 80)
+
+	url := fmt.Sprintf("/api/games/%d/franchises", game.ID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []GameFranchiseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	assert.Empty(t, result)
+}
+
+func TestGetGameFranchises_WithData(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Zelda1", 90)
+	game2 := createEnrichTestGame(t, env.database, "Zelda2", 85)
+
+	env.database.Create(&db.GameFranchise{GameID: game1.ID, IGDBFranchiseID: 100, FranchiseName: "The Legend of Zelda"})
+	env.database.Create(&db.GameFranchise{GameID: game2.ID, IGDBFranchiseID: 100, FranchiseName: "The Legend of Zelda"})
+
+	url := fmt.Sprintf("/api/games/%d/franchises", game1.ID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []GameFranchiseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.Len(t, result, 1)
+	assert.Equal(t, "100", result[0].ID)
+	assert.Equal(t, "The Legend of Zelda", result[0].Name)
+	assert.Equal(t, 2, result[0].GameCount)
+}
+
+func TestGetGameFranchises_GameNotFound(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/99999/franchises", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGetGameFranchises_InvalidID(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/abc/franchises", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetGameFranchises_MultipleFranchises(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game := createEnrichTestGame(t, env.database, "CrossFranchise", 90)
+
+	env.database.Create(&db.GameFranchise{GameID: game.ID, IGDBFranchiseID: 100, FranchiseName: "Franchise A"})
+	env.database.Create(&db.GameFranchise{GameID: game.ID, IGDBFranchiseID: 200, FranchiseName: "Franchise B"})
+
+	url := fmt.Sprintf("/api/games/%d/franchises", game.ID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []GameFranchiseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	assert.Len(t, result, 2)
+}
+
+func TestGetGameFranchises_ExcludesSoftDeletedGames(t *testing.T) {
+	env := setupEnrichTestEnv(t)
+
+	game1 := createEnrichTestGame(t, env.database, "Alive", 90)
+	game2 := createEnrichTestGame(t, env.database, "Deleted", 85)
+
+	env.database.Create(&db.GameFranchise{GameID: game1.ID, IGDBFranchiseID: 100, FranchiseName: "TestFranchise"})
+	env.database.Create(&db.GameFranchise{GameID: game2.ID, IGDBFranchiseID: 100, FranchiseName: "TestFranchise"})
+
+	// Soft-delete game2
+	env.database.Delete(&game2)
+
+	url := fmt.Sprintf("/api/games/%d/franchises", game1.ID)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []GameFranchiseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	require.Len(t, result, 1)
+	assert.Equal(t, 1, result[0].GameCount) // Only the alive game
 }
 
 // --- Authentication tests ---

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"log/slog"
 	"net/http"
 	"strconv"
 	"strings"
@@ -9,6 +10,16 @@ import (
 	"github.com/spela/server/internal/db"
 	"gorm.io/gorm"
 )
+
+// FeaturedSeriesResponse is the API response for a featured series on the Explore page.
+type FeaturedSeriesResponse struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	LibraryGames int    `json:"libraryGames"`
+	TotalGames   int    `json:"totalGames"`
+	ConsoleCount int    `json:"consoleCount"`
+	HeroURL      string `json:"heroUrl,omitempty"`
+}
 
 // ExploreHandler handles explore page endpoints.
 type ExploreHandler struct {
@@ -351,5 +362,126 @@ func (h *ExploreHandler) buildMostPlayedRow(userID uint) (*ExploreRowResponse, e
 		Title: "Most Played on Your Server",
 		Games: ToGameResponses(sortedGames, h.DB, userID),
 	}, nil
+}
+
+// GetExploreFeaturedSeries returns the top series for the Explore page shelf.
+// Only series with at least 2 library games are included, sorted by library game count DESC, limit 20.
+// GET /api/explore/series/featured
+func (h *ExploreHandler) GetExploreFeaturedSeries(c *gin.Context) {
+	// Query series with library game counts, filtering for >= 2 library games
+	type seriesRow struct {
+		ID           uint
+		Name         string
+		TotalGames   int
+		LibraryGames int
+	}
+
+	var rows []seriesRow
+	if err := h.DB.
+		Table("game_series").
+		Select(`game_series.id, game_series.name,
+			COUNT(game_series_entries.id) as total_games,
+			COUNT(CASE WHEN games.id IS NOT NULL AND games.deleted_at IS NULL THEN 1 END) as library_games`).
+		Joins("JOIN game_series_entries ON game_series_entries.series_id = game_series.id").
+		Joins("LEFT JOIN games ON games.id = game_series_entries.game_id").
+		Group("game_series.id").
+		Having("library_games >= 2").
+		Order("library_games DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch featured series"})
+		return
+	}
+
+	if len(rows) == 0 {
+		c.JSON(http.StatusOK, []FeaturedSeriesResponse{})
+		return
+	}
+
+	// Collect series IDs for batch lookups
+	seriesIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		seriesIDs[i] = r.ID
+	}
+
+	// For each series, find console count and hero art.
+	// Batch-load all entries with local games to count unique consoles per series.
+	type entryRow struct {
+		SeriesID  uint
+		GameID    uint
+		ConsoleID uint
+		Rating    float64
+	}
+	var entryRows []entryRow
+	if err := h.DB.Table("game_series_entries").
+		Select("game_series_entries.series_id, games.id as game_id, games.console_id, games.rating").
+		Joins("JOIN games ON games.id = game_series_entries.game_id AND games.deleted_at IS NULL").
+		Where("game_series_entries.series_id IN ?", seriesIDs).
+		Scan(&entryRows).Error; err != nil {
+		slog.Error("failed to batch-load series entries", "error", err)
+	}
+
+	// Group entries by series
+	type seriesGameInfo struct {
+		gameID    uint
+		consoleID uint
+		rating    float64
+	}
+	seriesGames := make(map[uint][]seriesGameInfo)
+	for _, e := range entryRows {
+		seriesGames[e.SeriesID] = append(seriesGames[e.SeriesID], seriesGameInfo{
+			gameID:    e.GameID,
+			consoleID: e.ConsoleID,
+			rating:    e.Rating,
+		})
+	}
+
+	// Collect all game IDs across all series for batch artwork lookup
+	allGameIDs := make([]uint, 0)
+	for _, games := range seriesGames {
+		for _, g := range games {
+			allGameIDs = append(allGameIDs, g.gameID)
+		}
+	}
+
+	// Batch-load hero artworks
+	artworkMap := make(map[uint]string) // gameID -> heroURL
+	if len(allGameIDs) > 0 {
+		var artworks []db.GameArtwork
+		h.DB.Where("game_id IN ? AND hero_url != ''", allGameIDs).Find(&artworks)
+		for _, a := range artworks {
+			artworkMap[a.GameID] = a.HeroURL
+		}
+	}
+
+	// Build responses
+	result := make([]FeaturedSeriesResponse, len(rows))
+	for i, r := range rows {
+		// Count unique consoles
+		consolesSet := make(map[uint]bool)
+		// Find best hero URL (highest rated library game with hero art)
+		var bestHeroURL string
+		var bestRating float64 = -1
+		for _, g := range seriesGames[r.ID] {
+			consolesSet[g.consoleID] = true
+			if heroURL, ok := artworkMap[g.gameID]; ok {
+				if g.rating > bestRating {
+					bestRating = g.rating
+					bestHeroURL = heroURL
+				}
+			}
+		}
+
+		result[i] = FeaturedSeriesResponse{
+			ID:           strconv.FormatUint(uint64(r.ID), 10),
+			Name:         r.Name,
+			LibraryGames: r.LibraryGames,
+			TotalGames:   r.TotalGames,
+			ConsoleCount: len(consolesSet),
+			HeroURL:      bestHeroURL,
+		}
+	}
+
+	c.JSON(http.StatusOK, result)
 }
 

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -832,3 +832,223 @@ func TestGetExploreFeatured_RequiresAuth(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
+
+// --- Featured Series endpoint tests ---
+
+func TestGetExploreFeaturedSeries_Empty(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/series/featured", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []FeaturedSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp)
+}
+
+func TestGetExploreFeaturedSeries_RequiresMinTwoLibraryGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game := createExploreGame(t, env.database, "NES", "Mario1", 90)
+
+	series := db.GameSeries{IGDBCollectionID: 100, Name: "Super Mario"}
+	require.NoError(t, env.database.Create(&series).Error)
+
+	// Only 1 library game + 1 non-library game = should NOT appear
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game.ID, IGDBGameID: 100, Name: "Mario 1",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: nil, IGDBGameID: 200, Name: "Mario 2",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/series/featured", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []FeaturedSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp, "series with only 1 library game should not appear")
+}
+
+func TestGetExploreFeaturedSeries_WithData(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "NES", "Zelda1", 90)
+	game2 := createExploreGame(t, env.database, "SNES", "Zelda2", 95)
+	game3 := createExploreGame(t, env.database, "NES", "Mario1", 85)
+	game4 := createExploreGame(t, env.database, "NES", "Mario2", 80)
+	game5 := createExploreGame(t, env.database, "NES", "Mario3", 75)
+
+	// Zelda series: 2 library games
+	zeldaSeries := db.GameSeries{IGDBCollectionID: 100, Name: "The Legend of Zelda"}
+	require.NoError(t, env.database.Create(&zeldaSeries).Error)
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: zeldaSeries.ID, GameID: &game1.ID, IGDBGameID: 100, Name: "Zelda 1",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: zeldaSeries.ID, GameID: &game2.ID, IGDBGameID: 200, Name: "Zelda 2",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: zeldaSeries.ID, GameID: nil, IGDBGameID: 300, Name: "Zelda 3",
+	})
+
+	// Mario series: 3 library games (should appear first)
+	marioSeries := db.GameSeries{IGDBCollectionID: 200, Name: "Super Mario"}
+	require.NoError(t, env.database.Create(&marioSeries).Error)
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: marioSeries.ID, GameID: &game3.ID, IGDBGameID: 400, Name: "Mario 1",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: marioSeries.ID, GameID: &game4.ID, IGDBGameID: 500, Name: "Mario 2",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: marioSeries.ID, GameID: &game5.ID, IGDBGameID: 600, Name: "Mario 3",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/series/featured", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []FeaturedSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 2)
+
+	// Sorted by library game count DESC
+	assert.Equal(t, "Super Mario", resp[0].Name)
+	assert.Equal(t, 3, resp[0].LibraryGames)
+	assert.Equal(t, 3, resp[0].TotalGames)
+	assert.Equal(t, 1, resp[0].ConsoleCount) // All NES
+
+	assert.Equal(t, "The Legend of Zelda", resp[1].Name)
+	assert.Equal(t, 2, resp[1].LibraryGames)
+	assert.Equal(t, 3, resp[1].TotalGames)
+	assert.Equal(t, 2, resp[1].ConsoleCount) // NES + SNES
+}
+
+func TestGetExploreFeaturedSeries_HeroArt(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "NES", "LowRated", 50)
+	game2 := createExploreGame(t, env.database, "NES", "HighRated", 95)
+
+	// Both have hero art, highest rated should win
+	env.database.Create(&db.GameArtwork{
+		GameID:  game1.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/low.png",
+	})
+	env.database.Create(&db.GameArtwork{
+		GameID:  game2.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/high.png",
+	})
+
+	series := db.GameSeries{IGDBCollectionID: 100, Name: "Test Series"}
+	require.NoError(t, env.database.Create(&series).Error)
+
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game1.ID, IGDBGameID: 100, Name: "Low",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game2.ID, IGDBGameID: 200, Name: "High",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/series/featured", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []FeaturedSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, "https://cdn.steamgriddb.com/hero/high.png", resp[0].HeroURL)
+}
+
+func TestGetExploreFeaturedSeries_ExcludesSoftDeletedGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "NES", "Alive1", 90)
+	game2 := createExploreGame(t, env.database, "NES", "Alive2", 85)
+	game3 := createExploreGame(t, env.database, "NES", "Deleted", 80)
+
+	series := db.GameSeries{IGDBCollectionID: 100, Name: "Test"}
+	require.NoError(t, env.database.Create(&series).Error)
+
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game1.ID, IGDBGameID: 100, Name: "G1",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game2.ID, IGDBGameID: 200, Name: "G2",
+	})
+	env.database.Create(&db.GameSeriesEntry{
+		SeriesID: series.ID, GameID: &game3.ID, IGDBGameID: 300, Name: "G3",
+	})
+
+	// Soft-delete one game — should drop library count to 2, still >= 2 threshold
+	env.database.Delete(&game3)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/series/featured", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []FeaturedSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp, 1)
+	assert.Equal(t, 2, resp[0].LibraryGames)
+}
+
+func TestGetExploreFeaturedSeries_RequiresAuth(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/series/featured", nil)
+	// No auth header
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestGetExploreFeaturedSeries_Limit20(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create 25 series, each with 2 library games
+	for i := 0; i < 25; i++ {
+		g1 := createExploreGame(t, env.database, "NES", fmt.Sprintf("Game%d_A", i), float64(90-i))
+		g2 := createExploreGame(t, env.database, "NES", fmt.Sprintf("Game%d_B", i), float64(85-i))
+
+		series := db.GameSeries{IGDBCollectionID: 1000 + i, Name: fmt.Sprintf("Series %d", i)}
+		require.NoError(t, env.database.Create(&series).Error)
+
+		env.database.Create(&db.GameSeriesEntry{
+			SeriesID: series.ID, GameID: &g1.ID, IGDBGameID: 1000 + i*2, Name: fmt.Sprintf("Game%d_A", i),
+		})
+		env.database.Create(&db.GameSeriesEntry{
+			SeriesID: series.ID, GameID: &g2.ID, IGDBGameID: 1001 + i*2, Name: fmt.Sprintf("Game%d_B", i),
+		})
+	}
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/series/featured", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []FeaturedSeriesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp, 20, "should be limited to 20 series")
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -239,6 +239,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		{
 			explore.GET("/featured", exploreHandler.GetExploreFeatured)
 			explore.GET("/rows", exploreHandler.GetExploreRows)
+			explore.GET("/series/featured", exploreHandler.GetExploreFeaturedSeries)
 		}
 
 		// Games
@@ -254,6 +255,8 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/games/:id/artwork", artworkHandler.GetGameArtwork)
 		api.GET("/games/:id/similar", discoveryHandler.GetSimilarGames)
 		api.GET("/games/:id/developer-games", discoveryHandler.GetDeveloperGames)
+		api.GET("/games/:id/series", enrichmentHandler.GetGameSeries)
+		api.GET("/games/:id/franchises", enrichmentHandler.GetGameFranchises)
 
 		// Game Sessions
 		api.POST("/games/:id/sessions", sessionHandler.CreateSession)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,9 @@ import { LicensesPage } from "@/pages/licenses-page";
 import { ChallengesPage } from "@/pages/challenges-page";
 import { TopListsPage } from "@/pages/top-lists-page";
 import { ExplorePage } from "@/pages/explore-page";
+import { ExploreThemePage } from "@/pages/explore-theme-page";
+import { ExploreKeywordPage } from "@/pages/explore-keyword-page";
+import { ExploreSeriesPage } from "@/pages/explore-series-page";
 import { ChallengeDetailPage } from "@/pages/challenge-detail-page";
 import { SessionDetailPage } from "@/pages/session-detail-page";
 import { SetupWizardPage } from "@/pages/setup-wizard-page";
@@ -84,6 +87,18 @@ export function App() {
                   >
                     <Route index element={<DashboardPage />} />
                     <Route path="explore" element={<ExplorePage />} />
+                    <Route
+                      path="explore/themes/:id"
+                      element={<ExploreThemePage />}
+                    />
+                    <Route
+                      path="explore/keywords/:id"
+                      element={<ExploreKeywordPage />}
+                    />
+                    <Route
+                      path="explore/series/:id"
+                      element={<ExploreSeriesPage />}
+                    />
                     <Route element={<LibraryLayout />}>
                       <Route path="consoles" element={<ConsolesPage />} />
                       <Route path="games" element={<GamesPage />} />

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { ExplorePage } from "@/pages/explore-page";
-import type { FeaturedGame, Game, ExploreRowsResponse, Theme, Keyword } from "@/types/api";
+import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword } from "@/types/api";
 
 // Mock hooks
 vi.mock("@/hooks/use-explore", () => ({
@@ -11,6 +11,7 @@ vi.mock("@/hooks/use-explore", () => ({
   useExploreRows: vi.fn(),
   useThemes: vi.fn(),
   useKeywords: vi.fn(),
+  useFeaturedSeries: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-games", () => ({
@@ -29,12 +30,13 @@ vi.mock("@/hooks/use-auto-scrape", () => ({
   useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
 }));
 
-import { useExploreFeatured, useExploreRows, useThemes, useKeywords } from "@/hooks/use-explore";
+import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries } from "@/hooks/use-explore";
 
 const mockUseExploreFeatured = useExploreFeatured as ReturnType<typeof vi.fn>;
 const mockUseExploreRows = useExploreRows as ReturnType<typeof vi.fn>;
 const mockUseThemes = useThemes as ReturnType<typeof vi.fn>;
 const mockUseKeywords = useKeywords as ReturnType<typeof vi.fn>;
+const mockUseFeaturedSeries = useFeaturedSeries as ReturnType<typeof vi.fn>;
 
 function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
   return {
@@ -89,6 +91,11 @@ const mockThemes: Theme[] = [
 const mockKeywords: Keyword[] = [
   { id: "100", name: "Time Travel", gameCount: 15 },
   { id: "101", name: "Post-Apocalyptic", gameCount: 12 },
+];
+
+const mockFeaturedSeries: FeaturedSeries[] = [
+  { id: 1, name: "Super Mario", libraryGames: 5, totalGames: 12, consoleCount: 3, heroUrl: "/hero/mario.jpg" },
+  { id: 2, name: "The Legend of Zelda", libraryGames: 4, totalGames: 10, consoleCount: 2, heroUrl: "/hero/zelda.jpg" },
 ];
 
 const mockRows: ExploreRowsResponse = {
@@ -164,6 +171,10 @@ describe("ExplorePage", () => {
     });
     mockUseKeywords.mockReturnValue({
       data: mockKeywords,
+      isLoading: false,
+    });
+    mockUseFeaturedSeries.mockReturnValue({
+      data: mockFeaturedSeries,
       isLoading: false,
     });
   });
@@ -330,5 +341,30 @@ describe("ExplorePage", () => {
     });
     renderPage();
     expect(screen.getByTestId("keyword-chips-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders the series shelf section", () => {
+    renderPage();
+    expect(screen.getByTestId("series-shelf")).toBeInTheDocument();
+    expect(screen.getByText("Super Mario")).toBeInTheDocument();
+    expect(screen.getByText("The Legend of Zelda")).toBeInTheDocument();
+  });
+
+  it("hides series shelf when no featured series available", () => {
+    mockUseFeaturedSeries.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("series-shelf")).not.toBeInTheDocument();
+  });
+
+  it("shows series shelf skeleton while loading", () => {
+    mockUseFeaturedSeries.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByTestId("series-shelf-skeleton")).toBeInTheDocument();
   });
 });

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -94,8 +94,8 @@ const mockKeywords: Keyword[] = [
 ];
 
 const mockFeaturedSeries: FeaturedSeries[] = [
-  { id: 1, name: "Super Mario", libraryGames: 5, totalGames: 12, consoleCount: 3, heroUrl: "/hero/mario.jpg" },
-  { id: 2, name: "The Legend of Zelda", libraryGames: 4, totalGames: 10, consoleCount: 2, heroUrl: "/hero/zelda.jpg" },
+  { id: "1", name: "Super Mario", libraryGames: 5, totalGames: 12, consoleCount: 3, heroUrl: "/hero/mario.jpg" },
+  { id: "2", name: "The Legend of Zelda", libraryGames: 4, totalGames: 10, consoleCount: 2, heroUrl: "/hero/zelda.jpg" },
 ];
 
 const mockRows: ExploreRowsResponse = {

--- a/web/src/features/explore/components/__tests__/series-shelf.test.tsx
+++ b/web/src/features/explore/components/__tests__/series-shelf.test.tsx
@@ -1,0 +1,130 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { SeriesShelf } from "../series-shelf";
+import type { FeaturedSeries } from "@/types/api";
+
+function makeSeries(overrides: Partial<FeaturedSeries> = {}): FeaturedSeries {
+  return {
+    id: "1",
+    name: "Super Mario",
+    libraryGames: 5,
+    totalGames: 12,
+    consoleCount: 3,
+    heroUrl: "/hero/mario.jpg",
+    ...overrides,
+  };
+}
+
+const mockSeries: FeaturedSeries[] = [
+  makeSeries({ id: "1", name: "Super Mario", libraryGames: 5, totalGames: 12, consoleCount: 3 }),
+  makeSeries({ id: "2", name: "The Legend of Zelda", libraryGames: 4, totalGames: 10, consoleCount: 2 }),
+  makeSeries({ id: "3", name: "Metroid", libraryGames: 3, totalGames: 8, consoleCount: 2 }),
+];
+
+function renderShelf(
+  props: { series?: FeaturedSeries[] | undefined; isLoading?: boolean } = {},
+) {
+  const series = "series" in props ? props.series : mockSeries;
+  return render(
+    <MemoryRouter>
+      <SeriesShelf series={series} isLoading={props.isLoading ?? false} />
+    </MemoryRouter>,
+  );
+}
+
+describe("SeriesShelf", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders section with heading", () => {
+    renderShelf();
+    expect(
+      screen.getByRole("heading", { name: "Browse by Series", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders series cards", () => {
+    renderShelf();
+    expect(screen.getByText("Super Mario")).toBeInTheDocument();
+    expect(screen.getByText("The Legend of Zelda")).toBeInTheDocument();
+    expect(screen.getByText("Metroid")).toBeInTheDocument();
+  });
+
+  it("shows game counts", () => {
+    renderShelf();
+    expect(screen.getByText(/5\/12 games/)).toBeInTheDocument();
+    expect(screen.getByText(/4\/10 games/)).toBeInTheDocument();
+    expect(screen.getByText(/3\/8 games/)).toBeInTheDocument();
+  });
+
+  it("shows console count", () => {
+    renderShelf();
+    expect(screen.getByText(/across 3 consoles/)).toBeInTheDocument();
+    expect(screen.getAllByText(/across 2 consoles/)).toHaveLength(2);
+  });
+
+  it("renders singular game count", () => {
+    renderShelf({
+      series: [makeSeries({ id: "10", name: "Test", libraryGames: 1, totalGames: 1, consoleCount: 1 })],
+    });
+    expect(screen.getByText(/1\/1 game/)).toBeInTheDocument();
+    expect(screen.getByText(/across 1 console/)).toBeInTheDocument();
+  });
+
+  it("renders cards as list items", () => {
+    renderShelf();
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(3);
+  });
+
+  it("renders the scrollable list with label", () => {
+    renderShelf();
+    expect(
+      screen.getByRole("list", { name: "Browse by Series" }),
+    ).toBeInTheDocument();
+  });
+
+  it("links series cards to series detail pages", () => {
+    renderShelf();
+    const links = screen.getAllByRole("listitem");
+    // The Link wraps the listitem content
+    expect(links[0].closest("a")).toHaveAttribute(
+      "href",
+      "/explore/series/1",
+    );
+    expect(links[1].closest("a")).toHaveAttribute(
+      "href",
+      "/explore/series/2",
+    );
+    expect(links[2].closest("a")).toHaveAttribute(
+      "href",
+      "/explore/series/3",
+    );
+  });
+
+  it("renders nothing when series array is empty", () => {
+    const { container } = renderShelf({ series: [] });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when series is undefined and not loading", () => {
+    const { container } = renderShelf({ series: undefined, isLoading: false });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders loading skeleton when loading", () => {
+    renderShelf({ isLoading: true, series: undefined });
+    expect(screen.getByTestId("series-shelf-skeleton")).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Browse by Series", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton with shimmer animation", () => {
+    const { container } = renderShelf({ isLoading: true, series: undefined });
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/features/explore/components/series-shelf.tsx
+++ b/web/src/features/explore/components/series-shelf.tsx
@@ -1,0 +1,154 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Skeleton } from "@/components/ui";
+import type { FeaturedSeries } from "@/types/api";
+
+interface SeriesShelfProps {
+  series: FeaturedSeries[] | undefined;
+  isLoading: boolean;
+}
+
+function SeriesShelfSkeleton() {
+  return (
+    <section data-testid="series-shelf-skeleton">
+      <h2 className="text-xl font-bold text-surface-100 mb-5">
+        Browse by Series
+      </h2>
+      <div className="flex gap-4 overflow-hidden">
+        {Array.from({ length: 5 }, (_, i) => (
+          <Skeleton
+            key={i}
+            className="w-56 sm:w-60 lg:w-64 h-36 flex-shrink-0 rounded-2xl"
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function SeriesShelf({ series, isLoading }: SeriesShelfProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, series]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return <SeriesShelfSkeleton />;
+  }
+
+  if (!series || series.length === 0) {
+    return null;
+  }
+
+  return (
+    <section data-testid="series-shelf" className="group/series relative">
+      <h2 className="text-xl font-bold text-surface-100 mb-5">
+        Browse by Series
+      </h2>
+
+      <div className="relative">
+        {/* Scroll arrows */}
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/series:opacity-100 group-focus-within/series:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100 transition-all duration-300 shadow-lg"
+            aria-label="Scroll series left"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/series:opacity-100 group-focus-within/series:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100 transition-all duration-300 shadow-lg"
+            aria-label="Scroll series right"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        {/* Scrollable row */}
+        <div
+          ref={scrollRef}
+          className="flex gap-4 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label="Browse by Series"
+        >
+          {series.map((s) => (
+            <Link
+              key={s.id}
+              to={`/explore/series/${s.id}`}
+              className="w-56 sm:w-60 lg:w-64 flex-shrink-0 rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950"
+              role="listitem"
+            >
+              <div className="relative h-36 rounded-2xl overflow-hidden border border-white/[0.06] transition-all duration-300 hover:border-white/[0.12] hover:shadow-xl hover:shadow-black/30 hover:-translate-y-1 group/card">
+                {/* Background image */}
+                {s.heroUrl ? (
+                  <img
+                    src={s.heroUrl}
+                    alt=""
+                    className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover/card:scale-105"
+                    loading="lazy"
+                  />
+                ) : (
+                  <div className="absolute inset-0 bg-gradient-to-br from-brand-900/80 via-brand-800/60 to-surface-950/80" />
+                )}
+
+                {/* Gradient overlay */}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent pointer-events-none" />
+
+                {/* Content */}
+                <div className="relative flex flex-col justify-end h-full p-4">
+                  <h3 className="text-base font-bold text-white leading-tight group-hover/card:text-brand-300 transition-colors truncate">
+                    {s.name}
+                  </h3>
+                  <p className="text-xs text-white/70 mt-1">
+                    {s.libraryGames}/{s.totalGames} {s.totalGames === 1 ? "game" : "games"}
+                    {s.consoleCount > 0 && (
+                      <span className="text-white/50">
+                        {" "}
+                        across {s.consoleCount}{" "}
+                        {s.consoleCount === 1 ? "console" : "consoles"}
+                      </span>
+                    )}
+                  </p>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/hooks/use-explore.ts
+++ b/web/src/hooks/use-explore.ts
@@ -2,6 +2,10 @@ import { useQuery } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
 import type {
   FeaturedGame,
+  FeaturedSeries,
+  SeriesDetail,
+  GameSeriesLink,
+  GameFranchiseLink,
   ExploreRowsResponse,
   Theme,
   Keyword,
@@ -63,5 +67,37 @@ export function useKeywordGames(
         `/keywords/${keywordId}/games?page=${page}&pageSize=${pageSize}`,
       ),
     enabled: !!keywordId,
+  });
+}
+
+export function useFeaturedSeries() {
+  return useQuery({
+    queryKey: ["explore", "series", "featured"],
+    queryFn: () => api.get<FeaturedSeries[]>("/explore/series/featured"),
+  });
+}
+
+export function useSeriesDetail(id: string | undefined) {
+  return useQuery({
+    queryKey: ["series", id],
+    queryFn: () => api.get<SeriesDetail>(`/series/${id}`),
+    enabled: !!id,
+  });
+}
+
+export function useGameSeries(gameId: string | undefined) {
+  return useQuery({
+    queryKey: ["games", gameId, "series"],
+    queryFn: () => api.get<GameSeriesLink[]>(`/games/${gameId}/series`),
+    enabled: !!gameId,
+  });
+}
+
+export function useGameFranchises(gameId: string | undefined) {
+  return useQuery({
+    queryKey: ["games", gameId, "franchises"],
+    queryFn: () =>
+      api.get<GameFranchiseLink[]>(`/games/${gameId}/franchises`),
+    enabled: !!gameId,
   });
 }

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -20,6 +20,10 @@ export type ApiGetPath = WithQuery<
   // Explore
   | "/explore/featured"
   | "/explore/rows"
+  | "/explore/series/featured"
+
+  // Series
+  | `/series/${string}`
 
   // Themes & Keywords
   | "/themes"
@@ -45,6 +49,8 @@ export type ApiGetPath = WithQuery<
   | `/games/${string}/core`
   | `/games/${string}/shared-sessions`
   | `/games/${string}/challenges`
+  | `/games/${string}/series`
+  | `/games/${string}/franchises`
 
   // Game sessions
   | `/games/${string}/sessions`

--- a/web/src/pages/__tests__/explore-series-page.test.tsx
+++ b/web/src/pages/__tests__/explore-series-page.test.tsx
@@ -1,0 +1,276 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ExploreSeriesPage } from "@/pages/explore-series-page";
+import type { SeriesDetail, SeriesGame, SeriesConsole } from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-explore", () => ({
+  useSeriesDetail: vi.fn(),
+}));
+
+import { useSeriesDetail } from "@/hooks/use-explore";
+
+const mockUseSeriesDetail = useSeriesDetail as ReturnType<typeof vi.fn>;
+
+function makeSeriesGame(overrides: Partial<SeriesGame> = {}): SeriesGame {
+  return {
+    igdbGameId: 1,
+    name: "Test Game",
+    inLibrary: true,
+    localGameId: "game-1",
+    coverUrl: "/cover/test.jpg",
+    releaseDate: "1990-01-01",
+    rating: 85,
+    consoleAbbreviation: "snes",
+    consoleName: "SNES",
+    consoleColor: "#805ad5",
+    ...overrides,
+  };
+}
+
+function makeSeriesConsole(
+  overrides: Partial<SeriesConsole> = {},
+): SeriesConsole {
+  return {
+    abbreviation: "snes",
+    name: "SNES",
+    color: "#805ad5",
+    gameCount: 3,
+    ...overrides,
+  };
+}
+
+const mockSeriesDetail: SeriesDetail = {
+  id: "1",
+  name: "Super Mario",
+  heroUrl: "/hero/mario.jpg",
+  consoles: [
+    makeSeriesConsole({ abbreviation: "nes", name: "NES", color: "#e53e3e", gameCount: 2 }),
+    makeSeriesConsole({ abbreviation: "snes", name: "SNES", color: "#805ad5", gameCount: 3 }),
+  ],
+  libraryGames: 3,
+  totalGames: 5,
+  games: [
+    makeSeriesGame({
+      igdbGameId: 1,
+      name: "Super Mario Bros.",
+      inLibrary: true,
+      localGameId: "game-1",
+      releaseDate: "1985-09-13",
+      consoleAbbreviation: "nes",
+      consoleName: "NES",
+    }),
+    makeSeriesGame({
+      igdbGameId: 2,
+      name: "Super Mario Bros. 2",
+      inLibrary: true,
+      localGameId: "game-2",
+      releaseDate: "1988-10-09",
+      consoleAbbreviation: "nes",
+      consoleName: "NES",
+    }),
+    makeSeriesGame({
+      igdbGameId: 3,
+      name: "Super Mario World",
+      inLibrary: true,
+      localGameId: "game-3",
+      releaseDate: "1990-11-21",
+      consoleAbbreviation: "snes",
+      consoleName: "SNES",
+    }),
+    makeSeriesGame({
+      igdbGameId: 4,
+      name: "Super Mario World 2: Yoshi's Island",
+      inLibrary: false,
+      localGameId: null,
+      releaseDate: "1995-08-05",
+      consoleAbbreviation: "snes",
+      consoleName: "SNES",
+    }),
+    makeSeriesGame({
+      igdbGameId: 5,
+      name: "Super Mario Unknown",
+      inLibrary: false,
+      localGameId: null,
+      releaseDate: null,
+      rating: 0,
+      consoleAbbreviation: "snes",
+      consoleName: "SNES",
+    }),
+  ],
+};
+
+function renderPage(seriesId = "1") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/explore/series/${seriesId}`]}>
+        <Routes>
+          <Route
+            path="/explore/series/:id"
+            element={<ExploreSeriesPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ExploreSeriesPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseSeriesDetail.mockReturnValue({
+      data: mockSeriesDetail,
+      isLoading: false,
+    });
+  });
+
+  it("renders the page with test id", () => {
+    renderPage();
+    expect(screen.getByTestId("series-detail-page")).toBeInTheDocument();
+  });
+
+  it("renders series name in hero banner", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: "Super Mario", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders back button", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /back to explore/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders ownership progress", () => {
+    renderPage();
+    const progress = screen.getByTestId("ownership-progress");
+    expect(progress).toBeInTheDocument();
+    expect(
+      within(progress).getByText("You own 3 of 5 games"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders progress bar with correct value", () => {
+    renderPage();
+    const progressBar = screen.getByRole("progressbar");
+    expect(progressBar).toHaveAttribute("aria-valuenow", "3");
+    expect(progressBar).toHaveAttribute("aria-valuemax", "5");
+  });
+
+  it("renders console filter badges", () => {
+    renderPage();
+    const filters = screen.getByTestId("console-filters");
+    expect(within(filters).getByText(/All \(/)).toBeInTheDocument();
+    const buttons = within(filters).getAllByRole("button");
+    const buttonTexts = buttons.map((b) => b.textContent);
+    expect(buttonTexts).toContainEqual(expect.stringContaining("NES"));
+    expect(buttonTexts).toContainEqual(expect.stringContaining("SNES"));
+  });
+
+  it("renders games in timeline", () => {
+    renderPage();
+    const timeline = screen.getByTestId("series-timeline");
+    expect(
+      within(timeline).getByText("Super Mario Bros."),
+    ).toBeInTheDocument();
+    expect(
+      within(timeline).getByText("Super Mario World"),
+    ).toBeInTheDocument();
+    expect(
+      within(timeline).getByText("Super Mario World 2: Yoshi's Island"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders games in chronological order", () => {
+    renderPage();
+    const timeline = screen.getByTestId("series-timeline");
+    const gameNames = within(timeline)
+      .getAllByRole("heading", { level: 3 })
+      .map((el) => el.textContent);
+    expect(gameNames[0]).toBe("Super Mario Bros.");
+    expect(gameNames[1]).toBe("Super Mario Bros. 2");
+    expect(gameNames[2]).toBe("Super Mario World");
+    expect(gameNames[3]).toBe("Super Mario World 2: Yoshi's Island");
+    // Game without release date sorts to end
+    expect(gameNames[4]).toBe("Super Mario Unknown");
+  });
+
+  it("renders in-library games as links", () => {
+    renderPage();
+    const link = screen.getByText("Super Mario Bros.").closest("a");
+    expect(link).toHaveAttribute("href", "/games/game-1");
+  });
+
+  it("renders not-in-library games as dimmed", () => {
+    renderPage();
+    const dimmedGame = screen.getByTestId("series-game-4");
+    expect(dimmedGame).toHaveClass("opacity-50");
+  });
+
+  it("shows not in library text for games not in library", () => {
+    renderPage();
+    expect(screen.getAllByText("Not in library")).toHaveLength(2);
+  });
+
+  it("filters games by console", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const filters = screen.getByTestId("console-filters");
+    // Find the NES button (not SNES) by matching exact text content
+    const buttons = within(filters).getAllByRole("button");
+    const nesButton = buttons.find(
+      (b) => b.textContent?.trim().startsWith("NES"),
+    );
+    expect(nesButton).toBeDefined();
+    await user.click(nesButton!);
+
+    const timeline = screen.getByTestId("series-timeline");
+    const gameHeadings = within(timeline).getAllByRole("heading", { level: 3 });
+
+    // Only NES games should be shown (2 NES games from mock data)
+    expect(gameHeadings).toHaveLength(2);
+    expect(gameHeadings[0].textContent).toBe("Super Mario Bros.");
+    expect(gameHeadings[1].textContent).toBe("Super Mario Bros. 2");
+  });
+
+  it("shows loading skeleton while loading", () => {
+    mockUseSeriesDetail.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByTestId("series-detail-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows not found when series does not exist", () => {
+    mockUseSeriesDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    renderPage("999");
+    expect(screen.getByText("Series not found")).toBeInTheDocument();
+  });
+
+  it("renders hero image when heroUrl is present", () => {
+    renderPage();
+    const heroImg = screen
+      .getByTestId("series-detail-page")
+      .querySelector("img[src='/hero/mario.jpg']");
+    expect(heroImg).toBeInTheDocument();
+  });
+
+  it("renders release year for games", () => {
+    renderPage();
+    expect(screen.getByText("1985")).toBeInTheDocument();
+    expect(screen.getByText("1990")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -5,11 +5,13 @@ import { HeroCarousel } from "@/features/explore/components/hero-carousel";
 import { GameShelf } from "@/features/explore/components/game-shelf";
 import { ThemeGrid } from "@/features/explore/components/theme-grid";
 import { KeywordChips } from "@/features/explore/components/keyword-chips";
+import { SeriesShelf } from "@/features/explore/components/series-shelf";
 import {
   useExploreFeatured,
   useExploreRows,
   useThemes,
   useKeywords,
+  useFeaturedSeries,
 } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -33,6 +35,10 @@ export function ExplorePage() {
     data: keywords,
     isLoading: isKeywordsLoading,
   } = useKeywords(30);
+  const {
+    data: featuredSeries,
+    isLoading: isSeriesLoading,
+  } = useFeaturedSeries();
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
 
@@ -113,6 +119,9 @@ export function ExplorePage() {
       {/* Keyword Chips */}
       <KeywordChips keywords={keywords} isLoading={isKeywordsLoading} />
 
+      {/* Series shelf */}
+      <SeriesShelf series={featuredSeries} isLoading={isSeriesLoading} />
+
       {/* Remaining shelf rows */}
       {isRowsLoading ? (
         <GameShelf
@@ -132,6 +141,7 @@ export function ExplorePage() {
           />
         ))
       )}
+
     </div>
   );
 }

--- a/web/src/pages/explore-series-page.tsx
+++ b/web/src/pages/explore-series-page.tsx
@@ -1,0 +1,270 @@
+import { useState } from "react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { BackButton, Badge, Skeleton } from "@/components/ui";
+import { useSeriesDetail } from "@/hooks/use-explore";
+import { cn } from "@/lib/cn";
+import type { SeriesGame, SeriesConsole } from "@/types/api";
+
+function SeriesPageSkeleton() {
+  return (
+    <div className="space-y-8" data-testid="series-detail-skeleton">
+      {/* Hero skeleton */}
+      <Skeleton className="w-full h-48 rounded-2xl" />
+      {/* Title */}
+      <Skeleton className="w-64 h-8" />
+      {/* Progress bar */}
+      <Skeleton className="w-full h-2 rounded-full" />
+      {/* Console badges */}
+      <div className="flex gap-2">
+        {Array.from({ length: 3 }, (_, i) => (
+          <Skeleton key={i} className="w-24 h-7 rounded-full" />
+        ))}
+      </div>
+      {/* Timeline */}
+      <div className="space-y-4">
+        {Array.from({ length: 4 }, (_, i) => (
+          <Skeleton key={i} className="w-full h-20 rounded-xl" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function GameTimelineCard({ game }: { game: SeriesGame }) {
+  const year = game.releaseDate
+    ? new Date(game.releaseDate).getFullYear()
+    : null;
+
+  const content = (
+    <div
+      className={cn(
+        "flex items-center gap-4 p-4 rounded-xl border transition-all duration-200",
+        game.inLibrary
+          ? "bg-surface-900/60 border-surface-800/50 hover:border-surface-700/50 hover:bg-surface-800/60 cursor-pointer"
+          : "bg-surface-950/40 border-surface-800/30 opacity-50 cursor-default",
+      )}
+      data-testid={`series-game-${game.igdbGameId}`}
+    >
+      {/* Cover art */}
+      <div className="w-12 h-16 rounded-lg overflow-hidden bg-surface-800 flex-shrink-0">
+        {game.coverUrl ? (
+          <img
+            src={game.coverUrl}
+            alt={game.name}
+            className="w-full h-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-surface-600 text-lg font-bold">
+            {game.name.charAt(0)}
+          </div>
+        )}
+      </div>
+
+      {/* Info */}
+      <div className="flex-1 min-w-0">
+        <h3
+          className={cn(
+            "text-sm font-semibold truncate",
+            game.inLibrary ? "text-surface-100" : "text-surface-500",
+          )}
+        >
+          {game.name}
+        </h3>
+        <div className="flex items-center gap-2 mt-1">
+          <Badge
+            variant="default"
+            style={
+              game.inLibrary && game.consoleColor
+                ? {
+                    backgroundColor: `${game.consoleColor}20`,
+                    color: game.consoleColor,
+                    borderColor: `${game.consoleColor}40`,
+                  }
+                : undefined
+            }
+          >
+            {game.consoleName}
+          </Badge>
+          {year && (
+            <span className="text-xs text-surface-500">{year}</span>
+          )}
+          {game.rating > 0 && (
+            <span className="text-xs text-surface-400">
+              {game.rating.toFixed(0)}%
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* In-library indicator */}
+      {!game.inLibrary && (
+        <span className="text-xs text-surface-600 flex-shrink-0">
+          Not in library
+        </span>
+      )}
+    </div>
+  );
+
+  if (game.inLibrary && game.localGameId) {
+    return (
+      <Link to={`/games/${game.localGameId}`} className="block">
+        {content}
+      </Link>
+    );
+  }
+
+  return content;
+}
+
+export function ExploreSeriesPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data: series, isLoading } = useSeriesDetail(id);
+  const [consoleFilter, setConsoleFilter] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="max-w-4xl space-y-6">
+        <BackButton onClick={() => navigate("/explore")}>
+          Back to Explore
+        </BackButton>
+        <SeriesPageSkeleton />
+      </div>
+    );
+  }
+
+  if (!series) {
+    return (
+      <div className="max-w-4xl space-y-6">
+        <BackButton onClick={() => navigate("/explore")}>
+          Back to Explore
+        </BackButton>
+        <p className="text-surface-400 text-center py-20">
+          Series not found
+        </p>
+      </div>
+    );
+  }
+
+  // Sort games by release date, games without dates go to end
+  const sortedGames = [...series.games].sort((a, b) => {
+    if (!a.releaseDate && !b.releaseDate) return 0;
+    if (!a.releaseDate) return 1;
+    if (!b.releaseDate) return -1;
+    return a.releaseDate.localeCompare(b.releaseDate);
+  });
+
+  // Filter by console if selected
+  const filteredGames = consoleFilter
+    ? sortedGames.filter((g) => g.consoleAbbreviation === consoleFilter)
+    : sortedGames;
+
+  const progressPercent =
+    series.totalGames > 0
+      ? Math.round((series.libraryGames / series.totalGames) * 100)
+      : 0;
+
+  return (
+    <div className="max-w-4xl space-y-8" data-testid="series-detail-page">
+      <BackButton onClick={() => navigate("/explore")}>
+        Back to Explore
+      </BackButton>
+
+      {/* Hero banner */}
+      {series.heroUrl && (
+        <div className="relative w-full h-48 sm:h-56 rounded-2xl overflow-hidden">
+          <img
+            src={series.heroUrl}
+            alt=""
+            className="w-full h-full object-cover"
+          />
+          <div className="absolute inset-0 bg-gradient-to-t from-surface-950 via-surface-950/50 to-transparent" />
+          <div className="absolute bottom-0 left-0 right-0 p-6">
+            <h1 className="text-3xl font-bold text-white">{series.name}</h1>
+          </div>
+        </div>
+      )}
+
+      {!series.heroUrl && (
+        <h1 className="text-3xl font-bold text-surface-100">{series.name}</h1>
+      )}
+
+      {/* Ownership progress */}
+      <div data-testid="ownership-progress">
+        <p className="text-sm text-surface-400 mb-2">
+          You own {series.libraryGames} of {series.totalGames} games
+        </p>
+        <div className="w-full h-2 bg-surface-800 rounded-full overflow-hidden">
+          <div
+            className="h-full bg-brand-500 rounded-full transition-all duration-500"
+            style={{ width: `${progressPercent}%` }}
+            role="progressbar"
+            aria-valuenow={series.libraryGames}
+            aria-valuemin={0}
+            aria-valuemax={series.totalGames}
+            aria-label={`${series.libraryGames} of ${series.totalGames} games owned`}
+          />
+        </div>
+      </div>
+
+      {/* Console badges */}
+      {series.consoles.length > 0 && (
+        <div className="flex flex-wrap gap-2" data-testid="console-filters">
+          <button
+            onClick={() => setConsoleFilter(null)}
+            className={cn(
+              "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+              consoleFilter === null
+                ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
+                : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
+            )}
+          >
+            All ({series.games.length})
+          </button>
+          {series.consoles.map((console: SeriesConsole) => (
+            <button
+              key={console.abbreviation}
+              onClick={() =>
+                setConsoleFilter(
+                  consoleFilter === console.abbreviation
+                    ? null
+                    : console.abbreviation,
+                )
+              }
+              className={cn(
+                "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+                consoleFilter === console.abbreviation
+                  ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
+                  : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
+              )}
+              style={
+                consoleFilter === console.abbreviation && console.color
+                  ? {
+                      backgroundColor: `${console.color}20`,
+                      color: console.color,
+                      borderColor: `${console.color}40`,
+                    }
+                  : undefined
+              }
+            >
+              {console.name} ({console.gameCount})
+            </button>
+          ))}
+        </div>
+      )}
+
+      {/* Timeline */}
+      <div className="space-y-3" data-testid="series-timeline">
+        {filteredGames.map((game) => (
+          <GameTimelineCard key={game.igdbGameId} game={game} />
+        ))}
+        {filteredGames.length === 0 && (
+          <p className="text-sm text-surface-500 text-center py-8">
+            No games match the selected filter.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, Link } from "react-router-dom";
 import {
   Button,
   BackButton,
@@ -36,6 +36,7 @@ import { useGameSessions } from "@/hooks/use-sessions";
 import { GameCheats } from "@/features/game-detail/components/game-cheats";
 import { GameChallenges } from "@/features/challenges/components/game-challenges";
 import { useGameAchievements } from "@/hooks/use-retroachievements";
+import { useGameSeries, useGameFranchises } from "@/hooks/use-explore";
 import { useBiosStatus } from "@/hooks/use-bios";
 import { BiosWarningBanner } from "@/features/bios/components/bios-warning-banner";
 import { ScrapeMatchModal } from "@/features/game-detail/components/scrape-match-modal";
@@ -116,6 +117,8 @@ export function GameDetailPage() {
   const { data: biosData } = useBiosStatus();
   const { data: sessions } = useGameSessions(id ?? "");
   const { data: gameAchievements } = useGameAchievements(id);
+  const { data: gameSeries } = useGameSeries(id);
+  const { data: gameFranchises } = useGameFranchises(id);
   const consoleInfo = consoles?.find((c) => c.id === game?.consoleId);
   const canPlayInBrowser = !!consoleInfo?.emulatorJsCore;
   const hasAchievements = (gameAchievements?.achievements?.length ?? 0) > 0;
@@ -226,6 +229,41 @@ export function GameDetailPage() {
         open={showCollectionPicker}
         onClose={() => setShowCollectionPicker(false)}
       />
+
+      {/* Series & Franchise links */}
+      {((gameSeries && gameSeries.length > 0) ||
+        (gameFranchises && gameFranchises.length > 0)) && (
+        <div
+          className="flex flex-wrap items-center gap-3"
+          data-testid="series-franchise-links"
+        >
+          {gameSeries?.map((s) => (
+            <Link
+              key={`series-${s.id}`}
+              to={`/explore/series/${s.id}`}
+              className="inline-flex items-center gap-1.5 text-sm text-surface-300 hover:text-brand-400 transition-colors bg-surface-900/60 border border-surface-800/50 rounded-lg px-3 py-1.5 hover:border-surface-700/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+            >
+              Part of{" "}
+              <span className="font-semibold text-surface-100">{s.name}</span>
+              <span className="text-xs text-surface-500">
+                ({s.libraryGames}/{s.totalGames} games)
+              </span>
+            </Link>
+          ))}
+          {gameFranchises?.map((f) => (
+            <span
+              key={`franchise-${f.id}`}
+              className="inline-flex items-center gap-1.5 text-sm text-surface-300 bg-surface-900/60 border border-surface-800/50 rounded-lg px-3 py-1.5"
+            >
+              Part of{" "}
+              <span className="font-semibold text-surface-100">{f.name}</span>
+              <span className="text-xs text-surface-500">
+                ({f.gameCount} games)
+              </span>
+            </span>
+          ))}
+        </div>
+      )}
 
       <GameSessions gameId={game.id} />
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -829,6 +829,60 @@ export interface Keyword {
   gameCount: number;
 }
 
+// --- Series & Franchises ---
+
+export interface FeaturedSeries {
+  id: string;
+  name: string;
+  libraryGames: number;
+  totalGames: number;
+  consoleCount: number;
+  heroUrl: string;
+}
+
+export interface SeriesConsole {
+  abbreviation: string;
+  name: string;
+  color: string;
+  gameCount: number;
+}
+
+export interface SeriesGame {
+  igdbGameId: number;
+  name: string;
+  inLibrary: boolean;
+  localGameId: string | null;
+  coverUrl: string | null;
+  releaseDate: string | null;
+  rating: number;
+  consoleAbbreviation: string;
+  consoleName: string;
+  consoleColor: string;
+}
+
+export interface SeriesDetail {
+  id: string;
+  name: string;
+  heroUrl: string;
+  consoles: SeriesConsole[];
+  libraryGames: number;
+  totalGames: number;
+  games: SeriesGame[];
+}
+
+export interface GameSeriesLink {
+  id: string;
+  name: string;
+  totalGames: number;
+  libraryGames: number;
+}
+
+export interface GameFranchiseLink {
+  id: string;
+  name: string;
+  gameCount: number;
+}
+
 // --- Explore ---
 
 export interface FeaturedGame {


### PR DESCRIPTION
## Summary
- **Backend**: New endpoints for featured series (`GET /api/explore/series/featured`), series detail (`GET /api/series/:id`), game series links (`GET /api/games/:id/series`), and game franchise links (`GET /api/games/:id/franchises`) with full game metadata, console grouping, and ownership counts
- **Web**: Series shelf on Explore page, full series detail page (`/explore/series/:id`) with hero banner, ownership progress bar, console filter badges, chronological timeline, dimmed non-library games; "Part of [Series]" links and "Part of [Franchise]" labels on game detail page
- **Player**: Matching Compose Multiplatform implementation — SeriesShelf, ExploreSeriesScreen with console filtering and timeline, SeriesFranchiseSection on game detail, new navigation route

## Test plan
- [x] Go unit tests for all 4 new endpoints (featured series, series detail, game series, game franchises) — 15+ test cases including edge cases
- [x] Web Vitest tests: 12 tests for series shelf, 16 tests for series detail page, 3 tests for Explore page integration (838 total pass)
- [x] Player desktop E2E tests: 8 tests covering series shelf rendering, navigation, timeline, ownership progress, console filter, dimmed treatment, series links on game detail (509 total pass)
- [x] All existing tests pass with no regressions