### PR TITLE
fix: prevent lazy-loading sentinel deadlock on Explore page

### DIFF
--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -259,14 +259,13 @@ export function ExplorePage() {
       <WildFeaturesSection />
 
       {/* Personalized & Social Discovery — lazy-loaded */}
-      <div ref={social.ref}>
-        <ForYouSection
-          rows={forYouData?.rows}
-          isLoading={isForYouLoading}
-          onToggleFavorite={handleToggleFavorite}
-          onTogglePlayLater={handleTogglePlayLater}
-        />
-      </div>
+      <div ref={social.ref} />
+      <ForYouSection
+        rows={forYouData?.rows}
+        isLoading={isForYouLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
 
       {/* Players Like You */}
       <PlayersLikeYouShelf
@@ -313,14 +312,13 @@ export function ExplorePage() {
       />
 
       {/* Temporal Discovery — lazy-loaded */}
-      <div ref={temporal.ref}>
-        <OnThisDayShelf
-          data={onThisDayData}
-          isLoading={isOnThisDayLoading}
-          onToggleFavorite={handleToggleFavorite}
-          onTogglePlayLater={handleTogglePlayLater}
-        />
-      </div>
+      <div ref={temporal.ref} />
+      <OnThisDayShelf
+        data={onThisDayData}
+        isLoading={isOnThisDayLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
 
       <AnniversariesShelf
         anniversaries={anniversariesData?.anniversaries}
@@ -346,14 +344,13 @@ export function ExplorePage() {
       />
 
       {/* Achievement & Challenge Discovery — lazy-loaded */}
-      <div ref={achievements.ref}>
-        <EasyToCompleteShelf
-          data={easyToCompleteData}
-          isLoading={isEasyToCompleteLoading}
-          onToggleFavorite={handleToggleFavorite}
-          onTogglePlayLater={handleTogglePlayLater}
-        />
-      </div>
+      <div ref={achievements.ref} />
+      <EasyToCompleteShelf
+        data={easyToCompleteData}
+        isLoading={isEasyToCompleteLoading}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
 
       <HardestGamesShelf
         data={hardestGamesData}
@@ -400,9 +397,8 @@ export function ExplorePage() {
       ) : null}
 
       {/* Catalog bottom — lazy-loaded */}
-      <div ref={catalogBottom.ref}>
-        <ThemeGrid themes={themes} isLoading={isThemesLoading} />
-      </div>
+      <div ref={catalogBottom.ref} />
+      <ThemeGrid themes={themes} isLoading={isThemesLoading} />
 
       <KeywordChips keywords={keywords} isLoading={isKeywordsLoading} />
 


### PR DESCRIPTION
## Summary
- Sentinel divs for IntersectionObserver-based lazy loading previously wrapped child components that could render `null`, creating zero-height containers the observer might never intersect
- This caused a deadlock: data couldn't load because the observer hadn't fired, and the observer couldn't fire because the section had no height
- Fix: use self-closing `<div ref={sentinel.ref} />` divs so they always exist in the DOM

## Test plan
- [x] All 31 explore-page tests pass
- [x] TypeScript compiles with no errors