### PR TITLE
feat: add Visual Browsing — gallery & art modes (Explore Phase 9)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreGalleryTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreGalleryTest.kt
@@ -1,0 +1,183 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.ArtworkItem
+import com.spela.player.domain.model.ScreenshotItem
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for Phase 9: Visual Browsing — Gallery & Art Modes.
+ *
+ * Covers:
+ * - Artwork showcase section renders on Explore screen
+ * - Gallery screen renders with screenshots
+ * - Gallery shows game titles
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ExploreGalleryTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private val sampleArtwork = listOf(
+        ArtworkItem(
+            url = "https://example.com/art1.jpg",
+            width = 1920,
+            height = 1080,
+            gameId = "game-1",
+            gameTitle = "Super Mario World",
+            consoleName = "Super Nintendo",
+            consoleAbbreviation = "SNES",
+            consoleColor = "#6B21A8",
+        ),
+        ArtworkItem(
+            url = "https://example.com/art2.jpg",
+            width = 1920,
+            height = 1080,
+            gameId = "game-2",
+            gameTitle = "The Legend of Zelda",
+            consoleName = "Nintendo Entertainment System",
+            consoleAbbreviation = "NES",
+            consoleColor = "#DC2626",
+        ),
+    )
+
+    private val sampleScreenshots = listOf(
+        ScreenshotItem(
+            url = "https://example.com/ss1.jpg",
+            gameId = "game-1",
+            gameTitle = "Super Mario World",
+            consoleName = "Super Nintendo",
+            consoleAbbreviation = "SNES",
+            consoleColor = "#6B21A8",
+        ),
+        ScreenshotItem(
+            url = "https://example.com/ss2.jpg",
+            gameId = "game-2",
+            gameTitle = "The Legend of Zelda",
+            consoleName = "Nintendo Entertainment System",
+            consoleAbbreviation = "NES",
+            consoleColor = "#DC2626",
+        ),
+        ScreenshotItem(
+            url = "https://example.com/ss3.jpg",
+            gameId = "game-3",
+            gameTitle = "Chrono Trigger",
+            consoleName = "Super Nintendo",
+            consoleAbbreviation = "SNES",
+            consoleColor = "#6B21A8",
+        ),
+    )
+
+    // --- Artwork showcase section renders on Explore screen ---
+
+    @Test
+    fun artworkShowcaseSectionRendersOnExploreScreen() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.artworkItems = sampleArtwork
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+
+        // Scroll to find the artwork section (it may be off-screen)
+        onNodeWithTag("explore_artwork_section").assertExists()
+        onNodeWithText("Visual Discovery").assertExists()
+        onNodeWithTag("artwork_showcase").assertExists()
+    }
+
+    // --- Artwork showcase shows game titles ---
+
+    @Test
+    fun artworkShowcaseShowsGameTitles() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.artworkItems = sampleArtwork
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("artwork_card_game-1").assertExists()
+        onNodeWithTag("artwork_card_game-2").assertExists()
+    }
+
+    // --- Gallery screen renders with screenshots ---
+
+    @Test
+    fun galleryScreenRendersWithScreenshots() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.screenshotItems = sampleScreenshots
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreGallery)
+        )
+        advanceFully(harness)
+
+        onNodeWithTag("gallery_screen").assertIsDisplayed()
+        onNodeWithTag("gallery_grid").assertExists()
+        onNodeWithTag("gallery_screenshot_game-1").assertExists()
+        onNodeWithTag("gallery_screenshot_game-2").assertExists()
+    }
+
+    // --- Gallery shows game titles ---
+
+    @Test
+    fun galleryScreenShowsGameTitles() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.screenshotItems = sampleScreenshots
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreGallery)
+        )
+        advanceFully(harness)
+
+        onNodeWithTag("gallery_title_game-1", useUnmergedTree = true).assertExists()
+        onNodeWithTag("gallery_title_game-2", useUnmergedTree = true).assertExists()
+    }
+
+    // --- Gallery empty state ---
+
+    @Test
+    fun galleryScreenShowsEmptyStateWhenNoScreenshots() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.screenshotItems = emptyList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreGallery)
+        )
+        advanceFully(harness)
+
+        onNodeWithTag("gallery_screen").assertIsDisplayed()
+        onNodeWithTag("gallery_empty_state").assertExists()
+    }
+
+    // --- Navigation from Explore to Gallery ---
+
+    @Test
+    fun navigationToGalleryScreenWorks() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.screenshotItems = sampleScreenshots
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreGallery)
+        )
+        advanceFully(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("explore_gallery", navState.currentScreen.route)
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1341,6 +1341,8 @@ class FakeExploreRepository : ExploreRepository {
     var developerSpotlightData: DeveloperSpotlight? = null
     var consoleShowcases: Map<String, ConsoleShowcase> = emptyMap()
     var consoleHighlightsList: List<ConsoleHighlight> = emptyList()
+    var artworkItems: List<ArtworkItem> = emptyList()
+    var screenshotItems: List<ScreenshotItem> = emptyList()
     var shouldFail: Boolean = false
 
     override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> =
@@ -1462,6 +1464,14 @@ class FakeExploreRepository : ExploreRepository {
     override suspend fun getConsoleHighlights(): Result<List<ConsoleHighlight>> =
         if (shouldFail) Result.failure(Exception("Failed to load console highlights"))
         else Result.success(consoleHighlightsList)
+
+    override suspend fun getArtworkGallery(page: Int): Result<List<ArtworkItem>> =
+        if (shouldFail) Result.failure(Exception("Failed to load artwork gallery"))
+        else Result.success(artworkItems)
+
+    override suspend fun getScreenshotGallery(page: Int): Result<List<ScreenshotItem>> =
+        if (shouldFail) Result.failure(Exception("Failed to load screenshot gallery"))
+        else Result.success(screenshotItems)
 }
 
 class FakeCheatRepository : CheatRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -357,6 +357,20 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/explore/console-highlights").body()
     }
 
+    /** Returns a paginated list of IGDB artwork for the gallery */
+    suspend fun getArtworkGallery(page: Int = 1): ArtworkGalleryResponseDto {
+        return client.get("$baseUrl/api/explore/artwork") {
+            parameter("page", page)
+        }.body()
+    }
+
+    /** Returns a paginated list of screenshots for the gallery */
+    suspend fun getScreenshotGallery(page: Int = 1): ScreenshotGalleryResponseDto {
+        return client.get("$baseUrl/api/explore/screenshots") {
+            parameter("page", page)
+        }.body()
+    }
+
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
     suspend fun getRecentGames(): List<GameDto> {
         return client.get("$baseUrl/api/user/recent").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -724,3 +724,23 @@ fun ConsoleHighlightDto.toDomain(): ConsoleHighlight = ConsoleHighlight(
     gameCount = gameCount,
     topGame = topGame?.toDomain(),
 )
+
+fun ArtworkItemDto.toDomain(): ArtworkItem = ArtworkItem(
+    url = url,
+    width = width,
+    height = height,
+    gameId = gameId,
+    gameTitle = gameTitle,
+    consoleName = consoleName,
+    consoleAbbreviation = consoleAbbreviation,
+    consoleColor = consoleColor,
+)
+
+fun ScreenshotItemDto.toDomain(): ScreenshotItem = ScreenshotItem(
+    url = url,
+    gameId = gameId,
+    gameTitle = gameTitle,
+    consoleName = consoleName,
+    consoleAbbreviation = consoleAbbreviation,
+    consoleColor = consoleColor,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1230,3 +1230,45 @@ data class ConsoleHighlightDto(
 data class ConsoleHighlightsResponseDto(
     val consoles: List<ConsoleHighlightDto>,
 )
+
+// Artwork Gallery
+
+@Serializable
+data class ArtworkItemDto(
+    val url: String,
+    val width: Int,
+    val height: Int,
+    val gameId: String,
+    val gameTitle: String,
+    val consoleName: String,
+    val consoleAbbreviation: String,
+    val consoleColor: String,
+)
+
+@Serializable
+data class ArtworkGalleryResponseDto(
+    val artworks: List<ArtworkItemDto>,
+    val page: Int,
+    val totalPages: Int,
+    val totalCount: Int,
+)
+
+// Screenshot Gallery
+
+@Serializable
+data class ScreenshotItemDto(
+    val url: String,
+    val gameId: String,
+    val gameTitle: String,
+    val consoleName: String,
+    val consoleAbbreviation: String,
+    val consoleColor: String,
+)
+
+@Serializable
+data class ScreenshotGalleryResponseDto(
+    val screenshots: List<ScreenshotItemDto>,
+    val page: Int,
+    val totalPages: Int,
+    val totalCount: Int,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.spela.player.data.repository
 
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.toDomain
+import com.spela.player.domain.model.ArtworkItem
 import com.spela.player.domain.model.ConsoleHighlight
 import com.spela.player.domain.model.ConsoleShowcase
 import com.spela.player.domain.model.DeveloperDetail
@@ -17,6 +18,7 @@ import com.spela.player.domain.model.GameSeriesLink
 import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
 import com.spela.player.domain.model.PlayersLikeYouResult
+import com.spela.player.domain.model.ScreenshotItem
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.TasteProfile
 import com.spela.player.domain.model.Theme
@@ -241,6 +243,22 @@ class ExploreRepositoryImpl(
                         coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                     )
                 },
+            )
+        }
+    }
+
+    override suspend fun getArtworkGallery(page: Int): Result<List<ArtworkItem>> = runCatching {
+        apiClient.getArtworkGallery(page).artworks.map { dto ->
+            dto.toDomain().copy(
+                url = apiClient.resolveUrl(dto.url) ?: dto.url,
+            )
+        }
+    }
+
+    override suspend fun getScreenshotGallery(page: Int): Result<List<ScreenshotItem>> = runCatching {
+        apiClient.getScreenshotGallery(page).screenshots.map { dto ->
+            dto.toDomain().copy(
+                url = apiClient.resolveUrl(dto.url) ?: dto.url,
             )
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -172,3 +172,23 @@ data class ConsoleHighlight(
     val gameCount: Int,
     val topGame: Game?,
 )
+
+data class ArtworkItem(
+    val url: String,
+    val width: Int,
+    val height: Int,
+    val gameId: String,
+    val gameTitle: String,
+    val consoleName: String,
+    val consoleAbbreviation: String,
+    val consoleColor: String,
+)
+
+data class ScreenshotItem(
+    val url: String,
+    val gameId: String,
+    val gameTitle: String,
+    val consoleName: String,
+    val consoleAbbreviation: String,
+    val consoleColor: String,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -1,5 +1,6 @@
 package com.spela.player.domain.repository
 
+import com.spela.player.domain.model.ArtworkItem
 import com.spela.player.domain.model.ConsoleHighlight
 import com.spela.player.domain.model.ConsoleShowcase
 import com.spela.player.domain.model.DeveloperDetail
@@ -15,6 +16,7 @@ import com.spela.player.domain.model.GameSeriesLink
 import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
 import com.spela.player.domain.model.PlayersLikeYouResult
+import com.spela.player.domain.model.ScreenshotItem
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.TasteProfile
 import com.spela.player.domain.model.Theme
@@ -42,4 +44,6 @@ interface ExploreRepository {
     suspend fun getDeveloperSpotlight(): Result<DeveloperSpotlight>
     suspend fun getConsoleShowcase(consoleId: String): Result<ConsoleShowcase>
     suspend fun getConsoleHighlights(): Result<List<ConsoleHighlight>>
+    suspend fun getArtworkGallery(page: Int = 1): Result<List<ArtworkItem>>
+    suspend fun getScreenshotGallery(page: Int = 1): Result<List<ScreenshotItem>>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -36,6 +36,7 @@ sealed class SpScreen(val route: String) {
     data class ExploreDeveloper(val name: String) : SpScreen("explore_developer/$name")
     data class ExplorePublisher(val name: String) : SpScreen("explore_publisher/$name")
     data class ExploreConsoleShowcase(val consoleId: String) : SpScreen("explore_console/$consoleId")
+    data object ExploreGallery : SpScreen("explore_gallery")
 }
 
 data class NavigationState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -94,6 +94,7 @@ import com.spela.player.presentation.ui.screen.GlobalChallengesScreen
 import com.spela.player.presentation.ui.screen.StatsScreen
 import com.spela.player.presentation.ui.screen.ExploreConsoleShowcaseScreen
 import com.spela.player.presentation.ui.screen.ExploreDeveloperScreen
+import com.spela.player.presentation.ui.screen.ExploreGalleryScreen
 import com.spela.player.presentation.ui.screen.ExploreKeywordScreen
 import com.spela.player.presentation.ui.screen.ExploreMoodScreen
 import com.spela.player.presentation.ui.screen.ExploreScreen
@@ -488,6 +489,11 @@ fun SpelaApp(
                                                 NavigationIntent.NavigateTo(SpScreen.ExploreConsoleShowcase(consoleId))
                                             )
                                         },
+                                        onGallerySelected = {
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreGallery)
+                                            )
+                                        },
                                         onSurpriseMe = {
                                             exploreViewModel.loadSurpriseGame { gameId ->
                                                 navigationViewModel.onIntent(
@@ -620,6 +626,22 @@ fun SpelaApp(
                                         onDeveloperSelected = { name ->
                                             navigationViewModel.onIntent(
                                                 NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper(name))
+                                            )
+                                        },
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.ExploreGallery -> {
+                                if (exploreViewModel != null) {
+                                    ExploreGalleryScreen(
+                                        viewModel = exploreViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
                                             )
                                         },
                                         onBack = {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ArtworkShowcaseSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ArtworkShowcaseSection.kt
@@ -1,0 +1,210 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import com.spela.player.domain.model.ArtworkItem
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpShimmer
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+private val ArtworkCardWidth = 280.dp
+private const val ARTWORK_ASPECT_RATIO = 16f / 9f
+
+@Composable
+fun ArtworkShowcaseSection(
+    artworks: List<ArtworkItem>,
+    onGameSelected: (gameId: String) -> Unit,
+    onGallerySelected: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier.testTag("artwork_showcase"),
+    ) {
+        if (onGallerySelected != null) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XXSmall),
+                contentAlignment = Alignment.CenterEnd,
+            ) {
+                Text(
+                    text = "Browse Gallery",
+                    style = SpTypography.LabelLarge,
+                    color = SpColor.Primary,
+                    modifier = Modifier
+                        .clip(RoundedCornerShape(SpSpacing.Small))
+                        .clickable(onClick = onGallerySelected)
+                        .padding(SpSpacing.Small)
+                        .testTag("browse_gallery_button")
+                        .semantics {
+                            contentDescription = "Browse screenshot gallery"
+                            role = Role.Button
+                        },
+                )
+            }
+        }
+        LazyRow(
+            modifier = Modifier.testTag("artwork_showcase_row"),
+            contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+        ) {
+            items(artworks, key = { "${it.gameId}_${it.url}" }) { artwork ->
+                ArtworkCard(
+                    artwork = artwork,
+                    onClick = { onGameSelected(artwork.gameId) },
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ArtworkCard(
+    artwork: ArtworkItem,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
+
+    SpCard(
+        modifier = Modifier
+            .width(ArtworkCardWidth)
+            .testTag("artwork_card_${artwork.gameId}")
+            .semantics {
+                contentDescription = "${artwork.gameTitle}, ${artwork.consoleName}"
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(shape),
+        ) {
+            // Artwork image
+            SubcomposeAsyncImage(
+                model = artwork.url,
+                contentDescription = "${artwork.gameTitle} artwork",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(ARTWORK_ASPECT_RATIO),
+                contentScale = ContentScale.Crop,
+                loading = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(ARTWORK_ASPECT_RATIO)
+                            .background(SpColor.SurfaceBright.copy(alpha = 0.25f)),
+                    )
+                },
+                error = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(ARTWORK_ASPECT_RATIO)
+                            .background(
+                                Brush.linearGradient(
+                                    listOf(SpColor.SurfaceVariant, SpColor.SurfaceElevated),
+                                ),
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = artwork.gameTitle.take(2).uppercase(),
+                            style = SpTypography.DisplaySmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                },
+            )
+
+            // Gradient overlay at bottom for text
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(ARTWORK_ASPECT_RATIO)
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                Color.Transparent,
+                                Color.Black.copy(alpha = 0.7f),
+                            ),
+                        ),
+                    ),
+                contentAlignment = Alignment.BottomStart,
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(SpSpacing.Medium),
+                ) {
+                    Text(
+                        text = artwork.gameTitle,
+                        style = SpTypography.TitleSmall,
+                        color = Color.White,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.testTag("artwork_title_${artwork.gameId}"),
+                    )
+                    Text(
+                        text = artwork.consoleName,
+                        style = SpTypography.LabelSmall,
+                        color = Color.White.copy(alpha = 0.8f),
+                        maxLines = 1,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ArtworkShowcaseSkeleton(
+    modifier: Modifier = Modifier,
+    count: Int = 3,
+) {
+    LazyRow(
+        modifier = modifier.testTag("artwork_showcase_skeleton"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(count) {
+            SpShimmer(
+                modifier = Modifier
+                    .width(ArtworkCardWidth)
+                    .clip(RoundedCornerShape(SpSpacing.CardCornerRadius)),
+                width = ArtworkCardWidth,
+                height = (ArtworkCardWidth.value / ARTWORK_ASPECT_RATIO).dp,
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ConsoleQuickJumpSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ConsoleQuickJumpSection.kt
@@ -24,7 +24,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreGalleryScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreGalleryScreen.kt
@@ -1,0 +1,270 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Photo
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import com.spela.player.domain.model.ScreenshotItem
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+
+private const val SCREENSHOT_ASPECT_RATIO = 16f / 9f
+
+@Composable
+fun ExploreGalleryScreen(
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val state by viewModel.screenshotGalleryState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadScreenshotGallery()
+    }
+
+    Box(modifier = Modifier.fillMaxSize().testTag("gallery_screen")) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = "Screenshot Gallery",
+                showBack = true,
+                onBack = onBack,
+            )
+
+            when {
+                state.isLoading && state.screenshots.isEmpty() -> {
+                    // Loading skeleton grid
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(minSize = 200.dp),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("gallery_loading"),
+                        contentPadding = PaddingValues(SpSpacing.ScreenHorizontal),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                    ) {
+                        items(6) {
+                            SpGameCardSkeleton(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .aspectRatio(SCREENSHOT_ASPECT_RATIO),
+                            )
+                        }
+                    }
+                }
+
+                state.screenshots.isNotEmpty() -> {
+                    val gridState = rememberLazyGridState()
+
+                    // Load more when nearing the end
+                    LaunchedEffect(gridState) {
+                        snapshotFlow {
+                            val layoutInfo = gridState.layoutInfo
+                            val totalItems = layoutInfo.totalItemsCount
+                            val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()?.index ?: 0
+                            lastVisible >= totalItems - 4
+                        }.collect { nearEnd ->
+                            if (nearEnd && state.hasMore && !state.isLoading) {
+                                viewModel.loadMoreScreenshots()
+                            }
+                        }
+                    }
+
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(minSize = 200.dp),
+                        state = gridState,
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("gallery_grid"),
+                        contentPadding = PaddingValues(SpSpacing.ScreenHorizontal),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                    ) {
+                        items(
+                            items = state.screenshots,
+                            key = { "${it.gameId}_${it.url}" },
+                        ) { screenshot ->
+                            ScreenshotGridCard(
+                                screenshot = screenshot,
+                                onClick = { onGameSelected(screenshot.gameId) },
+                            )
+                        }
+                    }
+                }
+
+                else -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.Photo,
+                            title = "No screenshots yet",
+                            message = "Screenshots will appear here once games have been enriched with metadata.",
+                            modifier = Modifier.testTag("gallery_empty_state"),
+                        )
+                    }
+                }
+            }
+        }
+
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.dismissScreenshotGalleryError() },
+                )
+            },
+            onDismiss = { viewModel.dismissScreenshotGalleryError() },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@Composable
+private fun ScreenshotGridCard(
+    screenshot: ScreenshotItem,
+    onClick: () -> Unit,
+) {
+    val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
+
+    SpCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("gallery_screenshot_${screenshot.gameId}")
+            .semantics {
+                contentDescription = "${screenshot.gameTitle}, ${screenshot.consoleName}"
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(shape),
+        ) {
+            SubcomposeAsyncImage(
+                model = screenshot.url,
+                contentDescription = "${screenshot.gameTitle} screenshot",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(SCREENSHOT_ASPECT_RATIO),
+                contentScale = ContentScale.Crop,
+                loading = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(SCREENSHOT_ASPECT_RATIO)
+                            .background(SpColor.SurfaceBright.copy(alpha = 0.25f)),
+                    )
+                },
+                error = {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .aspectRatio(SCREENSHOT_ASPECT_RATIO)
+                            .background(
+                                Brush.linearGradient(
+                                    listOf(SpColor.SurfaceVariant, SpColor.SurfaceElevated),
+                                ),
+                            ),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = screenshot.gameTitle.take(2).uppercase(),
+                            style = SpTypography.DisplaySmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                },
+            )
+
+            // Overlay with game title at the bottom
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .aspectRatio(SCREENSHOT_ASPECT_RATIO)
+                    .background(
+                        Brush.verticalGradient(
+                            colors = listOf(
+                                Color.Transparent,
+                                Color.Transparent,
+                                Color.Black.copy(alpha = 0.7f),
+                            ),
+                        ),
+                    ),
+                contentAlignment = Alignment.BottomStart,
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(SpSpacing.Small),
+                ) {
+                    Text(
+                        text = screenshot.gameTitle,
+                        style = SpTypography.LabelSmall,
+                        color = Color.White,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.testTag("gallery_title_${screenshot.gameId}"),
+                    )
+                    Text(
+                        text = screenshot.consoleName,
+                        style = SpTypography.LabelSmall,
+                        color = Color.White.copy(alpha = 0.7f),
+                        maxLines = 1,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -22,6 +22,8 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.feature.explore.ArtworkShowcaseSection
+import com.spela.player.presentation.ui.feature.explore.ArtworkShowcaseSkeleton
 import com.spela.player.presentation.ui.feature.explore.ConsoleQuickJumpSection
 import com.spela.player.presentation.ui.feature.explore.ConsoleQuickJumpSkeleton
 import com.spela.player.presentation.ui.feature.explore.DeveloperSpotlightSection
@@ -54,6 +56,7 @@ fun ExploreScreen(
     onMoodSelected: ((moodId: String, moodName: String) -> Unit)? = null,
     onDeveloperSelected: ((name: String) -> Unit)? = null,
     onConsoleSelected: ((consoleId: String) -> Unit)? = null,
+    onGallerySelected: (() -> Unit)? = null,
     onSurpriseMe: (() -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
@@ -307,6 +310,33 @@ fun ExploreScreen(
                                         onDeveloperSelected?.invoke(name)
                                     },
                                     onGameSelected = onGameSelected,
+                                )
+                            }
+                        }
+                    }
+
+                    // Artwork showcase section
+                    item {
+                        if (state.isLoadingArtwork && state.artworkShowcase.isEmpty()) {
+                            SpTitledSection(
+                                title = "Visual Discovery",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                ArtworkShowcaseSkeleton()
+                            }
+                        } else if (state.artworkShowcase.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "Visual Discovery",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_artwork_section"),
+                            ) {
+                                ArtworkShowcaseSection(
+                                    artworks = state.artworkShowcase,
+                                    onGameSelected = onGameSelected,
+                                    onGallerySelected = onGallerySelected,
                                 )
                             }
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.viewmodel
 
+import com.spela.player.domain.model.ArtworkItem
 import com.spela.player.domain.model.ConsoleHighlight
 import com.spela.player.domain.model.ConsoleShowcase
 import com.spela.player.domain.model.DeveloperDetail
@@ -11,6 +12,7 @@ import com.spela.player.domain.model.ForYouRow
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
+import com.spela.player.domain.model.ScreenshotItem
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.Theme
 import com.spela.player.domain.repository.ExploreRepository
@@ -34,6 +36,7 @@ data class ExploreState(
     val forYouRows: List<ForYouRow> = emptyList(),
     val developerSpotlight: DeveloperSpotlight? = null,
     val consoleHighlights: List<ConsoleHighlight> = emptyList(),
+    val artworkShowcase: List<ArtworkItem> = emptyList(),
     val isLoadingFeatured: Boolean = false,
     val isLoadingRows: Boolean = false,
     val isLoadingThemes: Boolean = false,
@@ -43,10 +46,11 @@ data class ExploreState(
     val isLoadingForYou: Boolean = false,
     val isLoadingDeveloperSpotlight: Boolean = false,
     val isLoadingConsoleHighlights: Boolean = false,
+    val isLoadingArtwork: Boolean = false,
     val error: String? = null,
 ) {
-    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods || isLoadingForYou || isLoadingDeveloperSpotlight || isLoadingConsoleHighlights
-    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && forYouRows.isEmpty() && developerSpotlight == null && consoleHighlights.isEmpty() && !isLoading
+    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods || isLoadingForYou || isLoadingDeveloperSpotlight || isLoadingConsoleHighlights || isLoadingArtwork
+    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && forYouRows.isEmpty() && developerSpotlight == null && consoleHighlights.isEmpty() && artworkShowcase.isEmpty() && !isLoading
 }
 
 data class ThemeDetailState(
@@ -99,6 +103,14 @@ data class ConsoleShowcaseState(
     val error: String? = null,
 )
 
+data class ScreenshotGalleryState(
+    val screenshots: List<ScreenshotItem> = emptyList(),
+    val isLoading: Boolean = false,
+    val page: Int = 1,
+    val hasMore: Boolean = true,
+    val error: String? = null,
+)
+
 data class SeriesDetailState(
     val seriesId: String = "",
     val seriesName: String = "",
@@ -118,6 +130,8 @@ data class SeriesDetailState(
             return filtered.sortedWith(compareBy(nullsLast()) { it.releaseDate })
         }
 }
+
+private const val GALLERY_PAGE_SIZE = 40
 
 class ExploreViewModel(
     private val exploreRepository: ExploreRepository,
@@ -145,6 +159,9 @@ class ExploreViewModel(
     private val _consoleShowcaseState = MutableStateFlow(ConsoleShowcaseState())
     val consoleShowcaseState: StateFlow<ConsoleShowcaseState> = _consoleShowcaseState.asStateFlow()
 
+    private val _screenshotGalleryState = MutableStateFlow(ScreenshotGalleryState())
+    val screenshotGalleryState: StateFlow<ScreenshotGalleryState> = _screenshotGalleryState.asStateFlow()
+
     private var featuredJob: Job? = null
     private var rowsJob: Job? = null
     private var themesJob: Job? = null
@@ -160,6 +177,8 @@ class ExploreViewModel(
     private var developerDetailJob: Job? = null
     private var consoleHighlightsJob: Job? = null
     private var consoleShowcaseJob: Job? = null
+    private var artworkShowcaseJob: Job? = null
+    private var screenshotGalleryJob: Job? = null
 
     fun load() {
         loadFeatured()
@@ -171,6 +190,7 @@ class ExploreViewModel(
         loadForYou()
         loadDeveloperSpotlight()
         loadConsoleHighlights()
+        loadArtworkShowcase()
     }
 
     fun dismissError() {
@@ -477,5 +497,76 @@ class ExploreViewModel(
 
     fun dismissConsoleShowcaseError() {
         _consoleShowcaseState.update { it.copy(error = null) }
+    }
+
+    private fun loadArtworkShowcase() {
+        if (artworkShowcaseJob?.isActive == true) return
+        _state.update { it.copy(isLoadingArtwork = true) }
+        artworkShowcaseJob = scope.launch(dispatchers.io) {
+            exploreRepository.getArtworkGallery(page = 1).fold(
+                onSuccess = { artworks ->
+                    _state.update { it.copy(artworkShowcase = artworks, isLoadingArtwork = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoadingArtwork = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun loadScreenshotGallery() {
+        screenshotGalleryJob?.cancel()
+        _screenshotGalleryState.update {
+            ScreenshotGalleryState(isLoading = true)
+        }
+        screenshotGalleryJob = scope.launch(dispatchers.io) {
+            exploreRepository.getScreenshotGallery(page = 1).fold(
+                onSuccess = { screenshots ->
+                    _screenshotGalleryState.update {
+                        it.copy(
+                            screenshots = screenshots,
+                            isLoading = false,
+                            page = 1,
+                            hasMore = screenshots.size >= GALLERY_PAGE_SIZE,
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _screenshotGalleryState.update {
+                        it.copy(isLoading = false, error = error.message)
+                    }
+                },
+            )
+        }
+    }
+
+    fun loadMoreScreenshots() {
+        val current = _screenshotGalleryState.value
+        if (current.isLoading || !current.hasMore) return
+        _screenshotGalleryState.update { it.copy(isLoading = true) }
+        val nextPage = current.page + 1
+        screenshotGalleryJob = scope.launch(dispatchers.io) {
+            exploreRepository.getScreenshotGallery(page = nextPage).fold(
+                onSuccess = { screenshots ->
+                    _screenshotGalleryState.update {
+                        it.copy(
+                            screenshots = it.screenshots + screenshots,
+                            isLoading = false,
+                            page = nextPage,
+                            hasMore = screenshots.size >= GALLERY_PAGE_SIZE,
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _screenshotGalleryState.update {
+                        it.copy(isLoading = false, error = error.message)
+                    }
+                },
+            )
+        }
+    }
+
+    fun dismissScreenshotGalleryError() {
+        _screenshotGalleryState.update { it.copy(error = null) }
     }
 }

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/igdb"
 	"gorm.io/gorm"
 )
 
@@ -2166,5 +2167,292 @@ func (h *ExploreHandler) GetConsoleHighlights(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, ConsoleHighlightsResponse{Consoles: highlights})
+}
+
+// --- Phase 9: Visual Browsing — Gallery & Art Modes ---
+
+// ScreenshotItem represents a single screenshot in the gallery response.
+type ScreenshotItem struct {
+	URL              string `json:"url"`
+	GameID           string `json:"gameId"`
+	GameTitle        string `json:"gameTitle"`
+	ConsoleName      string `json:"consoleName"`
+	ConsoleAbbr      string `json:"consoleAbbreviation"`
+	ConsoleColor     string `json:"consoleColor"`
+}
+
+// ScreenshotGalleryResponse is the paginated response for the screenshot gallery.
+type ScreenshotGalleryResponse struct {
+	Screenshots []ScreenshotItem `json:"screenshots"`
+	Page        int              `json:"page"`
+	TotalPages  int              `json:"totalPages"`
+	TotalCount  int              `json:"totalCount"`
+}
+
+// ArtworkItem represents a single IGDB artwork image in the gallery response.
+type ArtworkItem struct {
+	URL          string `json:"url"`
+	Width        int    `json:"width"`
+	Height       int    `json:"height"`
+	GameID       string `json:"gameId"`
+	GameTitle    string `json:"gameTitle"`
+	ConsoleName  string `json:"consoleName"`
+	ConsoleAbbr  string `json:"consoleAbbreviation"`
+	ConsoleColor string `json:"consoleColor"`
+}
+
+// ArtworkGalleryResponse is the paginated response for the IGDB artwork gallery.
+type ArtworkGalleryResponse struct {
+	Artworks   []ArtworkItem `json:"artworks"`
+	Page       int           `json:"page"`
+	TotalPages int           `json:"totalPages"`
+	TotalCount int           `json:"totalCount"`
+}
+
+// CoverItem represents a single cover in the cover gallery response.
+type CoverItem struct {
+	CoverURL         string  `json:"coverUrl"`
+	GameID           string  `json:"gameId"`
+	GameTitle        string  `json:"gameTitle"`
+	ConsoleName      string  `json:"consoleName"`
+	ConsoleAbbr      string  `json:"consoleAbbreviation"`
+	ConsoleColor     string  `json:"consoleColor"`
+	Rating           float64 `json:"rating"`
+	CoverAspectRatio float64 `json:"coverAspectRatio"`
+}
+
+// CoverGalleryResponse is the paginated response for the cover gallery.
+type CoverGalleryResponse struct {
+	Covers     []CoverItem `json:"covers"`
+	Page       int         `json:"page"`
+	TotalPages int         `json:"totalPages"`
+	TotalCount int         `json:"totalCount"`
+}
+
+// parsePagination parses page/limit query params with defaults and max bounds.
+// Returns page (1-based), limit, and offset for SQL queries.
+func parsePagination(c *gin.Context, defaultLimit, maxLimit int) (page, limit, offset int) {
+	page = 1
+	if p, err := strconv.Atoi(c.Query("page")); err == nil && p > 0 {
+		page = p
+	}
+	limit = defaultLimit
+	if l, err := strconv.Atoi(c.Query("limit")); err == nil && l > 0 {
+		limit = l
+	}
+	if limit > maxLimit {
+		limit = maxLimit
+	}
+	offset = (page - 1) * limit
+	return
+}
+
+// totalPages computes the number of pages given a total count and page size.
+func totalPages(totalCount, limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	return int(math.Ceil(float64(totalCount) / float64(limit)))
+}
+
+// GetScreenshotGallery returns a paginated stream of screenshots with minimal game metadata.
+func (h *ExploreHandler) GetScreenshotGallery(c *gin.Context) {
+	page, limit, offset := parsePagination(c, 40, 100)
+
+	consoleFilter := strings.TrimSpace(c.Query("console"))
+	genreFilter := strings.TrimSpace(c.Query("genre"))
+
+	// Build the base query joining screenshots with games and consoles.
+	baseQuery := h.DB.Table("game_screenshots").
+		Joins("JOIN games ON games.id = game_screenshots.game_id AND games.deleted_at IS NULL").
+		Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.deleted_at IS NULL").
+		Where("game_screenshots.deleted_at IS NULL")
+
+	if consoleFilter != "" {
+		baseQuery = baseQuery.Where("LOWER(consoles.abbreviation) = LOWER(?)", consoleFilter)
+	}
+	if genreFilter != "" {
+		baseQuery = baseQuery.Where("LOWER(games.genre) = LOWER(?)", genreFilter)
+	}
+
+	// Count total matching screenshots.
+	var count int64
+	if err := baseQuery.Count(&count).Error; err != nil {
+		slog.Error("failed to count screenshots for gallery", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load screenshot gallery"})
+		return
+	}
+
+	type screenshotRow struct {
+		URL          string
+		GameID       uint
+		GameTitle    string
+		ConsoleName  string
+		ConsoleAbbr  string
+		ConsoleColor string
+	}
+
+	var rows []screenshotRow
+	// Reuse baseQuery with select/order/pagination for the data fetch.
+	if err := baseQuery.
+		Select("game_screenshots.url, games.id as game_id, games.title as game_title, consoles.name as console_name, LOWER(consoles.abbreviation) as console_abbr, consoles.color_theme as console_color").
+		Order("(game_screenshots.id * 2654435761) % 2147483647").
+		Offset(offset).
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to load screenshot gallery", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load screenshot gallery"})
+		return
+	}
+
+	items := make([]ScreenshotItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, ScreenshotItem{
+			URL:          resolveImageURL(r.URL),
+			GameID:       strconv.FormatUint(uint64(r.GameID), 10),
+			GameTitle:    r.GameTitle,
+			ConsoleName:  r.ConsoleName,
+			ConsoleAbbr:  r.ConsoleAbbr,
+			ConsoleColor: r.ConsoleColor,
+		})
+	}
+
+	c.JSON(http.StatusOK, ScreenshotGalleryResponse{
+		Screenshots: items,
+		Page:        page,
+		TotalPages:  totalPages(int(count), limit),
+		TotalCount:  int(count),
+	})
+}
+
+// GetArtworkGallery returns a paginated stream of IGDB promotional artwork.
+func (h *ExploreHandler) GetArtworkGallery(c *gin.Context) {
+	page, limit, offset := parsePagination(c, 40, 100)
+
+	// Count total artwork images.
+	var count int64
+	if err := h.DB.Table("game_artwork_images").
+		Joins("JOIN games ON games.id = game_artwork_images.game_id AND games.deleted_at IS NULL").
+		Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.deleted_at IS NULL").
+		Count(&count).Error; err != nil {
+		slog.Error("failed to count artwork for gallery", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load artwork gallery"})
+		return
+	}
+
+	type artworkRow struct {
+		IGDBImageID  string
+		Width        int
+		Height       int
+		GameID       uint
+		GameTitle    string
+		ConsoleName  string
+		ConsoleAbbr  string
+		ConsoleColor string
+		Rating       float64
+	}
+
+	var rows []artworkRow
+	if err := h.DB.Table("game_artwork_images").
+		Select("game_artwork_images.igdb_image_id, game_artwork_images.width, game_artwork_images.height, games.id as game_id, games.title as game_title, games.rating, consoles.name as console_name, LOWER(consoles.abbreviation) as console_abbr, consoles.color_theme as console_color").
+		Joins("JOIN games ON games.id = game_artwork_images.game_id AND games.deleted_at IS NULL").
+		Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.deleted_at IS NULL").
+		Order("games.rating DESC").
+		Offset(offset).
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to load artwork gallery", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load artwork gallery"})
+		return
+	}
+
+	items := make([]ArtworkItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, ArtworkItem{
+			URL:          igdb.ImageURL(r.IGDBImageID, "screenshot_big"),
+			Width:        r.Width,
+			Height:       r.Height,
+			GameID:       strconv.FormatUint(uint64(r.GameID), 10),
+			GameTitle:    r.GameTitle,
+			ConsoleName:  r.ConsoleName,
+			ConsoleAbbr:  r.ConsoleAbbr,
+			ConsoleColor: r.ConsoleColor,
+		})
+	}
+
+	c.JSON(http.StatusOK, ArtworkGalleryResponse{
+		Artworks:   items,
+		Page:       page,
+		TotalPages: totalPages(int(count), limit),
+		TotalCount: int(count),
+	})
+}
+
+// GetCoverGallery returns a paginated dense cover art feed with minimal metadata.
+func (h *ExploreHandler) GetCoverGallery(c *gin.Context) {
+	page, limit, offset := parsePagination(c, 60, 200)
+
+	consoleFilter := strings.TrimSpace(c.Query("console"))
+
+	baseQuery := h.DB.Table("games").
+		Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.deleted_at IS NULL").
+		Where("games.deleted_at IS NULL").
+		Where("games.cover_url != ''")
+
+	if consoleFilter != "" {
+		baseQuery = baseQuery.Where("LOWER(consoles.abbreviation) = LOWER(?)", consoleFilter)
+	}
+
+	// Count total covers.
+	var count int64
+	if err := baseQuery.Count(&count).Error; err != nil {
+		slog.Error("failed to count covers for gallery", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load cover gallery"})
+		return
+	}
+
+	type coverRow struct {
+		CoverURL     string
+		GameID       uint
+		GameTitle    string
+		ConsoleName  string
+		ConsoleAbbr  string
+		ConsoleColor string
+		Rating       float64
+		CoverAspect  string
+	}
+
+	var rows []coverRow
+	if err := baseQuery.
+		Select("games.cover_url, games.id as game_id, games.title as game_title, games.rating, consoles.name as console_name, LOWER(consoles.abbreviation) as console_abbr, consoles.color_theme as console_color, consoles.cover_aspect").
+		Order("games.rating DESC").
+		Offset(offset).
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to load cover gallery", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load cover gallery"})
+		return
+	}
+
+	items := make([]CoverItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, CoverItem{
+			CoverURL:         resolveImageURL(r.CoverURL),
+			GameID:           strconv.FormatUint(uint64(r.GameID), 10),
+			GameTitle:        r.GameTitle,
+			ConsoleName:      r.ConsoleName,
+			ConsoleAbbr:      r.ConsoleAbbr,
+			ConsoleColor:     r.ConsoleColor,
+			Rating:           r.Rating,
+			CoverAspectRatio: parseAspectRatio(r.CoverAspect),
+		})
+	}
+
+	c.JSON(http.StatusOK, CoverGalleryResponse{
+		Covers:     items,
+		Page:       page,
+		TotalPages: totalPages(int(count), limit),
+		TotalCount: int(count),
+	})
 }
 

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -2511,3 +2511,221 @@ func TestGetConsoleHighlights_TopGameRequiresHeroArt(t *testing.T) {
 	assert.Equal(t, 1, nesEntry.GameCount)
 	assert.Nil(t, nesEntry.TopGame) // No hero art = no top game
 }
+
+// --- Phase 9: Visual Browsing — Gallery & Art Modes ---
+
+func TestGetScreenshotGallery_Success(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "SNES", "Chrono Trigger", 95.0)
+	game2 := createExploreGame(t, env.database, "NES", "Super Mario Bros", 90.0)
+
+	// Create screenshots
+	env.database.Create(&db.GameScreenshot{GameID: game1.ID, URL: "snes/chrono/screenshot_0.jpg", Position: 0})
+	env.database.Create(&db.GameScreenshot{GameID: game1.ID, URL: "snes/chrono/screenshot_1.jpg", Position: 1})
+	env.database.Create(&db.GameScreenshot{GameID: game2.ID, URL: "nes/smb/screenshot_0.jpg", Position: 0})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/screenshots", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ScreenshotGalleryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 3, resp.TotalCount)
+	assert.Equal(t, 1, resp.Page)
+	assert.Equal(t, 1, resp.TotalPages)
+	assert.Len(t, resp.Screenshots, 3)
+
+	// Verify screenshot fields are populated
+	for _, s := range resp.Screenshots {
+		assert.NotEmpty(t, s.URL)
+		assert.NotEmpty(t, s.GameID)
+		assert.NotEmpty(t, s.GameTitle)
+		assert.NotEmpty(t, s.ConsoleName)
+		assert.NotEmpty(t, s.ConsoleAbbr)
+		assert.NotEmpty(t, s.ConsoleColor)
+	}
+}
+
+func TestGetScreenshotGallery_ConsoleFilter(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	snesGame := createExploreGame(t, env.database, "SNES", "Chrono Trigger", 95.0)
+	nesGame := createExploreGame(t, env.database, "NES", "Super Mario Bros", 90.0)
+
+	env.database.Create(&db.GameScreenshot{GameID: snesGame.ID, URL: "snes/chrono/screenshot_0.jpg", Position: 0})
+	env.database.Create(&db.GameScreenshot{GameID: nesGame.ID, URL: "nes/smb/screenshot_0.jpg", Position: 0})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/screenshots?console=snes", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ScreenshotGalleryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.TotalCount)
+	require.Len(t, resp.Screenshots, 1)
+	assert.Equal(t, "snes", resp.Screenshots[0].ConsoleAbbr)
+	assert.Equal(t, "Chrono Trigger", resp.Screenshots[0].GameTitle)
+}
+
+func TestGetScreenshotGallery_Empty(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/screenshots", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ScreenshotGalleryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 0, resp.TotalCount)
+	assert.Equal(t, 1, resp.Page)
+	assert.Equal(t, 0, resp.TotalPages)
+	assert.Empty(t, resp.Screenshots)
+}
+
+func TestGetArtworkGallery_Success(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "SNES", "Chrono Trigger", 95.0)
+	game2 := createExploreGame(t, env.database, "NES", "Super Mario Bros", 85.0)
+
+	// Create IGDB artwork images
+	env.database.Create(&db.GameArtworkImage{GameID: game1.ID, IGDBImageID: "abc123", Width: 1920, Height: 1080})
+	env.database.Create(&db.GameArtworkImage{GameID: game2.ID, IGDBImageID: "def456", Width: 1280, Height: 720})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/artwork", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ArtworkGalleryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.TotalCount)
+	assert.Equal(t, 1, resp.Page)
+	assert.Equal(t, 1, resp.TotalPages)
+	require.Len(t, resp.Artworks, 2)
+
+	// Ordered by rating DESC, so Chrono Trigger (95) first
+	assert.Equal(t, "Chrono Trigger", resp.Artworks[0].GameTitle)
+	assert.Equal(t, 1920, resp.Artworks[0].Width)
+	assert.Equal(t, 1080, resp.Artworks[0].Height)
+	// Verify IGDB URL construction
+	assert.Contains(t, resp.Artworks[0].URL, "abc123")
+	assert.Contains(t, resp.Artworks[0].URL, "t_screenshot_big")
+	assert.Contains(t, resp.Artworks[0].URL, "images.igdb.com")
+
+	assert.Equal(t, "Super Mario Bros", resp.Artworks[1].GameTitle)
+	assert.NotEmpty(t, resp.Artworks[1].ConsoleAbbr)
+	assert.NotEmpty(t, resp.Artworks[1].ConsoleColor)
+}
+
+func TestGetCoverGallery_Success(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "SNES", "Chrono Trigger", 95.0)
+	game2 := createExploreGame(t, env.database, "NES", "Super Mario Bros", 85.0)
+	// game3 has no cover — should not appear
+	createExploreGame(t, env.database, "GBA", "No Cover Game", 80.0)
+
+	// Set cover URLs
+	env.database.Model(&game1).Update("cover_url", "snes/chrono/cover.jpg")
+	env.database.Model(&game2).Update("cover_url", "nes/smb/cover.jpg")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/covers", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp CoverGalleryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 2, resp.TotalCount)
+	assert.Equal(t, 1, resp.Page)
+	require.Len(t, resp.Covers, 2)
+
+	// Ordered by rating DESC
+	assert.Equal(t, "Chrono Trigger", resp.Covers[0].GameTitle)
+	assert.Equal(t, 95.0, resp.Covers[0].Rating)
+	assert.Contains(t, resp.Covers[0].CoverURL, "snes/chrono/cover.jpg")
+	assert.Greater(t, resp.Covers[0].CoverAspectRatio, 0.0)
+
+	assert.Equal(t, "Super Mario Bros", resp.Covers[1].GameTitle)
+	assert.Equal(t, 85.0, resp.Covers[1].Rating)
+}
+
+func TestGetCoverGallery_ConsoleFilter(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	snesGame := createExploreGame(t, env.database, "SNES", "Chrono Trigger", 95.0)
+	nesGame := createExploreGame(t, env.database, "NES", "Super Mario Bros", 85.0)
+
+	env.database.Model(&snesGame).Update("cover_url", "snes/chrono/cover.jpg")
+	env.database.Model(&nesGame).Update("cover_url", "nes/smb/cover.jpg")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/covers?console=NES", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp CoverGalleryResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1, resp.TotalCount)
+	require.Len(t, resp.Covers, 1)
+	assert.Equal(t, "Super Mario Bros", resp.Covers[0].GameTitle)
+	assert.Equal(t, "nes", resp.Covers[0].ConsoleAbbr)
+}
+
+func TestGetCoverGallery_Pagination(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create enough games to require multiple pages (using limit=2 for easy testing)
+	for i := 0; i < 5; i++ {
+		g := createExploreGame(t, env.database, "SNES", fmt.Sprintf("Game %d", i), float64(90-i))
+		env.database.Model(&g).Update("cover_url", fmt.Sprintf("snes/game%d/cover.jpg", i))
+	}
+
+	// Page 1 with limit=2
+	w1 := httptest.NewRecorder()
+	req1 := httptest.NewRequest("GET", "/api/explore/covers?page=1&limit=2", nil)
+	req1.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w1, req1)
+
+	assert.Equal(t, http.StatusOK, w1.Code)
+
+	var resp1 CoverGalleryResponse
+	require.NoError(t, json.Unmarshal(w1.Body.Bytes(), &resp1))
+	assert.Equal(t, 5, resp1.TotalCount)
+	assert.Equal(t, 3, resp1.TotalPages)
+	assert.Equal(t, 1, resp1.Page)
+	assert.Len(t, resp1.Covers, 2)
+
+	// Page 2 with limit=2
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("GET", "/api/explore/covers?page=2&limit=2", nil)
+	req2.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w2, req2)
+
+	assert.Equal(t, http.StatusOK, w2.Code)
+
+	var resp2 CoverGalleryResponse
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp2))
+	assert.Equal(t, 2, resp2.Page)
+	assert.Len(t, resp2.Covers, 2)
+
+	// Page 2 should have different games than page 1
+	assert.NotEqual(t, resp1.Covers[0].GameID, resp2.Covers[0].GameID)
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -251,6 +251,9 @@ func NewRouter(cfg Config) *gin.Engine {
 			explore.GET("/publishers/:name", exploreHandler.GetPublisherDetail)
 			explore.GET("/consoles/:id/showcase", exploreHandler.GetConsoleShowcase)
 			explore.GET("/console-highlights", exploreHandler.GetConsoleHighlights)
+			explore.GET("/screenshots", exploreHandler.GetScreenshotGallery)
+			explore.GET("/artwork", exploreHandler.GetArtworkGallery)
+			explore.GET("/covers", exploreHandler.GetCoverGallery)
 		}
 
 		// Games

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -43,6 +43,8 @@ import { DeveloperDetailPage } from "@/pages/developer-detail-page";
 import { PublisherDetailPage } from "@/pages/publisher-detail-page";
 import { ExploreMoodPage } from "@/pages/explore-mood-page";
 import { ConsoleShowcasePage } from "@/pages/console-showcase-page";
+import { ScreenshotGalleryPage } from "@/pages/screenshot-gallery-page";
+import { CoverGalleryPage } from "@/pages/cover-gallery-page";
 import { ChallengeDetailPage } from "@/pages/challenge-detail-page";
 import { SessionDetailPage } from "@/pages/session-detail-page";
 import { SetupWizardPage } from "@/pages/setup-wizard-page";
@@ -102,6 +104,14 @@ export function App() {
                     <Route
                       path="explore/series/:id"
                       element={<ExploreSeriesPage />}
+                    />
+                    <Route
+                      path="explore/gallery"
+                      element={<ScreenshotGalleryPage />}
+                    />
+                    <Route
+                      path="explore/covers"
+                      element={<CoverGalleryPage />}
                     />
                     <Route
                       path="explore/consoles/:id"

--- a/web/src/features/explore/components/__tests__/artwork-showcase.test.tsx
+++ b/web/src/features/explore/components/__tests__/artwork-showcase.test.tsx
@@ -1,0 +1,167 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { ArtworkShowcase } from "../artwork-showcase";
+import type { ArtworkItem } from "@/types/api";
+
+function makeArtwork(overrides: Partial<ArtworkItem> = {}): ArtworkItem {
+  return {
+    url: "/artwork/default.jpg",
+    width: 1920,
+    height: 1080,
+    gameId: "game-1",
+    gameTitle: "Test Game",
+    consoleName: "SNES",
+    consoleAbbreviation: "snes",
+    consoleColor: "#805ad5",
+    ...overrides,
+  };
+}
+
+const mockArtworks: ArtworkItem[] = [
+  makeArtwork({
+    url: "/artwork/mario.jpg",
+    gameId: "game-1",
+    gameTitle: "Super Mario World",
+    consoleName: "SNES",
+  }),
+  makeArtwork({
+    url: "/artwork/zelda.jpg",
+    gameId: "game-2",
+    gameTitle: "A Link to the Past",
+    consoleName: "SNES",
+  }),
+  makeArtwork({
+    url: "/artwork/metroid.jpg",
+    gameId: "game-3",
+    gameTitle: "Super Metroid",
+    consoleName: "SNES",
+  }),
+];
+
+function renderShowcase(
+  props: {
+    artworks?: ArtworkItem[] | undefined;
+    isLoading?: boolean;
+  } = {},
+) {
+  const artworks = "artworks" in props ? props.artworks : mockArtworks;
+  return render(
+    <MemoryRouter>
+      <ArtworkShowcase
+        artworks={artworks}
+        isLoading={props.isLoading ?? false}
+      />
+    </MemoryRouter>,
+  );
+}
+
+describe("ArtworkShowcase", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders section with heading", () => {
+    renderShowcase();
+    expect(
+      screen.getByRole("heading", { name: "Artwork Showcase", level: 2 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders artwork cards", () => {
+    renderShowcase();
+    const cards = screen.getAllByTestId("artwork-card");
+    expect(cards).toHaveLength(3);
+  });
+
+  it("renders artwork images", () => {
+    renderShowcase();
+    const images = screen.getAllByRole("img");
+    expect(
+      images.some(
+        (img) => img.getAttribute("src") === "/artwork/mario.jpg",
+      ),
+    ).toBe(true);
+    expect(
+      images.some(
+        (img) => img.getAttribute("src") === "/artwork/zelda.jpg",
+      ),
+    ).toBe(true);
+  });
+
+  it("shows game titles on cards", () => {
+    renderShowcase();
+    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+    expect(screen.getByText("A Link to the Past")).toBeInTheDocument();
+    expect(screen.getByText("Super Metroid")).toBeInTheDocument();
+  });
+
+  it("shows console names on cards", () => {
+    renderShowcase();
+    // All three cards have "SNES" as consoleName
+    const snesTexts = screen.getAllByText("SNES");
+    expect(snesTexts.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("navigates to game detail on click", () => {
+    renderShowcase();
+    const cards = screen.getAllByTestId("artwork-card");
+    expect(cards[0]).toHaveAttribute("href", "/games/game-1");
+    expect(cards[1]).toHaveAttribute("href", "/games/game-2");
+    expect(cards[2]).toHaveAttribute("href", "/games/game-3");
+  });
+
+  it("renders loading skeleton when loading", () => {
+    renderShowcase({ isLoading: true, artworks: undefined });
+    expect(
+      screen.getByTestId("artwork-showcase-skeleton"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders nothing when artworks is empty", () => {
+    const { container } = renderShowcase({ artworks: [] });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when artworks is undefined and not loading", () => {
+    const { container } = renderShowcase({
+      artworks: undefined,
+      isLoading: false,
+    });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders browse screenshots link", () => {
+    renderShowcase();
+    const link = screen.getByTestId("browse-screenshots-link");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/explore/gallery");
+  });
+
+  it("renders browse covers link", () => {
+    renderShowcase();
+    const link = screen.getByTestId("browse-covers-link");
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute("href", "/explore/covers");
+  });
+
+  it("limits displayed artworks to 10", () => {
+    const manyArtworks = Array.from({ length: 15 }, (_, i) =>
+      makeArtwork({
+        url: `/artwork/${i}.jpg`,
+        gameId: `game-${i}`,
+        gameTitle: `Game ${i}`,
+      }),
+    );
+    renderShowcase({ artworks: manyArtworks });
+    const cards = screen.getAllByTestId("artwork-card");
+    expect(cards).toHaveLength(10);
+  });
+
+  it("renders the scrollable list with label", () => {
+    renderShowcase();
+    expect(
+      screen.getByRole("list", { name: "Artwork showcase" }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { ExplorePage } from "@/pages/explore-page";
-import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition, ForYouResponse, PlayersLikeYouResponse, DeveloperSpotlightResponse, ConsoleHighlightsResponse } from "@/types/api";
+import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition, ForYouResponse, PlayersLikeYouResponse, DeveloperSpotlightResponse, ConsoleHighlightsResponse, ArtworkGalleryResponse } from "@/types/api";
 
 // Mock hooks
 vi.mock("@/hooks/use-explore", () => ({
@@ -17,6 +17,7 @@ vi.mock("@/hooks/use-explore", () => ({
   usePlayersLikeYou: vi.fn(),
   useDeveloperSpotlight: vi.fn(),
   useConsoleHighlights: vi.fn(),
+  useArtworkGallery: vi.fn(),
   useSurpriseGame: vi.fn(() => ({
     data: undefined,
     refetch: vi.fn(),
@@ -40,7 +41,7 @@ vi.mock("@/hooks/use-auto-scrape", () => ({
   useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
 }));
 
-import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods, useForYou, usePlayersLikeYou, useDeveloperSpotlight, useConsoleHighlights } from "@/hooks/use-explore";
+import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods, useForYou, usePlayersLikeYou, useDeveloperSpotlight, useConsoleHighlights, useArtworkGallery } from "@/hooks/use-explore";
 
 const mockUseExploreFeatured = useExploreFeatured as ReturnType<typeof vi.fn>;
 const mockUseExploreRows = useExploreRows as ReturnType<typeof vi.fn>;
@@ -52,6 +53,7 @@ const mockUseForYou = useForYou as ReturnType<typeof vi.fn>;
 const mockUsePlayersLikeYou = usePlayersLikeYou as ReturnType<typeof vi.fn>;
 const mockUseDeveloperSpotlight = useDeveloperSpotlight as ReturnType<typeof vi.fn>;
 const mockUseConsoleHighlights = useConsoleHighlights as ReturnType<typeof vi.fn>;
+const mockUseArtworkGallery = useArtworkGallery as ReturnType<typeof vi.fn>;
 
 function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
   return {
@@ -240,6 +242,10 @@ describe("ExplorePage", () => {
     });
     mockUseConsoleHighlights.mockReturnValue({
       data: { consoles: [] },
+      isLoading: false,
+    });
+    mockUseArtworkGallery.mockReturnValue({
+      data: { artworks: [], page: 1, totalPages: 0, totalCount: 0 },
       isLoading: false,
     });
   });

--- a/web/src/features/explore/components/artwork-showcase.tsx
+++ b/web/src/features/explore/components/artwork-showcase.tsx
@@ -1,0 +1,160 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { Badge, Skeleton } from "@/components/ui";
+import type { ArtworkItem } from "@/types/api";
+
+interface ArtworkShowcaseProps {
+  artworks: ArtworkItem[] | undefined;
+  isLoading: boolean;
+}
+
+function ArtworkShowcaseSkeleton() {
+  return (
+    <section data-testid="artwork-showcase-skeleton">
+      <Skeleton className="w-48 h-7 mb-5" />
+      <div className="flex gap-5 overflow-hidden">
+        {Array.from({ length: 4 }, (_, i) => (
+          <div key={i} className="w-80 sm:w-96 flex-shrink-0">
+            <Skeleton className="w-full rounded-xl" style={{ aspectRatio: "16/9" }} />
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function ArtworkShowcase({ artworks, isLoading }: ArtworkShowcaseProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, artworks]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return <ArtworkShowcaseSkeleton />;
+  }
+
+  if (!artworks || artworks.length === 0) {
+    return null;
+  }
+
+  // Show up to 10 items
+  const displayArtworks = artworks.slice(0, 10);
+
+  return (
+    <section data-testid="artwork-showcase" className="group/artwork">
+      <div className="flex items-center justify-between mb-5">
+        <h2 className="text-xl font-bold text-surface-100">
+          Artwork Showcase
+        </h2>
+        <div className="flex items-center gap-3 text-sm text-surface-400">
+          <Link
+            to="/explore/gallery"
+            className="hover:text-brand-400 transition-colors"
+            data-testid="browse-screenshots-link"
+          >
+            Browse Screenshots
+          </Link>
+          <span className="text-surface-700">|</span>
+          <Link
+            to="/explore/covers"
+            className="hover:text-brand-400 transition-colors"
+            data-testid="browse-covers-link"
+          >
+            Browse Cover Art
+          </Link>
+        </div>
+      </div>
+
+      <div className="relative">
+        {/* Scroll arrows */}
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/artwork:opacity-100 group-focus-within/artwork:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label="Scroll artwork left"
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/artwork:opacity-100 group-focus-within/artwork:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label="Scroll artwork right"
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        <div
+          ref={scrollRef}
+          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label="Artwork showcase"
+        >
+          {displayArtworks.map((artwork, i) => (
+            <Link
+              key={`${artwork.gameId}-${i}`}
+              to={`/games/${artwork.gameId}`}
+              className="w-80 sm:w-96 flex-shrink-0 group/card"
+              role="listitem"
+              data-testid="artwork-card"
+            >
+              <div className="relative rounded-xl overflow-hidden">
+                <div style={{ aspectRatio: "16/9" }}>
+                  <img
+                    src={artwork.url}
+                    alt={`Artwork for ${artwork.gameTitle}`}
+                    className="w-full h-full object-cover transition-transform duration-300 group-hover/card:scale-[1.03]"
+                    loading="lazy"
+                  />
+                </div>
+                {/* Overlay with game info */}
+                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent pointer-events-none" />
+                <div className="absolute bottom-0 left-0 right-0 p-4">
+                  <p className="text-sm font-semibold text-white truncate">
+                    {artwork.gameTitle}
+                  </p>
+                  <p className="text-xs text-white/60 mt-0.5">
+                    {artwork.consoleName}
+                  </p>
+                </div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/hooks/use-explore.ts
+++ b/web/src/hooks/use-explore.ts
@@ -21,6 +21,9 @@ import type {
   DeveloperSpotlightResponse,
   ConsoleShowcase,
   ConsoleHighlightsResponse,
+  ScreenshotGalleryResponse,
+  ArtworkGalleryResponse,
+  CoverGalleryResponse,
 } from "@/types/api";
 
 export function useExploreFeatured() {
@@ -211,5 +214,39 @@ export function useConsoleHighlights() {
     queryKey: ["console-highlights"],
     queryFn: () =>
       api.get<ConsoleHighlightsResponse>("/explore/console-highlights"),
+  });
+}
+
+export function useScreenshotGallery(
+  page: number,
+  filters?: { console?: string; genre?: string },
+) {
+  const params = new URLSearchParams({ page: String(page) });
+  if (filters?.console) params.set("console", filters.console);
+  if (filters?.genre) params.set("genre", filters.genre);
+  return useQuery({
+    queryKey: ["screenshot-gallery", page, filters],
+    queryFn: () =>
+      api.get<ScreenshotGalleryResponse>(
+        `/explore/screenshots?${params}`,
+      ),
+  });
+}
+
+export function useArtworkGallery(page: number) {
+  return useQuery({
+    queryKey: ["artwork-gallery", page],
+    queryFn: () =>
+      api.get<ArtworkGalleryResponse>(`/explore/artwork?page=${page}`),
+  });
+}
+
+export function useCoverGallery(page: number, consoleFilter?: string) {
+  const params = new URLSearchParams({ page: String(page) });
+  if (consoleFilter) params.set("console", consoleFilter);
+  return useQuery({
+    queryKey: ["cover-gallery", page, consoleFilter],
+    queryFn: () =>
+      api.get<CoverGalleryResponse>(`/explore/covers?${params}`),
   });
 }

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -26,6 +26,9 @@ export type ApiGetPath = WithQuery<
   | "/explore/surprise"
   | "/explore/for-you"
   | "/explore/players-like-you"
+  | "/explore/screenshots"
+  | "/explore/artwork"
+  | "/explore/covers"
 
   // Console Showcase
   | `/explore/consoles/${string}/showcase`

--- a/web/src/pages/__tests__/cover-gallery-page.test.tsx
+++ b/web/src/pages/__tests__/cover-gallery-page.test.tsx
@@ -1,0 +1,262 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { CoverGalleryPage } from "@/pages/cover-gallery-page";
+import type { CoverGalleryResponse, Console } from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-explore", () => ({
+  useCoverGallery: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-consoles", () => ({
+  useConsoles: vi.fn(),
+}));
+
+import { useCoverGallery } from "@/hooks/use-explore";
+import { useConsoles } from "@/hooks/use-consoles";
+
+const mockUseCoverGallery = useCoverGallery as ReturnType<typeof vi.fn>;
+const mockUseConsoles = useConsoles as ReturnType<typeof vi.fn>;
+
+const mockCovers: CoverGalleryResponse = {
+  covers: [
+    {
+      coverUrl: "/covers/mario.jpg",
+      gameId: "game-1",
+      gameTitle: "Super Mario World",
+      consoleName: "SNES",
+      consoleAbbreviation: "snes",
+      consoleColor: "#805ad5",
+      rating: 92,
+      coverAspectRatio: 0.75,
+    },
+    {
+      coverUrl: "/covers/zelda.jpg",
+      gameId: "game-2",
+      gameTitle: "A Link to the Past",
+      consoleName: "SNES",
+      consoleAbbreviation: "snes",
+      consoleColor: "#805ad5",
+      rating: 95,
+      coverAspectRatio: 0.75,
+    },
+    {
+      coverUrl: "/covers/sonic.jpg",
+      gameId: "game-3",
+      gameTitle: "Sonic the Hedgehog",
+      consoleName: "Genesis",
+      consoleAbbreviation: "gen",
+      consoleColor: "#3b82f6",
+      rating: 85,
+      coverAspectRatio: 0.75,
+    },
+  ],
+  page: 1,
+  totalPages: 2,
+  totalCount: 30,
+};
+
+const mockConsoles: Console[] = [
+  {
+    id: "snes",
+    name: "SNES",
+    abbreviation: "snes",
+    extensions: [".sfc", ".smc"],
+    defaultCore: "snes9x",
+    coverAspectRatio: 0.75,
+    colorTheme: "#805ad5",
+    iconUrl: "/icons/snes.png",
+    logoUrl: "/logos/snes.png",
+    gameCount: 50,
+    saveStateSupport: true,
+    browserPlayable: true,
+    playable: true,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  },
+  {
+    id: "gen",
+    name: "Genesis",
+    abbreviation: "gen",
+    extensions: [".md", ".gen"],
+    defaultCore: "genesis_plus_gx",
+    coverAspectRatio: 0.75,
+    colorTheme: "#3b82f6",
+    iconUrl: "/icons/gen.png",
+    logoUrl: "/logos/gen.png",
+    gameCount: 30,
+    saveStateSupport: true,
+    browserPlayable: true,
+    playable: true,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  },
+];
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/explore/covers"]}>
+        <Routes>
+          <Route
+            path="/explore/covers"
+            element={<CoverGalleryPage />}
+          />
+          <Route path="/games/:id" element={<div>Game Detail</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("CoverGalleryPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCoverGallery.mockReturnValue({
+      data: mockCovers,
+      isLoading: false,
+    });
+    mockUseConsoles.mockReturnValue({
+      data: mockConsoles,
+      isLoading: false,
+    });
+  });
+
+  it("renders the page with test id", () => {
+    renderPage();
+    expect(screen.getByTestId("cover-gallery-page")).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton while loading", () => {
+    mockUseCoverGallery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(
+      screen.getByTestId("cover-gallery-skeleton"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders cover art grid", () => {
+    renderPage();
+    expect(screen.getByTestId("cover-grid")).toBeInTheDocument();
+    const cards = screen.getAllByTestId("cover-card");
+    expect(cards).toHaveLength(3);
+  });
+
+  it("renders cover images", () => {
+    renderPage();
+    const images = screen.getAllByRole("img");
+    expect(images.some((img) => img.getAttribute("src") === "/covers/mario.jpg")).toBe(true);
+    expect(images.some((img) => img.getAttribute("src") === "/covers/zelda.jpg")).toBe(true);
+  });
+
+  it("renders hover overlay with game title", () => {
+    renderPage();
+    const overlays = screen.getAllByTestId("cover-overlay");
+    expect(overlays[0]).toHaveTextContent("Super Mario World");
+    expect(overlays[1]).toHaveTextContent("A Link to the Past");
+  });
+
+  it("navigates to game detail on click", () => {
+    renderPage();
+    const cards = screen.getAllByTestId("cover-card");
+    expect(cards[0]).toHaveAttribute("href", "/games/game-1");
+  });
+
+  it("renders zoom controls", () => {
+    renderPage();
+    expect(screen.getByTestId("zoom-controls")).toBeInTheDocument();
+    expect(screen.getByTestId("zoom-small")).toBeInTheDocument();
+    expect(screen.getByTestId("zoom-medium")).toBeInTheDocument();
+    expect(screen.getByTestId("zoom-large")).toBeInTheDocument();
+  });
+
+  it("zoom controls change grid layout", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const grid = screen.getByTestId("cover-grid");
+
+    // Default is medium
+    expect(grid.className).toContain("grid-cols-4");
+
+    // Click small zoom
+    await user.click(screen.getByTestId("zoom-small"));
+    expect(grid.className).toContain("grid-cols-5");
+
+    // Click large zoom
+    await user.click(screen.getByTestId("zoom-large"));
+    expect(grid.className).toContain("grid-cols-3");
+  });
+
+  it("renders console filter chips", () => {
+    renderPage();
+    const chips = screen.getByTestId("console-chips");
+    expect(chips).toBeInTheDocument();
+    expect(chips).toHaveTextContent("All");
+    expect(chips).toHaveTextContent("SNES");
+    expect(chips).toHaveTextContent("GEN");
+  });
+
+  it("console filter triggers re-fetch", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const chips = screen.getByTestId("console-chips");
+    const buttons = chips.querySelectorAll("button");
+    // First button is "All", second is "SNES", third is "GEN"
+    const snesChip = buttons[1];
+    await user.click(snesChip);
+    expect(mockUseCoverGallery).toHaveBeenCalledWith(1, "snes");
+  });
+
+  it("renders empty state when no covers", () => {
+    mockUseCoverGallery.mockReturnValue({
+      data: { covers: [], page: 1, totalPages: 0, totalCount: 0 },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No covers found")).toBeInTheDocument();
+  });
+
+  it("renders load more button when more pages", () => {
+    renderPage();
+    expect(screen.getByTestId("load-more-button")).toBeInTheDocument();
+  });
+
+  it("hides load more when on last page", () => {
+    mockUseCoverGallery.mockReturnValue({
+      data: {
+        ...mockCovers,
+        page: 2,
+        totalPages: 2,
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("load-more-button"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders back button", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /back to explore/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders page heading", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: "Cover Art Wall", level: 1 }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/__tests__/screenshot-gallery-page.test.tsx
+++ b/web/src/pages/__tests__/screenshot-gallery-page.test.tsx
@@ -1,0 +1,244 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ScreenshotGalleryPage } from "@/pages/screenshot-gallery-page";
+import type { ScreenshotGalleryResponse, Console } from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-explore", () => ({
+  useScreenshotGallery: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-consoles", () => ({
+  useConsoles: vi.fn(),
+}));
+
+import { useScreenshotGallery } from "@/hooks/use-explore";
+import { useConsoles } from "@/hooks/use-consoles";
+
+const mockUseScreenshotGallery = useScreenshotGallery as ReturnType<
+  typeof vi.fn
+>;
+const mockUseConsoles = useConsoles as ReturnType<typeof vi.fn>;
+
+const mockScreenshots: ScreenshotGalleryResponse = {
+  screenshots: [
+    {
+      url: "/screenshots/mario1.jpg",
+      gameId: "game-1",
+      gameTitle: "Super Mario World",
+      consoleName: "SNES",
+      consoleAbbreviation: "snes",
+      consoleColor: "#805ad5",
+    },
+    {
+      url: "/screenshots/zelda1.jpg",
+      gameId: "game-2",
+      gameTitle: "A Link to the Past",
+      consoleName: "SNES",
+      consoleAbbreviation: "snes",
+      consoleColor: "#805ad5",
+    },
+    {
+      url: "/screenshots/mega1.jpg",
+      gameId: "game-3",
+      gameTitle: "Mega Man X",
+      consoleName: "SNES",
+      consoleAbbreviation: "snes",
+      consoleColor: "#805ad5",
+    },
+  ],
+  page: 1,
+  totalPages: 3,
+  totalCount: 30,
+};
+
+const mockConsoles: Console[] = [
+  {
+    id: "snes",
+    name: "SNES",
+    abbreviation: "snes",
+    extensions: [".sfc", ".smc"],
+    defaultCore: "snes9x",
+    coverAspectRatio: 0.75,
+    colorTheme: "#805ad5",
+    iconUrl: "/icons/snes.png",
+    logoUrl: "/logos/snes.png",
+    gameCount: 50,
+    saveStateSupport: true,
+    browserPlayable: true,
+    playable: true,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  },
+  {
+    id: "nes",
+    name: "NES",
+    abbreviation: "nes",
+    extensions: [".nes"],
+    defaultCore: "fceumm",
+    coverAspectRatio: 0.75,
+    colorTheme: "#e53e3e",
+    iconUrl: "/icons/nes.png",
+    logoUrl: "/logos/nes.png",
+    gameCount: 30,
+    saveStateSupport: true,
+    browserPlayable: true,
+    playable: true,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+  },
+];
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/explore/gallery"]}>
+        <Routes>
+          <Route
+            path="/explore/gallery"
+            element={<ScreenshotGalleryPage />}
+          />
+          <Route path="/games/:id" element={<div>Game Detail</div>} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ScreenshotGalleryPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseScreenshotGallery.mockReturnValue({
+      data: mockScreenshots,
+      isLoading: false,
+    });
+    mockUseConsoles.mockReturnValue({
+      data: mockConsoles,
+      isLoading: false,
+    });
+  });
+
+  it("renders the page with test id", () => {
+    renderPage();
+    expect(
+      screen.getByTestId("screenshot-gallery-page"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders loading skeleton while loading", () => {
+    mockUseScreenshotGallery.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    expect(
+      screen.getByTestId("screenshot-gallery-skeleton"),
+    ).toBeInTheDocument();
+  });
+
+  it("renders screenshots in gallery", () => {
+    renderPage();
+    expect(screen.getByTestId("screenshot-grid")).toBeInTheDocument();
+    const cards = screen.getAllByTestId("screenshot-card");
+    expect(cards).toHaveLength(3);
+  });
+
+  it("renders screenshot images", () => {
+    renderPage();
+    const images = screen.getAllByRole("img");
+    expect(images.some((img) => img.getAttribute("src") === "/screenshots/mario1.jpg")).toBe(true);
+    expect(images.some((img) => img.getAttribute("src") === "/screenshots/zelda1.jpg")).toBe(true);
+  });
+
+  it("renders hover overlay with game title", () => {
+    renderPage();
+    const overlays = screen.getAllByTestId("screenshot-overlay");
+    expect(overlays).toHaveLength(3);
+    expect(overlays[0]).toHaveTextContent("Super Mario World");
+    expect(overlays[1]).toHaveTextContent("A Link to the Past");
+  });
+
+  it("renders hover overlay with console badge", () => {
+    renderPage();
+    const overlays = screen.getAllByTestId("screenshot-overlay");
+    expect(overlays[0]).toHaveTextContent("SNES");
+  });
+
+  it("navigates to game detail on click", () => {
+    renderPage();
+    const cards = screen.getAllByTestId("screenshot-card");
+    const link = cards[0].querySelector("a");
+    expect(link).toHaveAttribute("href", "/games/game-1");
+  });
+
+  it("renders console filter dropdown", () => {
+    renderPage();
+    expect(screen.getByTestId("console-filter")).toBeInTheDocument();
+    const select = screen.getByTestId("console-filter");
+    expect(select).toHaveTextContent("All Consoles");
+    expect(select).toHaveTextContent("SNES");
+    expect(select).toHaveTextContent("NES");
+  });
+
+  it("console filter triggers re-fetch", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    const select = screen.getByTestId("console-filter");
+    await user.selectOptions(select, "snes");
+    // The hook should be called with the new filter
+    expect(mockUseScreenshotGallery).toHaveBeenCalledWith(1, {
+      console: "snes",
+      genre: undefined,
+    });
+  });
+
+  it("renders empty state when no screenshots", () => {
+    mockUseScreenshotGallery.mockReturnValue({
+      data: { screenshots: [], page: 1, totalPages: 0, totalCount: 0 },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No screenshots found")).toBeInTheDocument();
+  });
+
+  it("renders load more button when more pages", () => {
+    renderPage();
+    expect(screen.getByTestId("load-more-button")).toBeInTheDocument();
+    expect(screen.getByTestId("load-more-button")).toHaveTextContent(
+      "Load More",
+    );
+  });
+
+  it("hides load more when on last page", () => {
+    mockUseScreenshotGallery.mockReturnValue({
+      data: {
+        ...mockScreenshots,
+        page: 3,
+        totalPages: 3,
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("load-more-button")).not.toBeInTheDocument();
+  });
+
+  it("renders back button", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /back to explore/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders page heading", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: "Screenshot Gallery", level: 1 }),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/cover-gallery-page.tsx
+++ b/web/src/pages/cover-gallery-page.tsx
@@ -1,0 +1,269 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { Grid2x2, Grid3x3, LayoutGrid, ImageIcon } from "lucide-react";
+import { BackButton, Badge, Button, Skeleton, EmptyState } from "@/components/ui";
+import { cn } from "@/lib/cn";
+import { useCoverGallery } from "@/hooks/use-explore";
+import { useConsoles } from "@/hooks/use-consoles";
+import type { CoverItem } from "@/types/api";
+
+type ZoomLevel = "small" | "medium" | "large";
+
+const zoomGridClasses: Record<ZoomLevel, string> = {
+  small: "grid-cols-5 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 xl:grid-cols-12 gap-2",
+  medium: "grid-cols-4 sm:grid-cols-5 md:grid-cols-6 lg:grid-cols-8 xl:grid-cols-10 gap-3",
+  large: "grid-cols-3 sm:grid-cols-4 md:grid-cols-5 lg:grid-cols-6 xl:grid-cols-8 gap-3",
+};
+
+function CoverGallerySkeleton() {
+  return (
+    <div data-testid="cover-gallery-skeleton">
+      <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 gap-3">
+        {Array.from({ length: 20 }, (_, i) => (
+          <Skeleton
+            key={i}
+            className="w-full rounded-lg"
+            style={{ aspectRatio: "3/4" }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function CoverCard({ cover }: { cover: CoverItem }) {
+  return (
+    <Link
+      to={`/games/${cover.gameId}`}
+      className="group relative block rounded-lg overflow-hidden"
+      role="listitem"
+      data-testid="cover-card"
+    >
+      <div
+        className="w-full bg-surface-800"
+        style={{ aspectRatio: `${cover.coverAspectRatio || 0.75}` }}
+      >
+        {cover.coverUrl ? (
+          <img
+            src={cover.coverUrl}
+            alt={cover.gameTitle}
+            className="w-full h-full object-cover transition-transform duration-300 group-hover:scale-105"
+            loading="lazy"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center text-surface-600 text-lg font-bold">
+            {cover.gameTitle.charAt(0)}
+          </div>
+        )}
+      </div>
+      {/* Hover overlay */}
+      <div
+        className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/10 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex flex-col justify-end p-2"
+        data-testid="cover-overlay"
+      >
+        <p className="text-xs font-semibold text-white truncate">
+          {cover.gameTitle}
+        </p>
+        <Badge
+          variant="default"
+          className="mt-0.5 w-fit text-[10px] px-1.5 py-0"
+          style={
+            cover.consoleColor
+              ? {
+                  backgroundColor: `${cover.consoleColor}20`,
+                  color: cover.consoleColor,
+                  borderColor: `${cover.consoleColor}40`,
+                }
+              : undefined
+          }
+        >
+          {cover.consoleAbbreviation.toUpperCase()}
+        </Badge>
+      </div>
+    </Link>
+  );
+}
+
+export function CoverGalleryPage() {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [consoleFilter, setConsoleFilter] = useState<string | undefined>();
+  const [zoom, setZoom] = useState<ZoomLevel>("medium");
+  const { data: consolesData } = useConsoles();
+
+  const [allCovers, setAllCovers] = useState<CoverItem[]>([]);
+
+  const { data, isLoading } = useCoverGallery(page, consoleFilter);
+
+  const covers =
+    page === 1
+      ? data?.covers ?? []
+      : [...allCovers, ...(data?.covers ?? [])];
+
+  const hasMore = data ? data.page < data.totalPages : false;
+
+  const handleLoadMore = () => {
+    setAllCovers(covers);
+    setPage((p) => p + 1);
+  };
+
+  const handleConsoleFilter = (value: string) => {
+    setConsoleFilter(value || undefined);
+    setPage(1);
+    setAllCovers([]);
+  };
+
+  const isInitialLoading = isLoading && page === 1;
+
+  return (
+    <div
+      className="max-w-7xl space-y-6"
+      data-testid="cover-gallery-page"
+    >
+      <BackButton onClick={() => navigate(-1)}>Back to Explore</BackButton>
+
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold text-surface-100">
+            Cover Art Wall
+          </h1>
+          <p className="mt-1 text-surface-400">
+            Browse cover art from your library.
+          </p>
+        </div>
+
+        {/* Zoom controls */}
+        <div
+          className="flex items-center gap-1 rounded-lg border border-surface-700 bg-surface-900 p-1"
+          role="group"
+          aria-label="Grid size"
+          data-testid="zoom-controls"
+        >
+          <button
+            onClick={() => setZoom("small")}
+            className={cn(
+              "p-1.5 rounded transition-colors",
+              zoom === "small"
+                ? "bg-brand-500/20 text-brand-400"
+                : "text-surface-400 hover:text-surface-200",
+            )}
+            aria-label="Small grid"
+            aria-pressed={zoom === "small"}
+            data-testid="zoom-small"
+          >
+            <Grid3x3 className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => setZoom("medium")}
+            className={cn(
+              "p-1.5 rounded transition-colors",
+              zoom === "medium"
+                ? "bg-brand-500/20 text-brand-400"
+                : "text-surface-400 hover:text-surface-200",
+            )}
+            aria-label="Medium grid"
+            aria-pressed={zoom === "medium"}
+            data-testid="zoom-medium"
+          >
+            <Grid2x2 className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => setZoom("large")}
+            className={cn(
+              "p-1.5 rounded transition-colors",
+              zoom === "large"
+                ? "bg-brand-500/20 text-brand-400"
+                : "text-surface-400 hover:text-surface-200",
+            )}
+            aria-label="Large grid"
+            aria-pressed={zoom === "large"}
+            data-testid="zoom-large"
+          >
+            <LayoutGrid className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {/* Console filter chips */}
+      <div
+        className="flex gap-2 overflow-x-auto pb-1 scrollbar-hide"
+        style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+        data-testid="console-chips"
+      >
+        <button
+          onClick={() => handleConsoleFilter("")}
+          className={cn(
+            "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+            !consoleFilter
+              ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
+              : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
+          )}
+        >
+          All
+        </button>
+        {consolesData?.map((c) => (
+          <button
+            key={c.id}
+            onClick={() => handleConsoleFilter(c.id)}
+            className={cn(
+              "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer whitespace-nowrap focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+              consoleFilter === c.id
+                ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
+                : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
+            )}
+            style={
+              consoleFilter === c.id && c.colorTheme
+                ? {
+                    backgroundColor: `${c.colorTheme}20`,
+                    color: c.colorTheme,
+                    borderColor: `${c.colorTheme}40`,
+                  }
+                : undefined
+            }
+          >
+            {c.abbreviation.toUpperCase()}
+          </button>
+        ))}
+      </div>
+
+      {/* Cover grid */}
+      {isInitialLoading ? (
+        <CoverGallerySkeleton />
+      ) : covers.length === 0 ? (
+        <EmptyState
+          icon={ImageIcon}
+          title="No covers found"
+          description="There are no cover art images matching your filters."
+          data-testid="empty-state"
+        />
+      ) : (
+        <>
+          <div
+            className={cn("grid", zoomGridClasses[zoom])}
+            role="list"
+            aria-label="Cover art gallery"
+            data-testid="cover-grid"
+          >
+            {covers.map((cover, i) => (
+              <CoverCard key={`${cover.gameId}-${i}`} cover={cover} />
+            ))}
+          </div>
+
+          {/* Load more */}
+          {hasMore && (
+            <div className="flex justify-center pt-4">
+              <Button
+                variant="secondary"
+                onClick={handleLoadMore}
+                disabled={isLoading}
+                data-testid="load-more-button"
+              >
+                {isLoading ? "Loading..." : "Load More"}
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -6,6 +6,7 @@ import { GameShelf } from "@/features/explore/components/game-shelf";
 import { ThemeGrid } from "@/features/explore/components/theme-grid";
 import { KeywordChips } from "@/features/explore/components/keyword-chips";
 import { SeriesShelf } from "@/features/explore/components/series-shelf";
+import { ArtworkShowcase } from "@/features/explore/components/artwork-showcase";
 import { DeveloperSpotlight } from "@/features/explore/components/developer-spotlight";
 import { MoodPicker } from "@/features/explore/components/mood-picker";
 import { ForYouSection } from "@/features/explore/components/for-you-section";
@@ -22,6 +23,7 @@ import {
   usePlayersLikeYou,
   useDeveloperSpotlight,
   useConsoleHighlights,
+  useArtworkGallery,
 } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -69,6 +71,10 @@ export function ExplorePage() {
     data: consoleHighlightsData,
     isLoading: isConsoleHighlightsLoading,
   } = useConsoleHighlights();
+  const {
+    data: artworkData,
+    isLoading: isArtworkLoading,
+  } = useArtworkGallery(1);
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
 
@@ -184,6 +190,12 @@ export function ExplorePage() {
         isLoading={isSpotlightLoading}
         onToggleFavorite={handleToggleFavorite}
         onTogglePlayLater={handleTogglePlayLater}
+      />
+
+      {/* Artwork Showcase */}
+      <ArtworkShowcase
+        artworks={artworkData?.artworks}
+        isLoading={isArtworkLoading}
       />
 
       {/* Remaining shelf rows */}

--- a/web/src/pages/screenshot-gallery-page.tsx
+++ b/web/src/pages/screenshot-gallery-page.tsx
@@ -1,0 +1,178 @@
+import { useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ImageIcon } from "lucide-react";
+import { BackButton, Badge, Button, Skeleton, EmptyState } from "@/components/ui";
+import { useScreenshotGallery } from "@/hooks/use-explore";
+import { useConsoles } from "@/hooks/use-consoles";
+import type { ScreenshotItem } from "@/types/api";
+
+function GallerySkeleton() {
+  return (
+    <div data-testid="screenshot-gallery-skeleton">
+      <div className="columns-2 md:columns-3 xl:columns-4 gap-4">
+        {Array.from({ length: 12 }, (_, i) => (
+          <div key={i} className="break-inside-avoid mb-4">
+            <Skeleton
+              className="w-full rounded-xl"
+              style={{ height: `${160 + (i % 3) * 60}px` }}
+            />
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ScreenshotCard({ screenshot }: { screenshot: ScreenshotItem }) {
+  return (
+    <div className="break-inside-avoid mb-4" role="listitem" data-testid="screenshot-card">
+      <Link
+        to={`/games/${screenshot.gameId}`}
+        className="group relative block rounded-xl overflow-hidden"
+      >
+        <img
+          src={screenshot.url}
+          alt={`Screenshot from ${screenshot.gameTitle}`}
+          className="w-full object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+          loading="lazy"
+        />
+        {/* Hover overlay */}
+        <div
+          className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-200 flex flex-col justify-end p-3"
+          data-testid="screenshot-overlay"
+        >
+          <p className="text-sm font-semibold text-white truncate">
+            {screenshot.gameTitle}
+          </p>
+          <Badge
+            variant="default"
+            className="mt-1 w-fit"
+            style={
+              screenshot.consoleColor
+                ? {
+                    backgroundColor: `${screenshot.consoleColor}20`,
+                    color: screenshot.consoleColor,
+                    borderColor: `${screenshot.consoleColor}40`,
+                  }
+                : undefined
+            }
+          >
+            {screenshot.consoleAbbreviation.toUpperCase()}
+          </Badge>
+        </div>
+      </Link>
+    </div>
+  );
+}
+
+export function ScreenshotGalleryPage() {
+  const navigate = useNavigate();
+  const [page, setPage] = useState(1);
+  const [consoleFilter, setConsoleFilter] = useState<string | undefined>();
+  const { data: consolesData } = useConsoles();
+
+  // Collect all pages of screenshots
+  const [allScreenshots, setAllScreenshots] = useState<ScreenshotItem[]>([]);
+
+  const { data, isLoading } = useScreenshotGallery(page, {
+    console: consoleFilter,
+  });
+
+  // When data changes, merge into accumulated screenshots
+  // Reset when filters change
+  const screenshots =
+    page === 1
+      ? data?.screenshots ?? []
+      : [...allScreenshots, ...(data?.screenshots ?? [])];
+
+  const hasMore = data ? data.page < data.totalPages : false;
+
+  const handleLoadMore = () => {
+    setAllScreenshots(screenshots);
+    setPage((p) => p + 1);
+  };
+
+  const handleFilterChange = (newConsole?: string) => {
+    setConsoleFilter(newConsole);
+    setPage(1);
+    setAllScreenshots([]);
+  };
+
+  const isInitialLoading = isLoading && page === 1;
+
+  return (
+    <div
+      className="max-w-6xl space-y-6"
+      data-testid="screenshot-gallery-page"
+    >
+      <BackButton onClick={() => navigate(-1)}>Back to Explore</BackButton>
+
+      <div>
+        <h1 className="text-3xl font-bold text-surface-100">
+          Screenshot Gallery
+        </h1>
+        <p className="mt-1 text-surface-400">
+          Browse screenshots from your library.
+        </p>
+      </div>
+
+      {/* Filter bar */}
+      <div className="flex flex-wrap gap-3" data-testid="gallery-filters">
+        <select
+          value={consoleFilter ?? ""}
+          onChange={(e) =>
+            handleFilterChange(e.target.value || undefined)
+          }
+          className="rounded-lg border border-surface-700 bg-surface-900 px-3 py-2 text-sm text-surface-200 focus:outline-none focus:ring-2 focus:ring-brand-500"
+          data-testid="console-filter"
+        >
+          <option value="">All Consoles</option>
+          {consolesData?.map((c) => (
+            <option key={c.id} value={c.id}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      {/* Gallery */}
+      {isInitialLoading ? (
+        <GallerySkeleton />
+      ) : screenshots.length === 0 ? (
+        <EmptyState
+          icon={ImageIcon}
+          title="No screenshots found"
+          description="There are no screenshots matching your filters."
+          data-testid="empty-state"
+        />
+      ) : (
+        <>
+          <div
+            className="columns-2 md:columns-3 xl:columns-4 gap-4"
+            role="list"
+            aria-label="Screenshot gallery"
+            data-testid="screenshot-grid"
+          >
+            {screenshots.map((ss, i) => (
+              <ScreenshotCard key={`${ss.gameId}-${ss.url}-${i}`} screenshot={ss} />
+            ))}
+          </div>
+
+          {/* Load more */}
+          {hasMore && (
+            <div className="flex justify-center pt-4">
+              <Button
+                variant="secondary"
+                onClick={handleLoadMore}
+                disabled={isLoading}
+                data-testid="load-more-button"
+              >
+                {isLoading ? "Loading..." : "Load More"}
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -883,6 +883,60 @@ export interface GameFranchiseLink {
   gameCount: number;
 }
 
+// --- Visual Browsing / Gallery ---
+
+export interface ScreenshotItem {
+  url: string;
+  gameId: string;
+  gameTitle: string;
+  consoleName: string;
+  consoleAbbreviation: string;
+  consoleColor: string;
+}
+
+export interface ScreenshotGalleryResponse {
+  screenshots: ScreenshotItem[];
+  page: number;
+  totalPages: number;
+  totalCount: number;
+}
+
+export interface ArtworkItem {
+  url: string;
+  width: number;
+  height: number;
+  gameId: string;
+  gameTitle: string;
+  consoleName: string;
+  consoleAbbreviation: string;
+  consoleColor: string;
+}
+
+export interface ArtworkGalleryResponse {
+  artworks: ArtworkItem[];
+  page: number;
+  totalPages: number;
+  totalCount: number;
+}
+
+export interface CoverItem {
+  coverUrl: string;
+  gameId: string;
+  gameTitle: string;
+  consoleName: string;
+  consoleAbbreviation: string;
+  consoleColor: string;
+  rating: number;
+  coverAspectRatio: number;
+}
+
+export interface CoverGalleryResponse {
+  covers: CoverItem[];
+  page: number;
+  totalPages: number;
+  totalCount: number;
+}
+
 // --- Console Showcase ---
 
 export interface GenreCount {


### PR DESCRIPTION
## Summary
- **Screenshot Gallery** (`/explore/gallery`) — masonry-style grid with hover overlays, console filtering, and load-more pagination
- **Cover Art Wall** (`/explore/covers`) — dense responsive grid with 3 zoom levels (small/medium/large), console filter chips, and pagination
- **Artwork Showcase** on Explore page — horizontal row of 16:9 IGDB promotional artwork cards with "Browse Gallery" links
- **Backend**: 3 new paginated endpoints (`screenshots`, `artwork`, `covers`) with shared `baseQuery` for consistent filtering, plus `parsePagination` helper
- **Accessibility**: ARIA roles on gallery grids, `aria-pressed` on zoom controls, `aria-label` on groups
- Full implementation across Go backend, React web, and Kotlin Multiplatform player

## Test plan
- [x] Go tests pass (7 new gallery tests)
- [x] Web Vitest tests pass (990/990 including 42 new)
- [x] TypeScript compiles cleanly
- [x] Go compiles cleanly
- [x] Code review: fixed duplicate filter logic, player API URLs, hasMore threshold
- [x] UX review: fixed player gallery entry point, dead genre filter state, ARIA landmarks, zoom a11y