### PR TITLE
fix: use camelCase JSON field names in Phase 6 web types

### DIFF
--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -119,7 +119,7 @@ const mockForYou: ForYouResponse = {
     {
       type: "because_you_played",
       title: "Because you played Chrono Trigger",
-      source_game: makeGame({ id: "ct", title: "Chrono Trigger", coverUrl: "/covers/ct.jpg" }),
+      sourceGame: makeGame({ id: "ct", title: "Chrono Trigger", coverUrl: "/covers/ct.jpg" }),
       games: [makeGame({ id: "fy1", title: "For You Game 1" })],
     },
   ],
@@ -127,7 +127,7 @@ const mockForYou: ForYouResponse = {
 
 const mockPlayersLikeYou: PlayersLikeYouResponse = {
   games: [makeGame({ id: "ply1", title: "Players Pick" })],
-  similar_users_count: 5,
+  similarUsersCount: 5,
 };
 
 const mockRows: ExploreRowsResponse = {
@@ -460,7 +460,7 @@ describe("ExplorePage", () => {
 
   it("hides Players Like You shelf when no data", () => {
     mockUsePlayersLikeYou.mockReturnValue({
-      data: { games: [], similar_users_count: 0 },
+      data: { games: [], similarUsersCount: 0 },
       isLoading: false,
     });
     renderPage();

--- a/web/src/features/explore/components/__tests__/for-you-section.test.tsx
+++ b/web/src/features/explore/components/__tests__/for-you-section.test.tsx
@@ -52,7 +52,7 @@ describe("ForYouSection", () => {
       {
         type: "because_you_played",
         title: "Because you played Chrono Trigger",
-        source_game: makeGame({
+        sourceGame: makeGame({
           id: "source-1",
           title: "Chrono Trigger",
           coverUrl: "/covers/chrono.jpg",

--- a/web/src/features/explore/components/for-you-section.tsx
+++ b/web/src/features/explore/components/for-you-section.tsx
@@ -85,10 +85,10 @@ function ForYouShelf({
     <section data-testid={testId} className="group/shelf relative">
       <div className="flex items-center gap-3 mb-5">
         {/* Show source game thumbnail for "because_you_played" rows */}
-        {row.type === "because_you_played" && row.source_game?.coverUrl && (
+        {row.type === "because_you_played" && row.sourceGame?.coverUrl && (
           <img
-            src={row.source_game.coverUrl}
-            alt={row.source_game.title}
+            src={row.sourceGame.coverUrl}
+            alt={row.sourceGame.title}
             className="h-8 w-6 rounded object-cover flex-shrink-0"
             data-testid="source-game-cover"
           />

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -128,7 +128,7 @@ export function ExplorePage() {
       <PlayersLikeYouShelf
         games={playersLikeYouData?.games}
         isLoading={isPlayersLoading}
-        similarUsersCount={playersLikeYouData?.similar_users_count ?? 0}
+        similarUsersCount={playersLikeYouData?.similarUsersCount ?? 0}
         onToggleFavorite={handleToggleFavorite}
         onTogglePlayLater={handleTogglePlayLater}
       />

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -926,7 +926,7 @@ export type GameSummary = Game;
 export interface ForYouRow {
   type: "because_you_played" | "more_genre" | "unfinished" | "expand_horizons";
   title: string;
-  source_game?: GameSummary;
+  sourceGame?: GameSummary;
   genre?: string;
   games: GameSummary[];
 }
@@ -938,27 +938,27 @@ export interface ForYouResponse {
 export interface TasteBreakdown {
   name: string;
   percentage: number;
-  play_time: number;
-  game_count: number;
+  playTime: number;
+  gameCount: number;
 }
 
 export interface ConsoleBreakdown {
   name: string;
   abbreviation: string;
-  play_time: number;
-  game_count: number;
+  playTime: number;
+  gameCount: number;
 }
 
 export interface TasteProfile {
-  total_play_time: number;
+  totalPlayTime: number;
   genres: TasteBreakdown[];
   themes: TasteBreakdown[];
-  top_consoles: ConsoleBreakdown[];
+  topConsoles: ConsoleBreakdown[];
 }
 
 export interface PlayersLikeYouResponse {
   games: GameSummary[];
-  similar_users_count: number;
+  similarUsersCount: number;
 }
 
 export interface StagedUpload {


### PR DESCRIPTION
## Summary
- Fixed all Phase 6 TypeScript interfaces to use camelCase field names matching the Go backend JSON tags
- Changed: `source_game` → `sourceGame`, `similar_users_count` → `similarUsersCount`, `play_time` → `playTime`, `game_count` → `gameCount`, `total_play_time` → `totalPlayTime`, `top_consoles` → `topConsoles`
- Updated all component references and test files

## Test plan
- [x] All 880 web tests pass
- [x] No snake_case field references remain in web/src/