### PR TITLE
feat: add Developer & Publisher Spotlight pages (Explore Phase 7)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreDeveloperTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreDeveloperTest.kt
@@ -1,0 +1,195 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.DeveloperDetail
+import com.spela.player.domain.model.DeveloperSpotlight
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for Phase 7: Developer & Publisher Spotlight Pages.
+ *
+ * Covers:
+ * - Developer spotlight section renders on Explore screen
+ * - Developer spotlight displays developer name and stats
+ * - Navigate to developer detail screen
+ * - Developer detail shows games
+ * - Developer detail console filter works
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ExploreDeveloperTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private val sampleGames = listOf(
+        Game(
+            id = "game-dev-1",
+            title = "Final Fantasy VI",
+            consoleId = "snes",
+            consoleName = "SNES",
+            genre = "RPG",
+            rating = 92.0,
+        ),
+        Game(
+            id = "game-dev-2",
+            title = "Chrono Trigger",
+            consoleId = "snes",
+            consoleName = "SNES",
+            genre = "RPG",
+            rating = 95.0,
+        ),
+        Game(
+            id = "game-dev-3",
+            title = "Kingdom Hearts",
+            consoleId = "ps2",
+            consoleName = "PS2",
+            genre = "Action RPG",
+            rating = 85.0,
+        ),
+    )
+
+    private val sampleSpotlight = DeveloperSpotlight(
+        name = "Square",
+        gameCount = 24,
+        avgRating = 88.5,
+        consoles = listOf("SNES", "PS1", "PS2"),
+        topGames = sampleGames.take(2),
+        heroUrl = null,
+    )
+
+    private val sampleDeveloperDetail = DeveloperDetail(
+        name = "Square",
+        gameCount = 3,
+        avgRating = 90.7,
+        consoles = listOf("SNES", "PS2"),
+        games = sampleGames,
+    )
+
+    // --- Developer spotlight on Explore screen ---
+
+    @Test
+    fun developerSpotlightRendersOnExploreScreen() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerSpotlightData = sampleSpotlight
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_developer_spotlight_section").assertExists()
+        onNodeWithText("Developer Spotlight").assertExists()
+    }
+
+    @Test
+    fun developerSpotlightDisplaysNameAndStats() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerSpotlightData = sampleSpotlight
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("developer_spotlight").assertExists()
+        onNodeWithText("Square").assertExists()
+        onNodeWithText("24 games").assertExists()
+    }
+
+    @Test
+    fun developerSpotlightHiddenWhenNoData() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerSpotlightData = null
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_developer_spotlight_section").assertDoesNotExist()
+    }
+
+    // --- Navigation to developer detail ---
+
+    @Test
+    fun navigationToDeveloperDetailWorks() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerSpotlightData = sampleSpotlight
+        harness.exploreRepo.developerDetails = mapOf("Square" to sampleDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("developer_spotlight_card").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("explore_developer/Square", navState.currentScreen.route)
+    }
+
+    // --- Developer detail screen ---
+
+    @Test
+    fun developerDetailShowsGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Square" to sampleDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Square"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_screen").assertIsDisplayed()
+        onAllNodesWithText("Square").fetchSemanticsNodes().let {
+            assert(it.isNotEmpty()) { "Expected at least one 'Square' text node" }
+        }
+        onNodeWithText("Final Fantasy VI").assertExists()
+        onNodeWithText("Chrono Trigger").assertExists()
+        onNodeWithText("Kingdom Hearts").assertExists()
+    }
+
+    @Test
+    fun developerDetailConsoleFilterWorks() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Square" to sampleDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Square"))
+        )
+        advance(harness)
+
+        // All 3 games visible initially
+        onNodeWithTag("developer_game_game-dev-1").assertExists()
+        onNodeWithTag("developer_game_game-dev-2").assertExists()
+        onNodeWithTag("developer_game_game-dev-3").assertExists()
+
+        // Click SNES filter
+        onNodeWithTag("developer_console_chip_SNES").performClick()
+        advanceQuick(harness)
+
+        // Only SNES games visible
+        onNodeWithTag("developer_game_game-dev-1").assertExists()
+        onNodeWithTag("developer_game_game-dev-2").assertExists()
+        onNodeWithTag("developer_game_game-dev-3").assertDoesNotExist()
+
+        // Click SNES again to clear filter
+        onNodeWithTag("developer_console_chip_SNES").performClick()
+        advanceQuick(harness)
+
+        // All games visible again
+        onNodeWithTag("developer_game_game-dev-1").assertExists()
+        onNodeWithTag("developer_game_game-dev-2").assertExists()
+        onNodeWithTag("developer_game_game-dev-3").assertExists()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1335,6 +1335,10 @@ class FakeExploreRepository : ExploreRepository {
     var forYouRows: List<ForYouRow> = emptyList()
     var tasteProfile: TasteProfile? = null
     var playersLikeYou: PlayersLikeYouResult? = null
+    var developerSummaries: List<DeveloperSummary> = emptyList()
+    var developerDetails: Map<String, DeveloperDetail> = emptyMap()
+    var publisherDetails: Map<String, DeveloperDetail> = emptyMap()
+    var developerSpotlightData: DeveloperSpotlight? = null
     var shouldFail: Boolean = false
 
     override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> =
@@ -1415,6 +1419,34 @@ class FakeExploreRepository : ExploreRepository {
             val result = playersLikeYou
             if (result != null) Result.success(result)
             else Result.failure(Exception("No players like you available"))
+        }
+
+    override suspend fun getDevelopers(): Result<List<DeveloperSummary>> =
+        if (shouldFail) Result.failure(Exception("Failed to load developers"))
+        else Result.success(developerSummaries)
+
+    override suspend fun getDeveloperDetail(name: String): Result<DeveloperDetail> =
+        if (shouldFail) Result.failure(Exception("Failed to load developer detail"))
+        else {
+            val detail = developerDetails[name]
+            if (detail != null) Result.success(detail)
+            else Result.failure(Exception("Developer not found"))
+        }
+
+    override suspend fun getPublisherDetail(name: String): Result<DeveloperDetail> =
+        if (shouldFail) Result.failure(Exception("Failed to load publisher detail"))
+        else {
+            val detail = publisherDetails[name]
+            if (detail != null) Result.success(detail)
+            else Result.failure(Exception("Publisher not found"))
+        }
+
+    override suspend fun getDeveloperSpotlight(): Result<DeveloperSpotlight> =
+        if (shouldFail) Result.failure(Exception("Failed to load developer spotlight"))
+        else {
+            val spotlight = developerSpotlightData
+            if (spotlight != null) Result.success(spotlight)
+            else Result.failure(Exception("No developer spotlight available"))
         }
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -324,6 +324,28 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/explore/players-like-you").body()
     }
 
+    /** Returns list of developer summaries */
+    suspend fun getDevelopers(): DeveloperListResponseDto {
+        return client.get("$baseUrl/api/explore/developers").body()
+    }
+
+    /** Returns detail for a specific developer */
+    suspend fun getDeveloperDetail(name: String): DeveloperDetailResponseDto {
+        val encoded = name.encodeURLParameter()
+        return client.get("$baseUrl/api/explore/developers/$encoded").body()
+    }
+
+    /** Returns detail for a specific publisher (same response type as developer) */
+    suspend fun getPublisherDetail(name: String): DeveloperDetailResponseDto {
+        val encoded = name.encodeURLParameter()
+        return client.get("$baseUrl/api/explore/publishers/$encoded").body()
+    }
+
+    /** Returns developer spotlight for the Explore page */
+    suspend fun getDeveloperSpotlight(): DeveloperSpotlightResponseDto {
+        return client.get("$baseUrl/api/explore/developers/spotlight").body()
+    }
+
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
     suspend fun getRecentGames(): List<GameDto> {
         return client.get("$baseUrl/api/user/recent").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -672,3 +672,29 @@ fun PlayersLikeYouResponseDto.toDomain(): PlayersLikeYouResult = PlayersLikeYouR
     games = games.map { it.toDomain() },
     similarUsersCount = similarUsersCount,
 )
+
+// Developer / Publisher mappers
+
+fun DeveloperSummaryDto.toDomain(): DeveloperSummary = DeveloperSummary(
+    name = name,
+    gameCount = gameCount,
+    avgRating = avgRating,
+    consoles = consoles,
+)
+
+fun DeveloperDetailResponseDto.toDomain(): DeveloperDetail = DeveloperDetail(
+    name = name,
+    gameCount = gameCount,
+    avgRating = avgRating,
+    consoles = consoles,
+    games = games.map { it.toDomain() },
+)
+
+fun DeveloperSpotlightResponseDto.toDomain(): DeveloperSpotlight = DeveloperSpotlight(
+    name = name,
+    gameCount = gameCount,
+    avgRating = avgRating,
+    consoles = consoles,
+    topGames = topGames.map { it.toDomain() },
+    heroUrl = heroUrl.ifBlank { null },
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1162,3 +1162,37 @@ data class PlayersLikeYouResponseDto(
     val games: List<GameDto>,
     val similarUsersCount: Int,
 )
+
+// Developer / Publisher
+
+@Serializable
+data class DeveloperSummaryDto(
+    val name: String,
+    val gameCount: Int,
+    val avgRating: Double,
+    val consoles: List<String>,
+)
+
+@Serializable
+data class DeveloperListResponseDto(
+    val developers: List<DeveloperSummaryDto>,
+)
+
+@Serializable
+data class DeveloperDetailResponseDto(
+    val name: String,
+    val gameCount: Int,
+    val avgRating: Double,
+    val consoles: List<String>,
+    val games: List<GameDto>,
+)
+
+@Serializable
+data class DeveloperSpotlightResponseDto(
+    val name: String,
+    val gameCount: Int,
+    val avgRating: Double,
+    val consoles: List<String>,
+    val topGames: List<GameDto>,
+    val heroUrl: String = "",
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -2,6 +2,9 @@ package com.spela.player.data.repository
 
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.toDomain
+import com.spela.player.domain.model.DeveloperDetail
+import com.spela.player.domain.model.DeveloperSpotlight
+import com.spela.player.domain.model.DeveloperSummary
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
 import com.spela.player.domain.model.FeaturedSeries
@@ -156,6 +159,44 @@ class ExploreRepositoryImpl(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                     heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
                     logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+                )
+            },
+        )
+    }
+
+    override suspend fun getDevelopers(): Result<List<DeveloperSummary>> = runCatching {
+        apiClient.getDevelopers().developers.map { it.toDomain() }
+    }
+
+    override suspend fun getDeveloperDetail(name: String): Result<DeveloperDetail> = runCatching {
+        val dto = apiClient.getDeveloperDetail(name)
+        dto.toDomain().copy(
+            games = dto.games.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                )
+            },
+        )
+    }
+
+    override suspend fun getPublisherDetail(name: String): Result<DeveloperDetail> = runCatching {
+        val dto = apiClient.getPublisherDetail(name)
+        dto.toDomain().copy(
+            games = dto.games.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                )
+            },
+        )
+    }
+
+    override suspend fun getDeveloperSpotlight(): Result<DeveloperSpotlight> = runCatching {
+        val dto = apiClient.getDeveloperSpotlight()
+        dto.toDomain().copy(
+            heroUrl = apiClient.resolveUrl(dto.heroUrl),
+            topGames = dto.topGames.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 )
             },
         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -124,3 +124,27 @@ data class PlayersLikeYouResult(
     val games: List<Game>,
     val similarUsersCount: Int,
 )
+
+data class DeveloperSummary(
+    val name: String,
+    val gameCount: Int,
+    val avgRating: Double,
+    val consoles: List<String>,
+)
+
+data class DeveloperDetail(
+    val name: String,
+    val gameCount: Int,
+    val avgRating: Double,
+    val consoles: List<String>,
+    val games: List<Game>,
+)
+
+data class DeveloperSpotlight(
+    val name: String,
+    val gameCount: Int,
+    val avgRating: Double,
+    val consoles: List<String>,
+    val topGames: List<Game>,
+    val heroUrl: String?,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -1,5 +1,8 @@
 package com.spela.player.domain.repository
 
+import com.spela.player.domain.model.DeveloperDetail
+import com.spela.player.domain.model.DeveloperSpotlight
+import com.spela.player.domain.model.DeveloperSummary
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
 import com.spela.player.domain.model.FeaturedSeries
@@ -31,4 +34,8 @@ interface ExploreRepository {
     suspend fun getForYou(): Result<List<ForYouRow>>
     suspend fun getTasteProfile(): Result<TasteProfile>
     suspend fun getPlayersLikeYou(): Result<PlayersLikeYouResult>
+    suspend fun getDevelopers(): Result<List<DeveloperSummary>>
+    suspend fun getDeveloperDetail(name: String): Result<DeveloperDetail>
+    suspend fun getPublisherDetail(name: String): Result<DeveloperDetail>
+    suspend fun getDeveloperSpotlight(): Result<DeveloperSpotlight>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
@@ -187,7 +187,14 @@ class NavigationViewModel(
 
     companion object {
         fun activeTabForScreen(screen: SpScreen): BottomNavTab = when (screen) {
-            is SpScreen.Explore -> BottomNavTab.EXPLORE
+            is SpScreen.Explore,
+            is SpScreen.ExploreTheme,
+            is SpScreen.ExploreKeyword,
+            is SpScreen.ExploreSeries,
+            is SpScreen.ExploreMood,
+            is SpScreen.ExploreDeveloper,
+            is SpScreen.ExplorePublisher,
+            -> BottomNavTab.EXPLORE
             is SpScreen.Consoles, is SpScreen.Console -> BottomNavTab.CONSOLES
             is SpScreen.Collections, is SpScreen.CollectionDetail -> BottomNavTab.COLLECTIONS
             is SpScreen.Activity, is SpScreen.Stats -> BottomNavTab.ACTIVITY

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -33,6 +33,8 @@ sealed class SpScreen(val route: String) {
     data class ExploreKeyword(val keywordId: String, val keywordName: String) : SpScreen("explore_keyword/$keywordId")
     data class ExploreSeries(val seriesId: String, val seriesName: String) : SpScreen("explore_series/$seriesId")
     data class ExploreMood(val moodId: String, val moodName: String) : SpScreen("explore_mood/$moodId")
+    data class ExploreDeveloper(val name: String) : SpScreen("explore_developer/$name")
+    data class ExplorePublisher(val name: String) : SpScreen("explore_publisher/$name")
 }
 
 data class NavigationState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -92,6 +92,7 @@ import com.spela.player.presentation.ui.screen.ChallengeDetailScreen
 import com.spela.player.presentation.ui.screen.ChallengeListScreen
 import com.spela.player.presentation.ui.screen.GlobalChallengesScreen
 import com.spela.player.presentation.ui.screen.StatsScreen
+import com.spela.player.presentation.ui.screen.ExploreDeveloperScreen
 import com.spela.player.presentation.ui.screen.ExploreKeywordScreen
 import com.spela.player.presentation.ui.screen.ExploreMoodScreen
 import com.spela.player.presentation.ui.screen.ExploreScreen
@@ -476,6 +477,11 @@ fun SpelaApp(
                                                 NavigationIntent.NavigateTo(SpScreen.ExploreMood(moodId, moodName))
                                             )
                                         },
+                                        onDeveloperSelected = { name ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper(name))
+                                            )
+                                        },
                                         onSurpriseMe = {
                                             exploreViewModel.loadSurpriseGame { gameId ->
                                                 navigationViewModel.onIntent(
@@ -546,6 +552,42 @@ fun SpelaApp(
                                     ExploreMoodScreen(
                                         moodId = screen.moodId,
                                         moodName = screen.moodName,
+                                        viewModel = exploreViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.ExploreDeveloper -> {
+                                if (exploreViewModel != null) {
+                                    ExploreDeveloperScreen(
+                                        name = screen.name,
+                                        isDeveloper = true,
+                                        viewModel = exploreViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.ExplorePublisher -> {
+                                if (exploreViewModel != null) {
+                                    ExploreDeveloperScreen(
+                                        name = screen.name,
+                                        isDeveloper = false,
                                         viewModel = exploreViewModel,
                                         onGameSelected = { gameId ->
                                             navigationViewModel.onIntent(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperSpotlightSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperSpotlightSection.kt
@@ -1,0 +1,223 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.DeveloperSpotlight
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpShimmer
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.formatRating
+
+@Composable
+fun DeveloperSpotlightSection(
+    spotlight: DeveloperSpotlight,
+    onDeveloperSelected: (name: String) -> Unit,
+    onGameSelected: (gameId: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.testTag("developer_spotlight"),
+    ) {
+        // Developer info header
+        SpCard(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = SpSpacing.ScreenHorizontal)
+                .testTag("developer_spotlight_card")
+                .semantics {
+                    contentDescription = "${spotlight.name}, ${spotlight.gameCount} games, rating ${formatRating(spotlight.avgRating)}"
+                    role = Role.Button
+                },
+            onClick = { onDeveloperSelected(spotlight.name) },
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(100.dp)
+                    .clip(RoundedCornerShape(SpSpacing.CardCornerRadius))
+                    .background(
+                        Brush.linearGradient(
+                            listOf(
+                                Color(0xFF1A237E),
+                                Color(0xFF283593),
+                            ),
+                        ),
+                    ),
+                contentAlignment = Alignment.Center,
+            ) {
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    modifier = Modifier.padding(SpSpacing.Medium),
+                ) {
+                    Text(
+                        text = spotlight.name,
+                        style = SpTypography.TitleLarge,
+                        color = Color.White,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    Spacer(Modifier.height(SpSpacing.XXSmall))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                    ) {
+                        Text(
+                            text = "${spotlight.gameCount} games",
+                            style = SpTypography.LabelSmall,
+                            color = Color.White.copy(alpha = 0.85f),
+                        )
+                        if (spotlight.avgRating > 0) {
+                            Icon(
+                                imageVector = Icons.Filled.Star,
+                                contentDescription = null,
+                                tint = SpColor.Rating,
+                                modifier = Modifier.size(10.dp),
+                            )
+                            Text(
+                                text = formatRating(spotlight.avgRating),
+                                style = SpTypography.LabelSmall,
+                                color = Color.White.copy(alpha = 0.85f),
+                            )
+                        }
+                    }
+                    if (spotlight.consoles.isNotEmpty()) {
+                        Spacer(Modifier.height(SpSpacing.XXSmall))
+                        Text(
+                            text = spotlight.consoles.joinToString(", "),
+                            style = SpTypography.LabelSmall,
+                            color = Color.White.copy(alpha = 0.65f),
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    }
+                }
+            }
+        }
+
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // Top games row
+        if (spotlight.topGames.isNotEmpty()) {
+            LazyRow(
+                modifier = Modifier.testTag("developer_spotlight_games"),
+                contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+            ) {
+                items(spotlight.topGames, key = { it.id }) { game ->
+                    SpotlightGameCard(
+                        game = game,
+                        onClick = { onGameSelected(game.id) },
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun SpotlightGameCard(
+    game: Game,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        modifier = Modifier
+            .width(SpSpacing.CoverMediumWidth)
+            .testTag("developer_spotlight_game_${game.id}")
+            .semantics {
+                contentDescription = "${game.title}, ${game.consoleName}"
+                role = Role.Button
+            },
+        onClick = onClick,
+        onGradient = true,
+    ) {
+        Column {
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.title} cover art",
+                modifier = Modifier.fillMaxWidth(),
+                aspectRatio = game.coverAspectRatio,
+            )
+            Column(
+                modifier = Modifier.padding(
+                    horizontal = SpSpacing.Small,
+                    vertical = SpSpacing.Small,
+                ),
+            ) {
+                Text(
+                    text = game.title,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+                Text(
+                    text = game.consoleName,
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun DeveloperSpotlightSkeleton(
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.testTag("developer_spotlight_skeleton")) {
+        SpShimmer(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = SpSpacing.ScreenHorizontal)
+                .clip(RoundedCornerShape(SpSpacing.CardCornerRadius)),
+            width = 400.dp,
+            height = 100.dp,
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+        ) {
+            items(4) {
+                SpGameCardSkeleton(modifier = Modifier.width(SpSpacing.CoverMediumWidth))
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
@@ -1,0 +1,380 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+import com.spela.player.util.formatRating
+
+@Composable
+fun ExploreDeveloperScreen(
+    name: String,
+    isDeveloper: Boolean = true,
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val state by viewModel.developerDetailState.collectAsState()
+
+    LaunchedEffect(name, isDeveloper) {
+        if (isDeveloper) {
+            viewModel.loadDeveloperDetail(name)
+        } else {
+            viewModel.loadPublisherDetail(name)
+        }
+    }
+
+    Box(modifier = Modifier.fillMaxSize().testTag("developer_detail_screen")) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = name,
+                showBack = true,
+                onBack = onBack,
+            )
+
+            when {
+                state.isLoading && state.detail == null -> {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(SpSpacing.ScreenHorizontal)
+                            .testTag("developer_detail_loading"),
+                    ) {
+                        Spacer(Modifier.height(SpSpacing.Large))
+                        repeat(4) {
+                            SpGameCardSkeleton(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(bottom = SpSpacing.Medium),
+                            )
+                        }
+                    }
+                }
+
+                state.detail != null -> {
+                    val detail = state.detail!!
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = SpSpacing.XXLarge),
+                    ) {
+                        // Stats banner
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(120.dp)
+                                    .background(
+                                        Brush.verticalGradient(
+                                            listOf(
+                                                SpColor.Primary.copy(alpha = 0.3f),
+                                                SpColor.Background,
+                                            ),
+                                        ),
+                                    )
+                                    .testTag("developer_stats_banner"),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Column(
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                ) {
+                                    Text(
+                                        text = detail.name,
+                                        style = SpTypography.DisplaySmall,
+                                        color = SpColor.OnBackground,
+                                    )
+                                    Spacer(Modifier.height(SpSpacing.Small))
+                                    Row(
+                                        verticalAlignment = Alignment.CenterVertically,
+                                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                                    ) {
+                                        Text(
+                                            text = "${detail.gameCount} games",
+                                            style = SpTypography.BodyMedium,
+                                            color = SpColor.OnBackgroundSecondary,
+                                            modifier = Modifier.testTag("developer_game_count"),
+                                        )
+                                        if (detail.avgRating > 0) {
+                                            Row(
+                                                verticalAlignment = Alignment.CenterVertically,
+                                                horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+                                            ) {
+                                                Icon(
+                                                    imageVector = Icons.Filled.Star,
+                                                    contentDescription = null,
+                                                    tint = SpColor.Rating,
+                                                    modifier = Modifier.size(14.dp),
+                                                )
+                                                Text(
+                                                    text = formatRating(detail.avgRating),
+                                                    style = SpTypography.BodyMedium,
+                                                    color = SpColor.OnBackgroundSecondary,
+                                                    modifier = Modifier.testTag("developer_avg_rating"),
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Console filter chips
+                        if (detail.consoles.isNotEmpty()) {
+                            item {
+                                DeveloperConsoleFilterRow(
+                                    consoles = detail.consoles,
+                                    totalGames = detail.gameCount,
+                                    selectedConsole = state.consoleFilter,
+                                    onConsoleSelected = { console ->
+                                        viewModel.setDeveloperConsoleFilter(
+                                            if (console != null && state.consoleFilter == console) null else console,
+                                        )
+                                    },
+                                    modifier = Modifier
+                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                        .testTag("developer_console_filters"),
+                                )
+                                Spacer(Modifier.height(SpSpacing.Large))
+                            }
+                        }
+
+                        // Games grid
+                        val filteredGames = state.filteredGames
+                        if (filteredGames.isEmpty() && !state.isLoading) {
+                            item {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(SpSpacing.XXLarge),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    SpEmptyState(
+                                        icon = Icons.Filled.Code,
+                                        title = "No games found",
+                                        message = "No games match the selected filter.",
+                                        modifier = Modifier.testTag("developer_empty_state"),
+                                    )
+                                }
+                            }
+                        } else {
+                            items(
+                                items = filteredGames,
+                                key = { it.id },
+                            ) { game ->
+                                DeveloperGameItem(
+                                    game = game,
+                                    onClick = { onGameSelected(game.id) },
+                                )
+                            }
+                        }
+                    }
+                }
+
+                else -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.Code,
+                            title = if (isDeveloper) "Developer not found" else "Publisher not found",
+                            message = "Could not load details.",
+                            modifier = Modifier.testTag("developer_error_state"),
+                        )
+                    }
+                }
+            }
+        }
+
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.dismissDeveloperDetailError() },
+                )
+            },
+            onDismiss = { viewModel.dismissDeveloperDetailError() },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun DeveloperConsoleFilterRow(
+    consoles: List<String>,
+    totalGames: Int,
+    selectedConsole: String?,
+    onConsoleSelected: (String?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        // "All" chip
+        SpChip(
+            text = "All ($totalGames)",
+            onClick = { onConsoleSelected(null) },
+            isSelected = selectedConsole == null,
+            modifier = Modifier
+                .testTag("developer_console_chip_all")
+                .semantics {
+                    contentDescription = "All, $totalGames games"
+                    role = Role.Button
+                },
+        )
+
+        consoles.forEach { console ->
+            val isSelected = console.equals(selectedConsole, ignoreCase = true)
+
+            SpChip(
+                text = console,
+                onClick = { onConsoleSelected(console) },
+                isSelected = isSelected,
+                modifier = Modifier
+                    .testTag("developer_console_chip_$console")
+                    .semantics {
+                        contentDescription = console
+                        role = Role.Button
+                    },
+            )
+        }
+    }
+}
+
+@Composable
+private fun DeveloperGameItem(
+    game: Game,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.XSmall,
+            )
+            .testTag("developer_game_${game.id}")
+            .semantics {
+                contentDescription = "${game.title}, ${game.consoleName}"
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SpSpacing.Medium),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+        ) {
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.title} cover art",
+                modifier = Modifier
+                    .width(48.dp)
+                    .height(64.dp)
+                    .clip(RoundedCornerShape(SpSpacing.RadiusSmall)),
+                aspectRatio = 0.75f,
+            )
+
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = game.title,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    Text(
+                        text = game.consoleName,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                    )
+
+                    if (game.rating > 0) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(10.dp),
+                        )
+                        Text(
+                            text = formatRating(game.rating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -22,6 +22,8 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.feature.explore.DeveloperSpotlightSection
+import com.spela.player.presentation.ui.feature.explore.DeveloperSpotlightSkeleton
 import com.spela.player.presentation.ui.feature.explore.ForYouSection
 import com.spela.player.presentation.ui.feature.explore.ForYouSkeleton
 import com.spela.player.presentation.ui.feature.explore.GameShelf
@@ -48,6 +50,7 @@ fun ExploreScreen(
     onKeywordSelected: ((keywordId: String, keywordName: String) -> Unit)? = null,
     onSeriesSelected: ((seriesId: String, seriesName: String) -> Unit)? = null,
     onMoodSelected: ((moodId: String, moodName: String) -> Unit)? = null,
+    onDeveloperSelected: ((name: String) -> Unit)? = null,
     onSurpriseMe: (() -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
@@ -244,6 +247,35 @@ fun ExploreScreen(
                                     onSeriesSelected = { seriesId, seriesName ->
                                         onSeriesSelected?.invoke(seriesId, seriesName)
                                     },
+                                )
+                            }
+                        }
+                    }
+
+                    // Developer spotlight section
+                    item {
+                        if (state.isLoadingDeveloperSpotlight && state.developerSpotlight == null) {
+                            SpTitledSection(
+                                title = "Developer Spotlight",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                DeveloperSpotlightSkeleton()
+                            }
+                        } else if (state.developerSpotlight != null) {
+                            SpTitledSection(
+                                title = "Developer Spotlight",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_developer_spotlight_section"),
+                            ) {
+                                DeveloperSpotlightSection(
+                                    spotlight = state.developerSpotlight!!,
+                                    onDeveloperSelected = { name ->
+                                        onDeveloperSelected?.invoke(name)
+                                    },
+                                    onGameSelected = onGameSelected,
                                 )
                             }
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -1,5 +1,7 @@
 package com.spela.player.presentation.viewmodel
 
+import com.spela.player.domain.model.DeveloperDetail
+import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
 import com.spela.player.domain.model.FeaturedSeries
@@ -28,6 +30,7 @@ data class ExploreState(
     val featuredSeries: List<FeaturedSeries> = emptyList(),
     val moods: List<MoodDefinition> = emptyList(),
     val forYouRows: List<ForYouRow> = emptyList(),
+    val developerSpotlight: DeveloperSpotlight? = null,
     val isLoadingFeatured: Boolean = false,
     val isLoadingRows: Boolean = false,
     val isLoadingThemes: Boolean = false,
@@ -35,10 +38,11 @@ data class ExploreState(
     val isLoadingFeaturedSeries: Boolean = false,
     val isLoadingMoods: Boolean = false,
     val isLoadingForYou: Boolean = false,
+    val isLoadingDeveloperSpotlight: Boolean = false,
     val error: String? = null,
 ) {
-    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods || isLoadingForYou
-    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && forYouRows.isEmpty() && !isLoading
+    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods || isLoadingForYou || isLoadingDeveloperSpotlight
+    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && forYouRows.isEmpty() && developerSpotlight == null && !isLoading
 }
 
 data class ThemeDetailState(
@@ -65,6 +69,24 @@ data class MoodDetailState(
     val isLoading: Boolean = false,
     val error: String? = null,
 )
+
+data class DeveloperDetailState(
+    val name: String = "",
+    val detail: DeveloperDetail? = null,
+    val consoleFilter: String? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+) {
+    val filteredGames: List<Game>
+        get() {
+            val games = detail?.games ?: return emptyList()
+            return if (consoleFilter != null) {
+                games.filter { it.consoleName.equals(consoleFilter, ignoreCase = true) }
+            } else {
+                games
+            }
+        }
+}
 
 data class SeriesDetailState(
     val seriesId: String = "",
@@ -106,6 +128,9 @@ class ExploreViewModel(
     private val _moodDetailState = MutableStateFlow(MoodDetailState())
     val moodDetailState: StateFlow<MoodDetailState> = _moodDetailState.asStateFlow()
 
+    private val _developerDetailState = MutableStateFlow(DeveloperDetailState())
+    val developerDetailState: StateFlow<DeveloperDetailState> = _developerDetailState.asStateFlow()
+
     private var featuredJob: Job? = null
     private var rowsJob: Job? = null
     private var themesJob: Job? = null
@@ -117,6 +142,8 @@ class ExploreViewModel(
     private var moodsJob: Job? = null
     private var moodDetailJob: Job? = null
     private var forYouJob: Job? = null
+    private var developerSpotlightJob: Job? = null
+    private var developerDetailJob: Job? = null
 
     fun load() {
         loadFeatured()
@@ -126,6 +153,7 @@ class ExploreViewModel(
         loadFeaturedSeries()
         loadMoods()
         loadForYou()
+        loadDeveloperSpotlight()
     }
 
     fun dismissError() {
@@ -339,5 +367,62 @@ class ExploreViewModel(
 
     fun dismissMoodDetailError() {
         _moodDetailState.update { it.copy(error = null) }
+    }
+
+    private fun loadDeveloperSpotlight() {
+        if (developerSpotlightJob?.isActive == true) return
+        _state.update { it.copy(isLoadingDeveloperSpotlight = true) }
+        developerSpotlightJob = scope.launch(dispatchers.io) {
+            exploreRepository.getDeveloperSpotlight().fold(
+                onSuccess = { spotlight ->
+                    _state.update { it.copy(developerSpotlight = spotlight, isLoadingDeveloperSpotlight = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoadingDeveloperSpotlight = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun loadDeveloperDetail(name: String) {
+        developerDetailJob?.cancel()
+        _developerDetailState.update {
+            DeveloperDetailState(name = name, isLoading = true)
+        }
+        developerDetailJob = scope.launch(dispatchers.io) {
+            exploreRepository.getDeveloperDetail(name).fold(
+                onSuccess = { detail ->
+                    _developerDetailState.update { it.copy(detail = detail, isLoading = false) }
+                },
+                onFailure = { error ->
+                    _developerDetailState.update { it.copy(isLoading = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun loadPublisherDetail(name: String) {
+        developerDetailJob?.cancel()
+        _developerDetailState.update {
+            DeveloperDetailState(name = name, isLoading = true)
+        }
+        developerDetailJob = scope.launch(dispatchers.io) {
+            exploreRepository.getPublisherDetail(name).fold(
+                onSuccess = { detail ->
+                    _developerDetailState.update { it.copy(detail = detail, isLoading = false) }
+                },
+                onFailure = { error ->
+                    _developerDetailState.update { it.copy(isLoading = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun setDeveloperConsoleFilter(abbreviation: String?) {
+        _developerDetailState.update { it.copy(consoleFilter = abbreviation) }
+    }
+
+    fun dismissDeveloperDetailError() {
+        _developerDetailState.update { it.copy(error = null) }
     }
 }

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"math"
 	"net/http"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -13,6 +14,49 @@ import (
 	"github.com/spela/server/internal/db"
 	"gorm.io/gorm"
 )
+
+// --- Phase 7: Developer & Publisher Spotlight ---
+
+// DeveloperSummary is the API response for a single developer in the developer list.
+type DeveloperSummary struct {
+	Name      string   `json:"name"`
+	GameCount int      `json:"gameCount"`
+	AvgRating float64  `json:"avgRating"`
+	Consoles  []string `json:"consoles"`
+}
+
+// DeveloperListResponse is the API response for the developers list endpoint.
+type DeveloperListResponse struct {
+	Developers []DeveloperSummary `json:"developers"`
+}
+
+// DeveloperDetailResponse is the API response for a developer detail page.
+type DeveloperDetailResponse struct {
+	Name      string         `json:"name"`
+	GameCount int            `json:"gameCount"`
+	AvgRating float64        `json:"avgRating"`
+	Consoles  []string       `json:"consoles"`
+	Games     []GameResponse `json:"games"`
+}
+
+// PublisherDetailResponse is the API response for a publisher detail page.
+type PublisherDetailResponse struct {
+	Name      string         `json:"name"`
+	GameCount int            `json:"gameCount"`
+	AvgRating float64        `json:"avgRating"`
+	Consoles  []string       `json:"consoles"`
+	Games     []GameResponse `json:"games"`
+}
+
+// DeveloperSpotlightResponse is the API response for the featured developer spotlight.
+type DeveloperSpotlightResponse struct {
+	Name      string         `json:"name"`
+	GameCount int            `json:"gameCount"`
+	AvgRating float64        `json:"avgRating"`
+	Consoles  []string       `json:"consoles"`
+	TopGames  []GameResponse `json:"topGames"`
+	HeroURL   string         `json:"heroUrl"`
+}
 
 // FeaturedSeriesResponse is the API response for a featured series on the Explore page.
 type FeaturedSeriesResponse struct {
@@ -1479,5 +1523,272 @@ func (h *ExploreHandler) GetPlayersLikeYou(c *gin.Context) {
 		Games:             ToGameResponses(sorted, h.DB, userID),
 		SimilarUsersCount: len(similarUsers),
 	})
+}
+
+// GetDevelopers returns a list of developers with game counts, average ratings, and console lists.
+// GET /api/explore/developers
+func (h *ExploreHandler) GetDevelopers(c *gin.Context) {
+	type devRow struct {
+		Developer string
+		GameCount int
+		AvgRating float64
+	}
+
+	var rows []devRow
+	if err := h.DB.
+		Table("games").
+		Select("developer, COUNT(*) as game_count, AVG(CASE WHEN rating > 0 THEN rating ELSE NULL END) as avg_rating").
+		Where("games.deleted_at IS NULL AND developer != ''").
+		Group("developer").
+		Order("game_count DESC").
+		Limit(50).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch developers", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch developers"})
+		return
+	}
+
+	if len(rows) == 0 {
+		c.JSON(http.StatusOK, DeveloperListResponse{Developers: []DeveloperSummary{}})
+		return
+	}
+
+	// Collect developer names for batch console lookup
+	devNames := make([]string, len(rows))
+	for i, r := range rows {
+		devNames[i] = r.Developer
+	}
+
+	// Batch-load distinct consoles per developer
+	type devConsoleRow struct {
+		Developer    string
+		Abbreviation string
+	}
+	var consoleRows []devConsoleRow
+	if err := h.DB.
+		Table("games").
+		Select("DISTINCT games.developer, consoles.abbreviation").
+		Joins("JOIN consoles ON consoles.id = games.console_id").
+		Where("games.deleted_at IS NULL AND games.developer IN ?", devNames).
+		Scan(&consoleRows).Error; err != nil {
+		slog.Error("failed to fetch developer consoles", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch developers"})
+		return
+	}
+
+	devConsoles := make(map[string][]string)
+	for _, cr := range consoleRows {
+		abbr := strings.ToLower(cr.Abbreviation)
+		devConsoles[cr.Developer] = append(devConsoles[cr.Developer], abbr)
+	}
+
+	developers := make([]DeveloperSummary, len(rows))
+	for i, r := range rows {
+		avgRating := 0.0
+		if r.AvgRating > 0 {
+			avgRating = math.Round(r.AvgRating*10) / 10
+		}
+		consoles := devConsoles[r.Developer]
+		if consoles == nil {
+			consoles = []string{}
+		}
+		developers[i] = DeveloperSummary{
+			Name:      r.Developer,
+			GameCount: r.GameCount,
+			AvgRating: avgRating,
+			Consoles:  consoles,
+		}
+	}
+
+	c.JSON(http.StatusOK, DeveloperListResponse{Developers: developers})
+}
+
+// GetDeveloperDetail returns all games by a specific developer with user context.
+// GET /api/explore/developers/:name
+func (h *ExploreHandler) GetDeveloperDetail(c *gin.Context) {
+	userID := getUserID(c)
+	name := c.Param("name")
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("LOWER(games.developer) = LOWER(?) AND games.deleted_at IS NULL", name).
+		Order("games.rating DESC, games.title ASC").
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch developer games", "developer", name, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch developer games"})
+		return
+	}
+
+	// Calculate stats
+	avgRating, consoles := calcRatingAndConsoles(games)
+
+	// Use canonical casing from the first game's developer field
+	canonicalName := name
+	if len(games) > 0 && games[0].Developer != "" {
+		canonicalName = games[0].Developer
+	}
+
+	c.JSON(http.StatusOK, DeveloperDetailResponse{
+		Name:      canonicalName,
+		GameCount: len(games),
+		AvgRating: avgRating,
+		Consoles:  consoles,
+		Games:     ToGameResponses(games, h.DB, userID),
+	})
+}
+
+// GetPublisherDetail returns all games by a specific publisher with user context.
+// GET /api/explore/publishers/:name
+func (h *ExploreHandler) GetPublisherDetail(c *gin.Context) {
+	userID := getUserID(c)
+	name := c.Param("name")
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("LOWER(games.publisher) = LOWER(?) AND games.deleted_at IS NULL", name).
+		Order("games.rating DESC, games.title ASC").
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch publisher games", "publisher", name, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch publisher games"})
+		return
+	}
+
+	// Calculate stats
+	avgRating, consoles := calcRatingAndConsoles(games)
+
+	// Use canonical casing from the first game's publisher field
+	canonicalName := name
+	if len(games) > 0 && games[0].Publisher != "" {
+		canonicalName = games[0].Publisher
+	}
+
+	c.JSON(http.StatusOK, PublisherDetailResponse{
+		Name:      canonicalName,
+		GameCount: len(games),
+		AvgRating: avgRating,
+		Consoles:  consoles,
+		Games:     ToGameResponses(games, h.DB, userID),
+	})
+}
+
+// GetDeveloperSpotlight returns a featured developer with top games and hero art.
+// The spotlight rotates weekly using a deterministic selection from the top 5 developers.
+// GET /api/explore/developers/spotlight
+func (h *ExploreHandler) GetDeveloperSpotlight(c *gin.Context) {
+	userID := getUserID(c)
+
+	// Find the top 5 developers by game count (only those with games that have hero art)
+	type devRow struct {
+		Developer string
+		GameCount int
+	}
+	var rows []devRow
+	if err := h.DB.
+		Table("games").
+		Select("games.developer, COUNT(DISTINCT games.id) as game_count").
+		Joins("JOIN game_artworks ON game_artworks.game_id = games.id AND game_artworks.hero_url != ''").
+		Where("games.deleted_at IS NULL AND games.developer != ''").
+		Group("games.developer").
+		Order("game_count DESC").
+		Limit(5).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch developer spotlight candidates", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch developer spotlight"})
+		return
+	}
+
+	if len(rows) == 0 {
+		c.JSON(http.StatusNotFound, gin.H{"error": "no developers with hero art found"})
+		return
+	}
+
+	// Pick based on week number for deterministic weekly rotation
+	_, weekNumber := time.Now().ISOWeek()
+	selectedDev := rows[weekNumber%len(rows)]
+
+	// Load all games for this developer
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("LOWER(games.developer) = LOWER(?) AND games.deleted_at IS NULL", selectedDev.Developer).
+		Order("games.rating DESC, games.title ASC").
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch spotlight developer games", "developer", selectedDev.Developer, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch developer spotlight"})
+		return
+	}
+
+	avgRating, consoles := calcRatingAndConsoles(games)
+
+	// Take top 8 for the response
+	topGames := games
+	if len(topGames) > 8 {
+		topGames = topGames[:8]
+	}
+
+	// Find hero URL from the highest-rated game with hero art
+	heroURL := ""
+	if len(games) > 0 {
+		gameIDs := make([]uint, len(games))
+		for i, g := range games {
+			gameIDs[i] = g.ID
+		}
+		var artwork db.GameArtwork
+		if err := h.DB.
+			Joins("JOIN games ON games.id = game_artworks.game_id").
+			Where("game_artworks.game_id IN ? AND game_artworks.hero_url != ''", gameIDs).
+			Order("games.rating DESC").
+			First(&artwork).Error; err == nil {
+			heroURL = artwork.HeroURL
+		}
+	}
+
+	// Count total games by this developer (including those without hero art)
+	var totalGameCount int64
+	h.DB.Model(&db.Game{}).
+		Where("LOWER(developer) = LOWER(?) AND deleted_at IS NULL", selectedDev.Developer).
+		Count(&totalGameCount)
+
+	c.JSON(http.StatusOK, DeveloperSpotlightResponse{
+		Name:      selectedDev.Developer,
+		GameCount: int(totalGameCount),
+		AvgRating: avgRating,
+		Consoles:  consoles,
+		TopGames:  ToGameResponses(topGames, h.DB, userID),
+		HeroURL:   heroURL,
+	})
+}
+
+// calcRatingAndConsoles computes the average rating and distinct console display names
+// for a slice of games. Returns (avgRating, consoles) sorted alphabetically.
+func calcRatingAndConsoles(games []db.Game) (float64, []string) {
+	var ratingSum float64
+	var ratingCount int
+	consoleSet := make(map[string]bool)
+
+	for _, g := range games {
+		if g.Rating > 0 {
+			ratingSum += g.Rating
+			ratingCount++
+		}
+		if g.Console.Name != "" {
+			consoleSet[g.Console.Name] = true
+		}
+	}
+
+	avgRating := 0.0
+	if ratingCount > 0 {
+		avgRating = math.Round(ratingSum/float64(ratingCount)*10) / 10
+	}
+
+	consoles := make([]string, 0, len(consoleSet))
+	for name := range consoleSet {
+		consoles = append(consoles, name)
+	}
+	sort.Strings(consoles)
+	if len(consoles) == 0 {
+		consoles = []string{}
+	}
+
+	return avgRating, consoles
 }
 

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -1944,3 +1944,266 @@ func TestGetPlayersLikeYou_AuthRequired(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
+
+// --- Phase 7: Developer & Publisher Spotlight tests ---
+
+// createExploreGameWithDev creates a game with developer and publisher fields set.
+func createExploreGameWithDev(t *testing.T, database *gorm.DB, consoleAbbr, title string, rating float64, developer, publisher string) db.Game {
+	t.Helper()
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", consoleAbbr).First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     title,
+		FileName:  title + ".rom",
+		FilePath:  consoleAbbr + "/" + title + ".rom",
+		Rating:    rating,
+		Genre:     "Action",
+		Developer: developer,
+		Publisher: publisher,
+	}
+	require.NoError(t, database.Create(&game).Error)
+	return game
+}
+
+func TestGetDevelopers_SortedByGameCount(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create games with different developers
+	createExploreGameWithDev(t, env.database, "NES", "Game A", 90, "Nintendo", "Nintendo")
+	createExploreGameWithDev(t, env.database, "SNES", "Game B", 80, "Nintendo", "Nintendo")
+	createExploreGameWithDev(t, env.database, "NES", "Game C", 85, "Nintendo", "Capcom")
+	createExploreGameWithDev(t, env.database, "GBA", "Game D", 70, "Capcom", "Capcom")
+	createExploreGameWithDev(t, env.database, "SNES", "Game E", 60, "Square", "Square")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.GreaterOrEqual(t, len(resp.Developers), 3)
+
+	// Nintendo has 3 games, should be first
+	assert.Equal(t, "Nintendo", resp.Developers[0].Name)
+	assert.Equal(t, 3, resp.Developers[0].GameCount)
+	assert.Greater(t, resp.Developers[0].AvgRating, 0.0)
+	assert.NotEmpty(t, resp.Developers[0].Consoles)
+
+	// Capcom has 1, Square has 1 — both after Nintendo
+	assert.Equal(t, 1, resp.Developers[1].GameCount)
+	assert.Equal(t, 1, resp.Developers[2].GameCount)
+}
+
+func TestGetDevelopers_EmptyDevelopersExcluded(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create a game with empty developer — should not appear
+	createExploreGameWithDev(t, env.database, "NES", "No Dev Game", 90, "", "SomePub")
+	createExploreGameWithDev(t, env.database, "NES", "Has Dev Game", 80, "Nintendo", "Nintendo")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Only "Nintendo" should appear, not the empty developer
+	for _, d := range resp.Developers {
+		assert.NotEmpty(t, d.Name, "developer name should not be empty")
+	}
+}
+
+func TestGetDeveloperDetail_ReturnsGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameWithDev(t, env.database, "NES", "Mega Man 2", 92, "Capcom", "Capcom")
+	createExploreGameWithDev(t, env.database, "SNES", "Mega Man X", 90, "Capcom", "Capcom")
+	createExploreGameWithDev(t, env.database, "GBA", "Zelda LTTP", 95, "Nintendo", "Nintendo")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/Capcom", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "Capcom", resp.Name)
+	assert.Equal(t, 2, resp.GameCount)
+	assert.Greater(t, resp.AvgRating, 0.0)
+	assert.Len(t, resp.Games, 2)
+	assert.NotEmpty(t, resp.Consoles)
+
+	// Games should be sorted by rating DESC
+	assert.Equal(t, "Mega Man 2", resp.Games[0].Title)
+	assert.Equal(t, "Mega Man X", resp.Games[1].Title)
+}
+
+func TestGetDeveloperDetail_CaseInsensitive(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameWithDev(t, env.database, "NES", "Game A", 85, "Capcom", "Capcom")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/capcom", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "Capcom", resp.Name) // canonical casing from game data
+	assert.Equal(t, 1, resp.GameCount)
+	assert.Len(t, resp.Games, 1)
+}
+
+func TestGetDeveloperDetail_URLEncodedName(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameWithDev(t, env.database, "SNES", "Final Fantasy VI", 96, "Square Enix", "Square Enix")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/Square%20Enix", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "Square Enix", resp.Name)
+	assert.Equal(t, 1, resp.GameCount)
+	assert.Len(t, resp.Games, 1)
+	assert.Equal(t, "Final Fantasy VI", resp.Games[0].Title)
+}
+
+func TestGetDeveloperDetail_NonExistentDeveloper(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/NonExistentDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "NonExistentDev", resp.Name)
+	assert.Equal(t, 0, resp.GameCount)
+	assert.Empty(t, resp.Games)
+}
+
+func TestGetPublisherDetail_ReturnsGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameWithDev(t, env.database, "NES", "Castlevania", 88, "Konami", "Konami")
+	createExploreGameWithDev(t, env.database, "SNES", "Contra III", 85, "Konami", "Konami")
+	createExploreGameWithDev(t, env.database, "GBA", "Metroid Fusion", 92, "Nintendo R&D1", "Nintendo")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/publishers/Konami", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PublisherDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "Konami", resp.Name)
+	assert.Equal(t, 2, resp.GameCount)
+	assert.Greater(t, resp.AvgRating, 0.0)
+	assert.Len(t, resp.Games, 2)
+	assert.NotEmpty(t, resp.Consoles)
+
+	// Games sorted by rating DESC
+	assert.Equal(t, "Castlevania", resp.Games[0].Title)
+	assert.Equal(t, "Contra III", resp.Games[1].Title)
+}
+
+func TestGetPublisherDetail_CaseInsensitive(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameWithDev(t, env.database, "NES", "Game A", 85, "Dev", "Konami")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/publishers/konami", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PublisherDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "Konami", resp.Name) // canonical casing from game data
+	assert.Equal(t, 1, resp.GameCount)
+	assert.Len(t, resp.Games, 1)
+}
+
+func TestGetDeveloperSpotlight_ReturnsSpotlight(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create games for a developer with hero art
+	game1 := createExploreGameWithDev(t, env.database, "NES", "Mega Man 2", 92, "Capcom", "Capcom")
+	game2 := createExploreGameWithDev(t, env.database, "SNES", "Mega Man X", 90, "Capcom", "Capcom")
+	createExploreGameWithDev(t, env.database, "GBA", "Street Fighter", 85, "Capcom", "Capcom")
+
+	// Add hero art to some games
+	env.database.Create(&db.GameArtwork{
+		GameID:  game1.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/megaman2.png",
+	})
+	env.database.Create(&db.GameArtwork{
+		GameID:  game2.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/megamanx.png",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/spotlight", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperSpotlightResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.NotEmpty(t, resp.Name)
+	assert.Greater(t, resp.GameCount, 0)
+	assert.Greater(t, resp.AvgRating, 0.0)
+	assert.NotEmpty(t, resp.Consoles)
+	assert.NotEmpty(t, resp.TopGames)
+	assert.NotEmpty(t, resp.HeroURL)
+	assert.LessOrEqual(t, len(resp.TopGames), 8)
+}
+
+func TestGetDeveloperSpotlight_NoHeroArt(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create games without hero art
+	createExploreGameWithDev(t, env.database, "NES", "Game A", 90, "Nintendo", "Nintendo")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/spotlight", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -245,6 +245,10 @@ func NewRouter(cfg Config) *gin.Engine {
 			explore.GET("/surprise", exploreHandler.GetSurpriseGame)
 			explore.GET("/for-you", exploreHandler.GetForYou)
 			explore.GET("/players-like-you", exploreHandler.GetPlayersLikeYou)
+			explore.GET("/developers", exploreHandler.GetDevelopers)
+			explore.GET("/developers/spotlight", exploreHandler.GetDeveloperSpotlight)
+			explore.GET("/developers/:name", exploreHandler.GetDeveloperDetail)
+			explore.GET("/publishers/:name", exploreHandler.GetPublisherDetail)
 		}
 
 		// Games

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -39,6 +39,8 @@ import { ExplorePage } from "@/pages/explore-page";
 import { ExploreThemePage } from "@/pages/explore-theme-page";
 import { ExploreKeywordPage } from "@/pages/explore-keyword-page";
 import { ExploreSeriesPage } from "@/pages/explore-series-page";
+import { DeveloperDetailPage } from "@/pages/developer-detail-page";
+import { PublisherDetailPage } from "@/pages/publisher-detail-page";
 import { ExploreMoodPage } from "@/pages/explore-mood-page";
 import { ChallengeDetailPage } from "@/pages/challenge-detail-page";
 import { SessionDetailPage } from "@/pages/session-detail-page";
@@ -103,6 +105,14 @@ export function App() {
                     <Route
                       path="explore/mood/:mood"
                       element={<ExploreMoodPage />}
+                    />
+                    <Route
+                      path="explore/developers/:name"
+                      element={<DeveloperDetailPage />}
+                    />
+                    <Route
+                      path="explore/publishers/:name"
+                      element={<PublisherDetailPage />}
                     />
                     <Route element={<LibraryLayout />}>
                       <Route path="consoles" element={<ConsolesPage />} />

--- a/web/src/components/meta-item.tsx
+++ b/web/src/components/meta-item.tsx
@@ -1,18 +1,29 @@
+import { Link } from "react-router-dom";
 import type { LucideIcon } from "lucide-react";
 
 interface MetaItemProps {
   icon: LucideIcon;
   label: string;
   value: string;
+  href?: string;
 }
 
-export function MetaItem({ icon: Icon, label, value }: MetaItemProps) {
+export function MetaItem({ icon: Icon, label, value, href }: MetaItemProps) {
   return (
     <div className="flex items-start gap-2.5 text-sm">
       <Icon className="h-4 w-4 text-surface-500 flex-shrink-0 mt-0.5" />
       <div className="flex flex-col">
         <span className="text-surface-500">{label}</span>
-        <span className="text-surface-200">{value}</span>
+        {href ? (
+          <Link
+            to={href}
+            className="text-brand-300 hover:text-brand-400 underline decoration-brand-300/30 hover:decoration-brand-400/60 transition-colors"
+          >
+            {value}
+          </Link>
+        ) : (
+          <span className="text-surface-200">{value}</span>
+        )}
       </div>
     </div>
   );

--- a/web/src/features/explore/components/__tests__/developer-spotlight.test.tsx
+++ b/web/src/features/explore/components/__tests__/developer-spotlight.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { DeveloperSpotlight } from "../developer-spotlight";
+import type { DeveloperSpotlightResponse, Game } from "@/types/api";
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const mockSpotlight: DeveloperSpotlightResponse = {
+  name: "Capcom",
+  gameCount: 10,
+  avgRating: 85.5,
+  consoles: ["SNES", "GBA"],
+  topGames: [
+    makeGame({ id: "1", title: "Mega Man X" }),
+    makeGame({ id: "2", title: "Street Fighter II" }),
+    makeGame({ id: "3", title: "Breath of Fire" }),
+  ],
+  heroUrl: "/hero/capcom.jpg",
+};
+
+function renderSpotlight(
+  props: {
+    spotlight?: DeveloperSpotlightResponse | undefined;
+    isLoading?: boolean;
+  } = {},
+) {
+  return render(
+    <MemoryRouter>
+      <DeveloperSpotlight
+        spotlight={"spotlight" in props ? props.spotlight : mockSpotlight}
+        isLoading={props.isLoading ?? false}
+        onToggleFavorite={vi.fn()}
+        onTogglePlayLater={vi.fn()}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("DeveloperSpotlight", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the spotlight section", () => {
+    renderSpotlight();
+    expect(screen.getByTestId("developer-spotlight")).toBeInTheDocument();
+  });
+
+  it("renders developer name as heading", () => {
+    renderSpotlight();
+    expect(
+      screen.getByRole("heading", { name: "Capcom", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders Developer Spotlight label", () => {
+    renderSpotlight();
+    expect(screen.getByText("Developer Spotlight")).toBeInTheDocument();
+  });
+
+  it("renders stats subtitle", () => {
+    renderSpotlight();
+    expect(screen.getByText(/10 games/)).toBeInTheDocument();
+    expect(screen.getByText(/Avg rating: 85.5/)).toBeInTheDocument();
+    expect(screen.getByText(/SNES, GBA/)).toBeInTheDocument();
+  });
+
+  it("renders top games", () => {
+    renderSpotlight();
+    expect(screen.getByText("Mega Man X")).toBeInTheDocument();
+    expect(screen.getByText("Street Fighter II")).toBeInTheDocument();
+    expect(screen.getByText("Breath of Fire")).toBeInTheDocument();
+  });
+
+  it("renders See all games link", () => {
+    renderSpotlight();
+    const link = screen.getByText("See all games");
+    expect(link.closest("a")).toHaveAttribute(
+      "href",
+      "/explore/developers/Capcom",
+    );
+  });
+
+  it("renders hero background image", () => {
+    renderSpotlight();
+    const img = screen
+      .getByTestId("developer-spotlight")
+      .querySelector("img[src='/hero/capcom.jpg']");
+    expect(img).toBeInTheDocument();
+  });
+
+  it("renders game list items", () => {
+    renderSpotlight();
+    const listItems = screen.getAllByRole("listitem");
+    expect(listItems).toHaveLength(3);
+  });
+
+  it("renders nothing when spotlight is undefined and not loading", () => {
+    const { container } = renderSpotlight({
+      spotlight: undefined,
+      isLoading: false,
+    });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders loading skeleton when loading", () => {
+    renderSpotlight({ isLoading: true, spotlight: undefined });
+    expect(
+      screen.getByTestId("developer-spotlight-skeleton"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton with shimmer animation", () => {
+    const { container } = renderSpotlight({
+      isLoading: true,
+      spotlight: undefined,
+    });
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+});

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { ExplorePage } from "@/pages/explore-page";
-import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition, ForYouResponse, PlayersLikeYouResponse } from "@/types/api";
+import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition, ForYouResponse, PlayersLikeYouResponse, DeveloperSpotlightResponse } from "@/types/api";
 
 // Mock hooks
 vi.mock("@/hooks/use-explore", () => ({
@@ -15,6 +15,7 @@ vi.mock("@/hooks/use-explore", () => ({
   useMoods: vi.fn(),
   useForYou: vi.fn(),
   usePlayersLikeYou: vi.fn(),
+  useDeveloperSpotlight: vi.fn(),
   useSurpriseGame: vi.fn(() => ({
     data: undefined,
     refetch: vi.fn(),
@@ -38,7 +39,7 @@ vi.mock("@/hooks/use-auto-scrape", () => ({
   useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
 }));
 
-import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods, useForYou, usePlayersLikeYou } from "@/hooks/use-explore";
+import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods, useForYou, usePlayersLikeYou, useDeveloperSpotlight } from "@/hooks/use-explore";
 
 const mockUseExploreFeatured = useExploreFeatured as ReturnType<typeof vi.fn>;
 const mockUseExploreRows = useExploreRows as ReturnType<typeof vi.fn>;
@@ -48,6 +49,7 @@ const mockUseFeaturedSeries = useFeaturedSeries as ReturnType<typeof vi.fn>;
 const mockUseMoods = useMoods as ReturnType<typeof vi.fn>;
 const mockUseForYou = useForYou as ReturnType<typeof vi.fn>;
 const mockUsePlayersLikeYou = usePlayersLikeYou as ReturnType<typeof vi.fn>;
+const mockUseDeveloperSpotlight = useDeveloperSpotlight as ReturnType<typeof vi.fn>;
 
 function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
   return {
@@ -128,6 +130,15 @@ const mockForYou: ForYouResponse = {
 const mockPlayersLikeYou: PlayersLikeYouResponse = {
   games: [makeGame({ id: "ply1", title: "Players Pick" })],
   similarUsersCount: 5,
+};
+
+const mockDeveloperSpotlight: DeveloperSpotlightResponse = {
+  name: "Capcom",
+  gameCount: 10,
+  avgRating: 85.5,
+  consoles: ["SNES", "GBA"],
+  topGames: [makeGame({ id: "sp1", title: "Spotlight Game 1" })],
+  heroUrl: "/hero/capcom.jpg",
 };
 
 const mockRows: ExploreRowsResponse = {
@@ -219,6 +230,10 @@ describe("ExplorePage", () => {
     });
     mockUsePlayersLikeYou.mockReturnValue({
       data: mockPlayersLikeYou,
+      isLoading: false,
+    });
+    mockUseDeveloperSpotlight.mockReturnValue({
+      data: mockDeveloperSpotlight,
       isLoading: false,
     });
   });
@@ -483,5 +498,29 @@ describe("ExplorePage", () => {
     });
     renderPage();
     expect(screen.getByTestId("players-like-you-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders the developer spotlight section", () => {
+    renderPage();
+    expect(screen.getByTestId("developer-spotlight")).toBeInTheDocument();
+    expect(screen.getByText("Spotlight Game 1")).toBeInTheDocument();
+  });
+
+  it("hides developer spotlight when no data", () => {
+    mockUseDeveloperSpotlight.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("developer-spotlight")).not.toBeInTheDocument();
+  });
+
+  it("shows developer spotlight skeleton while loading", () => {
+    mockUseDeveloperSpotlight.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByTestId("developer-spotlight-skeleton")).toBeInTheDocument();
   });
 });

--- a/web/src/features/explore/components/developer-spotlight.tsx
+++ b/web/src/features/explore/components/developer-spotlight.tsx
@@ -1,0 +1,173 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import { ChevronLeft, ChevronRight, ArrowRight } from "lucide-react";
+import { Skeleton } from "@/components/ui";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton } from "@/components/ui";
+import type { DeveloperSpotlightResponse, Game } from "@/types/api";
+
+interface DeveloperSpotlightProps {
+  spotlight: DeveloperSpotlightResponse | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+function DeveloperSpotlightSkeleton() {
+  return (
+    <section data-testid="developer-spotlight-skeleton">
+      <Skeleton className="w-full h-64 rounded-2xl" />
+    </section>
+  );
+}
+
+export function DeveloperSpotlight({
+  spotlight,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: DeveloperSpotlightProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, spotlight]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return <DeveloperSpotlightSkeleton />;
+  }
+
+  if (!spotlight) {
+    return null;
+  }
+
+  return (
+    <section
+      data-testid="developer-spotlight"
+      className="group/spotlight relative"
+    >
+      {/* Full-width card with hero background */}
+      <div className="relative rounded-2xl overflow-hidden border border-white/[0.06]">
+        {/* Background image */}
+        {spotlight.heroUrl ? (
+          <img
+            src={spotlight.heroUrl}
+            alt=""
+            className="absolute inset-0 w-full h-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="absolute inset-0 bg-gradient-to-br from-brand-900/80 via-brand-800/60 to-surface-950/80" />
+        )}
+
+        {/* Gradient overlay */}
+        <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/60 to-black/30 pointer-events-none" />
+
+        {/* Content */}
+        <div className="relative p-6 sm:p-8">
+          <div className="flex items-center justify-between mb-1">
+            <p className="text-xs font-medium uppercase tracking-wider text-brand-400">
+              Developer Spotlight
+            </p>
+            <Link
+              to={`/explore/developers/${encodeURIComponent(spotlight.name)}`}
+              className="inline-flex items-center gap-1 text-sm text-surface-300 hover:text-brand-400 transition-colors"
+            >
+              See all games
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+          <h2 className="text-2xl font-bold text-white mb-2">
+            {spotlight.name}
+          </h2>
+          <p className="text-sm text-white/70 mb-6">
+            {spotlight.gameCount}{" "}
+            {spotlight.gameCount === 1 ? "game" : "games"}
+            {spotlight.avgRating > 0 && (
+              <> | Avg rating: {spotlight.avgRating.toFixed(1)}</>
+            )}
+            {spotlight.consoles.length > 0 && (
+              <> | {spotlight.consoles.join(", ")}</>
+            )}
+          </p>
+
+          {/* Scrollable game row */}
+          {spotlight.topGames.length > 0 && (
+            <div className="relative">
+              {/* Scroll arrows */}
+              {canScrollLeft && (
+                <button
+                  onClick={() => scroll("left")}
+                  className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/spotlight:opacity-100 group-focus-within/spotlight:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+                  aria-label="Scroll spotlight games left"
+                >
+                  <ChevronLeft className="h-5 w-5" />
+                </button>
+              )}
+              {canScrollRight && (
+                <button
+                  onClick={() => scroll("right")}
+                  className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/spotlight:opacity-100 group-focus-within/spotlight:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+                  aria-label="Scroll spotlight games right"
+                >
+                  <ChevronRight className="h-5 w-5" />
+                </button>
+              )}
+
+              <div
+                ref={scrollRef}
+                className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+                style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+                role="list"
+                aria-label="Developer spotlight games"
+              >
+                {spotlight.topGames.map((game) => (
+                  <div
+                    key={game.id}
+                    className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+                    role="listitem"
+                  >
+                    <GameCard
+                      game={game}
+                      showConsoleBadge
+                      onToggleFavorite={onToggleFavorite}
+                      onTogglePlayLater={onTogglePlayLater}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -272,6 +272,7 @@ export function GameHero({
               icon={Building2}
               label="Developer"
               value={game.developer}
+              href={`/explore/developers/${encodeURIComponent(game.developer)}`}
             />
           )}
           {game.publisher && (
@@ -279,6 +280,7 @@ export function GameHero({
               icon={Building2}
               label="Publisher"
               value={game.publisher}
+              href={`/explore/publishers/${encodeURIComponent(game.publisher)}`}
             />
           )}
           {game.releaseDate && (

--- a/web/src/hooks/use-explore.ts
+++ b/web/src/hooks/use-explore.ts
@@ -15,6 +15,10 @@ import type {
   ForYouResponse,
   TasteProfile,
   PlayersLikeYouResponse,
+  DeveloperListResponse,
+  DeveloperDetailResponse,
+  PublisherDetailResponse,
+  DeveloperSpotlightResponse,
 } from "@/types/api";
 
 export function useExploreFeatured() {
@@ -149,5 +153,42 @@ export function usePlayersLikeYou() {
     queryKey: ["explore", "players-like-you"],
     queryFn: () =>
       api.get<PlayersLikeYouResponse>("/explore/players-like-you"),
+  });
+}
+
+export function useDevelopers() {
+  return useQuery({
+    queryKey: ["explore", "developers"],
+    queryFn: () => api.get<DeveloperListResponse>("/explore/developers"),
+  });
+}
+
+export function useDeveloperDetail(name: string) {
+  return useQuery({
+    queryKey: ["explore", "developers", name],
+    queryFn: () =>
+      api.get<DeveloperDetailResponse>(
+        `/explore/developers/${encodeURIComponent(name)}`,
+      ),
+    enabled: !!name,
+  });
+}
+
+export function usePublisherDetail(name: string) {
+  return useQuery({
+    queryKey: ["explore", "publishers", name],
+    queryFn: () =>
+      api.get<PublisherDetailResponse>(
+        `/explore/publishers/${encodeURIComponent(name)}`,
+      ),
+    enabled: !!name,
+  });
+}
+
+export function useDeveloperSpotlight() {
+  return useQuery({
+    queryKey: ["explore", "developers", "spotlight"],
+    queryFn: () =>
+      api.get<DeveloperSpotlightResponse>("/explore/developers/spotlight"),
   });
 }

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -27,6 +27,12 @@ export type ApiGetPath = WithQuery<
   | "/explore/for-you"
   | "/explore/players-like-you"
 
+  // Developers & Publishers
+  | "/explore/developers"
+  | "/explore/developers/spotlight"
+  | `/explore/developers/${string}`
+  | `/explore/publishers/${string}`
+
   // Series
   | `/series/${string}`
 

--- a/web/src/pages/__tests__/developer-detail-page.test.tsx
+++ b/web/src/pages/__tests__/developer-detail-page.test.tsx
@@ -1,0 +1,224 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { DeveloperDetailPage } from "@/pages/developer-detail-page";
+import type { DeveloperDetailResponse, Game } from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-explore", () => ({
+  useDeveloperDetail: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-games", () => ({
+  useToggleFavorite: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-play-later", () => ({
+  useTogglePlayLater: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+import { useDeveloperDetail } from "@/hooks/use-explore";
+
+const mockUseDeveloperDetail = useDeveloperDetail as ReturnType<typeof vi.fn>;
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const mockDeveloperDetail: DeveloperDetailResponse = {
+  name: "Capcom",
+  gameCount: 5,
+  avgRating: 88.5,
+  consoles: ["SNES", "GBA"],
+  games: [
+    makeGame({ id: "1", title: "Mega Man X", consoleName: "SNES", developer: "Capcom" }),
+    makeGame({ id: "2", title: "Mega Man X2", consoleName: "SNES", developer: "Capcom" }),
+    makeGame({ id: "3", title: "Mega Man Zero", consoleName: "GBA", developer: "Capcom" }),
+    makeGame({ id: "4", title: "Street Fighter II", consoleName: "SNES", developer: "Capcom" }),
+    makeGame({ id: "5", title: "Breath of Fire", consoleName: "SNES", developer: "Capcom" }),
+  ],
+};
+
+function renderPage(name = "Capcom") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter
+        initialEntries={[`/explore/developers/${encodeURIComponent(name)}`]}
+      >
+        <Routes>
+          <Route
+            path="/explore/developers/:name"
+            element={<DeveloperDetailPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("DeveloperDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseDeveloperDetail.mockReturnValue({
+      data: mockDeveloperDetail,
+      isLoading: false,
+    });
+  });
+
+  it("renders the page with test id", () => {
+    renderPage();
+    expect(screen.getByTestId("developer-detail-page")).toBeInTheDocument();
+  });
+
+  it("renders developer name as heading", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: "Capcom", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders back button", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /back to explore/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders stats row with game count and avg rating", () => {
+    renderPage();
+    const stats = screen.getByTestId("developer-stats");
+    expect(stats).toHaveTextContent("5 games");
+    expect(stats).toHaveTextContent("Avg rating: 88.5");
+    expect(stats).toHaveTextContent("Consoles: SNES, GBA");
+  });
+
+  it("renders console filter chips", () => {
+    renderPage();
+    const filters = screen.getByTestId("developer-console-filters");
+    expect(within(filters).getByText(/All \(/)).toBeInTheDocument();
+    const buttons = within(filters).getAllByRole("button");
+    const buttonTexts = buttons.map((b) => b.textContent);
+    expect(buttonTexts).toContainEqual(expect.stringContaining("SNES"));
+    expect(buttonTexts).toContainEqual(expect.stringContaining("GBA"));
+  });
+
+  it("renders all games in grid", () => {
+    renderPage();
+    expect(screen.getByText("Mega Man X")).toBeInTheDocument();
+    expect(screen.getByText("Mega Man X2")).toBeInTheDocument();
+    expect(screen.getByText("Mega Man Zero")).toBeInTheDocument();
+    expect(screen.getByText("Street Fighter II")).toBeInTheDocument();
+    expect(screen.getByText("Breath of Fire")).toBeInTheDocument();
+  });
+
+  it("filters games by console", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const filters = screen.getByTestId("developer-console-filters");
+    const buttons = within(filters).getAllByRole("button");
+    const gbaButton = buttons.find(
+      (b) => b.textContent?.trim().startsWith("GBA"),
+    );
+    expect(gbaButton).toBeDefined();
+    await user.click(gbaButton!);
+
+    const grid = screen.getByTestId("developer-game-grid");
+    const gameLinks = within(grid).getAllByRole("link");
+    expect(gameLinks).toHaveLength(1);
+    expect(screen.getByText("Mega Man Zero")).toBeInTheDocument();
+    expect(screen.queryByText("Mega Man X2")).not.toBeInTheDocument();
+  });
+
+  it("shows loading skeleton while loading", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByTestId("developer-detail-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows empty state when developer not found", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    renderPage("Unknown");
+    expect(
+      screen.getByText("No games found for this developer"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides console filters when only one console", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        consoles: ["SNES"],
+        games: [makeGame({ id: "1", title: "Mega Man X", consoleName: "SNES" })],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("developer-console-filters"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders singular game count correctly", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        gameCount: 1,
+        consoles: ["SNES"],
+        games: [makeGame({ id: "1", title: "Test", consoleName: "SNES" })],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    const stats = screen.getByTestId("developer-stats");
+    expect(stats).toHaveTextContent("1 game");
+  });
+
+  it("hides avg rating when zero", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        avgRating: 0,
+      },
+      isLoading: false,
+    });
+    renderPage();
+    const stats = screen.getByTestId("developer-stats");
+    expect(stats).not.toHaveTextContent("Avg rating");
+  });
+});

--- a/web/src/pages/__tests__/publisher-detail-page.test.tsx
+++ b/web/src/pages/__tests__/publisher-detail-page.test.tsx
@@ -1,0 +1,223 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { PublisherDetailPage } from "@/pages/publisher-detail-page";
+import type { PublisherDetailResponse, Game } from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-explore", () => ({
+  usePublisherDetail: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-games", () => ({
+  useToggleFavorite: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-play-later", () => ({
+  useTogglePlayLater: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+import { usePublisherDetail } from "@/hooks/use-explore";
+
+const mockUsePublisherDetail = usePublisherDetail as ReturnType<typeof vi.fn>;
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const mockPublisherDetail: PublisherDetailResponse = {
+  name: "Nintendo",
+  gameCount: 4,
+  avgRating: 92.3,
+  consoles: ["NES", "SNES"],
+  games: [
+    makeGame({ id: "1", title: "Super Mario World", consoleName: "SNES", publisher: "Nintendo" }),
+    makeGame({ id: "2", title: "Zelda: ALTTP", consoleName: "SNES", publisher: "Nintendo" }),
+    makeGame({ id: "3", title: "Super Mario Bros.", consoleName: "NES", publisher: "Nintendo" }),
+    makeGame({ id: "4", title: "Metroid", consoleName: "NES", publisher: "Nintendo" }),
+  ],
+};
+
+function renderPage(name = "Nintendo") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter
+        initialEntries={[`/explore/publishers/${encodeURIComponent(name)}`]}
+      >
+        <Routes>
+          <Route
+            path="/explore/publishers/:name"
+            element={<PublisherDetailPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("PublisherDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUsePublisherDetail.mockReturnValue({
+      data: mockPublisherDetail,
+      isLoading: false,
+    });
+  });
+
+  it("renders the page with test id", () => {
+    renderPage();
+    expect(screen.getByTestId("publisher-detail-page")).toBeInTheDocument();
+  });
+
+  it("renders publisher name as heading", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: "Nintendo", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders back button", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /back to explore/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders stats row with game count and avg rating", () => {
+    renderPage();
+    const stats = screen.getByTestId("publisher-stats");
+    expect(stats).toHaveTextContent("4 games");
+    expect(stats).toHaveTextContent("Avg rating: 92.3");
+    expect(stats).toHaveTextContent("Consoles: NES, SNES");
+  });
+
+  it("renders console filter chips", () => {
+    renderPage();
+    const filters = screen.getByTestId("publisher-console-filters");
+    expect(within(filters).getByText(/All \(/)).toBeInTheDocument();
+    const buttons = within(filters).getAllByRole("button");
+    const buttonTexts = buttons.map((b) => b.textContent);
+    expect(buttonTexts).toContainEqual(expect.stringContaining("NES"));
+    expect(buttonTexts).toContainEqual(expect.stringContaining("SNES"));
+  });
+
+  it("renders all games in grid", () => {
+    renderPage();
+    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+    expect(screen.getByText("Zelda: ALTTP")).toBeInTheDocument();
+    expect(screen.getByText("Super Mario Bros.")).toBeInTheDocument();
+    expect(screen.getByText("Metroid")).toBeInTheDocument();
+  });
+
+  it("filters games by console", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const filters = screen.getByTestId("publisher-console-filters");
+    const buttons = within(filters).getAllByRole("button");
+    const nesButton = buttons.find(
+      (b) => b.textContent?.trim().startsWith("NES"),
+    );
+    expect(nesButton).toBeDefined();
+    await user.click(nesButton!);
+
+    const grid = screen.getByTestId("publisher-game-grid");
+    const gameLinks = within(grid).getAllByRole("link");
+    expect(gameLinks).toHaveLength(2);
+    expect(screen.getByText("Super Mario Bros.")).toBeInTheDocument();
+    expect(screen.getByText("Metroid")).toBeInTheDocument();
+    expect(screen.queryByText("Super Mario World")).not.toBeInTheDocument();
+  });
+
+  it("shows loading skeleton while loading", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(screen.getByTestId("publisher-detail-skeleton")).toBeInTheDocument();
+  });
+
+  it("shows empty state when publisher not found", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    renderPage("Unknown");
+    expect(
+      screen.getByText("No games found for this publisher"),
+    ).toBeInTheDocument();
+  });
+
+  it("hides console filters when only one console", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        consoles: ["SNES"],
+        games: [makeGame({ id: "1", title: "Test", consoleName: "SNES" })],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("publisher-console-filters"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders singular game count correctly", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        gameCount: 1,
+        consoles: ["SNES"],
+        games: [makeGame({ id: "1", title: "Test", consoleName: "SNES" })],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    const stats = screen.getByTestId("publisher-stats");
+    expect(stats).toHaveTextContent("1 game");
+  });
+
+  it("hides avg rating when zero", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        avgRating: 0,
+      },
+      isLoading: false,
+    });
+    renderPage();
+    const stats = screen.getByTestId("publisher-stats");
+    expect(stats).not.toHaveTextContent("Avg rating");
+  });
+});

--- a/web/src/pages/developer-detail-page.tsx
+++ b/web/src/pages/developer-detail-page.tsx
@@ -1,0 +1,158 @@
+import { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { BackButton, Skeleton } from "@/components/ui";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton } from "@/components/ui";
+import { useDeveloperDetail } from "@/hooks/use-explore";
+import { useToggleFavorite } from "@/hooks/use-games";
+import { useTogglePlayLater } from "@/hooks/use-play-later";
+import { cn } from "@/lib/cn";
+import type { Game } from "@/types/api";
+
+function DeveloperPageSkeleton() {
+  return (
+    <div className="space-y-8" data-testid="developer-detail-skeleton">
+      {/* Title */}
+      <Skeleton className="w-64 h-10" />
+      {/* Stats row */}
+      <Skeleton className="w-96 h-5" />
+      {/* Console chips */}
+      <div className="flex gap-2">
+        {Array.from({ length: 4 }, (_, i) => (
+          <Skeleton key={i} className="w-20 h-8 rounded-full" />
+        ))}
+      </div>
+      {/* Game grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-5">
+        {Array.from({ length: 12 }, (_, i) => (
+          <GameCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function DeveloperDetailPage() {
+  const { name: rawName } = useParams<{ name: string }>();
+  const name = rawName ? decodeURIComponent(rawName) : "";
+  const navigate = useNavigate();
+  const { data: developer, isLoading } = useDeveloperDetail(name);
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+  const [consoleFilter, setConsoleFilter] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <div className="max-w-6xl space-y-6" data-testid="developer-detail-page">
+        <BackButton onClick={() => navigate(-1)}>
+          Back to Explore
+        </BackButton>
+        <DeveloperPageSkeleton />
+      </div>
+    );
+  }
+
+  if (!developer) {
+    return (
+      <div className="max-w-6xl space-y-6" data-testid="developer-detail-page">
+        <BackButton onClick={() => navigate(-1)}>
+          Back to Explore
+        </BackButton>
+        <p className="text-surface-400 text-center py-20">
+          No games found for this developer
+        </p>
+      </div>
+    );
+  }
+
+  const filteredGames = consoleFilter
+    ? developer.games.filter((g: Game) => g.consoleName === consoleFilter)
+    : developer.games;
+
+  return (
+    <div className="max-w-6xl space-y-8" data-testid="developer-detail-page">
+      <BackButton onClick={() => navigate(-1)}>
+        Back to Explore
+      </BackButton>
+
+      {/* Page heading */}
+      <h1 className="text-3xl font-bold text-surface-100">{developer.name}</h1>
+
+      {/* Stats row */}
+      <p className="text-sm text-surface-400" data-testid="developer-stats">
+        {developer.gameCount} {developer.gameCount === 1 ? "game" : "games"}
+        {developer.avgRating > 0 && (
+          <> | Avg rating: {developer.avgRating.toFixed(1)}</>
+        )}
+        {developer.consoles.length > 0 && (
+          <> | Consoles: {developer.consoles.join(", ")}</>
+        )}
+      </p>
+
+      {/* Console filter chips */}
+      {developer.consoles.length > 1 && (
+        <div
+          className="flex flex-wrap gap-2"
+          data-testid="developer-console-filters"
+        >
+          <button
+            onClick={() => setConsoleFilter(null)}
+            className={cn(
+              "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+              consoleFilter === null
+                ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
+                : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
+            )}
+          >
+            All ({developer.games.length})
+          </button>
+          {developer.consoles.map((consoleName: string) => {
+            const count = developer.games.filter(
+              (g: Game) => g.consoleName === consoleName,
+            ).length;
+            return (
+              <button
+                key={consoleName}
+                onClick={() =>
+                  setConsoleFilter(
+                    consoleFilter === consoleName ? null : consoleName,
+                  )
+                }
+                className={cn(
+                  "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+                  consoleFilter === consoleName
+                    ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
+                    : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
+                )}
+              >
+                {consoleName} ({count})
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Game grid */}
+      {filteredGames.length > 0 ? (
+        <div
+          className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-5"
+          data-testid="developer-game-grid"
+        >
+          {filteredGames.map((game: Game) => (
+            <GameCard
+              key={game.id}
+              game={game}
+              showConsoleBadge
+              onToggleFavorite={handleToggleFavorite}
+              onTogglePlayLater={handleTogglePlayLater}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-surface-400 text-center py-12">
+          No games match the selected filter.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -6,6 +6,7 @@ import { GameShelf } from "@/features/explore/components/game-shelf";
 import { ThemeGrid } from "@/features/explore/components/theme-grid";
 import { KeywordChips } from "@/features/explore/components/keyword-chips";
 import { SeriesShelf } from "@/features/explore/components/series-shelf";
+import { DeveloperSpotlight } from "@/features/explore/components/developer-spotlight";
 import { MoodPicker } from "@/features/explore/components/mood-picker";
 import { ForYouSection } from "@/features/explore/components/for-you-section";
 import { PlayersLikeYouShelf } from "@/features/explore/components/players-like-you-shelf";
@@ -18,6 +19,7 @@ import {
   useMoods,
   useForYou,
   usePlayersLikeYou,
+  useDeveloperSpotlight,
 } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -57,6 +59,10 @@ export function ExplorePage() {
     data: playersLikeYouData,
     isLoading: isPlayersLoading,
   } = usePlayersLikeYou();
+  const {
+    data: spotlightData,
+    isLoading: isSpotlightLoading,
+  } = useDeveloperSpotlight();
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
 
@@ -159,6 +165,14 @@ export function ExplorePage() {
 
       {/* Series shelf */}
       <SeriesShelf series={featuredSeries} isLoading={isSeriesLoading} />
+
+      {/* Developer Spotlight */}
+      <DeveloperSpotlight
+        spotlight={spotlightData}
+        isLoading={isSpotlightLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
 
       {/* Remaining shelf rows */}
       {isRowsLoading ? (

--- a/web/src/pages/publisher-detail-page.tsx
+++ b/web/src/pages/publisher-detail-page.tsx
@@ -1,0 +1,167 @@
+import { useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { BackButton, Skeleton } from "@/components/ui";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton } from "@/components/ui";
+import { usePublisherDetail } from "@/hooks/use-explore";
+import { useToggleFavorite } from "@/hooks/use-games";
+import { useTogglePlayLater } from "@/hooks/use-play-later";
+import { cn } from "@/lib/cn";
+import type { Game } from "@/types/api";
+
+function PublisherPageSkeleton() {
+  return (
+    <div className="space-y-8" data-testid="publisher-detail-skeleton">
+      {/* Title */}
+      <Skeleton className="w-64 h-10" />
+      {/* Stats row */}
+      <Skeleton className="w-96 h-5" />
+      {/* Console chips */}
+      <div className="flex gap-2">
+        {Array.from({ length: 4 }, (_, i) => (
+          <Skeleton key={i} className="w-20 h-8 rounded-full" />
+        ))}
+      </div>
+      {/* Game grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-5">
+        {Array.from({ length: 12 }, (_, i) => (
+          <GameCardSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export function PublisherDetailPage() {
+  const { name: rawName } = useParams<{ name: string }>();
+  const name = rawName ? decodeURIComponent(rawName) : "";
+  const navigate = useNavigate();
+  const { data: publisher, isLoading } = usePublisherDetail(name);
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+  const [consoleFilter, setConsoleFilter] = useState<string | null>(null);
+
+  if (isLoading) {
+    return (
+      <div
+        className="max-w-6xl space-y-6"
+        data-testid="publisher-detail-page"
+      >
+        <BackButton onClick={() => navigate(-1)}>
+          Back to Explore
+        </BackButton>
+        <PublisherPageSkeleton />
+      </div>
+    );
+  }
+
+  if (!publisher) {
+    return (
+      <div
+        className="max-w-6xl space-y-6"
+        data-testid="publisher-detail-page"
+      >
+        <BackButton onClick={() => navigate(-1)}>
+          Back to Explore
+        </BackButton>
+        <p className="text-surface-400 text-center py-20">
+          No games found for this publisher
+        </p>
+      </div>
+    );
+  }
+
+  const filteredGames = consoleFilter
+    ? publisher.games.filter((g: Game) => g.consoleName === consoleFilter)
+    : publisher.games;
+
+  return (
+    <div
+      className="max-w-6xl space-y-8"
+      data-testid="publisher-detail-page"
+    >
+      <BackButton onClick={() => navigate(-1)}>
+        Back to Explore
+      </BackButton>
+
+      {/* Page heading */}
+      <h1 className="text-3xl font-bold text-surface-100">{publisher.name}</h1>
+
+      {/* Stats row */}
+      <p className="text-sm text-surface-400" data-testid="publisher-stats">
+        {publisher.gameCount} {publisher.gameCount === 1 ? "game" : "games"}
+        {publisher.avgRating > 0 && (
+          <> | Avg rating: {publisher.avgRating.toFixed(1)}</>
+        )}
+        {publisher.consoles.length > 0 && (
+          <> | Consoles: {publisher.consoles.join(", ")}</>
+        )}
+      </p>
+
+      {/* Console filter chips */}
+      {publisher.consoles.length > 1 && (
+        <div
+          className="flex flex-wrap gap-2"
+          data-testid="publisher-console-filters"
+        >
+          <button
+            onClick={() => setConsoleFilter(null)}
+            className={cn(
+              "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+              consoleFilter === null
+                ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
+                : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
+            )}
+          >
+            All ({publisher.games.length})
+          </button>
+          {publisher.consoles.map((consoleName: string) => {
+            const count = publisher.games.filter(
+              (g: Game) => g.consoleName === consoleName,
+            ).length;
+            return (
+              <button
+                key={consoleName}
+                onClick={() =>
+                  setConsoleFilter(
+                    consoleFilter === consoleName ? null : consoleName,
+                  )
+                }
+                className={cn(
+                  "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+                  consoleFilter === consoleName
+                    ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
+                    : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
+                )}
+              >
+                {consoleName} ({count})
+              </button>
+            );
+          })}
+        </div>
+      )}
+
+      {/* Game grid */}
+      {filteredGames.length > 0 ? (
+        <div
+          className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-5"
+          data-testid="publisher-game-grid"
+        >
+          {filteredGames.map((game: Game) => (
+            <GameCard
+              key={game.id}
+              game={game}
+              showConsoleBadge
+              onToggleFavorite={handleToggleFavorite}
+              onTogglePlayLater={handleTogglePlayLater}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-surface-400 text-center py-12">
+          No games match the selected filter.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -961,6 +961,44 @@ export interface PlayersLikeYouResponse {
   similarUsersCount: number;
 }
 
+// --- Developers & Publishers ---
+
+export interface DeveloperSummary {
+  name: string;
+  gameCount: number;
+  avgRating: number;
+  consoles: string[];
+}
+
+export interface DeveloperListResponse {
+  developers: DeveloperSummary[];
+}
+
+export interface DeveloperDetailResponse {
+  name: string;
+  gameCount: number;
+  avgRating: number;
+  consoles: string[];
+  games: Game[];
+}
+
+export interface PublisherDetailResponse {
+  name: string;
+  gameCount: number;
+  avgRating: number;
+  consoles: string[];
+  games: Game[];
+}
+
+export interface DeveloperSpotlightResponse {
+  name: string;
+  gameCount: number;
+  avgRating: number;
+  consoles: string[];
+  topGames: Game[];
+  heroUrl: string;
+}
+
 export interface StagedUpload {
   id: string;
   fileName: string;


### PR DESCRIPTION
## Summary
- **Developer & Publisher detail pages** with game grids, console filter chips, stats row, and back navigation — available at `/explore/developers/:name` and `/explore/publishers/:name`
- **Developer Spotlight card** on the Explore page — weekly-rotating featured developer with hero background, stats, and scrollable top games row
- **Clickable developer/publisher links** in game detail hero section, linking to their respective detail pages
- Full implementation across all three platforms: Go backend (4 new endpoints), React web (2 new pages + spotlight component), Kotlin Multiplatform player (detail screen + spotlight section)
- 38 new web tests, 10 new Go tests, 6 new desktop E2E tests

## Test plan
- [x] Go tests pass (14/14 including 10 new explore handler tests)
- [x] Web Vitest tests pass (918/918 including 38 new tests)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Go compiles cleanly (`go build ./...`)
- [x] Code review agent: all critical/high issues resolved
- [x] UX review agent: all high-severity findings fixed (back navigation, link affordance)