### PR TITLE
feat: add Temporal Discovery to Explore page (Phase 11)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreTemporalTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreTemporalTest.kt
@@ -1,0 +1,104 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.AnniversaryItem
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+
+/**
+ * Desktop E2E tests for Phase 11: Temporal Discovery.
+ *
+ * Covers:
+ * - On This Day section renders with games
+ * - Anniversaries section renders
+ * - Empty temporal data hides sections
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ExploreTemporalTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun makeGame(id: String, title: String, releaseDate: String? = null): Game = Game(
+        id = id,
+        title = title,
+        consoleId = "snes",
+        consoleName = "Super Nintendo",
+        fileName = "$title.sfc",
+        fileSize = 1024,
+        discCount = 1,
+        description = "",
+        coverUrl = null,
+        developer = "",
+        publisher = "",
+        releaseDate = releaseDate,
+        genre = "Action",
+        players = 1,
+        rating = 80.0,
+        isFavorite = false,
+        isInPlayLater = false,
+        coverAspectRatio = 0.75f,
+    )
+
+    @Test
+    fun onThisDaySectionRendersWithGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.onThisDayDate = "March 10"
+        harness.exploreRepo.onThisDayGames = listOf(
+            makeGame("otd1", "Classic Alpha", releaseDate = "1994-03-10"),
+            makeGame("otd2", "Classic Beta", releaseDate = "2001-03-10"),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_on_this_day_section").assertExists()
+        onNodeWithTag("on_this_day_row").assertExists()
+        onNodeWithTag("on_this_day_year_otd1").assertExists()
+    }
+
+    @Test
+    fun anniversariesSectionRenders() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.anniversariesList = listOf(
+            AnniversaryItem(
+                game = makeGame("ann1", "Nostalgic RPG"),
+                yearsAgo = 3,
+                playedAt = "2023-03-10T14:00:00Z",
+            ),
+            AnniversaryItem(
+                game = makeGame("ann2", "Old Favorite"),
+                yearsAgo = 1,
+                playedAt = "2025-03-10T10:00:00Z",
+            ),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_anniversaries_section").assertExists()
+        onNodeWithTag("anniversaries_row").assertExists()
+        onNodeWithTag("anniversary_years_ann1").assertExists()
+    }
+
+    @Test
+    fun emptyTemporalDataHidesSections() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_on_this_day_section").assertDoesNotExist()
+        onNodeWithTag("explore_anniversaries_section").assertDoesNotExist()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1348,6 +1348,11 @@ class FakeExploreRepository : ExploreRepository {
     var cultClassicsList: List<CultClassicGame> = emptyList()
     var recentReviews: List<RecentReviewItem> = emptyList()
     var activeNowGames: List<ActiveNowItem> = emptyList()
+    var onThisDayDate: String = ""
+    var onThisDayGames: List<Game> = emptyList()
+    var bestOfYearGames: Map<Int, List<Game>> = emptyMap()
+    var anniversariesList: List<AnniversaryItem> = emptyList()
+    var decadeResults: Map<String, Pair<String, List<Game>>> = emptyMap()
     var shouldFail: Boolean = false
 
     override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> =
@@ -1497,6 +1502,26 @@ class FakeExploreRepository : ExploreRepository {
     override suspend fun getActiveNow(): Result<List<ActiveNowItem>> =
         if (shouldFail) Result.failure(Exception("Failed to load active now"))
         else Result.success(activeNowGames)
+
+    override suspend fun getOnThisDay(): Result<Pair<String, List<Game>>> =
+        if (shouldFail) Result.failure(Exception("Failed to load on this day"))
+        else Result.success(Pair(onThisDayDate, onThisDayGames))
+
+    override suspend fun getBestOfYear(year: Int): Result<List<Game>> =
+        if (shouldFail) Result.failure(Exception("Failed to load best of year"))
+        else Result.success(bestOfYearGames[year] ?: emptyList())
+
+    override suspend fun getYourAnniversaries(): Result<List<AnniversaryItem>> =
+        if (shouldFail) Result.failure(Exception("Failed to load anniversaries"))
+        else Result.success(anniversariesList)
+
+    override suspend fun getDecade(decade: String): Result<Pair<String, List<Game>>> =
+        if (shouldFail) Result.failure(Exception("Failed to load decade"))
+        else {
+            val result = decadeResults[decade]
+            if (result != null) Result.success(result)
+            else Result.success(Pair("", emptyList()))
+        }
 }
 
 class FakeCheatRepository : CheatRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -396,6 +396,26 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/explore/active-now").body()
     }
 
+    /** Returns games released on this day in history */
+    suspend fun getOnThisDay(): OnThisDayResponseDto {
+        return client.get("$baseUrl/api/explore/on-this-day").body()
+    }
+
+    /** Returns best games from a given year */
+    suspend fun getBestOfYear(year: Int): BestOfYearResponseDto {
+        return client.get("$baseUrl/api/explore/best-of-year/$year").body()
+    }
+
+    /** Returns personal play anniversaries */
+    suspend fun getYourAnniversaries(): YourAnniversariesResponseDto {
+        return client.get("$baseUrl/api/explore/your-anniversaries").body()
+    }
+
+    /** Returns games from a specific decade */
+    suspend fun getDecade(decade: String): DecadeResponseDto {
+        return client.get("$baseUrl/api/explore/decades/$decade").body()
+    }
+
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
     suspend fun getRecentGames(): List<GameDto> {
         return client.get("$baseUrl/api/user/recent").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -778,3 +778,11 @@ fun ActiveNowItemDto.toDomain(): ActiveNowItem = ActiveNowItem(
     activeSessions = activeSessions,
     activeChallenges = activeChallenges,
 )
+
+// --- Phase 11: Temporal Discovery ---
+
+fun AnniversaryItemDto.toDomain(): AnniversaryItem = AnniversaryItem(
+    game = game.toDomain(),
+    yearsAgo = yearsAgo,
+    playedAt = playedAt,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1336,3 +1336,36 @@ data class ActiveNowItemDto(
 data class ActiveNowResponseDto(
     val games: List<ActiveNowItemDto>,
 )
+
+// --- Phase 11: Temporal Discovery ---
+
+@Serializable
+data class OnThisDayResponseDto(
+    val date: String,
+    val games: List<GameDto>,
+)
+
+@Serializable
+data class BestOfYearResponseDto(
+    val year: Int,
+    val games: List<GameDto>,
+)
+
+@Serializable
+data class AnniversaryItemDto(
+    val game: GameDto,
+    val yearsAgo: Int,
+    val playedAt: String,
+)
+
+@Serializable
+data class YourAnniversariesResponseDto(
+    val anniversaries: List<AnniversaryItemDto>,
+)
+
+@Serializable
+data class DecadeResponseDto(
+    val decade: String,
+    val label: String,
+    val games: List<GameDto>,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.GameDto
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.ActiveNowItem
+import com.spela.player.domain.model.AnniversaryItem
 import com.spela.player.domain.model.ArtworkItem
 import com.spela.player.domain.model.CommunityTopGame
 import com.spela.player.domain.model.ConsoleHighlight
@@ -307,6 +308,36 @@ class ExploreRepositoryImpl(
                 game = resolveGameCovers(dto.game.toDomain(), dto.game),
             )
         }
+    }
+
+    override suspend fun getOnThisDay(): Result<Pair<String, List<Game>>> = runCatching {
+        val dto = apiClient.getOnThisDay()
+        val games = dto.games.map { gameDto ->
+            resolveGameCovers(gameDto.toDomain(), gameDto)
+        }
+        Pair(dto.date, games)
+    }
+
+    override suspend fun getBestOfYear(year: Int): Result<List<Game>> = runCatching {
+        apiClient.getBestOfYear(year).games.map { gameDto ->
+            resolveGameCovers(gameDto.toDomain(), gameDto)
+        }
+    }
+
+    override suspend fun getYourAnniversaries(): Result<List<AnniversaryItem>> = runCatching {
+        apiClient.getYourAnniversaries().anniversaries.map { dto ->
+            dto.toDomain().copy(
+                game = resolveGameCovers(dto.game.toDomain(), dto.game),
+            )
+        }
+    }
+
+    override suspend fun getDecade(decade: String): Result<Pair<String, List<Game>>> = runCatching {
+        val dto = apiClient.getDecade(decade)
+        val games = dto.games.map { gameDto ->
+            resolveGameCovers(gameDto.toDomain(), gameDto)
+        }
+        Pair(dto.label, games)
     }
 
     private fun resolveGameCovers(game: Game, dto: GameDto): Game = game.copy(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -226,3 +226,11 @@ data class ActiveNowItem(
     val activeSessions: Int,
     val activeChallenges: Int,
 )
+
+// --- Phase 11: Temporal Discovery ---
+
+data class AnniversaryItem(
+    val game: Game,
+    val yearsAgo: Int,
+    val playedAt: String,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -1,6 +1,7 @@
 package com.spela.player.domain.repository
 
 import com.spela.player.domain.model.ActiveNowItem
+import com.spela.player.domain.model.AnniversaryItem
 import com.spela.player.domain.model.ArtworkItem
 import com.spela.player.domain.model.CommunityTopGame
 import com.spela.player.domain.model.ConsoleHighlight
@@ -56,4 +57,8 @@ interface ExploreRepository {
     suspend fun getCultClassics(): Result<List<CultClassicGame>>
     suspend fun getRecentlyReviewed(): Result<List<RecentReviewItem>>
     suspend fun getActiveNow(): Result<List<ActiveNowItem>>
+    suspend fun getOnThisDay(): Result<Pair<String, List<Game>>>
+    suspend fun getBestOfYear(year: Int): Result<List<Game>>
+    suspend fun getYourAnniversaries(): Result<List<AnniversaryItem>>
+    suspend fun getDecade(decade: String): Result<Pair<String, List<Game>>>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/TemporalDiscoverySection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/TemporalDiscoverySection.kt
@@ -1,0 +1,131 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.AnniversaryItem
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.ui.components.SpShimmer
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+private val CardWidth = 140.dp
+
+@Composable
+fun OnThisDaySection(
+    games: List<Game>,
+    onGameSelected: (gameId: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("on_this_day_row"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(games, key = { it.id }) { game ->
+            Column(
+                modifier = Modifier
+                    .width(CardWidth)
+                    .semantics {
+                        val year = game.releaseDate?.take(4) ?: ""
+                        contentDescription = "${game.title}, released $year"
+                    },
+            ) {
+                ExploreGameCard(
+                    game = game,
+                    onClick = { onGameSelected(game.id) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(4.dp))
+                val year = game.releaseDate?.take(4) ?: ""
+                if (year.isNotEmpty()) {
+                    Text(
+                        text = "Released $year",
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.testTag("on_this_day_year_${game.id}"),
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun AnniversariesSection(
+    anniversaries: List<AnniversaryItem>,
+    onGameSelected: (gameId: String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyRow(
+        modifier = modifier.testTag("anniversaries_row"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(anniversaries, key = { "${it.game.id}_${it.yearsAgo}" }) { item ->
+            Column(
+                modifier = Modifier
+                    .width(CardWidth)
+                    .semantics {
+                        contentDescription = "${item.game.title}, ${item.yearsAgo} year${if (item.yearsAgo != 1) "s" else ""} ago"
+                    },
+            ) {
+                ExploreGameCard(
+                    game = item.game,
+                    onClick = { onGameSelected(item.game.id) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+                Spacer(Modifier.height(4.dp))
+                Text(
+                    text = "${item.yearsAgo} year${if (item.yearsAgo != 1) "s" else ""} ago",
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.testTag("anniversary_years_${item.game.id}"),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun TemporalSectionSkeleton(
+    modifier: Modifier = Modifier,
+    count: Int = 5,
+) {
+    LazyRow(
+        modifier = modifier.testTag("temporal_skeleton"),
+        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(count) {
+            SpShimmer(
+                modifier = Modifier
+                    .width(CardWidth)
+                    .clip(RoundedCornerShape(SpSpacing.CardCornerRadius)),
+                width = CardWidth,
+                height = (CardWidth.value * 1.33f).dp,
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -47,6 +47,9 @@ import com.spela.player.presentation.ui.feature.explore.SeriesShelfSkeleton
 import com.spela.player.presentation.ui.feature.explore.SocialSectionSkeleton
 import com.spela.player.presentation.ui.feature.explore.ThemeGrid
 import com.spela.player.presentation.ui.feature.explore.ThemeGridSkeleton
+import com.spela.player.presentation.ui.feature.explore.AnniversariesSection
+import com.spela.player.presentation.ui.feature.explore.OnThisDaySection
+import com.spela.player.presentation.ui.feature.explore.TemporalSectionSkeleton
 import com.spela.player.presentation.ui.feature.explore.TrendingSection
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -473,6 +476,63 @@ fun ExploreScreen(
                             ) {
                                 RecentlyReviewedSection(
                                     reviews = state.recentReviews,
+                                    onGameSelected = onGameSelected,
+                                )
+                            }
+                        }
+                    }
+
+                    // Temporal Discovery: On This Day
+                    item {
+                        if (state.isLoadingTemporal && state.onThisDayGames.isEmpty()) {
+                            SpTitledSection(
+                                title = "On This Day",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                TemporalSectionSkeleton()
+                            }
+                        } else if (state.onThisDayGames.isNotEmpty()) {
+                            val title = if (state.onThisDayDate.isNotEmpty()) {
+                                "On This Day (${state.onThisDayDate})"
+                            } else {
+                                "On This Day"
+                            }
+                            SpTitledSection(
+                                title = title,
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_on_this_day_section"),
+                            ) {
+                                OnThisDaySection(
+                                    games = state.onThisDayGames,
+                                    onGameSelected = onGameSelected,
+                                )
+                            }
+                        }
+                    }
+
+                    // Temporal Discovery: Your Anniversaries
+                    item {
+                        if (state.isLoadingTemporal && state.anniversaries.isEmpty()) {
+                            SpTitledSection(
+                                title = "Your Anniversaries",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                            ) {
+                                TemporalSectionSkeleton()
+                            }
+                        } else if (state.anniversaries.isNotEmpty()) {
+                            SpTitledSection(
+                                title = "Your Anniversaries",
+                                edgeToEdgeContent = true,
+                                modifier = Modifier
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("explore_anniversaries_section"),
+                            ) {
+                                AnniversariesSection(
+                                    anniversaries = state.anniversaries,
                                     onGameSelected = onGameSelected,
                                 )
                             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.viewmodel
 
 import com.spela.player.domain.model.ActiveNowItem
+import com.spela.player.domain.model.AnniversaryItem
 import com.spela.player.domain.model.ArtworkItem
 import com.spela.player.domain.model.CommunityTopGame
 import com.spela.player.domain.model.ConsoleHighlight
@@ -49,6 +50,9 @@ data class ExploreState(
     val cultClassics: List<CultClassicGame> = emptyList(),
     val recentReviews: List<RecentReviewItem> = emptyList(),
     val activeNowGames: List<ActiveNowItem> = emptyList(),
+    val onThisDayDate: String = "",
+    val onThisDayGames: List<Game> = emptyList(),
+    val anniversaries: List<AnniversaryItem> = emptyList(),
     val isLoadingFeatured: Boolean = false,
     val isLoadingRows: Boolean = false,
     val isLoadingThemes: Boolean = false,
@@ -60,10 +64,11 @@ data class ExploreState(
     val isLoadingConsoleHighlights: Boolean = false,
     val isLoadingArtwork: Boolean = false,
     val isLoadingSocial: Boolean = false,
+    val isLoadingTemporal: Boolean = false,
     val error: String? = null,
 ) {
-    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods || isLoadingForYou || isLoadingDeveloperSpotlight || isLoadingConsoleHighlights || isLoadingArtwork || isLoadingSocial
-    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && forYouRows.isEmpty() && developerSpotlight == null && consoleHighlights.isEmpty() && artworkShowcase.isEmpty() && trendingGames.isEmpty() && communityTopGames.isEmpty() && cultClassics.isEmpty() && recentReviews.isEmpty() && activeNowGames.isEmpty() && !isLoading
+    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries || isLoadingMoods || isLoadingForYou || isLoadingDeveloperSpotlight || isLoadingConsoleHighlights || isLoadingArtwork || isLoadingSocial || isLoadingTemporal
+    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && moods.isEmpty() && forYouRows.isEmpty() && developerSpotlight == null && consoleHighlights.isEmpty() && artworkShowcase.isEmpty() && trendingGames.isEmpty() && communityTopGames.isEmpty() && cultClassics.isEmpty() && recentReviews.isEmpty() && activeNowGames.isEmpty() && onThisDayGames.isEmpty() && anniversaries.isEmpty() && !isLoading
 }
 
 data class ThemeDetailState(
@@ -192,6 +197,7 @@ class ExploreViewModel(
     private var consoleShowcaseJob: Job? = null
     private var artworkShowcaseJob: Job? = null
     private var socialJob: Job? = null
+    private var temporalJob: Job? = null
     private var screenshotGalleryJob: Job? = null
 
     fun load() {
@@ -206,6 +212,7 @@ class ExploreViewModel(
         loadConsoleHighlights()
         loadArtworkShowcase()
         loadSocialData()
+        loadTemporalData()
     }
 
     fun dismissError() {
@@ -550,6 +557,27 @@ class ExploreViewModel(
                     recentReviews = recentlyReviewedDeferred.await().getOrDefault(emptyList()),
                     activeNowGames = activeNowDeferred.await().getOrDefault(emptyList()),
                     isLoadingSocial = false,
+                )
+            }
+        }
+    }
+
+    private fun loadTemporalData() {
+        if (temporalJob?.isActive == true) return
+        _state.update { it.copy(isLoadingTemporal = true) }
+        temporalJob = scope.launch(dispatchers.io) {
+            val onThisDayDeferred = async { exploreRepository.getOnThisDay() }
+            val anniversariesDeferred = async { exploreRepository.getYourAnniversaries() }
+
+            awaitAll(onThisDayDeferred, anniversariesDeferred)
+
+            val onThisDayResult = onThisDayDeferred.await()
+            _state.update { current ->
+                current.copy(
+                    onThisDayDate = onThisDayResult.getOrNull()?.first ?: "",
+                    onThisDayGames = onThisDayResult.getOrNull()?.second ?: emptyList(),
+                    anniversaries = anniversariesDeferred.await().getOrDefault(emptyList()),
+                    isLoadingTemporal = false,
                 )
             }
         }

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -2916,3 +2916,390 @@ func (h *ExploreHandler) GetActiveNow(c *gin.Context) {
 	c.JSON(http.StatusOK, ActiveNowResponse{Games: result})
 }
 
+// --- Phase 11: Temporal Discovery ---
+
+// OnThisDayResponse is the API response for the on-this-day endpoint.
+type OnThisDayResponse struct {
+	Date  string         `json:"date"`
+	Games []GameResponse `json:"games"`
+}
+
+// BestOfYearResponse is the API response for the best-of-year endpoint.
+type BestOfYearResponse struct {
+	Year  int            `json:"year"`
+	Games []GameResponse `json:"games"`
+}
+
+// AnniversaryItem represents a game the user played roughly N years ago.
+type AnniversaryItem struct {
+	Game     GameResponse `json:"game"`
+	YearsAgo int         `json:"yearsAgo"`
+	PlayedAt time.Time    `json:"playedAt"`
+}
+
+// AnniversariesResponse is the API response for the your-anniversaries endpoint.
+type AnniversariesResponse struct {
+	Anniversaries []AnniversaryItem `json:"anniversaries"`
+}
+
+// DecadesResponse is the API response for the decades endpoint.
+type DecadesResponse struct {
+	Decade string         `json:"decade"`
+	Label  string         `json:"label"`
+	Games  []GameResponse `json:"games"`
+}
+
+// parseReleaseDateMonthDay attempts to extract month and day from a release_date string.
+// Supports formats like "2000-03-10", "March 10, 2000", "Mar 10, 2000".
+// Returns (month, day, true) on success, or (0, 0, false) if unparseable or year-only.
+func parseReleaseDateMonthDay(releaseDate string) (time.Month, int, bool) {
+	releaseDate = strings.TrimSpace(releaseDate)
+	if releaseDate == "" {
+		return 0, 0, false
+	}
+
+	// Try ISO format: "2000-03-10" or "2000-3-10"
+	if len(releaseDate) >= 10 && releaseDate[4] == '-' {
+		t, err := time.Parse("2006-01-02", releaseDate[:10])
+		if err == nil {
+			return t.Month(), t.Day(), true
+		}
+	}
+
+	// Try "January 2, 2006" / "Jan 2, 2006" formats
+	layouts := []string{
+		"January 2, 2006",
+		"Jan 2, 2006",
+		"January 02, 2006",
+		"Jan 02, 2006",
+		"2 January 2006",
+		"02 January 2006",
+	}
+	for _, layout := range layouts {
+		t, err := time.Parse(layout, releaseDate)
+		if err == nil {
+			return t.Month(), t.Day(), true
+		}
+	}
+
+	return 0, 0, false
+}
+
+// parseReleaseDateYear attempts to extract the year from a release_date string.
+// Supports "2000-03-10", "March 10, 2000", "1996", etc.
+func parseReleaseDateYear(releaseDate string) (int, bool) {
+	releaseDate = strings.TrimSpace(releaseDate)
+	if releaseDate == "" {
+		return 0, false
+	}
+
+	// Try ISO format first
+	if len(releaseDate) >= 4 {
+		year, err := strconv.Atoi(releaseDate[:4])
+		if err == nil && year >= 1970 && year <= 2100 {
+			return year, true
+		}
+	}
+
+	// Try text formats like "March 10, 2000"
+	layouts := []string{
+		"January 2, 2006",
+		"Jan 2, 2006",
+		"January 02, 2006",
+		"Jan 02, 2006",
+	}
+	for _, layout := range layouts {
+		t, err := time.Parse(layout, releaseDate)
+		if err == nil {
+			return t.Year(), true
+		}
+	}
+
+	// Try plain 4-digit year at end (e.g. "Q4 1996" — just grab trailing year)
+	parts := strings.Fields(releaseDate)
+	for i := len(parts) - 1; i >= 0; i-- {
+		year, err := strconv.Atoi(parts[i])
+		if err == nil && year >= 1970 && year <= 2100 {
+			return year, true
+		}
+	}
+
+	return 0, false
+}
+
+// GetOnThisDay returns games released on today's month/day across all years.
+// GET /api/explore/on-this-day
+func (h *ExploreHandler) GetOnThisDay(c *gin.Context) {
+	userID := getUserID(c)
+	now := time.Now()
+	targetMonth := now.Month()
+	targetDay := now.Day()
+
+	dateLabel := now.Format("January 2")
+
+	// Load all games that have a release_date set
+	var allGames []db.Game
+	if err := h.DB.Preload("Console").
+		Where("release_date != '' AND release_date IS NOT NULL AND deleted_at IS NULL").
+		Find(&allGames).Error; err != nil {
+		slog.Error("failed to fetch games for on-this-day", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch games"})
+		return
+	}
+
+	// Filter to games matching today's month+day
+	type matchedGame struct {
+		game db.Game
+		year int
+	}
+	var matched []matchedGame
+	for _, g := range allGames {
+		month, day, ok := parseReleaseDateMonthDay(g.ReleaseDate)
+		if !ok {
+			continue
+		}
+		if month == targetMonth && day == targetDay {
+			year, _ := parseReleaseDateYear(g.ReleaseDate)
+			matched = append(matched, matchedGame{game: g, year: year})
+		}
+	}
+
+	// Sort by year ascending (oldest first)
+	sort.Slice(matched, func(i, j int) bool {
+		return matched[i].year < matched[j].year
+	})
+
+	// Limit to 20
+	if len(matched) > 20 {
+		matched = matched[:20]
+	}
+
+	if len(matched) == 0 {
+		c.JSON(http.StatusOK, OnThisDayResponse{Date: dateLabel, Games: []GameResponse{}})
+		return
+	}
+
+	games := make([]db.Game, len(matched))
+	gameIDs := make([]uint, len(matched))
+	for i, m := range matched {
+		games[i] = m.game
+		gameIDs[i] = m.game.ID
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+	result := make([]GameResponse, len(games))
+	for i, g := range games {
+		result[i] = toGameResponseWithData(g, &userData)
+	}
+
+	c.JSON(http.StatusOK, OnThisDayResponse{Date: dateLabel, Games: result})
+}
+
+// GetBestOfYear returns the top-rated games from a specific year.
+// GET /api/explore/best-of-year/:year
+func (h *ExploreHandler) GetBestOfYear(c *gin.Context) {
+	userID := getUserID(c)
+
+	yearStr := c.Param("year")
+	year, err := strconv.Atoi(yearStr)
+	if err != nil || year < 1970 || year > 2100 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid year"})
+		return
+	}
+
+	yearPrefix := fmt.Sprintf("%d", year)
+
+	// Find games whose release_date starts with the year
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("release_date LIKE ? AND deleted_at IS NULL", yearPrefix+"%").
+		Where("rating > 0").
+		Order("rating DESC").
+		Limit(30).
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch best-of-year games", "error", err, "year", year)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch games"})
+		return
+	}
+
+	if len(games) == 0 {
+		c.JSON(http.StatusOK, BestOfYearResponse{Year: year, Games: []GameResponse{}})
+		return
+	}
+
+	c.JSON(http.StatusOK, BestOfYearResponse{
+		Year:  year,
+		Games: ToGameResponses(games, h.DB, userID),
+	})
+}
+
+// GetYourAnniversaries returns personal milestones — games the user played
+// roughly 1, 2, 3... years ago (within a 3-day window around today's date).
+// GET /api/explore/your-anniversaries
+func (h *ExploreHandler) GetYourAnniversaries(c *gin.Context) {
+	userID := getUserID(c)
+
+	now := time.Now()
+
+	// Look back up to 10 years
+	var allAnniversaries []AnniversaryItem
+	for yearsAgo := 1; yearsAgo <= 10; yearsAgo++ {
+		anniversary := now.AddDate(-yearsAgo, 0, 0)
+		windowStart := anniversary.AddDate(0, 0, -3)
+		windowEnd := anniversary.AddDate(0, 0, 3)
+
+		var histories []db.PlayHistory
+		if err := h.DB.
+			Where("user_id = ? AND last_played BETWEEN ? AND ? AND deleted_at IS NULL",
+				userID, windowStart, windowEnd).
+			Find(&histories).Error; err != nil {
+			slog.Error("failed to fetch anniversary play histories", "error", err, "yearsAgo", yearsAgo)
+			continue
+		}
+
+		// Deduplicate by game ID (keep the one closest to the anniversary date)
+		gameMap := make(map[uint]db.PlayHistory)
+		for _, ph := range histories {
+			existing, exists := gameMap[ph.GameID]
+			if !exists {
+				gameMap[ph.GameID] = ph
+			} else {
+				// Keep the one closest to the exact anniversary date
+				existingDiff := existing.LastPlayed.Sub(anniversary)
+				if existingDiff < 0 {
+					existingDiff = -existingDiff
+				}
+				newDiff := ph.LastPlayed.Sub(anniversary)
+				if newDiff < 0 {
+					newDiff = -newDiff
+				}
+				if newDiff < existingDiff {
+					gameMap[ph.GameID] = ph
+				}
+			}
+		}
+
+		for _, ph := range gameMap {
+			allAnniversaries = append(allAnniversaries, AnniversaryItem{
+				YearsAgo: yearsAgo,
+				PlayedAt: ph.LastPlayed,
+				Game:     GameResponse{ID: strconv.FormatUint(uint64(ph.GameID), 10)}, // placeholder, will be filled
+			})
+		}
+	}
+
+	if len(allAnniversaries) == 0 {
+		c.JSON(http.StatusOK, AnniversariesResponse{Anniversaries: []AnniversaryItem{}})
+		return
+	}
+
+	// Collect unique game IDs
+	gameIDSet := make(map[uint]bool)
+	for _, a := range allAnniversaries {
+		gid, _ := strconv.ParseUint(a.Game.ID, 10, 64)
+		gameIDSet[uint(gid)] = true
+	}
+	gameIDs := make([]uint, 0, len(gameIDSet))
+	for id := range gameIDSet {
+		gameIDs = append(gameIDs, id)
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load anniversary games", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load games"})
+		return
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]AnniversaryItem, 0, len(allAnniversaries))
+	for _, a := range allAnniversaries {
+		gid, _ := strconv.ParseUint(a.Game.ID, 10, 64)
+		g, ok := gameMap[uint(gid)]
+		if !ok {
+			continue
+		}
+		result = append(result, AnniversaryItem{
+			Game:     toGameResponseWithData(g, &userData),
+			YearsAgo: a.YearsAgo,
+			PlayedAt: a.PlayedAt,
+		})
+	}
+
+	// Sort by yearsAgo ascending (most recent anniversaries first)
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].YearsAgo != result[j].YearsAgo {
+			return result[i].YearsAgo < result[j].YearsAgo
+		}
+		return result[i].Game.Title < result[j].Game.Title
+	})
+
+	c.JSON(http.StatusOK, AnniversariesResponse{Anniversaries: result})
+}
+
+// decadeRange maps a decade string to its year range.
+var decadeRange = map[string][2]int{
+	"80s": {1980, 1989},
+	"90s": {1990, 1999},
+	"00s": {2000, 2009},
+}
+
+// decadeLabel maps a decade string to a display label.
+var decadeLabel = map[string]string{
+	"80s": "The 80s",
+	"90s": "The 90s",
+	"00s": "The 00s",
+}
+
+// GetDecades returns the best games of a given decade.
+// GET /api/explore/decades/:decade
+func (h *ExploreHandler) GetDecades(c *gin.Context) {
+	userID := getUserID(c)
+
+	decade := c.Param("decade")
+	yearRange, ok := decadeRange[decade]
+	if !ok {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid decade; valid values: 80s, 90s, 00s"})
+		return
+	}
+	label := decadeLabel[decade]
+
+	// Build LIKE conditions for each year in the range
+	conditions := make([]string, 0, yearRange[1]-yearRange[0]+1)
+	args := make([]interface{}, 0, yearRange[1]-yearRange[0]+1)
+	for y := yearRange[0]; y <= yearRange[1]; y++ {
+		conditions = append(conditions, "release_date LIKE ?")
+		args = append(args, fmt.Sprintf("%d%%", y))
+	}
+	whereClause := "(" + strings.Join(conditions, " OR ") + ")"
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where(whereClause, args...).
+		Where("rating > 0 AND deleted_at IS NULL").
+		Order("rating DESC").
+		Limit(30).
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch decade games", "error", err, "decade", decade)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch games"})
+		return
+	}
+
+	if len(games) == 0 {
+		c.JSON(http.StatusOK, DecadesResponse{Decade: decade, Label: label, Games: []GameResponse{}})
+		return
+	}
+
+	c.JSON(http.StatusOK, DecadesResponse{
+		Decade: decade,
+		Label:  label,
+		Games:  ToGameResponses(games, h.DB, userID),
+	})
+}
+

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -3003,3 +3003,474 @@ func TestGetActiveNow_ReturnsMergedSessions(t *testing.T) {
 	assert.Equal(t, 1, resp.Games[0].ActiveSessions)
 	assert.Equal(t, 1, resp.Games[0].ActiveChallenges)
 }
+
+// --- Phase 11: Temporal Discovery tests ---
+
+// createExploreGameWithRelease creates a game with a specific release date and rating.
+func createExploreGameWithRelease(t *testing.T, database *gorm.DB, consoleAbbr, title string, rating float64, releaseDate string) db.Game {
+	t.Helper()
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", consoleAbbr).First(&console).Error)
+	game := db.Game{
+		ConsoleID:   console.ID,
+		Title:       title,
+		FileName:    title + ".rom",
+		FilePath:    consoleAbbr + "/" + title + ".rom",
+		Rating:      rating,
+		Genre:       "Action",
+		ReleaseDate: releaseDate,
+	}
+	require.NoError(t, database.Create(&game).Error)
+	return game
+}
+
+// --- On This Day tests ---
+
+func TestGetOnThisDay_NoGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/on-this-day", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp OnThisDayResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp.Date) // e.g. "March 10"
+	assert.Empty(t, resp.Games)
+}
+
+func TestGetOnThisDay_MatchesToday(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	now := time.Now()
+	todayISO := now.Format("2006-01-02")
+	otherDate := fmt.Sprintf("1995-%02d-%02d", (now.Month()%12)+1, 15) // Different month
+
+	// Game matching today's date
+	createExploreGameWithRelease(t, env.database, "SNES", "Birthday Game", 90.0, todayISO)
+	// Game on a different date — should NOT appear
+	createExploreGameWithRelease(t, env.database, "NES", "Other Game", 85.0, otherDate)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/on-this-day", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp OnThisDayResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Games, 1)
+	assert.Equal(t, "Birthday Game", resp.Games[0].Title)
+}
+
+func TestGetOnThisDay_MultipleYearsSortedOldestFirst(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	now := time.Now()
+	todayMD := now.Format("01-02") // MM-DD
+
+	// Games released on today's date in different years
+	createExploreGameWithRelease(t, env.database, "SNES", "Newer Game", 80.0, "2005-"+todayMD)
+	createExploreGameWithRelease(t, env.database, "NES", "Older Game", 70.0, "1990-"+todayMD)
+	createExploreGameWithRelease(t, env.database, "GBA", "Mid Game", 75.0, "1998-"+todayMD)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/on-this-day", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp OnThisDayResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Games, 3)
+	// Sorted oldest first
+	assert.Equal(t, "Older Game", resp.Games[0].Title)
+	assert.Equal(t, "Mid Game", resp.Games[1].Title)
+	assert.Equal(t, "Newer Game", resp.Games[2].Title)
+}
+
+func TestGetOnThisDay_TextDateFormat(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	now := time.Now()
+	// Use "January 2, 2006" text format for today's date
+	textDate := now.Format("January 2, 2006")
+	// Use ISO format for a different day
+	otherDate := fmt.Sprintf("2000-%02d-%02d", (now.Month()%12)+1, 15)
+
+	createExploreGameWithRelease(t, env.database, "SNES", "Text Date Game", 88.0, textDate)
+	createExploreGameWithRelease(t, env.database, "NES", "Wrong Date Game", 85.0, otherDate)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/on-this-day", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp OnThisDayResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Games, 1)
+	assert.Equal(t, "Text Date Game", resp.Games[0].Title)
+}
+
+// --- Best of Year tests ---
+
+func TestGetBestOfYear_InvalidYear(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/best-of-year/abc", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetBestOfYear_NoGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/best-of-year/1995", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp BestOfYearResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1995, resp.Year)
+	assert.Empty(t, resp.Games)
+}
+
+func TestGetBestOfYear_ReturnsSortedByRating(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameWithRelease(t, env.database, "SNES", "Top Game 1995", 95.0, "1995-06-15")
+	createExploreGameWithRelease(t, env.database, "NES", "Mid Game 1995", 80.0, "1995-03-01")
+	createExploreGameWithRelease(t, env.database, "GBA", "Low Game 1995", 70.0, "1995-12-25")
+	// Different year — should NOT appear
+	createExploreGameWithRelease(t, env.database, "SNES", "Game 1996", 99.0, "1996-01-01")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/best-of-year/1995", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp BestOfYearResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, 1995, resp.Year)
+	require.Len(t, resp.Games, 3)
+	assert.Equal(t, "Top Game 1995", resp.Games[0].Title)
+	assert.Equal(t, "Mid Game 1995", resp.Games[1].Title)
+	assert.Equal(t, "Low Game 1995", resp.Games[2].Title)
+}
+
+func TestGetBestOfYear_ExcludesZeroRating(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameWithRelease(t, env.database, "SNES", "Rated Game", 85.0, "2000-05-10")
+	createExploreGameWithRelease(t, env.database, "NES", "Unrated Game", 0.0, "2000-08-20")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/best-of-year/2000", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp BestOfYearResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Games, 1)
+	assert.Equal(t, "Rated Game", resp.Games[0].Title)
+}
+
+// --- Your Anniversaries tests ---
+
+func TestGetYourAnniversaries_NoHistory(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/your-anniversaries", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp AnniversariesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Anniversaries)
+}
+
+func TestGetYourAnniversaries_FindsAnniversary(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game := createExploreGame(t, env.database, "SNES", "Anniversary Game", 90.0)
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Create play history exactly 1 year ago
+	oneYearAgo := time.Now().AddDate(-1, 0, 0)
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game.ID,
+		LastPlayed: oneYearAgo,
+		PlayTime:   3600,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/your-anniversaries", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp AnniversariesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Anniversaries, 1)
+	assert.Equal(t, "Anniversary Game", resp.Anniversaries[0].Game.Title)
+	assert.Equal(t, 1, resp.Anniversaries[0].YearsAgo)
+}
+
+func TestGetYourAnniversaries_WithinWindow(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game := createExploreGame(t, env.database, "SNES", "Window Game", 85.0)
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Create play history 2 years ago + 2 days (within 3-day window)
+	twoYearsAgoPlus2 := time.Now().AddDate(-2, 0, 2)
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game.ID,
+		LastPlayed: twoYearsAgoPlus2,
+		PlayTime:   1800,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/your-anniversaries", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp AnniversariesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Anniversaries, 1)
+	assert.Equal(t, "Window Game", resp.Anniversaries[0].Game.Title)
+	assert.Equal(t, 2, resp.Anniversaries[0].YearsAgo)
+}
+
+func TestGetYourAnniversaries_OutsideWindow(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game := createExploreGame(t, env.database, "SNES", "Far Game", 85.0)
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Create play history 1 year ago + 5 days (outside 3-day window)
+	oneYearAgoPlus5 := time.Now().AddDate(-1, 0, 5)
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game.ID,
+		LastPlayed: oneYearAgoPlus5,
+		PlayTime:   1800,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/your-anniversaries", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp AnniversariesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Anniversaries)
+}
+
+func TestGetYourAnniversaries_MultipleYears(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGame(t, env.database, "SNES", "One Year Game", 90.0)
+	game2 := createExploreGame(t, env.database, "NES", "Three Year Game", 85.0)
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game1.ID,
+		LastPlayed: time.Now().AddDate(-1, 0, 0),
+		PlayTime:   3600,
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game2.ID,
+		LastPlayed: time.Now().AddDate(-3, 0, 1),
+		PlayTime:   7200,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/your-anniversaries", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp AnniversariesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Anniversaries, 2)
+	// Sorted by yearsAgo ascending
+	assert.Equal(t, 1, resp.Anniversaries[0].YearsAgo)
+	assert.Equal(t, "One Year Game", resp.Anniversaries[0].Game.Title)
+	assert.Equal(t, 3, resp.Anniversaries[1].YearsAgo)
+	assert.Equal(t, "Three Year Game", resp.Anniversaries[1].Game.Title)
+}
+
+// --- Decades tests ---
+
+func TestGetDecades_InvalidDecade(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/decades/70s", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestGetDecades_NoGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/decades/80s", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp DecadesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "80s", resp.Decade)
+	assert.Equal(t, "The 80s", resp.Label)
+	assert.Empty(t, resp.Games)
+}
+
+func TestGetDecades_Returns90sGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameWithRelease(t, env.database, "SNES", "90s Best", 95.0, "1995-06-15")
+	createExploreGameWithRelease(t, env.database, "NES", "90s Good", 80.0, "1990-01-01")
+	createExploreGameWithRelease(t, env.database, "GBA", "90s End", 85.0, "1999-12-31")
+	// 80s game — should NOT appear
+	createExploreGameWithRelease(t, env.database, "NES", "80s Game", 99.0, "1989-05-01")
+	// 00s game — should NOT appear
+	createExploreGameWithRelease(t, env.database, "GBA", "00s Game", 99.0, "2000-01-01")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/decades/90s", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp DecadesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "90s", resp.Decade)
+	assert.Equal(t, "The 90s", resp.Label)
+	require.Len(t, resp.Games, 3)
+	// Sorted by rating DESC
+	assert.Equal(t, "90s Best", resp.Games[0].Title)
+	assert.Equal(t, "90s End", resp.Games[1].Title)
+	assert.Equal(t, "90s Good", resp.Games[2].Title)
+}
+
+func TestGetDecades_00s(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameWithRelease(t, env.database, "GBA", "GBA Classic", 88.0, "2004-11-15")
+	createExploreGameWithRelease(t, env.database, "GBA", "GBA Gem", 82.0, "2009-06-01")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/decades/00s", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp DecadesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "00s", resp.Decade)
+	assert.Equal(t, "The 00s", resp.Label)
+	require.Len(t, resp.Games, 2)
+	assert.Equal(t, "GBA Classic", resp.Games[0].Title)
+	assert.Equal(t, "GBA Gem", resp.Games[1].Title)
+}
+
+func TestGetDecades_ExcludesZeroRating(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameWithRelease(t, env.database, "SNES", "Rated 90s", 85.0, "1995-06-15")
+	createExploreGameWithRelease(t, env.database, "NES", "Unrated 90s", 0.0, "1993-03-01")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/decades/90s", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp DecadesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Len(t, resp.Games, 1)
+	assert.Equal(t, "Rated 90s", resp.Games[0].Title)
+}
+
+// --- parseReleaseDateMonthDay unit tests ---
+
+func TestParseReleaseDateMonthDay_ISOFormat(t *testing.T) {
+	month, day, ok := parseReleaseDateMonthDay("2000-03-10")
+	assert.True(t, ok)
+	assert.Equal(t, time.March, month)
+	assert.Equal(t, 10, day)
+}
+
+func TestParseReleaseDateMonthDay_TextFormat(t *testing.T) {
+	month, day, ok := parseReleaseDateMonthDay("March 10, 2000")
+	assert.True(t, ok)
+	assert.Equal(t, time.March, month)
+	assert.Equal(t, 10, day)
+}
+
+func TestParseReleaseDateMonthDay_ShortTextFormat(t *testing.T) {
+	month, day, ok := parseReleaseDateMonthDay("Jan 5, 1999")
+	assert.True(t, ok)
+	assert.Equal(t, time.January, month)
+	assert.Equal(t, 5, day)
+}
+
+func TestParseReleaseDateMonthDay_YearOnly(t *testing.T) {
+	_, _, ok := parseReleaseDateMonthDay("1996")
+	assert.False(t, ok)
+}
+
+func TestParseReleaseDateMonthDay_Empty(t *testing.T) {
+	_, _, ok := parseReleaseDateMonthDay("")
+	assert.False(t, ok)
+}
+
+func TestParseReleaseDateYear_ISOFormat(t *testing.T) {
+	year, ok := parseReleaseDateYear("1995-06-15")
+	assert.True(t, ok)
+	assert.Equal(t, 1995, year)
+}
+
+func TestParseReleaseDateYear_TextFormat(t *testing.T) {
+	year, ok := parseReleaseDateYear("March 10, 2000")
+	assert.True(t, ok)
+	assert.Equal(t, 2000, year)
+}
+
+func TestParseReleaseDateYear_PlainYear(t *testing.T) {
+	year, ok := parseReleaseDateYear("1996")
+	assert.True(t, ok)
+	assert.Equal(t, 1996, year)
+}
+
+func TestParseReleaseDateYear_Empty(t *testing.T) {
+	_, ok := parseReleaseDateYear("")
+	assert.False(t, ok)
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -259,6 +259,10 @@ func NewRouter(cfg Config) *gin.Engine {
 			explore.GET("/cult-classics", exploreHandler.GetCultClassics)
 			explore.GET("/recently-reviewed", exploreHandler.GetRecentlyReviewed)
 			explore.GET("/active-now", exploreHandler.GetActiveNow)
+			explore.GET("/on-this-day", exploreHandler.GetOnThisDay)
+			explore.GET("/best-of-year/:year", exploreHandler.GetBestOfYear)
+			explore.GET("/your-anniversaries", exploreHandler.GetYourAnniversaries)
+			explore.GET("/decades/:decade", exploreHandler.GetDecades)
 		}
 
 		// Games

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { ExplorePage } from "@/pages/explore-page";
-import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition, ForYouResponse, PlayersLikeYouResponse, DeveloperSpotlightResponse, ConsoleHighlightsResponse, ArtworkGalleryResponse } from "@/types/api";
+import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition, ForYouResponse, PlayersLikeYouResponse, DeveloperSpotlightResponse, ConsoleHighlightsResponse, ArtworkGalleryResponse, OnThisDayResponse, BestOfYearResponse, YourAnniversariesResponse, DecadeResponse } from "@/types/api";
 
 // Mock hooks
 vi.mock("@/hooks/use-explore", () => ({
@@ -23,6 +23,10 @@ vi.mock("@/hooks/use-explore", () => ({
   useCultClassics: vi.fn(),
   useRecentlyReviewed: vi.fn(),
   useActiveNow: vi.fn(),
+  useOnThisDay: vi.fn(),
+  useBestOfYear: vi.fn(),
+  useYourAnniversaries: vi.fn(),
+  useDecade: vi.fn(),
   useSurpriseGame: vi.fn(() => ({
     data: undefined,
     refetch: vi.fn(),
@@ -46,7 +50,7 @@ vi.mock("@/hooks/use-auto-scrape", () => ({
   useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
 }));
 
-import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods, useForYou, usePlayersLikeYou, useDeveloperSpotlight, useConsoleHighlights, useArtworkGallery, useTrending, useCommunityTop, useCultClassics, useRecentlyReviewed, useActiveNow } from "@/hooks/use-explore";
+import { useExploreFeatured, useExploreRows, useThemes, useKeywords, useFeaturedSeries, useMoods, useForYou, usePlayersLikeYou, useDeveloperSpotlight, useConsoleHighlights, useArtworkGallery, useTrending, useCommunityTop, useCultClassics, useRecentlyReviewed, useActiveNow, useOnThisDay, useBestOfYear, useYourAnniversaries, useDecade } from "@/hooks/use-explore";
 
 const mockUseExploreFeatured = useExploreFeatured as ReturnType<typeof vi.fn>;
 const mockUseExploreRows = useExploreRows as ReturnType<typeof vi.fn>;
@@ -64,6 +68,10 @@ const mockUseCommunityTop = useCommunityTop as ReturnType<typeof vi.fn>;
 const mockUseCultClassics = useCultClassics as ReturnType<typeof vi.fn>;
 const mockUseRecentlyReviewed = useRecentlyReviewed as ReturnType<typeof vi.fn>;
 const mockUseActiveNow = useActiveNow as ReturnType<typeof vi.fn>;
+const mockUseOnThisDay = useOnThisDay as ReturnType<typeof vi.fn>;
+const mockUseBestOfYear = useBestOfYear as ReturnType<typeof vi.fn>;
+const mockUseYourAnniversaries = useYourAnniversaries as ReturnType<typeof vi.fn>;
+const mockUseDecade = useDecade as ReturnType<typeof vi.fn>;
 
 function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
   return {
@@ -275,6 +283,22 @@ describe("ExplorePage", () => {
       isLoading: false,
     });
     mockUseActiveNow.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    mockUseOnThisDay.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    mockUseBestOfYear.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    mockUseYourAnniversaries.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+    });
+    mockUseDecade.mockReturnValue({
       data: undefined,
       isLoading: false,
     });

--- a/web/src/features/explore/components/__tests__/temporal-shelves.test.tsx
+++ b/web/src/features/explore/components/__tests__/temporal-shelves.test.tsx
@@ -1,0 +1,344 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import {
+  OnThisDayShelf,
+  BestOfYearSection,
+  AnniversariesShelf,
+  DecadeSpotlight,
+} from "../temporal-shelves";
+import type {
+  Game,
+  OnThisDayResponse,
+  BestOfYearResponse,
+  AnniversaryItem,
+  DecadeResponse,
+} from "@/types/api";
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+// --- On This Day Shelf ---
+
+describe("OnThisDayShelf", () => {
+  function renderShelf(props: {
+    data?: OnThisDayResponse;
+    isLoading?: boolean;
+  }) {
+    return render(
+      <MemoryRouter>
+        <OnThisDayShelf
+          data={props.data}
+          isLoading={props.isLoading ?? false}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders games with release years", () => {
+    const data: OnThisDayResponse = {
+      date: "March 10",
+      games: [
+        makeGame({
+          id: "otd1",
+          title: "Chrono Trigger",
+          releaseDate: "1995-03-11",
+        }),
+        makeGame({
+          id: "otd2",
+          title: "Super Metroid",
+          releaseDate: "1994-03-19",
+        }),
+      ],
+    };
+    renderShelf({ data });
+
+    expect(screen.getByTestId("on-this-day-shelf")).toBeInTheDocument();
+    expect(
+      screen.getByText("On This Day in Gaming — March 10"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
+    expect(screen.getByText("Super Metroid")).toBeInTheDocument();
+    const years = screen.getAllByTestId("release-year");
+    expect(years[0]).toHaveTextContent("Released 1995");
+    expect(years[1]).toHaveTextContent("Released 1994");
+  });
+
+  it("shows skeleton when loading", () => {
+    renderShelf({ isLoading: true });
+    expect(
+      screen.getByTestId("on-this-day-shelf-skeleton"),
+    ).toBeInTheDocument();
+  });
+
+  it("returns null when empty", () => {
+    const { container } = renderShelf({
+      data: { date: "March 10", games: [] },
+    });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when data is undefined", () => {
+    const { container } = renderShelf({});
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+// --- Best of Year Section ---
+
+describe("BestOfYearSection", () => {
+  function renderSection(props: {
+    year?: number;
+    onYearChange?: (year: number) => void;
+    data?: BestOfYearResponse;
+    isLoading?: boolean;
+  }) {
+    return render(
+      <MemoryRouter>
+        <BestOfYearSection
+          year={props.year ?? 1995}
+          onYearChange={props.onYearChange ?? vi.fn()}
+          data={props.data}
+          isLoading={props.isLoading ?? false}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders games in a grid with year selector", () => {
+    const data: BestOfYearResponse = {
+      year: 1995,
+      games: [
+        makeGame({ id: "boy1", title: "Donkey Kong Country 2" }),
+        makeGame({ id: "boy2", title: "Earthbound" }),
+      ],
+    };
+    renderSection({ data, year: 1995 });
+
+    expect(screen.getByTestId("best-of-year-section")).toBeInTheDocument();
+    expect(screen.getByText("Best of 1995")).toBeInTheDocument();
+    expect(screen.getByText("Donkey Kong Country 2")).toBeInTheDocument();
+    expect(screen.getByText("Earthbound")).toBeInTheDocument();
+    expect(screen.getByTestId("year-selector")).toBeInTheDocument();
+  });
+
+  it("calls onYearChange when a year button is clicked", () => {
+    const onYearChange = vi.fn();
+    const data: BestOfYearResponse = {
+      year: 1995,
+      games: [makeGame({ id: "boy1", title: "Game" })],
+    };
+    renderSection({ data, year: 1995, onYearChange });
+
+    fireEvent.click(screen.getByText("2000"));
+    expect(onYearChange).toHaveBeenCalledWith(2000);
+  });
+
+  it("highlights the selected year button", () => {
+    const data: BestOfYearResponse = {
+      year: 1995,
+      games: [makeGame({ id: "boy1", title: "Game" })],
+    };
+    renderSection({ data, year: 1995 });
+
+    const selectedBtn = screen.getByText("1995");
+    expect(selectedBtn).toHaveAttribute("aria-pressed", "true");
+
+    const otherBtn = screen.getByText("2000");
+    expect(otherBtn).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("shows skeleton when loading", () => {
+    renderSection({ isLoading: true });
+    expect(
+      screen.getByTestId("best-of-year-skeleton"),
+    ).toBeInTheDocument();
+  });
+
+  it("returns null when empty", () => {
+    const { container } = renderSection({
+      data: { year: 1995, games: [] },
+    });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when data is undefined", () => {
+    const { container } = renderSection({});
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+// --- Anniversaries Shelf ---
+
+describe("AnniversariesShelf", () => {
+  function renderShelf(props: {
+    anniversaries?: AnniversaryItem[];
+    isLoading?: boolean;
+  }) {
+    return render(
+      <MemoryRouter>
+        <AnniversariesShelf
+          anniversaries={props.anniversaries}
+          isLoading={props.isLoading ?? false}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders anniversaries with year labels", () => {
+    const anniversaries: AnniversaryItem[] = [
+      {
+        game: makeGame({ id: "ann1", title: "Final Fantasy VI" }),
+        yearsAgo: 3,
+        playedAt: "2023-03-10T12:00:00Z",
+      },
+      {
+        game: makeGame({ id: "ann2", title: "Mega Man X" }),
+        yearsAgo: 1,
+        playedAt: "2025-03-10T15:00:00Z",
+      },
+    ];
+    renderShelf({ anniversaries });
+
+    expect(screen.getByTestId("anniversaries-shelf")).toBeInTheDocument();
+    expect(
+      screen.getByText("Your Gaming Anniversaries"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Final Fantasy VI")).toBeInTheDocument();
+    expect(screen.getByText("Mega Man X")).toBeInTheDocument();
+    const labels = screen.getAllByTestId("anniversary-label");
+    expect(labels[0]).toHaveTextContent("3 years ago you played this");
+    expect(labels[1]).toHaveTextContent("1 year ago you played this");
+  });
+
+  it("uses singular for 1 year", () => {
+    const anniversaries: AnniversaryItem[] = [
+      {
+        game: makeGame({ id: "ann1", title: "Solo" }),
+        yearsAgo: 1,
+        playedAt: "2025-03-10T12:00:00Z",
+      },
+    ];
+    renderShelf({ anniversaries });
+
+    expect(screen.getByTestId("anniversary-label")).toHaveTextContent(
+      "1 year ago you played this",
+    );
+  });
+
+  it("uses plural for multiple years", () => {
+    const anniversaries: AnniversaryItem[] = [
+      {
+        game: makeGame({ id: "ann1", title: "Multi" }),
+        yearsAgo: 5,
+        playedAt: "2021-03-10T12:00:00Z",
+      },
+    ];
+    renderShelf({ anniversaries });
+
+    expect(screen.getByTestId("anniversary-label")).toHaveTextContent(
+      "5 years ago you played this",
+    );
+  });
+
+  it("shows skeleton when loading", () => {
+    renderShelf({ isLoading: true });
+    expect(
+      screen.getByTestId("anniversaries-shelf-skeleton"),
+    ).toBeInTheDocument();
+  });
+
+  it("returns null when empty", () => {
+    const { container } = renderShelf({ anniversaries: [] });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when data is undefined", () => {
+    const { container } = renderShelf({});
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+// --- Decade Spotlight ---
+
+describe("DecadeSpotlight", () => {
+  function renderShelf(props: {
+    data?: DecadeResponse;
+    isLoading?: boolean;
+  }) {
+    return render(
+      <MemoryRouter>
+        <DecadeSpotlight
+          data={props.data}
+          isLoading={props.isLoading ?? false}
+        />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders decade games with label", () => {
+    const data: DecadeResponse = {
+      decade: "90s",
+      label: "The 90s",
+      games: [
+        makeGame({ id: "d1", title: "Street Fighter II" }),
+        makeGame({ id: "d2", title: "Sonic the Hedgehog" }),
+      ],
+    };
+    renderShelf({ data });
+
+    expect(screen.getByTestId("decade-spotlight")).toBeInTheDocument();
+    expect(
+      screen.getByText("The 90s"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("The defining games of the 90s"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Street Fighter II")).toBeInTheDocument();
+    expect(screen.getByText("Sonic the Hedgehog")).toBeInTheDocument();
+  });
+
+  it("shows skeleton when loading", () => {
+    renderShelf({ isLoading: true });
+    expect(
+      screen.getByTestId("decade-spotlight-skeleton"),
+    ).toBeInTheDocument();
+  });
+
+  it("returns null when empty", () => {
+    const { container } = renderShelf({
+      data: { decade: "90s", label: "The 90s", games: [] },
+    });
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("returns null when data is undefined", () => {
+    const { container } = renderShelf({});
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/web/src/features/explore/components/temporal-shelves.tsx
+++ b/web/src/features/explore/components/temporal-shelves.tsx
@@ -1,0 +1,380 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Calendar,
+  Trophy,
+  Heart,
+  Clock,
+} from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton, Skeleton } from "@/components/ui";
+import type {
+  Game,
+  OnThisDayResponse,
+  BestOfYearResponse,
+  AnniversaryItem,
+  DecadeResponse,
+} from "@/types/api";
+
+// --- Shared scroll shelf wrapper (same pattern as social-shelves.tsx) ---
+
+function ScrollShelf({
+  title,
+  subtitle,
+  icon: Icon,
+  testId,
+  isLoading,
+  isEmpty,
+  children,
+}: {
+  title: string;
+  subtitle?: string;
+  icon: React.ElementType;
+  testId: string;
+  isLoading: boolean;
+  isEmpty: boolean;
+  children: React.ReactNode;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(
+      el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
+    );
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, children]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return (
+      <section data-testid={`${testId}-skeleton`}>
+        <div className="flex items-center gap-2 mb-1">
+          <Icon className="h-5 w-5 text-surface-400" />
+          <Skeleton className="h-7 w-60 rounded" />
+        </div>
+        {subtitle && (
+          <Skeleton className="h-4 w-40 rounded mt-1 mb-5" />
+        )}
+        <div className="flex gap-5 overflow-hidden mt-4">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+              <GameCardSkeleton />
+            </div>
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (isEmpty) return null;
+
+  return (
+    <section data-testid={testId} className="group/shelf relative">
+      <div className="flex items-center gap-2 mb-1">
+        <Icon className="h-5 w-5 text-brand-400" />
+        <h2 className="text-xl font-bold text-surface-100">{title}</h2>
+      </div>
+      {subtitle && (
+        <p className="text-sm text-surface-400 mb-4">{subtitle}</p>
+      )}
+
+      <div className="relative">
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+            aria-label={`Scroll ${title} left`}
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+            aria-label={`Scroll ${title} right`}
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        <div
+          ref={scrollRef}
+          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label={title}
+        >
+          {children}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+// --- On This Day Shelf ---
+
+interface OnThisDayShelfProps {
+  data: OnThisDayResponse | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+export function OnThisDayShelf({
+  data,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: OnThisDayShelfProps) {
+  const dateLabel = data?.date ?? "";
+
+  return (
+    <ScrollShelf
+      title={dateLabel ? `On This Day in Gaming — ${dateLabel}` : "On This Day in Gaming"}
+      subtitle="Games released on this date across the years"
+      icon={Calendar}
+      testId="on-this-day-shelf"
+      isLoading={isLoading}
+      isEmpty={!data?.games || data.games.length === 0}
+    >
+      {data?.games.map((game) => (
+        <div
+          key={game.id}
+          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          role="listitem"
+        >
+          <GameCard
+            game={game}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+          {game.releaseDate && (
+            <p
+              className="text-xs text-surface-400 mt-1.5"
+              data-testid="release-year"
+            >
+              Released {new Date(game.releaseDate).getFullYear()}
+            </p>
+          )}
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+
+// --- Best of Year Section ---
+
+const YEAR_RANGE_START = 1985;
+const YEAR_RANGE_END = 2005;
+const DEFAULT_YEAR = 1995;
+
+interface BestOfYearSectionProps {
+  year: number;
+  onYearChange: (year: number) => void;
+  data: BestOfYearResponse | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+export function BestOfYearSection({
+  year,
+  onYearChange,
+  data,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: BestOfYearSectionProps) {
+  if (isLoading) {
+    return (
+      <section data-testid="best-of-year-skeleton">
+        <div className="flex items-center gap-2 mb-1">
+          <Trophy className="h-5 w-5 text-surface-400" />
+          <Skeleton className="h-7 w-60 rounded" />
+        </div>
+        <Skeleton className="h-4 w-40 rounded mt-1 mb-5" />
+        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-5 mt-4">
+          {Array.from({ length: 6 }, (_, i) => (
+            <GameCardSkeleton key={i} />
+          ))}
+        </div>
+      </section>
+    );
+  }
+
+  if (!data?.games || data.games.length === 0) return null;
+
+  return (
+    <section data-testid="best-of-year-section">
+      <div className="flex items-center gap-2 mb-1">
+        <Trophy className="h-5 w-5 text-brand-400" />
+        <h2 className="text-xl font-bold text-surface-100">
+          Best of {year}
+        </h2>
+      </div>
+      <p className="text-sm text-surface-400 mb-4">
+        Top games from {year} in your library
+      </p>
+
+      {/* Year selector */}
+      <div
+        className="flex flex-wrap gap-1.5 mb-6"
+        data-testid="year-selector"
+        role="group"
+        aria-label="Select year"
+      >
+        {Array.from(
+          { length: YEAR_RANGE_END - YEAR_RANGE_START + 1 },
+          (_, i) => YEAR_RANGE_START + i,
+        ).map((y) => (
+          <button
+            key={y}
+            onClick={() => onYearChange(y)}
+            className={`px-2.5 py-1 text-xs rounded-full transition-colors ${
+              y === year
+                ? "bg-brand-500 text-white font-semibold"
+                : "bg-surface-800 text-surface-400 hover:bg-surface-700 hover:text-surface-200"
+            }`}
+            aria-pressed={y === year}
+          >
+            {y}
+          </button>
+        ))}
+      </div>
+
+      {/* Game grid */}
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-5">
+        {data.games.map((game) => (
+          <GameCard
+            key={game.id}
+            game={game}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+// --- Anniversaries Shelf ---
+
+interface AnniversariesShelfProps {
+  anniversaries: AnniversaryItem[] | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+export function AnniversariesShelf({
+  anniversaries,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: AnniversariesShelfProps) {
+  return (
+    <ScrollShelf
+      title="Your Gaming Anniversaries"
+      subtitle="Milestones from your play history"
+      icon={Heart}
+      testId="anniversaries-shelf"
+      isLoading={isLoading}
+      isEmpty={!anniversaries || anniversaries.length === 0}
+    >
+      {anniversaries?.map((item) => (
+        <div
+          key={`${item.game.id}-${item.yearsAgo}`}
+          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          role="listitem"
+        >
+          <GameCard
+            game={item.game}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+          <p
+            className="text-xs text-amber-400 mt-1.5 font-medium"
+            data-testid="anniversary-label"
+          >
+            {item.yearsAgo} year{item.yearsAgo !== 1 ? "s" : ""} ago you
+            played this
+          </p>
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+
+// --- Decade Spotlight ---
+
+interface DecadeSpotlightProps {
+  data: DecadeResponse | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+export function DecadeSpotlight({
+  data,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: DecadeSpotlightProps) {
+  return (
+    <ScrollShelf
+      title={data?.label ?? "Decade Spotlight"}
+      subtitle={`The defining games of the ${data?.decade ?? "era"}`}
+      icon={Clock}
+      testId="decade-spotlight"
+      isLoading={isLoading}
+      isEmpty={!data?.games || data.games.length === 0}
+    >
+      {data?.games.map((game) => (
+        <div
+          key={game.id}
+          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          role="listitem"
+        >
+          <GameCard
+            game={game}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+
+export { DEFAULT_YEAR, YEAR_RANGE_START, YEAR_RANGE_END };

--- a/web/src/hooks/use-explore.ts
+++ b/web/src/hooks/use-explore.ts
@@ -29,6 +29,10 @@ import type {
   CultClassicsResponse,
   RecentlyReviewedResponse,
   ActiveNowResponse,
+  OnThisDayResponse,
+  BestOfYearResponse,
+  YourAnniversariesResponse,
+  DecadeResponse,
 } from "@/types/api";
 
 export function useExploreFeatured() {
@@ -289,5 +293,35 @@ export function useActiveNow() {
   return useQuery({
     queryKey: ["explore", "active-now"],
     queryFn: () => api.get<ActiveNowResponse>("/explore/active-now"),
+  });
+}
+
+export function useOnThisDay() {
+  return useQuery({
+    queryKey: ["explore", "on-this-day"],
+    queryFn: () => api.get<OnThisDayResponse>("/explore/on-this-day"),
+  });
+}
+
+export function useBestOfYear(year: number) {
+  return useQuery({
+    queryKey: ["explore", "best-of-year", year],
+    queryFn: () => api.get<BestOfYearResponse>(`/explore/best-of-year/${year}`),
+  });
+}
+
+export function useYourAnniversaries() {
+  return useQuery({
+    queryKey: ["explore", "your-anniversaries"],
+    queryFn: () =>
+      api.get<YourAnniversariesResponse>("/explore/your-anniversaries"),
+  });
+}
+
+export function useDecade(decade: string) {
+  return useQuery({
+    queryKey: ["explore", "decades", decade],
+    queryFn: () => api.get<DecadeResponse>(`/explore/decades/${decade}`),
+    enabled: !!decade,
   });
 }

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -34,6 +34,12 @@ export type ApiGetPath = WithQuery<
   | `/explore/consoles/${string}/showcase`
   | "/explore/console-highlights"
 
+  // Temporal Discovery
+  | "/explore/on-this-day"
+  | `/explore/best-of-year/${string}`
+  | `/explore/decades/${string}`
+  | "/explore/your-anniversaries"
+
   // Social & Community Discovery
   | "/explore/trending"
   | "/explore/community-top"

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Library } from "lucide-react";
 import { Link } from "react-router-dom";
 import { EmptyState, Button } from "@/components/ui";
@@ -20,6 +21,13 @@ import {
   ActiveNowShelf,
 } from "@/features/explore/components/social-shelves";
 import {
+  OnThisDayShelf,
+  BestOfYearSection,
+  AnniversariesShelf,
+  DecadeSpotlight,
+  DEFAULT_YEAR,
+} from "@/features/explore/components/temporal-shelves";
+import {
   useExploreFeatured,
   useExploreRows,
   useThemes,
@@ -36,6 +44,10 @@ import {
   useCultClassics,
   useRecentlyReviewed,
   useActiveNow,
+  useOnThisDay,
+  useBestOfYear,
+  useYourAnniversaries,
+  useDecade,
 } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -43,6 +55,7 @@ import { useAuth } from "@/hooks/use-auth";
 
 export function ExplorePage() {
   const { isAdmin } = useAuth();
+  const [bestOfYear, setBestOfYear] = useState(DEFAULT_YEAR);
   const {
     data: featuredGames,
     isLoading: isFeaturedLoading,
@@ -107,6 +120,22 @@ export function ExplorePage() {
     data: activeNowData,
     isLoading: isActiveNowLoading,
   } = useActiveNow();
+  const {
+    data: onThisDayData,
+    isLoading: isOnThisDayLoading,
+  } = useOnThisDay();
+  const {
+    data: bestOfYearData,
+    isLoading: isBestOfYearLoading,
+  } = useBestOfYear(bestOfYear);
+  const {
+    data: anniversariesData,
+    isLoading: isAnniversariesLoading,
+  } = useYourAnniversaries();
+  const {
+    data: decadeData,
+    isLoading: isDecadeLoading,
+  } = useDecade("90s");
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
 
@@ -225,6 +254,37 @@ export function ExplorePage() {
       <RecentlyReviewedShelf
         reviews={recentlyReviewedData?.reviews}
         isLoading={isRecentlyReviewedLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
+
+      {/* Temporal Discovery */}
+      <OnThisDayShelf
+        data={onThisDayData}
+        isLoading={isOnThisDayLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
+
+      <AnniversariesShelf
+        anniversaries={anniversariesData?.anniversaries}
+        isLoading={isAnniversariesLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
+
+      <BestOfYearSection
+        year={bestOfYear}
+        onYearChange={setBestOfYear}
+        data={bestOfYearData}
+        isLoading={isBestOfYearLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
+
+      <DecadeSpotlight
+        data={decadeData}
+        isLoading={isDecadeLoading}
         onToggleFavorite={handleToggleFavorite}
         onTogglePlayLater={handleTogglePlayLater}
       />

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1153,3 +1153,31 @@ export interface ActiveNowItem {
 export interface ActiveNowResponse {
   games: ActiveNowItem[];
 }
+
+// --- Phase 11: Temporal Discovery ---
+
+export interface OnThisDayResponse {
+  date: string;
+  games: Game[];
+}
+
+export interface BestOfYearResponse {
+  year: number;
+  games: Game[];
+}
+
+export interface AnniversaryItem {
+  game: Game;
+  yearsAgo: number;
+  playedAt: string;
+}
+
+export interface YourAnniversariesResponse {
+  anniversaries: AnniversaryItem[];
+}
+
+export interface DecadeResponse {
+  decade: string;
+  label: string;
+  games: Game[];
+}


### PR DESCRIPTION
## Summary
- Add 4 new API endpoints: `/explore/on-this-day`, `/explore/best-of-year/:year`, `/explore/your-anniversaries`, `/explore/decades/:decade`
- On This Day: parses multiple release date formats (ISO, text, year-only) to find games released on today's month/day
- Best of Year: year browser with top-rated games per year, validated year range [1970-2100]
- Your Anniversaries: scans play history for milestones (1-10 years ago, +/-3 day window), deduplicates by game
- Decade Spotlight: best games of 80s/90s/00s decades, validated against allowlist
- Web: 4 new shelf components (OnThisDayShelf, BestOfYearSection with year selector, AnniversariesShelf, DecadeSpotlight)
- Player app: On This Day and Anniversaries sections with concurrent async loading

## Test plan
- [x] 22 new Go backend tests (date parsing, year filtering, anniversary windows, decade validation, edge cases)
- [x] 20 new web component tests (all 4 components: rendering, loading, empty, year selector interaction)
- [x] 3 new player desktop E2E tests (On This Day renders, Anniversaries render, empty state hides sections)
- [x] Existing explore-page tests updated with mocks for 4 new hooks
- [x] Full test suites pass: Go (all), Web (1029), Player desktop (485+)