### PR TITLE
feat: move Explore console showcase sections into console detail page

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -705,6 +705,7 @@ fun SpelaApp(
                                 ConsoleScreen(
                                     consoleId = screen.consoleId,
                                     viewModel = gameListViewModel,
+                                    exploreViewModel = exploreViewModel,
                                     onGameSelected = { gameId ->
                                         navigationViewModel.onIntent(
                                             NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
@@ -712,6 +713,11 @@ fun SpelaApp(
                                     },
                                     onBack = {
                                         navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                    },
+                                    onDeveloperSelected = { name ->
+                                        navigationViewModel.onIntent(
+                                            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper(name))
+                                        )
                                     },
                                     onNavigateToConsoleSettings = {
                                         navigationViewModel.onIntent(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ConsoleShowcaseSections.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ConsoleShowcaseSections.kt
@@ -1,0 +1,253 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.DeveloperSummary
+import com.spela.player.domain.model.GenreCount
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+import com.spela.player.util.formatRating
+import com.spela.player.util.parseHexColor
+
+@Composable
+fun ConsoleEssentials(
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+) {
+    val state by viewModel.consoleShowcaseState.collectAsState()
+    val showcase = state.showcase ?: return
+    if (showcase.essentials.isEmpty()) return
+
+    SpTitledSection(
+        title = "Essentials",
+        edgeToEdgeContent = true,
+        modifier = Modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .testTag("console_essentials_section"),
+    ) {
+        GameShelf(
+            games = showcase.essentials,
+            onGameSelected = onGameSelected,
+        )
+    }
+}
+
+@Composable
+fun ConsoleHiddenGems(
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+) {
+    val state by viewModel.consoleShowcaseState.collectAsState()
+    val showcase = state.showcase ?: return
+    if (showcase.hiddenGems.isEmpty()) return
+
+    SpTitledSection(
+        title = "Hidden Gems",
+        edgeToEdgeContent = true,
+        modifier = Modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .testTag("console_hidden_gems_section"),
+    ) {
+        GameShelf(
+            games = showcase.hiddenGems,
+            onGameSelected = onGameSelected,
+        )
+    }
+}
+
+@Composable
+fun ConsoleGenreBreakdown(
+    viewModel: ExploreViewModel,
+) {
+    val state by viewModel.consoleShowcaseState.collectAsState()
+    val showcase = state.showcase ?: return
+    if (showcase.genreBreakdown.isEmpty()) return
+
+    val accentColor = parseHexColor(showcase.console.colorTheme, SpColor.Primary)
+
+    SpTitledSection(
+        title = "Genre Breakdown",
+        edgeToEdgeContent = true,
+        modifier = Modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .testTag("console_genre_breakdown_section"),
+    ) {
+        GenreBreakdownChips(
+            genres = showcase.genreBreakdown,
+            accentColor = accentColor,
+        )
+    }
+}
+
+@Composable
+fun ConsoleTopDevelopers(
+    viewModel: ExploreViewModel,
+    onDeveloperSelected: (String) -> Unit,
+) {
+    val state by viewModel.consoleShowcaseState.collectAsState()
+    val showcase = state.showcase ?: return
+    if (showcase.topDevelopers.isEmpty()) return
+
+    SpTitledSection(
+        title = "Top Developers",
+        edgeToEdgeContent = true,
+        modifier = Modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .testTag("console_top_developers_section"),
+    ) {
+        TopDevelopersList(
+            developers = showcase.topDevelopers,
+            onDeveloperSelected = onDeveloperSelected,
+        )
+    }
+}
+
+@Composable
+fun ConsoleRecentlyPlayed(
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+) {
+    val state by viewModel.consoleShowcaseState.collectAsState()
+    val showcase = state.showcase ?: return
+    if (showcase.recentlyPlayed.isEmpty()) return
+
+    SpTitledSection(
+        title = "Recently Played",
+        edgeToEdgeContent = true,
+        modifier = Modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .testTag("console_recently_played_section"),
+    ) {
+        GameShelf(
+            games = showcase.recentlyPlayed,
+            onGameSelected = onGameSelected,
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun GenreBreakdownChips(
+    genres: List<GenreCount>,
+    accentColor: Color,
+    modifier: Modifier = Modifier,
+) {
+    FlowRow(
+        modifier = modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .testTag("genre_breakdown_chips"),
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        genres.forEach { genre ->
+            SpChip(
+                text = "${genre.name} (${genre.gameCount})",
+                color = accentColor,
+                modifier = Modifier
+                    .testTag("genre_chip_${genre.name}")
+                    .semantics {
+                        contentDescription = "${genre.name}, ${genre.gameCount} games"
+                    },
+            )
+        }
+    }
+}
+
+@Composable
+internal fun TopDevelopersList(
+    developers: List<DeveloperSummary>,
+    onDeveloperSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .testTag("top_developers_list"),
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        developers.forEach { developer ->
+            SpCard(
+                onClick = { onDeveloperSelected(developer.name) },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("developer_card_${developer.name}")
+                    .semantics {
+                        contentDescription = "${developer.name}, ${developer.gameCount} games"
+                    },
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(SpSpacing.Medium),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween,
+                ) {
+                    Column(
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Text(
+                            text = developer.name,
+                            style = SpTypography.TitleSmall,
+                            color = SpColor.OnCard,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                        Spacer(Modifier.height(SpSpacing.XXSmall))
+                        Text(
+                            text = "${developer.gameCount} games",
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+
+                    if (developer.avgRating > 0) {
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Star,
+                                contentDescription = null,
+                                tint = SpColor.Rating,
+                                modifier = Modifier.size(14.dp),
+                            )
+                            Text(
+                                text = formatRating(developer.avgRating),
+                                style = SpTypography.BodyMedium,
+                                color = SpColor.OnBackgroundSecondary,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -68,6 +68,11 @@ import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.feature.explore.ConsoleEssentials
+import com.spela.player.presentation.ui.feature.explore.ConsoleGenreBreakdown
+import com.spela.player.presentation.ui.feature.explore.ConsoleHiddenGems
+import com.spela.player.presentation.ui.feature.explore.ConsoleRecentlyPlayed
+import com.spela.player.presentation.ui.feature.explore.ConsoleTopDevelopers
 import com.spela.player.presentation.ui.feature.home.ContinuePlayingRow
 import com.spela.player.presentation.ui.feature.home.TopRatedRow
 import com.spela.player.presentation.ui.feature.library.BiosWarningBanner
@@ -79,6 +84,7 @@ import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.viewmodel.ExploreViewModel
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
 private data class SortOption(val key: String, val label: String)
@@ -94,8 +100,10 @@ private val sortOptions = listOf(
 fun ConsoleScreen(
     consoleId: String,
     viewModel: GameListViewModel,
+    exploreViewModel: ExploreViewModel? = null,
     onGameSelected: (String) -> Unit,
     onBack: () -> Unit,
+    onDeveloperSelected: (String) -> Unit = {},
     onNavigateToConsoleSettings: () -> Unit = {},
 ) {
     val state by viewModel.state.collectAsState()
@@ -119,6 +127,10 @@ fun ConsoleScreen(
 
     LaunchedEffect(consoleId) {
         viewModel.onIntent(GameListIntent.SelectConsole(consoleId))
+    }
+
+    LaunchedEffect(consoleId) {
+        exploreViewModel?.loadConsoleShowcase(consoleId)
     }
 
     // Auto-focus search field when it becomes visible
@@ -275,6 +287,24 @@ fun ConsoleScreen(
                                     .fillMaxWidth()
                                     .padding(vertical = SpSpacing.Small),
                             )
+                        }
+                    }
+
+                    if (exploreViewModel != null) {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            ConsoleEssentials(exploreViewModel, onGameSelected)
+                        }
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            ConsoleHiddenGems(exploreViewModel, onGameSelected)
+                        }
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            ConsoleGenreBreakdown(exploreViewModel)
+                        }
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            ConsoleTopDevelopers(exploreViewModel, onDeveloperSelected)
+                        }
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            ConsoleRecentlyPlayed(exploreViewModel, onGameSelected)
                         }
                     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreConsoleShowcaseScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreConsoleShowcaseScreen.kt
@@ -1,28 +1,17 @@
 package com.spela.player.presentation.ui.screen
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.lazy.LazyRow
-import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SportsEsports
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -30,35 +19,25 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.spela.player.domain.model.DeveloperSummary
-import com.spela.player.domain.model.Game
-import com.spela.player.domain.model.GenreCount
 import com.spela.player.presentation.ui.components.PlatformBackHandler
-import com.spela.player.presentation.ui.components.SpCard
-import com.spela.player.presentation.ui.components.SpChip
-import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpGameCardSkeleton
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
-import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.components.SpTopBar
-import com.spela.player.presentation.ui.feature.explore.GameShelf
-import com.spela.player.presentation.ui.feature.explore.GameShelfSkeleton
+import com.spela.player.presentation.ui.feature.explore.ConsoleEssentials
+import com.spela.player.presentation.ui.feature.explore.ConsoleGenreBreakdown
+import com.spela.player.presentation.ui.feature.explore.ConsoleHiddenGems
+import com.spela.player.presentation.ui.feature.explore.ConsoleRecentlyPlayed
+import com.spela.player.presentation.ui.feature.explore.ConsoleTopDevelopers
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.ExploreViewModel
-import com.spela.player.util.formatRating
 import com.spela.player.util.parseHexColor
 
 @Composable
@@ -153,94 +132,24 @@ fun ExploreConsoleShowcaseScreen(
                             }
                         }
 
-                        // Essentials section
-                        if (showcase.essentials.isNotEmpty()) {
-                            item {
-                                SpTitledSection(
-                                    title = "Essentials",
-                                    edgeToEdgeContent = true,
-                                    modifier = Modifier
-                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
-                                        .testTag("console_essentials_section"),
-                                ) {
-                                    GameShelf(
-                                        games = showcase.essentials,
-                                        onGameSelected = onGameSelected,
-                                    )
-                                }
-                            }
+                        item {
+                            ConsoleEssentials(viewModel, onGameSelected)
                         }
 
-                        // Hidden Gems section
-                        if (showcase.hiddenGems.isNotEmpty()) {
-                            item {
-                                SpTitledSection(
-                                    title = "Hidden Gems",
-                                    edgeToEdgeContent = true,
-                                    modifier = Modifier
-                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
-                                        .testTag("console_hidden_gems_section"),
-                                ) {
-                                    GameShelf(
-                                        games = showcase.hiddenGems,
-                                        onGameSelected = onGameSelected,
-                                    )
-                                }
-                            }
+                        item {
+                            ConsoleHiddenGems(viewModel, onGameSelected)
                         }
 
-                        // Genre Breakdown section
-                        if (showcase.genreBreakdown.isNotEmpty()) {
-                            item {
-                                SpTitledSection(
-                                    title = "Genre Breakdown",
-                                    edgeToEdgeContent = true,
-                                    modifier = Modifier
-                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
-                                        .testTag("console_genre_breakdown_section"),
-                                ) {
-                                    GenreBreakdownChips(
-                                        genres = showcase.genreBreakdown,
-                                        accentColor = accentColor,
-                                    )
-                                }
-                            }
+                        item {
+                            ConsoleGenreBreakdown(viewModel)
                         }
 
-                        // Top Developers section
-                        if (showcase.topDevelopers.isNotEmpty()) {
-                            item {
-                                SpTitledSection(
-                                    title = "Top Developers",
-                                    edgeToEdgeContent = true,
-                                    modifier = Modifier
-                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
-                                        .testTag("console_top_developers_section"),
-                                ) {
-                                    TopDevelopersList(
-                                        developers = showcase.topDevelopers,
-                                        onDeveloperSelected = onDeveloperSelected,
-                                    )
-                                }
-                            }
+                        item {
+                            ConsoleTopDevelopers(viewModel, onDeveloperSelected)
                         }
 
-                        // Recently Played section (only if non-empty)
-                        if (showcase.recentlyPlayed.isNotEmpty()) {
-                            item {
-                                SpTitledSection(
-                                    title = "Recently Played",
-                                    edgeToEdgeContent = true,
-                                    modifier = Modifier
-                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
-                                        .testTag("console_recently_played_section"),
-                                ) {
-                                    GameShelf(
-                                        games = showcase.recentlyPlayed,
-                                        onGameSelected = onGameSelected,
-                                    )
-                                }
-                            }
+                        item {
+                            ConsoleRecentlyPlayed(viewModel, onGameSelected)
                         }
                     }
                 }
@@ -273,104 +182,5 @@ fun ExploreConsoleShowcaseScreen(
             onDismiss = { viewModel.dismissConsoleShowcaseError() },
             modifier = Modifier.align(Alignment.BottomCenter),
         )
-    }
-}
-
-@OptIn(ExperimentalLayoutApi::class)
-@Composable
-private fun GenreBreakdownChips(
-    genres: List<GenreCount>,
-    accentColor: Color,
-    modifier: Modifier = Modifier,
-) {
-    FlowRow(
-        modifier = modifier
-            .padding(horizontal = SpSpacing.ScreenHorizontal)
-            .testTag("genre_breakdown_chips"),
-        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-    ) {
-        genres.forEach { genre ->
-            SpChip(
-                text = "${genre.name} (${genre.gameCount})",
-                color = accentColor,
-                modifier = Modifier
-                    .testTag("genre_chip_${genre.name}")
-                    .semantics {
-                        contentDescription = "${genre.name}, ${genre.gameCount} games"
-                    },
-            )
-        }
-    }
-}
-
-@Composable
-private fun TopDevelopersList(
-    developers: List<DeveloperSummary>,
-    onDeveloperSelected: (String) -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier
-            .padding(horizontal = SpSpacing.ScreenHorizontal)
-            .testTag("top_developers_list"),
-        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-    ) {
-        developers.forEach { developer ->
-            SpCard(
-                onClick = { onDeveloperSelected(developer.name) },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .testTag("developer_card_${developer.name}")
-                    .semantics {
-                        contentDescription = "${developer.name}, ${developer.gameCount} games"
-                    },
-            ) {
-                Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(SpSpacing.Medium),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.SpaceBetween,
-                ) {
-                    Column(
-                        modifier = Modifier.weight(1f),
-                    ) {
-                        Text(
-                            text = developer.name,
-                            style = SpTypography.TitleSmall,
-                            color = SpColor.OnCard,
-                            maxLines = 1,
-                            overflow = TextOverflow.Ellipsis,
-                        )
-                        Spacer(Modifier.height(SpSpacing.XXSmall))
-                        Text(
-                            text = "${developer.gameCount} games",
-                            style = SpTypography.LabelSmall,
-                            color = SpColor.OnBackgroundTertiary,
-                        )
-                    }
-
-                    if (developer.avgRating > 0) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
-                        ) {
-                            Icon(
-                                imageVector = Icons.Filled.Star,
-                                contentDescription = null,
-                                tint = SpColor.Rating,
-                                modifier = Modifier.size(14.dp),
-                            )
-                            Text(
-                                text = formatRating(developer.avgRating),
-                                style = SpTypography.BodyMedium,
-                                color = SpColor.OnBackgroundSecondary,
-                            )
-                        }
-                    }
-                }
-            }
-        }
     }
 }

--- a/web/src/features/explore/components/console-showcase-sections.tsx
+++ b/web/src/features/explore/components/console-showcase-sections.tsx
@@ -1,0 +1,162 @@
+import { Link } from "react-router-dom";
+import { Star } from "lucide-react";
+import { GameShelf } from "@/features/explore/components/game-shelf";
+import { useConsoleShowcase } from "@/hooks/use-explore";
+import { useToggleFavorite } from "@/hooks/use-games";
+import { useTogglePlayLater } from "@/hooks/use-play-later";
+import type { GenreCount, DeveloperSummary } from "@/types/api";
+
+interface ConsoleShowcaseSectionProps {
+  consoleId: string;
+}
+
+export function ConsoleEssentials({ consoleId }: ConsoleShowcaseSectionProps) {
+  const { data: showcase } = useConsoleShowcase(consoleId);
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+
+  if (!showcase || showcase.essentials.length === 0) return null;
+
+  return (
+    <GameShelf
+      title="Essentials"
+      games={showcase.essentials}
+      isLoading={false}
+      onToggleFavorite={handleToggleFavorite}
+      onTogglePlayLater={handleTogglePlayLater}
+    />
+  );
+}
+
+export function ConsoleHiddenGems({ consoleId }: ConsoleShowcaseSectionProps) {
+  const { data: showcase } = useConsoleShowcase(consoleId);
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+
+  if (!showcase || showcase.hiddenGems.length === 0) return null;
+
+  return (
+    <GameShelf
+      title="Hidden Gems"
+      games={showcase.hiddenGems}
+      isLoading={false}
+      onToggleFavorite={handleToggleFavorite}
+      onTogglePlayLater={handleTogglePlayLater}
+    />
+  );
+}
+
+export function ConsoleGenreBreakdown({
+  consoleId,
+}: ConsoleShowcaseSectionProps) {
+  const { data: showcase } = useConsoleShowcase(consoleId);
+
+  if (!showcase || showcase.genreBreakdown.length === 0) return null;
+
+  const colorTheme = showcase.console.colorTheme || "#6366f1";
+
+  return (
+    <section
+      data-testid="genre-breakdown"
+      aria-labelledby="genre-breakdown-heading"
+    >
+      <h2
+        id="genre-breakdown-heading"
+        className="text-xl font-bold text-surface-100 mb-5"
+      >
+        Genre Breakdown
+      </h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
+        {showcase.genreBreakdown.map((genre: GenreCount) => (
+          <div
+            key={genre.name}
+            className="rounded-xl border border-white/[0.06] p-4"
+            style={{
+              background: `linear-gradient(135deg, ${colorTheme}15, transparent)`,
+            }}
+            data-testid={`genre-card-${genre.name}`}
+          >
+            <p className="text-sm font-semibold text-surface-100">
+              {genre.name}
+            </p>
+            <p className="text-xs text-surface-400 mt-1">
+              {genre.gameCount} {genre.gameCount === 1 ? "game" : "games"}
+            </p>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function ConsoleTopDevelopers({
+  consoleId,
+}: ConsoleShowcaseSectionProps) {
+  const { data: showcase } = useConsoleShowcase(consoleId);
+
+  if (!showcase || showcase.topDevelopers.length === 0) return null;
+
+  const colorTheme = showcase.console.colorTheme || "#6366f1";
+
+  return (
+    <section
+      data-testid="top-developers"
+      aria-labelledby="top-developers-heading"
+    >
+      <h2
+        id="top-developers-heading"
+        className="text-xl font-bold text-surface-100 mb-5"
+      >
+        Studios That Defined This Console
+      </h2>
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        {showcase.topDevelopers.map((dev: DeveloperSummary) => (
+          <Link
+            key={dev.name}
+            to={`/explore/developers/${encodeURIComponent(dev.name)}`}
+            className="group/dev rounded-xl border border-white/[0.06] p-4 transition-colors hover:border-white/[0.12]"
+            style={{
+              background: `linear-gradient(135deg, ${colorTheme}10, transparent)`,
+            }}
+            data-testid={`developer-card-${dev.name}`}
+          >
+            <p className="text-sm font-semibold text-surface-100 group-hover/dev:text-brand-400 transition-colors">
+              {dev.name}
+            </p>
+            <p className="text-xs text-surface-400 mt-1">
+              {dev.gameCount} {dev.gameCount === 1 ? "game" : "games"}
+            </p>
+            {dev.avgRating > 0 && (
+              <span className="inline-flex items-center gap-1 text-xs text-surface-400 mt-1">
+                <Star className="h-3 w-3 text-amber-400 fill-amber-400" />
+                {dev.avgRating.toFixed(1)}
+              </span>
+            )}
+          </Link>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+export function ConsoleRecentlyPlayed({
+  consoleId,
+}: ConsoleShowcaseSectionProps) {
+  const { data: showcase } = useConsoleShowcase(consoleId);
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+
+  if (!showcase || showcase.recentlyPlayed.length === 0) return null;
+
+  return (
+    <div data-testid="recently-played-section">
+      <GameShelf
+        title="Recently Played"
+        games={showcase.recentlyPlayed}
+        isLoading={false}
+        onToggleFavorite={handleToggleFavorite}
+        onTogglePlayLater={handleTogglePlayLater}
+      />
+    </div>
+  );
+}

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -16,6 +16,13 @@ import { useBiosStatus } from "@/hooks/use-bios";
 import { useAuth } from "@/hooks/use-auth";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { BiosWarningBanner } from "@/features/bios/components/bios-warning-banner";
+import {
+  ConsoleEssentials,
+  ConsoleHiddenGems,
+  ConsoleGenreBreakdown,
+  ConsoleTopDevelopers,
+  ConsoleRecentlyPlayed,
+} from "@/features/explore/components/console-showcase-sections";
 import { Pagination } from "@/components/pagination";
 import { getConsoleStyle } from "@/lib/console-metadata";
 import { cn } from "@/lib/cn";
@@ -157,6 +164,12 @@ export function ConsoleDetailPage() {
         }}
         className="max-w-sm"
       />
+
+      <ConsoleEssentials consoleId={id!} />
+      <ConsoleHiddenGems consoleId={id!} />
+      <ConsoleGenreBreakdown consoleId={id!} />
+      <ConsoleTopDevelopers consoleId={id!} />
+      <ConsoleRecentlyPlayed consoleId={id!} />
 
       {/* Games grid */}
       {isLoading ? (

--- a/web/src/pages/console-showcase-page.tsx
+++ b/web/src/pages/console-showcase-page.tsx
@@ -1,11 +1,13 @@
-import { useParams, useNavigate, Link } from "react-router-dom";
-import { Star } from "lucide-react";
+import { useParams, useNavigate } from "react-router-dom";
 import { BackButton, Skeleton, GameCardSkeleton } from "@/components/ui";
-import { GameShelf } from "@/features/explore/components/game-shelf";
+import {
+  ConsoleEssentials,
+  ConsoleHiddenGems,
+  ConsoleGenreBreakdown,
+  ConsoleTopDevelopers,
+  ConsoleRecentlyPlayed,
+} from "@/features/explore/components/console-showcase-sections";
 import { useConsoleShowcase } from "@/hooks/use-explore";
-import { useToggleFavorite } from "@/hooks/use-games";
-import { useTogglePlayLater } from "@/hooks/use-play-later";
-import type { GenreCount, DeveloperSummary } from "@/types/api";
 
 function ShowcasePageSkeleton() {
   return (
@@ -62,8 +64,6 @@ export function ConsoleShowcasePage() {
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const { data: showcase, isLoading } = useConsoleShowcase(id ?? "");
-  const { toggle: handleToggleFavorite } = useToggleFavorite();
-  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
 
   if (isLoading) {
     return (
@@ -103,7 +103,6 @@ export function ConsoleShowcasePage() {
         className="relative rounded-2xl overflow-hidden border border-white/[0.06]"
         data-testid="console-showcase-hero"
       >
-        {/* Color gradient background */}
         <div
           className="absolute inset-0"
           style={{
@@ -113,7 +112,6 @@ export function ConsoleShowcasePage() {
         <div className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/30 to-transparent" />
 
         <div className="relative p-8 sm:p-10 flex items-center gap-6">
-          {/* Console logo */}
           {con.logoUrl && (
             <img
               src={con.logoUrl}
@@ -140,105 +138,11 @@ export function ConsoleShowcasePage() {
         </div>
       </div>
 
-      {/* Essentials Shelf */}
-      {showcase.essentials.length > 0 && (
-        <GameShelf
-          title="Essentials"
-          games={showcase.essentials}
-          isLoading={false}
-          onToggleFavorite={handleToggleFavorite}
-          onTogglePlayLater={handleTogglePlayLater}
-        />
-      )}
-
-      {/* Hidden Gems Shelf */}
-      {showcase.hiddenGems.length > 0 && (
-        <GameShelf
-          title="Hidden Gems"
-          games={showcase.hiddenGems}
-          isLoading={false}
-          onToggleFavorite={handleToggleFavorite}
-          onTogglePlayLater={handleTogglePlayLater}
-        />
-      )}
-
-      {/* Genre Breakdown */}
-      {showcase.genreBreakdown.length > 0 && (
-        <section data-testid="genre-breakdown" aria-labelledby="genre-breakdown-heading">
-          <h2 id="genre-breakdown-heading" className="text-xl font-bold text-surface-100 mb-5">
-            Genre Breakdown
-          </h2>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4">
-            {showcase.genreBreakdown.map((genre: GenreCount) => (
-              <div
-                key={genre.name}
-                className="rounded-xl border border-white/[0.06] p-4"
-                style={{
-                  background: `linear-gradient(135deg, ${colorTheme}15, transparent)`,
-                }}
-                data-testid={`genre-card-${genre.name}`}
-              >
-                <p className="text-sm font-semibold text-surface-100">
-                  {genre.name}
-                </p>
-                <p className="text-xs text-surface-400 mt-1">
-                  {genre.gameCount}{" "}
-                  {genre.gameCount === 1 ? "game" : "games"}
-                </p>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* Studios That Defined This Console */}
-      {showcase.topDevelopers.length > 0 && (
-        <section data-testid="top-developers" aria-labelledby="top-developers-heading">
-          <h2 id="top-developers-heading" className="text-xl font-bold text-surface-100 mb-5">
-            Studios That Defined This Console
-          </h2>
-          <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
-            {showcase.topDevelopers.map((dev: DeveloperSummary) => (
-              <Link
-                key={dev.name}
-                to={`/explore/developers/${encodeURIComponent(dev.name)}`}
-                className="group/dev rounded-xl border border-white/[0.06] p-4 transition-colors hover:border-white/[0.12]"
-                style={{
-                  background: `linear-gradient(135deg, ${colorTheme}10, transparent)`,
-                }}
-                data-testid={`developer-card-${dev.name}`}
-              >
-                <p className="text-sm font-semibold text-surface-100 group-hover/dev:text-brand-400 transition-colors">
-                  {dev.name}
-                </p>
-                <p className="text-xs text-surface-400 mt-1">
-                  {dev.gameCount}{" "}
-                  {dev.gameCount === 1 ? "game" : "games"}
-                </p>
-                {dev.avgRating > 0 && (
-                  <span className="inline-flex items-center gap-1 text-xs text-surface-400 mt-1">
-                    <Star className="h-3 w-3 text-amber-400 fill-amber-400" />
-                    {dev.avgRating.toFixed(1)}
-                  </span>
-                )}
-              </Link>
-            ))}
-          </div>
-        </section>
-      )}
-
-      {/* Recently Played */}
-      {showcase.recentlyPlayed.length > 0 && (
-        <div data-testid="recently-played-section">
-          <GameShelf
-            title="Recently Played"
-            games={showcase.recentlyPlayed}
-            isLoading={false}
-            onToggleFavorite={handleToggleFavorite}
-            onTogglePlayLater={handleTogglePlayLater}
-          />
-        </div>
-      )}
+      <ConsoleEssentials consoleId={id!} />
+      <ConsoleHiddenGems consoleId={id!} />
+      <ConsoleGenreBreakdown consoleId={id!} />
+      <ConsoleTopDevelopers consoleId={id!} />
+      <ConsoleRecentlyPlayed consoleId={id!} />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Extract each Explore console section (Essentials, Hidden Gems, Genre Breakdown, Top Developers, Recently Played) into self-contained components that fetch their own data
- Embed them in the console detail page (both web and player app) between the search field and games grid
- Sections render nothing when data is unavailable (no IGDB enrichment), so the page degrades gracefully

## Changes
- **New**: `web/src/features/explore/components/console-showcase-sections.tsx` — 5 standalone React components using `useConsoleShowcase` (React Query deduplicates)
- **New**: `player/.../feature/explore/ConsoleShowcaseSections.kt` — 5 standalone Compose composables reading from shared ViewModel state
- **Modified**: Console detail pages (web + player) to render the showcase sections
- **Refactored**: Explore console showcase pages to use the extracted components

## Test plan
- [x] Web: 1126 Vitest tests pass
- [x] Player: 79 desktop E2E tests pass, Kotlin compiles clean
- [x] Go: all server tests pass (no server changes needed)
- [ ] Manual: verify sections appear on console detail page when IGDB data exists
- [ ] Manual: verify page looks normal (no empty sections) without IGDB enrichment