### PR TITLE
fix: resolve Kotlin compilation errors from bad merge

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -49,8 +49,6 @@ import com.spela.player.presentation.ui.feature.explore.SeriesShelfSkeleton
 import com.spela.player.presentation.ui.feature.explore.MoodPicker
 import com.spela.player.presentation.ui.feature.explore.MoodPickerSkeleton
 import com.spela.player.presentation.ui.feature.explore.RecentlyReviewedSection
-import com.spela.player.presentation.ui.feature.explore.SeriesShelf
-import com.spela.player.presentation.ui.feature.explore.SeriesShelfSkeleton
 import com.spela.player.presentation.ui.feature.explore.SocialSectionSkeleton
 import com.spela.player.presentation.ui.feature.explore.ThemeGrid
 import com.spela.player.presentation.ui.feature.explore.ThemeGridSkeleton

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -51,7 +51,6 @@ data class ExploreState(
     val themes: List<Theme> = emptyList(),
     val keywords: List<Keyword> = emptyList(),
     val featuredSeries: List<FeaturedSeries> = emptyList(),
-
     val moods: List<MoodDefinition> = emptyList(),
     val forYouRows: List<ForYouRow> = emptyList(),
     val developerSpotlight: DeveloperSpotlight? = null,
@@ -75,10 +74,6 @@ data class ExploreState(
     val isLoadingThemes: Boolean = false,
     val isLoadingKeywords: Boolean = false,
     val isLoadingFeaturedSeries: Boolean = false,
-    val error: String? = null,
-) {
-    val isLoading: Boolean get() = isLoadingFeatured || isLoadingRows || isLoadingThemes || isLoadingKeywords || isLoadingFeaturedSeries
-    val isEmpty: Boolean get() = featuredGames.isEmpty() && rows.isEmpty() && themes.isEmpty() && keywords.isEmpty() && featuredSeries.isEmpty() && !isLoading
     val isLoadingMoods: Boolean = false,
     val isLoadingForYou: Boolean = false,
     val isLoadingDeveloperSpotlight: Boolean = false,


### PR DESCRIPTION
## Summary
- Fixed malformed `ExploreState` data class in `ExploreViewModel.kt` — the merge of PR #120 produced duplicate `error` properties, duplicate closing brackets, and constructor parameters placed after the closing parenthesis
- Removed duplicate imports for `SeriesShelf` and `SeriesShelfSkeleton` in `ExploreScreen.kt`

## Test plan
- [x] `./gradlew :shared:compileKotlinDesktop` — passes
- [x] `./gradlew :shared:desktopTest` — passes