### PR TITLE
feat: add Console Showcase pages (Explore Phase 8)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreConsoleShowcaseTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreConsoleShowcaseTest.kt
@@ -1,0 +1,297 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import androidx.compose.ui.test.hasTestTag
+import com.spela.player.domain.model.Console
+import com.spela.player.domain.model.ConsoleHighlight
+import com.spela.player.domain.model.ConsoleShowcase
+import com.spela.player.domain.model.DeveloperSummary
+import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.GenreCount
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for Phase 8: Console Showcase Pages.
+ *
+ * Covers:
+ * - Console showcase screen renders with console name
+ * - Essentials section shows games
+ * - Hidden gems section shows games
+ * - Genre breakdown shows genre chips
+ * - Top developers section shows developer names
+ * - Recently played section hidden when empty
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ExploreConsoleShowcaseTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private val sampleConsole = Console(
+        id = "snes",
+        name = "Super Nintendo",
+        abbreviation = "SNES",
+        gameCount = 42,
+        colorTheme = "#6B21A8",
+    )
+
+    private val sampleEssentials = listOf(
+        Game(
+            id = "game-ess-1",
+            title = "Super Mario World",
+            consoleId = "snes",
+            consoleName = "SNES",
+            genre = "Platformer",
+            rating = 95.0,
+        ),
+        Game(
+            id = "game-ess-2",
+            title = "The Legend of Zelda: A Link to the Past",
+            consoleId = "snes",
+            consoleName = "SNES",
+            genre = "Action RPG",
+            rating = 94.0,
+        ),
+    )
+
+    private val sampleHiddenGems = listOf(
+        Game(
+            id = "game-gem-1",
+            title = "Terranigma",
+            consoleId = "snes",
+            consoleName = "SNES",
+            genre = "Action RPG",
+            rating = 88.0,
+        ),
+    )
+
+    private val sampleGenres = listOf(
+        GenreCount(name = "Platformer", gameCount = 12),
+        GenreCount(name = "RPG", gameCount = 8),
+        GenreCount(name = "Action", gameCount = 6),
+    )
+
+    private val sampleDevelopers = listOf(
+        DeveloperSummary(
+            name = "Nintendo",
+            gameCount = 10,
+            avgRating = 92.0,
+            consoles = listOf("SNES"),
+        ),
+        DeveloperSummary(
+            name = "Square",
+            gameCount = 7,
+            avgRating = 90.0,
+            consoles = listOf("SNES"),
+        ),
+    )
+
+    private val sampleRecentlyPlayed = listOf(
+        Game(
+            id = "game-recent-1",
+            title = "Chrono Trigger",
+            consoleId = "snes",
+            consoleName = "SNES",
+            genre = "RPG",
+            rating = 96.0,
+        ),
+    )
+
+    private val sampleShowcase = ConsoleShowcase(
+        console = sampleConsole,
+        essentials = sampleEssentials,
+        hiddenGems = sampleHiddenGems,
+        genreBreakdown = sampleGenres,
+        topDevelopers = sampleDevelopers,
+        recentlyPlayed = sampleRecentlyPlayed,
+    )
+
+    private val sampleShowcaseNoRecent = sampleShowcase.copy(
+        recentlyPlayed = emptyList(),
+    )
+
+    private val sampleHighlights = listOf(
+        ConsoleHighlight(
+            id = "snes",
+            name = "Super Nintendo",
+            colorTheme = "#6B21A8",
+            iconUrl = "",
+            logoUrl = "",
+            gameCount = 42,
+            topGame = null,
+        ),
+        ConsoleHighlight(
+            id = "nes",
+            name = "Nintendo Entertainment System",
+            colorTheme = "#DC2626",
+            iconUrl = "",
+            logoUrl = "",
+            gameCount = 30,
+            topGame = null,
+        ),
+    )
+
+    // --- Console showcase screen renders ---
+
+    @Test
+    fun consoleShowcaseScreenRendersWithConsoleName() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.consoleShowcases = mapOf("snes" to sampleShowcase)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreConsoleShowcase("snes"))
+        )
+        advanceFully(harness)
+
+        onNodeWithTag("console_showcase_screen").assertIsDisplayed()
+        onAllNodesWithText("Super Nintendo").fetchSemanticsNodes().let {
+            assert(it.isNotEmpty()) { "Expected at least one 'Super Nintendo' text node" }
+        }
+    }
+
+    // --- Essentials section ---
+
+    @Test
+    fun essentialsSectionShowsGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.consoleShowcases = mapOf("snes" to sampleShowcase)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreConsoleShowcase("snes"))
+        )
+        advanceFully(harness)
+
+        onNodeWithTag("console_essentials_section").assertExists()
+        onNodeWithText("Essentials").assertExists()
+    }
+
+    // --- Hidden gems section ---
+
+    @Test
+    fun hiddenGemsSectionShowsGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.consoleShowcases = mapOf("snes" to sampleShowcase)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreConsoleShowcase("snes"))
+        )
+        advanceFully(harness)
+
+        onNodeWithTag("console_hidden_gems_section").assertExists()
+        onNodeWithText("Hidden Gems").assertExists()
+    }
+
+    // --- Genre breakdown ---
+
+    @Test
+    fun genreBreakdownShowsGenreChips() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.consoleShowcases = mapOf("snes" to sampleShowcase)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreConsoleShowcase("snes"))
+        )
+        advanceFully(harness)
+
+        // Scroll down to find the genre breakdown section (may be off-screen in LazyColumn)
+        onNodeWithTag("console_showcase_list").performScrollToNode(
+            hasTestTag("console_genre_breakdown_section")
+        )
+        advanceQuick(harness)
+
+        onNodeWithTag("console_genre_breakdown_section").assertExists()
+        onNodeWithText("Genre Breakdown").assertExists()
+        onNodeWithTag("genre_chip_Platformer").assertExists()
+        onNodeWithTag("genre_chip_RPG").assertExists()
+        onNodeWithTag("genre_chip_Action").assertExists()
+    }
+
+    // --- Top developers ---
+
+    @Test
+    fun topDevelopersSectionShowsDeveloperNames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.consoleShowcases = mapOf("snes" to sampleShowcase)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreConsoleShowcase("snes"))
+        )
+        advanceFully(harness)
+
+        // Scroll down to find the top developers section (may be off-screen in LazyColumn)
+        onNodeWithTag("console_showcase_list").performScrollToNode(
+            hasTestTag("console_top_developers_section")
+        )
+        advanceQuick(harness)
+
+        onNodeWithTag("console_top_developers_section").assertExists()
+        onNodeWithText("Top Developers").assertExists()
+        onNodeWithTag("developer_card_Nintendo").assertExists()
+        onNodeWithTag("developer_card_Square").assertExists()
+    }
+
+    // --- Recently played hidden when empty ---
+
+    @Test
+    fun recentlyPlayedSectionHiddenWhenEmpty() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.consoleShowcases = mapOf("snes" to sampleShowcaseNoRecent)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreConsoleShowcase("snes"))
+        )
+        advanceFully(harness)
+
+        onNodeWithTag("console_showcase_screen").assertIsDisplayed()
+        onNodeWithTag("console_recently_played_section").assertDoesNotExist()
+    }
+
+    // --- Console highlights on Explore screen ---
+
+    @Test
+    fun consoleHighlightsRendersOnExploreScreen() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.consoleHighlightsList = sampleHighlights
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_consoles_section").assertExists()
+        onNodeWithText("Browse by Console").assertExists()
+    }
+
+    // --- Navigation from highlights to showcase ---
+
+    @Test
+    fun navigationFromHighlightToShowcaseWorks() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.consoleHighlightsList = sampleHighlights
+        harness.exploreRepo.consoleShowcases = mapOf("snes" to sampleShowcase)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("console_card_snes").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("explore_console/snes", navState.currentScreen.route)
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1339,6 +1339,8 @@ class FakeExploreRepository : ExploreRepository {
     var developerDetails: Map<String, DeveloperDetail> = emptyMap()
     var publisherDetails: Map<String, DeveloperDetail> = emptyMap()
     var developerSpotlightData: DeveloperSpotlight? = null
+    var consoleShowcases: Map<String, ConsoleShowcase> = emptyMap()
+    var consoleHighlightsList: List<ConsoleHighlight> = emptyList()
     var shouldFail: Boolean = false
 
     override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> =
@@ -1448,6 +1450,18 @@ class FakeExploreRepository : ExploreRepository {
             if (spotlight != null) Result.success(spotlight)
             else Result.failure(Exception("No developer spotlight available"))
         }
+
+    override suspend fun getConsoleShowcase(consoleId: String): Result<ConsoleShowcase> =
+        if (shouldFail) Result.failure(Exception("Failed to load console showcase"))
+        else {
+            val showcase = consoleShowcases[consoleId]
+            if (showcase != null) Result.success(showcase)
+            else Result.failure(Exception("Console not found"))
+        }
+
+    override suspend fun getConsoleHighlights(): Result<List<ConsoleHighlight>> =
+        if (shouldFail) Result.failure(Exception("Failed to load console highlights"))
+        else Result.success(consoleHighlightsList)
 }
 
 class FakeCheatRepository : CheatRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -346,6 +346,17 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/explore/developers/spotlight").body()
     }
 
+    /** Returns console showcase data for a specific console */
+    suspend fun getConsoleShowcase(consoleId: String): ConsoleShowcaseDto {
+        val encoded = consoleId.encodeURLParameter()
+        return client.get("$baseUrl/api/explore/consoles/$encoded/showcase").body()
+    }
+
+    /** Returns console highlights for the Explore page quick-jump section */
+    suspend fun getConsoleHighlights(): ConsoleHighlightsResponseDto {
+        return client.get("$baseUrl/api/explore/console-highlights").body()
+    }
+
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
     suspend fun getRecentGames(): List<GameDto> {
         return client.get("$baseUrl/api/user/recent").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -698,3 +698,29 @@ fun DeveloperSpotlightResponseDto.toDomain(): DeveloperSpotlight = DeveloperSpot
     topGames = topGames.map { it.toDomain() },
     heroUrl = heroUrl.ifBlank { null },
 )
+
+// Console Showcase mappers
+
+fun GenreCountDto.toDomain(): GenreCount = GenreCount(
+    name = name,
+    gameCount = gameCount,
+)
+
+fun ConsoleShowcaseDto.toDomain(): ConsoleShowcase = ConsoleShowcase(
+    console = console.toDomain(),
+    essentials = essentials.map { it.toDomain() },
+    hiddenGems = hiddenGems.map { it.toDomain() },
+    genreBreakdown = genreBreakdown.map { it.toDomain() },
+    topDevelopers = topDevelopers.map { it.toDomain() },
+    recentlyPlayed = recentlyPlayed.map { it.toDomain() },
+)
+
+fun ConsoleHighlightDto.toDomain(): ConsoleHighlight = ConsoleHighlight(
+    id = id,
+    name = name,
+    colorTheme = colorTheme,
+    iconUrl = iconUrl,
+    logoUrl = logoUrl,
+    gameCount = gameCount,
+    topGame = topGame?.toDomain(),
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1196,3 +1196,37 @@ data class DeveloperSpotlightResponseDto(
     val topGames: List<GameDto>,
     val heroUrl: String = "",
 )
+
+// Console Showcase
+
+@Serializable
+data class GenreCountDto(
+    val name: String,
+    val gameCount: Int,
+)
+
+@Serializable
+data class ConsoleShowcaseDto(
+    val console: ConsoleDto,
+    val essentials: List<GameDto>,
+    val hiddenGems: List<GameDto>,
+    val genreBreakdown: List<GenreCountDto>,
+    val topDevelopers: List<DeveloperSummaryDto>,
+    val recentlyPlayed: List<GameDto>,
+)
+
+@Serializable
+data class ConsoleHighlightDto(
+    val id: String,
+    val name: String,
+    val colorTheme: String,
+    val iconUrl: String,
+    val logoUrl: String,
+    val gameCount: Int,
+    val topGame: GameDto? = null,
+)
+
+@Serializable
+data class ConsoleHighlightsResponseDto(
+    val consoles: List<ConsoleHighlightDto>,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -2,6 +2,8 @@ package com.spela.player.data.repository
 
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.toDomain
+import com.spela.player.domain.model.ConsoleHighlight
+import com.spela.player.domain.model.ConsoleShowcase
 import com.spela.player.domain.model.DeveloperDetail
 import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.DeveloperSummary
@@ -200,5 +202,46 @@ class ExploreRepositoryImpl(
                 )
             },
         )
+    }
+
+    override suspend fun getConsoleShowcase(consoleId: String): Result<ConsoleShowcase> = runCatching {
+        val dto = apiClient.getConsoleShowcase(consoleId)
+        dto.toDomain().copy(
+            essentials = dto.essentials.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                    heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+                    logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+                )
+            },
+            hiddenGems = dto.hiddenGems.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                    heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+                    logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+                )
+            },
+            recentlyPlayed = dto.recentlyPlayed.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                    heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+                    logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+                )
+            },
+        )
+    }
+
+    override suspend fun getConsoleHighlights(): Result<List<ConsoleHighlight>> = runCatching {
+        apiClient.getConsoleHighlights().consoles.map { dto ->
+            dto.toDomain().copy(
+                iconUrl = apiClient.resolveUrl(dto.iconUrl) ?: "",
+                logoUrl = apiClient.resolveUrl(dto.logoUrl) ?: "",
+                topGame = dto.topGame?.let { gameDto ->
+                    gameDto.toDomain().copy(
+                        coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                    )
+                },
+            )
+        }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -148,3 +148,27 @@ data class DeveloperSpotlight(
     val topGames: List<Game>,
     val heroUrl: String?,
 )
+
+data class GenreCount(
+    val name: String,
+    val gameCount: Int,
+)
+
+data class ConsoleShowcase(
+    val console: Console,
+    val essentials: List<Game>,
+    val hiddenGems: List<Game>,
+    val genreBreakdown: List<GenreCount>,
+    val topDevelopers: List<DeveloperSummary>,
+    val recentlyPlayed: List<Game>,
+)
+
+data class ConsoleHighlight(
+    val id: String,
+    val name: String,
+    val colorTheme: String,
+    val iconUrl: String,
+    val logoUrl: String,
+    val gameCount: Int,
+    val topGame: Game?,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -1,5 +1,7 @@
 package com.spela.player.domain.repository
 
+import com.spela.player.domain.model.ConsoleHighlight
+import com.spela.player.domain.model.ConsoleShowcase
 import com.spela.player.domain.model.DeveloperDetail
 import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.DeveloperSummary
@@ -38,4 +40,6 @@ interface ExploreRepository {
     suspend fun getDeveloperDetail(name: String): Result<DeveloperDetail>
     suspend fun getPublisherDetail(name: String): Result<DeveloperDetail>
     suspend fun getDeveloperSpotlight(): Result<DeveloperSpotlight>
+    suspend fun getConsoleShowcase(consoleId: String): Result<ConsoleShowcase>
+    suspend fun getConsoleHighlights(): Result<List<ConsoleHighlight>>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -35,6 +35,7 @@ sealed class SpScreen(val route: String) {
     data class ExploreMood(val moodId: String, val moodName: String) : SpScreen("explore_mood/$moodId")
     data class ExploreDeveloper(val name: String) : SpScreen("explore_developer/$name")
     data class ExplorePublisher(val name: String) : SpScreen("explore_publisher/$name")
+    data class ExploreConsoleShowcase(val consoleId: String) : SpScreen("explore_console/$consoleId")
 }
 
 data class NavigationState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -92,6 +92,7 @@ import com.spela.player.presentation.ui.screen.ChallengeDetailScreen
 import com.spela.player.presentation.ui.screen.ChallengeListScreen
 import com.spela.player.presentation.ui.screen.GlobalChallengesScreen
 import com.spela.player.presentation.ui.screen.StatsScreen
+import com.spela.player.presentation.ui.screen.ExploreConsoleShowcaseScreen
 import com.spela.player.presentation.ui.screen.ExploreDeveloperScreen
 import com.spela.player.presentation.ui.screen.ExploreKeywordScreen
 import com.spela.player.presentation.ui.screen.ExploreMoodScreen
@@ -482,6 +483,11 @@ fun SpelaApp(
                                                 NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper(name))
                                             )
                                         },
+                                        onConsoleSelected = { consoleId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreConsoleShowcase(consoleId))
+                                            )
+                                        },
                                         onSurpriseMe = {
                                             exploreViewModel.loadSurpriseGame { gameId ->
                                                 navigationViewModel.onIntent(
@@ -592,6 +598,28 @@ fun SpelaApp(
                                         onGameSelected = { gameId ->
                                             navigationViewModel.onIntent(
                                                 NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.ExploreConsoleShowcase -> {
+                                if (exploreViewModel != null) {
+                                    ExploreConsoleShowcaseScreen(
+                                        consoleId = screen.consoleId,
+                                        viewModel = exploreViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onDeveloperSelected = { name ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper(name))
                                             )
                                         },
                                         onBack = {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ConsoleQuickJumpSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ConsoleQuickJumpSection.kt
@@ -1,0 +1,130 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SportsEsports
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.ConsoleHighlight
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpShimmer
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.parseHexColor
+
+@Composable
+fun ConsoleQuickJumpSection(
+    consoles: List<ConsoleHighlight>,
+    onConsoleSelected: (consoleId: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("console_quick_jump"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(consoles, key = { it.id }) { console ->
+            ConsoleQuickJumpCard(
+                console = console,
+                onClick = { onConsoleSelected(console.id) },
+            )
+        }
+    }
+}
+
+@Composable
+private fun ConsoleQuickJumpCard(
+    console: ConsoleHighlight,
+    onClick: () -> Unit,
+) {
+    val accentColor = parseHexColor(console.colorTheme, SpColor.Primary)
+
+    SpCard(
+        modifier = Modifier
+            .width(140.dp)
+            .testTag("console_card_${console.id}")
+            .semantics {
+                contentDescription = "${console.name}, ${console.gameCount} games"
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(90.dp)
+                .clip(RoundedCornerShape(SpSpacing.CardCornerRadius))
+                .background(accentColor.copy(alpha = 0.15f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                modifier = Modifier.padding(SpSpacing.Small),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.SportsEsports,
+                    contentDescription = null,
+                    tint = accentColor,
+                    modifier = Modifier.size(28.dp),
+                )
+                Spacer(Modifier.height(SpSpacing.XSmall))
+                Text(
+                    text = console.name,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Text(
+                    text = "${console.gameCount} games",
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
+                    maxLines = 1,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun ConsoleQuickJumpSkeleton(
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("console_quick_jump_skeleton"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(5) {
+            SpShimmer(
+                modifier = Modifier.clip(RoundedCornerShape(SpSpacing.CardCornerRadius)),
+                width = 140.dp,
+                height = 90.dp,
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreConsoleShowcaseScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreConsoleShowcaseScreen.kt
@@ -1,0 +1,376 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.SportsEsports
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.DeveloperSummary
+import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.GenreCount
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.feature.explore.GameShelf
+import com.spela.player.presentation.ui.feature.explore.GameShelfSkeleton
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+import com.spela.player.util.formatRating
+import com.spela.player.util.parseHexColor
+
+@Composable
+fun ExploreConsoleShowcaseScreen(
+    consoleId: String,
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+    onDeveloperSelected: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val state by viewModel.consoleShowcaseState.collectAsState()
+
+    LaunchedEffect(consoleId) {
+        viewModel.loadConsoleShowcase(consoleId)
+    }
+
+    Box(modifier = Modifier.fillMaxSize().testTag("console_showcase_screen")) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = state.showcase?.console?.name ?: consoleId,
+                showBack = true,
+                onBack = onBack,
+            )
+
+            when {
+                state.isLoading && state.showcase == null -> {
+                    // Loading skeleton
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(SpSpacing.ScreenHorizontal)
+                            .testTag("console_showcase_loading"),
+                    ) {
+                        Spacer(Modifier.height(SpSpacing.Large))
+                        repeat(4) {
+                            SpGameCardSkeleton(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(bottom = SpSpacing.Medium),
+                            )
+                        }
+                    }
+                }
+
+                state.showcase != null -> {
+                    val showcase = state.showcase!!
+                    val accentColor = parseHexColor(showcase.console.colorTheme, SpColor.Primary)
+
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize().testTag("console_showcase_list"),
+                        contentPadding = PaddingValues(bottom = SpSpacing.XXLarge),
+                    ) {
+                        // Hero banner with console color accent
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(120.dp)
+                                    .background(
+                                        Brush.verticalGradient(
+                                            listOf(
+                                                accentColor.copy(alpha = 0.3f),
+                                                SpColor.Background,
+                                            ),
+                                        ),
+                                    )
+                                    .testTag("console_showcase_banner"),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Column(
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                ) {
+                                    Text(
+                                        text = showcase.console.name,
+                                        style = SpTypography.DisplaySmall,
+                                        color = SpColor.OnBackground,
+                                    )
+                                    Spacer(Modifier.height(SpSpacing.Small))
+                                    Text(
+                                        text = "${showcase.console.gameCount} games in library",
+                                        style = SpTypography.BodyMedium,
+                                        color = SpColor.OnBackgroundSecondary,
+                                        modifier = Modifier.testTag("console_showcase_game_count"),
+                                    )
+                                }
+                            }
+                        }
+
+                        // Essentials section
+                        if (showcase.essentials.isNotEmpty()) {
+                            item {
+                                SpTitledSection(
+                                    title = "Essentials",
+                                    edgeToEdgeContent = true,
+                                    modifier = Modifier
+                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                        .testTag("console_essentials_section"),
+                                ) {
+                                    GameShelf(
+                                        games = showcase.essentials,
+                                        onGameSelected = onGameSelected,
+                                    )
+                                }
+                            }
+                        }
+
+                        // Hidden Gems section
+                        if (showcase.hiddenGems.isNotEmpty()) {
+                            item {
+                                SpTitledSection(
+                                    title = "Hidden Gems",
+                                    edgeToEdgeContent = true,
+                                    modifier = Modifier
+                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                        .testTag("console_hidden_gems_section"),
+                                ) {
+                                    GameShelf(
+                                        games = showcase.hiddenGems,
+                                        onGameSelected = onGameSelected,
+                                    )
+                                }
+                            }
+                        }
+
+                        // Genre Breakdown section
+                        if (showcase.genreBreakdown.isNotEmpty()) {
+                            item {
+                                SpTitledSection(
+                                    title = "Genre Breakdown",
+                                    edgeToEdgeContent = true,
+                                    modifier = Modifier
+                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                        .testTag("console_genre_breakdown_section"),
+                                ) {
+                                    GenreBreakdownChips(
+                                        genres = showcase.genreBreakdown,
+                                        accentColor = accentColor,
+                                    )
+                                }
+                            }
+                        }
+
+                        // Top Developers section
+                        if (showcase.topDevelopers.isNotEmpty()) {
+                            item {
+                                SpTitledSection(
+                                    title = "Top Developers",
+                                    edgeToEdgeContent = true,
+                                    modifier = Modifier
+                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                        .testTag("console_top_developers_section"),
+                                ) {
+                                    TopDevelopersList(
+                                        developers = showcase.topDevelopers,
+                                        onDeveloperSelected = onDeveloperSelected,
+                                    )
+                                }
+                            }
+                        }
+
+                        // Recently Played section (only if non-empty)
+                        if (showcase.recentlyPlayed.isNotEmpty()) {
+                            item {
+                                SpTitledSection(
+                                    title = "Recently Played",
+                                    edgeToEdgeContent = true,
+                                    modifier = Modifier
+                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                        .testTag("console_recently_played_section"),
+                                ) {
+                                    GameShelf(
+                                        games = showcase.recentlyPlayed,
+                                        onGameSelected = onGameSelected,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                else -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.SportsEsports,
+                            title = "Console not found",
+                            message = "Could not load console details.",
+                            modifier = Modifier.testTag("console_showcase_error_state"),
+                        )
+                    }
+                }
+            }
+        }
+
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.dismissConsoleShowcaseError() },
+                )
+            },
+            onDismiss = { viewModel.dismissConsoleShowcaseError() },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun GenreBreakdownChips(
+    genres: List<GenreCount>,
+    accentColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    FlowRow(
+        modifier = modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .testTag("genre_breakdown_chips"),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        genres.forEach { genre ->
+            SpChip(
+                text = "${genre.name} (${genre.gameCount})",
+                color = accentColor,
+                modifier = Modifier
+                    .testTag("genre_chip_${genre.name}")
+                    .semantics {
+                        contentDescription = "${genre.name}, ${genre.gameCount} games"
+                    },
+            )
+        }
+    }
+}
+
+@Composable
+private fun TopDevelopersList(
+    developers: List<DeveloperSummary>,
+    onDeveloperSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .testTag("top_developers_list"),
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        developers.forEach { developer ->
+            SpCard(
+                onClick = { onDeveloperSelected(developer.name) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("developer_card_${developer.name}")
+                    .semantics {
+                        contentDescription = "${developer.name}, ${developer.gameCount} games"
+                    },
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(SpSpacing.Medium),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Text(
+                            text = developer.name,
+                            style = SpTypography.TitleSmall,
+                            color = SpColor.OnCard,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Spacer(Modifier.height(SpSpacing.XXSmall))
+                        Text(
+                            text = "${developer.gameCount} games",
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+
+                    if (developer.avgRating > 0) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Star,
+                                contentDescription = null,
+                                tint = SpColor.Rating,
+                                modifier = Modifier.size(14.dp),
+                            )
+                            Text(
+                                text = formatRating(developer.avgRating),
+                                style = SpTypography.BodyMedium,
+                                color = SpColor.OnBackgroundSecondary,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -22,6 +22,8 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.feature.explore.ConsoleQuickJumpSection
+import com.spela.player.presentation.ui.feature.explore.ConsoleQuickJumpSkeleton
 import com.spela.player.presentation.ui.feature.explore.DeveloperSpotlightSection
 import com.spela.player.presentation.ui.feature.explore.DeveloperSpotlightSkeleton
 import com.spela.player.presentation.ui.feature.explore.ForYouSection
@@ -51,6 +53,7 @@ fun ExploreScreen(
     onSeriesSelected: ((seriesId: String, seriesName: String) -> Unit)? = null,
     onMoodSelected: ((moodId: String, moodName: String) -> Unit)? = null,
     onDeveloperSelected: ((name: String) -> Unit)? = null,
+    onConsoleSelected: ((consoleId: String) -> Unit)? = null,
     onSurpriseMe: (() -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
@@ -108,6 +111,34 @@ fun ExploreScreen(
                                     vertical = SpSpacing.Default,
                                 ),
                             )
+                        }
+                    }
+
+                    // Console quick-jump section
+                    item {
+                        if (state.isLoadingConsoleHighlights && state.consoleHighlights.isEmpty()) {
+                            SpTitledSection(
+                                title = "Browse by Console",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                ConsoleQuickJumpSkeleton()
+                            }
+                        } else if (state.consoleHighlights.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "Browse by Console",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_consoles_section"),
+                            ) {
+                                ConsoleQuickJumpSection(
+                                    consoles = state.consoleHighlights,
+                                    onConsoleSelected = { consoleId ->
+                                        onConsoleSelected?.invoke(consoleId)
+                                    },
+                                )
+                            }
                         }
                     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -1,5 +1,7 @@
 package com.spela.player.presentation.viewmodel
 
+import com.spela.player.domain.model.ConsoleHighlight
+import com.spela.player.domain.model.ConsoleShowcase
 import com.spela.player.domain.model.DeveloperDetail
 import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.ExploreRow
@@ -31,6 +33,7 @@ data class ExploreState(
     val moods: List<MoodDefinition> = emptyList(),
     val forYouRows: List<ForYouRow> = emptyList(),
     val developerSpotlight: DeveloperSpotlight? = null,
+    val consoleHighlights: List<ConsoleHighlight> = emptyList(),
     val isLoadingFeatured: Boolean = false,
     val isLoadingRows: Boolean = false,
     val isLoadingThemes: Boolean = false,
@@ -39,10 +42,11 @@ data class ExploreState(
     val isLoadingMoods: Boolean = false,
     val isLoadingForYou: Boolean = false,
     val isLoadingDeveloperSpotlight: Boolean = false,
+    val isLoadingConsoleHighlights: Boolean = false,
     val error: String? = null,
 ) {
-    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods || isLoadingForYou || isLoadingDeveloperSpotlight
-    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && forYouRows.isEmpty() && developerSpotlight == null && !isLoading
+    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods || isLoadingForYou || isLoadingDeveloperSpotlight || isLoadingConsoleHighlights
+    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && forYouRows.isEmpty() && developerSpotlight == null && consoleHighlights.isEmpty() && !isLoading
 }
 
 data class ThemeDetailState(
@@ -88,6 +92,13 @@ data class DeveloperDetailState(
         }
 }
 
+data class ConsoleShowcaseState(
+    val consoleId: String = "",
+    val showcase: ConsoleShowcase? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
 data class SeriesDetailState(
     val seriesId: String = "",
     val seriesName: String = "",
@@ -131,6 +142,9 @@ class ExploreViewModel(
     private val _developerDetailState = MutableStateFlow(DeveloperDetailState())
     val developerDetailState: StateFlow<DeveloperDetailState> = _developerDetailState.asStateFlow()
 
+    private val _consoleShowcaseState = MutableStateFlow(ConsoleShowcaseState())
+    val consoleShowcaseState: StateFlow<ConsoleShowcaseState> = _consoleShowcaseState.asStateFlow()
+
     private var featuredJob: Job? = null
     private var rowsJob: Job? = null
     private var themesJob: Job? = null
@@ -144,6 +158,8 @@ class ExploreViewModel(
     private var forYouJob: Job? = null
     private var developerSpotlightJob: Job? = null
     private var developerDetailJob: Job? = null
+    private var consoleHighlightsJob: Job? = null
+    private var consoleShowcaseJob: Job? = null
 
     fun load() {
         loadFeatured()
@@ -154,6 +170,7 @@ class ExploreViewModel(
         loadMoods()
         loadForYou()
         loadDeveloperSpotlight()
+        loadConsoleHighlights()
     }
 
     fun dismissError() {
@@ -424,5 +441,41 @@ class ExploreViewModel(
 
     fun dismissDeveloperDetailError() {
         _developerDetailState.update { it.copy(error = null) }
+    }
+
+    private fun loadConsoleHighlights() {
+        if (consoleHighlightsJob?.isActive == true) return
+        _state.update { it.copy(isLoadingConsoleHighlights = true) }
+        consoleHighlightsJob = scope.launch(dispatchers.io) {
+            exploreRepository.getConsoleHighlights().fold(
+                onSuccess = { highlights ->
+                    _state.update { it.copy(consoleHighlights = highlights, isLoadingConsoleHighlights = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoadingConsoleHighlights = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun loadConsoleShowcase(consoleId: String) {
+        consoleShowcaseJob?.cancel()
+        _consoleShowcaseState.update {
+            ConsoleShowcaseState(consoleId = consoleId, isLoading = true)
+        }
+        consoleShowcaseJob = scope.launch(dispatchers.io) {
+            exploreRepository.getConsoleShowcase(consoleId).fold(
+                onSuccess = { showcase ->
+                    _consoleShowcaseState.update { it.copy(showcase = showcase, isLoading = false) }
+                },
+                onFailure = { error ->
+                    _consoleShowcaseState.update { it.copy(isLoading = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun dismissConsoleShowcaseError() {
+        _consoleShowcaseState.update { it.copy(error = null) }
     }
 }

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -1792,3 +1792,379 @@ func calcRatingAndConsoles(games []db.Game) (float64, []string) {
 	return avgRating, consoles
 }
 
+// --- Phase 8: Console Showcase Pages ---
+
+// GenreCount holds a genre name and the number of games in that genre.
+type GenreCount struct {
+	Name      string `json:"name"`
+	GameCount int    `json:"gameCount"`
+}
+
+// ConsoleShowcaseResponse is the API response for a console showcase page.
+type ConsoleShowcaseResponse struct {
+	Console        ConsoleResponse    `json:"console"`
+	Essentials     []GameResponse     `json:"essentials"`
+	HiddenGems     []GameResponse     `json:"hiddenGems"`
+	GenreBreakdown []GenreCount       `json:"genreBreakdown"`
+	TopDevelopers  []DeveloperSummary `json:"topDevelopers"`
+	RecentlyPlayed []GameResponse     `json:"recentlyPlayed"`
+}
+
+// ConsoleHighlight is a compact summary of a console for the explore page quick-jump row.
+type ConsoleHighlight struct {
+	ID         string        `json:"id"`
+	Name       string        `json:"name"`
+	ColorTheme string        `json:"colorTheme"`
+	IconURL    string        `json:"iconUrl"`
+	LogoURL    string        `json:"logoUrl"`
+	GameCount  int           `json:"gameCount"`
+	TopGame    *GameResponse `json:"topGame"`
+}
+
+// ConsoleHighlightsResponse is the API response for the console highlights endpoint.
+type ConsoleHighlightsResponse struct {
+	Consoles []ConsoleHighlight `json:"consoles"`
+}
+
+// GetConsoleShowcase returns aggregated showcase data for a specific console.
+// GET /api/explore/consoles/:id/showcase
+func (h *ExploreHandler) GetConsoleShowcase(c *gin.Context) {
+	userID := getUserID(c)
+	abbr := strings.ToLower(c.Param("id"))
+
+	// Look up the console by abbreviation
+	var console db.Console
+	if err := h.DB.Where("LOWER(abbreviation) = ?", abbr).First(&console).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "console not found"})
+		return
+	}
+
+	// Count games for the console response
+	var gameCount int64
+	h.DB.Model(&db.Game{}).Where("console_id = ? AND deleted_at IS NULL", console.ID).Count(&gameCount)
+	console.GameCount = int(gameCount)
+
+	// --- Essentials: top 10 by IGDB rating ---
+	var essentials []db.Game
+	if err := h.DB.Preload("Console").
+		Where("console_id = ? AND rating > 0 AND deleted_at IS NULL", console.ID).
+		Order("rating DESC").
+		Limit(10).
+		Find(&essentials).Error; err != nil {
+		slog.Error("failed to fetch console essentials", "console", abbr, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch console data"})
+		return
+	}
+
+	// --- Hidden Gems: high rating + low play time for this console ---
+	// Exclude essentials to avoid showing the same games in both shelves
+	essentialIDs := make([]uint, len(essentials))
+	for i, g := range essentials {
+		essentialIDs[i] = g.ID
+	}
+	hiddenGems := h.buildConsoleHiddenGems(console.ID, essentialIDs)
+
+	// --- Genre Breakdown: count games per genre for this console ---
+	genreBreakdown := h.buildGenreBreakdown(console.ID)
+
+	// --- Top Developers: top 5 developers by game count for this console ---
+	topDevelopers := h.buildConsoleTopDevelopers(console.ID, console.Name)
+
+	// --- Recently Played: user's recently played on this console ---
+	var recentlyPlayed []db.Game
+	if userID > 0 {
+		var playHistories []db.PlayHistory
+		if err := h.DB.
+			Joins("JOIN games ON games.id = play_histories.game_id").
+			Where("play_histories.user_id = ? AND games.console_id = ? AND games.deleted_at IS NULL", userID, console.ID).
+			Order("play_histories.last_played DESC").
+			Limit(10).
+			Find(&playHistories).Error; err != nil {
+			slog.Error("failed to fetch recently played", "console", abbr, "error", err)
+		} else {
+			gameIDs := make([]uint, 0, len(playHistories))
+			for _, ph := range playHistories {
+				gameIDs = append(gameIDs, ph.GameID)
+			}
+			if len(gameIDs) > 0 {
+				if err := h.DB.Preload("Console").
+					Where("id IN ? AND deleted_at IS NULL", gameIDs).
+					Find(&recentlyPlayed).Error; err != nil {
+					slog.Error("failed to fetch recently played games", "console", abbr, "error", err)
+				}
+				// Re-order to match play history order
+				gameMap := make(map[uint]db.Game, len(recentlyPlayed))
+				for _, g := range recentlyPlayed {
+					gameMap[g.ID] = g
+				}
+				ordered := make([]db.Game, 0, len(gameIDs))
+				for _, id := range gameIDs {
+					if g, ok := gameMap[id]; ok {
+						ordered = append(ordered, g)
+					}
+				}
+				recentlyPlayed = ordered
+			}
+		}
+	}
+
+	// Batch-load user game data for all games at once (essentials + hidden gems + recently played)
+	allGames := make([]db.Game, 0, len(essentials)+len(hiddenGems)+len(recentlyPlayed))
+	allGames = append(allGames, essentials...)
+	allGames = append(allGames, hiddenGems...)
+	allGames = append(allGames, recentlyPlayed...)
+	allGameIDs := make([]uint, len(allGames))
+	for i, g := range allGames {
+		allGameIDs[i] = g.ID
+	}
+	userData := loadUserGameData(h.DB, userID, allGameIDs)
+
+	toResponses := func(games []db.Game) []GameResponse {
+		result := make([]GameResponse, len(games))
+		for i, g := range games {
+			result[i] = toGameResponseWithData(g, &userData)
+		}
+		return result
+	}
+
+	c.JSON(http.StatusOK, ConsoleShowcaseResponse{
+		Console:        ToConsoleResponse(console),
+		Essentials:     toResponses(essentials),
+		HiddenGems:     toResponses(hiddenGems),
+		GenreBreakdown: genreBreakdown,
+		TopDevelopers:  topDevelopers,
+		RecentlyPlayed: toResponses(recentlyPlayed),
+	})
+}
+
+// buildConsoleHiddenGems returns games with high rating but low play time for a console.
+func (h *ExploreHandler) buildConsoleHiddenGems(consoleID uint, excludeIDs []uint) []db.Game {
+	// Calculate play-time threshold (25th percentile) for this console
+	type thresholdRow struct {
+		TotalPlayTime int64
+	}
+	var playTimes []thresholdRow
+	if err := h.DB.Model(&db.PlayHistory{}).
+		Select("COALESCE(SUM(play_histories.play_time), 0) as total_play_time").
+		Joins("JOIN games ON games.id = play_histories.game_id").
+		Where("games.console_id = ? AND games.deleted_at IS NULL", consoleID).
+		Group("play_histories.game_id").
+		Having("total_play_time > 0").
+		Order("total_play_time ASC").
+		Scan(&playTimes).Error; err != nil {
+		slog.Error("failed to calculate play time threshold for console hidden gems", "error", err)
+		return nil
+	}
+
+	var threshold int64
+	if len(playTimes) > 0 {
+		idx := len(playTimes) / 4
+		threshold = playTimes[idx].TotalPlayTime
+		if threshold == 0 {
+			threshold = 1
+		}
+	}
+
+	var games []db.Game
+	query := h.DB.Preload("Console").
+		Joins("LEFT JOIN (SELECT game_id, COALESCE(SUM(play_time), 0) as total_play_time FROM play_histories GROUP BY game_id) ph ON ph.game_id = games.id").
+		Where("games.console_id = ?", consoleID).
+		Where("games.rating >= 70").
+		Where("games.deleted_at IS NULL")
+
+	if len(excludeIDs) > 0 {
+		query = query.Where("games.id NOT IN ?", excludeIDs)
+	}
+
+	if threshold > 0 {
+		query = query.Where("ph.total_play_time IS NULL OR ph.total_play_time <= ?", threshold)
+	}
+
+	if err := query.
+		Order("games.rating DESC").
+		Limit(10).
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch console hidden gems", "error", err)
+		return nil
+	}
+
+	return games
+}
+
+// buildGenreBreakdown returns genre counts for games on a specific console.
+func (h *ExploreHandler) buildGenreBreakdown(consoleID uint) []GenreCount {
+	type genreRow struct {
+		Genre     string
+		GameCount int
+	}
+	var rows []genreRow
+	if err := h.DB.
+		Table("games").
+		Select("genre, COUNT(*) as game_count").
+		Where("console_id = ? AND deleted_at IS NULL AND genre != ''", consoleID).
+		Group("genre").
+		Order("game_count DESC").
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch genre breakdown", "error", err)
+		return []GenreCount{}
+	}
+
+	result := make([]GenreCount, len(rows))
+	for i, r := range rows {
+		result[i] = GenreCount{
+			Name:      r.Genre,
+			GameCount: r.GameCount,
+		}
+	}
+	return result
+}
+
+// buildConsoleTopDevelopers returns the top 5 developers by game count for a console.
+func (h *ExploreHandler) buildConsoleTopDevelopers(consoleID uint, consoleName string) []DeveloperSummary {
+	type devRow struct {
+		Developer string
+		GameCount int
+		AvgRating float64
+	}
+
+	var rows []devRow
+	if err := h.DB.
+		Table("games").
+		Select("developer, COUNT(*) as game_count, AVG(CASE WHEN rating > 0 THEN rating ELSE NULL END) as avg_rating").
+		Where("console_id = ? AND deleted_at IS NULL AND developer != ''", consoleID).
+		Group("developer").
+		Order("game_count DESC").
+		Limit(5).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch top developers for console", "error", err)
+		return []DeveloperSummary{}
+	}
+
+	developers := make([]DeveloperSummary, len(rows))
+	for i, r := range rows {
+		avgRating := 0.0
+		if r.AvgRating > 0 {
+			avgRating = math.Round(r.AvgRating*10) / 10
+		}
+		developers[i] = DeveloperSummary{
+			Name:      r.Developer,
+			GameCount: r.GameCount,
+			AvgRating: avgRating,
+			Consoles:  []string{consoleName},
+		}
+	}
+	return developers
+}
+
+// GetConsoleHighlights returns a compact list of consoles with their top game for the explore page.
+// GET /api/explore/console-highlights
+func (h *ExploreHandler) GetConsoleHighlights(c *gin.Context) {
+	userID := getUserID(c)
+
+	// Get all consoles with game counts
+	var consoles []db.Console
+	if err := h.DB.Order("name ASC").Find(&consoles).Error; err != nil {
+		slog.Error("failed to fetch consoles for highlights", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch consoles"})
+		return
+	}
+
+	// Count games per console
+	type consoleCount struct {
+		ConsoleID uint
+		GameCount int
+	}
+	var counts []consoleCount
+	if err := h.DB.
+		Table("games").
+		Select("console_id, COUNT(*) as game_count").
+		Where("deleted_at IS NULL").
+		Group("console_id").
+		Scan(&counts).Error; err != nil {
+		slog.Error("failed to count games per console", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch console data"})
+		return
+	}
+
+	countMap := make(map[uint]int, len(counts))
+	for _, cc := range counts {
+		countMap[cc.ConsoleID] = cc.GameCount
+	}
+
+	// Find the top game per console (highest rated game with hero art)
+	type topGameRow struct {
+		ConsoleID uint
+		GameID    uint
+	}
+	// For each console, find the highest-rated game that has hero art.
+	// Use GROUP BY to get the max-rated game per console efficiently.
+	var topGameRows []topGameRow
+	if err := h.DB.Raw(`
+		SELECT console_id, game_id FROM (
+			SELECT games.console_id, games.id as game_id, games.rating,
+				ROW_NUMBER() OVER (PARTITION BY games.console_id ORDER BY games.rating DESC) as rn
+			FROM games
+			JOIN game_artworks ON game_artworks.game_id = games.id AND game_artworks.hero_url != ''
+			WHERE games.deleted_at IS NULL AND games.rating > 0
+		) ranked WHERE rn = 1
+	`).Scan(&topGameRows).Error; err != nil {
+		slog.Error("failed to fetch top games for console highlights", "error", err)
+		// Continue without top games
+	}
+
+	// Map top game per console (query already returns exactly one per console)
+	topGameByConsole := make(map[uint]uint, len(topGameRows))
+	for _, row := range topGameRows {
+		topGameByConsole[row.ConsoleID] = row.GameID
+	}
+
+	// Batch-load all top games
+	topGameIDs := make([]uint, 0, len(topGameByConsole))
+	for _, gid := range topGameByConsole {
+		topGameIDs = append(topGameIDs, gid)
+	}
+
+	var topGames []db.Game
+	if len(topGameIDs) > 0 {
+		if err := h.DB.Preload("Console").Where("id IN ?", topGameIDs).Find(&topGames).Error; err != nil {
+			slog.Error("failed to load top games for console highlights", "error", err)
+		}
+	}
+
+	topGameResponses := ToGameResponses(topGames, h.DB, userID)
+	topGameResponseMap := make(map[string]*GameResponse, len(topGameResponses))
+	for i := range topGameResponses {
+		topGameResponseMap[topGameResponses[i].ID] = &topGameResponses[i]
+	}
+
+	highlights := make([]ConsoleHighlight, 0, len(consoles))
+	for _, con := range consoles {
+		gc := countMap[con.ID]
+		if gc == 0 {
+			continue // Skip consoles with no games
+		}
+
+		abbr := strings.ToLower(con.Abbreviation)
+		highlight := ConsoleHighlight{
+			ID:         abbr,
+			Name:       con.Name,
+			ColorTheme: con.ColorTheme,
+			IconURL:    "/api/consoles/" + abbr + "/icon",
+			LogoURL:    "/api/consoles/" + abbr + "/logo",
+			GameCount:  gc,
+		}
+
+		// Attach top game if found
+		if topGameID, ok := topGameByConsole[con.ID]; ok {
+			idStr := strconv.FormatUint(uint64(topGameID), 10)
+			if gr, ok := topGameResponseMap[idStr]; ok {
+				highlight.TopGame = gr
+			}
+		}
+
+		highlights = append(highlights, highlight)
+	}
+
+	c.JSON(http.StatusOK, ConsoleHighlightsResponse{Consoles: highlights})
+}
+

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -2207,3 +2207,307 @@ func TestGetDeveloperSpotlight_NoHeroArt(t *testing.T) {
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
+
+// --- Phase 8: Console Showcase tests ---
+
+// createExploreGameFull creates a game with developer, publisher, and genre.
+func createExploreGameFull(t *testing.T, database *gorm.DB, consoleAbbr, title string, rating float64, developer, publisher, genre string) db.Game {
+	t.Helper()
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", consoleAbbr).First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     title,
+		FileName:  title + ".rom",
+		FilePath:  consoleAbbr + "/" + title + ".rom",
+		Rating:    rating,
+		Genre:     genre,
+		Developer: developer,
+		Publisher: publisher,
+	}
+	require.NoError(t, database.Create(&game).Error)
+	return game
+}
+
+func TestGetConsoleShowcase_Success(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create games on SNES
+	createExploreGameFull(t, env.database, "SNES", "Chrono Trigger", 95, "Square", "Square", "RPG")
+	createExploreGameFull(t, env.database, "SNES", "Super Mario World", 92, "Nintendo", "Nintendo", "Platformer")
+	createExploreGameFull(t, env.database, "SNES", "Zelda LTTP", 94, "Nintendo", "Nintendo", "Action RPG")
+
+	// Create a game on NES — should NOT appear in SNES showcase
+	createExploreGameFull(t, env.database, "NES", "Super Mario Bros", 90, "Nintendo", "Nintendo", "Platformer")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/consoles/snes/showcase", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ConsoleShowcaseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Console info
+	assert.Equal(t, "snes", resp.Console.ID)
+	assert.Equal(t, "Super Nintendo", resp.Console.Name)
+	assert.Equal(t, 3, resp.Console.GameCount)
+
+	// Essentials should be sorted by rating DESC and only include SNES games
+	require.Len(t, resp.Essentials, 3)
+	assert.Equal(t, "Chrono Trigger", resp.Essentials[0].Title)
+	assert.Equal(t, "Zelda LTTP", resp.Essentials[1].Title)
+	assert.Equal(t, "Super Mario World", resp.Essentials[2].Title)
+
+	// NES game should not be in essentials
+	for _, g := range resp.Essentials {
+		assert.Equal(t, "snes", g.ConsoleID)
+	}
+
+	// Genre breakdown should have 3 genres
+	assert.Len(t, resp.GenreBreakdown, 3)
+
+	// Top developers — Nintendo has 2 games, Square has 1
+	require.NotEmpty(t, resp.TopDevelopers)
+	assert.Equal(t, "Nintendo", resp.TopDevelopers[0].Name)
+	assert.Equal(t, 2, resp.TopDevelopers[0].GameCount)
+}
+
+func TestGetConsoleShowcase_GenreBreakdown(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create games with various genres on SNES
+	createExploreGameWithGenre(t, env.database, "SNES", "Game A", 90, "RPG", 1)
+	createExploreGameWithGenre(t, env.database, "SNES", "Game B", 85, "RPG", 1)
+	createExploreGameWithGenre(t, env.database, "SNES", "Game C", 80, "RPG", 1)
+	createExploreGameWithGenre(t, env.database, "SNES", "Game D", 75, "Platformer", 1)
+	createExploreGameWithGenre(t, env.database, "SNES", "Game E", 70, "Platformer", 1)
+	createExploreGameWithGenre(t, env.database, "SNES", "Game F", 65, "Action", 1)
+
+	// NES game should not be counted
+	createExploreGameWithGenre(t, env.database, "NES", "NES Game", 90, "RPG", 1)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/consoles/snes/showcase", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ConsoleShowcaseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Genre breakdown sorted by count desc
+	require.Len(t, resp.GenreBreakdown, 3)
+	assert.Equal(t, "RPG", resp.GenreBreakdown[0].Name)
+	assert.Equal(t, 3, resp.GenreBreakdown[0].GameCount)
+	assert.Equal(t, "Platformer", resp.GenreBreakdown[1].Name)
+	assert.Equal(t, 2, resp.GenreBreakdown[1].GameCount)
+	assert.Equal(t, "Action", resp.GenreBreakdown[2].Name)
+	assert.Equal(t, 1, resp.GenreBreakdown[2].GameCount)
+}
+
+func TestGetConsoleShowcase_TopDevelopers(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create games with specific developers on SNES
+	createExploreGameWithDev(t, env.database, "SNES", "FF6", 96, "Square", "Square")
+	createExploreGameWithDev(t, env.database, "SNES", "Chrono Trigger", 95, "Square", "Square")
+	createExploreGameWithDev(t, env.database, "SNES", "Secret of Mana", 88, "Square", "Square")
+	createExploreGameWithDev(t, env.database, "SNES", "Super Mario World", 92, "Nintendo", "Nintendo")
+	createExploreGameWithDev(t, env.database, "SNES", "Donkey Kong Country", 87, "Rare", "Nintendo")
+	createExploreGameWithDev(t, env.database, "SNES", "Mega Man X", 90, "Capcom", "Capcom")
+	createExploreGameWithDev(t, env.database, "SNES", "Street Fighter 2", 85, "Capcom", "Capcom")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/consoles/snes/showcase", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ConsoleShowcaseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Top developers sorted by game count: Square(3), Capcom(2), Nintendo(1), Rare(1)
+	require.GreaterOrEqual(t, len(resp.TopDevelopers), 4)
+	assert.Equal(t, "Square", resp.TopDevelopers[0].Name)
+	assert.Equal(t, 3, resp.TopDevelopers[0].GameCount)
+	assert.Equal(t, "Capcom", resp.TopDevelopers[1].Name)
+	assert.Equal(t, 2, resp.TopDevelopers[1].GameCount)
+
+	// All developers should list SNES as their console
+	for _, dev := range resp.TopDevelopers {
+		assert.Contains(t, dev.Consoles, "Super Nintendo")
+		assert.Greater(t, dev.AvgRating, 0.0)
+	}
+
+	// Limit to 5 developers max
+	assert.LessOrEqual(t, len(resp.TopDevelopers), 5)
+}
+
+func TestGetConsoleShowcase_NotFound(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/consoles/nonexistent/showcase", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGetConsoleShowcase_RecentlyPlayed(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "SNES", "Game A", 90)
+	game2 := createExploreGame(t, env.database, "SNES", "Game B", 85)
+	createExploreGame(t, env.database, "NES", "NES Game", 80) // Different console
+
+	// Get user ID
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Add play history for SNES games
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game1.ID,
+		LastPlayed: time.Now().Add(-1 * time.Hour),
+		PlayTime:   3600,
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game2.ID,
+		LastPlayed: time.Now(),
+		PlayTime:   1800,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/consoles/snes/showcase", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ConsoleShowcaseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Recently played should have 2 SNES games, ordered by last_played DESC
+	require.Len(t, resp.RecentlyPlayed, 2)
+	assert.Equal(t, "Game B", resp.RecentlyPlayed[0].Title) // played more recently
+	assert.Equal(t, "Game A", resp.RecentlyPlayed[1].Title)
+}
+
+func TestGetConsoleShowcase_CaseInsensitive(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGame(t, env.database, "SNES", "Test Game", 85)
+
+	// Use uppercase in URL — should still work
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/consoles/SNES/showcase", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ConsoleShowcaseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "snes", resp.Console.ID)
+}
+
+func TestGetConsoleHighlights(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create games across consoles
+	game1 := createExploreGame(t, env.database, "SNES", "SNES Best Game", 95)
+	createExploreGame(t, env.database, "NES", "NES Game", 88)
+	createExploreGame(t, env.database, "GBA", "GBA Game", 82)
+
+	// Add hero art for the SNES game (top game requires hero art)
+	env.database.Create(&db.GameArtwork{
+		GameID:  game1.ID,
+		HeroURL: "https://cdn.steamgriddb.com/hero/snes_best.png",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/console-highlights", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ConsoleHighlightsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Should have entries for consoles that have games
+	require.GreaterOrEqual(t, len(resp.Consoles), 3)
+
+	// Find the SNES entry
+	var snesEntry *ConsoleHighlight
+	for i := range resp.Consoles {
+		if resp.Consoles[i].ID == "snes" {
+			snesEntry = &resp.Consoles[i]
+			break
+		}
+	}
+	require.NotNil(t, snesEntry)
+	assert.Equal(t, "Super Nintendo", snesEntry.Name)
+	assert.Equal(t, 1, snesEntry.GameCount)
+	assert.NotEmpty(t, snesEntry.ColorTheme)
+	assert.NotEmpty(t, snesEntry.IconURL)
+	assert.NotEmpty(t, snesEntry.LogoURL)
+
+	// SNES should have a top game (it has hero art)
+	require.NotNil(t, snesEntry.TopGame)
+	assert.Equal(t, "SNES Best Game", snesEntry.TopGame.Title)
+}
+
+func TestGetConsoleHighlights_NoGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// No games at all — should return empty consoles list (all skipped)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/console-highlights", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ConsoleHighlightsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Empty(t, resp.Consoles)
+}
+
+func TestGetConsoleHighlights_TopGameRequiresHeroArt(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create a game without hero art
+	createExploreGame(t, env.database, "NES", "No Art Game", 95)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/console-highlights", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ConsoleHighlightsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// NES should appear but without a top game (no hero art)
+	var nesEntry *ConsoleHighlight
+	for i := range resp.Consoles {
+		if resp.Consoles[i].ID == "nes" {
+			nesEntry = &resp.Consoles[i]
+			break
+		}
+	}
+	require.NotNil(t, nesEntry)
+	assert.Equal(t, 1, nesEntry.GameCount)
+	assert.Nil(t, nesEntry.TopGame) // No hero art = no top game
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -249,6 +249,8 @@ func NewRouter(cfg Config) *gin.Engine {
 			explore.GET("/developers/spotlight", exploreHandler.GetDeveloperSpotlight)
 			explore.GET("/developers/:name", exploreHandler.GetDeveloperDetail)
 			explore.GET("/publishers/:name", exploreHandler.GetPublisherDetail)
+			explore.GET("/consoles/:id/showcase", exploreHandler.GetConsoleShowcase)
+			explore.GET("/console-highlights", exploreHandler.GetConsoleHighlights)
 		}
 
 		// Games

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -42,6 +42,7 @@ import { ExploreSeriesPage } from "@/pages/explore-series-page";
 import { DeveloperDetailPage } from "@/pages/developer-detail-page";
 import { PublisherDetailPage } from "@/pages/publisher-detail-page";
 import { ExploreMoodPage } from "@/pages/explore-mood-page";
+import { ConsoleShowcasePage } from "@/pages/console-showcase-page";
 import { ChallengeDetailPage } from "@/pages/challenge-detail-page";
 import { SessionDetailPage } from "@/pages/session-detail-page";
 import { SetupWizardPage } from "@/pages/setup-wizard-page";
@@ -101,6 +102,10 @@ export function App() {
                     <Route
                       path="explore/series/:id"
                       element={<ExploreSeriesPage />}
+                    />
+                    <Route
+                      path="explore/consoles/:id"
+                      element={<ConsoleShowcasePage />}
                     />
                     <Route
                       path="explore/mood/:mood"

--- a/web/src/features/explore/components/__tests__/console-quick-jump.test.tsx
+++ b/web/src/features/explore/components/__tests__/console-quick-jump.test.tsx
@@ -1,0 +1,168 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { ConsoleQuickJump } from "@/features/explore/components/console-quick-jump";
+import type { ConsoleHighlight, Game } from "@/types/api";
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeConsoleHighlight(
+  overrides: Partial<ConsoleHighlight> = {},
+): ConsoleHighlight {
+  return {
+    id: "snes",
+    name: "Super Nintendo",
+    colorTheme: "#805ad5",
+    iconUrl: "/icons/snes.png",
+    logoUrl: "/logos/snes.png",
+    gameCount: 42,
+    topGame: makeGame({ id: "top1", title: "Top SNES Game" }),
+    ...overrides,
+  };
+}
+
+const mockConsoles: ConsoleHighlight[] = [
+  makeConsoleHighlight({
+    id: "snes",
+    name: "Super Nintendo",
+    gameCount: 42,
+    colorTheme: "#805ad5",
+  }),
+  makeConsoleHighlight({
+    id: "nes",
+    name: "NES",
+    gameCount: 30,
+    colorTheme: "#e53e3e",
+  }),
+  makeConsoleHighlight({
+    id: "gba",
+    name: "Game Boy Advance",
+    gameCount: 25,
+    colorTheme: "#3182ce",
+  }),
+];
+
+function renderComponent(
+  consoles: ConsoleHighlight[] | undefined = mockConsoles,
+  isLoading = false,
+) {
+  return render(
+    <MemoryRouter>
+      <ConsoleQuickJump consoles={consoles} isLoading={isLoading} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ConsoleQuickJump", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the section with test id", () => {
+    renderComponent();
+    expect(screen.getByTestId("console-quick-jump")).toBeInTheDocument();
+  });
+
+  it("renders the section heading", () => {
+    renderComponent();
+    expect(
+      screen.getByRole("heading", { name: "Browse by Console", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders console cards", () => {
+    renderComponent();
+    expect(screen.getByTestId("console-card-snes")).toBeInTheDocument();
+    expect(screen.getByTestId("console-card-nes")).toBeInTheDocument();
+    expect(screen.getByTestId("console-card-gba")).toBeInTheDocument();
+  });
+
+  it("renders console names", () => {
+    renderComponent();
+    expect(screen.getByText("Super Nintendo")).toBeInTheDocument();
+    expect(screen.getByText("NES")).toBeInTheDocument();
+    expect(screen.getByText("Game Boy Advance")).toBeInTheDocument();
+  });
+
+  it("shows game counts", () => {
+    renderComponent();
+    expect(screen.getByText("42 games")).toBeInTheDocument();
+    expect(screen.getByText("30 games")).toBeInTheDocument();
+    expect(screen.getByText("25 games")).toBeInTheDocument();
+  });
+
+  it("each card links to showcase page", () => {
+    renderComponent();
+    const snesCard = screen.getByTestId("console-card-snes");
+    expect(snesCard.tagName).toBe("A");
+    expect(snesCard).toHaveAttribute("href", "/explore/consoles/snes");
+
+    const nesCard = screen.getByTestId("console-card-nes");
+    expect(nesCard).toHaveAttribute("href", "/explore/consoles/nes");
+
+    const gbaCard = screen.getByTestId("console-card-gba");
+    expect(gbaCard).toHaveAttribute("href", "/explore/consoles/gba");
+  });
+
+  it("renders loading skeleton when loading", () => {
+    renderComponent(undefined, true);
+    expect(
+      screen.getByTestId("console-quick-jump-skeleton"),
+    ).toBeInTheDocument();
+  });
+
+  it("returns null when consoles array is empty", () => {
+    const { container } = renderComponent([]);
+    expect(
+      screen.queryByTestId("console-quick-jump"),
+    ).not.toBeInTheDocument();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when consoles is undefined and not loading", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ConsoleQuickJump consoles={undefined} isLoading={false} />
+      </MemoryRouter>,
+    );
+    expect(
+      screen.queryByTestId("console-quick-jump"),
+    ).not.toBeInTheDocument();
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders singular game count correctly", () => {
+    renderComponent([
+      makeConsoleHighlight({ id: "vb", name: "Virtual Boy", gameCount: 1 }),
+    ]);
+    expect(screen.getByText("1 game")).toBeInTheDocument();
+  });
+
+  it("renders list items with correct role", () => {
+    renderComponent();
+    const items = screen.getAllByRole("listitem");
+    expect(items).toHaveLength(3);
+  });
+});

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { ExplorePage } from "@/pages/explore-page";
-import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition, ForYouResponse, PlayersLikeYouResponse, DeveloperSpotlightResponse } from "@/types/api";
+import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition, ForYouResponse, PlayersLikeYouResponse, DeveloperSpotlightResponse, ConsoleHighlightsResponse } from "@/types/api";
 
 // Mock hooks
 vi.mock("@/hooks/use-explore", () => ({
@@ -16,6 +16,7 @@ vi.mock("@/hooks/use-explore", () => ({
   useForYou: vi.fn(),
   usePlayersLikeYou: vi.fn(),
   useDeveloperSpotlight: vi.fn(),
+  useConsoleHighlights: vi.fn(),
   useSurpriseGame: vi.fn(() => ({
     data: undefined,
     refetch: vi.fn(),
@@ -39,7 +40,7 @@ vi.mock("@/hooks/use-auto-scrape", () => ({
   useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
 }));
 
-import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods, useForYou, usePlayersLikeYou, useDeveloperSpotlight } from "@/hooks/use-explore";
+import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods, useForYou, usePlayersLikeYou, useDeveloperSpotlight, useConsoleHighlights } from "@/hooks/use-explore";
 
 const mockUseExploreFeatured = useExploreFeatured as ReturnType<typeof vi.fn>;
 const mockUseExploreRows = useExploreRows as ReturnType<typeof vi.fn>;
@@ -50,6 +51,7 @@ const mockUseMoods = useMoods as ReturnType<typeof vi.fn>;
 const mockUseForYou = useForYou as ReturnType<typeof vi.fn>;
 const mockUsePlayersLikeYou = usePlayersLikeYou as ReturnType<typeof vi.fn>;
 const mockUseDeveloperSpotlight = useDeveloperSpotlight as ReturnType<typeof vi.fn>;
+const mockUseConsoleHighlights = useConsoleHighlights as ReturnType<typeof vi.fn>;
 
 function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
   return {
@@ -234,6 +236,10 @@ describe("ExplorePage", () => {
     });
     mockUseDeveloperSpotlight.mockReturnValue({
       data: mockDeveloperSpotlight,
+      isLoading: false,
+    });
+    mockUseConsoleHighlights.mockReturnValue({
+      data: { consoles: [] },
       isLoading: false,
     });
   });

--- a/web/src/features/explore/components/console-quick-jump.tsx
+++ b/web/src/features/explore/components/console-quick-jump.tsx
@@ -1,0 +1,143 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Skeleton } from "@/components/ui";
+import type { ConsoleHighlight } from "@/types/api";
+
+interface ConsoleQuickJumpProps {
+  consoles: ConsoleHighlight[] | undefined;
+  isLoading: boolean;
+}
+
+function ConsoleQuickJumpSkeleton() {
+  return (
+    <section data-testid="console-quick-jump-skeleton">
+      <h2 className="text-xl font-bold text-surface-100 mb-5">
+        Browse by Console
+      </h2>
+      <div className="flex gap-4 overflow-hidden">
+        {Array.from({ length: 8 }, (_, i) => (
+          <Skeleton key={i} className="w-36 h-24 rounded-xl flex-shrink-0" />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function ConsoleQuickJump({
+  consoles,
+  isLoading,
+}: ConsoleQuickJumpProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, consoles]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return <ConsoleQuickJumpSkeleton />;
+  }
+
+  if (!consoles || consoles.length === 0) {
+    return null;
+  }
+
+  return (
+    <section
+      data-testid="console-quick-jump"
+      className="group/console-jump relative"
+    >
+      <h2 className="text-xl font-bold text-surface-100 mb-5">
+        Browse by Console
+      </h2>
+
+      <div className="relative">
+        {/* Scroll arrows */}
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/console-jump:opacity-100 group-focus-within/console-jump:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label="Scroll consoles left"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/console-jump:opacity-100 group-focus-within/console-jump:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label="Scroll consoles right"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        <div
+          ref={scrollRef}
+          className="flex gap-4 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label="Browse by Console"
+        >
+          {consoles.map((con) => {
+            const color = con.colorTheme || "#6366f1";
+            return (
+              <Link
+                key={con.id}
+                to={`/explore/consoles/${con.id}`}
+                className="group/card flex-shrink-0 w-36 rounded-xl border border-white/[0.06] p-4 transition-all duration-200 hover:border-white/[0.12] hover:-translate-y-0.5 hover:shadow-lg"
+                style={{
+                  background: `linear-gradient(135deg, ${color}30, ${color}08)`,
+                }}
+                role="listitem"
+                data-testid={`console-card-${con.id}`}
+              >
+                {con.iconUrl && (
+                  <img
+                    src={con.iconUrl}
+                    alt=""
+                    className="h-8 w-8 object-contain mb-2"
+                  />
+                )}
+                <p className="text-sm font-semibold text-surface-100 truncate group-hover/card:text-brand-400 transition-colors">
+                  {con.name}
+                </p>
+                <p className="text-xs text-surface-400 mt-0.5">
+                  {con.gameCount} {con.gameCount === 1 ? "game" : "games"}
+                </p>
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/hooks/use-explore.ts
+++ b/web/src/hooks/use-explore.ts
@@ -19,6 +19,8 @@ import type {
   DeveloperDetailResponse,
   PublisherDetailResponse,
   DeveloperSpotlightResponse,
+  ConsoleShowcase,
+  ConsoleHighlightsResponse,
 } from "@/types/api";
 
 export function useExploreFeatured() {
@@ -190,5 +192,24 @@ export function useDeveloperSpotlight() {
     queryKey: ["explore", "developers", "spotlight"],
     queryFn: () =>
       api.get<DeveloperSpotlightResponse>("/explore/developers/spotlight"),
+  });
+}
+
+export function useConsoleShowcase(consoleId: string) {
+  return useQuery({
+    queryKey: ["console-showcase", consoleId],
+    queryFn: () =>
+      api.get<ConsoleShowcase>(
+        `/explore/consoles/${encodeURIComponent(consoleId)}/showcase`,
+      ),
+    enabled: !!consoleId,
+  });
+}
+
+export function useConsoleHighlights() {
+  return useQuery({
+    queryKey: ["console-highlights"],
+    queryFn: () =>
+      api.get<ConsoleHighlightsResponse>("/explore/console-highlights"),
   });
 }

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -27,6 +27,10 @@ export type ApiGetPath = WithQuery<
   | "/explore/for-you"
   | "/explore/players-like-you"
 
+  // Console Showcase
+  | `/explore/consoles/${string}/showcase`
+  | "/explore/console-highlights"
+
   // Developers & Publishers
   | "/explore/developers"
   | "/explore/developers/spotlight"

--- a/web/src/pages/__tests__/console-showcase-page.test.tsx
+++ b/web/src/pages/__tests__/console-showcase-page.test.tsx
@@ -1,0 +1,338 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ConsoleShowcasePage } from "@/pages/console-showcase-page";
+import type {
+  ConsoleShowcase,
+  Console,
+  Game,
+  GenreCount,
+  DeveloperSummary,
+} from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-explore", () => ({
+  useConsoleShowcase: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-games", () => ({
+  useToggleFavorite: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-play-later", () => ({
+  useTogglePlayLater: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+import { useConsoleShowcase } from "@/hooks/use-explore";
+
+const mockUseConsoleShowcase = useConsoleShowcase as ReturnType<typeof vi.fn>;
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeConsole(overrides: Partial<Console> = {}): Console {
+  return {
+    id: "snes",
+    name: "Super Nintendo",
+    abbreviation: "snes",
+    extensions: [".sfc", ".smc"],
+    defaultCore: "snes9x",
+    coverAspectRatio: 0.75,
+    colorTheme: "#805ad5",
+    iconUrl: "/icons/snes.png",
+    logoUrl: "/logos/snes.png",
+    gameCount: 42,
+    saveStateSupport: true,
+    browserPlayable: true,
+    playable: true,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const mockShowcase: ConsoleShowcase = {
+  console: makeConsole(),
+  essentials: [
+    makeGame({ id: "e1", title: "Chrono Trigger", averageRating: 95 }),
+    makeGame({ id: "e2", title: "Super Metroid", averageRating: 94 }),
+  ],
+  hiddenGems: [
+    makeGame({ id: "h1", title: "EarthBound", averageRating: 88 }),
+    makeGame({ id: "h2", title: "Terranigma", averageRating: 85 }),
+  ],
+  genreBreakdown: [
+    { name: "RPG", gameCount: 15 } as GenreCount,
+    { name: "Action", gameCount: 10 } as GenreCount,
+    { name: "Platformer", gameCount: 8 } as GenreCount,
+  ],
+  topDevelopers: [
+    {
+      name: "Square",
+      gameCount: 12,
+      avgRating: 90.5,
+      consoles: ["SNES"],
+    } as DeveloperSummary,
+    {
+      name: "Capcom",
+      gameCount: 6,
+      avgRating: 85.2,
+      consoles: ["SNES"],
+    } as DeveloperSummary,
+  ],
+  recentlyPlayed: [
+    makeGame({ id: "r1", title: "Final Fantasy VI" }),
+    makeGame({ id: "r2", title: "Super Mario World" }),
+  ],
+};
+
+function renderPage(consoleId = "snes") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/explore/consoles/${consoleId}`]}>
+        <Routes>
+          <Route
+            path="/explore/consoles/:id"
+            element={<ConsoleShowcasePage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ConsoleShowcasePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseConsoleShowcase.mockReturnValue({
+      data: mockShowcase,
+      isLoading: false,
+    });
+  });
+
+  it("renders the page with test id", () => {
+    renderPage();
+    expect(screen.getByTestId("console-showcase-page")).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton while loading", () => {
+    mockUseConsoleShowcase.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(
+      screen.getByTestId("console-showcase-skeleton"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders console name", () => {
+    renderPage();
+    expect(screen.getByTestId("console-name")).toHaveTextContent(
+      "Super Nintendo",
+    );
+  });
+
+  it("renders console stats with game count", () => {
+    renderPage();
+    expect(screen.getByTestId("console-stats")).toHaveTextContent(
+      "42 games in library",
+    );
+  });
+
+  it("renders console logo", () => {
+    renderPage();
+    expect(screen.getByTestId("console-logo")).toBeInTheDocument();
+  });
+
+  it("renders essentials shelf with games", () => {
+    renderPage();
+    expect(screen.getByTestId("shelf-Essentials")).toBeInTheDocument();
+    expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
+    expect(screen.getByText("Super Metroid")).toBeInTheDocument();
+  });
+
+  it("renders hidden gems shelf with games", () => {
+    renderPage();
+    expect(screen.getByTestId("shelf-Hidden Gems")).toBeInTheDocument();
+    expect(screen.getByText("EarthBound")).toBeInTheDocument();
+    expect(screen.getByText("Terranigma")).toBeInTheDocument();
+  });
+
+  it("renders genre breakdown", () => {
+    renderPage();
+    const genreSection = screen.getByTestId("genre-breakdown");
+    expect(genreSection).toBeInTheDocument();
+    expect(screen.getByTestId("genre-card-RPG")).toBeInTheDocument();
+    expect(screen.getByTestId("genre-card-Action")).toBeInTheDocument();
+    expect(screen.getByTestId("genre-card-Platformer")).toBeInTheDocument();
+    // Check genre names are rendered
+    expect(screen.getByText("RPG")).toBeInTheDocument();
+    expect(screen.getByText("Action")).toBeInTheDocument();
+    expect(screen.getByText("Platformer")).toBeInTheDocument();
+  });
+
+  it("renders top developers", () => {
+    renderPage();
+    expect(screen.getByTestId("top-developers")).toBeInTheDocument();
+    expect(screen.getByTestId("developer-card-Square")).toBeInTheDocument();
+    expect(screen.getByTestId("developer-card-Capcom")).toBeInTheDocument();
+    expect(screen.getByText("Square")).toBeInTheDocument();
+    expect(screen.getByText("Capcom")).toBeInTheDocument();
+  });
+
+  it("renders developer cards as links to developer detail", () => {
+    renderPage();
+    const squareLink = screen.getByTestId("developer-card-Square");
+    expect(squareLink.tagName).toBe("A");
+    expect(squareLink).toHaveAttribute(
+      "href",
+      "/explore/developers/Square",
+    );
+  });
+
+  it("renders recently played when present", () => {
+    renderPage();
+    expect(
+      screen.getByTestId("recently-played-section"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Final Fantasy VI")).toBeInTheDocument();
+    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+  });
+
+  it("hides recently played when empty", () => {
+    mockUseConsoleShowcase.mockReturnValue({
+      data: {
+        ...mockShowcase,
+        recentlyPlayed: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("recently-played-section"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("back button calls navigate(-1)", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const backButton = screen.getByRole("button", {
+      name: /back to explore/i,
+    });
+    await user.click(backButton);
+    expect(mockNavigate).toHaveBeenCalledWith(-1);
+  });
+
+  it("shows not found when console does not exist", () => {
+    mockUseConsoleShowcase.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    renderPage("unknown");
+    expect(screen.getByText("Console not found")).toBeInTheDocument();
+  });
+
+  it("hides essentials shelf when empty", () => {
+    mockUseConsoleShowcase.mockReturnValue({
+      data: {
+        ...mockShowcase,
+        essentials: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("shelf-Essentials")).not.toBeInTheDocument();
+  });
+
+  it("hides hidden gems shelf when empty", () => {
+    mockUseConsoleShowcase.mockReturnValue({
+      data: {
+        ...mockShowcase,
+        hiddenGems: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("shelf-Hidden Gems"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides genre breakdown when empty", () => {
+    mockUseConsoleShowcase.mockReturnValue({
+      data: {
+        ...mockShowcase,
+        genreBreakdown: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("genre-breakdown")).not.toBeInTheDocument();
+  });
+
+  it("hides top developers when empty", () => {
+    mockUseConsoleShowcase.mockReturnValue({
+      data: {
+        ...mockShowcase,
+        topDevelopers: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("top-developers")).not.toBeInTheDocument();
+  });
+
+  it("renders singular game count correctly", () => {
+    mockUseConsoleShowcase.mockReturnValue({
+      data: {
+        ...mockShowcase,
+        console: makeConsole({ gameCount: 1 }),
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByTestId("console-stats")).toHaveTextContent(
+      "1 game in library",
+    );
+  });
+});

--- a/web/src/pages/console-showcase-page.tsx
+++ b/web/src/pages/console-showcase-page.tsx
@@ -1,0 +1,244 @@
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { Star } from "lucide-react";
+import { BackButton, Skeleton, GameCardSkeleton } from "@/components/ui";
+import { GameShelf } from "@/features/explore/components/game-shelf";
+import { useConsoleShowcase } from "@/hooks/use-explore";
+import { useToggleFavorite } from "@/hooks/use-games";
+import { useTogglePlayLater } from "@/hooks/use-play-later";
+import type { GenreCount, DeveloperSummary } from "@/types/api";
+
+function ShowcasePageSkeleton() {
+  return (
+    <div className="space-y-10" data-testid="console-showcase-skeleton">
+      {/* Hero skeleton */}
+      <div className="rounded-2xl overflow-hidden">
+        <Skeleton className="w-full h-56" />
+      </div>
+      {/* Essentials shelf skeleton */}
+      <div className="space-y-4">
+        <Skeleton className="w-48 h-7" />
+        <div className="flex gap-5 overflow-hidden">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+              <GameCardSkeleton />
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* Hidden gems shelf skeleton */}
+      <div className="space-y-4">
+        <Skeleton className="w-40 h-7" />
+        <div className="flex gap-5 overflow-hidden">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+              <GameCardSkeleton />
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* Genre breakdown skeleton */}
+      <div className="space-y-4">
+        <Skeleton className="w-48 h-7" />
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+          {Array.from({ length: 8 }, (_, i) => (
+            <Skeleton key={i} className="h-24 rounded-xl" />
+          ))}
+        </div>
+      </div>
+      {/* Developers skeleton */}
+      <div className="space-y-4">
+        <Skeleton className="w-64 h-7" />
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+          {Array.from({ length: 4 }, (_, i) => (
+            <Skeleton key={i} className="h-28 rounded-xl" />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ConsoleShowcasePage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const { data: showcase, isLoading } = useConsoleShowcase(id ?? "");
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+
+  if (isLoading) {
+    return (
+      <div
+        className="max-w-6xl space-y-6"
+        data-testid="console-showcase-page"
+      >
+        <BackButton onClick={() => navigate(-1)}>Back to Explore</BackButton>
+        <ShowcasePageSkeleton />
+      </div>
+    );
+  }
+
+  if (!showcase) {
+    return (
+      <div
+        className="max-w-6xl space-y-6"
+        data-testid="console-showcase-page"
+      >
+        <BackButton onClick={() => navigate(-1)}>Back to Explore</BackButton>
+        <p className="text-surface-400 text-center py-20">
+          Console not found
+        </p>
+      </div>
+    );
+  }
+
+  const { console: con } = showcase;
+  const colorTheme = con.colorTheme || "#6366f1";
+
+  return (
+    <div className="max-w-6xl space-y-10" data-testid="console-showcase-page">
+      <BackButton onClick={() => navigate(-1)}>Back to Explore</BackButton>
+
+      {/* Hero Section */}
+      <div
+        className="relative rounded-2xl overflow-hidden border border-white/[0.06]"
+        data-testid="console-showcase-hero"
+      >
+        {/* Color gradient background */}
+        <div
+          className="absolute inset-0"
+          style={{
+            background: `linear-gradient(135deg, ${colorTheme}40, ${colorTheme}10, transparent)`,
+          }}
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
+
+        <div className="relative p-8 sm:p-10 flex items-center gap-6">
+          {/* Console logo */}
+          {con.logoUrl && (
+            <img
+              src={con.logoUrl}
+              alt={`${con.name} logo`}
+              className="h-16 sm:h-20 object-contain drop-shadow-lg"
+              data-testid="console-logo"
+            />
+          )}
+          <div>
+            <h1
+              className="text-3xl sm:text-4xl font-bold text-white"
+              data-testid="console-name"
+            >
+              {con.name}
+            </h1>
+            <p
+              className="mt-2 text-sm text-white/70"
+              data-testid="console-stats"
+            >
+              {con.gameCount} {con.gameCount === 1 ? "game" : "games"} in
+              library
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Essentials Shelf */}
+      {showcase.essentials.length > 0 && (
+        <GameShelf
+          title="Essentials"
+          games={showcase.essentials}
+          isLoading={false}
+          onToggleFavorite={handleToggleFavorite}
+          onTogglePlayLater={handleTogglePlayLater}
+        />
+      )}
+
+      {/* Hidden Gems Shelf */}
+      {showcase.hiddenGems.length > 0 && (
+        <GameShelf
+          title="Hidden Gems"
+          games={showcase.hiddenGems}
+          isLoading={false}
+          onToggleFavorite={handleToggleFavorite}
+          onTogglePlayLater={handleTogglePlayLater}
+        />
+      )}
+
+      {/* Genre Breakdown */}
+      {showcase.genreBreakdown.length > 0 && (
+        <section data-testid="genre-breakdown" aria-labelledby="genre-breakdown-heading">
+          <h2 id="genre-breakdown-heading" className="text-xl font-bold text-surface-100 mb-5">
+            Genre Breakdown
+          </h2>
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+            {showcase.genreBreakdown.map((genre: GenreCount) => (
+              <div
+                key={genre.name}
+                className="rounded-xl border border-white/[0.06] p-4"
+                style={{
+                  background: `linear-gradient(135deg, ${colorTheme}15, transparent)`,
+                }}
+                data-testid={`genre-card-${genre.name}`}
+              >
+                <p className="text-sm font-semibold text-surface-100">
+                  {genre.name}
+                </p>
+                <p className="text-xs text-surface-400 mt-1">
+                  {genre.gameCount}{" "}
+                  {genre.gameCount === 1 ? "game" : "games"}
+                </p>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Studios That Defined This Console */}
+      {showcase.topDevelopers.length > 0 && (
+        <section data-testid="top-developers" aria-labelledby="top-developers-heading">
+          <h2 id="top-developers-heading" className="text-xl font-bold text-surface-100 mb-5">
+            Studios That Defined This Console
+          </h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+            {showcase.topDevelopers.map((dev: DeveloperSummary) => (
+              <Link
+                key={dev.name}
+                to={`/explore/developers/${encodeURIComponent(dev.name)}`}
+                className="group/dev rounded-xl border border-white/[0.06] p-4 transition-colors hover:border-white/[0.12]"
+                style={{
+                  background: `linear-gradient(135deg, ${colorTheme}10, transparent)`,
+                }}
+                data-testid={`developer-card-${dev.name}`}
+              >
+                <p className="text-sm font-semibold text-surface-100 group-hover/dev:text-brand-400 transition-colors">
+                  {dev.name}
+                </p>
+                <p className="text-xs text-surface-400 mt-1">
+                  {dev.gameCount}{" "}
+                  {dev.gameCount === 1 ? "game" : "games"}
+                </p>
+                {dev.avgRating > 0 && (
+                  <span className="inline-flex items-center gap-1 text-xs text-surface-400 mt-1">
+                    <Star className="h-3 w-3 text-amber-400 fill-amber-400" />
+                    {dev.avgRating.toFixed(1)}
+                  </span>
+                )}
+              </Link>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* Recently Played */}
+      {showcase.recentlyPlayed.length > 0 && (
+        <div data-testid="recently-played-section">
+          <GameShelf
+            title="Recently Played"
+            games={showcase.recentlyPlayed}
+            isLoading={false}
+            onToggleFavorite={handleToggleFavorite}
+            onTogglePlayLater={handleTogglePlayLater}
+          />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -10,6 +10,7 @@ import { DeveloperSpotlight } from "@/features/explore/components/developer-spot
 import { MoodPicker } from "@/features/explore/components/mood-picker";
 import { ForYouSection } from "@/features/explore/components/for-you-section";
 import { PlayersLikeYouShelf } from "@/features/explore/components/players-like-you-shelf";
+import { ConsoleQuickJump } from "@/features/explore/components/console-quick-jump";
 import {
   useExploreFeatured,
   useExploreRows,
@@ -20,6 +21,7 @@ import {
   useForYou,
   usePlayersLikeYou,
   useDeveloperSpotlight,
+  useConsoleHighlights,
 } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -63,6 +65,10 @@ export function ExplorePage() {
     data: spotlightData,
     isLoading: isSpotlightLoading,
   } = useDeveloperSpotlight();
+  const {
+    data: consoleHighlightsData,
+    isLoading: isConsoleHighlightsLoading,
+  } = useConsoleHighlights();
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
 
@@ -118,6 +124,12 @@ export function ExplorePage() {
 
       {/* Hero Carousel */}
       <HeroCarousel games={featuredGames} isLoading={isFeaturedLoading} />
+
+      {/* Console Quick-Jump */}
+      <ConsoleQuickJump
+        consoles={consoleHighlightsData?.consoles}
+        isLoading={isConsoleHighlightsLoading}
+      />
 
       {/* Mood Picker */}
       <MoodPicker moods={moods} isLoading={isMoodsLoading} />

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -883,6 +883,36 @@ export interface GameFranchiseLink {
   gameCount: number;
 }
 
+// --- Console Showcase ---
+
+export interface GenreCount {
+  name: string;
+  gameCount: number;
+}
+
+export interface ConsoleShowcase {
+  console: Console;
+  essentials: Game[];
+  hiddenGems: Game[];
+  genreBreakdown: GenreCount[];
+  topDevelopers: DeveloperSummary[];
+  recentlyPlayed: Game[];
+}
+
+export interface ConsoleHighlight {
+  id: string;
+  name: string;
+  colorTheme: string;
+  iconUrl: string;
+  logoUrl: string;
+  gameCount: number;
+  topGame: Game | null;
+}
+
+export interface ConsoleHighlightsResponse {
+  consoles: ConsoleHighlight[];
+}
+
 // --- Moods ---
 
 export interface MoodDefinition {


### PR DESCRIPTION
## Summary
- **Console Showcase page** (`/explore/consoles/:id`) with color-themed hero section, Essentials & Hidden Gems game shelves, genre breakdown cards, "Studios That Defined This Console" developer cards, and conditionally-shown Recently Played shelf
- **Console Quick-Jump row** on the Explore page — horizontal row of console cards with color gradients linking to showcase pages
- **Backend**: 2 new endpoints (`GET /explore/consoles/:id/showcase`, `GET /explore/console-highlights`) with efficient batched queries (window function for top-game-per-console, single `loadUserGameData` call for all game enrichment)
- **Accessibility**: ARIA landmarks on sections, developer cards navigable in player app
- Full implementation across Go backend, React web, and Kotlin Multiplatform player with 9 Go tests, 30 web tests, 8 desktop E2E tests

## Test plan
- [x] Go tests pass (9 new console showcase tests)
- [x] Web Vitest tests pass (948/948 including 30 new)
- [x] TypeScript compiles cleanly
- [x] Go compiles cleanly
- [x] Code review: all critical/high issues fixed (API URLs, query batching, hidden gems dedup, unbounded query)
- [x] UX review: all medium findings fixed (ARIA labels, interactive developer cards, genre chip semantics)