### PR TITLE
fix: remove duplicate token key in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -186,7 +186,6 @@ jobs:
           distribution: jetbrains
           java-version: 21
           token: ${{ secrets.GITHUB_TOKEN }}
-          token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Linux dependencies
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
## Summary
- Removed duplicate `token` line in the desktop build's `setup-java` step that caused YAML parse errors when triggering `workflow_dispatch`

## Test plan
- After merge, trigger release manually: `gh workflow run release.yml -f tag=v0.0.58`