### PR TITLE
feat: add Mood Picker to Explore page (Phase 5)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreMoodTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreMoodTest.kt
@@ -1,0 +1,189 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.MoodDefinition
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for Phase 5: Mood Picker on the Explore page.
+ *
+ * Covers:
+ * - Mood picker renders on Explore screen
+ * - Mood cards show correct info
+ * - Mood picker hidden when no moods
+ * - Navigate to mood detail screen
+ * - Mood detail shows games
+ * - Mood detail shows empty state
+ * - Surprise me button exists
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ExploreMoodTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private val sampleMoods = listOf(
+        MoodDefinition(
+            id = "chill",
+            name = "Chill",
+            description = "Relax with something easy-going",
+            icon = "\uD83C\uDFB5",
+            gradient = listOf("#1B5E20", "#4CAF50"),
+        ),
+        MoodDefinition(
+            id = "challenge",
+            name = "Challenge Me",
+            description = "Test your skills with something tough",
+            icon = "\uD83D\uDD25",
+            gradient = listOf("#B71C1C", "#F44336"),
+        ),
+        MoodDefinition(
+            id = "nostalgia",
+            name = "Nostalgia Trip",
+            description = "Revisit your most-played classics",
+            icon = "\u2728",
+            gradient = listOf("#4A148C", "#9C27B0"),
+        ),
+    )
+
+    private val sampleMoodGames = listOf(
+        Game(
+            id = "game-10",
+            title = "Relaxing Puzzle Game",
+            consoleId = "snes",
+            consoleName = "SNES",
+            genre = "Puzzle",
+        ),
+        Game(
+            id = "game-11",
+            title = "Chill Platformer",
+            consoleId = "gba",
+            consoleName = "GBA",
+            genre = "Platform",
+        ),
+    )
+
+    // --- Mood picker on Explore screen ---
+
+    @Test
+    fun moodPickerRendersOnExploreScreen() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.moodsList = sampleMoods
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_moods_section").assertIsDisplayed()
+        onNodeWithText("What are you in the mood for?").assertIsDisplayed()
+        onNodeWithTag("mood_picker").assertIsDisplayed()
+    }
+
+    @Test
+    fun moodCardsShowCorrectInfo() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.moodsList = sampleMoods
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithText("Chill").assertExists()
+        onNodeWithText("Challenge Me").assertExists()
+        onNodeWithText("Nostalgia Trip").assertExists()
+        onNodeWithText("Relax with something easy-going").assertExists()
+    }
+
+    @Test
+    fun moodPickerHiddenWhenNoMoods() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.moodsList = emptyList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_moods_section").assertDoesNotExist()
+    }
+
+    // --- Navigation to mood detail ---
+
+    @Test
+    fun navigationToMoodDetailWorks() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.moodsList = sampleMoods
+        harness.exploreRepo.moodGames = mapOf("chill" to sampleMoodGames)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("mood_card_chill").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("explore_mood/chill", navState.currentScreen.route)
+    }
+
+    // --- Mood detail screen ---
+
+    @Test
+    fun moodDetailShowsGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.moodsList = sampleMoods
+        harness.exploreRepo.moodGames = mapOf("chill" to sampleMoodGames)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreMood("chill", "Chill"))
+        )
+        advance(harness)
+
+        onNodeWithTag("explore_mood_screen").assertIsDisplayed()
+        onNodeWithText("Relaxing Puzzle Game").assertExists()
+        onNodeWithText("Chill Platformer").assertExists()
+        onNodeWithText("2 games").assertExists()
+    }
+
+    @Test
+    fun moodDetailShowsEmptyState() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.moodsList = sampleMoods
+        harness.exploreRepo.moodGames = mapOf("chill" to emptyList())
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreMood("chill", "Chill"))
+        )
+        advance(harness)
+
+        onNodeWithTag("explore_mood_screen").assertIsDisplayed()
+        onNodeWithTag("mood_empty_state").assertIsDisplayed()
+        onNodeWithText("No games found").assertExists()
+    }
+
+    @Test
+    fun surpriseMeButtonExists() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.moodsList = sampleMoods
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        // The "Surprise Me" card should exist in the mood picker row.
+        // It may require scrolling since it's at the end of the LazyRow.
+        onNodeWithTag("mood_card_surprise").assertExists()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InputModeTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InputModeTest.kt
@@ -131,6 +131,6 @@ class InputModeTest {
 
         // Should still be in gamepad mode with the section indicator
         onNodeWithContentDescription("Section indicator").assertExists()
-        onNodeWithContentDescription("Section: Consoles, active").assertExists()
+        onNodeWithContentDescription("Section: Explore, active").assertExists()
     }
 }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionIndicatorTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionIndicatorTest.kt
@@ -133,6 +133,6 @@ class SectionIndicatorTest {
 
         // Indicator should show new active section
         onNodeWithContentDescription("Section indicator").assertExists()
-        onNodeWithContentDescription("Section: Consoles, active").assertExists()
+        onNodeWithContentDescription("Section: Explore, active").assertExists()
     }
 }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SectionNavigationTest.kt
@@ -55,13 +55,14 @@ class SectionNavigationTest {
     }
 
     @Test
-    fun bottomNavShowsFiveTabs() = runComposeUiTest {
+    fun bottomNavShowsSixTabs() = runComposeUiTest {
         val harness = createLoggedInHarness()
 
         setContent { harness.App() }
         advance(harness)
 
         onNodeWithText("Home").assertIsDisplayed()
+        onNodeWithText("Explore").assertIsDisplayed()
         onNodeWithText("Consoles").assertIsDisplayed()
         onNodeWithText("Collections").assertIsDisplayed()
         onNodeWithText("Activity").assertIsDisplayed()
@@ -77,6 +78,10 @@ class SectionNavigationTest {
 
         // Start at Home
         assertEquals(SpScreen.Home, harness.navigationViewModel.state.value.currentScreen)
+
+        // NextSection → Explore
+        harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
+        assertEquals(SpScreen.Explore, harness.navigationViewModel.state.value.currentScreen)
 
         // NextSection → Consoles
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
@@ -125,6 +130,10 @@ class SectionNavigationTest {
         harness.navigationViewModel.onIntent(NavigationIntent.PreviousSection)
         assertEquals(SpScreen.Consoles, harness.navigationViewModel.state.value.currentScreen)
 
+        // PreviousSection → Explore
+        harness.navigationViewModel.onIntent(NavigationIntent.PreviousSection)
+        assertEquals(SpScreen.Explore, harness.navigationViewModel.state.value.currentScreen)
+
         // PreviousSection → Home
         harness.navigationViewModel.onIntent(NavigationIntent.PreviousSection)
         assertEquals(SpScreen.Home, harness.navigationViewModel.state.value.currentScreen)
@@ -156,7 +165,8 @@ class SectionNavigationTest {
         setContent { harness.App() }
         advance(harness)
 
-        // Navigate to Consoles via section cycling (empty backstack)
+        // Navigate to Consoles via section cycling (Home → Explore → Consoles)
+        harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
         assertEquals(SpScreen.Consoles, harness.navigationViewModel.state.value.currentScreen)
 
@@ -172,7 +182,8 @@ class SectionNavigationTest {
         setContent { harness.App() }
         advance(harness)
 
-        // Navigate to Collections via section cycling
+        // Navigate to Collections via section cycling (Home → Explore → Consoles → Collections)
+        harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
         assertEquals(SpScreen.Collections, harness.navigationViewModel.state.value.currentScreen)

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1329,6 +1329,9 @@ class FakeExploreRepository : ExploreRepository {
     var seriesDetails: Map<String, SeriesDetail> = emptyMap()
     var gameSeriesLinks: Map<String, List<GameSeriesLink>> = emptyMap()
     var gameFranchiseLinks: Map<String, List<GameFranchiseLink>> = emptyMap()
+    var moodsList: List<MoodDefinition> = emptyList()
+    var moodGames: Map<String, List<Game>> = emptyMap()
+    var surpriseGame: Game? = null
     var shouldFail: Boolean = false
 
     override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> =
@@ -1374,6 +1377,22 @@ class FakeExploreRepository : ExploreRepository {
     override suspend fun getGameFranchises(gameId: String): Result<List<GameFranchiseLink>> =
         if (shouldFail) Result.failure(Exception("Failed to load game franchises"))
         else Result.success(gameFranchiseLinks[gameId] ?: emptyList())
+
+    override suspend fun getMoods(): Result<List<MoodDefinition>> =
+        if (shouldFail) Result.failure(Exception("Failed to load moods"))
+        else Result.success(moodsList)
+
+    override suspend fun getMoodGames(mood: String): Result<List<Game>> =
+        if (shouldFail) Result.failure(Exception("Failed to load mood games"))
+        else Result.success(moodGames[mood] ?: emptyList())
+
+    override suspend fun getSurpriseGame(): Result<Game> =
+        if (shouldFail) Result.failure(Exception("Failed to load surprise game"))
+        else {
+            val game = surpriseGame
+            if (game != null) Result.success(game)
+            else Result.failure(Exception("No surprise game available"))
+        }
 }
 
 class FakeCheatRepository : CheatRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -294,6 +294,21 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/games/$gameId/franchises").body()
     }
 
+    /** Returns available mood definitions for the mood picker */
+    suspend fun getMoods(): List<MoodDefinitionDto> {
+        return client.get("$baseUrl/api/explore/moods").body()
+    }
+
+    /** Returns games matching a mood */
+    suspend fun getMoodGames(mood: String): List<GameDto> {
+        return client.get("$baseUrl/api/explore/mood/$mood").body()
+    }
+
+    /** Returns a single random surprise game */
+    suspend fun getSurpriseGame(): GameDto {
+        return client.get("$baseUrl/api/explore/surprise").body()
+    }
+
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
     suspend fun getRecentGames(): List<GameDto> {
         return client.get("$baseUrl/api/user/recent").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -630,3 +630,11 @@ fun GameFranchiseLinkDto.toDomain(): GameFranchiseLink = GameFranchiseLink(
     name = name,
     gameCount = gameCount,
 )
+
+fun MoodDefinitionDto.toDomain(): MoodDefinition = MoodDefinition(
+    id = id,
+    name = name,
+    description = description,
+    icon = icon,
+    gradient = gradient,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1107,3 +1107,12 @@ data class GameFranchiseLinkDto(
     val name: String,
     val gameCount: Int = 0,
 )
+
+@Serializable
+data class MoodDefinitionDto(
+    val id: String,
+    val name: String,
+    val description: String,
+    val icon: String,
+    val gradient: List<String>,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameFranchiseLink
 import com.spela.player.domain.model.GameSeriesLink
 import com.spela.player.domain.model.Keyword
+import com.spela.player.domain.model.MoodDefinition
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.Theme
 import com.spela.player.domain.repository.ExploreRepository
@@ -94,5 +95,28 @@ class ExploreRepositoryImpl(
 
     override suspend fun getGameFranchises(gameId: String): Result<List<GameFranchiseLink>> = runCatching {
         apiClient.getGameFranchises(gameId).map { it.toDomain() }
+    }
+
+    override suspend fun getMoods(): Result<List<MoodDefinition>> = runCatching {
+        apiClient.getMoods().map { it.toDomain() }
+    }
+
+    override suspend fun getMoodGames(mood: String): Result<List<Game>> = runCatching {
+        apiClient.getMoodGames(mood).map { gameDto ->
+            gameDto.toDomain().copy(
+                coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+                logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+            )
+        }
+    }
+
+    override suspend fun getSurpriseGame(): Result<Game> = runCatching {
+        val gameDto = apiClient.getSurpriseGame()
+        gameDto.toDomain().copy(
+            coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+            heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+            logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+        )
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -82,3 +82,11 @@ data class GameFranchiseLink(
     val name: String,
     val gameCount: Int,
 )
+
+data class MoodDefinition(
+    val id: String,
+    val name: String,
+    val description: String,
+    val icon: String,
+    val gradient: List<String>,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -7,6 +7,7 @@ import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameFranchiseLink
 import com.spela.player.domain.model.GameSeriesLink
 import com.spela.player.domain.model.Keyword
+import com.spela.player.domain.model.MoodDefinition
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.Theme
 
@@ -21,4 +22,7 @@ interface ExploreRepository {
     suspend fun getSeriesDetail(id: String): Result<SeriesDetail>
     suspend fun getGameSeries(gameId: String): Result<List<GameSeriesLink>>
     suspend fun getGameFranchises(gameId: String): Result<List<GameFranchiseLink>>
+    suspend fun getMoods(): Result<List<MoodDefinition>>
+    suspend fun getMoodGames(mood: String): Result<List<Game>>
+    suspend fun getSurpriseGame(): Result<Game>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -32,6 +32,7 @@ sealed class SpScreen(val route: String) {
     data class ExploreTheme(val themeId: String, val themeName: String) : SpScreen("explore_theme/$themeId")
     data class ExploreKeyword(val keywordId: String, val keywordName: String) : SpScreen("explore_keyword/$keywordId")
     data class ExploreSeries(val seriesId: String, val seriesName: String) : SpScreen("explore_series/$seriesId")
+    data class ExploreMood(val moodId: String, val moodName: String) : SpScreen("explore_mood/$moodId")
 }
 
 data class NavigationState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -93,6 +93,7 @@ import com.spela.player.presentation.ui.screen.ChallengeListScreen
 import com.spela.player.presentation.ui.screen.GlobalChallengesScreen
 import com.spela.player.presentation.ui.screen.StatsScreen
 import com.spela.player.presentation.ui.screen.ExploreKeywordScreen
+import com.spela.player.presentation.ui.screen.ExploreMoodScreen
 import com.spela.player.presentation.ui.screen.ExploreScreen
 import com.spela.player.presentation.ui.screen.ExploreSeriesScreen
 import com.spela.player.presentation.ui.screen.ExploreThemeScreen
@@ -470,6 +471,18 @@ fun SpelaApp(
                                                 NavigationIntent.NavigateTo(SpScreen.ExploreSeries(seriesId, seriesName))
                                             )
                                         },
+                                        onMoodSelected = { moodId, moodName ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreMood(moodId, moodName))
+                                            )
+                                        },
+                                        onSurpriseMe = {
+                                            exploreViewModel.loadSurpriseGame { gameId ->
+                                                navigationViewModel.onIntent(
+                                                    NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                                )
+                                            }
+                                        },
                                     )
                                 }
                             }
@@ -515,6 +528,24 @@ fun SpelaApp(
                                     ExploreSeriesScreen(
                                         seriesId = screen.seriesId,
                                         seriesName = screen.seriesName,
+                                        viewModel = exploreViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.ExploreMood -> {
+                                if (exploreViewModel != null) {
+                                    ExploreMoodScreen(
+                                        moodId = screen.moodId,
+                                        moodName = screen.moodName,
                                         viewModel = exploreViewModel,
                                         onGameSelected = { gameId ->
                                             navigationViewModel.onIntent(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/MoodPicker.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/MoodPicker.kt
@@ -1,0 +1,196 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.MoodDefinition
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpShimmer
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.parseHexColor
+
+@Composable
+fun MoodPicker(
+    moods: List<MoodDefinition>,
+    onMoodSelected: (moodId: String, moodName: String) -> Unit,
+    onSurpriseMe: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("mood_picker"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        itemsIndexed(moods, key = { _, item -> item.id }) { _, item ->
+            MoodCard(
+                mood = item,
+                onClick = { onMoodSelected(item.id, item.name) },
+            )
+        }
+
+        // "Surprise Me" card at the end
+        item {
+            SurpriseMeCard(onClick = onSurpriseMe)
+        }
+    }
+}
+
+@Composable
+private fun MoodCard(
+    mood: MoodDefinition,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
+    val gradientColors = mood.gradient.map { parseHexColor(it, Color(0xFF424242)) }.ifEmpty {
+        listOf(Color(0xFF424242), Color(0xFF616161))
+    }
+
+    SpCard(
+        modifier = Modifier
+            .width(200.dp)
+            .height(100.dp)
+            .testTag("mood_card_${mood.id}")
+            .semantics {
+                contentDescription = "${mood.name}, ${mood.description}"
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(100.dp)
+                .clip(shape)
+                .background(Brush.linearGradient(gradientColors)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(SpSpacing.Medium),
+            ) {
+                Text(
+                    text = mood.icon,
+                    style = SpTypography.HeadlineMedium,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = mood.name,
+                    style = SpTypography.TitleSmall,
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = mood.description,
+                    style = SpTypography.LabelSmall,
+                    color = Color.White.copy(alpha = 0.7f),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun SurpriseMeCard(
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
+    val gradientColors = listOf(Color(0xFF880E4F), Color(0xFFE91E63))
+
+    SpCard(
+        modifier = Modifier
+            .width(200.dp)
+            .height(100.dp)
+            .testTag("mood_card_surprise")
+            .semantics {
+                contentDescription = "Surprise Me, pick a random game"
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(100.dp)
+                .clip(shape)
+                .background(Brush.linearGradient(gradientColors)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(SpSpacing.Medium),
+            ) {
+                Text(
+                    text = "\uD83C\uDFB2",
+                    style = SpTypography.TitleLarge,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = "Surprise Me",
+                    style = SpTypography.TitleLarge,
+                    color = Color.White,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    textAlign = TextAlign.Center,
+                )
+                Text(
+                    text = "Pick a random game",
+                    style = SpTypography.LabelSmall,
+                    color = Color.White.copy(alpha = 0.85f),
+                    textAlign = TextAlign.Center,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun MoodPickerSkeleton(
+    modifier: Modifier = Modifier,
+    count: Int = 4,
+) {
+    LazyRow(
+        modifier = modifier.testTag("mood_picker_skeleton"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(count) {
+            SpShimmer(
+                modifier = Modifier
+                    .width(200.dp)
+                    .clip(RoundedCornerShape(SpSpacing.CardCornerRadius)),
+                width = 200.dp,
+                height = 100.dp,
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreMoodScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreMoodScreen.kt
@@ -1,0 +1,267 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SentimentSatisfied
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+import com.spela.player.util.parseHexColor
+
+@Composable
+fun ExploreMoodScreen(
+    moodId: String,
+    moodName: String,
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val state by viewModel.moodDetailState.collectAsState()
+
+    LaunchedEffect(moodId) {
+        viewModel.loadMoodGames(moodId, moodName)
+    }
+
+    Box(modifier = Modifier.fillMaxSize().testTag("explore_mood_screen")) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = moodName,
+                showBack = true,
+                onBack = onBack,
+            )
+
+            when {
+                state.isLoading && state.games.isEmpty() -> {
+                    // Loading skeleton
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(SpSpacing.ScreenHorizontal)
+                            .testTag("mood_detail_loading"),
+                    ) {
+                        Spacer(Modifier.height(SpSpacing.Large))
+                        repeat(4) {
+                            SpGameCardSkeleton(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(bottom = SpSpacing.Medium),
+                            )
+                        }
+                    }
+                }
+
+                state.games.isNotEmpty() -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = SpSpacing.XXLarge),
+                    ) {
+                        // Mood banner with gradient
+                        state.mood?.let { mood ->
+                            item {
+                                val gradientColors = mood.gradient.map { parseHexColor(it, Color(0xFF424242)) }.ifEmpty {
+                                    listOf(SpColor.Primary.copy(alpha = 0.3f), SpColor.Background)
+                                }
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .height(120.dp)
+                                        .background(Brush.verticalGradient(gradientColors + SpColor.Background))
+                                        .testTag("mood_hero_banner"),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    Column(
+                                        horizontalAlignment = Alignment.CenterHorizontally,
+                                    ) {
+                                        Text(
+                                            text = mood.icon,
+                                            style = SpTypography.DisplaySmall,
+                                        )
+                                        Spacer(Modifier.height(SpSpacing.Small))
+                                        Text(
+                                            text = mood.description,
+                                            style = SpTypography.BodyMedium,
+                                            color = Color.White.copy(alpha = 0.85f),
+                                        )
+                                    }
+                                }
+                            }
+                        }
+
+                        // Game count
+                        item {
+                            Text(
+                                text = "${state.games.size} games",
+                                style = SpTypography.BodyMedium,
+                                color = SpColor.OnBackgroundSecondary,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .padding(bottom = SpSpacing.Medium)
+                                    .testTag("mood_game_count"),
+                            )
+                        }
+
+                        // Game list
+                        items(
+                            items = state.games,
+                            key = { it.id },
+                        ) { game ->
+                            MoodGameItem(
+                                game = game,
+                                onClick = { onGameSelected(game.id) },
+                            )
+                        }
+                    }
+                }
+
+                state.error == null -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.SentimentSatisfied,
+                            title = "No games found",
+                            message = "No games match this mood right now.",
+                            modifier = Modifier.testTag("mood_empty_state"),
+                        )
+                    }
+                }
+            }
+        }
+
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.dismissMoodDetailError() },
+                )
+            },
+            onDismiss = { viewModel.dismissMoodDetailError() },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@Composable
+private fun MoodGameItem(
+    game: Game,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.XSmall,
+            )
+            .testTag("mood_game_${game.id}")
+            .semantics {
+                contentDescription = buildString {
+                    append(game.title)
+                    if (game.consoleName.isNotEmpty()) append(", ${game.consoleName}")
+                }
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SpSpacing.Medium),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+        ) {
+            // Cover art
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.title} cover art",
+                modifier = Modifier
+                    .width(48.dp)
+                    .height(64.dp)
+                    .clip(RoundedCornerShape(SpSpacing.RadiusSmall)),
+                aspectRatio = game.coverAspectRatio,
+            )
+
+            // Game info
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = game.title,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                if (game.consoleName.isNotEmpty()) {
+                    Spacer(Modifier.height(SpSpacing.XXSmall))
+                    Text(
+                        text = game.consoleName,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                    )
+                }
+
+                game.genre?.let { genre ->
+                    Spacer(Modifier.height(SpSpacing.XXSmall))
+                    Text(
+                        text = genre,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -28,6 +28,8 @@ import com.spela.player.presentation.ui.feature.explore.HeroCarousel
 import com.spela.player.presentation.ui.feature.explore.HeroCarouselSkeleton
 import com.spela.player.presentation.ui.feature.explore.KeywordChips
 import com.spela.player.presentation.ui.feature.explore.KeywordChipsSkeleton
+import com.spela.player.presentation.ui.feature.explore.MoodPicker
+import com.spela.player.presentation.ui.feature.explore.MoodPickerSkeleton
 import com.spela.player.presentation.ui.feature.explore.SeriesShelf
 import com.spela.player.presentation.ui.feature.explore.SeriesShelfSkeleton
 import com.spela.player.presentation.ui.feature.explore.ThemeGrid
@@ -43,6 +45,8 @@ fun ExploreScreen(
     onThemeSelected: ((themeId: String, themeName: String) -> Unit)? = null,
     onKeywordSelected: ((keywordId: String, keywordName: String) -> Unit)? = null,
     onSeriesSelected: ((seriesId: String, seriesName: String) -> Unit)? = null,
+    onMoodSelected: ((moodId: String, moodName: String) -> Unit)? = null,
+    onSurpriseMe: (() -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
 
@@ -99,6 +103,37 @@ fun ExploreScreen(
                                     vertical = SpSpacing.Default,
                                 ),
                             )
+                        }
+                    }
+
+                    // Mood picker section
+                    item {
+                        if (state.isLoadingMoods && state.moods.isEmpty()) {
+                            SpTitledSection(
+                                title = "What are you in the mood for?",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                MoodPickerSkeleton()
+                            }
+                        } else if (state.moods.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "What are you in the mood for?",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_moods_section"),
+                            ) {
+                                MoodPicker(
+                                    moods = state.moods,
+                                    onMoodSelected = { moodId, moodName ->
+                                        onMoodSelected?.invoke(moodId, moodName)
+                                    },
+                                    onSurpriseMe = {
+                                        onSurpriseMe?.invoke()
+                                    },
+                                )
+                            }
                         }
                     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -5,6 +5,7 @@ import com.spela.player.domain.model.FeaturedGame
 import com.spela.player.domain.model.FeaturedSeries
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.Keyword
+import com.spela.player.domain.model.MoodDefinition
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.Theme
 import com.spela.player.domain.repository.ExploreRepository
@@ -16,6 +17,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 data class ExploreState(
     val featuredGames: List<FeaturedGame> = emptyList(),
@@ -23,15 +25,17 @@ data class ExploreState(
     val themes: List<Theme> = emptyList(),
     val keywords: List<Keyword> = emptyList(),
     val featuredSeries: List<FeaturedSeries> = emptyList(),
+    val moods: List<MoodDefinition> = emptyList(),
     val isLoadingFeatured: Boolean = false,
     val isLoadingRows: Boolean = false,
     val isLoadingThemes: Boolean = false,
     val isLoadingKeywords: Boolean = false,
     val isLoadingFeaturedSeries: Boolean = false,
+    val isLoadingMoods: Boolean = false,
     val error: String? = null,
 ) {
-    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries
-    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && !isLoading
+    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods
+    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && !isLoading
 }
 
 data class ThemeDetailState(
@@ -45,6 +49,15 @@ data class ThemeDetailState(
 data class KeywordDetailState(
     val keywordId: String = "",
     val keywordName: String = "",
+    val games: List<Game> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+data class MoodDetailState(
+    val moodId: String = "",
+    val moodName: String = "",
+    val mood: MoodDefinition? = null,
     val games: List<Game> = emptyList(),
     val isLoading: Boolean = false,
     val error: String? = null,
@@ -87,6 +100,9 @@ class ExploreViewModel(
     private val _seriesDetailState = MutableStateFlow(SeriesDetailState())
     val seriesDetailState: StateFlow<SeriesDetailState> = _seriesDetailState.asStateFlow()
 
+    private val _moodDetailState = MutableStateFlow(MoodDetailState())
+    val moodDetailState: StateFlow<MoodDetailState> = _moodDetailState.asStateFlow()
+
     private var featuredJob: Job? = null
     private var rowsJob: Job? = null
     private var themesJob: Job? = null
@@ -95,6 +111,8 @@ class ExploreViewModel(
     private var keywordDetailJob: Job? = null
     private var featuredSeriesJob: Job? = null
     private var seriesDetailJob: Job? = null
+    private var moodsJob: Job? = null
+    private var moodDetailJob: Job? = null
 
     fun load() {
         loadFeatured()
@@ -102,6 +120,7 @@ class ExploreViewModel(
         loadThemes()
         loadKeywords()
         loadFeaturedSeries()
+        loadMoods()
     }
 
     fun dismissError() {
@@ -248,5 +267,57 @@ class ExploreViewModel(
                 },
             )
         }
+    }
+
+    private fun loadMoods() {
+        if (moodsJob?.isActive == true) return
+        _state.update { it.copy(isLoadingMoods = true) }
+        moodsJob = scope.launch(dispatchers.io) {
+            exploreRepository.getMoods().fold(
+                onSuccess = { moods ->
+                    _state.update { it.copy(moods = moods, isLoadingMoods = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoadingMoods = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun loadMoodGames(moodId: String, moodName: String) {
+        moodDetailJob?.cancel()
+        val mood = _state.value.moods.find { it.id == moodId }
+        _moodDetailState.update {
+            MoodDetailState(moodId = moodId, moodName = moodName, mood = mood, isLoading = true)
+        }
+        moodDetailJob = scope.launch(dispatchers.io) {
+            exploreRepository.getMoodGames(moodId).fold(
+                onSuccess = { games ->
+                    _moodDetailState.update { it.copy(games = games, isLoading = false) }
+                },
+                onFailure = { error ->
+                    _moodDetailState.update { it.copy(isLoading = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun loadSurpriseGame(onGameSelected: (String) -> Unit) {
+        scope.launch(dispatchers.io) {
+            exploreRepository.getSurpriseGame().fold(
+                onSuccess = { game ->
+                    withContext(dispatchers.main) {
+                        onGameSelected(game.id)
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun dismissMoodDetailError() {
+        _moodDetailState.update { it.copy(error = null) }
     }
 }

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -485,3 +485,303 @@ func (h *ExploreHandler) GetExploreFeaturedSeries(c *gin.Context) {
 	c.JSON(http.StatusOK, result)
 }
 
+// MoodResponse is the API response for a single mood option.
+type MoodResponse struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Icon        string   `json:"icon"`
+	Gradient    []string `json:"gradient"`
+}
+
+// moodDefinitions holds the static list of available moods.
+var moodDefinitions = []MoodResponse{
+	{ID: "chill", Name: "Chill", Description: "Relax with something easy-going", Icon: "\U0001F3B5", Gradient: []string{"#1B5E20", "#4CAF50"}},
+	{ID: "challenge", Name: "Challenge Me", Description: "Test your skills with something tough", Icon: "\U0001F525", Gradient: []string{"#B71C1C", "#F44336"}},
+	{ID: "nostalgia", Name: "Nostalgia Trip", Description: "Revisit your most-played classics", Icon: "\u2728", Gradient: []string{"#4A148C", "#9C27B0"}},
+	{ID: "something-new", Name: "Something New", Description: "Try a game you haven't played yet", Icon: "\U0001F195", Gradient: []string{"#0D47A1", "#2196F3"}},
+	{ID: "quick", Name: "Quick Session", Description: "Pick up and play in under 15 minutes", Icon: "\u26A1", Gradient: []string{"#E65100", "#FF9800"}},
+	{ID: "together", Name: "Play Together", Description: "Games built for multiplayer fun", Icon: "\U0001F3AE", Gradient: []string{"#006064", "#00BCD4"}},
+}
+
+// GetExploreMoods returns the list of available moods for the mood picker.
+// GET /api/explore/moods
+func (h *ExploreHandler) GetExploreMoods(c *gin.Context) {
+	c.JSON(http.StatusOK, moodDefinitions)
+}
+
+// GetMoodGames returns games matching the specified mood criteria.
+// GET /api/explore/mood/:mood
+func (h *ExploreHandler) GetMoodGames(c *gin.Context) {
+	userID := getUserID(c)
+	mood := c.Param("mood")
+
+	var games []db.Game
+	var err error
+
+	switch mood {
+	case "chill":
+		games, err = h.getMoodChillGames()
+	case "challenge":
+		games, err = h.getMoodChallengeGames()
+	case "nostalgia":
+		games, err = h.getMoodNostalgiaGames(userID)
+	case "something-new":
+		games, err = h.getMoodSomethingNewGames(userID)
+	case "quick":
+		games, err = h.getMoodQuickGames()
+	case "together":
+		games, err = h.getMoodTogetherGames()
+	default:
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid mood"})
+		return
+	}
+
+	if err != nil {
+		slog.Error("failed to fetch mood games", "mood", mood, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch mood games"})
+		return
+	}
+
+	c.JSON(http.StatusOK, ToGameResponses(games, h.DB, userID))
+}
+
+// getMoodChillGames returns games suitable for chill/relaxed play.
+// Matches themes (Fantasy, Comedy), genres (Puzzle, Simulation), or keywords (relaxing, casual).
+func (h *ExploreHandler) getMoodChillGames() ([]db.Game, error) {
+	// Collect matching game IDs from themes, keywords, and genre
+	gameIDSet := make(map[uint]bool)
+
+	// Themes: Fantasy, Comedy
+	var themeGameIDs []uint
+	if err := h.DB.Model(&db.GameTheme{}).
+		Select("DISTINCT game_id").
+		Where("name IN ?", []string{"Fantasy", "Comedy"}).
+		Pluck("game_id", &themeGameIDs).Error; err != nil {
+		return nil, err
+	}
+	for _, id := range themeGameIDs {
+		gameIDSet[id] = true
+	}
+
+	// Keywords: relaxing, casual
+	var keywordGameIDs []uint
+	if err := h.DB.Model(&db.GameKeyword{}).
+		Select("DISTINCT game_id").
+		Where("LOWER(name) LIKE ? OR LOWER(name) LIKE ?", "%relaxing%", "%casual%").
+		Pluck("game_id", &keywordGameIDs).Error; err != nil {
+		return nil, err
+	}
+	for _, id := range keywordGameIDs {
+		gameIDSet[id] = true
+	}
+
+	// Genre: Puzzle, Simulation
+	var genreGameIDs []uint
+	if err := h.DB.Model(&db.Game{}).
+		Select("id").
+		Where("LOWER(genre) LIKE ? OR LOWER(genre) LIKE ?", "%puzzle%", "%simulation%").
+		Pluck("id", &genreGameIDs).Error; err != nil {
+		return nil, err
+	}
+	for _, id := range genreGameIDs {
+		gameIDSet[id] = true
+	}
+
+	return h.loadGamesByIDs(gameIDSet, "games.rating DESC", 20)
+}
+
+// getMoodChallengeGames returns games that are difficult or intense.
+// Matches keywords (difficult, hardcore) or themes (Survival, Horror).
+func (h *ExploreHandler) getMoodChallengeGames() ([]db.Game, error) {
+	gameIDSet := make(map[uint]bool)
+
+	// Keywords: difficult, hardcore
+	var keywordGameIDs []uint
+	if err := h.DB.Model(&db.GameKeyword{}).
+		Select("DISTINCT game_id").
+		Where("LOWER(name) LIKE ? OR LOWER(name) LIKE ?", "%difficult%", "%hardcore%").
+		Pluck("game_id", &keywordGameIDs).Error; err != nil {
+		return nil, err
+	}
+	for _, id := range keywordGameIDs {
+		gameIDSet[id] = true
+	}
+
+	// Themes: Survival, Horror
+	var themeGameIDs []uint
+	if err := h.DB.Model(&db.GameTheme{}).
+		Select("DISTINCT game_id").
+		Where("name IN ?", []string{"Survival", "Horror"}).
+		Pluck("game_id", &themeGameIDs).Error; err != nil {
+		return nil, err
+	}
+	for _, id := range themeGameIDs {
+		gameIDSet[id] = true
+	}
+
+	return h.loadGamesByIDs(gameIDSet, "games.rating DESC", 20)
+}
+
+// getMoodNostalgiaGames returns the user's most-played games.
+func (h *ExploreHandler) getMoodNostalgiaGames(userID uint) ([]db.Game, error) {
+	// Get the user's most-played games ordered by play_time DESC
+	type playRow struct {
+		GameID   uint
+		PlayTime int64
+	}
+	var playRows []playRow
+	if err := h.DB.Model(&db.PlayHistory{}).
+		Select("game_id, play_time").
+		Where("user_id = ? AND play_time > 0", userID).
+		Order("play_time DESC").
+		Limit(20).
+		Scan(&playRows).Error; err != nil {
+		return nil, err
+	}
+
+	if len(playRows) == 0 {
+		return []db.Game{}, nil
+	}
+
+	gameIDs := make([]uint, len(playRows))
+	for i, r := range playRows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	// Re-sort by play time (IN query doesn't preserve order)
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+	sorted := make([]db.Game, 0, len(playRows))
+	for _, r := range playRows {
+		if g, ok := gameMap[r.GameID]; ok {
+			sorted = append(sorted, g)
+		}
+	}
+
+	return sorted, nil
+}
+
+// getMoodSomethingNewGames returns games the user hasn't played yet.
+func (h *ExploreHandler) getMoodSomethingNewGames(userID uint) ([]db.Game, error) {
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Joins("LEFT JOIN play_histories ON play_histories.game_id = games.id AND play_histories.user_id = ? AND play_histories.deleted_at IS NULL", userID).
+		Where("games.deleted_at IS NULL").
+		Where("play_histories.id IS NULL OR play_histories.play_time = 0").
+		Order("games.rating DESC").
+		Limit(20).
+		Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	return games, nil
+}
+
+// getMoodQuickGames returns games with short average session times (< 15 min / 900 seconds).
+func (h *ExploreHandler) getMoodQuickGames() ([]db.Game, error) {
+	// Aggregate play_histories per game: total_play_time / count(*) = avg session time
+	type quickRow struct {
+		GameID         uint
+		AvgSessionTime float64
+	}
+	var quickRows []quickRow
+	if err := h.DB.Model(&db.PlayHistory{}).
+		Select("game_id, CAST(SUM(play_time) AS REAL) / COUNT(*) as avg_session_time").
+		Where("play_time > 0").
+		Group("game_id").
+		Having("avg_session_time < 900 AND avg_session_time > 0").
+		Scan(&quickRows).Error; err != nil {
+		return nil, err
+	}
+
+	if len(quickRows) == 0 {
+		return []db.Game{}, nil
+	}
+
+	gameIDs := make([]uint, len(quickRows))
+	for i, r := range quickRows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("id IN ?", gameIDs).
+		Order("rating DESC").
+		Limit(20).
+		Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	return games, nil
+}
+
+// getMoodTogetherGames returns multiplayer-capable games (players > 1).
+func (h *ExploreHandler) getMoodTogetherGames() ([]db.Game, error) {
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("players > 1").
+		Order("rating DESC").
+		Limit(20).
+		Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	return games, nil
+}
+
+// loadGamesByIDs loads games by a set of IDs with the given order and limit.
+// Returns an empty slice (not nil) if no IDs match.
+func (h *ExploreHandler) loadGamesByIDs(idSet map[uint]bool, order string, limit int) ([]db.Game, error) {
+	if len(idSet) == 0 {
+		return []db.Game{}, nil
+	}
+
+	ids := make([]uint, 0, len(idSet))
+	for id := range idSet {
+		ids = append(ids, id)
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("id IN ?", ids).
+		Order(order).
+		Limit(limit).
+		Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	return games, nil
+}
+
+// GetSurpriseGame returns a single random game with high rating and cover art.
+// GET /api/explore/surprise
+func (h *ExploreHandler) GetSurpriseGame(c *gin.Context) {
+	userID := getUserID(c)
+
+	// Pick a random eligible game using SQL ORDER BY RANDOM() to avoid loading all games into memory
+	var game db.Game
+	if err := h.DB.Preload("Console").
+		Where("rating > 70 AND cover_url != ''").
+		Order("RANDOM()").
+		Limit(1).
+		First(&game).Error; err != nil {
+		if err.Error() == "record not found" {
+			c.JSON(http.StatusNotFound, gin.H{"error": "no eligible games found"})
+			return
+		}
+		slog.Error("failed to fetch surprise game", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch surprise game"})
+		return
+	}
+
+	c.JSON(http.StatusOK, ToGameResponse(game, h.DB, userID))
+}
+

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -1052,3 +1052,403 @@ func TestGetExploreFeaturedSeries_Limit20(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Len(t, resp, 20, "should be limited to 20 series")
 }
+
+// --- Helper: create game with custom genre and players ---
+
+func createExploreGameWithGenre(t *testing.T, database *gorm.DB, consoleAbbr, title string, rating float64, genre string, players int) db.Game {
+	t.Helper()
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", consoleAbbr).First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     title,
+		FileName:  title + ".rom",
+		FilePath:  consoleAbbr + "/" + title + ".rom",
+		Rating:    rating,
+		Genre:     genre,
+		Players:   players,
+	}
+	require.NoError(t, database.Create(&game).Error)
+	return game
+}
+
+// createExploreGameWithCover creates a game with cover art for surprise endpoint testing.
+func createExploreGameWithCover(t *testing.T, database *gorm.DB, consoleAbbr, title string, rating float64) db.Game {
+	t.Helper()
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", consoleAbbr).First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     title,
+		FileName:  title + ".rom",
+		FilePath:  consoleAbbr + "/" + title + ".rom",
+		Rating:    rating,
+		Genre:     "Action",
+		CoverURL:  "https://images.igdb.com/cover/" + title + ".jpg",
+	}
+	require.NoError(t, database.Create(&game).Error)
+	return game
+}
+
+// --- Mood endpoint tests ---
+
+func TestGetExploreMoods(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/moods", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []MoodResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp, 6)
+
+	// Verify all mood IDs are present
+	ids := make(map[string]bool)
+	for _, m := range resp {
+		ids[m.ID] = true
+		assert.NotEmpty(t, m.Name)
+		assert.NotEmpty(t, m.Description)
+		assert.NotEmpty(t, m.Icon)
+		assert.Len(t, m.Gradient, 2)
+	}
+	assert.True(t, ids["chill"])
+	assert.True(t, ids["challenge"])
+	assert.True(t, ids["nostalgia"])
+	assert.True(t, ids["something-new"])
+	assert.True(t, ids["quick"])
+	assert.True(t, ids["together"])
+}
+
+func TestGetMoodGames_Chill(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create games matching chill criteria
+	puzzleGame := createExploreGameWithGenre(t, env.database, "NES", "Puzzle Paradise", 80, "Puzzle", 1)
+	simGame := createExploreGameWithGenre(t, env.database, "SNES", "SimCity", 75, "Simulation", 1)
+
+	// Create a game with Fantasy theme
+	fantasyGame := createExploreGame(t, env.database, "GBA", "Fantasy Quest", 85)
+	env.database.Create(&db.GameTheme{GameID: fantasyGame.ID, IGDBThemeID: 1, Name: "Fantasy"})
+
+	// Create a game with "casual" keyword
+	casualGame := createExploreGame(t, env.database, "NES", "Casual Fun", 70)
+	env.database.Create(&db.GameKeyword{GameID: casualGame.ID, IGDBKeywordID: 1, Name: "casual"})
+
+	// Create a game that does NOT match chill criteria
+	createExploreGame(t, env.database, "NES", "Dark Shooter", 90)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/mood/chill", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Should have the 4 matching games
+	assert.Len(t, resp, 4)
+
+	// Collect returned titles
+	titles := make(map[string]bool)
+	for _, g := range resp {
+		titles[g.Title] = true
+	}
+	assert.True(t, titles[puzzleGame.Title], "puzzle game should be included")
+	assert.True(t, titles[simGame.Title], "simulation game should be included")
+	assert.True(t, titles[fantasyGame.Title], "fantasy theme game should be included")
+	assert.True(t, titles[casualGame.Title], "casual keyword game should be included")
+	assert.False(t, titles["Dark Shooter"], "non-chill game should not be included")
+}
+
+func TestGetMoodGames_Challenge(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Game with Horror theme
+	horrorGame := createExploreGame(t, env.database, "NES", "Resident Evil", 85)
+	env.database.Create(&db.GameTheme{GameID: horrorGame.ID, IGDBThemeID: 2, Name: "Horror"})
+
+	// Game with Survival theme
+	survivalGame := createExploreGame(t, env.database, "SNES", "Survival Island", 80)
+	env.database.Create(&db.GameTheme{GameID: survivalGame.ID, IGDBThemeID: 3, Name: "Survival"})
+
+	// Game with "difficult" keyword
+	hardGame := createExploreGame(t, env.database, "GBA", "Super Hard Game", 75)
+	env.database.Create(&db.GameKeyword{GameID: hardGame.ID, IGDBKeywordID: 2, Name: "difficult"})
+
+	// Non-matching game
+	createExploreGame(t, env.database, "NES", "Easy Game", 90)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/mood/challenge", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Len(t, resp, 3)
+
+	titles := make(map[string]bool)
+	for _, g := range resp {
+		titles[g.Title] = true
+	}
+	assert.True(t, titles["Resident Evil"])
+	assert.True(t, titles["Survival Island"])
+	assert.True(t, titles["Super Hard Game"])
+	assert.False(t, titles["Easy Game"])
+}
+
+func TestGetMoodGames_Nostalgia(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "NES", "Most Played Classic", 90)
+	game2 := createExploreGame(t, env.database, "SNES", "Second Most Played", 85)
+	createExploreGame(t, env.database, "GBA", "Never Played", 80)
+
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Add play history for user
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game1.ID,
+		PlayTime:   5000,
+		LastPlayed: time.Now(),
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game2.ID,
+		PlayTime:   2000,
+		LastPlayed: time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/mood/nostalgia", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Should return only played games, sorted by play time DESC
+	assert.Len(t, resp, 2)
+	assert.Equal(t, "Most Played Classic", resp[0].Title)
+	assert.Equal(t, "Second Most Played", resp[1].Title)
+}
+
+func TestGetMoodGames_SomethingNew(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	playedGame := createExploreGame(t, env.database, "NES", "Already Played", 90)
+	unplayedGame1 := createExploreGame(t, env.database, "SNES", "Brand New 1", 85)
+	unplayedGame2 := createExploreGame(t, env.database, "GBA", "Brand New 2", 80)
+
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// User has played one game
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     playedGame.ID,
+		PlayTime:   3000,
+		LastPlayed: time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/mood/something-new", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Should return only unplayed games, sorted by rating DESC
+	assert.Len(t, resp, 2)
+	titles := make(map[string]bool)
+	for _, g := range resp {
+		titles[g.Title] = true
+	}
+	assert.True(t, titles[unplayedGame1.Title])
+	assert.True(t, titles[unplayedGame2.Title])
+	assert.False(t, titles[playedGame.Title])
+}
+
+func TestGetMoodGames_Quick(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	quickGame := createExploreGame(t, env.database, "NES", "Quick Game", 80)
+	longGame := createExploreGame(t, env.database, "SNES", "Long Game", 85)
+
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Quick game: avg session time < 900 seconds (short sessions)
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     quickGame.ID,
+		PlayTime:   300, // 5 minutes
+		LastPlayed: time.Now(),
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     quickGame.ID,
+		PlayTime:   400, // ~6.7 minutes
+		LastPlayed: time.Now(),
+	})
+
+	// Long game: avg session time > 900 seconds
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     longGame.ID,
+		PlayTime:   3600, // 1 hour
+		LastPlayed: time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/mood/quick", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Should only return the quick game
+	assert.Len(t, resp, 1)
+	assert.Equal(t, "Quick Game", resp[0].Title)
+}
+
+func TestGetMoodGames_Together(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Multiplayer game
+	multiGame := createExploreGameWithGenre(t, env.database, "NES", "Mario Kart", 90, "Racing", 4)
+	// Another multiplayer
+	coopGame := createExploreGameWithGenre(t, env.database, "SNES", "Contra", 85, "Action", 2)
+	// Single player only
+	createExploreGameWithGenre(t, env.database, "GBA", "Solo RPG", 80, "RPG", 1)
+	// Players = 0 (unset, should not match)
+	createExploreGame(t, env.database, "NES", "Unknown Players", 75)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/mood/together", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Len(t, resp, 2)
+	titles := make(map[string]bool)
+	for _, g := range resp {
+		titles[g.Title] = true
+	}
+	assert.True(t, titles[multiGame.Title])
+	assert.True(t, titles[coopGame.Title])
+}
+
+func TestGetMoodGames_InvalidMood(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/mood/nonexistent", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetMoodGames_Empty(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// No games with Horror/Survival themes or difficult/hardcore keywords exist
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/mood/challenge", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp)
+
+	// Verify JSON is empty array, not null
+	assert.Contains(t, w.Body.String(), "[]")
+}
+
+// --- Surprise endpoint tests ---
+
+func TestGetSurpriseGame(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create eligible games (rating > 70 with cover art)
+	createExploreGameWithCover(t, env.database, "NES", "Great Game 1", 80)
+	createExploreGameWithCover(t, env.database, "SNES", "Great Game 2", 85)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/surprise", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.ID)
+	assert.NotEmpty(t, resp.Title)
+	assert.Greater(t, resp.Rating, 70.0)
+	assert.NotEmpty(t, resp.CoverURL)
+}
+
+func TestGetSurpriseGame_NoGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// No games with rating > 70 and cover art
+	createExploreGame(t, env.database, "NES", "Low Rated", 50)          // low rating
+	createExploreGame(t, env.database, "NES", "High Rated No Cover", 90) // no cover
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/surprise", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGetMoodGames_AuthRequired(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Test mood endpoint without auth
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/mood/chill", nil)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Test moods list without auth
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/explore/moods", nil)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Test surprise without auth
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/explore/surprise", nil)
+	env.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -240,6 +240,9 @@ func NewRouter(cfg Config) *gin.Engine {
 			explore.GET("/featured", exploreHandler.GetExploreFeatured)
 			explore.GET("/rows", exploreHandler.GetExploreRows)
 			explore.GET("/series/featured", exploreHandler.GetExploreFeaturedSeries)
+			explore.GET("/moods", exploreHandler.GetExploreMoods)
+			explore.GET("/mood/:mood", exploreHandler.GetMoodGames)
+			explore.GET("/surprise", exploreHandler.GetSurpriseGame)
 		}
 
 		// Games

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -39,6 +39,7 @@ import { ExplorePage } from "@/pages/explore-page";
 import { ExploreThemePage } from "@/pages/explore-theme-page";
 import { ExploreKeywordPage } from "@/pages/explore-keyword-page";
 import { ExploreSeriesPage } from "@/pages/explore-series-page";
+import { ExploreMoodPage } from "@/pages/explore-mood-page";
 import { ChallengeDetailPage } from "@/pages/challenge-detail-page";
 import { SessionDetailPage } from "@/pages/session-detail-page";
 import { SetupWizardPage } from "@/pages/setup-wizard-page";
@@ -98,6 +99,10 @@ export function App() {
                     <Route
                       path="explore/series/:id"
                       element={<ExploreSeriesPage />}
+                    />
+                    <Route
+                      path="explore/mood/:mood"
+                      element={<ExploreMoodPage />}
                     />
                     <Route element={<LibraryLayout />}>
                       <Route path="consoles" element={<ConsolesPage />} />

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { ExplorePage } from "@/pages/explore-page";
-import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword } from "@/types/api";
+import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition } from "@/types/api";
 
 // Mock hooks
 vi.mock("@/hooks/use-explore", () => ({
@@ -12,6 +12,12 @@ vi.mock("@/hooks/use-explore", () => ({
   useThemes: vi.fn(),
   useKeywords: vi.fn(),
   useFeaturedSeries: vi.fn(),
+  useMoods: vi.fn(),
+  useSurpriseGame: vi.fn(() => ({
+    data: undefined,
+    refetch: vi.fn(),
+    isSuccess: false,
+  })),
 }));
 
 vi.mock("@/hooks/use-games", () => ({
@@ -30,13 +36,14 @@ vi.mock("@/hooks/use-auto-scrape", () => ({
   useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
 }));
 
-import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries } from "@/hooks/use-explore";
+import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods } from "@/hooks/use-explore";
 
 const mockUseExploreFeatured = useExploreFeatured as ReturnType<typeof vi.fn>;
 const mockUseExploreRows = useExploreRows as ReturnType<typeof vi.fn>;
 const mockUseThemes = useThemes as ReturnType<typeof vi.fn>;
 const mockUseKeywords = useKeywords as ReturnType<typeof vi.fn>;
 const mockUseFeaturedSeries = useFeaturedSeries as ReturnType<typeof vi.fn>;
+const mockUseMoods = useMoods as ReturnType<typeof vi.fn>;
 
 function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
   return {
@@ -96,6 +103,11 @@ const mockKeywords: Keyword[] = [
 const mockFeaturedSeries: FeaturedSeries[] = [
   { id: "1", name: "Super Mario", libraryGames: 5, totalGames: 12, consoleCount: 3, heroUrl: "/hero/mario.jpg" },
   { id: "2", name: "The Legend of Zelda", libraryGames: 4, totalGames: 10, consoleCount: 2, heroUrl: "/hero/zelda.jpg" },
+];
+
+const mockMoods: MoodDefinition[] = [
+  { id: "chill", name: "Chill", description: "Relaxing games", icon: "😌", gradient: ["#1a237e", "#4a148c"] },
+  { id: "intense", name: "Intense", description: "Heart-pounding action", icon: "🔥", gradient: ["#b71c1c", "#ff6f00"] },
 ];
 
 const mockRows: ExploreRowsResponse = {
@@ -175,6 +187,10 @@ describe("ExplorePage", () => {
     });
     mockUseFeaturedSeries.mockReturnValue({
       data: mockFeaturedSeries,
+      isLoading: false,
+    });
+    mockUseMoods.mockReturnValue({
+      data: mockMoods,
       isLoading: false,
     });
   });
@@ -366,5 +382,30 @@ describe("ExplorePage", () => {
     });
     renderPage();
     expect(screen.getByTestId("series-shelf-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders the mood picker section", () => {
+    renderPage();
+    expect(screen.getByTestId("mood-picker")).toBeInTheDocument();
+    expect(screen.getByText("Chill")).toBeInTheDocument();
+    expect(screen.getByText("Intense")).toBeInTheDocument();
+  });
+
+  it("hides mood picker when no moods available", () => {
+    mockUseMoods.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("mood-picker")).not.toBeInTheDocument();
+  });
+
+  it("shows mood picker skeleton while loading", () => {
+    mockUseMoods.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByTestId("mood-picker-skeleton")).toBeInTheDocument();
   });
 });

--- a/web/src/features/explore/components/__tests__/mood-picker.test.tsx
+++ b/web/src/features/explore/components/__tests__/mood-picker.test.tsx
@@ -1,0 +1,143 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { MoodPicker } from "@/features/explore/components/mood-picker";
+import type { MoodDefinition } from "@/types/api";
+
+// Mock use-explore hooks
+const mockRefetch = vi.fn();
+vi.mock("@/hooks/use-explore", () => ({
+  useSurpriseGame: vi.fn(() => ({
+    data: undefined,
+    refetch: mockRefetch,
+    isSuccess: false,
+  })),
+}));
+
+const mockMoods: MoodDefinition[] = [
+  {
+    id: "chill",
+    name: "Chill",
+    description: "Relaxing and laid-back games",
+    icon: "😌",
+    gradient: ["#1a237e", "#4a148c"],
+  },
+  {
+    id: "intense",
+    name: "Intense",
+    description: "Heart-pounding action",
+    icon: "🔥",
+    gradient: ["#b71c1c", "#ff6f00"],
+  },
+  {
+    id: "nostalgic",
+    name: "Nostalgic",
+    description: "Classic retro vibes",
+    icon: "🕹️",
+    gradient: ["#4a148c", "#880e4f"],
+  },
+];
+
+function renderComponent(
+  moods: MoodDefinition[] | undefined = mockMoods,
+  isLoading = false,
+) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <MoodPicker moods={moods} isLoading={isLoading} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("MoodPicker", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders mood cards with correct names", () => {
+    renderComponent();
+    expect(screen.getByText("Chill")).toBeInTheDocument();
+    expect(screen.getByText("Intense")).toBeInTheDocument();
+    expect(screen.getByText("Nostalgic")).toBeInTheDocument();
+  });
+
+  it("renders correct test IDs", () => {
+    renderComponent();
+    expect(screen.getByTestId("mood-picker")).toBeInTheDocument();
+    expect(screen.getByTestId("mood-card-chill")).toBeInTheDocument();
+    expect(screen.getByTestId("mood-card-intense")).toBeInTheDocument();
+    expect(screen.getByTestId("mood-card-nostalgic")).toBeInTheDocument();
+  });
+
+  it("shows skeleton while loading", () => {
+    renderComponent(undefined, true);
+    expect(screen.getByTestId("mood-picker-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("mood-picker")).not.toBeInTheDocument();
+  });
+
+  it("returns null when moods is empty", () => {
+    const { container } = renderComponent([]);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("returns null when moods is undefined and not loading", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { container } = render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter>
+          <MoodPicker moods={undefined} isLoading={false} />
+        </MemoryRouter>
+      </QueryClientProvider>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("cards link to correct mood routes", () => {
+    renderComponent();
+    const chillLink = screen.getByTestId("mood-card-chill");
+    expect(chillLink).toHaveAttribute("href", "/explore/mood/chill");
+
+    const intenseLink = screen.getByTestId("mood-card-intense");
+    expect(intenseLink).toHaveAttribute("href", "/explore/mood/intense");
+  });
+
+  it("renders the surprise me button", () => {
+    renderComponent();
+    expect(screen.getByTestId("surprise-me-button")).toBeInTheDocument();
+    expect(screen.getByText("Surprise Me")).toBeInTheDocument();
+  });
+
+  it("calls refetch when surprise me button is clicked", () => {
+    renderComponent();
+    fireEvent.click(screen.getByTestId("surprise-me-button"));
+    expect(mockRefetch).toHaveBeenCalled();
+  });
+
+  it("renders mood descriptions", () => {
+    renderComponent();
+    expect(screen.getByText("Relaxing and laid-back games")).toBeInTheDocument();
+    expect(screen.getByText("Heart-pounding action")).toBeInTheDocument();
+  });
+
+  it("renders mood icons", () => {
+    renderComponent();
+    expect(screen.getByText("😌")).toBeInTheDocument();
+    expect(screen.getByText("🔥")).toBeInTheDocument();
+    expect(screen.getByText("🕹️")).toBeInTheDocument();
+  });
+
+  it("renders the section title", () => {
+    renderComponent();
+    expect(
+      screen.getByText("What are you in the mood for?"),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/features/explore/components/mood-picker.tsx
+++ b/web/src/features/explore/components/mood-picker.tsx
@@ -1,0 +1,106 @@
+import { useRef } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Skeleton } from "@/components/ui";
+import { useSurpriseGame } from "@/hooks/use-explore";
+import { buildGradient } from "@/features/explore/utils/gradient";
+import type { MoodDefinition } from "@/types/api";
+
+interface MoodPickerProps {
+  moods: MoodDefinition[] | undefined;
+  isLoading: boolean;
+}
+
+function MoodPickerSkeleton() {
+  return (
+    <section data-testid="mood-picker-skeleton">
+      <Skeleton className="w-72 h-7 mb-5" />
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {Array.from({ length: 6 }, (_, i) => (
+          <Skeleton key={i} className="h-32 rounded-xl" />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function MoodPicker({ moods, isLoading }: MoodPickerProps) {
+  const navigate = useNavigate();
+  const { refetch: fetchSurprise, isFetching: isSurpriseFetching } = useSurpriseGame();
+  const navigatedRef = useRef(false);
+
+  async function handleSurprise() {
+    navigatedRef.current = false;
+    const result = await fetchSurprise();
+    if (result?.data?.id && !navigatedRef.current) {
+      navigatedRef.current = true;
+      navigate(`/games/${result.data.id}`);
+    }
+  }
+
+  if (isLoading) {
+    return <MoodPickerSkeleton />;
+  }
+
+  if (!moods || moods.length === 0) {
+    return null;
+  }
+
+  return (
+    <section data-testid="mood-picker">
+      <h2 className="text-xl font-bold text-surface-100 mb-5">
+        What are you in the mood for?
+      </h2>
+
+      <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4" role="list" aria-label="What are you in the mood for?">
+        {moods.map((mood) => (
+          <Link
+            key={mood.id}
+            to={`/explore/mood/${mood.id}`}
+            data-testid={`mood-card-${mood.id}`}
+            className="group/mood block rounded-xl overflow-hidden shadow-md transition-all duration-200 hover:scale-[1.02] hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950"
+            style={{ background: buildGradient(mood.gradient) }}
+          >
+            <div className="relative h-32 flex flex-col justify-end p-4">
+              {/* Subtle overlay for text readability */}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-white/[0.04] pointer-events-none" />
+
+              <div className="relative">
+                <span className="text-2xl leading-none" aria-hidden="true">{mood.icon}</span>
+                <h3 className="text-base font-bold text-white leading-tight mt-1.5 group-hover/mood:text-brand-200 transition-colors">
+                  {mood.name}
+                </h3>
+                <p className="text-xs text-white/70 mt-0.5 line-clamp-2">
+                  {mood.description}
+                </p>
+              </div>
+            </div>
+          </Link>
+        ))}
+
+        {/* Surprise Me card */}
+        <button
+          data-testid="surprise-me-button"
+          onClick={handleSurprise}
+          disabled={isSurpriseFetching}
+          aria-busy={isSurpriseFetching}
+          className="group/mood block rounded-xl overflow-hidden shadow-md transition-all duration-200 hover:scale-[1.02] hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950 text-left cursor-pointer disabled:opacity-70 disabled:cursor-wait"
+          style={{ background: "linear-gradient(135deg, #880E4F, #E91E63)" }}
+        >
+          <div className="relative h-32 flex flex-col justify-end p-4">
+            <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-white/[0.04] pointer-events-none" />
+
+            <div className="relative">
+              <span className="text-2xl leading-none" aria-hidden="true">{isSurpriseFetching ? "⏳" : "🎲"}</span>
+              <h3 className="text-base font-bold text-white leading-tight mt-1.5 group-hover/mood:text-brand-200 transition-colors">
+                {isSurpriseFetching ? "Finding a game…" : "Surprise Me"}
+              </h3>
+              <p className="text-xs text-white/70 mt-0.5">
+                Pick a random game from your library
+              </p>
+            </div>
+          </div>
+        </button>
+      </div>
+    </section>
+  );
+}

--- a/web/src/features/explore/utils/gradient.ts
+++ b/web/src/features/explore/utils/gradient.ts
@@ -1,0 +1,6 @@
+export function buildGradient(colors: string[]): string {
+  if (colors.length === 0) return "linear-gradient(135deg, #4a1a6b, #6b21a8)";
+  if (colors.length === 1)
+    return `linear-gradient(135deg, ${colors[0]}, ${colors[0]})`;
+  return `linear-gradient(135deg, ${colors.join(", ")})`;
+}

--- a/web/src/hooks/use-explore.ts
+++ b/web/src/hooks/use-explore.ts
@@ -10,6 +10,8 @@ import type {
   Theme,
   Keyword,
   GamesResponse,
+  MoodDefinition,
+  Game,
 } from "@/types/api";
 
 export function useExploreFeatured() {
@@ -99,5 +101,28 @@ export function useGameFranchises(gameId: string | undefined) {
     queryFn: () =>
       api.get<GameFranchiseLink[]>(`/games/${gameId}/franchises`),
     enabled: !!gameId,
+  });
+}
+
+export function useMoods() {
+  return useQuery({
+    queryKey: ["explore", "moods"],
+    queryFn: () => api.get<MoodDefinition[]>("/explore/moods"),
+  });
+}
+
+export function useMoodGames(mood: string | undefined) {
+  return useQuery({
+    queryKey: ["explore", "mood", mood],
+    queryFn: () => api.get<Game[]>(`/explore/mood/${mood}`),
+    enabled: !!mood,
+  });
+}
+
+export function useSurpriseGame() {
+  return useQuery({
+    queryKey: ["explore", "surprise"],
+    queryFn: () => api.get<Game>("/explore/surprise"),
+    enabled: false,
   });
 }

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -21,6 +21,9 @@ export type ApiGetPath = WithQuery<
   | "/explore/featured"
   | "/explore/rows"
   | "/explore/series/featured"
+  | "/explore/moods"
+  | `/explore/mood/${string}`
+  | "/explore/surprise"
 
   // Series
   | `/series/${string}`

--- a/web/src/pages/__tests__/explore-mood-page.test.tsx
+++ b/web/src/pages/__tests__/explore-mood-page.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ExploreMoodPage } from "@/pages/explore-mood-page";
+import type { MoodDefinition, Game } from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-explore", () => ({
+  useMoods: vi.fn(),
+  useMoodGames: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-games", () => ({
+  useToggleFavorite: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-play-later", () => ({
+  useTogglePlayLater: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+import { useMoods, useMoodGames } from "@/hooks/use-explore";
+
+const mockUseMoods = useMoods as ReturnType<typeof vi.fn>;
+const mockUseMoodGames = useMoodGames as ReturnType<typeof vi.fn>;
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "nes",
+    consoleName: "NES",
+    fileName: "test.nes",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const mockMoods: MoodDefinition[] = [
+  {
+    id: "chill",
+    name: "Chill",
+    description: "Relaxing and laid-back games",
+    icon: "😌",
+    gradient: ["#1a237e", "#4a148c"],
+  },
+  {
+    id: "intense",
+    name: "Intense",
+    description: "Heart-pounding action",
+    icon: "🔥",
+    gradient: ["#b71c1c", "#ff6f00"],
+  },
+];
+
+const mockGames: Game[] = [
+  makeGame({ id: "1", title: "Stardew Valley", rating: 92 }),
+  makeGame({ id: "2", title: "Animal Crossing", rating: 88 }),
+  makeGame({ id: "3", title: "Harvest Moon", rating: 85 }),
+];
+
+function renderPage(moodId = "chill") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/explore/mood/${moodId}`]}>
+        <Routes>
+          <Route
+            path="/explore/mood/:mood"
+            element={<ExploreMoodPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ExploreMoodPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseMoods.mockReturnValue({
+      data: mockMoods,
+      isLoading: false,
+    });
+    mockUseMoodGames.mockReturnValue({
+      data: mockGames,
+      isLoading: false,
+    });
+  });
+
+  it("renders the page with test id", () => {
+    renderPage();
+    expect(screen.getByTestId("mood-results-page")).toBeInTheDocument();
+  });
+
+  it("shows mood name in header", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: "Chill", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows mood description in header", () => {
+    renderPage();
+    expect(
+      screen.getByText("Relaxing and laid-back games"),
+    ).toBeInTheDocument();
+  });
+
+  it("shows mood icon in header", () => {
+    renderPage();
+    expect(screen.getByText("😌")).toBeInTheDocument();
+  });
+
+  it("shows games in grid", () => {
+    renderPage();
+    expect(screen.getByText("Stardew Valley")).toBeInTheDocument();
+    expect(screen.getByText("Animal Crossing")).toBeInTheDocument();
+    expect(screen.getByText("Harvest Moon")).toBeInTheDocument();
+  });
+
+  it("shows loading skeletons while loading", () => {
+    mockUseMoodGames.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("shows empty state when no games", () => {
+    mockUseMoodGames.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No games found")).toBeInTheDocument();
+    expect(
+      screen.getByText("No games match this mood yet."),
+    ).toBeInTheDocument();
+  });
+
+  it("back button links to explore", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /back to explore/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("shows fallback mood name when mood not found", () => {
+    mockUseMoods.mockReturnValue({
+      data: [],
+      isLoading: false,
+    });
+    renderPage("unknown");
+    expect(
+      screen.getByRole("heading", { name: "Mood", level: 1 }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/explore-mood-page.tsx
+++ b/web/src/pages/explore-mood-page.tsx
@@ -1,0 +1,100 @@
+import { useParams, useNavigate } from "react-router-dom";
+import { AlertCircle, Library } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameGrid } from "@/components/game-grid";
+import {
+  BackButton,
+  Button,
+  GameCardSkeleton,
+  EmptyState,
+} from "@/components/ui";
+import { useMoods, useMoodGames } from "@/hooks/use-explore";
+import { useToggleFavorite } from "@/hooks/use-games";
+import { useTogglePlayLater } from "@/hooks/use-play-later";
+import { buildGradient } from "@/features/explore/utils/gradient";
+
+export function ExploreMoodPage() {
+  const { mood: moodId } = useParams<{ mood: string }>();
+  const navigate = useNavigate();
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+
+  const { data: moods } = useMoods();
+  const { data: games, isLoading, isError, refetch } = useMoodGames(moodId);
+
+  const mood = moods?.find((m) => m.id === moodId);
+  const moodName = mood?.name ?? "Mood";
+  const moodDescription = mood?.description ?? "";
+  const moodIcon = mood?.icon ?? "";
+  const moodGradient = mood?.gradient ?? [];
+
+  return (
+    <div className="space-y-6" data-testid="mood-results-page">
+      {/* Back button */}
+      <BackButton onClick={() => navigate("/explore")}>
+        Back to Explore
+      </BackButton>
+
+      {/* Mood banner header */}
+      <div
+        className="relative rounded-2xl overflow-hidden p-6 sm:p-8"
+        style={{ background: buildGradient(moodGradient) }}
+      >
+        <div className="absolute inset-0 bg-gradient-to-t from-black/40 via-transparent to-white/[0.04] pointer-events-none" />
+        <div className="relative flex items-center gap-4">
+          {moodIcon && (
+            <span className="text-4xl sm:text-5xl leading-none">
+              {moodIcon}
+            </span>
+          )}
+          <div>
+            <h1 className="text-2xl sm:text-3xl font-bold text-white">
+              {moodName}
+            </h1>
+            {moodDescription && (
+              <p className="mt-1 text-sm text-white/70">{moodDescription}</p>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Games grid */}
+      {isLoading ? (
+        <GameGrid>
+          {Array.from({ length: 12 }, (_, i) => (
+            <GameCardSkeleton key={i} />
+          ))}
+        </GameGrid>
+      ) : isError ? (
+        <EmptyState
+          icon={AlertCircle}
+          title="Something went wrong"
+          description="Could not load games for this mood."
+          action={
+            <Button variant="primary" onClick={() => refetch()}>
+              Try again
+            </Button>
+          }
+        />
+      ) : !games || games.length === 0 ? (
+        <EmptyState
+          icon={Library}
+          title="No games found"
+          description="No games match this mood yet."
+        />
+      ) : (
+        <GameGrid>
+          {games.map((game) => (
+            <GameCard
+              key={game.id}
+              game={game}
+              showConsoleBadge
+              onToggleFavorite={handleToggleFavorite}
+              onTogglePlayLater={handleTogglePlayLater}
+            />
+          ))}
+        </GameGrid>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -6,12 +6,14 @@ import { GameShelf } from "@/features/explore/components/game-shelf";
 import { ThemeGrid } from "@/features/explore/components/theme-grid";
 import { KeywordChips } from "@/features/explore/components/keyword-chips";
 import { SeriesShelf } from "@/features/explore/components/series-shelf";
+import { MoodPicker } from "@/features/explore/components/mood-picker";
 import {
   useExploreFeatured,
   useExploreRows,
   useThemes,
   useKeywords,
   useFeaturedSeries,
+  useMoods,
 } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -39,6 +41,10 @@ export function ExplorePage() {
     data: featuredSeries,
     isLoading: isSeriesLoading,
   } = useFeaturedSeries();
+  const {
+    data: moods,
+    isLoading: isMoodsLoading,
+  } = useMoods();
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
 
@@ -94,6 +100,9 @@ export function ExplorePage() {
 
       {/* Hero Carousel */}
       <HeroCarousel games={featuredGames} isLoading={isFeaturedLoading} />
+
+      {/* Mood Picker */}
+      <MoodPicker moods={moods} isLoading={isMoodsLoading} />
 
       {/* First shelf row */}
       {isRowsLoading ? (

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -883,6 +883,16 @@ export interface GameFranchiseLink {
   gameCount: number;
 }
 
+// --- Moods ---
+
+export interface MoodDefinition {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+  gradient: string[];
+}
+
 // --- Explore ---
 
 export interface FeaturedGame {


### PR DESCRIPTION
## Summary
- Add 6 curated mood categories (Chill, Challenge, Nostalgia, Something New, Quick Session, Play Together) with gradient-styled mood cards and a Surprise Me random game feature
- Backend: new `/explore/moods`, `/explore/mood/:mood`, and `/explore/surprise` endpoints with mood-specific IGDB-powered game queries (themes, keywords, play history, session duration, player count)
- Web: MoodPicker component on Explore page with mood results page, error handling, loading states, and ARIA accessibility
- Player: Native MoodPicker composable (LazyRow), ExploreMoodScreen with gradient banner, and Surprise Me navigation with main-thread callback safety

## Test plan
- [x] Go: 12 new tests for mood endpoints (all moods, invalid mood, empty results, auth required, surprise game)
- [x] Web: 11 mood-picker tests + 10 mood-results-page tests + updated explore-page tests (861 total pass)
- [x] Player: 7 new desktop E2E tests for mood picker rendering, navigation, and empty states (414 total, 3 pre-existing flaky FramerateRegressionTest failures)