### PR TITLE
fix: remove unused imports breaking web build

### DIFF
--- a/web/src/features/explore/components/__tests__/console-quick-jump.test.tsx
+++ b/web/src/features/explore/components/__tests__/console-quick-jump.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { MemoryRouter } from "react-router-dom";
 import { ConsoleQuickJump } from "@/features/explore/components/console-quick-jump";

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
 import { ExplorePage } from "@/pages/explore-page";
-import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition, ForYouResponse, PlayersLikeYouResponse, DeveloperSpotlightResponse, ConsoleHighlightsResponse, ArtworkGalleryResponse, OnThisDayResponse, BestOfYearResponse, YourAnniversariesResponse, DecadeResponse } from "@/types/api";
+import type { FeaturedGame, FeaturedSeries, Game, ExploreRowsResponse, Theme, Keyword, MoodDefinition, ForYouResponse, PlayersLikeYouResponse, DeveloperSpotlightResponse } from "@/types/api";
 
 // Mock hooks
 vi.mock("@/hooks/use-explore", () => ({

--- a/web/src/features/explore/components/artwork-showcase.tsx
+++ b/web/src/features/explore/components/artwork-showcase.tsx
@@ -1,7 +1,7 @@
 import { useRef, useState, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
 import { ChevronLeft, ChevronRight } from "lucide-react";
-import { Badge, Skeleton } from "@/components/ui";
+import { Skeleton } from "@/components/ui";
 import type { ArtworkItem } from "@/types/api";
 
 interface ArtworkShowcaseProps {

--- a/web/src/features/explore/components/developer-spotlight.tsx
+++ b/web/src/features/explore/components/developer-spotlight.tsx
@@ -3,7 +3,6 @@ import { Link } from "react-router-dom";
 import { ChevronLeft, ChevronRight, ArrowRight } from "lucide-react";
 import { Skeleton } from "@/components/ui";
 import { GameCard } from "@/components/game-card";
-import { GameCardSkeleton } from "@/components/ui";
 import type { DeveloperSpotlightResponse, Game } from "@/types/api";
 
 interface DeveloperSpotlightProps {

--- a/web/src/pages/__tests__/screenshot-gallery-page.test.tsx
+++ b/web/src/pages/__tests__/screenshot-gallery-page.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";


### PR DESCRIPTION
## Summary
- Remove unused imports (`within`, `Badge`, `GameCardSkeleton`, and 6 unused type imports) from explore page components and tests
- These were causing `tsc` strict mode errors (TS6133/TS6196) that broke CI on every push since Phase 7

## Test plan
- [x] `tsc --noEmit` passes locally
- [x] No functional changes — only removed dead imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)