### PR TITLE
feat: Advanced Search with multi-faceted filtering and saved searches (Phase 13)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreSearchTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreSearchTest.kt
@@ -1,0 +1,410 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.GameFilters
+import com.spela.player.domain.model.SavedSearch
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for Phase 13: Advanced Search & Multi-Faceted Filtering.
+ *
+ * Covers:
+ * - Search chip on Explore screen navigates to search
+ * - Filter panel renders with all filter sections
+ * - Saved searches render and can be applied
+ * - Filter selections update state correctly
+ * - Search results grid renders games
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ExploreSearchTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private val sampleGames = listOf(
+        Game(
+            id = "g1",
+            title = "Super Mario World",
+            consoleId = "snes",
+            consoleName = "SNES",
+            coverUrl = null,
+            rating = 94.0,
+            genre = "Platform",
+            developer = "Nintendo",
+            publisher = "Nintendo",
+        ),
+        Game(
+            id = "g2",
+            title = "Castlevania",
+            consoleId = "nes",
+            consoleName = "NES",
+            coverUrl = null,
+            rating = 80.0,
+            genre = "Action",
+            developer = "Konami",
+            publisher = "Konami",
+        ),
+    )
+
+    private val sampleSavedSearches = listOf(
+        SavedSearch(
+            id = "ss1",
+            name = "My SNES RPGs",
+            filters = mapOf("consoles" to "SNES", "genres" to "RPG"),
+            createdAt = "2026-03-10T00:00:00Z",
+        ),
+        SavedSearch(
+            id = "ss2",
+            name = "High Rated NES",
+            filters = mapOf("consoles" to "NES", "ratingMin" to "80"),
+            createdAt = "2026-03-09T00:00:00Z",
+        ),
+    )
+
+    // --- Search chip on Explore screen ---
+
+    @Test
+    fun searchChipRendersOnExploreScreen() = runComposeUiTest {
+        val harness = createHarness()
+        // Need at least one section so explore screen is not empty
+        harness.exploreRepo.featuredSeriesList = listOf(
+            com.spela.player.domain.model.FeaturedSeries(
+                id = "s1", name = "Mario", libraryGames = 1, totalGames = 3, consoleCount = 1, heroUrl = null,
+            ),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_screen").assertIsDisplayed()
+        onNodeWithTag("explore_search_chip").assertExists()
+    }
+
+    @Test
+    fun searchChipNavigatesToSearchScreen() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.featuredSeriesList = listOf(
+            com.spela.player.domain.model.FeaturedSeries(
+                id = "s1", name = "Mario", libraryGames = 1, totalGames = 3, consoleCount = 1, heroUrl = null,
+            ),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        onNodeWithTag("explore_search_chip").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("explore_search", navState.currentScreen.route)
+    }
+
+    // --- Search screen renders ---
+
+    @Test
+    fun searchScreenShowsEmptyState() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ExploreSearch))
+        advance(harness)
+
+        onNodeWithTag("explore_search_screen").assertIsDisplayed()
+        onNodeWithTag("search_empty_state").assertIsDisplayed()
+    }
+
+    // --- Filter panel ---
+
+    @Test
+    fun filterPanelTogglesVisibility() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ExploreSearch))
+        advance(harness)
+
+        // Filter panel should not be visible initially
+        onNodeWithTag("game_filter_panel").assertDoesNotExist()
+
+        // Toggle filter panel
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advanceQuick(harness)
+
+        onNodeWithTag("game_filter_panel").assertIsDisplayed()
+
+        // Toggle again to hide
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advanceQuick(harness)
+
+        onNodeWithTag("game_filter_panel").assertDoesNotExist()
+    }
+
+    @Test
+    fun filterPanelRendersAllSections() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ExploreSearch))
+        advance(harness)
+
+        // Open filter panel
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advanceQuick(harness)
+
+        // Verify all filter sections exist
+        onNodeWithTag("filter_search_field").assertExists()
+        onNodeWithTag("filter_consoles_chips").assertExists()
+        onNodeWithTag("filter_genres_chips").assertExists()
+        onNodeWithTag("filter_developer_field").assertExists()
+        onNodeWithTag("filter_publisher_field").assertExists()
+        onNodeWithTag("filter_year_min_field").assertExists()
+        onNodeWithTag("filter_year_max_field").assertExists()
+        onNodeWithTag("filter_rating_min_field").assertExists()
+        onNodeWithTag("filter_rating_max_field").assertExists()
+        onNodeWithTag("filter_play_status_chips").assertExists()
+        onNodeWithTag("filter_sort_chips").assertExists()
+        onNodeWithTag("apply_filters_button").assertExists()
+        onNodeWithTag("clear_filters_button").assertExists()
+    }
+
+    @Test
+    fun consoleChipSelectionWorks() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ExploreSearch))
+        advance(harness)
+
+        // Open filter panel
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advanceQuick(harness)
+
+        // Click SNES chip
+        onNodeWithTag("filter_console_chip_SNES").performClick()
+        advanceQuick(harness)
+
+        // Verify filter state updated
+        val filters = harness.exploreViewModel.gameSearchState.value.filters
+        assertEquals(listOf("SNES"), filters.consoles)
+
+        // Click NES chip too
+        onNodeWithTag("filter_console_chip_NES").performClick()
+        advanceQuick(harness)
+
+        val filters2 = harness.exploreViewModel.gameSearchState.value.filters
+        assertEquals(listOf("SNES", "NES"), filters2.consoles)
+
+        // Toggle SNES off
+        onNodeWithTag("filter_console_chip_SNES").performClick()
+        advanceQuick(harness)
+
+        val filters3 = harness.exploreViewModel.gameSearchState.value.filters
+        assertEquals(listOf("NES"), filters3.consoles)
+    }
+
+    @Test
+    fun genreChipSelectionWorks() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ExploreSearch))
+        advance(harness)
+
+        // Open filter panel
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advanceQuick(harness)
+
+        // Click RPG chip
+        onNodeWithTag("filter_genre_chip_RPG").performClick()
+        advanceQuick(harness)
+
+        val filters = harness.exploreViewModel.gameSearchState.value.filters
+        assertEquals(listOf("RPG"), filters.genres)
+    }
+
+    @Test
+    fun playStatusChipSelectionWorks() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ExploreSearch))
+        advance(harness)
+
+        // Open filter panel
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advanceQuick(harness)
+
+        // Select "unplayed"
+        onNodeWithTag("filter_play_status_chip_unplayed").performClick()
+        advanceQuick(harness)
+
+        val filters = harness.exploreViewModel.gameSearchState.value.filters
+        assertEquals("unplayed", filters.playStatus)
+
+        // Clicking same chip deselects
+        onNodeWithTag("filter_play_status_chip_unplayed").performClick()
+        advanceQuick(harness)
+
+        val filters2 = harness.exploreViewModel.gameSearchState.value.filters
+        assertEquals("", filters2.playStatus)
+    }
+
+    // --- Search results ---
+
+    @Test
+    fun applyFiltersShowsResults() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.filteredGames = sampleGames
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ExploreSearch))
+        advance(harness)
+
+        // Open filter panel and set a filter
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advanceQuick(harness)
+
+        onNodeWithTag("filter_console_chip_SNES").performClick()
+        advanceQuick(harness)
+
+        // Scroll to and click the apply button (it may be below the visible scroll area)
+        onNodeWithTag("apply_filters_button").performScrollTo()
+        onNodeWithTag("apply_filters_button").performClick()
+        advanceFully(harness)
+
+        // Filter panel should auto-collapse after applying
+        onNodeWithTag("game_filter_panel").assertDoesNotExist()
+
+        // Results should be visible
+        val searchState = harness.exploreViewModel.gameSearchState.value
+        assertEquals(false, searchState.isLoading)
+        assertEquals(2, searchState.results.size)
+        onNodeWithTag("search_results_grid").assertIsDisplayed()
+        onNodeWithTag("search_results_count").assertIsDisplayed()
+        onNodeWithTag("search_result_game_g1").assertExists()
+        onNodeWithTag("search_result_game_g2").assertExists()
+    }
+
+    // --- Saved searches ---
+
+    @Test
+    fun savedSearchesRender() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.savedSearchesList = sampleSavedSearches.toMutableList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ExploreSearch))
+        advance(harness)
+
+        // Open filter panel
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advance(harness)
+
+        // Saved searches should be visible
+        onNodeWithTag("saved_searches_title").assertIsDisplayed()
+        onNodeWithTag("saved_searches_list").assertIsDisplayed()
+        onNodeWithTag("saved_search_chip_ss1").assertExists()
+        onNodeWithTag("saved_search_chip_ss2").assertExists()
+    }
+
+    @Test
+    fun savedSearchCanBeApplied() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.savedSearchesList = sampleSavedSearches.toMutableList()
+        harness.exploreRepo.filteredGames = sampleGames
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ExploreSearch))
+        advance(harness)
+
+        // Open filter panel
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advance(harness)
+
+        // Click saved search chip
+        onNodeWithTag("saved_search_chip_ss1").performClick()
+        advance(harness)
+
+        // Filters should be applied from saved search
+        val filters = harness.exploreViewModel.gameSearchState.value.filters
+        assertEquals(listOf("SNES"), filters.consoles)
+        assertEquals(listOf("RPG"), filters.genres)
+    }
+
+    @Test
+    fun savedSearchCanBeDeleted() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.savedSearchesList = sampleSavedSearches.toMutableList()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ExploreSearch))
+        advance(harness)
+
+        // Open filter panel
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advance(harness)
+
+        // Delete saved search
+        onNodeWithTag("delete_saved_search_ss1").performClick()
+        advance(harness)
+
+        // Should be removed
+        onNodeWithTag("saved_search_chip_ss1").assertDoesNotExist()
+        onNodeWithTag("saved_search_chip_ss2").assertExists()
+    }
+
+    // --- Clear filters ---
+
+    @Test
+    fun clearFiltersResetsState() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.filteredGames = sampleGames
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.ExploreSearch))
+        advance(harness)
+
+        // Open filter panel and set filters
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advanceQuick(harness)
+
+        onNodeWithTag("filter_console_chip_SNES").performClick()
+        advanceQuick(harness)
+
+        // Scroll to and click apply button (may be below visible scroll area)
+        onNodeWithTag("apply_filters_button").performScrollTo()
+        onNodeWithTag("apply_filters_button").performClick()
+        advanceFully(harness)
+
+        // Results should be visible (filter panel auto-collapses on apply)
+        val searchState = harness.exploreViewModel.gameSearchState.value
+        assertEquals(false, searchState.isLoading)
+        assertEquals(2, searchState.results.size)
+        onNodeWithTag("search_results_grid").assertIsDisplayed()
+
+        // Re-open filter panel to access clear button
+        onNodeWithTag("toggle_filter_panel_button").performClick()
+        advanceQuick(harness)
+
+        // Scroll to and click clear button
+        onNodeWithTag("clear_filters_button").performScrollTo()
+        onNodeWithTag("clear_filters_button").performClick()
+        advanceQuick(harness)
+
+        // Filters should be reset
+        val filters = harness.exploreViewModel.gameSearchState.value.filters
+        assertEquals(true, filters.isEmpty)
+        assertEquals(emptyList(), harness.exploreViewModel.gameSearchState.value.results)
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1358,6 +1358,9 @@ class FakeExploreRepository : ExploreRepository {
     var almostDoneGamesList: List<AlmostDoneGame> = emptyList()
     var freshChallengeGamesList: List<FreshChallengeGame> = emptyList()
     var activeChallengesList: List<ExploreChallenge> = emptyList()
+    var filteredGames: List<Game> = emptyList()
+    var savedSearchesList: List<SavedSearch> = mutableListOf()
+    var createdSavedSearch: SavedSearch? = null
     var shouldFail: Boolean = false
 
     override suspend fun getFeaturedGames(): Result<List<FeaturedGame>> =
@@ -1547,6 +1550,34 @@ class FakeExploreRepository : ExploreRepository {
     override suspend fun getActiveChallenges(): Result<List<ExploreChallenge>> =
         if (shouldFail) Result.failure(Exception("Failed to load active challenges"))
         else Result.success(activeChallengesList)
+
+    override suspend fun getFilteredGames(filters: Map<String, String>, page: Int, pageSize: Int): Result<List<Game>> =
+        if (shouldFail) Result.failure(Exception("Failed to load filtered games"))
+        else Result.success(filteredGames)
+
+    override suspend fun getSavedSearches(): Result<List<SavedSearch>> =
+        if (shouldFail) Result.failure(Exception("Failed to load saved searches"))
+        else Result.success(savedSearchesList)
+
+    override suspend fun createSavedSearch(name: String, filters: Map<String, String>): Result<SavedSearch> =
+        if (shouldFail) Result.failure(Exception("Failed to create saved search"))
+        else {
+            val search = createdSavedSearch ?: SavedSearch(
+                id = "saved-${savedSearchesList.size + 1}",
+                name = name,
+                filters = filters,
+                createdAt = "2026-03-10T00:00:00Z",
+            )
+            savedSearchesList = savedSearchesList + search
+            Result.success(search)
+        }
+
+    override suspend fun deleteSavedSearch(id: String): Result<Unit> =
+        if (shouldFail) Result.failure(Exception("Failed to delete saved search"))
+        else {
+            savedSearchesList = savedSearchesList.filter { it.id != id }
+            Result.success(Unit)
+        }
 }
 
 class FakeCheatRepository : CheatRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -464,7 +464,10 @@ class SpelaApiClient(
     /** Creates a new saved search */
     suspend fun createSavedSearch(name: String, filters: Map<String, String>): SavedSearchDto {
         return client.post("$baseUrl/api/user/saved-searches") {
-            setBody(CreateSavedSearchRequest(name = name, filters = filters))
+            setBody(CreateSavedSearchRequest(
+                name = name,
+                filters = filters.mapValues { (_, v) -> kotlinx.serialization.json.JsonPrimitive(v) },
+            ))
         }.body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -441,6 +441,38 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/explore/active-challenges").body()
     }
 
+    /** Returns games filtered by multi-faceted criteria */
+    suspend fun getFilteredGames(
+        filters: Map<String, String>,
+        page: Int? = null,
+        pageSize: Int? = null,
+    ): GameListResponse {
+        return client.get("$baseUrl/api/games") {
+            filters.forEach { (key, value) ->
+                parameter(key, value)
+            }
+            page?.let { parameter("page", it) }
+            pageSize?.let { parameter("pageSize", it) }
+        }.body()
+    }
+
+    /** Returns user's saved searches */
+    suspend fun getSavedSearches(): List<SavedSearchDto> {
+        return client.get("$baseUrl/api/user/saved-searches").body()
+    }
+
+    /** Creates a new saved search */
+    suspend fun createSavedSearch(name: String, filters: Map<String, String>): SavedSearchDto {
+        return client.post("$baseUrl/api/user/saved-searches") {
+            setBody(CreateSavedSearchRequest(name = name, filters = filters))
+        }.body()
+    }
+
+    /** Deletes a saved search */
+    suspend fun deleteSavedSearch(id: String) {
+        client.delete("$baseUrl/api/user/saved-searches/$id")
+    }
+
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
     suspend fun getRecentGames(): List<GameDto> {
         return client.get("$baseUrl/api/user/recent").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -832,6 +832,6 @@ fun ExploreChallengeDto.toDomain() = ExploreChallenge(
 fun SavedSearchDto.toDomain() = SavedSearch(
     id = id,
     name = name,
-    filters = filters,
+    filters = filters.mapValues { (_, v) -> v.content },
     createdAt = createdAt,
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -826,3 +826,12 @@ fun ExploreChallengeDto.toDomain() = ExploreChallenge(
     expiresAt = expiresAt,
     createdAt = createdAt,
 )
+
+// --- Phase 13: Advanced Search & Saved Searches ---
+
+fun SavedSearchDto.toDomain() = SavedSearch(
+    id = id,
+    name = name,
+    filters = filters,
+    createdAt = createdAt,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1438,3 +1438,19 @@ data class ExploreChallengeDto(
 data class ActiveChallengesResponseDto(
     val challenges: List<ExploreChallengeDto>,
 )
+
+// --- Phase 13: Advanced Search & Saved Searches ---
+
+@Serializable
+data class SavedSearchDto(
+    val id: String,
+    val name: String,
+    val filters: Map<String, String> = emptyMap(),
+    val createdAt: String = "",
+)
+
+@Serializable
+data class CreateSavedSearchRequest(
+    val name: String,
+    val filters: Map<String, String>,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1,6 +1,7 @@
 package com.spela.player.data.remote.dto
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
 data class LoginRequest(
@@ -1445,12 +1446,12 @@ data class ActiveChallengesResponseDto(
 data class SavedSearchDto(
     val id: String,
     val name: String,
-    val filters: Map<String, String> = emptyMap(),
+    val filters: Map<String, JsonPrimitive> = emptyMap(),
     val createdAt: String = "",
 )
 
 @Serializable
 data class CreateSavedSearchRequest(
     val name: String,
-    val filters: Map<String, String>,
+    val filters: Map<String, JsonPrimitive>,
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -28,6 +28,7 @@ import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
 import com.spela.player.domain.model.PlayersLikeYouResult
 import com.spela.player.domain.model.RecentReviewItem
+import com.spela.player.domain.model.SavedSearch
 import com.spela.player.domain.model.ScreenshotItem
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.TasteProfile
@@ -378,6 +379,28 @@ class ExploreRepositoryImpl(
 
     override suspend fun getActiveChallenges(): Result<List<ExploreChallenge>> = runCatching {
         apiClient.getActiveChallenges().challenges.map { it.toDomain() }
+    }
+
+    override suspend fun getFilteredGames(filters: Map<String, String>, page: Int, pageSize: Int): Result<List<Game>> = runCatching {
+        apiClient.getFilteredGames(filters, page, pageSize).data.map { gameDto ->
+            gameDto.toDomain().copy(
+                coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+                logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+            )
+        }
+    }
+
+    override suspend fun getSavedSearches(): Result<List<SavedSearch>> = runCatching {
+        apiClient.getSavedSearches().map { it.toDomain() }
+    }
+
+    override suspend fun createSavedSearch(name: String, filters: Map<String, String>): Result<SavedSearch> = runCatching {
+        apiClient.createSavedSearch(name, filters).toDomain()
+    }
+
+    override suspend fun deleteSavedSearch(id: String): Result<Unit> = runCatching {
+        apiClient.deleteSavedSearch(id)
     }
 
     private fun resolveGameCovers(game: Game, dto: GameDto): Game = game.copy(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -274,3 +274,76 @@ data class ExploreChallenge(
     val expiresAt: String?,
     val createdAt: String,
 )
+
+// --- Phase 13: Advanced Search & Multi-Faceted Filtering ---
+
+data class SavedSearch(
+    val id: String,
+    val name: String,
+    val filters: Map<String, String>,
+    val createdAt: String,
+)
+
+data class GameFilters(
+    val search: String = "",
+    val consoles: List<String> = emptyList(),
+    val genres: List<String> = emptyList(),
+    val themes: List<String> = emptyList(),
+    val keywords: List<String> = emptyList(),
+    val perspectives: List<String> = emptyList(),
+    val developer: String = "",
+    val publisher: String = "",
+    val yearMin: Int? = null,
+    val yearMax: Int? = null,
+    val ratingMin: Double? = null,
+    val ratingMax: Double? = null,
+    val playStatus: String = "",
+    val sortBy: String = "",
+    val sortOrder: String = "",
+) {
+    val isEmpty: Boolean
+        get() = search.isBlank() && consoles.isEmpty() && genres.isEmpty() &&
+            themes.isEmpty() && keywords.isEmpty() && perspectives.isEmpty() &&
+            developer.isBlank() && publisher.isBlank() &&
+            yearMin == null && yearMax == null &&
+            ratingMin == null && ratingMax == null &&
+            playStatus.isBlank() && sortBy.isBlank()
+
+    fun toQueryMap(): Map<String, String> = buildMap {
+        if (search.isNotBlank()) put("search", search)
+        if (consoles.isNotEmpty()) put("consoles", consoles.joinToString(","))
+        if (genres.isNotEmpty()) put("genres", genres.joinToString(","))
+        if (themes.isNotEmpty()) put("themes", themes.joinToString(","))
+        if (keywords.isNotEmpty()) put("keywords", keywords.joinToString(","))
+        if (perspectives.isNotEmpty()) put("perspectives", perspectives.joinToString(","))
+        if (developer.isNotBlank()) put("developer", developer)
+        if (publisher.isNotBlank()) put("publisher", publisher)
+        yearMin?.let { put("yearMin", it.toString()) }
+        yearMax?.let { put("yearMax", it.toString()) }
+        ratingMin?.let { put("ratingMin", it.toString()) }
+        ratingMax?.let { put("ratingMax", it.toString()) }
+        if (playStatus.isNotBlank()) put("playStatus", playStatus)
+        if (sortBy.isNotBlank()) put("sortBy", sortBy)
+        if (sortOrder.isNotBlank()) put("sortOrder", sortOrder)
+    }
+
+    companion object {
+        fun fromQueryMap(map: Map<String, String>): GameFilters = GameFilters(
+            search = map["search"] ?: "",
+            consoles = map["consoles"]?.split(",")?.filter { it.isNotBlank() } ?: emptyList(),
+            genres = map["genres"]?.split(",")?.filter { it.isNotBlank() } ?: emptyList(),
+            themes = map["themes"]?.split(",")?.filter { it.isNotBlank() } ?: emptyList(),
+            keywords = map["keywords"]?.split(",")?.filter { it.isNotBlank() } ?: emptyList(),
+            perspectives = map["perspectives"]?.split(",")?.filter { it.isNotBlank() } ?: emptyList(),
+            developer = map["developer"] ?: "",
+            publisher = map["publisher"] ?: "",
+            yearMin = map["yearMin"]?.toIntOrNull(),
+            yearMax = map["yearMax"]?.toIntOrNull(),
+            ratingMin = map["ratingMin"]?.toDoubleOrNull(),
+            ratingMax = map["ratingMax"]?.toDoubleOrNull(),
+            playStatus = map["playStatus"] ?: "",
+            sortBy = map["sortBy"] ?: "",
+            sortOrder = map["sortOrder"] ?: "",
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -25,6 +25,7 @@ import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
 import com.spela.player.domain.model.PlayersLikeYouResult
 import com.spela.player.domain.model.RecentReviewItem
+import com.spela.player.domain.model.SavedSearch
 import com.spela.player.domain.model.ScreenshotItem
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.TasteProfile
@@ -70,4 +71,8 @@ interface ExploreRepository {
     suspend fun getAlmostDone(): Result<List<AlmostDoneGame>>
     suspend fun getFreshChallenges(): Result<List<FreshChallengeGame>>
     suspend fun getActiveChallenges(): Result<List<ExploreChallenge>>
+    suspend fun getFilteredGames(filters: Map<String, String>, page: Int = 1, pageSize: Int = 20): Result<List<Game>>
+    suspend fun getSavedSearches(): Result<List<SavedSearch>>
+    suspend fun createSavedSearch(name: String, filters: Map<String, String>): Result<SavedSearch>
+    suspend fun deleteSavedSearch(id: String): Result<Unit>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -37,6 +37,7 @@ sealed class SpScreen(val route: String) {
     data class ExplorePublisher(val name: String) : SpScreen("explore_publisher/$name")
     data class ExploreConsoleShowcase(val consoleId: String) : SpScreen("explore_console/$consoleId")
     data object ExploreGallery : SpScreen("explore_gallery")
+    data object ExploreSearch : SpScreen("explore_search")
 }
 
 data class NavigationState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -99,6 +99,7 @@ import com.spela.player.presentation.ui.screen.ExploreKeywordScreen
 import com.spela.player.presentation.ui.screen.ExploreMoodScreen
 import com.spela.player.presentation.ui.screen.ExploreScreen
 import com.spela.player.presentation.ui.screen.ExploreSeriesScreen
+import com.spela.player.presentation.ui.screen.ExploreSearchScreen
 import com.spela.player.presentation.ui.screen.ExploreThemeScreen
 import com.spela.player.presentation.ui.screen.TopListsScreen
 import com.spela.player.presentation.ui.screen.UserProfileScreen
@@ -506,6 +507,11 @@ fun SpelaApp(
                                                 )
                                             }
                                         },
+                                        onSearchSelected = {
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreSearch)
+                                            )
+                                        },
                                     )
                                 }
                             }
@@ -643,6 +649,22 @@ fun SpelaApp(
                             is SpScreen.ExploreGallery -> {
                                 if (exploreViewModel != null) {
                                     ExploreGalleryScreen(
+                                        viewModel = exploreViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.ExploreSearch -> {
+                                if (exploreViewModel != null) {
+                                    ExploreSearchScreen(
                                         viewModel = exploreViewModel,
                                         onGameSelected = { gameId ->
                                             navigationViewModel.onIntent(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameFilterPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameFilterPanel.kt
@@ -1,0 +1,430 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.GameFilters
+import com.spela.player.domain.model.SavedSearch
+import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpButtonStyle
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpTextField
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+private val CONSOLE_OPTIONS = listOf("NES", "SNES", "N64", "GB", "GBC", "GBA", "SMS", "GEN", "GG", "PSX", "SATURN")
+
+private val GENRE_OPTIONS = listOf(
+    "Action", "Adventure", "RPG", "Platform", "Puzzle",
+    "Racing", "Shooter", "Sports", "Strategy", "Fighting",
+    "Simulation", "Horror",
+)
+
+private val PLAY_STATUS_OPTIONS = listOf(
+    "unplayed" to "Unplayed",
+    "played" to "Played",
+    "favorited" to "Favorited",
+    "play-later" to "Play Later",
+)
+
+private val SORT_OPTIONS = listOf(
+    "title" to "Title",
+    "rating" to "Rating",
+    "release_date" to "Release Date",
+    "created_at" to "Date Added",
+    "file_size" to "File Size",
+)
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun GameFilterPanel(
+    filters: GameFilters,
+    savedSearches: List<SavedSearch>,
+    isLoading: Boolean,
+    isSaving: Boolean,
+    onFiltersChanged: (GameFilters) -> Unit,
+    onApplyFilters: () -> Unit,
+    onClearFilters: () -> Unit,
+    onSaveSearch: (String) -> Unit,
+    onDeleteSavedSearch: (String) -> Unit,
+    onApplySavedSearch: (SavedSearch) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var saveSearchName by remember { mutableStateOf("") }
+
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .verticalScroll(rememberScrollState())
+            .testTag("game_filter_panel"),
+    ) {
+        // --- Saved Searches Section ---
+        if (savedSearches.isNotEmpty()) {
+            Text(
+                text = "Saved Searches",
+                style = SpTypography.TitleSmall,
+                color = SpColor.OnBackground,
+                modifier = Modifier.testTag("saved_searches_title"),
+            )
+            Spacer(Modifier.height(SpSpacing.Small))
+            FlowRow(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("saved_searches_list"),
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            ) {
+                savedSearches.forEach { search ->
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        SpChip(
+                            text = search.name,
+                            onClick = { onApplySavedSearch(search) },
+                            modifier = Modifier.testTag("saved_search_chip_${search.id}"),
+                        )
+                        IconButton(
+                            onClick = { onDeleteSavedSearch(search.id) },
+                            modifier = Modifier.testTag("delete_saved_search_${search.id}"),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Delete,
+                                contentDescription = "Delete saved search",
+                                tint = SpColor.OnBackgroundSecondary,
+                            )
+                        }
+                    }
+                }
+            }
+            Spacer(Modifier.height(SpSpacing.Medium))
+        }
+
+        // --- Search text ---
+        Text(
+            text = "Search",
+            style = SpTypography.TitleSmall,
+            color = SpColor.OnBackground,
+        )
+        Spacer(Modifier.height(SpSpacing.XSmall))
+        SpTextField(
+            value = filters.search,
+            onValueChange = { onFiltersChanged(filters.copy(search = it)) },
+            placeholder = "Search games...",
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Filled.Search,
+                    contentDescription = "Search",
+                    tint = SpColor.OnBackgroundSecondary,
+                )
+            },
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("filter_search_field"),
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // --- Console chips ---
+        Text(
+            text = "Consoles",
+            style = SpTypography.TitleSmall,
+            color = SpColor.OnBackground,
+        )
+        Spacer(Modifier.height(SpSpacing.XSmall))
+        FlowRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("filter_consoles_chips"),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            CONSOLE_OPTIONS.forEach { console ->
+                SpChip(
+                    text = console,
+                    isSelected = console in filters.consoles,
+                    onClick = {
+                        val updated = if (console in filters.consoles) {
+                            filters.consoles - console
+                        } else {
+                            filters.consoles + console
+                        }
+                        onFiltersChanged(filters.copy(consoles = updated))
+                    },
+                    modifier = Modifier.testTag("filter_console_chip_$console"),
+                )
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // --- Genre chips ---
+        Text(
+            text = "Genres",
+            style = SpTypography.TitleSmall,
+            color = SpColor.OnBackground,
+        )
+        Spacer(Modifier.height(SpSpacing.XSmall))
+        FlowRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("filter_genres_chips"),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            GENRE_OPTIONS.forEach { genre ->
+                SpChip(
+                    text = genre,
+                    isSelected = genre in filters.genres,
+                    onClick = {
+                        val updated = if (genre in filters.genres) {
+                            filters.genres - genre
+                        } else {
+                            filters.genres + genre
+                        }
+                        onFiltersChanged(filters.copy(genres = updated))
+                    },
+                    modifier = Modifier.testTag("filter_genre_chip_$genre"),
+                )
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // --- Developer & Publisher text fields ---
+        Text(
+            text = "Developer",
+            style = SpTypography.TitleSmall,
+            color = SpColor.OnBackground,
+        )
+        Spacer(Modifier.height(SpSpacing.XSmall))
+        SpTextField(
+            value = filters.developer,
+            onValueChange = { onFiltersChanged(filters.copy(developer = it)) },
+            placeholder = "Developer name...",
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("filter_developer_field"),
+        )
+        Spacer(Modifier.height(SpSpacing.Small))
+        Text(
+            text = "Publisher",
+            style = SpTypography.TitleSmall,
+            color = SpColor.OnBackground,
+        )
+        Spacer(Modifier.height(SpSpacing.XSmall))
+        SpTextField(
+            value = filters.publisher,
+            onValueChange = { onFiltersChanged(filters.copy(publisher = it)) },
+            placeholder = "Publisher name...",
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("filter_publisher_field"),
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // --- Year range ---
+        Text(
+            text = "Release Year",
+            style = SpTypography.TitleSmall,
+            color = SpColor.OnBackground,
+        )
+        Spacer(Modifier.height(SpSpacing.XSmall))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            SpTextField(
+                value = filters.yearMin?.toString() ?: "",
+                onValueChange = { onFiltersChanged(filters.copy(yearMin = it.toIntOrNull())) },
+                placeholder = "From",
+                keyboardType = KeyboardType.Number,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("filter_year_min_field"),
+            )
+            SpTextField(
+                value = filters.yearMax?.toString() ?: "",
+                onValueChange = { onFiltersChanged(filters.copy(yearMax = it.toIntOrNull())) },
+                placeholder = "To",
+                keyboardType = KeyboardType.Number,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("filter_year_max_field"),
+            )
+        }
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // --- Rating range ---
+        Text(
+            text = "Rating",
+            style = SpTypography.TitleSmall,
+            color = SpColor.OnBackground,
+        )
+        Spacer(Modifier.height(SpSpacing.XSmall))
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            SpTextField(
+                value = filters.ratingMin?.let { "%.0f".format(it) } ?: "",
+                onValueChange = { onFiltersChanged(filters.copy(ratingMin = it.toDoubleOrNull())) },
+                placeholder = "Min",
+                keyboardType = KeyboardType.Number,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("filter_rating_min_field"),
+            )
+            SpTextField(
+                value = filters.ratingMax?.let { "%.0f".format(it) } ?: "",
+                onValueChange = { onFiltersChanged(filters.copy(ratingMax = it.toDoubleOrNull())) },
+                placeholder = "Max",
+                keyboardType = KeyboardType.Number,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("filter_rating_max_field"),
+            )
+        }
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // --- Play status chips ---
+        Text(
+            text = "Play Status",
+            style = SpTypography.TitleSmall,
+            color = SpColor.OnBackground,
+        )
+        Spacer(Modifier.height(SpSpacing.XSmall))
+        FlowRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("filter_play_status_chips"),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            PLAY_STATUS_OPTIONS.forEach { (value, label) ->
+                SpChip(
+                    text = label,
+                    isSelected = filters.playStatus == value,
+                    onClick = {
+                        val updated = if (filters.playStatus == value) "" else value
+                        onFiltersChanged(filters.copy(playStatus = updated))
+                    },
+                    modifier = Modifier.testTag("filter_play_status_chip_$value"),
+                )
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // --- Sort ---
+        Text(
+            text = "Sort By",
+            style = SpTypography.TitleSmall,
+            color = SpColor.OnBackground,
+        )
+        Spacer(Modifier.height(SpSpacing.XSmall))
+        FlowRow(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("filter_sort_chips"),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            SORT_OPTIONS.forEach { (value, label) ->
+                SpChip(
+                    text = label,
+                    isSelected = filters.sortBy == value,
+                    onClick = {
+                        if (filters.sortBy == value) {
+                            // Toggle sort order or deselect
+                            val newOrder = if (filters.sortOrder == "asc") "desc" else "asc"
+                            onFiltersChanged(filters.copy(sortOrder = newOrder))
+                        } else {
+                            onFiltersChanged(filters.copy(sortBy = value, sortOrder = "asc"))
+                        }
+                    },
+                    modifier = Modifier.testTag("filter_sort_chip_$value"),
+                )
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Large))
+
+        // --- Action buttons ---
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            SpButton(
+                text = "Apply Filters",
+                onClick = onApplyFilters,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("apply_filters_button"),
+                isLoading = isLoading,
+            )
+            SpButton(
+                text = "Clear",
+                onClick = onClearFilters,
+                modifier = Modifier
+                    .weight(1f)
+                    .testTag("clear_filters_button"),
+                style = SpButtonStyle.Secondary,
+            )
+        }
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // --- Save search ---
+        if (!filters.isEmpty) {
+            Text(
+                text = "Save This Search",
+                style = SpTypography.TitleSmall,
+                color = SpColor.OnBackground,
+            )
+            Spacer(Modifier.height(SpSpacing.XSmall))
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                SpTextField(
+                    value = saveSearchName,
+                    onValueChange = { saveSearchName = it },
+                    placeholder = "Search name...",
+                    modifier = Modifier
+                        .weight(1f)
+                        .testTag("save_search_name_field"),
+                )
+                SpButton(
+                    text = "Save",
+                    onClick = {
+                        if (saveSearchName.isNotBlank()) {
+                            onSaveSearch(saveSearchName)
+                            saveSearchName = ""
+                        }
+                    },
+                    modifier = Modifier.testTag("save_search_button"),
+                    isLoading = isSaving,
+                    enabled = saveSearchName.isNotBlank(),
+                )
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Medium))
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -4,19 +4,24 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Explore
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.material3.Icon
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
@@ -58,6 +63,7 @@ import com.spela.player.presentation.ui.feature.explore.OnThisDaySection
 import com.spela.player.presentation.ui.feature.explore.TemporalSectionSkeleton
 import com.spela.player.presentation.ui.feature.explore.TrendingSection
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
+import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 
@@ -74,6 +80,7 @@ fun ExploreScreen(
     onChallengeSelected: ((challengeId: String) -> Unit)? = null,
     onGallerySelected: (() -> Unit)? = null,
     onSurpriseMe: (() -> Unit)? = null,
+    onSearchSelected: (() -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
 
@@ -131,6 +138,28 @@ fun ExploreScreen(
                                 ),
                             )
                         }
+                    }
+
+                    // Advanced search entry point
+                    item {
+                        SpChip(
+                            text = "Advanced Search & Filters",
+                            onClick = { onSearchSelected?.invoke() },
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Filled.Search,
+                                    contentDescription = null,
+                                    tint = SpColor.OnBackgroundSecondary,
+                                    modifier = Modifier.height(16.dp),
+                                )
+                            },
+                            modifier = Modifier
+                                .padding(
+                                    horizontal = SpSpacing.ScreenHorizontal,
+                                    vertical = SpSpacing.Small,
+                                )
+                                .testTag("explore_search_chip"),
+                        )
                     }
 
                     // Console quick-jump section

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreSearchScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreSearchScreen.kt
@@ -1,0 +1,271 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.FilterList
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.feature.explore.GameFilterPanel
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+import com.spela.player.util.formatRating
+
+@Composable
+fun ExploreSearchScreen(
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val searchState by viewModel.gameSearchState.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.loadSavedSearches()
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("explore_search_screen"),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = "Advanced Search",
+                showBack = true,
+                onBack = onBack,
+                actions = {
+                    IconButton(
+                        onClick = { viewModel.toggleFilterPanel() },
+                        modifier = Modifier.testTag("toggle_filter_panel_button"),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.FilterList,
+                            contentDescription = "Toggle filters",
+                            tint = if (searchState.showFilterPanel) SpColor.Primary else SpColor.OnBackgroundSecondary,
+                        )
+                    }
+                },
+            )
+
+            if (searchState.showFilterPanel) {
+                GameFilterPanel(
+                    filters = searchState.filters,
+                    savedSearches = searchState.savedSearches,
+                    isLoading = searchState.isLoading,
+                    isSaving = searchState.isSaving,
+                    onFiltersChanged = { viewModel.updateFilters(it) },
+                    onApplyFilters = { viewModel.applyFilters() },
+                    onClearFilters = { viewModel.clearFilters() },
+                    onSaveSearch = { name -> viewModel.saveCurrentSearch(name) },
+                    onDeleteSavedSearch = { id -> viewModel.deleteSavedSearch(id) },
+                    onApplySavedSearch = { saved -> viewModel.applySavedSearch(saved) },
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = SpSpacing.ScreenHorizontal),
+                )
+                Spacer(Modifier.height(SpSpacing.Medium))
+            }
+
+            when {
+                searchState.isLoading && searchState.results.isEmpty() -> {
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("search_results_loading"),
+                        contentPadding = PaddingValues(SpSpacing.ScreenHorizontal),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                    ) {
+                        items(8) {
+                            SpGameCardSkeleton()
+                        }
+                    }
+                }
+
+                searchState.results.isEmpty() && !searchState.isLoading && searchState.filters.isEmpty -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.Search,
+                            title = "Search your library",
+                            message = "Use the filters above to find games by console, genre, developer, rating, and more.",
+                            modifier = Modifier.testTag("search_empty_state"),
+                        )
+                    }
+                }
+
+                searchState.results.isEmpty() && !searchState.isLoading && !searchState.filters.isEmpty -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.Search,
+                            title = "No results found",
+                            message = "Try adjusting your filters to find more games.",
+                            modifier = Modifier.testTag("search_no_results"),
+                        )
+                    }
+                }
+
+                else -> {
+                    Text(
+                        text = "${searchState.results.size} results",
+                        style = SpTypography.LabelMedium,
+                        color = SpColor.OnBackgroundSecondary,
+                        modifier = Modifier
+                            .padding(horizontal = SpSpacing.ScreenHorizontal)
+                            .testTag("search_results_count"),
+                    )
+                    Spacer(Modifier.height(SpSpacing.Small))
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .testTag("search_results_grid"),
+                        contentPadding = PaddingValues(SpSpacing.ScreenHorizontal),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                    ) {
+                        items(searchState.results, key = { it.id }) { game ->
+                            SearchResultGameCard(
+                                game = game,
+                                onClick = { onGameSelected(game.id) },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        // Error snackbar
+        SpSnackbar(
+            data = searchState.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.dismissSearchError() },
+                )
+            },
+            onDismiss = { viewModel.dismissSearchError() },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@Composable
+private fun SearchResultGameCard(
+    game: Game,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("search_result_game_${game.id}")
+            .semantics {
+                contentDescription = "${game.title}, ${game.consoleName}"
+                role = Role.Button
+            },
+        onClick = onClick,
+        onGradient = true,
+    ) {
+        Column {
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.title} cover art",
+                modifier = Modifier.fillMaxWidth(),
+                aspectRatio = game.coverAspectRatio,
+            )
+            Column(
+                modifier = Modifier.padding(
+                    horizontal = SpSpacing.Small,
+                    vertical = SpSpacing.Small,
+                ),
+            ) {
+                Text(
+                    text = game.title,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                ) {
+                    Text(
+                        text = game.consoleName,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                        maxLines = 1,
+                    )
+                    if (game.rating > 0) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(10.dp),
+                        )
+                        Text(
+                            text = formatRating(game.rating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -18,9 +18,11 @@ import com.spela.player.domain.model.FeaturedSeries
 import com.spela.player.domain.model.ForYouRow
 import com.spela.player.domain.model.FreshChallengeGame
 import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.GameFilters
 import com.spela.player.domain.model.Keyword
 import com.spela.player.domain.model.MoodDefinition
 import com.spela.player.domain.model.RecentReviewItem
+import com.spela.player.domain.model.SavedSearch
 import com.spela.player.domain.model.ScreenshotItem
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.Theme
@@ -139,6 +141,17 @@ data class ScreenshotGalleryState(
     val error: String? = null,
 )
 
+data class GameSearchState(
+    val filters: GameFilters = GameFilters(),
+    val results: List<Game> = emptyList(),
+    val savedSearches: List<SavedSearch> = emptyList(),
+    val isLoading: Boolean = false,
+    val isLoadingSavedSearches: Boolean = false,
+    val isSaving: Boolean = false,
+    val showFilterPanel: Boolean = false,
+    val error: String? = null,
+)
+
 data class SeriesDetailState(
     val seriesId: String = "",
     val seriesName: String = "",
@@ -190,6 +203,9 @@ class ExploreViewModel(
     private val _screenshotGalleryState = MutableStateFlow(ScreenshotGalleryState())
     val screenshotGalleryState: StateFlow<ScreenshotGalleryState> = _screenshotGalleryState.asStateFlow()
 
+    private val _gameSearchState = MutableStateFlow(GameSearchState())
+    val gameSearchState: StateFlow<GameSearchState> = _gameSearchState.asStateFlow()
+
     private var featuredJob: Job? = null
     private var rowsJob: Job? = null
     private var themesJob: Job? = null
@@ -210,6 +226,9 @@ class ExploreViewModel(
     private var temporalJob: Job? = null
     private var achievementJob: Job? = null
     private var screenshotGalleryJob: Job? = null
+    private var searchJob: Job? = null
+    private var savedSearchesJob: Job? = null
+    private var savingSearchJob: Job? = null
 
     fun load() {
         loadFeatured()
@@ -674,5 +693,97 @@ class ExploreViewModel(
 
     fun dismissScreenshotGalleryError() {
         _screenshotGalleryState.update { it.copy(error = null) }
+    }
+
+    // --- Phase 13: Advanced Search & Multi-Faceted Filtering ---
+
+    fun updateFilters(filters: GameFilters) {
+        _gameSearchState.update { it.copy(filters = filters) }
+    }
+
+    fun toggleFilterPanel() {
+        _gameSearchState.update { it.copy(showFilterPanel = !it.showFilterPanel) }
+    }
+
+    fun applyFilters() {
+        val filters = _gameSearchState.value.filters
+        searchJob?.cancel()
+        _gameSearchState.update { it.copy(isLoading = true, error = null, showFilterPanel = false) }
+        searchJob = scope.launch(dispatchers.io) {
+            exploreRepository.getFilteredGames(filters.toQueryMap(), page = 1, pageSize = 50).fold(
+                onSuccess = { games ->
+                    _gameSearchState.update { it.copy(results = games, isLoading = false) }
+                },
+                onFailure = { error ->
+                    _gameSearchState.update { it.copy(isLoading = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun clearFilters() {
+        _gameSearchState.update { it.copy(filters = GameFilters(), results = emptyList()) }
+    }
+
+    fun loadSavedSearches() {
+        savedSearchesJob?.cancel()
+        _gameSearchState.update { it.copy(isLoadingSavedSearches = true) }
+        savedSearchesJob = scope.launch(dispatchers.io) {
+            exploreRepository.getSavedSearches().fold(
+                onSuccess = { searches ->
+                    _gameSearchState.update { it.copy(savedSearches = searches, isLoadingSavedSearches = false) }
+                },
+                onFailure = { error ->
+                    _gameSearchState.update { it.copy(isLoadingSavedSearches = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun saveCurrentSearch(name: String) {
+        val filters = _gameSearchState.value.filters
+        if (filters.isEmpty) return
+        savingSearchJob?.cancel()
+        _gameSearchState.update { it.copy(isSaving = true) }
+        savingSearchJob = scope.launch(dispatchers.io) {
+            exploreRepository.createSavedSearch(name, filters.toQueryMap()).fold(
+                onSuccess = { savedSearch ->
+                    _gameSearchState.update {
+                        it.copy(
+                            savedSearches = it.savedSearches + savedSearch,
+                            isSaving = false,
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _gameSearchState.update { it.copy(isSaving = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun deleteSavedSearch(id: String) {
+        scope.launch(dispatchers.io) {
+            exploreRepository.deleteSavedSearch(id).fold(
+                onSuccess = {
+                    _gameSearchState.update {
+                        it.copy(savedSearches = it.savedSearches.filter { s -> s.id != id })
+                    }
+                },
+                onFailure = { error ->
+                    _gameSearchState.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun applySavedSearch(savedSearch: SavedSearch) {
+        val filters = GameFilters.fromQueryMap(savedSearch.filters)
+        _gameSearchState.update { it.copy(filters = filters) }
+        applyFilters()
+    }
+
+    fun dismissSearchError() {
+        _gameSearchState.update { it.copy(error = null) }
     }
 }

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -78,6 +78,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.GameSeries{},
 		&db.GameSeriesEntry{},
 		&db.GameArtworkImage{},
+		&db.SavedSearch{},
 	)
 	require.NoError(t, err)
 	err = db.SeedConsoles(database)

--- a/server/internal/api/game_filter_test.go
+++ b/server/internal/api/game_filter_test.go
@@ -1,0 +1,335 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// setupFilterEnv creates a test environment for ListGames filter tests.
+func setupFilterEnv(t *testing.T) (*gorm.DB, http.Handler, string) {
+	t.Helper()
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+	return database, router, token
+}
+
+// listGamesWithParams calls GET /api/games with the given query string and returns the parsed response.
+func listGamesWithParams(t *testing.T, router http.Handler, token, queryString string) ([]map[string]interface{}, int64) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games?"+queryString, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code, "ListGames failed: %s", w.Body.String())
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	data := resp["data"].([]interface{})
+	total := int64(resp["total"].(float64))
+
+	var games []map[string]interface{}
+	for _, d := range data {
+		games = append(games, d.(map[string]interface{}))
+	}
+	return games, total
+}
+
+// createFilterGame creates a game with customizable metadata fields for filter testing.
+func createFilterGame(t *testing.T, database *gorm.DB, consoleAbbr, title string, opts ...func(*db.Game)) db.Game {
+	t.Helper()
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", consoleAbbr).First(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     title,
+		FileName:  title + ".rom",
+		FilePath:  consoleAbbr + "/" + title + ".rom",
+	}
+	for _, opt := range opts {
+		opt(&game)
+	}
+	require.NoError(t, database.Create(&game).Error)
+	return game
+}
+
+func withDeveloper(dev string) func(*db.Game) {
+	return func(g *db.Game) { g.Developer = dev }
+}
+
+func withPublisher(pub string) func(*db.Game) {
+	return func(g *db.Game) { g.Publisher = pub }
+}
+
+func withReleaseDate(rd string) func(*db.Game) {
+	return func(g *db.Game) { g.ReleaseDate = rd }
+}
+
+func withRating(r float64) func(*db.Game) {
+	return func(g *db.Game) { g.Rating = r }
+}
+
+func withGenre(genre string) func(*db.Game) {
+	return func(g *db.Game) { g.Genre = genre }
+}
+
+func TestListGames_FilterByDeveloper(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	createFilterGame(t, database, "SNES", "Mario World", withDeveloper("Nintendo"))
+	createFilterGame(t, database, "SNES", "Street Fighter", withDeveloper("Capcom"))
+	createFilterGame(t, database, "SNES", "Donkey Kong Country", withDeveloper("Nintendo R&D"))
+
+	games, total := listGamesWithParams(t, router, token, "developer=Nintendo")
+	assert.Equal(t, int64(2), total, "should match both Nintendo and Nintendo R&D")
+	assert.Len(t, games, 2)
+}
+
+func TestListGames_FilterByPublisher(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	createFilterGame(t, database, "SNES", "Game A", withPublisher("Konami"))
+	createFilterGame(t, database, "SNES", "Game B", withPublisher("Capcom"))
+	createFilterGame(t, database, "SNES", "Game C", withPublisher("Konami Digital"))
+
+	games, total := listGamesWithParams(t, router, token, "publisher=Konami")
+	assert.Equal(t, int64(2), total)
+	assert.Len(t, games, 2)
+}
+
+func TestListGames_FilterByYearRange(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	createFilterGame(t, database, "SNES", "Game 1991", withReleaseDate("1991-06-15"))
+	createFilterGame(t, database, "SNES", "Game 1993", withReleaseDate("1993-11-21"))
+	createFilterGame(t, database, "SNES", "Game 1995", withReleaseDate("1995-03-10"))
+	createFilterGame(t, database, "SNES", "Game 1997", withReleaseDate("1997-01-01"))
+
+	// yearMin only
+	games, _ := listGamesWithParams(t, router, token, "yearMin=1993")
+	assert.Len(t, games, 3, "should include 1993, 1995, 1997")
+
+	// yearMax only
+	games, _ = listGamesWithParams(t, router, token, "yearMax=1993")
+	assert.Len(t, games, 2, "should include 1991, 1993")
+
+	// Both yearMin and yearMax
+	games, _ = listGamesWithParams(t, router, token, "yearMin=1993&yearMax=1995")
+	assert.Len(t, games, 2, "should include 1993 and 1995")
+}
+
+func TestListGames_FilterByRatingRange(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	createFilterGame(t, database, "SNES", "Low Rated", withRating(30.0))
+	createFilterGame(t, database, "SNES", "Medium Rated", withRating(65.0))
+	createFilterGame(t, database, "SNES", "High Rated", withRating(90.0))
+
+	// ratingMin only
+	games, _ := listGamesWithParams(t, router, token, "ratingMin=60")
+	assert.Len(t, games, 2, "should include medium and high rated games")
+
+	// ratingMax only
+	games, _ = listGamesWithParams(t, router, token, "ratingMax=70")
+	assert.Len(t, games, 2, "should include low and medium rated games")
+
+	// Both ratingMin and ratingMax
+	games, _ = listGamesWithParams(t, router, token, "ratingMin=50&ratingMax=80")
+	assert.Len(t, games, 1, "should include only medium rated game")
+	assert.Equal(t, "Medium Rated", games[0]["title"])
+}
+
+func TestListGames_FilterByPlayStatus_Unplayed(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	game1 := createFilterGame(t, database, "SNES", "Played Game", withRating(80))
+	_ = createFilterGame(t, database, "SNES", "Unplayed Game", withRating(70))
+
+	// Mark game1 as played by the test user
+	var user db.User
+	database.First(&user)
+	database.Create(&db.PlayHistory{UserID: user.ID, GameID: game1.ID, PlayTime: 60})
+
+	games, total := listGamesWithParams(t, router, token, "playStatus=unplayed")
+	assert.Equal(t, int64(1), total)
+	assert.Len(t, games, 1)
+	assert.Equal(t, "Unplayed Game", games[0]["title"])
+}
+
+func TestListGames_FilterByPlayStatus_Played(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	game1 := createFilterGame(t, database, "SNES", "Played Game", withRating(80))
+	_ = createFilterGame(t, database, "SNES", "Unplayed Game", withRating(70))
+
+	var user db.User
+	database.First(&user)
+	database.Create(&db.PlayHistory{UserID: user.ID, GameID: game1.ID, PlayTime: 120})
+
+	games, total := listGamesWithParams(t, router, token, "playStatus=played")
+	assert.Equal(t, int64(1), total)
+	assert.Len(t, games, 1)
+	assert.Equal(t, "Played Game", games[0]["title"])
+}
+
+func TestListGames_FilterByPlayStatus_Favorited(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	game1 := createFilterGame(t, database, "SNES", "Fav Game", withRating(90))
+	_ = createFilterGame(t, database, "SNES", "Not Fav Game", withRating(70))
+
+	var user db.User
+	database.First(&user)
+	database.Create(&db.Favorite{UserID: user.ID, GameID: game1.ID})
+
+	games, total := listGamesWithParams(t, router, token, "playStatus=favorited")
+	assert.Equal(t, int64(1), total)
+	assert.Len(t, games, 1)
+	assert.Equal(t, "Fav Game", games[0]["title"])
+}
+
+func TestListGames_FilterByPlayStatus_PlayLater(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	game1 := createFilterGame(t, database, "SNES", "Queued Game", withRating(85))
+	_ = createFilterGame(t, database, "SNES", "Regular Game", withRating(75))
+
+	var user db.User
+	database.First(&user)
+	database.Create(&db.PlayLaterItem{UserID: user.ID, GameID: game1.ID})
+
+	games, total := listGamesWithParams(t, router, token, "playStatus=play-later")
+	assert.Equal(t, int64(1), total)
+	assert.Len(t, games, 1)
+	assert.Equal(t, "Queued Game", games[0]["title"])
+}
+
+func TestListGames_MultipleThemes(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	game1 := createFilterGame(t, database, "SNES", "Fantasy Game", withRating(80))
+	game2 := createFilterGame(t, database, "SNES", "Sci-Fi Game", withRating(75))
+	_ = createFilterGame(t, database, "SNES", "No Theme Game", withRating(70))
+
+	database.Create(&db.GameTheme{GameID: game1.ID, IGDBThemeID: 17, Name: "Fantasy"})
+	database.Create(&db.GameTheme{GameID: game2.ID, IGDBThemeID: 18, Name: "Sci-Fi"})
+
+	// Multi-select themes
+	games, total := listGamesWithParams(t, router, token, "themes=17,18")
+	assert.Equal(t, int64(2), total)
+	assert.Len(t, games, 2)
+
+	// Single theme backward compat
+	games, _ = listGamesWithParams(t, router, token, "theme=17")
+	assert.Len(t, games, 1)
+	assert.Equal(t, "Fantasy Game", games[0]["title"])
+}
+
+func TestListGames_MultipleConsoles(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	createFilterGame(t, database, "SNES", "SNES Game", withRating(80))
+	createFilterGame(t, database, "NES", "NES Game", withRating(75))
+	createFilterGame(t, database, "GBA", "GBA Game", withRating(70))
+
+	// Multi-select
+	games, total := listGamesWithParams(t, router, token, "consoles=SNES,NES")
+	assert.Equal(t, int64(2), total)
+	assert.Len(t, games, 2)
+
+	// Backward compat (consoleId singular)
+	games, _ = listGamesWithParams(t, router, token, "consoleId=GBA")
+	assert.Len(t, games, 1)
+	assert.Equal(t, "GBA Game", games[0]["title"])
+}
+
+func TestListGames_MultipleGenres(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	createFilterGame(t, database, "SNES", "Action Game", withGenre("Action"))
+	createFilterGame(t, database, "SNES", "RPG Game", withGenre("RPG"))
+	createFilterGame(t, database, "SNES", "Puzzle Game", withGenre("Puzzle"))
+
+	games, total := listGamesWithParams(t, router, token, "genres=Action,RPG")
+	assert.Equal(t, int64(2), total)
+	assert.Len(t, games, 2)
+
+	// Backward compat
+	games, _ = listGamesWithParams(t, router, token, "genre=Puzzle")
+	assert.Len(t, games, 1)
+	assert.Equal(t, "Puzzle Game", games[0]["title"])
+}
+
+func TestListGames_MultipleKeywords(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	game1 := createFilterGame(t, database, "SNES", "Zombie Game", withRating(80))
+	game2 := createFilterGame(t, database, "SNES", "Time Travel Game", withRating(75))
+	_ = createFilterGame(t, database, "SNES", "Plain Game", withRating(70))
+
+	database.Create(&db.GameKeyword{GameID: game1.ID, IGDBKeywordID: 100, Name: "Zombies"})
+	database.Create(&db.GameKeyword{GameID: game2.ID, IGDBKeywordID: 200, Name: "Time Travel"})
+
+	games, total := listGamesWithParams(t, router, token, "keywords=100,200")
+	assert.Equal(t, int64(2), total)
+	assert.Len(t, games, 2)
+
+	// Backward compat
+	games, _ = listGamesWithParams(t, router, token, "keyword=100")
+	assert.Len(t, games, 1)
+	assert.Equal(t, "Zombie Game", games[0]["title"])
+}
+
+func TestListGames_MultiplePerspectives(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	game1 := createFilterGame(t, database, "SNES", "FPS Game", withRating(80))
+	game2 := createFilterGame(t, database, "SNES", "Side Scroller", withRating(75))
+	_ = createFilterGame(t, database, "SNES", "No Perspective Game", withRating(70))
+
+	database.Create(&db.GamePlayerPerspective{GameID: game1.ID, IGDBPerspectiveID: 1, Name: "First person"})
+	database.Create(&db.GamePlayerPerspective{GameID: game2.ID, IGDBPerspectiveID: 3, Name: "Side view"})
+
+	games, total := listGamesWithParams(t, router, token, "perspectives=1,3")
+	assert.Equal(t, int64(2), total)
+	assert.Len(t, games, 2)
+
+	// Backward compat
+	games, _ = listGamesWithParams(t, router, token, "perspective=1")
+	assert.Len(t, games, 1)
+	assert.Equal(t, "FPS Game", games[0]["title"])
+}
+
+func TestListGames_CombinedFilters(t *testing.T) {
+	database, router, token := setupFilterEnv(t)
+
+	// Create a game that matches all filters
+	createFilterGame(t, database, "SNES", "Super Action",
+		withDeveloper("Capcom"), withPublisher("Capcom"),
+		withGenre("Action"), withReleaseDate("1994-08-15"), withRating(85.0))
+
+	// Create games that only match some filters
+	createFilterGame(t, database, "SNES", "Bad Action",
+		withDeveloper("Capcom"), withPublisher("Capcom"),
+		withGenre("Action"), withReleaseDate("1994-05-01"), withRating(40.0))
+
+	createFilterGame(t, database, "NES", "NES RPG",
+		withDeveloper("Square"), withPublisher("Square"),
+		withGenre("RPG"), withReleaseDate("1994-06-01"), withRating(90.0))
+
+	// Combine: SNES + Action + Capcom developer + rating >= 80 + year 1994
+	games, total := listGamesWithParams(t, router, token,
+		"consoles=SNES&genres=Action&developer=Capcom&ratingMin=80&yearMin=1994&yearMax=1994")
+	assert.Equal(t, int64(1), total)
+	assert.Len(t, games, 1)
+	assert.Equal(t, "Super Action", games[0]["title"])
+}

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -36,36 +36,165 @@ type GameHandler struct {
 func (h *GameHandler) ListGames(c *gin.Context) {
 	var games []db.Game
 	query := h.DB.Preload("Console").Preload("Discs").Preload("Screenshots")
+	countQuery := h.DB.Model(&db.Game{})
 
-	if consoleAbbr := c.Query("consoleId"); consoleAbbr != "" {
-		var console db.Console
-		if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", consoleAbbr).First(&console).Error; err == nil {
-			query = query.Where("console_id = ?", console.ID)
-		} else {
-			// Unknown console abbreviation — return empty list
-			c.JSON(http.StatusOK, []GameResponse{})
+	userID := getUserID(c)
+
+	// --- Console filter (multi-select with backward compat) ---
+	consoles := c.Query("consoles")
+	if consoles == "" {
+		consoles = c.Query("consoleId")
+	}
+	if consoles != "" {
+		abbrs := strings.Split(consoles, ",")
+		var consoleIDs []uint
+		for _, abbr := range abbrs {
+			abbr = strings.TrimSpace(abbr)
+			if abbr == "" {
+				continue
+			}
+			var console db.Console
+			if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", abbr).First(&console).Error; err == nil {
+				consoleIDs = append(consoleIDs, console.ID)
+			}
+		}
+		if len(consoleIDs) == 0 {
+			// All abbreviations unknown — return empty list
+			c.JSON(http.StatusOK, PaginatedResponse{
+				Data:     []GameResponse{},
+				Total:    0,
+				Page:     1,
+				PageSize: 50,
+			})
 			return
 		}
-	}
-	if search := c.Query("search"); search != "" {
-		query = query.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")
-	}
-	if genre := c.Query("genre"); genre != "" {
-		query = query.Where("genre = ?", genre)
+		query = query.Where("console_id IN ?", consoleIDs)
+		countQuery = countQuery.Where("console_id IN ?", consoleIDs)
 	}
 
-	// Phase 2 Explore: enrichment-based filters (JOIN against enrichment tables)
-	if themeID := c.Query("theme"); themeID != "" {
+	// --- Text search ---
+	if search := c.Query("search"); search != "" {
+		query = query.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")
+		countQuery = countQuery.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")
+	}
+
+	// --- Genre filter (multi-select with backward compat) ---
+	genres := c.Query("genres")
+	if genres == "" {
+		genres = c.Query("genre")
+	}
+	if genres != "" {
+		genreList := strings.Split(genres, ",")
+		var trimmed []string
+		for _, g := range genreList {
+			g = strings.TrimSpace(g)
+			if g != "" {
+				trimmed = append(trimmed, g)
+			}
+		}
+		if len(trimmed) > 0 {
+			query = query.Where("genre IN ?", trimmed)
+			countQuery = countQuery.Where("genre IN ?", trimmed)
+		}
+	}
+
+	// --- Theme filter (multi-select with backward compat) ---
+	themes := c.Query("themes")
+	if themes == "" {
+		themes = c.Query("theme")
+	}
+	if themes != "" {
+		themeIDs := strings.Split(themes, ",")
 		query = query.Joins("JOIN game_themes ON game_themes.game_id = games.id").
-			Where("game_themes.igdb_theme_id = ?", themeID)
+			Where("game_themes.igdb_theme_id IN ?", themeIDs)
+		countQuery = countQuery.Joins("JOIN game_themes ON game_themes.game_id = games.id").
+			Where("game_themes.igdb_theme_id IN ?", themeIDs)
 	}
-	if keywordID := c.Query("keyword"); keywordID != "" {
+
+	// --- Keyword filter (multi-select with backward compat) ---
+	keywords := c.Query("keywords")
+	if keywords == "" {
+		keywords = c.Query("keyword")
+	}
+	if keywords != "" {
+		keywordIDs := strings.Split(keywords, ",")
 		query = query.Joins("JOIN game_keywords ON game_keywords.game_id = games.id").
-			Where("game_keywords.igdb_keyword_id = ?", keywordID)
+			Where("game_keywords.igdb_keyword_id IN ?", keywordIDs)
+		countQuery = countQuery.Joins("JOIN game_keywords ON game_keywords.game_id = games.id").
+			Where("game_keywords.igdb_keyword_id IN ?", keywordIDs)
 	}
-	if perspectiveID := c.Query("perspective"); perspectiveID != "" {
+
+	// --- Perspective filter (multi-select with backward compat) ---
+	perspectives := c.Query("perspectives")
+	if perspectives == "" {
+		perspectives = c.Query("perspective")
+	}
+	if perspectives != "" {
+		perspectiveIDs := strings.Split(perspectives, ",")
 		query = query.Joins("JOIN game_player_perspectives ON game_player_perspectives.game_id = games.id").
-			Where("game_player_perspectives.igdb_perspective_id = ?", perspectiveID)
+			Where("game_player_perspectives.igdb_perspective_id IN ?", perspectiveIDs)
+		countQuery = countQuery.Joins("JOIN game_player_perspectives ON game_player_perspectives.game_id = games.id").
+			Where("game_player_perspectives.igdb_perspective_id IN ?", perspectiveIDs)
+	}
+
+	// --- Developer filter (LIKE, case-insensitive) ---
+	if developer := c.Query("developer"); developer != "" {
+		query = query.Where("games.developer LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(developer)+"%")
+		countQuery = countQuery.Where("games.developer LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(developer)+"%")
+	}
+
+	// --- Publisher filter (LIKE, case-insensitive) ---
+	if publisher := c.Query("publisher"); publisher != "" {
+		query = query.Where("games.publisher LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(publisher)+"%")
+		countQuery = countQuery.Where("games.publisher LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(publisher)+"%")
+	}
+
+	// --- Year range filters ---
+	if yearMin := c.Query("yearMin"); yearMin != "" {
+		if y, err := strconv.Atoi(yearMin); err == nil && y >= 1970 && y <= 2100 {
+			query = query.Where("release_date >= ?", fmt.Sprintf("%d", y))
+			countQuery = countQuery.Where("release_date >= ?", fmt.Sprintf("%d", y))
+		}
+	}
+	if yearMax := c.Query("yearMax"); yearMax != "" {
+		if y, err := strconv.Atoi(yearMax); err == nil && y >= 1970 && y <= 2100 {
+			query = query.Where("release_date < ?", fmt.Sprintf("%d", y+1))
+			countQuery = countQuery.Where("release_date < ?", fmt.Sprintf("%d", y+1))
+		}
+	}
+
+	// --- Rating range filters ---
+	if ratingMin := c.Query("ratingMin"); ratingMin != "" {
+		if r, err := strconv.ParseFloat(ratingMin, 64); err == nil {
+			query = query.Where("games.rating >= ?", r)
+			countQuery = countQuery.Where("games.rating >= ?", r)
+		}
+	}
+	if ratingMax := c.Query("ratingMax"); ratingMax != "" {
+		if r, err := strconv.ParseFloat(ratingMax, 64); err == nil {
+			query = query.Where("games.rating <= ?", r)
+			countQuery = countQuery.Where("games.rating <= ?", r)
+		}
+	}
+
+	// --- Play status filter (requires user context) ---
+	if playStatus := c.Query("playStatus"); playStatus != "" && userID > 0 {
+		switch playStatus {
+		case "unplayed":
+			query = query.Joins("LEFT JOIN play_histories ON play_histories.game_id = games.id AND play_histories.user_id = ? AND play_histories.deleted_at IS NULL", userID).
+				Where("play_histories.id IS NULL")
+			countQuery = countQuery.Joins("LEFT JOIN play_histories ON play_histories.game_id = games.id AND play_histories.user_id = ? AND play_histories.deleted_at IS NULL", userID).
+				Where("play_histories.id IS NULL")
+		case "played":
+			query = query.Joins("JOIN play_histories ON play_histories.game_id = games.id AND play_histories.user_id = ? AND play_histories.deleted_at IS NULL", userID)
+			countQuery = countQuery.Joins("JOIN play_histories ON play_histories.game_id = games.id AND play_histories.user_id = ? AND play_histories.deleted_at IS NULL", userID)
+		case "favorited":
+			query = query.Joins("JOIN favorites ON favorites.game_id = games.id AND favorites.user_id = ? AND favorites.deleted_at IS NULL", userID)
+			countQuery = countQuery.Joins("JOIN favorites ON favorites.game_id = games.id AND favorites.user_id = ? AND favorites.deleted_at IS NULL", userID)
+		case "play-later":
+			query = query.Joins("JOIN play_later_items ON play_later_items.game_id = games.id AND play_later_items.user_id = ? AND play_later_items.deleted_at IS NULL", userID)
+			countQuery = countQuery.Joins("JOIN play_later_items ON play_later_items.game_id = games.id AND play_later_items.user_id = ? AND play_later_items.deleted_at IS NULL", userID)
+		}
 	}
 
 	// Sorting - whitelist both column and direction to prevent SQL injection
@@ -77,7 +206,7 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 	if o := c.Query("sortOrder"); o != "" {
 		order = o
 	}
-	allowedSorts := map[string]bool{"title": true, "created_at": true, "file_size": true, "rating": true}
+	allowedSorts := map[string]bool{"title": true, "created_at": true, "file_size": true, "rating": true, "release_date": true}
 	if !allowedSorts[sort] {
 		sort = "title"
 	}
@@ -99,35 +228,7 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 		perPage = 50
 	}
 
-	// Count with the same filters applied (reuse the resolved console ID
-	// from the data query above so we compare numeric IDs, not abbreviations).
 	var total int64
-	countQuery := h.DB.Model(&db.Game{})
-	if consoleAbbr := c.Query("consoleId"); consoleAbbr != "" {
-		var countConsole db.Console
-		if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", consoleAbbr).First(&countConsole).Error; err == nil {
-			countQuery = countQuery.Where("console_id = ?", countConsole.ID)
-		}
-	}
-	if search := c.Query("search"); search != "" {
-		countQuery = countQuery.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")
-	}
-	if genre := c.Query("genre"); genre != "" {
-		countQuery = countQuery.Where("genre = ?", genre)
-	}
-	// Phase 2 Explore: enrichment-based filters for count query
-	if themeID := c.Query("theme"); themeID != "" {
-		countQuery = countQuery.Joins("JOIN game_themes ON game_themes.game_id = games.id").
-			Where("game_themes.igdb_theme_id = ?", themeID)
-	}
-	if keywordID := c.Query("keyword"); keywordID != "" {
-		countQuery = countQuery.Joins("JOIN game_keywords ON game_keywords.game_id = games.id").
-			Where("game_keywords.igdb_keyword_id = ?", keywordID)
-	}
-	if perspectiveID := c.Query("perspective"); perspectiveID != "" {
-		countQuery = countQuery.Joins("JOIN game_player_perspectives ON game_player_perspectives.game_id = games.id").
-			Where("game_player_perspectives.igdb_perspective_id = ?", perspectiveID)
-	}
 	countQuery.Count(&total)
 
 	offset := (page - 1) * perPage
@@ -136,7 +237,6 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 		return
 	}
 
-	userID := getUserID(c)
 	c.JSON(http.StatusOK, PaginatedResponse{
 		Data:     ToGameResponses(games, h.DB, userID),
 		Total:    total,

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -98,6 +98,9 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 		}
 	}
 
+	// Track whether any join-based filter is active (needs DISTINCT to avoid duplicates)
+	needsDistinct := false
+
 	// --- Theme filter (multi-select with backward compat) ---
 	themes := c.Query("themes")
 	if themes == "" {
@@ -109,6 +112,7 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 			Where("game_themes.igdb_theme_id IN ?", themeIDs)
 		countQuery = countQuery.Joins("JOIN game_themes ON game_themes.game_id = games.id").
 			Where("game_themes.igdb_theme_id IN ?", themeIDs)
+		needsDistinct = true
 	}
 
 	// --- Keyword filter (multi-select with backward compat) ---
@@ -122,6 +126,7 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 			Where("game_keywords.igdb_keyword_id IN ?", keywordIDs)
 		countQuery = countQuery.Joins("JOIN game_keywords ON game_keywords.game_id = games.id").
 			Where("game_keywords.igdb_keyword_id IN ?", keywordIDs)
+		needsDistinct = true
 	}
 
 	// --- Perspective filter (multi-select with backward compat) ---
@@ -135,15 +140,16 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 			Where("game_player_perspectives.igdb_perspective_id IN ?", perspectiveIDs)
 		countQuery = countQuery.Joins("JOIN game_player_perspectives ON game_player_perspectives.game_id = games.id").
 			Where("game_player_perspectives.igdb_perspective_id IN ?", perspectiveIDs)
+		needsDistinct = true
 	}
 
-	// --- Developer filter (LIKE, case-insensitive) ---
+	// --- Developer filter (substring match) ---
 	if developer := c.Query("developer"); developer != "" {
 		query = query.Where("games.developer LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(developer)+"%")
 		countQuery = countQuery.Where("games.developer LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(developer)+"%")
 	}
 
-	// --- Publisher filter (LIKE, case-insensitive) ---
+	// --- Publisher filter (substring match) ---
 	if publisher := c.Query("publisher"); publisher != "" {
 		query = query.Where("games.publisher LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(publisher)+"%")
 		countQuery = countQuery.Where("games.publisher LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(publisher)+"%")
@@ -165,13 +171,13 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 
 	// --- Rating range filters ---
 	if ratingMin := c.Query("ratingMin"); ratingMin != "" {
-		if r, err := strconv.ParseFloat(ratingMin, 64); err == nil {
+		if r, err := strconv.ParseFloat(ratingMin, 64); err == nil && r >= 0 && r <= 100 {
 			query = query.Where("games.rating >= ?", r)
 			countQuery = countQuery.Where("games.rating >= ?", r)
 		}
 	}
 	if ratingMax := c.Query("ratingMax"); ratingMax != "" {
-		if r, err := strconv.ParseFloat(ratingMax, 64); err == nil {
+		if r, err := strconv.ParseFloat(ratingMax, 64); err == nil && r >= 0 && r <= 100 {
 			query = query.Where("games.rating <= ?", r)
 			countQuery = countQuery.Where("games.rating <= ?", r)
 		}
@@ -188,6 +194,7 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 		case "played":
 			query = query.Joins("JOIN play_histories ON play_histories.game_id = games.id AND play_histories.user_id = ? AND play_histories.deleted_at IS NULL", userID)
 			countQuery = countQuery.Joins("JOIN play_histories ON play_histories.game_id = games.id AND play_histories.user_id = ? AND play_histories.deleted_at IS NULL", userID)
+			needsDistinct = true
 		case "favorited":
 			query = query.Joins("JOIN favorites ON favorites.game_id = games.id AND favorites.user_id = ? AND favorites.deleted_at IS NULL", userID)
 			countQuery = countQuery.Joins("JOIN favorites ON favorites.game_id = games.id AND favorites.user_id = ? AND favorites.deleted_at IS NULL", userID)
@@ -195,6 +202,12 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 			query = query.Joins("JOIN play_later_items ON play_later_items.game_id = games.id AND play_later_items.user_id = ? AND play_later_items.deleted_at IS NULL", userID)
 			countQuery = countQuery.Joins("JOIN play_later_items ON play_later_items.game_id = games.id AND play_later_items.user_id = ? AND play_later_items.deleted_at IS NULL", userID)
 		}
+	}
+
+	// Apply DISTINCT when join-based filters are active to prevent duplicate rows
+	if needsDistinct {
+		query = query.Distinct("games.*")
+		countQuery = countQuery.Distinct("games.id")
 	}
 
 	// Sorting - whitelist both column and direction to prevent SQL injection

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -173,6 +173,7 @@ func NewRouter(cfg Config) *gin.Engine {
 	sessionHandler := &SessionHandler{DB: cfg.DB, Storage: cfg.Storage}
 	artworkHandler := &ArtworkHandler{DB: cfg.DB}
 	exploreHandler := &ExploreHandler{DB: cfg.DB}
+	savedSearchHandler := &SavedSearchHandler{DB: cfg.DB}
 	enrichmentHandler := &EnrichmentHandler{DB: cfg.DB, Scraper: cfg.Scraper, Hub: cfg.Hub}
 	discoveryHandler := &GameDiscoveryHandler{DB: cfg.DB, Scraper: cfg.Scraper}
 	setupHandler := &SetupHandler{
@@ -356,6 +357,11 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/user/games/:gameId/keymapping", gameKeyMappingHandler.GetGameKeyMapping)
 		api.PUT("/user/games/:gameId/keymapping", gameKeyMappingHandler.UpdateGameKeyMapping)
 		api.DELETE("/user/games/:gameId/keymapping", gameKeyMappingHandler.DeleteGameKeyMapping)
+
+		// Saved Searches
+		api.POST("/user/saved-searches", savedSearchHandler.CreateSavedSearch)
+		api.GET("/user/saved-searches", savedSearchHandler.ListSavedSearches)
+		api.DELETE("/user/saved-searches/:id", savedSearchHandler.DeleteSavedSearch)
 
 		// Play Later
 		api.GET("/user/play-later", playLaterHandler.ListPlayLater)

--- a/server/internal/api/saved_search_handler.go
+++ b/server/internal/api/saved_search_handler.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// SavedSearchHandler handles saved search CRUD endpoints.
+type SavedSearchHandler struct {
+	DB *gorm.DB
+}
+
+// SavedSearchRequest is the request body for creating a saved search.
+type SavedSearchRequest struct {
+	Name    string          `json:"name" binding:"required"`
+	Filters json.RawMessage `json:"filters" binding:"required"`
+}
+
+// SavedSearchResponse is the API response for a saved search.
+type SavedSearchResponse struct {
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Filters   json.RawMessage `json:"filters"`
+	CreatedAt time.Time       `json:"createdAt"`
+}
+
+// maxSavedSearchesPerUser is the maximum number of saved searches a user can have.
+const maxSavedSearchesPerUser = 50
+
+// CreateSavedSearch creates a new saved search for the authenticated user.
+// POST /api/user/saved-searches
+func (h *SavedSearchHandler) CreateSavedSearch(c *gin.Context) {
+	userID := getUserID(c)
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	var req SavedSearchRequest
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "name and filters are required"})
+		return
+	}
+
+	// Validate name length
+	if len(req.Name) > 255 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "name must be 255 characters or fewer"})
+		return
+	}
+
+	// Validate filters is valid JSON
+	if !json.Valid(req.Filters) {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "filters must be valid JSON"})
+		return
+	}
+
+	// Check per-user limit
+	var count int64
+	h.DB.Model(&db.SavedSearch{}).Where("user_id = ?", userID).Count(&count)
+	if count >= maxSavedSearchesPerUser {
+		c.JSON(http.StatusConflict, gin.H{"error": "maximum of 50 saved searches reached"})
+		return
+	}
+
+	savedSearch := db.SavedSearch{
+		UserID:  userID,
+		Name:    req.Name,
+		Filters: string(req.Filters),
+	}
+	if err := h.DB.Create(&savedSearch).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create saved search"})
+		return
+	}
+
+	c.JSON(http.StatusCreated, SavedSearchResponse{
+		ID:        strconv.FormatUint(uint64(savedSearch.ID), 10),
+		Name:      savedSearch.Name,
+		Filters:   json.RawMessage(savedSearch.Filters),
+		CreatedAt: savedSearch.CreatedAt,
+	})
+}
+
+// ListSavedSearches returns all saved searches for the authenticated user.
+// GET /api/user/saved-searches
+func (h *SavedSearchHandler) ListSavedSearches(c *gin.Context) {
+	userID := getUserID(c)
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	var searches []db.SavedSearch
+	if err := h.DB.Where("user_id = ?", userID).Order("created_at DESC").Find(&searches).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch saved searches"})
+		return
+	}
+
+	resp := make([]SavedSearchResponse, 0, len(searches))
+	for _, s := range searches {
+		resp = append(resp, SavedSearchResponse{
+			ID:        strconv.FormatUint(uint64(s.ID), 10),
+			Name:      s.Name,
+			Filters:   json.RawMessage(s.Filters),
+			CreatedAt: s.CreatedAt,
+		})
+	}
+
+	c.JSON(http.StatusOK, resp)
+}
+
+// DeleteSavedSearch soft-deletes a saved search owned by the authenticated user.
+// DELETE /api/user/saved-searches/:id
+func (h *SavedSearchHandler) DeleteSavedSearch(c *gin.Context) {
+	userID := getUserID(c)
+	if userID == 0 {
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "unauthorized"})
+		return
+	}
+
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid ID"})
+		return
+	}
+
+	var savedSearch db.SavedSearch
+	if err := h.DB.First(&savedSearch, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "saved search not found"})
+		return
+	}
+
+	// Verify ownership
+	if savedSearch.UserID != userID {
+		c.JSON(http.StatusForbidden, gin.H{"error": "access denied"})
+		return
+	}
+
+	if err := h.DB.Delete(&savedSearch).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to delete saved search"})
+		return
+	}
+
+	c.JSON(http.StatusOK, gin.H{"status": "deleted"})
+}

--- a/server/internal/api/saved_search_handler_test.go
+++ b/server/internal/api/saved_search_handler_test.go
@@ -1,0 +1,210 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupSavedSearchEnv(t *testing.T) (*gorm.DB, http.Handler, string) {
+	t.Helper()
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+	return database, router, token
+}
+
+func createSavedSearch(t *testing.T, router http.Handler, token, name string, filters interface{}) (int, map[string]interface{}) {
+	t.Helper()
+	body, _ := json.Marshal(map[string]interface{}{
+		"name":    name,
+		"filters": filters,
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/user/saved-searches", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	return w.Code, resp
+}
+
+func TestCreateSavedSearch_Success(t *testing.T) {
+	_, router, token := setupSavedSearchEnv(t)
+
+	filters := map[string]interface{}{
+		"consoles": "SNES,NES",
+		"genres":   "Action,RPG",
+		"ratingMin": 70,
+	}
+
+	code, resp := createSavedSearch(t, router, token, "My RPG Filter", filters)
+	assert.Equal(t, http.StatusCreated, code)
+	assert.Equal(t, "My RPG Filter", resp["name"])
+	assert.NotEmpty(t, resp["id"])
+	assert.NotNil(t, resp["filters"])
+
+	// Verify filters is valid JSON that can be parsed back
+	filtersJSON, ok := resp["filters"].(map[string]interface{})
+	require.True(t, ok, "filters should be a JSON object")
+	assert.Equal(t, "SNES,NES", filtersJSON["consoles"])
+}
+
+func TestCreateSavedSearch_MissingName(t *testing.T) {
+	_, router, token := setupSavedSearchEnv(t)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"filters": map[string]string{"genre": "Action"},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/user/saved-searches", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestCreateSavedSearch_InvalidJSON(t *testing.T) {
+	_, router, token := setupSavedSearchEnv(t)
+
+	// Send raw body with invalid JSON in filters
+	body := []byte(`{"name":"test","filters":"not json"}`)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/user/saved-searches", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	// "not json" is a valid JSON string, so the request should succeed
+	// but actual non-JSON would fail at binding. Let's test with truly bad JSON:
+	body = []byte(`{"name":"test","filters":invalid}`)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/user/saved-searches", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestListSavedSearches_Empty(t *testing.T) {
+	_, router, token := setupSavedSearchEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/saved-searches", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp)
+}
+
+func TestListSavedSearches_WithData(t *testing.T) {
+	_, router, token := setupSavedSearchEnv(t)
+
+	// Create two saved searches
+	createSavedSearch(t, router, token, "Search One", map[string]string{"genre": "Action"})
+	createSavedSearch(t, router, token, "Search Two", map[string]string{"developer": "Nintendo"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/user/saved-searches", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp []map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp, 2)
+
+	// Should be ordered by created_at DESC (newest first)
+	assert.Equal(t, "Search Two", resp[0]["name"])
+	assert.Equal(t, "Search One", resp[1]["name"])
+}
+
+func TestDeleteSavedSearch_Success(t *testing.T) {
+	_, router, token := setupSavedSearchEnv(t)
+
+	// Create a saved search
+	code, resp := createSavedSearch(t, router, token, "To Delete", map[string]string{"genre": "RPG"})
+	require.Equal(t, http.StatusCreated, code)
+	searchID := resp["id"].(string)
+
+	// Delete it
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/user/saved-searches/"+searchID, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Verify it's gone from the list
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/user/saved-searches", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	var list []interface{}
+	json.Unmarshal(w.Body.Bytes(), &list)
+	assert.Empty(t, list)
+}
+
+func TestDeleteSavedSearch_NotOwned(t *testing.T) {
+	database, router, token := setupSavedSearchEnv(t)
+
+	// Create a saved search as user 1
+	code, resp := createSavedSearch(t, router, token, "User1 Search", map[string]string{"genre": "Action"})
+	require.Equal(t, http.StatusCreated, code)
+	searchID := resp["id"].(string)
+
+	// Create a second user
+	token2 := createNonOwnerUser(t, router, token, "user2", "user2@example.com", "password123")
+	_ = database // suppress unused
+
+	// Try to delete user1's search as user2
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/user/saved-searches/"+searchID, nil)
+	req.Header.Set("Authorization", "Bearer "+token2)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestSavedSearches_Limit50(t *testing.T) {
+	database, router, token := setupSavedSearchEnv(t)
+
+	// Directly insert 50 saved searches to avoid slow HTTP round-trips
+	var user db.User
+	database.First(&user)
+	for i := 0; i < 50; i++ {
+		database.Create(&db.SavedSearch{
+			UserID:  user.ID,
+			Name:    fmt.Sprintf("Search %d", i),
+			Filters: `{"genre":"Action"}`,
+		})
+	}
+
+	// The 51st should be rejected
+	code, resp := createSavedSearch(t, router, token, "One Too Many", map[string]string{"genre": "RPG"})
+	assert.Equal(t, http.StatusConflict, code)
+	assert.Contains(t, resp["error"], "maximum")
+}
+
+func TestDeleteSavedSearch_NotFound(t *testing.T) {
+	_, router, token := setupSavedSearchEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/user/saved-searches/99999", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -162,6 +162,8 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&GameSeries{},
 		&GameSeriesEntry{},
 		&GameArtworkImage{},
+		// Phase 13: Saved Searches
+		&SavedSearch{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -707,6 +707,17 @@ type GameArtworkImage struct {
 	Height      int       `json:"height"`
 }
 
+// SavedSearch represents a user's saved filter configuration for the game library.
+type SavedSearch struct {
+	ID        uint           `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time      `json:"createdAt"`
+	UpdatedAt time.Time      `json:"updatedAt"`
+	DeletedAt gorm.DeletedAt `gorm:"index" json:"-"`
+	UserID    uint           `gorm:"index;not null" json:"userId"`
+	Name      string         `gorm:"size:255;not null" json:"name"`
+	Filters   string         `gorm:"type:text;not null" json:"filters"` // JSON-encoded filter params
+}
+
 // StagedUpload represents a ROM file uploaded to the staging area pending admin review.
 type StagedUpload struct {
 	ID               uint           `gorm:"primarykey" json:"id"`

--- a/web/src/features/games/components/__tests__/advanced-filter-panel.test.tsx
+++ b/web/src/features/games/components/__tests__/advanced-filter-panel.test.tsx
@@ -1,0 +1,303 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import {
+  AdvancedFilterPanel,
+  savedSearchToFilters,
+} from "../advanced-filter-panel";
+import type { GameFilters, Console, Theme, Keyword, SavedSearch } from "@/types/api";
+
+const makeConsole = (abbr: string, name: string): Console => ({
+  id: abbr,
+  name,
+  abbreviation: abbr,
+  extensions: [],
+  defaultCore: "",
+  coverAspectRatio: 0.75,
+  colorTheme: "",
+  iconUrl: "",
+  logoUrl: "",
+  gameCount: 10,
+  saveStateSupport: true,
+  browserPlayable: false,
+  playable: true,
+  createdAt: "",
+  updatedAt: "",
+});
+
+const testConsoles: Console[] = [
+  makeConsole("SNES", "Super Nintendo"),
+  makeConsole("NES", "Nintendo"),
+  makeConsole("GBA", "Game Boy Advance"),
+];
+
+const testThemes: Theme[] = [
+  { id: "17", name: "Fantasy", gameCount: 25 },
+  { id: "18", name: "Sci-fi", gameCount: 15 },
+];
+
+const testKeywords: Keyword[] = [
+  { id: "100", name: "Retro", gameCount: 50 },
+  { id: "200", name: "Classic", gameCount: 30 },
+];
+
+const testSavedSearches: SavedSearch[] = [
+  {
+    id: "1",
+    name: "SNES RPGs",
+    filters: { consoles: "SNES", genres: "RPG" },
+    createdAt: "2026-01-01T00:00:00Z",
+  },
+  {
+    id: "2",
+    name: "High-rated Action",
+    filters: { genres: "Action", ratingMin: 80 },
+    createdAt: "2026-01-02T00:00:00Z",
+  },
+];
+
+function renderPanel(overrides: Partial<React.ComponentProps<typeof AdvancedFilterPanel>> = {}) {
+  const defaultProps: React.ComponentProps<typeof AdvancedFilterPanel> = {
+    filters: {},
+    onFiltersChange: vi.fn(),
+    consoles: testConsoles,
+    themes: testThemes,
+    keywords: testKeywords,
+    savedSearches: testSavedSearches,
+    onSaveSearch: vi.fn(),
+    onDeleteSearch: vi.fn(),
+    onApplySearch: vi.fn(),
+    totalResults: 42,
+    isOpen: true,
+    onToggle: vi.fn(),
+    ...overrides,
+  };
+
+  return { ...render(<AdvancedFilterPanel {...defaultProps} />), props: defaultProps };
+}
+
+describe("AdvancedFilterPanel", () => {
+  it("renders toggle button", () => {
+    renderPanel({ isOpen: false });
+    expect(screen.getByTestId("advanced-filter-toggle")).toBeInTheDocument();
+    expect(screen.getByText("Filters")).toBeInTheDocument();
+  });
+
+  it("shows active filter count badge", () => {
+    renderPanel({
+      isOpen: false,
+      filters: { consoles: ["SNES"], genres: ["RPG"] },
+    });
+    expect(screen.getByText("2")).toBeInTheDocument();
+  });
+
+  it("shows panel when open", () => {
+    renderPanel({ isOpen: true });
+    expect(screen.getByText("Advanced Filters")).toBeInTheDocument();
+    expect(screen.getByText("42 games match")).toBeInTheDocument();
+  });
+
+  it("does not show panel when closed", () => {
+    renderPanel({ isOpen: false });
+    expect(screen.queryByText("Advanced Filters")).not.toBeInTheDocument();
+  });
+
+  it("calls onToggle when toggle button is clicked", async () => {
+    const user = userEvent.setup();
+    const { props } = renderPanel({ isOpen: false });
+    await user.click(screen.getByTestId("advanced-filter-toggle"));
+    expect(props.onToggle).toHaveBeenCalled();
+  });
+
+  it("renders console chips", () => {
+    renderPanel();
+    const consoleFilter = screen.getByTestId("console-filter");
+    expect(within(consoleFilter).getByText("Super Nintendo")).toBeInTheDocument();
+    expect(within(consoleFilter).getByText("Nintendo")).toBeInTheDocument();
+    expect(within(consoleFilter).getByText("Game Boy Advance")).toBeInTheDocument();
+  });
+
+  it("toggles console selection", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    renderPanel({ onFiltersChange });
+    const consoleFilter = screen.getByTestId("console-filter");
+    await user.click(within(consoleFilter).getByText("Super Nintendo"));
+    expect(onFiltersChange).toHaveBeenCalled();
+    const updater = onFiltersChange.mock.calls[0][0];
+    const result = updater({});
+    expect(result.consoles).toEqual(["SNES"]);
+    expect(result.page).toBe(1);
+  });
+
+  it("deselects a selected console", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    renderPanel({
+      onFiltersChange,
+      filters: { consoles: ["SNES", "NES"] },
+    });
+    const consoleFilter = screen.getByTestId("console-filter");
+    await user.click(within(consoleFilter).getByText("Super Nintendo"));
+    const updater = onFiltersChange.mock.calls[0][0];
+    const result = updater({ consoles: ["SNES", "NES"] });
+    expect(result.consoles).toEqual(["NES"]);
+  });
+
+  it("renders genre chips", () => {
+    renderPanel();
+    const genreFilter = screen.getByTestId("genre-filter");
+    expect(within(genreFilter).getByText("Action")).toBeInTheDocument();
+    expect(within(genreFilter).getByText("RPG")).toBeInTheDocument();
+  });
+
+  it("renders theme chips", () => {
+    renderPanel();
+    const themeFilter = screen.getByTestId("theme-filter");
+    expect(within(themeFilter).getByText("Fantasy (25)")).toBeInTheDocument();
+    expect(within(themeFilter).getByText("Sci-fi (15)")).toBeInTheDocument();
+  });
+
+  it("renders keyword chips", () => {
+    renderPanel();
+    const keywordFilter = screen.getByTestId("keyword-filter");
+    expect(within(keywordFilter).getByText("Retro (50)")).toBeInTheDocument();
+    expect(within(keywordFilter).getByText("Classic (30)")).toBeInTheDocument();
+  });
+
+  it("renders year range inputs", () => {
+    renderPanel();
+    const yearFilter = screen.getByTestId("year-filter");
+    expect(within(yearFilter).getByTestId("year-filter-min")).toBeInTheDocument();
+    expect(within(yearFilter).getByTestId("year-filter-max")).toBeInTheDocument();
+  });
+
+  it("renders rating range inputs", () => {
+    renderPanel();
+    const ratingFilter = screen.getByTestId("rating-filter");
+    expect(within(ratingFilter).getByTestId("rating-filter-min")).toBeInTheDocument();
+    expect(within(ratingFilter).getByTestId("rating-filter-max")).toBeInTheDocument();
+  });
+
+  it("renders play status chips", () => {
+    renderPanel();
+    const statusFilter = screen.getByTestId("play-status-filter");
+    expect(within(statusFilter).getByText("Any")).toBeInTheDocument();
+    expect(within(statusFilter).getByText("Unplayed")).toBeInTheDocument();
+    expect(within(statusFilter).getByText("Played")).toBeInTheDocument();
+    expect(within(statusFilter).getByText("Favorited")).toBeInTheDocument();
+    expect(within(statusFilter).getByText("Play Later")).toBeInTheDocument();
+  });
+
+  it("toggles play status", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    renderPanel({ onFiltersChange });
+    await user.click(screen.getByText("Unplayed"));
+    const updater = onFiltersChange.mock.calls[0][0];
+    const result = updater({});
+    expect(result.playStatus).toBe("unplayed");
+  });
+
+  it("renders developer and publisher inputs", () => {
+    renderPanel();
+    expect(screen.getByTestId("developer-filter")).toBeInTheDocument();
+    expect(screen.getByTestId("publisher-filter")).toBeInTheDocument();
+  });
+
+  it("clears all filters", async () => {
+    const user = userEvent.setup();
+    const onFiltersChange = vi.fn();
+    renderPanel({
+      onFiltersChange,
+      filters: { consoles: ["SNES"], genres: ["RPG"], developer: "Nintendo" },
+    });
+    await user.click(screen.getByTestId("clear-filters"));
+    const updater = onFiltersChange.mock.calls[0][0];
+    const result = updater({
+      consoles: ["SNES"],
+      genres: ["RPG"],
+      developer: "Nintendo",
+      sortBy: "title",
+      sortOrder: "asc",
+      pageSize: 48,
+      search: "mario",
+    });
+    // Should preserve search, sort, and pageSize but clear filter fields
+    expect(result.consoles).toBeUndefined();
+    expect(result.genres).toBeUndefined();
+    expect(result.developer).toBeUndefined();
+    expect(result.search).toBe("mario");
+    expect(result.sortBy).toBe("title");
+  });
+
+  // --- Saved Searches ---
+
+  it("renders saved searches list", () => {
+    renderPanel();
+    expect(screen.getByText("SNES RPGs")).toBeInTheDocument();
+    expect(screen.getByText("High-rated Action")).toBeInTheDocument();
+  });
+
+  it("applies a saved search", async () => {
+    const user = userEvent.setup();
+    const onApplySearch = vi.fn();
+    renderPanel({ onApplySearch });
+    const items = screen.getAllByTestId("saved-search-apply");
+    await user.click(items[0]);
+    expect(onApplySearch).toHaveBeenCalledWith({ consoles: "SNES", genres: "RPG" });
+  });
+
+  it("shows save button when filters are active", () => {
+    renderPanel({ filters: { consoles: ["SNES"] } });
+    expect(screen.getByTestId("save-search-button")).toBeInTheDocument();
+  });
+
+  it("does not show save button when no filters active", () => {
+    renderPanel({ filters: {} });
+    expect(screen.queryByTestId("save-search-button")).not.toBeInTheDocument();
+  });
+
+  it("saves a search", async () => {
+    const user = userEvent.setup();
+    const onSaveSearch = vi.fn();
+    renderPanel({
+      onSaveSearch,
+      filters: { consoles: ["SNES"], genres: ["RPG"] },
+    });
+    await user.click(screen.getByTestId("save-search-button"));
+    const nameInput = screen.getByTestId("save-search-name");
+    await user.type(nameInput, "My Filter");
+    await user.click(screen.getByText("Save"));
+    expect(onSaveSearch).toHaveBeenCalledWith("My Filter", {
+      consoles: "SNES",
+      genres: "RPG",
+    });
+  });
+
+  it("shows empty state when no saved searches", () => {
+    renderPanel({ savedSearches: [] });
+    expect(screen.getByText(/No saved searches yet/)).toBeInTheDocument();
+  });
+});
+
+describe("savedSearchToFilters", () => {
+  it("converts a saved search record to GameFilters", () => {
+    const base: GameFilters = { sortBy: "title", sortOrder: "asc", pageSize: 48 };
+    const result = savedSearchToFilters(
+      { consoles: "SNES,NES", genres: "RPG", ratingMin: 80, developer: "Square" },
+      base,
+    );
+    expect(result.consoles).toEqual(["SNES", "NES"]);
+    expect(result.genres).toEqual(["RPG"]);
+    expect(result.ratingMin).toBe(80);
+    expect(result.developer).toBe("Square");
+    expect(result.sortBy).toBe("title");
+    expect(result.page).toBe(1);
+  });
+
+  it("preserves search from record if present", () => {
+    const result = savedSearchToFilters({ search: "mario" }, { sortBy: "title" });
+    expect(result.search).toBe("mario");
+  });
+});

--- a/web/src/features/games/components/advanced-filter-panel.tsx
+++ b/web/src/features/games/components/advanced-filter-panel.tsx
@@ -29,18 +29,20 @@ function ChipPicker({
 }) {
   const [expanded, setExpanded] = useState(false);
   const visibleOptions = expanded ? options : options.slice(0, 12);
+  const labelId = `${testId}-label`;
 
   return (
     <div data-testid={testId}>
-      <label className="block text-sm font-medium text-surface-300 mb-2">
+      <span id={labelId} className="block text-sm font-medium text-surface-300 mb-2">
         {label}
-      </label>
-      <div className="flex flex-wrap gap-1.5">
+      </span>
+      <div className="flex flex-wrap gap-1.5" role="group" aria-labelledby={labelId}>
         {visibleOptions.map((opt) => {
           const isSelected = selected.includes(opt.value);
           return (
             <button
               key={opt.value}
+              aria-pressed={isSelected}
               onClick={() =>
                 onChange(
                   isSelected
@@ -103,9 +105,9 @@ function RangeInput({
 }) {
   return (
     <div data-testid={testId}>
-      <label className="block text-sm font-medium text-surface-300 mb-2">
+      <span className="block text-sm font-medium text-surface-300 mb-2">
         {label}
-      </label>
+      </span>
       <div className="flex items-center gap-2">
         <input
           type="number"
@@ -114,6 +116,7 @@ function RangeInput({
           placeholder={String(min)}
           value={valueMin ?? ""}
           onChange={(e) => onChangeMin(e.target.value ? Number(e.target.value) : undefined)}
+          aria-label={`${label} minimum`}
           className="w-24 rounded-lg bg-surface-900 border border-surface-700 px-3 py-1.5 text-sm text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500"
           data-testid={`${testId}-min`}
         />
@@ -125,6 +128,7 @@ function RangeInput({
           placeholder={String(max)}
           value={valueMax ?? ""}
           onChange={(e) => onChangeMax(e.target.value ? Number(e.target.value) : undefined)}
+          aria-label={`${label} maximum`}
           className="w-24 rounded-lg bg-surface-900 border border-surface-700 px-3 py-1.5 text-sm text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500"
           data-testid={`${testId}-max`}
         />
@@ -168,7 +172,7 @@ function SavedSearchItem({
       </button>
       <button
         onClick={onDelete}
-        className="p-1.5 rounded text-surface-500 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
+        className="p-1.5 rounded text-surface-500 hover:text-red-400 opacity-0 group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all"
         aria-label={`Delete ${search.name}`}
         data-testid="saved-search-delete"
       >
@@ -274,6 +278,7 @@ export function AdvancedFilterPanel({
       {/* Toggle button */}
       <button
         onClick={onToggle}
+        aria-expanded={isOpen}
         className={cn(
           "flex items-center gap-2 px-3 py-2.5 rounded-lg border text-sm font-medium transition-all",
           isOpen
@@ -368,12 +373,13 @@ export function AdvancedFilterPanel({
           )}
 
           {/* Developer / Publisher */}
-          <div className="grid grid-cols-2 gap-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-surface-300 mb-2">
+              <label htmlFor="filter-developer" className="block text-sm font-medium text-surface-300 mb-2">
                 Developer
               </label>
               <Input
+                id="filter-developer"
                 placeholder="e.g. Nintendo"
                 value={filters.developer ?? ""}
                 onChange={(e) =>
@@ -387,10 +393,11 @@ export function AdvancedFilterPanel({
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-surface-300 mb-2">
+              <label htmlFor="filter-publisher" className="block text-sm font-medium text-surface-300 mb-2">
                 Publisher
               </label>
               <Input
+                id="filter-publisher"
                 placeholder="e.g. Konami"
                 value={filters.publisher ?? ""}
                 onChange={(e) =>
@@ -439,13 +446,14 @@ export function AdvancedFilterPanel({
 
           {/* Play status */}
           <div data-testid="play-status-filter">
-            <label className="block text-sm font-medium text-surface-300 mb-2">
+            <span id="play-status-label" className="block text-sm font-medium text-surface-300 mb-2">
               Play Status
-            </label>
-            <div className="flex flex-wrap gap-1.5">
+            </span>
+            <div className="flex flex-wrap gap-1.5" role="group" aria-labelledby="play-status-label">
               {PLAY_STATUS_OPTIONS.map((opt) => (
                 <button
                   key={opt.label}
+                  aria-pressed={filters.playStatus === opt.value}
                   onClick={() =>
                     onFiltersChange((f) => ({
                       ...f,
@@ -507,6 +515,7 @@ export function AdvancedFilterPanel({
                     setSaveName("");
                   }}
                   className="p-2 text-surface-400 hover:text-surface-200"
+                  aria-label="Cancel"
                 >
                   <X className="h-4 w-4" />
                 </button>

--- a/web/src/features/games/components/advanced-filter-panel.tsx
+++ b/web/src/features/games/components/advanced-filter-panel.tsx
@@ -1,0 +1,577 @@
+import { useState } from "react";
+import {
+  SlidersHorizontal,
+  X,
+  ChevronDown,
+  ChevronUp,
+  Save,
+  Bookmark,
+  Trash2,
+} from "lucide-react";
+import { Button, Input, Badge } from "@/components/ui";
+import { cn } from "@/lib/cn";
+import type { GameFilters, Console, Theme, Keyword, SavedSearch } from "@/types/api";
+
+// --- Multi-select chip picker ---
+
+function ChipPicker({
+  label,
+  options,
+  selected,
+  onChange,
+  testId,
+}: {
+  label: string;
+  options: Array<{ value: string; label: string }>;
+  selected: string[];
+  onChange: (selected: string[]) => void;
+  testId: string;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const visibleOptions = expanded ? options : options.slice(0, 12);
+
+  return (
+    <div data-testid={testId}>
+      <label className="block text-sm font-medium text-surface-300 mb-2">
+        {label}
+      </label>
+      <div className="flex flex-wrap gap-1.5">
+        {visibleOptions.map((opt) => {
+          const isSelected = selected.includes(opt.value);
+          return (
+            <button
+              key={opt.value}
+              onClick={() =>
+                onChange(
+                  isSelected
+                    ? selected.filter((v) => v !== opt.value)
+                    : [...selected, opt.value],
+                )
+              }
+              className={cn(
+                "px-2.5 py-1 rounded-full text-xs font-medium transition-colors",
+                isSelected
+                  ? "bg-brand-600 text-white"
+                  : "bg-surface-800 text-surface-300 hover:bg-surface-700 hover:text-surface-100",
+              )}
+            >
+              {opt.label}
+            </button>
+          );
+        })}
+      </div>
+      {options.length > 12 && (
+        <button
+          onClick={() => setExpanded(!expanded)}
+          className="mt-1.5 text-xs text-surface-400 hover:text-surface-200 flex items-center gap-1"
+        >
+          {expanded ? (
+            <>
+              <ChevronUp className="h-3 w-3" /> Show less
+            </>
+          ) : (
+            <>
+              <ChevronDown className="h-3 w-3" /> Show all ({options.length})
+            </>
+          )}
+        </button>
+      )}
+    </div>
+  );
+}
+
+// --- Range input ---
+
+function RangeInput({
+  label,
+  min,
+  max,
+  valueMin,
+  valueMax,
+  onChangeMin,
+  onChangeMax,
+  testId,
+}: {
+  label: string;
+  min: number;
+  max: number;
+  valueMin: number | undefined;
+  valueMax: number | undefined;
+  onChangeMin: (v: number | undefined) => void;
+  onChangeMax: (v: number | undefined) => void;
+  testId: string;
+}) {
+  return (
+    <div data-testid={testId}>
+      <label className="block text-sm font-medium text-surface-300 mb-2">
+        {label}
+      </label>
+      <div className="flex items-center gap-2">
+        <input
+          type="number"
+          min={min}
+          max={max}
+          placeholder={String(min)}
+          value={valueMin ?? ""}
+          onChange={(e) => onChangeMin(e.target.value ? Number(e.target.value) : undefined)}
+          className="w-24 rounded-lg bg-surface-900 border border-surface-700 px-3 py-1.5 text-sm text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500"
+          data-testid={`${testId}-min`}
+        />
+        <span className="text-surface-500 text-sm">to</span>
+        <input
+          type="number"
+          min={min}
+          max={max}
+          placeholder={String(max)}
+          value={valueMax ?? ""}
+          onChange={(e) => onChangeMax(e.target.value ? Number(e.target.value) : undefined)}
+          className="w-24 rounded-lg bg-surface-900 border border-surface-700 px-3 py-1.5 text-sm text-surface-100 focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500"
+          data-testid={`${testId}-max`}
+        />
+      </div>
+    </div>
+  );
+}
+
+// --- Play status chips ---
+
+const PLAY_STATUS_OPTIONS: Array<{
+  value: GameFilters["playStatus"];
+  label: string;
+}> = [
+  { value: undefined, label: "Any" },
+  { value: "unplayed", label: "Unplayed" },
+  { value: "played", label: "Played" },
+  { value: "favorited", label: "Favorited" },
+  { value: "play-later", label: "Play Later" },
+];
+
+// --- Saved search item ---
+
+function SavedSearchItem({
+  search,
+  onApply,
+  onDelete,
+}: {
+  search: SavedSearch;
+  onApply: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <div className="flex items-center gap-2 group" data-testid="saved-search-item">
+      <button
+        onClick={onApply}
+        className="flex-1 text-left px-3 py-2 rounded-lg bg-surface-800 hover:bg-surface-700 text-sm text-surface-200 transition-colors truncate"
+        data-testid="saved-search-apply"
+      >
+        <span className="font-medium">{search.name}</span>
+      </button>
+      <button
+        onClick={onDelete}
+        className="p-1.5 rounded text-surface-500 hover:text-red-400 opacity-0 group-hover:opacity-100 transition-all"
+        aria-label={`Delete ${search.name}`}
+        data-testid="saved-search-delete"
+      >
+        <Trash2 className="h-3.5 w-3.5" />
+      </button>
+    </div>
+  );
+}
+
+// --- Main panel ---
+
+interface AdvancedFilterPanelProps {
+  filters: GameFilters;
+  onFiltersChange: (updater: (prev: GameFilters) => GameFilters) => void;
+  consoles: Console[] | undefined;
+  themes: Theme[] | undefined;
+  keywords: Keyword[] | undefined;
+  savedSearches: SavedSearch[] | undefined;
+  onSaveSearch: (name: string, filters: Record<string, string | number>) => void;
+  onDeleteSearch: (id: string) => void;
+  onApplySearch: (filters: Record<string, string | number>) => void;
+  totalResults?: number;
+  isOpen: boolean;
+  onToggle: () => void;
+}
+
+export function AdvancedFilterPanel({
+  filters,
+  onFiltersChange,
+  consoles,
+  themes,
+  keywords,
+  savedSearches,
+  onSaveSearch,
+  onDeleteSearch,
+  onApplySearch,
+  totalResults,
+  isOpen,
+  onToggle,
+}: AdvancedFilterPanelProps) {
+  const [saveName, setSaveName] = useState("");
+  const [showSaveInput, setShowSaveInput] = useState(false);
+
+  const consoleOptions = (consoles ?? []).map((c) => ({
+    value: c.abbreviation,
+    label: c.name,
+  }));
+
+  const genreOptions = [
+    "Action", "Adventure", "RPG", "Platformer", "Puzzle",
+    "Racing", "Shooter", "Sports", "Strategy", "Fighting",
+    "Simulation", "Beat 'em up", "Arcade", "Horror",
+  ].map((g) => ({ value: g, label: g }));
+
+  const themeOptions = (themes ?? []).map((t) => ({
+    value: String(t.id),
+    label: `${t.name} (${t.gameCount})`,
+  }));
+
+  const keywordOptions = (keywords ?? []).map((k) => ({
+    value: String(k.id),
+    label: `${k.name} (${k.gameCount})`,
+  }));
+
+  const activeFilterCount = countActiveFilters(filters);
+
+  const handleClearAll = () => {
+    onFiltersChange((prev) => ({
+      search: prev.search,
+      sortBy: prev.sortBy,
+      sortOrder: prev.sortOrder,
+      page: 1,
+      pageSize: prev.pageSize,
+    }));
+  };
+
+  const filtersToRecord = (f: GameFilters): Record<string, string | number> => {
+    const rec: Record<string, string | number> = {};
+    if (f.consoles?.length) rec.consoles = f.consoles.join(",");
+    if (f.genres?.length) rec.genres = f.genres.join(",");
+    if (f.themes?.length) rec.themes = f.themes.join(",");
+    if (f.keywords?.length) rec.keywords = f.keywords.join(",");
+    if (f.developer) rec.developer = f.developer;
+    if (f.publisher) rec.publisher = f.publisher;
+    if (f.yearMin != null) rec.yearMin = f.yearMin;
+    if (f.yearMax != null) rec.yearMax = f.yearMax;
+    if (f.ratingMin != null) rec.ratingMin = f.ratingMin;
+    if (f.ratingMax != null) rec.ratingMax = f.ratingMax;
+    if (f.playStatus) rec.playStatus = f.playStatus;
+    if (f.search) rec.search = f.search;
+    return rec;
+  };
+
+  const handleSave = () => {
+    if (!saveName.trim()) return;
+    onSaveSearch(saveName.trim(), filtersToRecord(filters));
+    setSaveName("");
+    setShowSaveInput(false);
+  };
+
+  return (
+    <div data-testid="advanced-filter-panel">
+      {/* Toggle button */}
+      <button
+        onClick={onToggle}
+        className={cn(
+          "flex items-center gap-2 px-3 py-2.5 rounded-lg border text-sm font-medium transition-all",
+          isOpen
+            ? "bg-brand-600/20 border-brand-500 text-brand-400"
+            : "bg-surface-900 border-surface-700 text-surface-300 hover:text-surface-100 hover:border-surface-600",
+        )}
+        data-testid="advanced-filter-toggle"
+      >
+        <SlidersHorizontal className="h-4 w-4" />
+        Filters
+        {activeFilterCount > 0 && (
+          <Badge className="bg-brand-600 text-white text-xs">
+            {activeFilterCount}
+          </Badge>
+        )}
+      </button>
+
+      {/* Panel */}
+      {isOpen && (
+        <div className="mt-3 p-5 rounded-xl bg-surface-900/80 border border-surface-700 space-y-5">
+          {/* Header */}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-3">
+              <h3 className="text-sm font-semibold text-surface-100">
+                Advanced Filters
+              </h3>
+              {totalResults != null && (
+                <span className="text-xs text-surface-400" data-testid="match-count">
+                  {totalResults} games match
+                </span>
+              )}
+            </div>
+            <div className="flex items-center gap-2">
+              {activeFilterCount > 0 && (
+                <button
+                  onClick={handleClearAll}
+                  className="text-xs text-surface-400 hover:text-surface-200 flex items-center gap-1"
+                  data-testid="clear-filters"
+                >
+                  <X className="h-3 w-3" /> Clear all
+                </button>
+              )}
+            </div>
+          </div>
+
+          {/* Console picker */}
+          <ChipPicker
+            label="Consoles"
+            options={consoleOptions}
+            selected={filters.consoles ?? []}
+            onChange={(consoles) =>
+              onFiltersChange((f) => ({ ...f, consoles, page: 1 }))
+            }
+            testId="console-filter"
+          />
+
+          {/* Genre picker */}
+          <ChipPicker
+            label="Genres"
+            options={genreOptions}
+            selected={filters.genres ?? []}
+            onChange={(genres) =>
+              onFiltersChange((f) => ({ ...f, genres, page: 1 }))
+            }
+            testId="genre-filter"
+          />
+
+          {/* Theme picker */}
+          {themeOptions.length > 0 && (
+            <ChipPicker
+              label="Themes"
+              options={themeOptions}
+              selected={filters.themes ?? []}
+              onChange={(themes) =>
+                onFiltersChange((f) => ({ ...f, themes, page: 1 }))
+              }
+              testId="theme-filter"
+            />
+          )}
+
+          {/* Keyword picker */}
+          {keywordOptions.length > 0 && (
+            <ChipPicker
+              label="Keywords"
+              options={keywordOptions}
+              selected={filters.keywords ?? []}
+              onChange={(keywords) =>
+                onFiltersChange((f) => ({ ...f, keywords, page: 1 }))
+              }
+              testId="keyword-filter"
+            />
+          )}
+
+          {/* Developer / Publisher */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-surface-300 mb-2">
+                Developer
+              </label>
+              <Input
+                placeholder="e.g. Nintendo"
+                value={filters.developer ?? ""}
+                onChange={(e) =>
+                  onFiltersChange((f) => ({
+                    ...f,
+                    developer: e.target.value || undefined,
+                    page: 1,
+                  }))
+                }
+                data-testid="developer-filter"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-surface-300 mb-2">
+                Publisher
+              </label>
+              <Input
+                placeholder="e.g. Konami"
+                value={filters.publisher ?? ""}
+                onChange={(e) =>
+                  onFiltersChange((f) => ({
+                    ...f,
+                    publisher: e.target.value || undefined,
+                    page: 1,
+                  }))
+                }
+                data-testid="publisher-filter"
+              />
+            </div>
+          </div>
+
+          {/* Year range */}
+          <RangeInput
+            label="Release Year"
+            min={1970}
+            max={2010}
+            valueMin={filters.yearMin}
+            valueMax={filters.yearMax}
+            onChangeMin={(yearMin) =>
+              onFiltersChange((f) => ({ ...f, yearMin, page: 1 }))
+            }
+            onChangeMax={(yearMax) =>
+              onFiltersChange((f) => ({ ...f, yearMax, page: 1 }))
+            }
+            testId="year-filter"
+          />
+
+          {/* Rating range */}
+          <RangeInput
+            label="Rating"
+            min={0}
+            max={100}
+            valueMin={filters.ratingMin}
+            valueMax={filters.ratingMax}
+            onChangeMin={(ratingMin) =>
+              onFiltersChange((f) => ({ ...f, ratingMin, page: 1 }))
+            }
+            onChangeMax={(ratingMax) =>
+              onFiltersChange((f) => ({ ...f, ratingMax, page: 1 }))
+            }
+            testId="rating-filter"
+          />
+
+          {/* Play status */}
+          <div data-testid="play-status-filter">
+            <label className="block text-sm font-medium text-surface-300 mb-2">
+              Play Status
+            </label>
+            <div className="flex flex-wrap gap-1.5">
+              {PLAY_STATUS_OPTIONS.map((opt) => (
+                <button
+                  key={opt.label}
+                  onClick={() =>
+                    onFiltersChange((f) => ({
+                      ...f,
+                      playStatus: opt.value,
+                      page: 1,
+                    }))
+                  }
+                  className={cn(
+                    "px-2.5 py-1 rounded-full text-xs font-medium transition-colors",
+                    filters.playStatus === opt.value
+                      ? "bg-brand-600 text-white"
+                      : "bg-surface-800 text-surface-300 hover:bg-surface-700 hover:text-surface-100",
+                  )}
+                >
+                  {opt.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Save / Saved searches section */}
+          <div className="border-t border-surface-700 pt-4 space-y-3">
+            <div className="flex items-center justify-between">
+              <h4 className="text-sm font-medium text-surface-300 flex items-center gap-1.5">
+                <Bookmark className="h-3.5 w-3.5" /> Saved Searches
+              </h4>
+              {activeFilterCount > 0 && !showSaveInput && (
+                <button
+                  onClick={() => setShowSaveInput(true)}
+                  className="text-xs text-brand-400 hover:text-brand-300 flex items-center gap-1"
+                  data-testid="save-search-button"
+                >
+                  <Save className="h-3 w-3" /> Save current
+                </button>
+              )}
+            </div>
+
+            {showSaveInput && (
+              <div className="flex items-center gap-2" data-testid="save-search-form">
+                <Input
+                  placeholder="Search name..."
+                  value={saveName}
+                  onChange={(e) => setSaveName(e.target.value)}
+                  onKeyDown={(e) => e.key === "Enter" && handleSave()}
+                  className="flex-1"
+                  autoFocus
+                  data-testid="save-search-name"
+                />
+                <Button
+                  variant="primary"
+                  onClick={handleSave}
+                  disabled={!saveName.trim()}
+                >
+                  Save
+                </Button>
+                <button
+                  onClick={() => {
+                    setShowSaveInput(false);
+                    setSaveName("");
+                  }}
+                  className="p-2 text-surface-400 hover:text-surface-200"
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            )}
+
+            {savedSearches && savedSearches.length > 0 ? (
+              <div className="space-y-1.5" data-testid="saved-searches-list">
+                {savedSearches.map((s) => (
+                  <SavedSearchItem
+                    key={s.id}
+                    search={s}
+                    onApply={() => onApplySearch(s.filters)}
+                    onDelete={() => onDeleteSearch(s.id)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-surface-500">
+                No saved searches yet. Apply filters and save them for quick access.
+              </p>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function countActiveFilters(filters: GameFilters): number {
+  let count = 0;
+  if (filters.consoles?.length) count++;
+  if (filters.genres?.length) count++;
+  if (filters.themes?.length) count++;
+  if (filters.keywords?.length) count++;
+  if (filters.perspectives?.length) count++;
+  if (filters.developer) count++;
+  if (filters.publisher) count++;
+  if (filters.yearMin != null) count++;
+  if (filters.yearMax != null) count++;
+  if (filters.ratingMin != null) count++;
+  if (filters.ratingMax != null) count++;
+  if (filters.playStatus) count++;
+  return count;
+}
+
+/** Convert a saved-search filter record back to GameFilters */
+export function savedSearchToFilters(
+  record: Record<string, string | number>,
+  base: GameFilters,
+): GameFilters {
+  return {
+    ...base,
+    consoles: record.consoles ? String(record.consoles).split(",") : undefined,
+    genres: record.genres ? String(record.genres).split(",") : undefined,
+    themes: record.themes ? String(record.themes).split(",") : undefined,
+    keywords: record.keywords ? String(record.keywords).split(",") : undefined,
+    developer: record.developer ? String(record.developer) : undefined,
+    publisher: record.publisher ? String(record.publisher) : undefined,
+    yearMin: record.yearMin != null ? Number(record.yearMin) : undefined,
+    yearMax: record.yearMax != null ? Number(record.yearMax) : undefined,
+    ratingMin: record.ratingMin != null ? Number(record.ratingMin) : undefined,
+    ratingMax: record.ratingMax != null ? Number(record.ratingMax) : undefined,
+    playStatus: record.playStatus as GameFilters["playStatus"],
+    search: record.search ? String(record.search) : base.search,
+    page: 1,
+  };
+}

--- a/web/src/features/games/components/games-filter-bar.tsx
+++ b/web/src/features/games/components/games-filter-bar.tsx
@@ -32,8 +32,9 @@ export function GamesFilterBar({
   const sortOptions = [
     { value: "title", label: "Title" },
     { value: "created_at", label: "Recently Added" },
-    { value: "file_size", label: "File Size" },
+    { value: "release_date", label: "Release Date" },
     { value: "rating", label: "Rating" },
+    { value: "file_size", label: "File Size" },
   ];
 
   return (

--- a/web/src/hooks/__tests__/use-saved-searches.test.tsx
+++ b/web/src/hooks/__tests__/use-saved-searches.test.tsx
@@ -1,0 +1,63 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useSavedSearches, useCreateSavedSearch, useDeleteSavedSearch } from "../use-saved-searches";
+
+const mockGet = vi.fn();
+const mockPost = vi.fn();
+const mockDelete = vi.fn();
+
+vi.mock("@/lib/api-client", () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+    post: (...args: unknown[]) => mockPost(...args),
+    delete: (...args: unknown[]) => mockDelete(...args),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("useSavedSearches", () => {
+  it("fetches saved searches", async () => {
+    const data = [
+      { id: "1", name: "RPGs", filters: { genres: "RPG" }, createdAt: "2026-01-01T00:00:00Z" },
+    ];
+    mockGet.mockResolvedValueOnce(data);
+    const { result } = renderHook(() => useSavedSearches(), { wrapper: createWrapper() });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockGet).toHaveBeenCalledWith("/user/saved-searches");
+    expect(result.current.data).toEqual(data);
+  });
+});
+
+describe("useCreateSavedSearch", () => {
+  it("creates a saved search", async () => {
+    const created = { id: "2", name: "Test", filters: { genres: "Action" }, createdAt: "2026-01-01T00:00:00Z" };
+    mockPost.mockResolvedValueOnce(created);
+    const { result } = renderHook(() => useCreateSavedSearch(), { wrapper: createWrapper() });
+    result.current.mutate({ name: "Test", filters: { genres: "Action" } });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockPost).toHaveBeenCalledWith("/user/saved-searches", { name: "Test", filters: { genres: "Action" } });
+  });
+});
+
+describe("useDeleteSavedSearch", () => {
+  it("deletes a saved search", async () => {
+    mockDelete.mockResolvedValueOnce({ status: "deleted" });
+    const { result } = renderHook(() => useDeleteSavedSearch(), { wrapper: createWrapper() });
+    result.current.mutate("123");
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(mockDelete).toHaveBeenCalledWith("/user/saved-searches/123");
+  });
+});

--- a/web/src/hooks/use-games.ts
+++ b/web/src/hooks/use-games.ts
@@ -7,6 +7,22 @@ export function useGames(filters?: GameFilters) {
   if (filters?.search) params.set("search", filters.search);
   if (filters?.consoleId) params.set("consoleId", filters.consoleId);
   if (filters?.genre) params.set("genre", filters.genre);
+  // Multi-select filters
+  if (filters?.consoles?.length) params.set("consoles", filters.consoles.join(","));
+  if (filters?.genres?.length) params.set("genres", filters.genres.join(","));
+  if (filters?.themes?.length) params.set("themes", filters.themes.join(","));
+  if (filters?.keywords?.length) params.set("keywords", filters.keywords.join(","));
+  if (filters?.perspectives?.length) params.set("perspectives", filters.perspectives.join(","));
+  // Text filters
+  if (filters?.developer) params.set("developer", filters.developer);
+  if (filters?.publisher) params.set("publisher", filters.publisher);
+  // Range filters
+  if (filters?.yearMin != null) params.set("yearMin", String(filters.yearMin));
+  if (filters?.yearMax != null) params.set("yearMax", String(filters.yearMax));
+  if (filters?.ratingMin != null) params.set("ratingMin", String(filters.ratingMin));
+  if (filters?.ratingMax != null) params.set("ratingMax", String(filters.ratingMax));
+  // Play status
+  if (filters?.playStatus) params.set("playStatus", filters.playStatus);
   if (filters?.sortBy) params.set("sortBy", filters.sortBy);
   if (filters?.sortOrder) params.set("sortOrder", filters.sortOrder);
   if (filters?.page) params.set("page", String(filters.page));

--- a/web/src/hooks/use-saved-searches.ts
+++ b/web/src/hooks/use-saved-searches.ts
@@ -1,0 +1,34 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type { SavedSearch } from "@/types/api";
+
+export function useSavedSearches() {
+  return useQuery({
+    queryKey: ["saved-searches"],
+    queryFn: () => api.get<SavedSearch[]>("/user/saved-searches"),
+  });
+}
+
+export function useCreateSavedSearch() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: { name: string; filters: Record<string, string | number> }) =>
+      api.post<SavedSearch>("/user/saved-searches", data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["saved-searches"] });
+    },
+  });
+}
+
+export function useDeleteSavedSearch() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) =>
+      api.delete(`/user/saved-searches/${id}`),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["saved-searches"] });
+    },
+  });
+}

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -139,6 +139,7 @@ export type ApiGetPath = WithQuery<
   | "/user/ra/token"
   | "/user/taste-profile"
   | "/user/achievements/recent"
+  | "/user/saved-searches"
 
   // Shared Sessions
   | "/shared-sessions"
@@ -236,6 +237,7 @@ export type ApiPostPath = WithQuery<
   | "/user/ra/link"
   | `/user/shared-session-invites/${string}/accept`
   | `/user/shared-session-invites/${string}/decline`
+  | "/user/saved-searches"
 
   // Collections
   | "/collections"
@@ -344,6 +346,7 @@ export type ApiDeletePath = WithQuery<
   | `/user/devices/${string}`
   | "/user/ra/link"
   | `/user/games/${string}/keymapping`
+  | `/user/saved-searches/${string}`
 
   // Collections
   | `/collections/${string}`

--- a/web/src/pages/games-page.tsx
+++ b/web/src/pages/games-page.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useState, useEffect, useCallback } from "react";
+import { useSearchParams } from "react-router-dom";
 import { Library } from "lucide-react";
 import { GameCard } from "@/components/game-card";
 import { GameGrid } from "@/components/game-grid";
@@ -7,30 +8,124 @@ import { useGames, useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
 import { useConsoles } from "@/hooks/use-consoles";
 import { GamesFilterBar } from "@/features/games/components/games-filter-bar";
+import {
+  AdvancedFilterPanel,
+  savedSearchToFilters,
+} from "@/features/games/components/advanced-filter-panel";
 import { GameListRow } from "@/features/games/components/game-list-row";
 import { Pagination } from "@/components/pagination";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useThemes, useKeywords } from "@/hooks/use-explore";
+import {
+  useSavedSearches,
+  useCreateSavedSearch,
+  useDeleteSavedSearch,
+} from "@/hooks/use-saved-searches";
 import type { GameFilters } from "@/types/api";
 
 type ViewMode = "grid" | "list";
 
+/** Parse URL search params into GameFilters */
+function parseUrlFilters(params: URLSearchParams): Partial<GameFilters> {
+  const f: Partial<GameFilters> = {};
+  const consoles = params.get("consoles");
+  if (consoles) f.consoles = consoles.split(",");
+  const genres = params.get("genres");
+  if (genres) f.genres = genres.split(",");
+  const themes = params.get("themes");
+  if (themes) f.themes = themes.split(",");
+  const keywords = params.get("keywords");
+  if (keywords) f.keywords = keywords.split(",");
+  if (params.get("developer")) f.developer = params.get("developer")!;
+  if (params.get("publisher")) f.publisher = params.get("publisher")!;
+  if (params.get("yearMin")) f.yearMin = Number(params.get("yearMin"));
+  if (params.get("yearMax")) f.yearMax = Number(params.get("yearMax"));
+  if (params.get("ratingMin")) f.ratingMin = Number(params.get("ratingMin"));
+  if (params.get("ratingMax")) f.ratingMax = Number(params.get("ratingMax"));
+  const ps = params.get("playStatus");
+  if (ps) f.playStatus = ps as GameFilters["playStatus"];
+  const sortBy = params.get("sortBy");
+  if (sortBy) f.sortBy = sortBy as GameFilters["sortBy"];
+  const sortOrder = params.get("sortOrder");
+  if (sortOrder) f.sortOrder = sortOrder as GameFilters["sortOrder"];
+  if (params.get("search")) f.search = params.get("search")!;
+  return f;
+}
+
+/** Serialize GameFilters to URL search params */
+function filtersToUrl(filters: GameFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  if (filters.consoles?.length) params.set("consoles", filters.consoles.join(","));
+  if (filters.genres?.length) params.set("genres", filters.genres.join(","));
+  if (filters.themes?.length) params.set("themes", filters.themes.join(","));
+  if (filters.keywords?.length) params.set("keywords", filters.keywords.join(","));
+  if (filters.developer) params.set("developer", filters.developer);
+  if (filters.publisher) params.set("publisher", filters.publisher);
+  if (filters.yearMin != null) params.set("yearMin", String(filters.yearMin));
+  if (filters.yearMax != null) params.set("yearMax", String(filters.yearMax));
+  if (filters.ratingMin != null) params.set("ratingMin", String(filters.ratingMin));
+  if (filters.ratingMax != null) params.set("ratingMax", String(filters.ratingMax));
+  if (filters.playStatus) params.set("playStatus", filters.playStatus);
+  if (filters.sortBy && filters.sortBy !== "title") params.set("sortBy", filters.sortBy);
+  if (filters.sortOrder && filters.sortOrder !== "asc") params.set("sortOrder", filters.sortOrder);
+  if (filters.search) params.set("search", filters.search);
+  return params;
+}
+
 export function GamesPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
   const [viewMode, setViewMode] = useState<ViewMode>("grid");
-  const [searchInput, setSearchInput] = useState("");
+  const [searchInput, setSearchInput] = useState(searchParams.get("search") ?? "");
   const debouncedSearch = useDebouncedValue(searchInput, 300);
-  const [filters, setFilters] = useState<GameFilters>({
+  const [filtersOpen, setFiltersOpen] = useState(false);
+
+  // Initialize filters from URL
+  const [filters, setFilters] = useState<GameFilters>(() => ({
     sortBy: "title",
     sortOrder: "asc",
     pageSize: 48,
-  });
+    ...parseUrlFilters(searchParams),
+  }));
+
+  // Sync filters to URL (debounced to avoid excessive updates)
+  useEffect(() => {
+    const params = filtersToUrl({ ...filters, search: debouncedSearch || undefined });
+    const current = searchParams.toString();
+    const next = params.toString();
+    if (current !== next) {
+      setSearchParams(params, { replace: true });
+    }
+  }, [filters, debouncedSearch]);
 
   const { data, isLoading } = useGames({
     ...filters,
     search: debouncedSearch || undefined,
   });
   const { data: consoles } = useConsoles();
+  const { data: themes } = useThemes();
+  const { data: keywords } = useKeywords(50);
+  const { data: savedSearches } = useSavedSearches();
+  const createSearch = useCreateSavedSearch();
+  const deleteSearch = useDeleteSavedSearch();
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+
+  const handleSaveSearch = useCallback(
+    (name: string, filterRecord: Record<string, string | number>) => {
+      createSearch.mutate({ name, filters: filterRecord });
+    },
+    [createSearch],
+  );
+
+  const handleApplySearch = useCallback(
+    (filterRecord: Record<string, string | number>) => {
+      setFilters((prev) => savedSearchToFilters(filterRecord, prev));
+      if (filterRecord.search) {
+        setSearchInput(String(filterRecord.search));
+      }
+    },
+    [],
+  );
 
   const games = data?.data ?? [];
 
@@ -56,6 +151,21 @@ export function GamesPage() {
         viewMode={viewMode}
         onViewModeChange={setViewMode}
         consoles={consoles}
+      />
+
+      <AdvancedFilterPanel
+        filters={filters}
+        onFiltersChange={setFilters}
+        consoles={consoles}
+        themes={themes}
+        keywords={keywords}
+        savedSearches={savedSearches}
+        onSaveSearch={handleSaveSearch}
+        onDeleteSearch={(id) => deleteSearch.mutate(id)}
+        onApplySearch={handleApplySearch}
+        totalResults={data?.total}
+        isOpen={filtersOpen}
+        onToggle={() => setFiltersOpen((o) => !o)}
       />
 
       {/* Content */}

--- a/web/src/pages/games-page.tsx
+++ b/web/src/pages/games-page.tsx
@@ -87,7 +87,7 @@ export function GamesPage() {
     ...parseUrlFilters(searchParams),
   }));
 
-  // Sync filters to URL (debounced to avoid excessive updates)
+  // Sync filters to URL
   useEffect(() => {
     const params = filtersToUrl({ ...filters, search: debouncedSearch || undefined });
     const current = searchParams.toString();
@@ -95,7 +95,7 @@ export function GamesPage() {
     if (current !== next) {
       setSearchParams(params, { replace: true });
     }
-  }, [filters, debouncedSearch]);
+  }, [filters, debouncedSearch, searchParams, setSearchParams]);
 
   const { data, isLoading } = useGames({
     ...filters,

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -113,10 +113,33 @@ export interface GameFilters {
   search?: string;
   consoleId?: string;
   genre?: string;
-  sortBy?: "title" | "created_at" | "file_size" | "rating";
+  // Multi-select filters (comma-separated when sent to API)
+  consoles?: string[];
+  genres?: string[];
+  themes?: string[];
+  keywords?: string[];
+  perspectives?: string[];
+  // Text search filters
+  developer?: string;
+  publisher?: string;
+  // Range filters
+  yearMin?: number;
+  yearMax?: number;
+  ratingMin?: number;
+  ratingMax?: number;
+  // Play status
+  playStatus?: "unplayed" | "played" | "favorited" | "play-later";
+  sortBy?: "title" | "created_at" | "file_size" | "rating" | "release_date";
   sortOrder?: "asc" | "desc";
   page?: number;
   pageSize?: number;
+}
+
+export interface SavedSearch {
+  id: string;
+  name: string;
+  filters: Record<string, string | number>;
+  createdAt: string;
 }
 
 export interface MetadataMatchesResponse {


### PR DESCRIPTION
## Summary
- **Backend:** Extended `GET /api/games` with multi-select filters (consoles, genres, themes, keywords, perspectives), text search (developer, publisher), range filters (year, rating), and play status filter. Added DISTINCT to prevent duplicate rows from JOINs. Added saved search CRUD endpoints (`POST/GET /user/saved-searches`, `DELETE /user/saved-searches/:id`) with per-user 50-search limit.
- **Web:** Advanced filter panel with chip-based multi-select, range inputs, play status toggles, developer/publisher text search, saved search management, and URL-based filter state for shareable links. Full ARIA accessibility (aria-pressed, aria-expanded, role="group", aria-labelledby).
- **Player:** GameFilterPanel composable with chip-based filters, ExploreSearchScreen for filtered browsing, saved search support via API client and repository.

## Test plan
- [x] 26 new Go tests (17 filter + 9 saved search) — all pass
- [x] 28 new web tests (25 filter panel + 3 saved search hooks) — all pass, full suite 1077 pass
- [x] 3 new desktop E2E tests (filter panel, saved searches, clear filters) — all pass
- [x] Code review: fixed duplicate rows from JOINs, rating bounds validation, useEffect deps, Kotlin DTO type mismatch
- [x] UX review: fixed all 5 MUST FIX accessibility issues (aria-pressed, aria-expanded, focus-visible, label associations, aria-labels)