### PR TITLE
fix: pass GITHUB_TOKEN to setup-java to avoid API rate limits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,8 @@ jobs:
         with:
           distribution: jetbrains
           java-version: 21
+          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |
@@ -217,6 +219,7 @@ jobs:
         with:
           distribution: jetbrains
           java-version: 21
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -255,6 +258,7 @@ jobs:
         with:
           distribution: jetbrains
           java-version: 21
+          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -301,6 +305,7 @@ jobs:
         with:
           distribution: jetbrains
           java-version: 21
+          token: ${{ secrets.GITHUB_TOKEN }}
       - uses: android-actions/setup-android@v3
         with:
           packages: ''


### PR DESCRIPTION
## Summary
- Added `token: ${{ secrets.GITHUB_TOKEN }}` to all `actions/setup-java` steps using the `jetbrains` distribution in the release workflow
- The JetBrains JDK resolver queries the GitHub API for download URLs; without auth, shared runner IPs hit the unauthenticated rate limit, causing macOS release builds to fail repeatedly

## Test plan
- [x] v0.0.58 release macOS build failed 3x with `API rate limit exceeded`
- After merge, delete and re-push the v0.0.58 tag to trigger a fresh release build