### PR TITLE
feat: add Social & Community Discovery to Explore page (Phase 10)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreSocialTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreSocialTest.kt
@@ -1,0 +1,161 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.ActiveNowItem
+import com.spela.player.domain.model.CommunityTopGame
+import com.spela.player.domain.model.CultClassicGame
+import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.RecentReviewItem
+import com.spela.player.domain.model.TrendingGame
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+
+/**
+ * Desktop E2E tests for Phase 10: Social & Community Discovery.
+ *
+ * Covers:
+ * - Trending shelf renders on Explore screen
+ * - Community Favorites shelf renders
+ * - Cult Classics shelf renders
+ * - Active Now shelf renders
+ * - Recently Reviewed shelf renders
+ * - Empty social data hides sections
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ExploreSocialTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun makeGame(id: String, title: String): Game = Game(
+        id = id,
+        title = title,
+        consoleId = "snes",
+        consoleName = "Super Nintendo",
+        fileName = "$title.sfc",
+        fileSize = 1024,
+        discCount = 1,
+        description = "",
+        coverUrl = null,
+        developer = "",
+        publisher = "",
+        releaseDate = "",
+        genre = "Action",
+        players = 1,
+        rating = 80.0,
+        isFavorite = false,
+        isInPlayLater = false,
+        coverAspectRatio = 0.75f,
+    )
+
+    @Test
+    fun trendingSectionRendersWithGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.trendingGames = listOf(
+            TrendingGame(game = makeGame("t1", "Trending Alpha"), playersThisWeek = 5),
+            TrendingGame(game = makeGame("t2", "Trending Beta"), playersThisWeek = 3),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_trending_section").assertExists()
+        onNodeWithTag("trending_row").assertExists()
+        onNodeWithTag("trending_players_t1").assertExists()
+    }
+
+    @Test
+    fun communityTopSectionRenders() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.communityTopGames = listOf(
+            CommunityTopGame(game = makeGame("c1", "Community Best"), avgRating = 4.8, ratingCount = 10),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_community_top_section").assertExists()
+        onNodeWithTag("community_top_row").assertExists()
+    }
+
+    @Test
+    fun cultClassicsSectionRenders() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.cultClassicsList = listOf(
+            CultClassicGame(
+                game = makeGame("cu1", "Hidden Treasure"),
+                communityRating = 4.5,
+                igdbRating = 55.0,
+                ratingCount = 3,
+            ),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_cult_classics_section").assertExists()
+        onNodeWithTag("cult_classics_row").assertExists()
+    }
+
+    @Test
+    fun activeNowSectionRenders() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.activeNowGames = listOf(
+            ActiveNowItem(game = makeGame("a1", "Active Game"), activeSessions = 2, activeChallenges = 1),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_active_now_section").assertExists()
+        onNodeWithTag("active_now_row").assertExists()
+        onNodeWithTag("active_badge_a1").assertExists()
+    }
+
+    @Test
+    fun recentlyReviewedSectionRenders() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.recentReviews = listOf(
+            RecentReviewItem(
+                game = makeGame("r1", "Reviewed RPG"),
+                rating = 5,
+                review = "Amazing classic!",
+                reviewerName = "player1",
+                reviewedAt = "2026-03-01T10:00:00Z",
+            ),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_recently_reviewed_section").assertExists()
+        onNodeWithTag("recently_reviewed_row").assertExists()
+        onNodeWithTag("review_text_r1").assertExists()
+    }
+
+    @Test
+    fun emptySocialDataHidesSections() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_trending_section").assertDoesNotExist()
+        onNodeWithTag("explore_community_top_section").assertDoesNotExist()
+        onNodeWithTag("explore_cult_classics_section").assertDoesNotExist()
+        onNodeWithTag("explore_active_now_section").assertDoesNotExist()
+        onNodeWithTag("explore_recently_reviewed_section").assertDoesNotExist()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1343,6 +1343,11 @@ class FakeExploreRepository : ExploreRepository {
     var consoleHighlightsList: List<ConsoleHighlight> = emptyList()
     var artworkItems: List<ArtworkItem> = emptyList()
     var screenshotItems: List<ScreenshotItem> = emptyList()
+    var trendingGames: List<TrendingGame> = emptyList()
+    var communityTopGames: List<CommunityTopGame> = emptyList()
+    var cultClassicsList: List<CultClassicGame> = emptyList()
+    var recentReviews: List<RecentReviewItem> = emptyList()
+    var activeNowGames: List<ActiveNowItem> = emptyList()
     var shouldFail: Boolean = false
 
     override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> =
@@ -1472,6 +1477,26 @@ class FakeExploreRepository : ExploreRepository {
     override suspend fun getScreenshotGallery(page: Int): Result<List<ScreenshotItem>> =
         if (shouldFail) Result.failure(Exception("Failed to load screenshot gallery"))
         else Result.success(screenshotItems)
+
+    override suspend fun getTrending(): Result<List<TrendingGame>> =
+        if (shouldFail) Result.failure(Exception("Failed to load trending"))
+        else Result.success(trendingGames)
+
+    override suspend fun getCommunityTop(): Result<List<CommunityTopGame>> =
+        if (shouldFail) Result.failure(Exception("Failed to load community top"))
+        else Result.success(communityTopGames)
+
+    override suspend fun getCultClassics(): Result<List<CultClassicGame>> =
+        if (shouldFail) Result.failure(Exception("Failed to load cult classics"))
+        else Result.success(cultClassicsList)
+
+    override suspend fun getRecentlyReviewed(): Result<List<RecentReviewItem>> =
+        if (shouldFail) Result.failure(Exception("Failed to load recently reviewed"))
+        else Result.success(recentReviews)
+
+    override suspend fun getActiveNow(): Result<List<ActiveNowItem>> =
+        if (shouldFail) Result.failure(Exception("Failed to load active now"))
+        else Result.success(activeNowGames)
 }
 
 class FakeCheatRepository : CheatRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -371,6 +371,31 @@ class SpelaApiClient(
         }.body()
     }
 
+    /** Returns trending games (most played this week) */
+    suspend fun getTrending(): TrendingResponseDto {
+        return client.get("$baseUrl/api/explore/trending").body()
+    }
+
+    /** Returns community top-rated games */
+    suspend fun getCommunityTop(): CommunityTopResponseDto {
+        return client.get("$baseUrl/api/explore/community-top").body()
+    }
+
+    /** Returns cult classics (high community, low IGDB) */
+    suspend fun getCultClassics(): CultClassicsResponseDto {
+        return client.get("$baseUrl/api/explore/cult-classics").body()
+    }
+
+    /** Returns recently reviewed games */
+    suspend fun getRecentlyReviewed(): RecentlyReviewedResponseDto {
+        return client.get("$baseUrl/api/explore/recently-reviewed").body()
+    }
+
+    /** Returns games with active shared sessions or challenges */
+    suspend fun getActiveNow(): ActiveNowResponseDto {
+        return client.get("$baseUrl/api/explore/active-now").body()
+    }
+
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
     suspend fun getRecentGames(): List<GameDto> {
         return client.get("$baseUrl/api/user/recent").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -744,3 +744,37 @@ fun ScreenshotItemDto.toDomain(): ScreenshotItem = ScreenshotItem(
     consoleAbbreviation = consoleAbbreviation,
     consoleColor = consoleColor,
 )
+
+// --- Phase 10: Social & Community Discovery ---
+
+fun TrendingGameDto.toDomain(): TrendingGame = TrendingGame(
+    game = game.toDomain(),
+    playersThisWeek = playersThisWeek,
+)
+
+fun CommunityTopGameDto.toDomain(): CommunityTopGame = CommunityTopGame(
+    game = game.toDomain(),
+    avgRating = avgRating,
+    ratingCount = ratingCount,
+)
+
+fun CultClassicGameDto.toDomain(): CultClassicGame = CultClassicGame(
+    game = game.toDomain(),
+    communityRating = communityRating,
+    igdbRating = igdbRating,
+    ratingCount = ratingCount,
+)
+
+fun RecentReviewItemDto.toDomain(): RecentReviewItem = RecentReviewItem(
+    game = game.toDomain(),
+    rating = rating,
+    review = review,
+    reviewerName = reviewerName,
+    reviewedAt = reviewedAt,
+)
+
+fun ActiveNowItemDto.toDomain(): ActiveNowItem = ActiveNowItem(
+    game = game.toDomain(),
+    activeSessions = activeSessions,
+    activeChallenges = activeChallenges,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1272,3 +1272,67 @@ data class ScreenshotGalleryResponseDto(
     val totalPages: Int,
     val totalCount: Int,
 )
+
+// --- Phase 10: Social & Community Discovery ---
+
+@Serializable
+data class TrendingGameDto(
+    val game: GameDto,
+    val playersThisWeek: Int,
+)
+
+@Serializable
+data class TrendingResponseDto(
+    val games: List<TrendingGameDto>,
+)
+
+@Serializable
+data class CommunityTopGameDto(
+    val game: GameDto,
+    val avgRating: Double,
+    val ratingCount: Int,
+)
+
+@Serializable
+data class CommunityTopResponseDto(
+    val games: List<CommunityTopGameDto>,
+)
+
+@Serializable
+data class CultClassicGameDto(
+    val game: GameDto,
+    val communityRating: Double,
+    val igdbRating: Double,
+    val ratingCount: Int,
+)
+
+@Serializable
+data class CultClassicsResponseDto(
+    val games: List<CultClassicGameDto>,
+)
+
+@Serializable
+data class RecentReviewItemDto(
+    val game: GameDto,
+    val rating: Int,
+    val review: String,
+    val reviewerName: String,
+    val reviewedAt: String,
+)
+
+@Serializable
+data class RecentlyReviewedResponseDto(
+    val reviews: List<RecentReviewItemDto>,
+)
+
+@Serializable
+data class ActiveNowItemDto(
+    val game: GameDto,
+    val activeSessions: Int,
+    val activeChallenges: Int,
+)
+
+@Serializable
+data class ActiveNowResponseDto(
+    val games: List<ActiveNowItemDto>,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -1,10 +1,14 @@
 package com.spela.player.data.repository
 
 import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.dto.GameDto
 import com.spela.player.data.remote.dto.toDomain
+import com.spela.player.domain.model.ActiveNowItem
 import com.spela.player.domain.model.ArtworkItem
+import com.spela.player.domain.model.CommunityTopGame
 import com.spela.player.domain.model.ConsoleHighlight
 import com.spela.player.domain.model.ConsoleShowcase
+import com.spela.player.domain.model.CultClassicGame
 import com.spela.player.domain.model.DeveloperDetail
 import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.DeveloperSummary
@@ -18,10 +22,12 @@ import com.spela.player.domain.model.GameSeriesLink
 import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
 import com.spela.player.domain.model.PlayersLikeYouResult
+import com.spela.player.domain.model.RecentReviewItem
 import com.spela.player.domain.model.ScreenshotItem
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.TasteProfile
 import com.spela.player.domain.model.Theme
+import com.spela.player.domain.model.TrendingGame
 import com.spela.player.domain.repository.ExploreRepository
 
 class ExploreRepositoryImpl(
@@ -262,4 +268,48 @@ class ExploreRepositoryImpl(
             )
         }
     }
+
+    override suspend fun getTrending(): Result<List<TrendingGame>> = runCatching {
+        apiClient.getTrending().games.map { dto ->
+            dto.toDomain().copy(
+                game = resolveGameCovers(dto.game.toDomain(), dto.game),
+            )
+        }
+    }
+
+    override suspend fun getCommunityTop(): Result<List<CommunityTopGame>> = runCatching {
+        apiClient.getCommunityTop().games.map { dto ->
+            dto.toDomain().copy(
+                game = resolveGameCovers(dto.game.toDomain(), dto.game),
+            )
+        }
+    }
+
+    override suspend fun getCultClassics(): Result<List<CultClassicGame>> = runCatching {
+        apiClient.getCultClassics().games.map { dto ->
+            dto.toDomain().copy(
+                game = resolveGameCovers(dto.game.toDomain(), dto.game),
+            )
+        }
+    }
+
+    override suspend fun getRecentlyReviewed(): Result<List<RecentReviewItem>> = runCatching {
+        apiClient.getRecentlyReviewed().reviews.map { dto ->
+            dto.toDomain().copy(
+                game = resolveGameCovers(dto.game.toDomain(), dto.game),
+            )
+        }
+    }
+
+    override suspend fun getActiveNow(): Result<List<ActiveNowItem>> = runCatching {
+        apiClient.getActiveNow().games.map { dto ->
+            dto.toDomain().copy(
+                game = resolveGameCovers(dto.game.toDomain(), dto.game),
+            )
+        }
+    }
+
+    private fun resolveGameCovers(game: Game, dto: GameDto): Game = game.copy(
+        coverUrl = apiClient.resolveUrl(dto.coverUrl),
+    )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -192,3 +192,37 @@ data class ScreenshotItem(
     val consoleAbbreviation: String,
     val consoleColor: String,
 )
+
+// --- Phase 10: Social & Community Discovery ---
+
+data class TrendingGame(
+    val game: Game,
+    val playersThisWeek: Int,
+)
+
+data class CommunityTopGame(
+    val game: Game,
+    val avgRating: Double,
+    val ratingCount: Int,
+)
+
+data class CultClassicGame(
+    val game: Game,
+    val communityRating: Double,
+    val igdbRating: Double,
+    val ratingCount: Int,
+)
+
+data class RecentReviewItem(
+    val game: Game,
+    val rating: Int,
+    val review: String,
+    val reviewerName: String,
+    val reviewedAt: String,
+)
+
+data class ActiveNowItem(
+    val game: Game,
+    val activeSessions: Int,
+    val activeChallenges: Int,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -1,8 +1,11 @@
 package com.spela.player.domain.repository
 
+import com.spela.player.domain.model.ActiveNowItem
 import com.spela.player.domain.model.ArtworkItem
+import com.spela.player.domain.model.CommunityTopGame
 import com.spela.player.domain.model.ConsoleHighlight
 import com.spela.player.domain.model.ConsoleShowcase
+import com.spela.player.domain.model.CultClassicGame
 import com.spela.player.domain.model.DeveloperDetail
 import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.DeveloperSummary
@@ -16,10 +19,12 @@ import com.spela.player.domain.model.GameSeriesLink
 import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
 import com.spela.player.domain.model.PlayersLikeYouResult
+import com.spela.player.domain.model.RecentReviewItem
 import com.spela.player.domain.model.ScreenshotItem
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.TasteProfile
 import com.spela.player.domain.model.Theme
+import com.spela.player.domain.model.TrendingGame
 
 interface ExploreRepository {
     suspend fun getFeaturedGames(): Result<List<FeaturedGame>>
@@ -46,4 +51,9 @@ interface ExploreRepository {
     suspend fun getConsoleHighlights(): Result<List<ConsoleHighlight>>
     suspend fun getArtworkGallery(page: Int = 1): Result<List<ArtworkItem>>
     suspend fun getScreenshotGallery(page: Int = 1): Result<List<ScreenshotItem>>
+    suspend fun getTrending(): Result<List<TrendingGame>>
+    suspend fun getCommunityTop(): Result<List<CommunityTopGame>>
+    suspend fun getCultClassics(): Result<List<CultClassicGame>>
+    suspend fun getRecentlyReviewed(): Result<List<RecentReviewItem>>
+    suspend fun getActiveNow(): Result<List<ActiveNowItem>>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
@@ -53,19 +53,20 @@ fun GameShelf(
             ExploreGameCard(
                 game = game,
                 onClick = { onGameSelected(game.id) },
+                modifier = Modifier.width(SpSpacing.CoverMediumWidth),
             )
         }
     }
 }
 
 @Composable
-private fun ExploreGameCard(
+internal fun ExploreGameCard(
     game: Game,
     onClick: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     SpCard(
-        modifier = Modifier
-            .width(SpSpacing.CoverMediumWidth)
+        modifier = modifier
             .testTag("explore_game_card_${game.id}")
             .semantics {
                 contentDescription = "${game.title}, ${game.consoleName}"

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SocialDiscoverySection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SocialDiscoverySection.kt
@@ -1,0 +1,274 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.ActiveNowItem
+import com.spela.player.domain.model.CommunityTopGame
+import com.spela.player.domain.model.CultClassicGame
+import com.spela.player.domain.model.RecentReviewItem
+import com.spela.player.domain.model.TrendingGame
+import com.spela.player.presentation.ui.components.SpShimmer
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+private val CardWidth = 140.dp
+
+@Composable
+fun TrendingSection(
+    games: List<TrendingGame>,
+    onGameSelected: (gameId: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("trending_row"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(games, key = { it.game.id }) { item ->
+            Column(
+                modifier = Modifier
+                    .width(CardWidth)
+                    .semantics { contentDescription = "${item.game.title}, ${item.playersThisWeek} players this week" },
+            ) {
+                ExploreGameCard(
+                    game = item.game,
+                    onClick = { onGameSelected(item.game.id) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "${item.playersThisWeek} player${if (item.playersThisWeek != 1) "s" else ""} this week",
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.testTag("trending_players_${item.game.id}"),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun CommunityTopSection(
+    games: List<CommunityTopGame>,
+    onGameSelected: (gameId: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("community_top_row"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(games, key = { it.game.id }) { item ->
+            Column(
+                modifier = Modifier
+                    .width(CardWidth)
+                    .semantics { contentDescription = "${item.game.title}, rated ${item.avgRating} out of 5" },
+            ) {
+                ExploreGameCard(
+                    game = item.game,
+                    onClick = { onGameSelected(item.game.id) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(4.dp))
+                Row(verticalAlignment = Alignment.CenterVertically) {
+                    Text(
+                        text = "★ ${String.format("%.1f", item.avgRating)}/5",
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundSecondary,
+                    )
+                    Text(
+                        text = " (${item.ratingCount})",
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CultClassicsSection(
+    games: List<CultClassicGame>,
+    onGameSelected: (gameId: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("cult_classics_row"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(games, key = { it.game.id }) { item ->
+            Column(
+                modifier = Modifier
+                    .width(CardWidth)
+                    .semantics {
+                        contentDescription = "${item.game.title}, community ${item.communityRating} vs IGDB ${item.igdbRating.toInt()}"
+                    },
+            ) {
+                ExploreGameCard(
+                    game = item.game,
+                    onClick = { onGameSelected(item.game.id) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "★ ${String.format("%.1f", item.communityRating)}/5 vs IGDB ${item.igdbRating.toInt()}/100",
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun RecentlyReviewedSection(
+    reviews: List<RecentReviewItem>,
+    onGameSelected: (gameId: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("recently_reviewed_row"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(reviews, key = { "${it.game.id}_${it.reviewerName}" }) { item ->
+            Column(
+                modifier = Modifier
+                    .width(200.dp)
+                    .semantics {
+                        contentDescription = "${item.game.title}, reviewed by ${item.reviewerName}"
+                    },
+            ) {
+                Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small)) {
+                    ExploreGameCard(
+                        game = item.game,
+                        onClick = { onGameSelected(item.game.id) },
+                        modifier = Modifier.width(80.dp),
+                    )
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = item.game.title,
+                            style = SpTypography.TitleSmall,
+                            color = SpColor.OnBackground,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Text(
+                            text = "★".repeat(item.rating) + "☆".repeat(5 - item.rating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundSecondary,
+                        )
+                        Spacer(Modifier.height(2.dp))
+                        Text(
+                            text = item.review,
+                            style = SpTypography.BodySmall,
+                            color = SpColor.OnBackgroundTertiary,
+                            maxLines = 3,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.testTag("review_text_${item.game.id}"),
+                        )
+                        Text(
+                            text = "— ${item.reviewerName}",
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ActiveNowSection(
+    games: List<ActiveNowItem>,
+    onGameSelected: (gameId: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("active_now_row"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(games, key = { it.game.id }) { item ->
+            Column(
+                modifier = Modifier
+                    .width(CardWidth)
+                    .semantics {
+                        val parts = mutableListOf<String>()
+                        if (item.activeSessions > 0) parts.add("${item.activeSessions} sessions")
+                        if (item.activeChallenges > 0) parts.add("${item.activeChallenges} challenges")
+                        contentDescription = "${item.game.title}, ${parts.joinToString(", ")}"
+                    },
+            ) {
+                ExploreGameCard(
+                    game = item.game,
+                    onClick = { onGameSelected(item.game.id) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(4.dp))
+                val badges = buildList {
+                    if (item.activeSessions > 0) add("${item.activeSessions} session${if (item.activeSessions != 1) "s" else ""}")
+                    if (item.activeChallenges > 0) add("${item.activeChallenges} challenge${if (item.activeChallenges != 1) "s" else ""}")
+                }
+                Text(
+                    text = badges.joinToString(" · "),
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.Primary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.testTag("active_badge_${item.game.id}"),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun SocialSectionSkeleton(
+    modifier: Modifier = Modifier,
+    count: Int = 5,
+) {
+    LazyRow(
+        modifier = modifier.testTag("social_skeleton"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(count) {
+            SpShimmer(
+                modifier = Modifier
+                    .width(CardWidth)
+                    .clip(RoundedCornerShape(SpSpacing.CardCornerRadius)),
+                width = CardWidth,
+                height = (CardWidth.value * 1.33f).dp,
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -22,10 +22,13 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.feature.explore.ActiveNowSection
 import com.spela.player.presentation.ui.feature.explore.ArtworkShowcaseSection
 import com.spela.player.presentation.ui.feature.explore.ArtworkShowcaseSkeleton
+import com.spela.player.presentation.ui.feature.explore.CommunityTopSection
 import com.spela.player.presentation.ui.feature.explore.ConsoleQuickJumpSection
 import com.spela.player.presentation.ui.feature.explore.ConsoleQuickJumpSkeleton
+import com.spela.player.presentation.ui.feature.explore.CultClassicsSection
 import com.spela.player.presentation.ui.feature.explore.DeveloperSpotlightSection
 import com.spela.player.presentation.ui.feature.explore.DeveloperSpotlightSkeleton
 import com.spela.player.presentation.ui.feature.explore.ForYouSection
@@ -38,10 +41,13 @@ import com.spela.player.presentation.ui.feature.explore.KeywordChips
 import com.spela.player.presentation.ui.feature.explore.KeywordChipsSkeleton
 import com.spela.player.presentation.ui.feature.explore.MoodPicker
 import com.spela.player.presentation.ui.feature.explore.MoodPickerSkeleton
+import com.spela.player.presentation.ui.feature.explore.RecentlyReviewedSection
 import com.spela.player.presentation.ui.feature.explore.SeriesShelf
 import com.spela.player.presentation.ui.feature.explore.SeriesShelfSkeleton
+import com.spela.player.presentation.ui.feature.explore.SocialSectionSkeleton
 import com.spela.player.presentation.ui.feature.explore.ThemeGrid
 import com.spela.player.presentation.ui.feature.explore.ThemeGridSkeleton
+import com.spela.player.presentation.ui.feature.explore.TrendingSection
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.viewmodel.ExploreViewModel
@@ -337,6 +343,137 @@ fun ExploreScreen(
                                     artworks = state.artworkShowcase,
                                     onGameSelected = onGameSelected,
                                     onGallerySelected = onGallerySelected,
+                                )
+                            }
+                        }
+                    }
+
+                    // Social & Community Discovery sections
+                    // Trending
+                    item {
+                        if (state.isLoadingSocial && state.trendingGames.isEmpty()) {
+                            SpTitledSection(
+                                title = "Trending on Your Server",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                SocialSectionSkeleton()
+                            }
+                        } else if (state.trendingGames.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "Trending on Your Server",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_trending_section"),
+                            ) {
+                                TrendingSection(
+                                    games = state.trendingGames,
+                                    onGameSelected = onGameSelected,
+                                )
+                            }
+                        }
+                    }
+
+                    // Community Favorites
+                    item {
+                        if (state.isLoadingSocial && state.communityTopGames.isEmpty()) {
+                            SpTitledSection(
+                                title = "Community Favorites",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                SocialSectionSkeleton()
+                            }
+                        } else if (state.communityTopGames.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "Community Favorites",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_community_top_section"),
+                            ) {
+                                CommunityTopSection(
+                                    games = state.communityTopGames,
+                                    onGameSelected = onGameSelected,
+                                )
+                            }
+                        }
+                    }
+
+                    // Cult Classics
+                    item {
+                        if (state.isLoadingSocial && state.cultClassics.isEmpty()) {
+                            SpTitledSection(
+                                title = "Cult Classics",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                SocialSectionSkeleton()
+                            }
+                        } else if (state.cultClassics.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "Cult Classics",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_cult_classics_section"),
+                            ) {
+                                CultClassicsSection(
+                                    games = state.cultClassics,
+                                    onGameSelected = onGameSelected,
+                                )
+                            }
+                        }
+                    }
+
+                    // Active Right Now
+                    item {
+                        if (state.isLoadingSocial && state.activeNowGames.isEmpty()) {
+                            SpTitledSection(
+                                title = "Active Right Now",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                SocialSectionSkeleton()
+                            }
+                        } else if (state.activeNowGames.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "Active Right Now",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_active_now_section"),
+                            ) {
+                                ActiveNowSection(
+                                    games = state.activeNowGames,
+                                    onGameSelected = onGameSelected,
+                                )
+                            }
+                        }
+                    }
+
+                    // Recently Reviewed
+                    item {
+                        if (state.isLoadingSocial && state.recentReviews.isEmpty()) {
+                            SpTitledSection(
+                                title = "Recently Reviewed",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                SocialSectionSkeleton()
+                            }
+                        } else if (state.recentReviews.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "Recently Reviewed",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_recently_reviewed_section"),
+                            ) {
+                                RecentlyReviewedSection(
+                                    reviews = state.recentReviews,
+                                    onGameSelected = onGameSelected,
                                 )
                             }
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -1,8 +1,11 @@
 package com.spela.player.presentation.viewmodel
 
+import com.spela.player.domain.model.ActiveNowItem
 import com.spela.player.domain.model.ArtworkItem
+import com.spela.player.domain.model.CommunityTopGame
 import com.spela.player.domain.model.ConsoleHighlight
 import com.spela.player.domain.model.ConsoleShowcase
+import com.spela.player.domain.model.CultClassicGame
 import com.spela.player.domain.model.DeveloperDetail
 import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.ExploreRow
@@ -12,9 +15,11 @@ import com.spela.player.domain.model.ForYouRow
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
+import com.spela.player.domain.model.RecentReviewItem
 import com.spela.player.domain.model.ScreenshotItem
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.Theme
+import com.spela.player.domain.model.TrendingGame
 import com.spela.player.domain.repository.ExploreRepository
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
@@ -23,6 +28,8 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -37,6 +44,11 @@ data class ExploreState(
     val developerSpotlight: DeveloperSpotlight? = null,
     val consoleHighlights: List<ConsoleHighlight> = emptyList(),
     val artworkShowcase: List<ArtworkItem> = emptyList(),
+    val trendingGames: List<TrendingGame> = emptyList(),
+    val communityTopGames: List<CommunityTopGame> = emptyList(),
+    val cultClassics: List<CultClassicGame> = emptyList(),
+    val recentReviews: List<RecentReviewItem> = emptyList(),
+    val activeNowGames: List<ActiveNowItem> = emptyList(),
     val isLoadingFeatured: Boolean = false,
     val isLoadingRows: Boolean = false,
     val isLoadingThemes: Boolean = false,
@@ -47,10 +59,11 @@ data class ExploreState(
     val isLoadingDeveloperSpotlight: Boolean = false,
     val isLoadingConsoleHighlights: Boolean = false,
     val isLoadingArtwork: Boolean = false,
+    val isLoadingSocial: Boolean = false,
     val error: String? = null,
 ) {
-    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods || isLoadingForYou || isLoadingDeveloperSpotlight || isLoadingConsoleHighlights || isLoadingArtwork
-    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && forYouRows.isEmpty() && developerSpotlight == null && consoleHighlights.isEmpty() && artworkShowcase.isEmpty() && !isLoading
+    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods || isLoadingForYou || isLoadingDeveloperSpotlight || isLoadingConsoleHighlights || isLoadingArtwork || isLoadingSocial
+    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && forYouRows.isEmpty() && developerSpotlight == null && consoleHighlights.isEmpty() && artworkShowcase.isEmpty() && trendingGames.isEmpty() && communityTopGames.isEmpty() && cultClassics.isEmpty() && recentReviews.isEmpty() && activeNowGames.isEmpty() && !isLoading
 }
 
 data class ThemeDetailState(
@@ -178,6 +191,7 @@ class ExploreViewModel(
     private var consoleHighlightsJob: Job? = null
     private var consoleShowcaseJob: Job? = null
     private var artworkShowcaseJob: Job? = null
+    private var socialJob: Job? = null
     private var screenshotGalleryJob: Job? = null
 
     fun load() {
@@ -191,6 +205,7 @@ class ExploreViewModel(
         loadDeveloperSpotlight()
         loadConsoleHighlights()
         loadArtworkShowcase()
+        loadSocialData()
     }
 
     fun dismissError() {
@@ -511,6 +526,32 @@ class ExploreViewModel(
                     _state.update { it.copy(isLoadingArtwork = false, error = error.message) }
                 },
             )
+        }
+    }
+
+    private fun loadSocialData() {
+        if (socialJob?.isActive == true) return
+        _state.update { it.copy(isLoadingSocial = true) }
+        socialJob = scope.launch(dispatchers.io) {
+            // Load all social endpoints concurrently
+            val trendingDeferred = async { exploreRepository.getTrending() }
+            val communityTopDeferred = async { exploreRepository.getCommunityTop() }
+            val cultClassicsDeferred = async { exploreRepository.getCultClassics() }
+            val recentlyReviewedDeferred = async { exploreRepository.getRecentlyReviewed() }
+            val activeNowDeferred = async { exploreRepository.getActiveNow() }
+
+            awaitAll(trendingDeferred, communityTopDeferred, cultClassicsDeferred, recentlyReviewedDeferred, activeNowDeferred)
+
+            _state.update { current ->
+                current.copy(
+                    trendingGames = trendingDeferred.await().getOrDefault(emptyList()),
+                    communityTopGames = communityTopDeferred.await().getOrDefault(emptyList()),
+                    cultClassics = cultClassicsDeferred.await().getOrDefault(emptyList()),
+                    recentReviews = recentlyReviewedDeferred.await().getOrDefault(emptyList()),
+                    activeNowGames = activeNowDeferred.await().getOrDefault(emptyList()),
+                    isLoadingSocial = false,
+                )
+            }
         }
     }
 

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -2456,3 +2456,463 @@ func (h *ExploreHandler) GetCoverGallery(c *gin.Context) {
 	})
 }
 
+// --- Phase 10: Social & Community Discovery ---
+
+// TrendingGameResponse is one game in the trending shelf, with player count this week.
+type TrendingGameResponse struct {
+	Game         GameResponse `json:"game"`
+	PlayersThisWeek int      `json:"playersThisWeek"`
+}
+
+// TrendingResponse is the API response for the trending endpoint.
+type TrendingResponse struct {
+	Games []TrendingGameResponse `json:"games"`
+}
+
+// CommunityTopGame is one game in the community-top shelf.
+type CommunityTopGame struct {
+	Game       GameResponse `json:"game"`
+	AvgRating  float64      `json:"avgRating"`
+	RatingCount int         `json:"ratingCount"`
+}
+
+// CommunityTopResponse is the API response for the community-top endpoint.
+type CommunityTopResponse struct {
+	Games []CommunityTopGame `json:"games"`
+}
+
+// CultClassicGame is one game in the cult classics shelf.
+type CultClassicGame struct {
+	Game            GameResponse `json:"game"`
+	CommunityRating float64     `json:"communityRating"`
+	IgdbRating      float64     `json:"igdbRating"`
+	RatingCount     int         `json:"ratingCount"`
+}
+
+// CultClassicsResponse is the API response for the cult-classics endpoint.
+type CultClassicsResponse struct {
+	Games []CultClassicGame `json:"games"`
+}
+
+// RecentReviewItem is one review in the recently-reviewed shelf.
+type RecentReviewItem struct {
+	Game       GameResponse `json:"game"`
+	Rating     int          `json:"rating"`
+	Review     string       `json:"review"`
+	ReviewerName string    `json:"reviewerName"`
+	ReviewedAt time.Time    `json:"reviewedAt"`
+}
+
+// RecentlyReviewedResponse is the API response for the recently-reviewed endpoint.
+type RecentlyReviewedResponse struct {
+	Reviews []RecentReviewItem `json:"reviews"`
+}
+
+// ActiveNowItem is one active game in the active-now shelf.
+type ActiveNowItem struct {
+	Game             GameResponse `json:"game"`
+	ActiveSessions   int          `json:"activeSessions"`
+	ActiveChallenges int          `json:"activeChallenges"`
+}
+
+// ActiveNowResponse is the API response for the active-now endpoint.
+type ActiveNowResponse struct {
+	Games []ActiveNowItem `json:"games"`
+}
+
+// GetTrending returns games with the most distinct players in the last 7 days.
+// GET /api/explore/trending
+func (h *ExploreHandler) GetTrending(c *gin.Context) {
+	userID := getUserID(c)
+	cutoff := time.Now().AddDate(0, 0, -7)
+
+	type trendingRow struct {
+		GameID          uint
+		PlayersThisWeek int
+	}
+	var rows []trendingRow
+	if err := h.DB.
+		Table("play_histories").
+		Select("game_id, COUNT(DISTINCT user_id) as players_this_week").
+		Where("last_played >= ? AND play_time > 0 AND deleted_at IS NULL", cutoff).
+		Group("game_id").
+		Having("players_this_week >= 1").
+		Order("players_this_week DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch trending games", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch trending games"})
+		return
+	}
+
+	if len(rows) == 0 {
+		c.JSON(http.StatusOK, TrendingResponse{Games: []TrendingGameResponse{}})
+		return
+	}
+
+	gameIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load trending games", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load trending games"})
+		return
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	// Build player-count map for quick lookup
+	playerCountMap := make(map[uint]int, len(rows))
+	for _, r := range rows {
+		playerCountMap[r.GameID] = r.PlayersThisWeek
+	}
+
+	// Batch load user game data
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]TrendingGameResponse, 0, len(rows))
+	for _, r := range rows {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		result = append(result, TrendingGameResponse{
+			Game:            toGameResponseWithData(g, &userData),
+			PlayersThisWeek: r.PlayersThisWeek,
+		})
+	}
+
+	c.JSON(http.StatusOK, TrendingResponse{Games: result})
+}
+
+// GetCommunityTop returns games with the highest average user ratings on this server.
+// Requires at least 2 ratings per game. Uses community ratings, not IGDB ratings.
+// GET /api/explore/community-top
+func (h *ExploreHandler) GetCommunityTop(c *gin.Context) {
+	userID := getUserID(c)
+
+	type communityRow struct {
+		GameID      uint
+		AvgRating   float64
+		RatingCount int
+	}
+	var rows []communityRow
+	if err := h.DB.
+		Table("game_ratings").
+		Select("game_id, AVG(rating) as avg_rating, COUNT(*) as rating_count").
+		Where("deleted_at IS NULL").
+		Group("game_id").
+		Having("rating_count >= 2").
+		Order("avg_rating DESC, rating_count DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch community top", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch community top games"})
+		return
+	}
+
+	if len(rows) == 0 {
+		c.JSON(http.StatusOK, CommunityTopResponse{Games: []CommunityTopGame{}})
+		return
+	}
+
+	gameIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load community top games", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load community top games"})
+		return
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	// Build lookup maps
+	ratingMap := make(map[uint]communityRow, len(rows))
+	for _, r := range rows {
+		ratingMap[r.GameID] = r
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]CommunityTopGame, 0, len(rows))
+	for _, r := range rows {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		result = append(result, CommunityTopGame{
+			Game:        toGameResponseWithData(g, &userData),
+			AvgRating:   math.Round(r.AvgRating*100) / 100,
+			RatingCount: r.RatingCount,
+		})
+	}
+
+	c.JSON(http.StatusOK, CommunityTopResponse{Games: result})
+}
+
+// GetCultClassics returns games with high community ratings but moderate IGDB ratings.
+// "Your community rates these higher than the critics."
+// Criteria: avg community rating >= 4.0 (out of 5), IGDB rating < 75, at least 2 ratings.
+// GET /api/explore/cult-classics
+func (h *ExploreHandler) GetCultClassics(c *gin.Context) {
+	userID := getUserID(c)
+
+	type cultRow struct {
+		GameID          uint
+		CommunityRating float64
+		RatingCount     int
+	}
+	var rows []cultRow
+	if err := h.DB.
+		Table("game_ratings").
+		Select("game_ratings.game_id, AVG(game_ratings.rating) as community_rating, COUNT(*) as rating_count").
+		Joins("JOIN games ON games.id = game_ratings.game_id AND games.deleted_at IS NULL").
+		Where("game_ratings.deleted_at IS NULL AND games.rating < 75").
+		Group("game_ratings.game_id").
+		Having("rating_count >= 2 AND community_rating >= 4.0").
+		Order("community_rating DESC, rating_count DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch cult classics", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch cult classics"})
+		return
+	}
+
+	if len(rows) == 0 {
+		c.JSON(http.StatusOK, CultClassicsResponse{Games: []CultClassicGame{}})
+		return
+	}
+
+	gameIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load cult classic games", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load cult classic games"})
+		return
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]CultClassicGame, 0, len(rows))
+	for _, r := range rows {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		result = append(result, CultClassicGame{
+			Game:            toGameResponseWithData(g, &userData),
+			CommunityRating: math.Round(r.CommunityRating*100) / 100,
+			IgdbRating:      g.Rating,
+			RatingCount:     r.RatingCount,
+		})
+	}
+
+	c.JSON(http.StatusOK, CultClassicsResponse{Games: result})
+}
+
+// GetRecentlyReviewed returns games with recent user reviews (non-empty review text).
+// GET /api/explore/recently-reviewed
+func (h *ExploreHandler) GetRecentlyReviewed(c *gin.Context) {
+	userID := getUserID(c)
+
+	type reviewRow struct {
+		GameID       uint
+		Rating       int
+		Review       string
+		ReviewerName string
+		CreatedAt    time.Time
+	}
+	var rows []reviewRow
+	if err := h.DB.
+		Table("game_ratings").
+		Select("game_ratings.game_id, game_ratings.rating, game_ratings.review, users.username as reviewer_name, game_ratings.created_at").
+		Joins("JOIN users ON users.id = game_ratings.user_id AND users.deleted_at IS NULL").
+		Where("game_ratings.deleted_at IS NULL AND game_ratings.review != ''").
+		Order("game_ratings.created_at DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch recently reviewed", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch recently reviewed"})
+		return
+	}
+
+	if len(rows) == 0 {
+		c.JSON(http.StatusOK, RecentlyReviewedResponse{Reviews: []RecentReviewItem{}})
+		return
+	}
+
+	// Collect unique game IDs
+	gameIDSet := make(map[uint]bool, len(rows))
+	for _, r := range rows {
+		gameIDSet[r.GameID] = true
+	}
+	gameIDs := make([]uint, 0, len(gameIDSet))
+	for id := range gameIDSet {
+		gameIDs = append(gameIDs, id)
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load reviewed games", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load reviewed games"})
+		return
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]RecentReviewItem, 0, len(rows))
+	for _, r := range rows {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		result = append(result, RecentReviewItem{
+			Game:         toGameResponseWithData(g, &userData),
+			Rating:       r.Rating,
+			Review:       r.Review,
+			ReviewerName: r.ReviewerName,
+			ReviewedAt:   r.CreatedAt,
+		})
+	}
+
+	c.JSON(http.StatusOK, RecentlyReviewedResponse{Reviews: result})
+}
+
+// GetActiveNow returns games with currently active shared sessions or challenges.
+// GET /api/explore/active-now
+func (h *ExploreHandler) GetActiveNow(c *gin.Context) {
+	userID := getUserID(c)
+
+	// Count active shared sessions per game
+	type sessionRow struct {
+		GameID       uint
+		SessionCount int
+	}
+	var sessionRows []sessionRow
+	if err := h.DB.
+		Table("shared_sessions").
+		Select("game_id, COUNT(*) as session_count").
+		Where("status = 'active' AND deleted_at IS NULL").
+		Group("game_id").
+		Scan(&sessionRows).Error; err != nil {
+		slog.Error("failed to fetch active sessions", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch active games"})
+		return
+	}
+
+	// Count active challenges per game
+	type challengeRow struct {
+		GameID         uint
+		ChallengeCount int
+	}
+	var challengeRows []challengeRow
+	if err := h.DB.
+		Table("challenges").
+		Select("game_id, COUNT(*) as challenge_count").
+		Where("status = 'active' AND deleted_at IS NULL").
+		Group("game_id").
+		Scan(&challengeRows).Error; err != nil {
+		slog.Error("failed to fetch active challenges", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch active games"})
+		return
+	}
+
+	// Merge into a combined map
+	type activeInfo struct {
+		sessions   int
+		challenges int
+	}
+	activeMap := make(map[uint]*activeInfo)
+	for _, r := range sessionRows {
+		activeMap[r.GameID] = &activeInfo{sessions: r.SessionCount}
+	}
+	for _, r := range challengeRows {
+		if info, ok := activeMap[r.GameID]; ok {
+			info.challenges = r.ChallengeCount
+		} else {
+			activeMap[r.GameID] = &activeInfo{challenges: r.ChallengeCount}
+		}
+	}
+
+	if len(activeMap) == 0 {
+		c.JSON(http.StatusOK, ActiveNowResponse{Games: []ActiveNowItem{}})
+		return
+	}
+
+	gameIDs := make([]uint, 0, len(activeMap))
+	for id := range activeMap {
+		gameIDs = append(gameIDs, id)
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load active games", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load active games"})
+		return
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	// Sort by total activity descending
+	type sortItem struct {
+		game  db.Game
+		info  *activeInfo
+		total int
+	}
+	sorted := make([]sortItem, 0, len(games))
+	for _, g := range games {
+		info := activeMap[g.ID]
+		sorted = append(sorted, sortItem{
+			game:  g,
+			info:  info,
+			total: info.sessions + info.challenges,
+		})
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].total > sorted[j].total
+	})
+
+	// Limit to 20
+	if len(sorted) > 20 {
+		sorted = sorted[:20]
+	}
+
+	result := make([]ActiveNowItem, 0, len(sorted))
+	for _, s := range sorted {
+		result = append(result, ActiveNowItem{
+			Game:             toGameResponseWithData(s.game, &userData),
+			ActiveSessions:   s.info.sessions,
+			ActiveChallenges: s.info.challenges,
+		})
+	}
+
+	c.JSON(http.StatusOK, ActiveNowResponse{Games: result})
+}
+

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -2729,3 +2729,277 @@ func TestGetCoverGallery_Pagination(t *testing.T) {
 	// Page 2 should have different games than page 1
 	assert.NotEqual(t, resp1.Covers[0].GameID, resp2.Covers[0].GameID)
 }
+
+// --- Phase 10: Social & Community Discovery tests ---
+
+func TestGetTrending_Empty(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/trending", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp TrendingResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Games)
+}
+
+func TestGetTrending_ReturnsGamesByPlayerCount(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "SNES", "Trending Game 1", 85.0)
+	game2 := createExploreGame(t, env.database, "NES", "Trending Game 2", 75.0)
+
+	var user1 db.User
+	require.NoError(t, env.database.First(&user1).Error)
+
+	user2Token := createNonOwnerUser(t, env.router, env.token, "trending_player", "trending@example.com", "password123")
+	_ = user2Token
+	var user2 db.User
+	require.NoError(t, env.database.Where("username = ?", "trending_player").First(&user2).Error)
+
+	// game1: played by 2 users this week
+	env.database.Create(&db.PlayHistory{UserID: user1.ID, GameID: game1.ID, PlayTime: 100, LastPlayed: time.Now()})
+	env.database.Create(&db.PlayHistory{UserID: user2.ID, GameID: game1.ID, PlayTime: 200, LastPlayed: time.Now()})
+	// game2: played by 1 user this week
+	env.database.Create(&db.PlayHistory{UserID: user1.ID, GameID: game2.ID, PlayTime: 300, LastPlayed: time.Now()})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/trending", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp TrendingResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Games, 2)
+	// game1 (2 players) should come first
+	assert.Equal(t, "Trending Game 1", resp.Games[0].Game.Title)
+	assert.Equal(t, 2, resp.Games[0].PlayersThisWeek)
+	assert.Equal(t, "Trending Game 2", resp.Games[1].Game.Title)
+	assert.Equal(t, 1, resp.Games[1].PlayersThisWeek)
+}
+
+func TestGetTrending_ExcludesOldActivity(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game := createExploreGame(t, env.database, "SNES", "Old Game", 90.0)
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Play history from 10 days ago — should NOT appear in trending
+	env.database.Create(&db.PlayHistory{UserID: user.ID, GameID: game.ID, PlayTime: 500, LastPlayed: time.Now().AddDate(0, 0, -10)})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/trending", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp TrendingResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Games)
+}
+
+func TestGetCommunityTop_Empty(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/community-top", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp CommunityTopResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Games)
+}
+
+func TestGetCommunityTop_RequiresMinRatings(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game := createExploreGame(t, env.database, "SNES", "One Rating Game", 80.0)
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Only 1 rating — should not appear (minimum is 2)
+	env.database.Create(&db.GameRating{UserID: user.ID, GameID: game.ID, Rating: 5})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/community-top", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp CommunityTopResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Games)
+}
+
+func TestGetCommunityTop_ReturnsRankedGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "SNES", "Community Best", 60.0)
+	game2 := createExploreGame(t, env.database, "NES", "Community Good", 90.0)
+
+	var user1 db.User
+	require.NoError(t, env.database.First(&user1).Error)
+	user2Token := createNonOwnerUser(t, env.router, env.token, "rater2", "rater2@example.com", "password123")
+	_ = user2Token
+	var user2 db.User
+	require.NoError(t, env.database.Where("username = ?", "rater2").First(&user2).Error)
+
+	// game1: avg 5.0
+	env.database.Create(&db.GameRating{UserID: user1.ID, GameID: game1.ID, Rating: 5})
+	env.database.Create(&db.GameRating{UserID: user2.ID, GameID: game1.ID, Rating: 5})
+	// game2: avg 3.5
+	env.database.Create(&db.GameRating{UserID: user1.ID, GameID: game2.ID, Rating: 4})
+	env.database.Create(&db.GameRating{UserID: user2.ID, GameID: game2.ID, Rating: 3})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/community-top", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp CommunityTopResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Games, 2)
+	assert.Equal(t, "Community Best", resp.Games[0].Game.Title)
+	assert.Equal(t, 5.0, resp.Games[0].AvgRating)
+	assert.Equal(t, 2, resp.Games[0].RatingCount)
+}
+
+func TestGetCultClassics_ReturnsHighCommunityLowIGDB(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Cult classic: high community rating but low IGDB
+	cult := createExploreGame(t, env.database, "SNES", "Cult Classic", 50.0)
+	// Not a cult classic: high IGDB rating too
+	nonCult := createExploreGame(t, env.database, "NES", "Mainstream Hit", 90.0)
+
+	var user1 db.User
+	require.NoError(t, env.database.First(&user1).Error)
+	user2Token := createNonOwnerUser(t, env.router, env.token, "cult_rater", "cult@example.com", "password123")
+	_ = user2Token
+	var user2 db.User
+	require.NoError(t, env.database.Where("username = ?", "cult_rater").First(&user2).Error)
+
+	// Both get high community ratings
+	env.database.Create(&db.GameRating{UserID: user1.ID, GameID: cult.ID, Rating: 5})
+	env.database.Create(&db.GameRating{UserID: user2.ID, GameID: cult.ID, Rating: 4})
+	env.database.Create(&db.GameRating{UserID: user1.ID, GameID: nonCult.ID, Rating: 5})
+	env.database.Create(&db.GameRating{UserID: user2.ID, GameID: nonCult.ID, Rating: 5})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/cult-classics", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp CultClassicsResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	// Only the cult classic (IGDB < 75) should appear
+	require.Len(t, resp.Games, 1)
+	assert.Equal(t, "Cult Classic", resp.Games[0].Game.Title)
+	assert.GreaterOrEqual(t, resp.Games[0].CommunityRating, 4.0)
+	assert.Less(t, resp.Games[0].IgdbRating, 75.0)
+}
+
+func TestGetRecentlyReviewed_Empty(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/recently-reviewed", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp RecentlyReviewedResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Reviews)
+}
+
+func TestGetRecentlyReviewed_ReturnsReviewsWithText(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game := createExploreGame(t, env.database, "SNES", "Reviewed Game", 85.0)
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Rating with review text — should appear
+	env.database.Create(&db.GameRating{UserID: user.ID, GameID: game.ID, Rating: 4, Review: "Great classic RPG!"})
+	// Rating without review text — should NOT appear
+	game2 := createExploreGame(t, env.database, "NES", "No Review Game", 70.0)
+	user2Token := createNonOwnerUser(t, env.router, env.token, "reviewer2", "reviewer2@example.com", "password123")
+	_ = user2Token
+	var user2 db.User
+	require.NoError(t, env.database.Where("username = ?", "reviewer2").First(&user2).Error)
+	env.database.Create(&db.GameRating{UserID: user2.ID, GameID: game2.ID, Rating: 3})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/recently-reviewed", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp RecentlyReviewedResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Reviews, 1)
+	assert.Equal(t, "Reviewed Game", resp.Reviews[0].Game.Title)
+	assert.Equal(t, 4, resp.Reviews[0].Rating)
+	assert.Equal(t, "Great classic RPG!", resp.Reviews[0].Review)
+}
+
+func TestGetActiveNow_Empty(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/active-now", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp ActiveNowResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Games)
+}
+
+func TestGetActiveNow_ReturnsMergedSessions(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game := createExploreGame(t, env.database, "SNES", "Active Game", 88.0)
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Create active shared session
+	env.database.Create(&db.SharedSession{
+		OwnerID: user.ID,
+		GameID:  game.ID,
+		Name:    "Test Session",
+		Status:  "active",
+	})
+	// Create active challenge
+	env.database.Create(&db.Challenge{
+		CreatorID:    user.ID,
+		GameID:       game.ID,
+		Name:         "Speed Run",
+		Status:       "active",
+		SaveFilePath: "/tmp/test.sav",
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/active-now", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp ActiveNowResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Games, 1)
+	assert.Equal(t, "Active Game", resp.Games[0].Game.Title)
+	assert.Equal(t, 1, resp.Games[0].ActiveSessions)
+	assert.Equal(t, 1, resp.Games[0].ActiveChallenges)
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -254,6 +254,11 @@ func NewRouter(cfg Config) *gin.Engine {
 			explore.GET("/screenshots", exploreHandler.GetScreenshotGallery)
 			explore.GET("/artwork", exploreHandler.GetArtworkGallery)
 			explore.GET("/covers", exploreHandler.GetCoverGallery)
+			explore.GET("/trending", exploreHandler.GetTrending)
+			explore.GET("/community-top", exploreHandler.GetCommunityTop)
+			explore.GET("/cult-classics", exploreHandler.GetCultClassics)
+			explore.GET("/recently-reviewed", exploreHandler.GetRecentlyReviewed)
+			explore.GET("/active-now", exploreHandler.GetActiveNow)
 		}
 
 		// Games

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -18,6 +18,11 @@ vi.mock("@/hooks/use-explore", () => ({
   useDeveloperSpotlight: vi.fn(),
   useConsoleHighlights: vi.fn(),
   useArtworkGallery: vi.fn(),
+  useTrending: vi.fn(),
+  useCommunityTop: vi.fn(),
+  useCultClassics: vi.fn(),
+  useRecentlyReviewed: vi.fn(),
+  useActiveNow: vi.fn(),
   useSurpriseGame: vi.fn(() => ({
     data: undefined,
     refetch: vi.fn(),
@@ -41,7 +46,7 @@ vi.mock("@/hooks/use-auto-scrape", () => ({
   useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
 }));
 
-import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods, useForYou, usePlayersLikeYou, useDeveloperSpotlight, useConsoleHighlights, useArtworkGallery } from "@/hooks/use-explore";
+import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods, useForYou, usePlayersLikeYou, useDeveloperSpotlight, useConsoleHighlights, useArtworkGallery, useTrending, useCommunityTop, useCultClassics, useRecentlyReviewed, useActiveNow } from "@/hooks/use-explore";
 
 const mockUseExploreFeatured = useExploreFeatured as ReturnType<typeof vi.fn>;
 const mockUseExploreRows = useExploreRows as ReturnType<typeof vi.fn>;
@@ -54,6 +59,11 @@ const mockUsePlayersLikeYou = usePlayersLikeYou as ReturnType<typeof vi.fn>;
 const mockUseDeveloperSpotlight = useDeveloperSpotlight as ReturnType<typeof vi.fn>;
 const mockUseConsoleHighlights = useConsoleHighlights as ReturnType<typeof vi.fn>;
 const mockUseArtworkGallery = useArtworkGallery as ReturnType<typeof vi.fn>;
+const mockUseTrending = useTrending as ReturnType<typeof vi.fn>;
+const mockUseCommunityTop = useCommunityTop as ReturnType<typeof vi.fn>;
+const mockUseCultClassics = useCultClassics as ReturnType<typeof vi.fn>;
+const mockUseRecentlyReviewed = useRecentlyReviewed as ReturnType<typeof vi.fn>;
+const mockUseActiveNow = useActiveNow as ReturnType<typeof vi.fn>;
 
 function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
   return {
@@ -246,6 +256,26 @@ describe("ExplorePage", () => {
     });
     mockUseArtworkGallery.mockReturnValue({
       data: { artworks: [], page: 1, totalPages: 0, totalCount: 0 },
+      isLoading: false,
+    });
+    mockUseTrending.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    mockUseCommunityTop.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    mockUseCultClassics.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    mockUseRecentlyReviewed.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    mockUseActiveNow.mockReturnValue({
+      data: undefined,
       isLoading: false,
     });
   });

--- a/web/src/features/explore/components/__tests__/social-shelves.test.tsx
+++ b/web/src/features/explore/components/__tests__/social-shelves.test.tsx
@@ -1,0 +1,314 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import {
+  TrendingShelf,
+  CommunityTopShelf,
+  CultClassicsShelf,
+  RecentlyReviewedShelf,
+  ActiveNowShelf,
+} from "../social-shelves";
+import type {
+  Game,
+  TrendingGame,
+  CommunityTopGame,
+  CultClassicGame,
+  RecentReviewItem,
+  ActiveNowItem,
+} from "@/types/api";
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// --- Trending Shelf ---
+
+describe("TrendingShelf", () => {
+  function renderTrending(props: {
+    games?: TrendingGame[];
+    isLoading?: boolean;
+  }) {
+    return render(
+      <MemoryRouter>
+        <TrendingShelf
+          games={props.games}
+          isLoading={props.isLoading ?? false}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders trending games with player counts", () => {
+    const games: TrendingGame[] = [
+      { game: makeGame({ id: "t1", title: "Super Metroid" }), playersThisWeek: 5 },
+      { game: makeGame({ id: "t2", title: "Castlevania" }), playersThisWeek: 3 },
+    ];
+    renderTrending({ games });
+
+    expect(screen.getByTestId("trending-shelf")).toBeInTheDocument();
+    expect(screen.getByText("Trending on Your Server")).toBeInTheDocument();
+    expect(screen.getByText("Super Metroid")).toBeInTheDocument();
+    expect(screen.getByText("Castlevania")).toBeInTheDocument();
+    const counts = screen.getAllByTestId("players-count");
+    expect(counts[0]).toHaveTextContent("5 players this week");
+    expect(counts[1]).toHaveTextContent("3 players this week");
+  });
+
+  it("uses singular form for 1 player", () => {
+    const games: TrendingGame[] = [
+      { game: makeGame({ id: "t1", title: "Solo" }), playersThisWeek: 1 },
+    ];
+    renderTrending({ games });
+
+    expect(screen.getByTestId("players-count")).toHaveTextContent("1 player this week");
+  });
+
+  it("shows skeleton when loading", () => {
+    renderTrending({ isLoading: true });
+    expect(screen.getByTestId("trending-shelf-skeleton")).toBeInTheDocument();
+  });
+
+  it("returns null when empty", () => {
+    const { container } = renderTrending({ games: [] });
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+// --- Community Top Shelf ---
+
+describe("CommunityTopShelf", () => {
+  function renderCommunityTop(props: {
+    games?: CommunityTopGame[];
+    isLoading?: boolean;
+  }) {
+    return render(
+      <MemoryRouter>
+        <CommunityTopShelf
+          games={props.games}
+          isLoading={props.isLoading ?? false}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders community favorites with ratings", () => {
+    const games: CommunityTopGame[] = [
+      { game: makeGame({ id: "c1", title: "A Link to the Past" }), avgRating: 4.8, ratingCount: 12 },
+    ];
+    renderCommunityTop({ games });
+
+    expect(screen.getByTestId("community-top-shelf")).toBeInTheDocument();
+    expect(screen.getByText("Community Favorites")).toBeInTheDocument();
+    expect(screen.getByText("A Link to the Past")).toBeInTheDocument();
+    expect(screen.getByTestId("community-rating")).toHaveTextContent("4.8/5");
+    expect(screen.getByText("(12 ratings)")).toBeInTheDocument();
+  });
+
+  it("uses singular for 1 rating", () => {
+    const games: CommunityTopGame[] = [
+      { game: makeGame({ id: "c1", title: "Game" }), avgRating: 5.0, ratingCount: 1 },
+    ];
+    renderCommunityTop({ games });
+    expect(screen.getByText("(1 rating)")).toBeInTheDocument();
+  });
+
+  it("shows skeleton when loading", () => {
+    renderCommunityTop({ isLoading: true });
+    expect(screen.getByTestId("community-top-shelf-skeleton")).toBeInTheDocument();
+  });
+
+  it("returns null when empty", () => {
+    const { container } = renderCommunityTop({ games: [] });
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+// --- Cult Classics Shelf ---
+
+describe("CultClassicsShelf", () => {
+  function renderCultClassics(props: {
+    games?: CultClassicGame[];
+    isLoading?: boolean;
+  }) {
+    return render(
+      <MemoryRouter>
+        <CultClassicsShelf
+          games={props.games}
+          isLoading={props.isLoading ?? false}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders cult classics with community vs IGDB ratings", () => {
+    const games: CultClassicGame[] = [
+      {
+        game: makeGame({ id: "cu1", title: "Hidden Treasure" }),
+        communityRating: 4.5,
+        igdbRating: 60,
+        ratingCount: 3,
+      },
+    ];
+    renderCultClassics({ games });
+
+    expect(screen.getByTestId("cult-classics-shelf")).toBeInTheDocument();
+    expect(screen.getByText("Cult Classics")).toBeInTheDocument();
+    expect(screen.getByText("Hidden Treasure")).toBeInTheDocument();
+    expect(screen.getByTestId("cult-community-rating")).toHaveTextContent("4.5/5");
+    expect(screen.getByText("vs IGDB 60/100")).toBeInTheDocument();
+  });
+
+  it("shows skeleton when loading", () => {
+    renderCultClassics({ isLoading: true });
+    expect(screen.getByTestId("cult-classics-shelf-skeleton")).toBeInTheDocument();
+  });
+
+  it("returns null when empty", () => {
+    const { container } = renderCultClassics({ games: [] });
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+// --- Recently Reviewed Shelf ---
+
+describe("RecentlyReviewedShelf", () => {
+  function renderRecentlyReviewed(props: {
+    reviews?: RecentReviewItem[];
+    isLoading?: boolean;
+  }) {
+    return render(
+      <MemoryRouter>
+        <RecentlyReviewedShelf
+          reviews={props.reviews}
+          isLoading={props.isLoading ?? false}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders reviews with text and reviewer name", () => {
+    const reviews: RecentReviewItem[] = [
+      {
+        game: makeGame({ id: "r1", title: "Final Fantasy" }),
+        rating: 5,
+        review: "Best RPG ever made!",
+        reviewerName: "playerone",
+        reviewedAt: "2025-03-01T10:00:00Z",
+      },
+    ];
+    renderRecentlyReviewed({ reviews });
+
+    expect(screen.getByTestId("recently-reviewed-shelf")).toBeInTheDocument();
+    expect(screen.getByText("Recently Reviewed")).toBeInTheDocument();
+    expect(screen.getAllByText("Final Fantasy").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByTestId("review-text")).toHaveTextContent("Best RPG ever made!");
+    expect(screen.getByText("— playerone")).toBeInTheDocument();
+  });
+
+  it("shows skeleton when loading", () => {
+    renderRecentlyReviewed({ isLoading: true });
+    expect(screen.getByTestId("recently-reviewed-shelf-skeleton")).toBeInTheDocument();
+  });
+
+  it("returns null when empty", () => {
+    const { container } = renderRecentlyReviewed({ reviews: [] });
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+// --- Active Now Shelf ---
+
+describe("ActiveNowShelf", () => {
+  function renderActiveNow(props: {
+    games?: ActiveNowItem[];
+    isLoading?: boolean;
+  }) {
+    return render(
+      <MemoryRouter>
+        <ActiveNowShelf
+          games={props.games}
+          isLoading={props.isLoading ?? false}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders active games with session and challenge counts", () => {
+    const games: ActiveNowItem[] = [
+      {
+        game: makeGame({ id: "a1", title: "Mario Kart" }),
+        activeSessions: 2,
+        activeChallenges: 1,
+      },
+    ];
+    renderActiveNow({ games });
+
+    expect(screen.getByTestId("active-now-shelf")).toBeInTheDocument();
+    expect(screen.getByText("Active Right Now")).toBeInTheDocument();
+    expect(screen.getByText("Mario Kart")).toBeInTheDocument();
+    expect(screen.getByText("2 sessions")).toBeInTheDocument();
+    expect(screen.getByText("1 challenge")).toBeInTheDocument();
+  });
+
+  it("uses singular for 1 session", () => {
+    const games: ActiveNowItem[] = [
+      {
+        game: makeGame({ id: "a1", title: "Tetris" }),
+        activeSessions: 1,
+        activeChallenges: 0,
+      },
+    ];
+    renderActiveNow({ games });
+    expect(screen.getByText("1 session")).toBeInTheDocument();
+    // No challenge badge should be rendered
+    expect(screen.queryByText(/\d+ challenge/)).not.toBeInTheDocument();
+  });
+
+  it("uses plural for multiple challenges", () => {
+    const games: ActiveNowItem[] = [
+      {
+        game: makeGame({ id: "a1", title: "Street Fighter" }),
+        activeSessions: 0,
+        activeChallenges: 3,
+      },
+    ];
+    renderActiveNow({ games });
+    // No session badge should be rendered
+    expect(screen.queryByText(/\d+ session/)).not.toBeInTheDocument();
+    expect(screen.getByText("3 challenges")).toBeInTheDocument();
+  });
+
+  it("shows skeleton when loading", () => {
+    renderActiveNow({ isLoading: true });
+    expect(screen.getByTestId("active-now-shelf-skeleton")).toBeInTheDocument();
+  });
+
+  it("returns null when empty", () => {
+    const { container } = renderActiveNow({ games: [] });
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/web/src/features/explore/components/social-shelves.tsx
+++ b/web/src/features/explore/components/social-shelves.tsx
@@ -1,0 +1,429 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import {
+  ChevronLeft,
+  ChevronRight,
+  TrendingUp,
+  Star,
+  Gem,
+  Radio,
+  MessageSquare,
+  Users,
+  Swords,
+} from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton, Badge, Skeleton } from "@/components/ui";
+import type {
+  Game,
+  TrendingGame,
+  CommunityTopGame,
+  CultClassicGame,
+  RecentReviewItem,
+  ActiveNowItem,
+} from "@/types/api";
+
+// --- Shared scroll shelf wrapper ---
+
+function ScrollShelf({
+  title,
+  subtitle,
+  icon: Icon,
+  testId,
+  isLoading,
+  isEmpty,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  icon: React.ElementType;
+  testId: string;
+  isLoading: boolean;
+  isEmpty: boolean;
+  children: React.ReactNode;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(
+      el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
+    );
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, children]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return (
+      <section data-testid={`${testId}-skeleton`}>
+        <div className="flex items-center gap-2 mb-1">
+          <Icon className="h-5 w-5 text-surface-400" />
+          <Skeleton className="h-7 w-60 rounded" />
+        </div>
+        {subtitle && (
+          <Skeleton className="h-4 w-40 rounded mt-1 mb-5" />
+        )}
+        <div className="flex gap-5 overflow-hidden mt-4">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+              <GameCardSkeleton />
+            </div>
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (isEmpty) return null;
+
+  return (
+    <section data-testid={testId} className="group/shelf relative">
+      <div className="flex items-center gap-2 mb-1">
+        <Icon className="h-5 w-5 text-brand-400" />
+        <h2 className="text-xl font-bold text-surface-100">{title}</h2>
+      </div>
+      {subtitle && (
+        <p className="text-sm text-surface-400 mb-4">{subtitle}</p>
+      )}
+
+      <div className="relative">
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+            aria-label={`Scroll ${title} left`}
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+            aria-label={`Scroll ${title} right`}
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        <div
+          ref={scrollRef}
+          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label={title}
+        >
+          {children}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// --- Trending Shelf ---
+
+interface TrendingShelfProps {
+  games: TrendingGame[] | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+export function TrendingShelf({
+  games,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: TrendingShelfProps) {
+  return (
+    <ScrollShelf
+      title="Trending on Your Server"
+      subtitle="Most played games this week"
+      icon={TrendingUp}
+      testId="trending-shelf"
+      isLoading={isLoading}
+      isEmpty={!games || games.length === 0}
+    >
+      {games?.map((item) => (
+        <div
+          key={item.game.id}
+          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          role="listitem"
+        >
+          <GameCard
+            game={item.game}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+          <div className="flex items-center gap-1 mt-1.5 text-xs text-surface-400">
+            <Users className="h-3 w-3" />
+            <span data-testid="players-count">
+              {item.playersThisWeek} player{item.playersThisWeek !== 1 ? "s" : ""} this week
+            </span>
+          </div>
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+
+// --- Community Top Shelf ---
+
+interface CommunityTopShelfProps {
+  games: CommunityTopGame[] | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+export function CommunityTopShelf({
+  games,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: CommunityTopShelfProps) {
+  return (
+    <ScrollShelf
+      title="Community Favorites"
+      subtitle="Highest rated by players on your server"
+      icon={Star}
+      testId="community-top-shelf"
+      isLoading={isLoading}
+      isEmpty={!games || games.length === 0}
+    >
+      {games?.map((item) => (
+        <div
+          key={item.game.id}
+          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          role="listitem"
+        >
+          <GameCard
+            game={item.game}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+          <div className="flex items-center gap-1.5 mt-1.5 text-xs text-surface-400">
+            <Star className="h-3 w-3 text-amber-400 fill-amber-400" />
+            <span data-testid="community-rating">
+              {item.avgRating.toFixed(1)}/5
+            </span>
+            <span className="text-surface-500">
+              ({item.ratingCount} rating{item.ratingCount !== 1 ? "s" : ""})
+            </span>
+          </div>
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+
+// --- Cult Classics Shelf ---
+
+interface CultClassicsShelfProps {
+  games: CultClassicGame[] | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+export function CultClassicsShelf({
+  games,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: CultClassicsShelfProps) {
+  return (
+    <ScrollShelf
+      title="Cult Classics"
+      subtitle="Your community rates these higher than the critics"
+      icon={Gem}
+      testId="cult-classics-shelf"
+      isLoading={isLoading}
+      isEmpty={!games || games.length === 0}
+    >
+      {games?.map((item) => (
+        <div
+          key={item.game.id}
+          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          role="listitem"
+        >
+          <GameCard
+            game={item.game}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+          <div className="flex items-center gap-1.5 mt-1.5 text-xs text-surface-400">
+            <Star className="h-3 w-3 text-amber-400 fill-amber-400" />
+            <span data-testid="cult-community-rating">
+              {item.communityRating.toFixed(1)}/5
+            </span>
+            <span className="text-surface-500">vs IGDB {item.igdbRating.toFixed(0)}/100</span>
+          </div>
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+
+// --- Recently Reviewed Shelf ---
+
+interface RecentlyReviewedShelfProps {
+  reviews: RecentReviewItem[] | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+export function RecentlyReviewedShelf({
+  reviews,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: RecentlyReviewedShelfProps) {
+  return (
+    <ScrollShelf
+      title="Recently Reviewed"
+      subtitle="Latest reviews from your community"
+      icon={MessageSquare}
+      testId="recently-reviewed-shelf"
+      isLoading={isLoading}
+      isEmpty={!reviews || reviews.length === 0}
+    >
+      {reviews?.map((item) => (
+        <div
+          key={`${item.game.id}-${item.reviewerName}`}
+          className="w-56 sm:w-60 flex-shrink-0"
+          role="listitem"
+        >
+          <div className="flex gap-3">
+            <div className="w-24 flex-shrink-0">
+              <GameCard
+                game={item.game}
+                showConsoleBadge={false}
+                onToggleFavorite={onToggleFavorite}
+                onTogglePlayLater={onTogglePlayLater}
+              />
+            </div>
+            <div className="flex flex-col min-w-0 py-0.5">
+              <Link
+                to={`/games/${item.game.id}`}
+                className="text-sm font-semibold text-surface-100 truncate hover:text-brand-400 transition-colors"
+              >
+                {item.game.title}
+              </Link>
+              <div className="flex items-center gap-1 mt-0.5">
+                {Array.from({ length: 5 }, (_, si) => (
+                  <Star
+                    key={si}
+                    className={`h-3 w-3 ${
+                      si < item.rating
+                        ? "text-amber-400 fill-amber-400"
+                        : "text-surface-600"
+                    }`}
+                  />
+                ))}
+              </div>
+              <p
+                className="text-xs text-surface-400 mt-1 line-clamp-3"
+                data-testid="review-text"
+              >
+                {item.review}
+              </p>
+              <p className="text-xs text-surface-500 mt-auto">
+                — {item.reviewerName}
+              </p>
+            </div>
+          </div>
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+
+// --- Active Now Shelf ---
+
+interface ActiveNowShelfProps {
+  games: ActiveNowItem[] | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+export function ActiveNowShelf({
+  games,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: ActiveNowShelfProps) {
+  return (
+    <ScrollShelf
+      title="Active Right Now"
+      subtitle="Games with live sessions and challenges"
+      icon={Radio}
+      testId="active-now-shelf"
+      isLoading={isLoading}
+      isEmpty={!games || games.length === 0}
+    >
+      {games?.map((item) => (
+        <div
+          key={item.game.id}
+          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          role="listitem"
+        >
+          <GameCard
+            game={item.game}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+          <div className="flex flex-wrap gap-1.5 mt-1.5">
+            {item.activeSessions > 0 && (
+              <Badge
+                variant="default"
+                className="text-[10px] px-1.5 py-0 gap-1 bg-green-500/15 text-green-400 border-green-500/30"
+              >
+                <Users className="h-2.5 w-2.5" />
+                {item.activeSessions} session{item.activeSessions !== 1 ? "s" : ""}
+              </Badge>
+            )}
+            {item.activeChallenges > 0 && (
+              <Badge
+                variant="default"
+                className="text-[10px] px-1.5 py-0 gap-1 bg-orange-500/15 text-orange-400 border-orange-500/30"
+              >
+                <Swords className="h-2.5 w-2.5" />
+                {item.activeChallenges} challenge{item.activeChallenges !== 1 ? "s" : ""}
+              </Badge>
+            )}
+          </div>
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}

--- a/web/src/hooks/use-explore.ts
+++ b/web/src/hooks/use-explore.ts
@@ -24,6 +24,11 @@ import type {
   ScreenshotGalleryResponse,
   ArtworkGalleryResponse,
   CoverGalleryResponse,
+  TrendingResponse,
+  CommunityTopResponse,
+  CultClassicsResponse,
+  RecentlyReviewedResponse,
+  ActiveNowResponse,
 } from "@/types/api";
 
 export function useExploreFeatured() {
@@ -248,5 +253,41 @@ export function useCoverGallery(page: number, consoleFilter?: string) {
     queryKey: ["cover-gallery", page, consoleFilter],
     queryFn: () =>
       api.get<CoverGalleryResponse>(`/explore/covers?${params}`),
+  });
+}
+
+export function useTrending() {
+  return useQuery({
+    queryKey: ["explore", "trending"],
+    queryFn: () => api.get<TrendingResponse>("/explore/trending"),
+  });
+}
+
+export function useCommunityTop() {
+  return useQuery({
+    queryKey: ["explore", "community-top"],
+    queryFn: () => api.get<CommunityTopResponse>("/explore/community-top"),
+  });
+}
+
+export function useCultClassics() {
+  return useQuery({
+    queryKey: ["explore", "cult-classics"],
+    queryFn: () => api.get<CultClassicsResponse>("/explore/cult-classics"),
+  });
+}
+
+export function useRecentlyReviewed() {
+  return useQuery({
+    queryKey: ["explore", "recently-reviewed"],
+    queryFn: () =>
+      api.get<RecentlyReviewedResponse>("/explore/recently-reviewed"),
+  });
+}
+
+export function useActiveNow() {
+  return useQuery({
+    queryKey: ["explore", "active-now"],
+    queryFn: () => api.get<ActiveNowResponse>("/explore/active-now"),
   });
 }

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -34,6 +34,13 @@ export type ApiGetPath = WithQuery<
   | `/explore/consoles/${string}/showcase`
   | "/explore/console-highlights"
 
+  // Social & Community Discovery
+  | "/explore/trending"
+  | "/explore/community-top"
+  | "/explore/cult-classics"
+  | "/explore/recently-reviewed"
+  | "/explore/active-now"
+
   // Developers & Publishers
   | "/explore/developers"
   | "/explore/developers/spotlight"

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -13,6 +13,13 @@ import { ForYouSection } from "@/features/explore/components/for-you-section";
 import { PlayersLikeYouShelf } from "@/features/explore/components/players-like-you-shelf";
 import { ConsoleQuickJump } from "@/features/explore/components/console-quick-jump";
 import {
+  TrendingShelf,
+  CommunityTopShelf,
+  CultClassicsShelf,
+  RecentlyReviewedShelf,
+  ActiveNowShelf,
+} from "@/features/explore/components/social-shelves";
+import {
   useExploreFeatured,
   useExploreRows,
   useThemes,
@@ -24,6 +31,11 @@ import {
   useDeveloperSpotlight,
   useConsoleHighlights,
   useArtworkGallery,
+  useTrending,
+  useCommunityTop,
+  useCultClassics,
+  useRecentlyReviewed,
+  useActiveNow,
 } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -75,6 +87,26 @@ export function ExplorePage() {
     data: artworkData,
     isLoading: isArtworkLoading,
   } = useArtworkGallery(1);
+  const {
+    data: trendingData,
+    isLoading: isTrendingLoading,
+  } = useTrending();
+  const {
+    data: communityTopData,
+    isLoading: isCommunityTopLoading,
+  } = useCommunityTop();
+  const {
+    data: cultClassicsData,
+    isLoading: isCultClassicsLoading,
+  } = useCultClassics();
+  const {
+    data: recentlyReviewedData,
+    isLoading: isRecentlyReviewedLoading,
+  } = useRecentlyReviewed();
+  const {
+    data: activeNowData,
+    isLoading: isActiveNowLoading,
+  } = useActiveNow();
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
 
@@ -153,6 +185,46 @@ export function ExplorePage() {
         games={playersLikeYouData?.games}
         isLoading={isPlayersLoading}
         similarUsersCount={playersLikeYouData?.similarUsersCount ?? 0}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
+
+      {/* Trending */}
+      <TrendingShelf
+        games={trendingData?.games}
+        isLoading={isTrendingLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
+
+      {/* Community Favorites */}
+      <CommunityTopShelf
+        games={communityTopData?.games}
+        isLoading={isCommunityTopLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
+
+      {/* Cult Classics */}
+      <CultClassicsShelf
+        games={cultClassicsData?.games}
+        isLoading={isCultClassicsLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
+
+      {/* Active Right Now */}
+      <ActiveNowShelf
+        games={activeNowData?.games}
+        isLoading={isActiveNowLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
+
+      {/* Recently Reviewed */}
+      <RecentlyReviewedShelf
+        reviews={recentlyReviewedData?.reviews}
+        isLoading={isRecentlyReviewedLoading}
         onToggleFavorite={handleToggleFavorite}
         onTogglePlayLater={handleTogglePlayLater}
       />

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1099,3 +1099,57 @@ export interface StagedUpload {
   crc32: string;
   canonicalName: string;
 }
+
+// --- Phase 10: Social & Community Discovery ---
+
+export interface TrendingGame {
+  game: Game;
+  playersThisWeek: number;
+}
+
+export interface TrendingResponse {
+  games: TrendingGame[];
+}
+
+export interface CommunityTopGame {
+  game: Game;
+  avgRating: number;
+  ratingCount: number;
+}
+
+export interface CommunityTopResponse {
+  games: CommunityTopGame[];
+}
+
+export interface CultClassicGame {
+  game: Game;
+  communityRating: number;
+  igdbRating: number;
+  ratingCount: number;
+}
+
+export interface CultClassicsResponse {
+  games: CultClassicGame[];
+}
+
+export interface RecentReviewItem {
+  game: Game;
+  rating: number;
+  review: string;
+  reviewerName: string;
+  reviewedAt: string;
+}
+
+export interface RecentlyReviewedResponse {
+  reviews: RecentReviewItem[];
+}
+
+export interface ActiveNowItem {
+  game: Game;
+  activeSessions: number;
+  activeChallenges: number;
+}
+
+export interface ActiveNowResponse {
+  games: ActiveNowItem[];
+}


### PR DESCRIPTION
## Summary
- Add 5 new API endpoints for social discovery: `/explore/trending`, `/explore/community-top`, `/explore/cult-classics`, `/explore/recently-reviewed`, `/explore/active-now`
- Add web shelf components (TrendingShelf, CommunityTopShelf, CultClassicsShelf, RecentlyReviewedShelf, ActiveNowShelf) with scroll arrows, skeletons, and empty states
- Add player app Compose composables for all 5 social sections with proper accessibility semantics
- Trending: most played games this week (distinct players from play_histories)
- Community Top: highest-rated games (avg rating from game_ratings, min 2 ratings)
- Cult Classics: community favorites underrated by IGDB (community ≥4.0/5 vs IGDB <75/100)
- Recently Reviewed: latest reviews with text, star ratings, reviewer names
- Active Now: games with live shared sessions and challenges, merged per game

## Test plan
- [x] 12 new Go backend tests (trending, community-top, cult-classics, recently-reviewed, active-now — empty states, data, edge cases)
- [x] 19 new web component tests (all 5 shelves: rendering, loading, empty, singular/plural)
- [x] 6 new player desktop E2E tests (all 5 sections render, empty state hides sections)
- [x] Existing explore-page tests updated with mocks for 5 new hooks
- [x] Full test suites pass: Go (all), Web (1009), Player desktop (546)