### PR TITLE
fix: use temurin JDK for macOS release build to avoid rate limits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,10 @@ jobs:
           ref: ${{ env.RELEASE_TAG }}
       - uses: actions/setup-java@v4
         with:
-          distribution: jetbrains
+          # JBR is needed on Windows/Linux for transparent title bar; macOS uses
+          # native apple.awt.transparentTitleBar which works with any JDK.
+          # Temurin avoids GitHub API rate limits on macOS runners.
+          distribution: ${{ runner.os == 'macOS' && 'temurin' || 'jetbrains' }}
           java-version: 21
           token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Linux dependencies


### PR DESCRIPTION
## Summary
- Switch macOS desktop build from JetBrains JDK to Temurin
- macOS uses native `apple.awt.transparentTitleBar` which works with any JDK — JBR custom title bar is only used on Windows and Linux
- This avoids the persistent GitHub API rate limit errors when `setup-java` resolves the JetBrains JDK download URL on macOS runners

## Test plan
- After merge, re-trigger v0.0.58 release build
- macOS DMG should build successfully with Temurin JDK 21
- Transparent title bar still works on macOS (uses native AWT property, not JBR)