### PR TITLE
feat: add personalized For You recommendations (Phase 6)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreForYouTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreForYouTest.kt
@@ -1,0 +1,174 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.ForYouRow
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+
+/**
+ * Desktop E2E tests for Phase 6: Personalized "For You" recommendations on the Explore page.
+ *
+ * Covers:
+ * - For You section renders when rows exist
+ * - "Because you played" row shows source game reference
+ * - Section hidden when no rows
+ * - Multiple row types render correctly
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ExploreForYouTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private val sourceGame = Game(
+        id = "game-source-1",
+        title = "Super Mario World",
+        consoleId = "snes",
+        consoleName = "SNES",
+        genre = "Platform",
+        coverUrl = "https://example.com/smw-cover.jpg",
+    )
+
+    private val sampleForYouRows = listOf(
+        ForYouRow(
+            type = "because_you_played",
+            title = "Because you played Super Mario World",
+            sourceGame = sourceGame,
+            genre = null,
+            games = listOf(
+                Game(
+                    id = "game-rec-1",
+                    title = "Donkey Kong Country",
+                    consoleId = "snes",
+                    consoleName = "SNES",
+                    genre = "Platform",
+                ),
+                Game(
+                    id = "game-rec-2",
+                    title = "Kirby Super Star",
+                    consoleId = "snes",
+                    consoleName = "SNES",
+                    genre = "Platform",
+                ),
+            ),
+        ),
+        ForYouRow(
+            type = "more_genre",
+            title = "More Platform for you",
+            sourceGame = null,
+            genre = null,
+            games = listOf(
+                Game(
+                    id = "game-rec-3",
+                    title = "Mega Man X",
+                    consoleId = "snes",
+                    consoleName = "SNES",
+                    genre = "Platform",
+                ),
+            ),
+        ),
+        ForYouRow(
+            type = "unfinished",
+            title = "Your unfinished business",
+            sourceGame = null,
+            genre = null,
+            games = listOf(
+                Game(
+                    id = "game-rec-4",
+                    title = "Chrono Trigger",
+                    consoleId = "snes",
+                    consoleName = "SNES",
+                    genre = "RPG",
+                ),
+            ),
+        ),
+        ForYouRow(
+            type = "expand_horizons",
+            title = "Expand your horizons — try Fighting",
+            sourceGame = null,
+            genre = "Fighting",
+            games = listOf(
+                Game(
+                    id = "game-rec-5",
+                    title = "Street Fighter II",
+                    consoleId = "snes",
+                    consoleName = "SNES",
+                    genre = "Fighting",
+                ),
+            ),
+        ),
+    )
+
+    // --- For You section on Explore screen ---
+
+    @Test
+    fun forYouSection_rendersWhenRowsExist() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.forYouRows = sampleForYouRows
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_for_you_section").assertExists()
+        onNodeWithTag("for_you_section").assertExists()
+        onNodeWithText("For You").assertExists()
+    }
+
+    @Test
+    fun forYouSection_becauseYouPlayedRow_showsSourceGame() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.forYouRows = listOf(sampleForYouRows[0])
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("for_you_row_because_you_played").assertExists()
+        onNodeWithText("Because you played Super Mario World").assertExists()
+        onNodeWithTag("for_you_source_game_game-source-1").assertExists()
+        onNodeWithTag("for_you_game_game-rec-1").assertExists()
+        onNodeWithText("Donkey Kong Country").assertExists()
+    }
+
+    @Test
+    fun forYouSection_hiddenWhenNoRows() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.forYouRows = emptyList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("for_you_section").assertDoesNotExist()
+    }
+
+    @Test
+    fun forYouSection_showsMultipleRowTypes() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.forYouRows = sampleForYouRows
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("for_you_row_because_you_played").assertExists()
+        onNodeWithTag("for_you_row_more_genre").assertExists()
+        onNodeWithText("More Platform for you").assertExists()
+        onNodeWithText("Mega Man X").assertExists()
+
+        // The unfinished and expand_horizons rows may need scrolling
+        // but the tags should exist in the tree
+        onNodeWithTag("for_you_row_unfinished").assertExists()
+        onNodeWithTag("for_you_row_expand_horizons").assertExists()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1332,6 +1332,9 @@ class FakeExploreRepository : ExploreRepository {
     var moodsList: List<MoodDefinition> = emptyList()
     var moodGames: Map<String, List<Game>> = emptyMap()
     var surpriseGame: Game? = null
+    var forYouRows: List<ForYouRow> = emptyList()
+    var tasteProfile: TasteProfile? = null
+    var playersLikeYou: PlayersLikeYouResult? = null
     var shouldFail: Boolean = false
 
     override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> =
@@ -1392,6 +1395,26 @@ class FakeExploreRepository : ExploreRepository {
             val game = surpriseGame
             if (game != null) Result.success(game)
             else Result.failure(Exception("No surprise game available"))
+        }
+
+    override suspend fun getForYou(): Result<List<ForYouRow>> =
+        if (shouldFail) Result.failure(Exception("Failed to load for-you rows"))
+        else Result.success(forYouRows)
+
+    override suspend fun getTasteProfile(): Result<TasteProfile> =
+        if (shouldFail) Result.failure(Exception("Failed to load taste profile"))
+        else {
+            val profile = tasteProfile
+            if (profile != null) Result.success(profile)
+            else Result.failure(Exception("No taste profile available"))
+        }
+
+    override suspend fun getPlayersLikeYou(): Result<PlayersLikeYouResult> =
+        if (shouldFail) Result.failure(Exception("Failed to load players like you"))
+        else {
+            val result = playersLikeYou
+            if (result != null) Result.success(result)
+            else Result.failure(Exception("No players like you available"))
         }
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -309,6 +309,21 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/explore/surprise").body()
     }
 
+    /** Returns personalized "For You" recommendation rows */
+    suspend fun getForYou(): ForYouResponseDto {
+        return client.get("$baseUrl/api/explore/for-you").body()
+    }
+
+    /** Returns the user's taste profile (genre/theme/console breakdown) */
+    suspend fun getTasteProfile(): TasteProfileDto {
+        return client.get("$baseUrl/api/user/taste-profile").body()
+    }
+
+    /** Returns collaborative filtering recommendations */
+    suspend fun getPlayersLikeYou(): PlayersLikeYouResponseDto {
+        return client.get("$baseUrl/api/explore/players-like-you").body()
+    }
+
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
     suspend fun getRecentGames(): List<GameDto> {
         return client.get("$baseUrl/api/user/recent").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -638,3 +638,37 @@ fun MoodDefinitionDto.toDomain(): MoodDefinition = MoodDefinition(
     icon = icon,
     gradient = gradient,
 )
+
+fun ForYouRowDto.toDomain(): ForYouRow = ForYouRow(
+    type = type,
+    title = title,
+    sourceGame = sourceGame?.toDomain(),
+    genre = genre,
+    games = games.map { it.toDomain() },
+)
+
+fun TasteBreakdownDto.toDomain(): TasteBreakdown = TasteBreakdown(
+    name = name,
+    percentage = percentage,
+    playTime = playTime,
+    gameCount = gameCount,
+)
+
+fun ConsoleBreakdownDto.toDomain(): ConsoleBreakdown = ConsoleBreakdown(
+    name = name,
+    abbreviation = abbreviation,
+    playTime = playTime,
+    gameCount = gameCount,
+)
+
+fun TasteProfileDto.toDomain(): TasteProfile = TasteProfile(
+    totalPlayTime = totalPlayTime,
+    genres = genres.map { it.toDomain() },
+    themes = themes.map { it.toDomain() },
+    topConsoles = topConsoles.map { it.toDomain() },
+)
+
+fun PlayersLikeYouResponseDto.toDomain(): PlayersLikeYouResult = PlayersLikeYouResult(
+    games = games.map { it.toDomain() },
+    similarUsersCount = similarUsersCount,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1116,3 +1116,49 @@ data class MoodDefinitionDto(
     val icon: String,
     val gradient: List<String>,
 )
+
+// For You (Personalized Recommendations)
+
+@Serializable
+data class ForYouRowDto(
+    val type: String,
+    val title: String,
+    val sourceGame: GameDto? = null,
+    val genre: String? = null,
+    val games: List<GameDto>,
+)
+
+@Serializable
+data class ForYouResponseDto(
+    val rows: List<ForYouRowDto>,
+)
+
+@Serializable
+data class TasteBreakdownDto(
+    val name: String,
+    val percentage: Double,
+    val playTime: Long,
+    val gameCount: Int,
+)
+
+@Serializable
+data class ConsoleBreakdownDto(
+    val name: String,
+    val abbreviation: String,
+    val playTime: Long,
+    val gameCount: Int,
+)
+
+@Serializable
+data class TasteProfileDto(
+    val totalPlayTime: Long,
+    val genres: List<TasteBreakdownDto>,
+    val themes: List<TasteBreakdownDto>,
+    val topConsoles: List<ConsoleBreakdownDto>,
+)
+
+@Serializable
+data class PlayersLikeYouResponseDto(
+    val games: List<GameDto>,
+    val similarUsersCount: Int,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -5,12 +5,15 @@ import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
 import com.spela.player.domain.model.FeaturedSeries
+import com.spela.player.domain.model.ForYouRow
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameFranchiseLink
 import com.spela.player.domain.model.GameSeriesLink
 import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
+import com.spela.player.domain.model.PlayersLikeYouResult
 import com.spela.player.domain.model.SeriesDetail
+import com.spela.player.domain.model.TasteProfile
 import com.spela.player.domain.model.Theme
 import com.spela.player.domain.repository.ExploreRepository
 
@@ -117,6 +120,44 @@ class ExploreRepositoryImpl(
             coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
             heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
             logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+        )
+    }
+
+    override suspend fun getForYou(): Result<List<ForYouRow>> = runCatching {
+        apiClient.getForYou().rows.map { rowDto ->
+            rowDto.toDomain().copy(
+                sourceGame = rowDto.sourceGame?.let { sgDto ->
+                    sgDto.toDomain().copy(
+                        coverUrl = apiClient.resolveUrl(sgDto.coverUrl),
+                        heroUrl = apiClient.resolveUrl(sgDto.heroUrl),
+                        logoUrl = apiClient.resolveUrl(sgDto.logoUrl),
+                    )
+                },
+                games = rowDto.games.map { gameDto ->
+                    gameDto.toDomain().copy(
+                        coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                        heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+                        logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+                    )
+                },
+            )
+        }
+    }
+
+    override suspend fun getTasteProfile(): Result<TasteProfile> = runCatching {
+        apiClient.getTasteProfile().toDomain()
+    }
+
+    override suspend fun getPlayersLikeYou(): Result<PlayersLikeYouResult> = runCatching {
+        val dto = apiClient.getPlayersLikeYou()
+        dto.toDomain().copy(
+            games = dto.games.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                    heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+                    logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+                )
+            },
         )
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -90,3 +90,37 @@ data class MoodDefinition(
     val icon: String,
     val gradient: List<String>,
 )
+
+data class ForYouRow(
+    val type: String,  // "because_you_played", "more_genre", "unfinished", "expand_horizons"
+    val title: String,
+    val sourceGame: Game?,  // only for because_you_played
+    val genre: String?,     // only for expand_horizons
+    val games: List<Game>,
+)
+
+data class TasteBreakdown(
+    val name: String,
+    val percentage: Double,
+    val playTime: Long,
+    val gameCount: Int,
+)
+
+data class ConsoleBreakdown(
+    val name: String,
+    val abbreviation: String,
+    val playTime: Long,
+    val gameCount: Int,
+)
+
+data class TasteProfile(
+    val totalPlayTime: Long,
+    val genres: List<TasteBreakdown>,
+    val themes: List<TasteBreakdown>,
+    val topConsoles: List<ConsoleBreakdown>,
+)
+
+data class PlayersLikeYouResult(
+    val games: List<Game>,
+    val similarUsersCount: Int,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -3,12 +3,15 @@ package com.spela.player.domain.repository
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
 import com.spela.player.domain.model.FeaturedSeries
+import com.spela.player.domain.model.ForYouRow
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameFranchiseLink
 import com.spela.player.domain.model.GameSeriesLink
 import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
+import com.spela.player.domain.model.PlayersLikeYouResult
 import com.spela.player.domain.model.SeriesDetail
+import com.spela.player.domain.model.TasteProfile
 import com.spela.player.domain.model.Theme
 
 interface ExploreRepository {
@@ -25,4 +28,7 @@ interface ExploreRepository {
     suspend fun getMoods(): Result<List<MoodDefinition>>
     suspend fun getMoodGames(mood: String): Result<List<Game>>
     suspend fun getSurpriseGame(): Result<Game>
+    suspend fun getForYou(): Result<List<ForYouRow>>
+    suspend fun getTasteProfile(): Result<TasteProfile>
+    suspend fun getPlayersLikeYou(): Result<PlayersLikeYouResult>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ForYouSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ForYouSection.kt
@@ -1,0 +1,215 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.ForYouRow
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpShimmer
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.formatRating
+
+@Composable
+fun ForYouSection(
+    rows: List<ForYouRow>,
+    onGameSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.testTag("for_you_section"),
+    ) {
+        rows.forEach { row ->
+            if (row.games.isNotEmpty()) {
+                ForYouRowSection(
+                    row = row,
+                    onGameSelected = onGameSelected,
+                )
+                Spacer(Modifier.height(SpSpacing.Default))
+            }
+        }
+    }
+}
+
+@Composable
+private fun ForYouRowSection(
+    row: ForYouRow,
+    onGameSelected: (String) -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("for_you_row_${row.type}"),
+    ) {
+        // Row header with title (and source game thumbnail for "because_you_played")
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = SpSpacing.ScreenHorizontal),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (row.type == "because_you_played" && row.sourceGame != null) {
+                SpCoverArt(
+                    imageUrl = row.sourceGame.coverUrl,
+                    contentDescription = "${row.sourceGame.title} cover",
+                    modifier = Modifier
+                        .size(32.dp)
+                        .clip(RoundedCornerShape(4.dp))
+                        .testTag("for_you_source_game_${row.sourceGame.id}"),
+                    aspectRatio = row.sourceGame.coverAspectRatio,
+                )
+                Spacer(Modifier.width(SpSpacing.Small))
+            }
+            Text(
+                text = row.title,
+                style = SpTypography.TitleMedium,
+                color = SpColor.OnBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+        }
+
+        Spacer(Modifier.height(SpSpacing.Small))
+
+        // Horizontal game shelf
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+        ) {
+            items(row.games, key = { it.id }) { game ->
+                ForYouGameCard(
+                    game = game,
+                    onClick = { onGameSelected(game.id) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ForYouGameCard(
+    game: Game,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        modifier = Modifier
+            .width(SpSpacing.CoverMediumWidth)
+            .testTag("for_you_game_${game.id}")
+            .semantics {
+                contentDescription = "${game.title}, ${game.consoleName}"
+                role = Role.Button
+            },
+        onClick = onClick,
+        onGradient = true,
+    ) {
+        Column {
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.title} cover art",
+                modifier = Modifier.fillMaxWidth(),
+                aspectRatio = game.coverAspectRatio,
+            )
+            Column(
+                modifier = Modifier.padding(
+                    horizontal = SpSpacing.Small,
+                    vertical = SpSpacing.Small,
+                ),
+            ) {
+                Text(
+                    text = game.title,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                ) {
+                    Text(
+                        text = game.consoleName,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                        maxLines = 1,
+                    )
+
+                    if (game.rating > 0) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(10.dp),
+                        )
+                        Text(
+                            text = formatRating(game.rating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ForYouSkeleton(
+    modifier: Modifier = Modifier,
+    rowCount: Int = 2,
+) {
+    Column(modifier = modifier.testTag("for_you_skeleton")) {
+        repeat(rowCount) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                SpShimmer(
+                    modifier = Modifier
+                        .padding(horizontal = SpSpacing.ScreenHorizontal)
+                        .clip(RoundedCornerShape(4.dp)),
+                    width = 200.dp,
+                    height = 20.dp,
+                )
+                Spacer(Modifier.height(SpSpacing.Small))
+                LazyRow(
+                    contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                ) {
+                    items(5) {
+                        SpGameCardSkeleton(modifier = Modifier.width(SpSpacing.CoverMediumWidth))
+                    }
+                }
+                Spacer(Modifier.height(SpSpacing.Default))
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -22,6 +22,8 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.feature.explore.ForYouSection
+import com.spela.player.presentation.ui.feature.explore.ForYouSkeleton
 import com.spela.player.presentation.ui.feature.explore.GameShelf
 import com.spela.player.presentation.ui.feature.explore.GameShelfSkeleton
 import com.spela.player.presentation.ui.feature.explore.HeroCarousel
@@ -132,6 +134,32 @@ fun ExploreScreen(
                                     onSurpriseMe = {
                                         onSurpriseMe?.invoke()
                                     },
+                                )
+                            }
+                        }
+                    }
+
+                    // For You section (personalized recommendations)
+                    item {
+                        if (state.isLoadingForYou && state.forYouRows.isEmpty()) {
+                            SpTitledSection(
+                                title = "For You",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                ForYouSkeleton()
+                            }
+                        } else if (state.forYouRows.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "For You",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_for_you_section"),
+                            ) {
+                                ForYouSection(
+                                    rows = state.forYouRows,
+                                    onGameSelected = onGameSelected,
                                 )
                             }
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -3,6 +3,7 @@ package com.spela.player.presentation.viewmodel
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
 import com.spela.player.domain.model.FeaturedSeries
+import com.spela.player.domain.model.ForYouRow
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
@@ -26,16 +27,18 @@ data class ExploreState(
     val keywords: List<Keyword> = emptyList(),
     val featuredSeries: List<FeaturedSeries> = emptyList(),
     val moods: List<MoodDefinition> = emptyList(),
+    val forYouRows: List<ForYouRow> = emptyList(),
     val isLoadingFeatured: Boolean = false,
     val isLoadingRows: Boolean = false,
     val isLoadingThemes: Boolean = false,
     val isLoadingKeywords: Boolean = false,
     val isLoadingFeaturedSeries: Boolean = false,
     val isLoadingMoods: Boolean = false,
+    val isLoadingForYou: Boolean = false,
     val error: String? = null,
 ) {
-    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods
-    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && !isLoading
+    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods || isLoadingForYou
+    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && forYouRows.isEmpty() && !isLoading
 }
 
 data class ThemeDetailState(
@@ -113,6 +116,7 @@ class ExploreViewModel(
     private var seriesDetailJob: Job? = null
     private var moodsJob: Job? = null
     private var moodDetailJob: Job? = null
+    private var forYouJob: Job? = null
 
     fun load() {
         loadFeatured()
@@ -121,6 +125,7 @@ class ExploreViewModel(
         loadKeywords()
         loadFeaturedSeries()
         loadMoods()
+        loadForYou()
     }
 
     fun dismissError() {
@@ -279,6 +284,21 @@ class ExploreViewModel(
                 },
                 onFailure = { error ->
                     _state.update { it.copy(isLoadingMoods = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    private fun loadForYou() {
+        if (forYouJob?.isActive == true) return
+        _state.update { it.copy(isLoadingForYou = true) }
+        forYouJob = scope.launch(dispatchers.io) {
+            exploreRepository.getForYou().fold(
+                onSuccess = { rows ->
+                    _state.update { it.copy(forYouRows = rows, isLoadingForYou = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoadingForYou = false, error = error.message) }
                 },
             )
         }

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -1,10 +1,13 @@
 package api
 
 import (
+	"fmt"
 	"log/slog"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/db"
@@ -783,5 +786,698 @@ func (h *ExploreHandler) GetSurpriseGame(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, ToGameResponse(game, h.DB, userID))
+}
+
+// --- Phase 6: Personalized Recommendations ---
+
+// ForYouRowResponse represents a single recommendation row in the "For You" response.
+type ForYouRowResponse struct {
+	Type       string        `json:"type"`
+	Title      string        `json:"title"`
+	SourceGame *GameResponse `json:"sourceGame,omitempty"`
+	Genre      string        `json:"genre,omitempty"`
+	Games      []GameResponse `json:"games"`
+}
+
+// ForYouResponse is the API response for the personalized for-you endpoint.
+type ForYouResponse struct {
+	Rows []ForYouRowResponse `json:"rows"`
+}
+
+// TasteProfileGenre represents a genre breakdown in the taste profile.
+type TasteProfileGenre struct {
+	Name       string  `json:"name"`
+	Percentage float64 `json:"percentage"`
+	PlayTime   int64   `json:"playTime"`
+	GameCount  int     `json:"gameCount"`
+}
+
+// TasteProfileTheme represents a theme breakdown in the taste profile.
+type TasteProfileTheme struct {
+	Name       string  `json:"name"`
+	Percentage float64 `json:"percentage"`
+	PlayTime   int64   `json:"playTime"`
+	GameCount  int     `json:"gameCount"`
+}
+
+// TasteProfileConsole represents a console breakdown in the taste profile.
+type TasteProfileConsole struct {
+	Name         string `json:"name"`
+	Abbreviation string `json:"abbreviation"`
+	PlayTime     int64  `json:"playTime"`
+	GameCount    int    `json:"gameCount"`
+}
+
+// TasteProfileResponse is the API response for the user taste profile.
+type TasteProfileResponse struct {
+	TotalPlayTime int64                 `json:"totalPlayTime"`
+	Genres        []TasteProfileGenre   `json:"genres"`
+	Themes        []TasteProfileTheme   `json:"themes"`
+	TopConsoles   []TasteProfileConsole `json:"topConsoles"`
+}
+
+// PlayersLikeYouResponse is the API response for collaborative filtering recommendations.
+type PlayersLikeYouResponse struct {
+	Games             []GameResponse `json:"games"`
+	SimilarUsersCount int            `json:"similarUsersCount"`
+}
+
+// GetForYou returns personalized recommendation rows based on the user's play history.
+// GET /api/explore/for-you
+func (h *ExploreHandler) GetForYou(c *gin.Context) {
+	userID := getUserID(c)
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		return
+	}
+
+	rows := []ForYouRowResponse{}
+
+	// a) "Because you played [Game]" — top 3 most-played games, find same-genre unplayed games
+	becauseRows, err := h.buildBecauseYouPlayedRows(userID)
+	if err != nil {
+		slog.Error("failed to build because-you-played rows", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build recommendations"})
+		return
+	}
+	rows = append(rows, becauseRows...)
+
+	// b) "More [Genre] for you" — most-played genre, top-rated unplayed games
+	moreGenreRow, err := h.buildMoreGenreRow(userID)
+	if err != nil {
+		slog.Error("failed to build more-genre row", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build recommendations"})
+		return
+	}
+	if moreGenreRow != nil {
+		rows = append(rows, *moreGenreRow)
+	}
+
+	// c) "Your unfinished business" — played < 30 min, last played > 7 days ago
+	unfinishedRow, err := h.buildUnfinishedRow(userID)
+	if err != nil {
+		slog.Error("failed to build unfinished row", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build recommendations"})
+		return
+	}
+	if unfinishedRow != nil {
+		rows = append(rows, *unfinishedRow)
+	}
+
+	// d) "Expand your horizons" — genres the user has never played
+	expandRow, err := h.buildExpandHorizonsRow(userID)
+	if err != nil {
+		slog.Error("failed to build expand-horizons row", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build recommendations"})
+		return
+	}
+	if expandRow != nil {
+		rows = append(rows, *expandRow)
+	}
+
+	c.JSON(http.StatusOK, ForYouResponse{Rows: rows})
+}
+
+// buildBecauseYouPlayedRows generates "Because you played [Game]" recommendation rows.
+func (h *ExploreHandler) buildBecauseYouPlayedRows(userID uint) ([]ForYouRowResponse, error) {
+	// Get top 3 most-played games
+	type playRow struct {
+		GameID   uint
+		PlayTime int64
+	}
+	var topPlayed []playRow
+	if err := h.DB.Model(&db.PlayHistory{}).
+		Select("game_id, play_time").
+		Where("user_id = ? AND play_time > 0", userID).
+		Order("play_time DESC").
+		Limit(3).
+		Scan(&topPlayed).Error; err != nil {
+		return nil, err
+	}
+
+	if len(topPlayed) == 0 {
+		return nil, nil
+	}
+
+	// Get all played game IDs for this user (to exclude from recommendations)
+	var playedGameIDs []uint
+	if err := h.DB.Model(&db.PlayHistory{}).
+		Select("game_id").
+		Where("user_id = ? AND play_time > 0", userID).
+		Pluck("game_id", &playedGameIDs).Error; err != nil {
+		return nil, err
+	}
+	playedSet := make(map[uint]bool, len(playedGameIDs))
+	for _, id := range playedGameIDs {
+		playedSet[id] = true
+	}
+
+	// Load the source games
+	sourceGameIDs := make([]uint, len(topPlayed))
+	for i, tp := range topPlayed {
+		sourceGameIDs[i] = tp.GameID
+	}
+	var sourceGames []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", sourceGameIDs).Find(&sourceGames).Error; err != nil {
+		return nil, err
+	}
+	sourceGameMap := make(map[uint]db.Game, len(sourceGames))
+	for _, g := range sourceGames {
+		sourceGameMap[g.ID] = g
+	}
+
+	var rows []ForYouRowResponse
+	// Track already-recommended game IDs to avoid duplication across rows
+	alreadyRecommended := make(map[uint]bool)
+
+	for _, tp := range topPlayed {
+		srcGame, ok := sourceGameMap[tp.GameID]
+		if !ok || srcGame.Genre == "" {
+			continue
+		}
+
+		// Find games in the same genre that the user hasn't played
+		var recGames []db.Game
+		query := h.DB.Preload("Console").
+			Where("games.genre = ? AND games.deleted_at IS NULL", srcGame.Genre)
+
+		if len(playedGameIDs) > 0 {
+			query = query.Where("games.id NOT IN ?", playedGameIDs)
+		}
+
+		if err := query.
+			Order("games.rating DESC").
+			Limit(20). // fetch extra to filter duplicates
+			Find(&recGames).Error; err != nil {
+			return nil, err
+		}
+
+		// Filter out already-recommended games
+		var filtered []db.Game
+		for _, g := range recGames {
+			if !alreadyRecommended[g.ID] {
+				filtered = append(filtered, g)
+				alreadyRecommended[g.ID] = true
+				if len(filtered) >= 10 {
+					break
+				}
+			}
+		}
+
+		if len(filtered) == 0 {
+			continue
+		}
+
+		srcResp := ToGameResponse(srcGame, h.DB, userID)
+		rows = append(rows, ForYouRowResponse{
+			Type:       "because_you_played",
+			Title:      fmt.Sprintf("Because you played %s", srcGame.Title),
+			SourceGame: &srcResp,
+			Games:      ToGameResponses(filtered, h.DB, userID),
+		})
+	}
+
+	return rows, nil
+}
+
+// buildMoreGenreRow generates the "More [Genre] for you" recommendation row.
+func (h *ExploreHandler) buildMoreGenreRow(userID uint) (*ForYouRowResponse, error) {
+	// Find the user's most-played genre by summing play time per genre
+	type genreRow struct {
+		Genre         string
+		TotalPlayTime int64
+	}
+	var genreRows []genreRow
+	if err := h.DB.
+		Table("play_histories").
+		Select("games.genre, SUM(play_histories.play_time) as total_play_time").
+		Joins("JOIN games ON games.id = play_histories.game_id AND games.deleted_at IS NULL").
+		Where("play_histories.user_id = ? AND play_histories.play_time > 0 AND games.genre != '' AND play_histories.deleted_at IS NULL", userID).
+		Group("games.genre").
+		Order("total_play_time DESC").
+		Limit(1).
+		Scan(&genreRows).Error; err != nil {
+		return nil, err
+	}
+
+	if len(genreRows) == 0 || genreRows[0].Genre == "" {
+		return nil, nil
+	}
+
+	topGenre := genreRows[0].Genre
+
+	// Get played game IDs for this user
+	var playedGameIDs []uint
+	if err := h.DB.Model(&db.PlayHistory{}).
+		Select("game_id").
+		Where("user_id = ? AND play_time > 0", userID).
+		Pluck("game_id", &playedGameIDs).Error; err != nil {
+		return nil, err
+	}
+
+	// Find top-rated unplayed games in this genre
+	var games []db.Game
+	query := h.DB.Preload("Console").
+		Where("games.genre = ? AND games.deleted_at IS NULL", topGenre)
+	if len(playedGameIDs) > 0 {
+		query = query.Where("games.id NOT IN ?", playedGameIDs)
+	}
+	if err := query.
+		Order("games.rating DESC").
+		Limit(10).
+		Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	if len(games) == 0 {
+		return nil, nil
+	}
+
+	return &ForYouRowResponse{
+		Type:  "more_genre",
+		Title: fmt.Sprintf("More %s for you", topGenre),
+		Games: ToGameResponses(games, h.DB, userID),
+	}, nil
+}
+
+// buildUnfinishedRow generates the "Your unfinished business" recommendation row.
+func (h *ExploreHandler) buildUnfinishedRow(userID uint) (*ForYouRowResponse, error) {
+	sevenDaysAgo := time.Now().Add(-7 * 24 * time.Hour)
+
+	// Find games played < 30 min (1800 seconds) and last played > 7 days ago
+	var histories []db.PlayHistory
+	if err := h.DB.
+		Where("user_id = ? AND play_time > 0 AND play_time < 1800 AND last_played < ?", userID, sevenDaysAgo).
+		Order("last_played DESC").
+		Limit(10).
+		Find(&histories).Error; err != nil {
+		return nil, err
+	}
+
+	if len(histories) == 0 {
+		return nil, nil
+	}
+
+	gameIDs := make([]uint, len(histories))
+	for i, h := range histories {
+		gameIDs[i] = h.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	if len(games) == 0 {
+		return nil, nil
+	}
+
+	// Re-sort by last_played DESC (the IN query may not preserve order)
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+	sorted := make([]db.Game, 0, len(histories))
+	for _, h := range histories {
+		if g, ok := gameMap[h.GameID]; ok {
+			sorted = append(sorted, g)
+		}
+	}
+
+	return &ForYouRowResponse{
+		Type:  "unfinished",
+		Title: "Your unfinished business",
+		Games: ToGameResponses(sorted, h.DB, userID),
+	}, nil
+}
+
+// buildExpandHorizonsRow generates the "Expand your horizons" recommendation row.
+func (h *ExploreHandler) buildExpandHorizonsRow(userID uint) (*ForYouRowResponse, error) {
+	// Get all genres the user has played
+	var playedGenres []string
+	if err := h.DB.
+		Table("play_histories").
+		Select("DISTINCT games.genre").
+		Joins("JOIN games ON games.id = play_histories.game_id AND games.deleted_at IS NULL").
+		Where("play_histories.user_id = ? AND play_histories.play_time > 0 AND games.genre != '' AND play_histories.deleted_at IS NULL", userID).
+		Pluck("games.genre", &playedGenres).Error; err != nil {
+		return nil, err
+	}
+
+	// If user has no play history, we can't determine what's "new" for them
+	if len(playedGenres) == 0 {
+		return nil, nil
+	}
+
+	// Find genres the user has never played, ranked by number of high-rated games (rating > 70)
+	type unplayedGenreRow struct {
+		Genre     string
+		GameCount int64
+	}
+	var unplayedGenres []unplayedGenreRow
+	if err := h.DB.Model(&db.Game{}).
+		Select("genre, COUNT(*) as game_count").
+		Where("genre NOT IN ? AND genre != '' AND rating > 70 AND deleted_at IS NULL", playedGenres).
+		Group("genre").
+		Order("game_count DESC").
+		Limit(1).
+		Scan(&unplayedGenres).Error; err != nil {
+		return nil, err
+	}
+
+	if len(unplayedGenres) == 0 {
+		return nil, nil
+	}
+
+	targetGenre := unplayedGenres[0].Genre
+
+	// Get top-rated games in this genre
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("genre = ? AND rating > 70 AND deleted_at IS NULL", targetGenre).
+		Order("rating DESC").
+		Limit(10).
+		Find(&games).Error; err != nil {
+		return nil, err
+	}
+
+	if len(games) == 0 {
+		return nil, nil
+	}
+
+	return &ForYouRowResponse{
+		Type:  "expand_horizons",
+		Title: fmt.Sprintf("Expand your horizons — try %s", targetGenre),
+		Genre: targetGenre,
+		Games: ToGameResponses(games, h.DB, userID),
+	}, nil
+}
+
+// GetTasteProfile returns the user's genre/theme breakdown based on play history.
+// GET /api/user/taste-profile
+func (h *ExploreHandler) GetTasteProfile(c *gin.Context) {
+	userID := getUserID(c)
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		return
+	}
+
+	// Calculate total play time
+	var totalPlayTime int64
+	if err := h.DB.Model(&db.PlayHistory{}).
+		Select("COALESCE(SUM(play_time), 0)").
+		Where("user_id = ? AND play_time > 0", userID).
+		Scan(&totalPlayTime).Error; err != nil {
+		slog.Error("failed to calculate total play time", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build taste profile"})
+		return
+	}
+
+	// Genre breakdown
+	type genreRow struct {
+		Genre     string
+		PlayTime  int64
+		GameCount int
+	}
+	var genreRows []genreRow
+	if err := h.DB.
+		Table("play_histories").
+		Select("games.genre, SUM(play_histories.play_time) as play_time, COUNT(DISTINCT play_histories.game_id) as game_count").
+		Joins("JOIN games ON games.id = play_histories.game_id AND games.deleted_at IS NULL").
+		Where("play_histories.user_id = ? AND play_histories.play_time > 0 AND games.genre != '' AND play_histories.deleted_at IS NULL", userID).
+		Group("games.genre").
+		Order("play_time DESC").
+		Scan(&genreRows).Error; err != nil {
+		slog.Error("failed to get genre breakdown", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build taste profile"})
+		return
+	}
+
+	genres := make([]TasteProfileGenre, len(genreRows))
+	for i, r := range genreRows {
+		pct := float64(0)
+		if totalPlayTime > 0 {
+			pct = math.Round(float64(r.PlayTime) / float64(totalPlayTime) * 100)
+		}
+		genres[i] = TasteProfileGenre{
+			Name:       r.Genre,
+			Percentage: pct,
+			PlayTime:   r.PlayTime,
+			GameCount:  r.GameCount,
+		}
+	}
+
+	// Theme breakdown
+	type themeRow struct {
+		Name      string
+		PlayTime  int64
+		GameCount int
+	}
+	var themeRows []themeRow
+	if err := h.DB.
+		Table("play_histories").
+		Select("game_themes.name, SUM(play_histories.play_time) as play_time, COUNT(DISTINCT play_histories.game_id) as game_count").
+		Joins("JOIN game_themes ON game_themes.game_id = play_histories.game_id").
+		Where("play_histories.user_id = ? AND play_histories.play_time > 0 AND play_histories.deleted_at IS NULL", userID).
+		Group("game_themes.name").
+		Order("play_time DESC").
+		Scan(&themeRows).Error; err != nil {
+		slog.Error("failed to get theme breakdown", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build taste profile"})
+		return
+	}
+
+	themes := make([]TasteProfileTheme, len(themeRows))
+	for i, r := range themeRows {
+		pct := float64(0)
+		if totalPlayTime > 0 {
+			pct = math.Round(float64(r.PlayTime) / float64(totalPlayTime) * 100)
+		}
+		themes[i] = TasteProfileTheme{
+			Name:       r.Name,
+			Percentage: pct,
+			PlayTime:   r.PlayTime,
+			GameCount:  r.GameCount,
+		}
+	}
+
+	// Console breakdown
+	type consoleRow struct {
+		Name         string
+		Abbreviation string
+		PlayTime     int64
+		GameCount    int
+	}
+	var consoleRows []consoleRow
+	if err := h.DB.
+		Table("play_histories").
+		Select("consoles.name, consoles.abbreviation, SUM(play_histories.play_time) as play_time, COUNT(DISTINCT play_histories.game_id) as game_count").
+		Joins("JOIN games ON games.id = play_histories.game_id AND games.deleted_at IS NULL").
+		Joins("JOIN consoles ON consoles.id = games.console_id").
+		Where("play_histories.user_id = ? AND play_histories.play_time > 0 AND play_histories.deleted_at IS NULL", userID).
+		Group("consoles.id").
+		Order("play_time DESC").
+		Scan(&consoleRows).Error; err != nil {
+		slog.Error("failed to get console breakdown", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to build taste profile"})
+		return
+	}
+
+	topConsoles := make([]TasteProfileConsole, len(consoleRows))
+	for i, r := range consoleRows {
+		topConsoles[i] = TasteProfileConsole{
+			Name:         r.Name,
+			Abbreviation: strings.ToLower(r.Abbreviation),
+			PlayTime:     r.PlayTime,
+			GameCount:    r.GameCount,
+		}
+	}
+
+	c.JSON(http.StatusOK, TasteProfileResponse{
+		TotalPlayTime: totalPlayTime,
+		Genres:        genres,
+		Themes:        themes,
+		TopConsoles:   topConsoles,
+	})
+}
+
+// GetPlayersLikeYou returns collaborative filtering recommendations based on favorite overlap.
+// GET /api/explore/players-like-you
+func (h *ExploreHandler) GetPlayersLikeYou(c *gin.Context) {
+	userID := getUserID(c)
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "authentication required"})
+		return
+	}
+
+	// Get the current user's favorites
+	var myFavIDs []uint
+	if err := h.DB.Model(&db.Favorite{}).
+		Select("game_id").
+		Where("user_id = ?", userID).
+		Pluck("game_id", &myFavIDs).Error; err != nil {
+		slog.Error("failed to get user favorites", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get recommendations"})
+		return
+	}
+
+	if len(myFavIDs) == 0 {
+		c.JSON(http.StatusOK, PlayersLikeYouResponse{
+			Games:             []GameResponse{},
+			SimilarUsersCount: 0,
+		})
+		return
+	}
+
+	myFavSet := make(map[uint]bool, len(myFavIDs))
+	for _, id := range myFavIDs {
+		myFavSet[id] = true
+	}
+
+	// Find all other users who have at least one overlapping favorite
+	type userOverlap struct {
+		UserID       uint
+		OverlapCount int
+	}
+	var overlaps []userOverlap
+	if err := h.DB.Model(&db.Favorite{}).
+		Select("user_id, COUNT(*) as overlap_count").
+		Where("user_id != ? AND game_id IN ?", userID, myFavIDs).
+		Group("user_id").
+		Order("overlap_count DESC").
+		Scan(&overlaps).Error; err != nil {
+		slog.Error("failed to find similar users", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get recommendations"})
+		return
+	}
+
+	if len(overlaps) == 0 {
+		c.JSON(http.StatusOK, PlayersLikeYouResponse{
+			Games:             []GameResponse{},
+			SimilarUsersCount: 0,
+		})
+		return
+	}
+
+	// Compute Jaccard similarity for each candidate user
+	// Jaccard = |intersection| / |union|
+	// We need the total favorite count for each candidate
+	type similarUser struct {
+		userID     uint
+		similarity float64
+	}
+
+	candidateUserIDs := make([]uint, len(overlaps))
+	overlapMap := make(map[uint]int, len(overlaps))
+	for i, o := range overlaps {
+		candidateUserIDs[i] = o.UserID
+		overlapMap[o.UserID] = o.OverlapCount
+	}
+
+	// Get total favorite count for each candidate
+	type favCountRow struct {
+		UserID   uint
+		FavCount int
+	}
+	var favCounts []favCountRow
+	if err := h.DB.Model(&db.Favorite{}).
+		Select("user_id, COUNT(*) as fav_count").
+		Where("user_id IN ?", candidateUserIDs).
+		Group("user_id").
+		Scan(&favCounts).Error; err != nil {
+		slog.Error("failed to get candidate favorite counts", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get recommendations"})
+		return
+	}
+
+	var similarUsers []similarUser
+	myFavCount := len(myFavIDs)
+	for _, fc := range favCounts {
+		intersection := overlapMap[fc.UserID]
+		union := myFavCount + fc.FavCount - intersection
+		if union == 0 {
+			continue
+		}
+		similarity := float64(intersection) / float64(union)
+		similarUsers = append(similarUsers, similarUser{
+			userID:     fc.UserID,
+			similarity: similarity,
+		})
+	}
+
+	// Sort by similarity DESC (already mostly sorted by overlap, but Jaccard may reorder)
+	for i := 0; i < len(similarUsers); i++ {
+		for j := i + 1; j < len(similarUsers); j++ {
+			if similarUsers[j].similarity > similarUsers[i].similarity {
+				similarUsers[i], similarUsers[j] = similarUsers[j], similarUsers[i]
+			}
+		}
+	}
+
+	// Take top 5
+	if len(similarUsers) > 5 {
+		similarUsers = similarUsers[:5]
+	}
+
+	// Get favorites from similar users that the current user hasn't favorited
+	topUserIDs := make([]uint, len(similarUsers))
+	for i, su := range similarUsers {
+		topUserIDs[i] = su.userID
+	}
+
+	type recGameRow struct {
+		GameID    uint
+		UserCount int
+	}
+	var recGameRows []recGameRow
+	if err := h.DB.Model(&db.Favorite{}).
+		Select("game_id, COUNT(DISTINCT user_id) as user_count").
+		Where("user_id IN ? AND game_id NOT IN ?", topUserIDs, myFavIDs).
+		Group("game_id").
+		Order("user_count DESC").
+		Limit(20).
+		Scan(&recGameRows).Error; err != nil {
+		slog.Error("failed to get recommended games from similar users", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get recommendations"})
+		return
+	}
+
+	if len(recGameRows) == 0 {
+		c.JSON(http.StatusOK, PlayersLikeYouResponse{
+			Games:             []GameResponse{},
+			SimilarUsersCount: len(similarUsers),
+		})
+		return
+	}
+
+	// Load and sort games
+	gameIDs := make([]uint, len(recGameRows))
+	for i, r := range recGameRows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load recommended games", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to get recommendations"})
+		return
+	}
+
+	// Re-sort by user_count (preserve the order from the recommendation query)
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+	sorted := make([]db.Game, 0, len(recGameRows))
+	for _, r := range recGameRows {
+		if g, ok := gameMap[r.GameID]; ok {
+			sorted = append(sorted, g)
+		}
+	}
+
+	c.JSON(http.StatusOK, PlayersLikeYouResponse{
+		Games:             ToGameResponses(sorted, h.DB, userID),
+		SimilarUsersCount: len(similarUsers),
+	})
 }
 

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -1452,3 +1452,495 @@ func TestGetMoodGames_AuthRequired(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
+
+// --- For You endpoint tests ---
+
+func TestGetForYou_BecauseYouPlayed(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create an RPG that the user has played a lot
+	playedGame := createExploreGameWithGenre(t, env.database, "SNES", "Chrono Trigger", 95, "RPG", 1)
+	// Create RPGs that the user hasn't played
+	recGame1 := createExploreGameWithGenre(t, env.database, "SNES", "Final Fantasy VI", 92, "RPG", 1)
+	recGame2 := createExploreGameWithGenre(t, env.database, "SNES", "Earthbound", 88, "RPG", 1)
+	// Create an Action game (different genre, should NOT appear in this row)
+	createExploreGameWithGenre(t, env.database, "NES", "Contra", 85, "Action", 2)
+
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// User has played Chrono Trigger for 5 hours
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     playedGame.ID,
+		PlayTime:   18000,
+		LastPlayed: time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/for-you", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ForYouResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Should have a "because_you_played" row
+	var becauseRow *ForYouRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].Type == "because_you_played" {
+			becauseRow = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, becauseRow, "should have a because_you_played row")
+	assert.Contains(t, becauseRow.Title, "Chrono Trigger")
+	assert.NotNil(t, becauseRow.SourceGame)
+	assert.Equal(t, "Chrono Trigger", becauseRow.SourceGame.Title)
+
+	// Should recommend the unplayed RPGs, NOT the played game, NOT the Action game
+	titles := make(map[string]bool)
+	for _, g := range becauseRow.Games {
+		titles[g.Title] = true
+	}
+	assert.True(t, titles[recGame1.Title], "should recommend Final Fantasy VI")
+	assert.True(t, titles[recGame2.Title], "should recommend Earthbound")
+	assert.False(t, titles[playedGame.Title], "should not recommend the played game")
+	assert.False(t, titles["Contra"], "should not recommend different genre")
+}
+
+func TestGetForYou_MoreGenre(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// User plays RPGs mostly, Action a little
+	rpgGame := createExploreGameWithGenre(t, env.database, "SNES", "RPG Played", 85, "RPG", 1)
+	actionGame := createExploreGameWithGenre(t, env.database, "NES", "Action Played", 80, "Action", 1)
+	// Unplayed RPG (should be recommended)
+	unplayedRPG := createExploreGameWithGenre(t, env.database, "SNES", "Unplayed RPG", 90, "RPG", 1)
+	// Unplayed Action (should NOT be in this row — RPG is the top genre)
+	createExploreGameWithGenre(t, env.database, "NES", "Unplayed Action", 88, "Action", 1)
+
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     rpgGame.ID,
+		PlayTime:   10000,
+		LastPlayed: time.Now(),
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     actionGame.ID,
+		PlayTime:   2000,
+		LastPlayed: time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/for-you", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ForYouResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var moreGenreRow *ForYouRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].Type == "more_genre" {
+			moreGenreRow = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, moreGenreRow, "should have a more_genre row")
+	assert.Contains(t, moreGenreRow.Title, "RPG")
+
+	titles := make(map[string]bool)
+	for _, g := range moreGenreRow.Games {
+		titles[g.Title] = true
+	}
+	assert.True(t, titles[unplayedRPG.Title], "should recommend unplayed RPG")
+	assert.False(t, titles[rpgGame.Title], "should not include already-played RPG")
+}
+
+func TestGetForYou_UnfinishedBusiness(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Game played for 10 minutes (< 30 min), last played 10 days ago (> 7 days)
+	unfinishedGame := createExploreGame(t, env.database, "NES", "Started But Not Finished", 85)
+	// Game played for 2 hours (> 30 min, should NOT be "unfinished")
+	finishedGame := createExploreGame(t, env.database, "SNES", "Played A Lot", 90)
+	// Game played 2 minutes ago (< 7 days, should NOT be "unfinished")
+	recentGame := createExploreGame(t, env.database, "GBA", "Just Started", 80)
+
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	tenDaysAgo := time.Now().Add(-10 * 24 * time.Hour)
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     unfinishedGame.ID,
+		PlayTime:   600, // 10 minutes
+		LastPlayed: tenDaysAgo,
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     finishedGame.ID,
+		PlayTime:   7200, // 2 hours
+		LastPlayed: tenDaysAgo,
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     recentGame.ID,
+		PlayTime:   300, // 5 minutes
+		LastPlayed: time.Now().Add(-1 * time.Hour),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/for-you", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ForYouResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var unfinishedRow *ForYouRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].Type == "unfinished" {
+			unfinishedRow = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, unfinishedRow, "should have an unfinished row")
+	assert.Equal(t, "Your unfinished business", unfinishedRow.Title)
+
+	titles := make(map[string]bool)
+	for _, g := range unfinishedRow.Games {
+		titles[g.Title] = true
+	}
+	assert.True(t, titles[unfinishedGame.Title], "should include short/old game")
+	assert.False(t, titles[finishedGame.Title], "should not include game with > 30 min play time")
+	assert.False(t, titles[recentGame.Title], "should not include recently played game")
+}
+
+func TestGetForYou_ExpandHorizons(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// User has only played RPGs
+	playedRPG := createExploreGameWithGenre(t, env.database, "SNES", "RPG Game", 90, "RPG", 1)
+	// Racing games exist but user hasn't played any (rating > 70)
+	racingGame1 := createExploreGameWithGenre(t, env.database, "SNES", "Mario Kart", 88, "Racing", 2)
+	racingGame2 := createExploreGameWithGenre(t, env.database, "NES", "Excitebike", 75, "Racing", 1)
+	// Low-rated Puzzle game (rating <= 70, should not make Puzzle qualify)
+	createExploreGameWithGenre(t, env.database, "NES", "Bad Puzzle", 50, "Puzzle", 1)
+
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     playedRPG.ID,
+		PlayTime:   5000,
+		LastPlayed: time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/for-you", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ForYouResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	var expandRow *ForYouRowResponse
+	for i := range resp.Rows {
+		if resp.Rows[i].Type == "expand_horizons" {
+			expandRow = &resp.Rows[i]
+			break
+		}
+	}
+	require.NotNil(t, expandRow, "should have an expand_horizons row")
+	assert.Contains(t, expandRow.Title, "Racing")
+	assert.Equal(t, "Racing", expandRow.Genre)
+
+	titles := make(map[string]bool)
+	for _, g := range expandRow.Games {
+		titles[g.Title] = true
+	}
+	assert.True(t, titles[racingGame1.Title])
+	assert.True(t, titles[racingGame2.Title])
+	assert.False(t, titles["Bad Puzzle"], "low-rated puzzle should not appear")
+}
+
+func TestGetForYou_EmptyHistory(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create some games but no play history
+	createExploreGame(t, env.database, "NES", "Game 1", 90)
+	createExploreGame(t, env.database, "SNES", "Game 2", 85)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/for-you", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ForYouResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// With no play history, all personalized rows should be empty
+	assert.Empty(t, resp.Rows, "user with no play history should have no recommendation rows")
+}
+
+func TestGetForYou_AuthRequired(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/for-you", nil)
+	// No auth header
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// --- Taste Profile endpoint tests ---
+
+func TestGetTasteProfile(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create games in different genres and consoles
+	rpgGame := createExploreGameWithGenre(t, env.database, "SNES", "Chrono Trigger", 95, "RPG", 1)
+	actionGame := createExploreGameWithGenre(t, env.database, "NES", "Contra", 85, "Action", 2)
+	rpgGame2 := createExploreGameWithGenre(t, env.database, "SNES", "FF6", 92, "RPG", 1)
+
+	// Add themes to RPG games
+	env.database.Create(&db.GameTheme{GameID: rpgGame.ID, IGDBThemeID: 1, Name: "Fantasy"})
+	env.database.Create(&db.GameTheme{GameID: rpgGame2.ID, IGDBThemeID: 1, Name: "Fantasy"})
+	env.database.Create(&db.GameTheme{GameID: actionGame.ID, IGDBThemeID: 2, Name: "Sci-Fi"})
+
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// RPG: 7000 seconds, Action: 3000 seconds => total 10000
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     rpgGame.ID,
+		PlayTime:   4000,
+		LastPlayed: time.Now(),
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     rpgGame2.ID,
+		PlayTime:   3000,
+		LastPlayed: time.Now(),
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     actionGame.ID,
+		PlayTime:   3000,
+		LastPlayed: time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/taste-profile", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp TasteProfileResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, int64(10000), resp.TotalPlayTime)
+
+	// Genre breakdown
+	require.GreaterOrEqual(t, len(resp.Genres), 2)
+	// RPG should be first (70% of play time)
+	assert.Equal(t, "RPG", resp.Genres[0].Name)
+	assert.Equal(t, float64(70), resp.Genres[0].Percentage)
+	assert.Equal(t, int64(7000), resp.Genres[0].PlayTime)
+	assert.Equal(t, 2, resp.Genres[0].GameCount)
+
+	assert.Equal(t, "Action", resp.Genres[1].Name)
+	assert.Equal(t, float64(30), resp.Genres[1].Percentage)
+	assert.Equal(t, int64(3000), resp.Genres[1].PlayTime)
+	assert.Equal(t, 1, resp.Genres[1].GameCount)
+
+	// Theme breakdown
+	require.GreaterOrEqual(t, len(resp.Themes), 1)
+	// Fantasy should have the most play time (both RPG games = 7000s)
+	fantasyFound := false
+	for _, theme := range resp.Themes {
+		if theme.Name == "Fantasy" {
+			fantasyFound = true
+			assert.Equal(t, int64(7000), theme.PlayTime)
+			assert.Equal(t, 2, theme.GameCount)
+		}
+	}
+	assert.True(t, fantasyFound, "Fantasy theme should be present")
+
+	// Console breakdown
+	require.GreaterOrEqual(t, len(resp.TopConsoles), 1)
+	// SNES should be first (7000s play time)
+	snesFound := false
+	for _, con := range resp.TopConsoles {
+		if con.Abbreviation == "snes" {
+			snesFound = true
+			assert.Equal(t, int64(7000), con.PlayTime)
+			assert.Equal(t, 2, con.GameCount)
+			assert.Equal(t, "Super Nintendo", con.Name)
+		}
+	}
+	assert.True(t, snesFound, "SNES console should be in top consoles")
+}
+
+func TestGetTasteProfile_EmptyHistory(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/taste-profile", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp TasteProfileResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, int64(0), resp.TotalPlayTime)
+	assert.Empty(t, resp.Genres)
+	assert.Empty(t, resp.Themes)
+	assert.Empty(t, resp.TopConsoles)
+}
+
+func TestGetTasteProfile_AuthRequired(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/taste-profile", nil)
+	// No auth header
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// --- Players Like You endpoint tests ---
+
+func TestGetPlayersLikeYou(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create games
+	game1 := createExploreGame(t, env.database, "NES", "Mario", 90)
+	game2 := createExploreGame(t, env.database, "SNES", "Zelda", 95)
+	game3 := createExploreGame(t, env.database, "GBA", "Metroid", 88)
+	game4 := createExploreGame(t, env.database, "NES", "Castlevania", 85)
+	game5 := createExploreGame(t, env.database, "SNES", "Mega Man", 82)
+
+	// Current user (owner) favorites: Mario, Zelda
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+	env.database.Create(&db.Favorite{UserID: user.ID, GameID: game1.ID}) // Mario
+	env.database.Create(&db.Favorite{UserID: user.ID, GameID: game2.ID}) // Zelda
+
+	// Create similar user2: favorites Mario, Zelda, Metroid (overlap: 2)
+	user2Token := createNonOwnerUser(t, env.router, env.token, "user2", "user2@test.com", "password123")
+	_ = user2Token
+	var user2 db.User
+	require.NoError(t, env.database.Where("username = ?", "user2").First(&user2).Error)
+	env.database.Create(&db.Favorite{UserID: user2.ID, GameID: game1.ID}) // Mario
+	env.database.Create(&db.Favorite{UserID: user2.ID, GameID: game2.ID}) // Zelda
+	env.database.Create(&db.Favorite{UserID: user2.ID, GameID: game3.ID}) // Metroid
+
+	// Create user3: favorites Mario, Castlevania, Mega Man (overlap: 1)
+	user3Token := createNonOwnerUser(t, env.router, env.token, "user3", "user3@test.com", "password123")
+	_ = user3Token
+	var user3 db.User
+	require.NoError(t, env.database.Where("username = ?", "user3").First(&user3).Error)
+	env.database.Create(&db.Favorite{UserID: user3.ID, GameID: game1.ID}) // Mario
+	env.database.Create(&db.Favorite{UserID: user3.ID, GameID: game4.ID}) // Castlevania
+	env.database.Create(&db.Favorite{UserID: user3.ID, GameID: game5.ID}) // Mega Man
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/players-like-you", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PlayersLikeYouResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, 2, resp.SimilarUsersCount)
+	assert.GreaterOrEqual(t, len(resp.Games), 1, "should recommend at least 1 game")
+
+	// The recommended games should NOT include the user's own favorites (Mario, Zelda)
+	titles := make(map[string]bool)
+	for _, g := range resp.Games {
+		titles[g.Title] = true
+	}
+	assert.False(t, titles["Mario"], "should not recommend user's own favorite")
+	assert.False(t, titles["Zelda"], "should not recommend user's own favorite")
+
+	// Metroid should be recommended (favorited by user2 who has highest overlap)
+	assert.True(t, titles["Metroid"], "Metroid should be recommended (from most similar user)")
+}
+
+func TestGetPlayersLikeYou_NoSimilarUsers(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create a game and favorite it — but no other users exist with favorites
+	game := createExploreGame(t, env.database, "NES", "Lonely Game", 85)
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+	env.database.Create(&db.Favorite{UserID: user.ID, GameID: game.ID})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/players-like-you", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PlayersLikeYouResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, 0, resp.SimilarUsersCount)
+	assert.Empty(t, resp.Games)
+}
+
+func TestGetPlayersLikeYou_NoFavorites(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// User has no favorites at all
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/players-like-you", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PlayersLikeYouResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, 0, resp.SimilarUsersCount)
+	assert.Empty(t, resp.Games)
+}
+
+func TestGetPlayersLikeYou_AuthRequired(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/players-like-you", nil)
+	// No auth header
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -243,6 +243,8 @@ func NewRouter(cfg Config) *gin.Engine {
 			explore.GET("/moods", exploreHandler.GetExploreMoods)
 			explore.GET("/mood/:mood", exploreHandler.GetMoodGames)
 			explore.GET("/surprise", exploreHandler.GetSurpriseGame)
+			explore.GET("/for-you", exploreHandler.GetForYou)
+			explore.GET("/players-like-you", exploreHandler.GetPlayersLikeYou)
 		}
 
 		// Games
@@ -321,6 +323,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/user/stats", userHandler.GetUserStats)
 		api.GET("/user/play-stats", userHandler.GetPlayStats)
 		api.GET("/user/play-heatmap", statsHandler.GetPlayHeatmap)
+		api.GET("/user/taste-profile", exploreHandler.GetTasteProfile)
 		api.GET("/user/recent", userHandler.GetRecentGames)
 		api.GET("/user/favorites", userHandler.GetFavorites)
 		api.POST("/user/favorites/:gameId", userHandler.AddFavorite)

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { ExplorePage } from "@/pages/explore-page";
-import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition } from "@/types/api";
+import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition, ForYouResponse, PlayersLikeYouResponse } from "@/types/api";
 
 // Mock hooks
 vi.mock("@/hooks/use-explore", () => ({
@@ -13,6 +13,8 @@ vi.mock("@/hooks/use-explore", () => ({
   useKeywords: vi.fn(),
   useFeaturedSeries: vi.fn(),
   useMoods: vi.fn(),
+  useForYou: vi.fn(),
+  usePlayersLikeYou: vi.fn(),
   useSurpriseGame: vi.fn(() => ({
     data: undefined,
     refetch: vi.fn(),
@@ -36,7 +38,7 @@ vi.mock("@/hooks/use-auto-scrape", () => ({
   useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
 }));
 
-import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods } from "@/hooks/use-explore";
+import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods, useForYou, usePlayersLikeYou } from "@/hooks/use-explore";
 
 const mockUseExploreFeatured = useExploreFeatured as ReturnType<typeof vi.fn>;
 const mockUseExploreRows = useExploreRows as ReturnType<typeof vi.fn>;
@@ -44,6 +46,8 @@ const mockUseThemes = useThemes as ReturnType<typeof vi.fn>;
 const mockUseKeywords = useKeywords as ReturnType<typeof vi.fn>;
 const mockUseFeaturedSeries = useFeaturedSeries as ReturnType<typeof vi.fn>;
 const mockUseMoods = useMoods as ReturnType<typeof vi.fn>;
+const mockUseForYou = useForYou as ReturnType<typeof vi.fn>;
+const mockUsePlayersLikeYou = usePlayersLikeYou as ReturnType<typeof vi.fn>;
 
 function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
   return {
@@ -109,6 +113,22 @@ const mockMoods: MoodDefinition[] = [
   { id: "chill", name: "Chill", description: "Relaxing games", icon: "😌", gradient: ["#1a237e", "#4a148c"] },
   { id: "intense", name: "Intense", description: "Heart-pounding action", icon: "🔥", gradient: ["#b71c1c", "#ff6f00"] },
 ];
+
+const mockForYou: ForYouResponse = {
+  rows: [
+    {
+      type: "because_you_played",
+      title: "Because you played Chrono Trigger",
+      source_game: makeGame({ id: "ct", title: "Chrono Trigger", coverUrl: "/covers/ct.jpg" }),
+      games: [makeGame({ id: "fy1", title: "For You Game 1" })],
+    },
+  ],
+};
+
+const mockPlayersLikeYou: PlayersLikeYouResponse = {
+  games: [makeGame({ id: "ply1", title: "Players Pick" })],
+  similar_users_count: 5,
+};
 
 const mockRows: ExploreRowsResponse = {
   rows: [
@@ -191,6 +211,14 @@ describe("ExplorePage", () => {
     });
     mockUseMoods.mockReturnValue({
       data: mockMoods,
+      isLoading: false,
+    });
+    mockUseForYou.mockReturnValue({
+      data: mockForYou,
+      isLoading: false,
+    });
+    mockUsePlayersLikeYou.mockReturnValue({
+      data: mockPlayersLikeYou,
       isLoading: false,
     });
   });
@@ -407,5 +435,53 @@ describe("ExplorePage", () => {
     });
     renderPage();
     expect(screen.getByTestId("mood-picker-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders the For You section", () => {
+    renderPage();
+    expect(screen.getByTestId("for-you-section")).toBeInTheDocument();
+    expect(screen.getByText("For You Game 1")).toBeInTheDocument();
+  });
+
+  it("renders the Players Like You shelf", () => {
+    renderPage();
+    expect(screen.getByTestId("players-like-you-shelf")).toBeInTheDocument();
+    expect(screen.getByText("Players Pick")).toBeInTheDocument();
+  });
+
+  it("hides For You section when no data", () => {
+    mockUseForYou.mockReturnValue({
+      data: { rows: [] },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("for-you-section")).not.toBeInTheDocument();
+  });
+
+  it("hides Players Like You shelf when no data", () => {
+    mockUsePlayersLikeYou.mockReturnValue({
+      data: { games: [], similar_users_count: 0 },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("players-like-you-shelf")).not.toBeInTheDocument();
+  });
+
+  it("shows For You skeleton while loading", () => {
+    mockUseForYou.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByTestId("for-you-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows Players Like You skeleton while loading", () => {
+    mockUsePlayersLikeYou.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByTestId("players-like-you-skeleton")).toBeInTheDocument();
   });
 });

--- a/web/src/features/explore/components/__tests__/for-you-section.test.tsx
+++ b/web/src/features/explore/components/__tests__/for-you-section.test.tsx
@@ -1,0 +1,154 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { ForYouSection } from "../for-you-section";
+import type { ForYouRow, Game } from "@/types/api";
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderComponent(props: {
+  rows?: ForYouRow[];
+  isLoading?: boolean;
+}) {
+  return render(
+    <MemoryRouter>
+      <ForYouSection
+        rows={props.rows}
+        isLoading={props.isLoading ?? false}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("ForYouSection", () => {
+  it("renders 'Because you played' row with source game reference", () => {
+    const rows: ForYouRow[] = [
+      {
+        type: "because_you_played",
+        title: "Because you played Chrono Trigger",
+        source_game: makeGame({
+          id: "source-1",
+          title: "Chrono Trigger",
+          coverUrl: "/covers/chrono.jpg",
+        }),
+        games: [
+          makeGame({ id: "rec-1", title: "Final Fantasy VI" }),
+          makeGame({ id: "rec-2", title: "Secret of Mana" }),
+        ],
+      },
+    ];
+
+    renderComponent({ rows });
+
+    expect(screen.getByTestId("for-you-section")).toBeInTheDocument();
+    expect(screen.getByTestId("for-you-row-because_you_played")).toBeInTheDocument();
+    expect(screen.getByText("Because you played Chrono Trigger")).toBeInTheDocument();
+    expect(screen.getByTestId("source-game-cover")).toBeInTheDocument();
+    expect(screen.getByTestId("source-game-cover")).toHaveAttribute("src", "/covers/chrono.jpg");
+    expect(screen.getByText("Final Fantasy VI")).toBeInTheDocument();
+    expect(screen.getByText("Secret of Mana")).toBeInTheDocument();
+  });
+
+  it("renders 'More Genre' row", () => {
+    const rows: ForYouRow[] = [
+      {
+        type: "more_genre",
+        title: "More RPGs for you",
+        games: [
+          makeGame({ id: "g1", title: "Dragon Quest V" }),
+          makeGame({ id: "g2", title: "Earthbound" }),
+        ],
+      },
+    ];
+
+    renderComponent({ rows });
+
+    expect(screen.getByTestId("for-you-row-more_genre")).toBeInTheDocument();
+    expect(screen.getByText("More RPGs for you")).toBeInTheDocument();
+    expect(screen.getByText("Dragon Quest V")).toBeInTheDocument();
+    expect(screen.getByText("Earthbound")).toBeInTheDocument();
+  });
+
+  it("renders 'Unfinished business' row", () => {
+    const rows: ForYouRow[] = [
+      {
+        type: "unfinished",
+        title: "Unfinished business",
+        games: [
+          makeGame({ id: "u1", title: "Mega Man X" }),
+        ],
+      },
+    ];
+
+    renderComponent({ rows });
+
+    expect(screen.getByTestId("for-you-row-unfinished")).toBeInTheDocument();
+    expect(screen.getByText("Unfinished business")).toBeInTheDocument();
+    expect(screen.getByText("Mega Man X")).toBeInTheDocument();
+  });
+
+  it("renders 'Expand horizons' row with genre callout", () => {
+    const rows: ForYouRow[] = [
+      {
+        type: "expand_horizons",
+        title: "Expand your horizons",
+        genre: "Puzzle",
+        games: [
+          makeGame({ id: "e1", title: "Tetris Attack" }),
+          makeGame({ id: "e2", title: "Panel de Pon" }),
+        ],
+      },
+    ];
+
+    renderComponent({ rows });
+
+    expect(screen.getByTestId("for-you-row-expand_horizons")).toBeInTheDocument();
+    expect(screen.getByText("Expand your horizons")).toBeInTheDocument();
+    expect(screen.getByText("Puzzle")).toBeInTheDocument();
+    expect(screen.getByText("Tetris Attack")).toBeInTheDocument();
+    expect(screen.getByText("Panel de Pon")).toBeInTheDocument();
+  });
+
+  it("shows skeleton when loading", () => {
+    renderComponent({ isLoading: true });
+
+    expect(screen.getByTestId("for-you-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("for-you-section")).not.toBeInTheDocument();
+  });
+
+  it("returns null when no rows", () => {
+    const { container } = renderComponent({ rows: undefined });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when rows is empty array", () => {
+    const { container } = renderComponent({ rows: [] });
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/web/src/features/explore/components/__tests__/players-like-you-shelf.test.tsx
+++ b/web/src/features/explore/components/__tests__/players-like-you-shelf.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { PlayersLikeYouShelf } from "../players-like-you-shelf";
+import type { Game } from "@/types/api";
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderComponent(props: {
+  games?: Game[];
+  isLoading?: boolean;
+  similarUsersCount?: number;
+}) {
+  return render(
+    <MemoryRouter>
+      <PlayersLikeYouShelf
+        games={props.games}
+        isLoading={props.isLoading ?? false}
+        similarUsersCount={props.similarUsersCount ?? 0}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("PlayersLikeYouShelf", () => {
+  it("renders shelf with games", () => {
+    const games = [
+      makeGame({ id: "p1", title: "Super Metroid" }),
+      makeGame({ id: "p2", title: "Castlevania" }),
+    ];
+
+    renderComponent({ games, similarUsersCount: 5 });
+
+    expect(screen.getByTestId("players-like-you-shelf")).toBeInTheDocument();
+    expect(screen.getByText("Players like you also enjoyed")).toBeInTheDocument();
+    expect(screen.getByText("Super Metroid")).toBeInTheDocument();
+    expect(screen.getByText("Castlevania")).toBeInTheDocument();
+  });
+
+  it("shows similar users count", () => {
+    const games = [makeGame({ id: "p1", title: "Super Metroid" })];
+
+    renderComponent({ games, similarUsersCount: 12 });
+
+    expect(screen.getByTestId("similar-users-count")).toBeInTheDocument();
+    expect(screen.getByText("Based on 12 players with similar taste")).toBeInTheDocument();
+  });
+
+  it("shows singular form for 1 player", () => {
+    const games = [makeGame({ id: "p1", title: "Super Metroid" })];
+
+    renderComponent({ games, similarUsersCount: 1 });
+
+    expect(screen.getByText("Based on 1 player with similar taste")).toBeInTheDocument();
+  });
+
+  it("shows skeleton when loading", () => {
+    renderComponent({ isLoading: true });
+
+    expect(screen.getByTestId("players-like-you-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("players-like-you-shelf")).not.toBeInTheDocument();
+  });
+
+  it("returns null when no games", () => {
+    const { container } = renderComponent({ games: undefined });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when games is empty array", () => {
+    const { container } = renderComponent({ games: [] });
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/web/src/features/explore/components/for-you-section.tsx
+++ b/web/src/features/explore/components/for-you-section.tsx
@@ -1,0 +1,181 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton } from "@/components/ui";
+import type { ForYouRow, Game } from "@/types/api";
+
+interface ForYouSectionProps {
+  rows: ForYouRow[] | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+function ForYouSkeleton() {
+  return (
+    <div data-testid="for-you-skeleton" className="space-y-10">
+      {Array.from({ length: 3 }, (_, i) => (
+        <section key={i}>
+          <div className="h-7 w-64 rounded bg-surface-800 animate-pulse mb-5" />
+          <div className="flex gap-5 overflow-hidden">
+            {Array.from({ length: 6 }, (_, j) => (
+              <div key={j} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+                <GameCardSkeleton />
+              </div>
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function ForYouShelf({
+  row,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: {
+  row: ForYouRow;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(
+      el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
+    );
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, row.games]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (!row.games || row.games.length === 0) {
+    return null;
+  }
+
+  const testId = `for-you-row-${row.type}`;
+
+  return (
+    <section data-testid={testId} className="group/shelf relative">
+      <div className="flex items-center gap-3 mb-5">
+        {/* Show source game thumbnail for "because_you_played" rows */}
+        {row.type === "because_you_played" && row.source_game?.coverUrl && (
+          <img
+            src={row.source_game.coverUrl}
+            alt={row.source_game.title}
+            className="h-8 w-6 rounded object-cover flex-shrink-0"
+            data-testid="source-game-cover"
+          />
+        )}
+        <div>
+          <h3 className="text-xl font-bold text-surface-100">{row.title}</h3>
+          {row.type === "expand_horizons" && row.genre && (
+            <p className="text-sm text-surface-400 mt-0.5">
+              Try something from <span className="text-brand-400 font-medium">{row.genre}</span>
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="relative">
+        {/* Scroll arrows */}
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label={`Scroll ${row.title} left`}
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label={`Scroll ${row.title} right`}
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        {/* Scrollable row */}
+        <div
+          ref={scrollRef}
+          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label={row.title}
+        >
+          {row.games.map((game) => (
+            <div
+              key={game.id}
+              className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+              role="listitem"
+            >
+              <GameCard
+                game={game}
+                showConsoleBadge
+                onToggleFavorite={onToggleFavorite}
+                onTogglePlayLater={onTogglePlayLater}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function ForYouSection({
+  rows,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: ForYouSectionProps) {
+  if (isLoading) {
+    return <ForYouSkeleton />;
+  }
+
+  if (!rows || rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-testid="for-you-section" className="space-y-10">
+      {rows.map((row, index) => (
+        <ForYouShelf
+          key={`${row.type}-${index}`}
+          row={row}
+          onToggleFavorite={onToggleFavorite}
+          onTogglePlayLater={onTogglePlayLater}
+        />
+      ))}
+    </div>
+  );
+}

--- a/web/src/features/explore/components/players-like-you-shelf.tsx
+++ b/web/src/features/explore/components/players-like-you-shelf.tsx
@@ -1,0 +1,140 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton } from "@/components/ui";
+import type { Game, GameSummary } from "@/types/api";
+
+interface PlayersLikeYouShelfProps {
+  games: GameSummary[] | undefined;
+  isLoading: boolean;
+  similarUsersCount: number;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+function PlayersLikeYouSkeleton() {
+  return (
+    <section data-testid="players-like-you-skeleton">
+      <div className="h-7 w-80 rounded bg-surface-800 animate-pulse mb-2" />
+      <div className="h-4 w-56 rounded bg-surface-800/60 animate-pulse mb-5" />
+      <div className="flex gap-5 overflow-hidden">
+        {Array.from({ length: 6 }, (_, i) => (
+          <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+            <GameCardSkeleton />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function PlayersLikeYouShelf({
+  games,
+  isLoading,
+  similarUsersCount,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: PlayersLikeYouShelfProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(
+      el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
+    );
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, games]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return <PlayersLikeYouSkeleton />;
+  }
+
+  if (!games || games.length === 0) {
+    return null;
+  }
+
+  const title = "Players like you also enjoyed";
+
+  return (
+    <section data-testid="players-like-you-shelf" className="group/shelf relative">
+      <h2 className="text-xl font-bold text-surface-100 mb-1">{title}</h2>
+      {similarUsersCount > 0 && (
+        <p className="text-sm text-surface-400 mb-5" data-testid="similar-users-count">
+          Based on {similarUsersCount} player{similarUsersCount !== 1 ? "s" : ""} with similar taste
+        </p>
+      )}
+
+      <div className="relative">
+        {/* Scroll arrows */}
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label={`Scroll ${title} left`}
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label={`Scroll ${title} right`}
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        {/* Scrollable row */}
+        <div
+          ref={scrollRef}
+          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label={title}
+        >
+          {games.map((game) => (
+            <div
+              key={game.id}
+              className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+              role="listitem"
+            >
+              <GameCard
+                game={game}
+                showConsoleBadge
+                onToggleFavorite={onToggleFavorite}
+                onTogglePlayLater={onTogglePlayLater}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/hooks/use-explore.ts
+++ b/web/src/hooks/use-explore.ts
@@ -12,6 +12,9 @@ import type {
   GamesResponse,
   MoodDefinition,
   Game,
+  ForYouResponse,
+  TasteProfile,
+  PlayersLikeYouResponse,
 } from "@/types/api";
 
 export function useExploreFeatured() {
@@ -124,5 +127,27 @@ export function useSurpriseGame() {
     queryKey: ["explore", "surprise"],
     queryFn: () => api.get<Game>("/explore/surprise"),
     enabled: false,
+  });
+}
+
+export function useForYou() {
+  return useQuery({
+    queryKey: ["explore", "for-you"],
+    queryFn: () => api.get<ForYouResponse>("/explore/for-you"),
+  });
+}
+
+export function useTasteProfile() {
+  return useQuery({
+    queryKey: ["user", "taste-profile"],
+    queryFn: () => api.get<TasteProfile>("/user/taste-profile"),
+  });
+}
+
+export function usePlayersLikeYou() {
+  return useQuery({
+    queryKey: ["explore", "players-like-you"],
+    queryFn: () =>
+      api.get<PlayersLikeYouResponse>("/explore/players-like-you"),
   });
 }

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -24,6 +24,8 @@ export type ApiGetPath = WithQuery<
   | "/explore/moods"
   | `/explore/mood/${string}`
   | "/explore/surprise"
+  | "/explore/for-you"
+  | "/explore/players-like-you"
 
   // Series
   | `/series/${string}`
@@ -102,6 +104,7 @@ export type ApiGetPath = WithQuery<
   | "/user/shared-session-invites/count"
   | "/user/ra/status"
   | "/user/ra/token"
+  | "/user/taste-profile"
   | "/user/achievements/recent"
 
   // Shared Sessions

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -7,6 +7,8 @@ import { ThemeGrid } from "@/features/explore/components/theme-grid";
 import { KeywordChips } from "@/features/explore/components/keyword-chips";
 import { SeriesShelf } from "@/features/explore/components/series-shelf";
 import { MoodPicker } from "@/features/explore/components/mood-picker";
+import { ForYouSection } from "@/features/explore/components/for-you-section";
+import { PlayersLikeYouShelf } from "@/features/explore/components/players-like-you-shelf";
 import {
   useExploreFeatured,
   useExploreRows,
@@ -14,6 +16,8 @@ import {
   useKeywords,
   useFeaturedSeries,
   useMoods,
+  useForYou,
+  usePlayersLikeYou,
 } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -45,6 +49,14 @@ export function ExplorePage() {
     data: moods,
     isLoading: isMoodsLoading,
   } = useMoods();
+  const {
+    data: forYouData,
+    isLoading: isForYouLoading,
+  } = useForYou();
+  const {
+    data: playersLikeYouData,
+    isLoading: isPlayersLoading,
+  } = usePlayersLikeYou();
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
 
@@ -103,6 +115,23 @@ export function ExplorePage() {
 
       {/* Mood Picker */}
       <MoodPicker moods={moods} isLoading={isMoodsLoading} />
+
+      {/* For You — personalized recommendations */}
+      <ForYouSection
+        rows={forYouData?.rows}
+        isLoading={isForYouLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
+
+      {/* Players Like You */}
+      <PlayersLikeYouShelf
+        games={playersLikeYouData?.games}
+        isLoading={isPlayersLoading}
+        similarUsersCount={playersLikeYouData?.similar_users_count ?? 0}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
 
       {/* First shelf row */}
       {isRowsLoading ? (

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -918,6 +918,49 @@ export interface ExploreRowsResponse {
   rows: ExploreRow[];
 }
 
+// --- For You / Personalized Recommendations ---
+
+/** GameSummary is a full Game object when returned by recommendation endpoints */
+export type GameSummary = Game;
+
+export interface ForYouRow {
+  type: "because_you_played" | "more_genre" | "unfinished" | "expand_horizons";
+  title: string;
+  source_game?: GameSummary;
+  genre?: string;
+  games: GameSummary[];
+}
+
+export interface ForYouResponse {
+  rows: ForYouRow[];
+}
+
+export interface TasteBreakdown {
+  name: string;
+  percentage: number;
+  play_time: number;
+  game_count: number;
+}
+
+export interface ConsoleBreakdown {
+  name: string;
+  abbreviation: string;
+  play_time: number;
+  game_count: number;
+}
+
+export interface TasteProfile {
+  total_play_time: number;
+  genres: TasteBreakdown[];
+  themes: TasteBreakdown[];
+  top_consoles: ConsoleBreakdown[];
+}
+
+export interface PlayersLikeYouResponse {
+  games: GameSummary[];
+  similar_users_count: number;
+}
+
 export interface StagedUpload {
   id: string;
   fileName: string;


### PR DESCRIPTION
## Summary
- Add personalized game discovery with 4 recommendation row types: "Because you played [Game]" (genre-based), "More [Genre] for you" (most-played genre), "Your unfinished business" (short sessions, abandoned), and "Expand your horizons" (unplayed genres)
- Add taste profile endpoint (`GET /user/taste-profile`) returning genre/theme/console breakdown from play history
- Add collaborative filtering (`GET /explore/players-like-you`) using Jaccard similarity on favorites to recommend games from similar users
- Web: ForYouSection and PlayersLikeYouShelf components with horizontal scroll, chevron navigation, skeletons, and ARIA accessibility
- Player: ForYouSection composable with LazyRow game cards, source game thumbnails, and loading skeletons

## Test plan
- [x] Go: 13 new tests for for-you, taste-profile, and players-like-you endpoints (all row types, empty history, auth required, collaborative filtering)
- [x] Web: 7 for-you-section tests + 6 players-like-you tests + 6 updated explore-page tests (880 total pass)
- [x] Player: 4 new desktop E2E tests for ForYouSection rendering and multiple row types (520 total pass)