### PR TITLE
feat: redesign developer/publisher detail pages with rich studio profiles

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreDeveloperTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreDeveloperTest.kt
@@ -2,6 +2,10 @@ package com.spela.player.desktop.e2e
 
 import androidx.compose.ui.test.*
 import com.spela.player.domain.model.DeveloperDetail
+import com.spela.player.domain.model.DeveloperDetailGenreBreakdown
+import com.spela.player.domain.model.DeveloperDetailPlatformBreakdown
+import com.spela.player.domain.model.DeveloperDetailPublisher
+import com.spela.player.domain.model.DeveloperDetailUserStats
 import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.Game
 import com.spela.player.presentation.navigation.NavigationIntent
@@ -12,14 +16,17 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * Desktop E2E tests for Phase 7: Developer & Publisher Spotlight Pages.
+ * Desktop E2E tests for the Developer Detail screen.
  *
  * Covers:
- * - Developer spotlight section renders on Explore screen
- * - Developer spotlight displays developer name and stats
- * - Navigate to developer detail screen
- * - Developer detail shows games
- * - Developer detail console filter works
+ * - Developer spotlight section on Explore screen
+ * - Developer detail hero banner
+ * - Top rated row
+ * - Genre breakdown chips and filtering
+ * - User stats card
+ * - Games grouped by platform
+ * - Publisher chips
+ * - Console filter fallback
  */
 @OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
 class ExploreDeveloperTest {
@@ -72,6 +79,68 @@ class ExploreDeveloperTest {
         avgRating = 90.7,
         consoles = listOf("SNES", "PS2"),
         games = sampleGames,
+    )
+
+    private val richDeveloperDetail = DeveloperDetail(
+        name = "Capcom",
+        gameCount = 8,
+        avgRating = 82.3,
+        consoles = listOf("SNES", "GBA"),
+        heroUrl = "https://example.com/hero.jpg",
+        topGames = listOf(
+            Game(
+                id = "top-1",
+                title = "Mega Man X",
+                consoleId = "snes",
+                consoleName = "SNES",
+                genre = "Platformer",
+                rating = 90.0,
+            ),
+            Game(
+                id = "top-2",
+                title = "Street Fighter II",
+                consoleId = "snes",
+                consoleName = "SNES",
+                genre = "Fighting",
+                rating = 88.0,
+            ),
+        ),
+        genreBreakdown = listOf(
+            DeveloperDetailGenreBreakdown(name = "Platformer", gameCount = 4),
+            DeveloperDetailGenreBreakdown(name = "Fighting", gameCount = 3),
+            DeveloperDetailGenreBreakdown(name = "Action", gameCount = 1),
+        ),
+        platformBreakdown = listOf(
+            DeveloperDetailPlatformBreakdown("SNES", "snes", 5),
+            DeveloperDetailPlatformBreakdown("GBA", "gba", 3),
+        ),
+        userStats = DeveloperDetailUserStats(
+            totalPlayTime = 14400,
+            gamesPlayed = 5,
+            favoriteCount = 3,
+            mostPlayedGame = Game(
+                id = "most-played-1",
+                title = "Mega Man X",
+                consoleId = "snes",
+                consoleName = "SNES",
+                genre = "Platformer",
+                rating = 90.0,
+            ),
+        ),
+        publishers = listOf(
+            DeveloperDetailPublisher("Capcom", 6),
+            DeveloperDetailPublisher("Nintendo", 2),
+        ),
+        games = listOf(
+            Game(id = "cap-1", title = "Mega Man X", consoleId = "snes", consoleName = "SNES", genre = "Platformer", rating = 90.0),
+            Game(id = "cap-2", title = "Street Fighter II", consoleId = "snes", consoleName = "SNES", genre = "Fighting", rating = 88.0),
+            Game(id = "cap-3", title = "Breath of Fire", consoleId = "snes", consoleName = "SNES", genre = "RPG", rating = 78.0),
+            Game(id = "cap-4", title = "Mega Man Zero", consoleId = "gba", consoleName = "GBA", genre = "Platformer", rating = 85.0),
+            Game(id = "cap-5", title = "Street Fighter Alpha", consoleId = "gba", consoleName = "GBA", genre = "Fighting", rating = 75.0),
+            Game(id = "cap-6", title = "Final Fight One", consoleId = "gba", consoleName = "GBA", genre = "Action", rating = 72.0),
+            Game(id = "cap-7", title = "Mega Man Battle Network", consoleId = "gba", consoleName = "GBA", genre = "Platformer", rating = 80.0, coverUrl = null),
+            Game(id = "cap-8", title = "Mega Man X2", consoleId = "snes", consoleName = "SNES", genre = "Platformer", rating = 87.0),
+        ),
     )
 
     // --- Developer spotlight on Explore screen ---
@@ -161,6 +230,7 @@ class ExploreDeveloperTest {
     @Test
     fun developerDetailConsoleFilterWorks() = runComposeUiTest {
         val harness = createHarness()
+        // Use a detail without platformBreakdown to trigger console filter fallback
         harness.exploreRepo.developerDetails = mapOf("Square" to sampleDeveloperDetail)
 
         setContent { harness.App() }
@@ -191,5 +261,313 @@ class ExploreDeveloperTest {
         onNodeWithTag("developer_game_game-dev-1").assertExists()
         onNodeWithTag("developer_game_game-dev-2").assertExists()
         onNodeWithTag("developer_game_game-dev-3").assertExists()
+    }
+
+    // --- Hero Banner ---
+
+    @Test
+    fun heroBannerDisplaysNameAndStats() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_hero_banner").assertExists()
+        onNodeWithTag("developer_hero_name").assertExists()
+        onNodeWithTag("developer_game_count").assertExists()
+        onNodeWithTag("developer_avg_rating").assertExists()
+        onNodeWithTag("developer_platform_count").assertExists()
+        onNodeWithText("8 games").assertExists()
+        onNodeWithText("2 platforms").assertExists()
+    }
+
+    @Test
+    fun heroBannerFallbackWhenNoHeroUrl() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Square" to sampleDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Square"))
+        )
+        advance(harness)
+
+        // Should still show hero banner with gradient fallback
+        onNodeWithTag("developer_hero_banner").assertExists()
+        onNodeWithTag("developer_hero_name").assertExists()
+    }
+
+    // --- Top Rated Row ---
+
+    @Test
+    fun topRatedRowShowsWhenEnoughGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_top_rated_section").assertExists()
+        onNodeWithTag("developer_top_rated_header").assertExists()
+        onNodeWithText("Top Rated").assertExists()
+        onNodeWithTag("developer_top_game_top-1").assertExists()
+        onNodeWithTag("developer_top_game_top-2").assertExists()
+    }
+
+    @Test
+    fun topRatedRowHiddenWhenFewGames() = runComposeUiTest {
+        val harness = createHarness()
+        // Only 3 games, need 5+ for top rated
+        harness.exploreRepo.developerDetails = mapOf("Square" to sampleDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Square"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_top_rated_section").assertDoesNotExist()
+    }
+
+    // --- Genre Breakdown ---
+
+    @Test
+    fun genreBreakdownShowsChips() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_genre_breakdown").assertExists()
+        onNodeWithTag("developer_genre_header").assertExists()
+        onNodeWithText("Genres").assertExists()
+        // "All" chip should be first and selected by default
+        onNodeWithTag("developer_genre_chip_all").assertExists()
+        onNodeWithTag("developer_genre_chip_Platformer").assertExists()
+        onNodeWithTag("developer_genre_chip_Fighting").assertExists()
+        onNodeWithTag("developer_genre_chip_Action").assertExists()
+    }
+
+    @Test
+    fun genreChipFiltersGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        // Scroll to game items which may be below the viewport
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_game_cap-1"))
+
+        // Initially all games visible
+        onNodeWithTag("developer_game_cap-1").assertExists() // Platformer
+        onNodeWithTag("developer_game_cap-2").assertExists() // Fighting
+
+        // Click Platformer chip to filter (scroll up first)
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_genre_chip_Platformer"))
+        onNodeWithTag("developer_genre_chip_Platformer").performClick()
+        advanceQuick(harness)
+
+        // Scroll to see filtered games
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_game_cap-1"))
+
+        // Only Platformer games should be visible
+        onNodeWithTag("developer_game_cap-1").assertExists()   // Mega Man X - Platformer
+        onNodeWithTag("developer_game_cap-2").assertDoesNotExist() // Street Fighter II - Fighting
+        onNodeWithTag("developer_game_cap-3").assertDoesNotExist() // Breath of Fire - RPG
+
+        // Click again to clear
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_genre_chip_Platformer"))
+        onNodeWithTag("developer_genre_chip_Platformer").performClick()
+        advanceQuick(harness)
+
+        // Scroll to see all games again
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_game_cap-1"))
+
+        // All games visible again
+        onNodeWithTag("developer_game_cap-1").assertExists()
+        onNodeWithTag("developer_game_cap-2").assertExists()
+    }
+
+    @Test
+    fun genreBreakdownHiddenWhenFewGenres() = runComposeUiTest {
+        val harness = createHarness()
+        val detailWithOneGenre = richDeveloperDetail.copy(
+            genreBreakdown = listOf(DeveloperDetailGenreBreakdown(name = "RPG", gameCount = 3)),
+        )
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithOneGenre)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_genre_breakdown").assertDoesNotExist()
+    }
+
+    // --- User Stats Card ---
+
+    @Test
+    fun userStatsCardShowsStats() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_user_stats").assertExists()
+        onNodeWithTag("developer_user_stats_header").assertExists()
+        onNodeWithText("Your Stats").assertExists()
+        onNodeWithTag("developer_user_stats_card").assertExists()
+        onNodeWithTag("developer_user_stat_playtime").assertExists()
+        onNodeWithTag("developer_user_stat_played").assertExists()
+        onNodeWithTag("developer_user_stat_favorites").assertExists()
+        // 14400 seconds = 4h 0m
+        onNodeWithText("4h 0m").assertExists()
+        onNodeWithText("5/8").assertExists()
+        onNodeWithText("3").assertExists()
+    }
+
+    @Test
+    fun userStatsCardShowsMostPlayedGame() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_most_played_game").assertExists()
+        onNodeWithText("Most played:").assertExists()
+    }
+
+    @Test
+    fun userStatsHiddenWhenNoStats() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Square" to sampleDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Square"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_user_stats").assertDoesNotExist()
+    }
+
+    // --- Games Grouped by Platform ---
+
+    @Test
+    fun gamesGroupedByPlatform() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        // Scroll to platform headers which may be below the viewport
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_platform_header_snes"))
+        onNodeWithTag("developer_platform_header_snes").assertExists()
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_platform_header_gba"))
+        onNodeWithTag("developer_platform_header_gba").assertExists()
+
+        // Games should be present under their respective platforms
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_game_cap-1"))
+        onNodeWithTag("developer_game_cap-1").assertExists()
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_game_cap-4"))
+        onNodeWithTag("developer_game_cap-4").assertExists()
+    }
+
+    @Test
+    fun platformHeadersOrderedByGameCount() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        // SNES has 5 games, GBA has 3 -- SNES header should come first
+        // Scroll to and verify both exist
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_platform_header_snes"))
+        onNodeWithTag("developer_platform_header_snes").assertExists()
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_platform_header_gba"))
+        onNodeWithTag("developer_platform_header_gba").assertExists()
+    }
+
+    // --- Publishers Section ---
+
+    @Test
+    fun publishersSectionShowsChips() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        // Scroll to publishers section at the bottom
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_publishers_section"))
+        onNodeWithTag("developer_publishers_section").assertExists()
+        onNodeWithTag("developer_publishers_header").assertExists()
+        onNodeWithText("Publishers").assertExists()
+        onNodeWithTag("developer_publisher_chip_Capcom").assertExists()
+        onNodeWithTag("developer_publisher_chip_Nintendo").assertExists()
+    }
+
+    @Test
+    fun publishersHiddenWhenEmpty() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Square" to sampleDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Square"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_publishers_section").assertDoesNotExist()
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -683,11 +683,40 @@ fun DeveloperSummaryDto.toDomain(): DeveloperSummary = DeveloperSummary(
     consoles = consoles,
 )
 
+fun GenreCountDto.toDeveloperGenreBreakdown(): DeveloperDetailGenreBreakdown = DeveloperDetailGenreBreakdown(
+    name = name,
+    gameCount = gameCount,
+)
+
+fun DeveloperDetailPlatformBreakdownDto.toDomain(): DeveloperDetailPlatformBreakdown = DeveloperDetailPlatformBreakdown(
+    consoleName = consoleName,
+    consoleId = consoleId,
+    count = count,
+)
+
+fun DeveloperDetailUserStatsDto.toDomain(): DeveloperDetailUserStats = DeveloperDetailUserStats(
+    totalPlayTime = totalPlayTime,
+    gamesPlayed = gamesPlayed,
+    favoriteCount = favoriteCount,
+    mostPlayedGame = mostPlayedGame?.toDomain(),
+)
+
+fun DeveloperDetailPublisherDto.toDomain(): DeveloperDetailPublisher = DeveloperDetailPublisher(
+    name = name,
+    count = count,
+)
+
 fun DeveloperDetailResponseDto.toDomain(): DeveloperDetail = DeveloperDetail(
     name = name,
     gameCount = gameCount,
     avgRating = avgRating,
     consoles = consoles,
+    heroUrl = heroUrl,
+    topGames = topGames.map { it.toDomain() },
+    genreBreakdown = genreBreakdown.map { it.toDeveloperGenreBreakdown() },
+    platformBreakdown = platformBreakdown.map { it.toDomain() },
+    userStats = userStats?.toDomain(),
+    publishers = publishers.map { it.toDomain() },
     games = games.map { it.toDomain() },
 )
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1181,11 +1181,38 @@ data class DeveloperListResponseDto(
 )
 
 @Serializable
+data class DeveloperDetailPlatformBreakdownDto(
+    val consoleName: String = "",
+    val consoleId: String = "",
+    val count: Int = 0,
+)
+
+@Serializable
+data class DeveloperDetailUserStatsDto(
+    val totalPlayTime: Long = 0,
+    val gamesPlayed: Int = 0,
+    val favoriteCount: Int = 0,
+    val mostPlayedGame: GameDto? = null,
+)
+
+@Serializable
+data class DeveloperDetailPublisherDto(
+    val name: String = "",
+    val count: Int = 0,
+)
+
+@Serializable
 data class DeveloperDetailResponseDto(
     val name: String,
     val gameCount: Int,
     val avgRating: Double,
     val consoles: List<String>,
+    val heroUrl: String? = null,
+    val topGames: List<GameDto> = emptyList(),
+    val genreBreakdown: List<GenreCountDto> = emptyList(),
+    val platformBreakdown: List<DeveloperDetailPlatformBreakdownDto> = emptyList(),
+    val userStats: DeveloperDetailUserStatsDto? = null,
+    val publishers: List<DeveloperDetailPublisherDto> = emptyList(),
     val games: List<GameDto>,
 )
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.spela.player.data.repository
 
 import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.dto.DeveloperDetailResponseDto
 import com.spela.player.data.remote.dto.GameDto
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.AchievementGameItem
@@ -191,25 +192,11 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getDeveloperDetail(name: String): Result<DeveloperDetail> = runCatching {
-        val dto = apiClient.getDeveloperDetail(name)
-        dto.toDomain().copy(
-            games = dto.games.map { gameDto ->
-                gameDto.toDomain().copy(
-                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
-                )
-            },
-        )
+        resolveEntityDetail(apiClient.getDeveloperDetail(name))
     }
 
     override suspend fun getPublisherDetail(name: String): Result<DeveloperDetail> = runCatching {
-        val dto = apiClient.getPublisherDetail(name)
-        dto.toDomain().copy(
-            games = dto.games.map { gameDto ->
-                gameDto.toDomain().copy(
-                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
-                )
-            },
-        )
+        resolveEntityDetail(apiClient.getPublisherDetail(name))
     }
 
     override suspend fun getDeveloperSpotlight(): Result<DeveloperSpotlight> = runCatching {
@@ -431,6 +418,30 @@ class ExploreRepositoryImpl(
     override suspend fun getCompletionistMap(): Result<CompletionistMap> = runCatching {
         apiClient.getCompletionistMap().toDomain()
     }
+
+    private fun resolveEntityDetail(dto: DeveloperDetailResponseDto): DeveloperDetail =
+        dto.toDomain().copy(
+            heroUrl = apiClient.resolveUrl(dto.heroUrl),
+            topGames = dto.topGames.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                )
+            },
+            userStats = dto.userStats?.let { stats ->
+                stats.toDomain().copy(
+                    mostPlayedGame = stats.mostPlayedGame?.let { gameDto ->
+                        gameDto.toDomain().copy(
+                            coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                        )
+                    },
+                )
+            },
+            games = dto.games.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                )
+            },
+        )
 
     private fun resolveGameCovers(game: Game, dto: GameDto): Game = game.copy(
         coverUrl = apiClient.resolveUrl(dto.coverUrl),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -133,11 +133,40 @@ data class DeveloperSummary(
     val consoles: List<String>,
 )
 
+data class DeveloperDetailGenreBreakdown(
+    val name: String,
+    val gameCount: Int,
+)
+
+data class DeveloperDetailPlatformBreakdown(
+    val consoleName: String,
+    val consoleId: String,
+    val count: Int,
+)
+
+data class DeveloperDetailUserStats(
+    val totalPlayTime: Long,
+    val gamesPlayed: Int,
+    val favoriteCount: Int,
+    val mostPlayedGame: Game?,
+)
+
+data class DeveloperDetailPublisher(
+    val name: String,
+    val count: Int,
+)
+
 data class DeveloperDetail(
     val name: String,
     val gameCount: Int,
     val avgRating: Double,
     val consoles: List<String>,
+    val heroUrl: String? = null,
+    val topGames: List<Game> = emptyList(),
+    val genreBreakdown: List<DeveloperDetailGenreBreakdown> = emptyList(),
+    val platformBreakdown: List<DeveloperDetailPlatformBreakdown> = emptyList(),
+    val userStats: DeveloperDetailUserStats? = null,
+    val publishers: List<DeveloperDetailPublisher> = emptyList(),
     val games: List<Game>,
 )
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -605,6 +605,11 @@ fun SpelaApp(
                                                 NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
                                             )
                                         },
+                                        onPublisherSelected = { publisherName ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExplorePublisher(publisherName))
+                                            )
+                                        },
                                         onBack = {
                                             navigationViewModel.onIntent(NavigationIntent.GoBack)
                                         },
@@ -621,6 +626,11 @@ fun SpelaApp(
                                         onGameSelected = { gameId ->
                                             navigationViewModel.onIntent(
                                                 NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onPublisherSelected = { publisherName ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExplorePublisher(publisherName))
                                             )
                                         },
                                         onBack = {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
@@ -1,0 +1,580 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.SportsEsports
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.DeveloperDetail
+import com.spela.player.domain.model.DeveloperDetailPublisher
+import com.spela.player.domain.model.DeveloperDetailUserStats
+import com.spela.player.domain.model.Game
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpHeroCover
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.formatPlayTime
+import com.spela.player.util.formatRating
+
+// --- (a) Hero Banner ---
+
+@Composable
+internal fun DeveloperHeroBanner(
+    detail: DeveloperDetail,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .height(200.dp),
+    ) {
+        if (detail.heroUrl != null) {
+            SpHeroCover(
+                imageUrl = detail.heroUrl,
+                contentDescription = "${detail.name} hero image",
+                modifier = Modifier.fillMaxSize(),
+            )
+        } else {
+            // Dark gradient fallback
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .background(
+                        Brush.verticalGradient(
+                            listOf(
+                                SpColor.Primary.copy(alpha = 0.3f),
+                                SpColor.Background,
+                            ),
+                        ),
+                    ),
+            )
+        }
+
+        // Content overlaid on bottom
+        Column(
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .padding(horizontal = SpSpacing.ScreenHorizontal)
+                .padding(bottom = SpSpacing.Medium),
+        ) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+            ) {
+                // Avatar (first letter)
+                Box(
+                    modifier = Modifier
+                        .size(48.dp)
+                        .clip(CircleShape)
+                        .background(SpColor.Primary.copy(alpha = 0.6f)),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    Text(
+                        text = detail.name.take(1).uppercase(),
+                        style = SpTypography.HeadlineMedium,
+                        color = SpColor.OnPrimary,
+                    )
+                }
+
+                Column {
+                    Text(
+                        text = detail.name,
+                        style = SpTypography.DisplaySmall,
+                        color = SpColor.OnBackground,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                        modifier = Modifier.testTag("developer_hero_name"),
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(SpSpacing.Small))
+
+            // Stats row
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                modifier = Modifier.testTag("developer_stats_row"),
+            ) {
+                Text(
+                    text = "${detail.gameCount} games",
+                    style = SpTypography.BodyMedium,
+                    color = SpColor.OnBackgroundSecondary,
+                    modifier = Modifier.testTag("developer_game_count"),
+                )
+                if (detail.avgRating > 0) {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(14.dp),
+                        )
+                        Text(
+                            text = formatRating(detail.avgRating),
+                            style = SpTypography.BodyMedium,
+                            color = SpColor.OnBackgroundSecondary,
+                            modifier = Modifier.testTag("developer_avg_rating"),
+                        )
+                    }
+                }
+                if (detail.consoles.isNotEmpty()) {
+                    Text(
+                        text = "${detail.consoles.size} platforms",
+                        style = SpTypography.BodyMedium,
+                        color = SpColor.OnBackgroundSecondary,
+                        modifier = Modifier.testTag("developer_platform_count"),
+                    )
+                }
+            }
+        }
+    }
+}
+
+// --- (b) Top Rated Row ---
+
+@Composable
+internal fun DeveloperTopRatedRow(
+    topGames: List<Game>,
+    onGameSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(top = SpSpacing.Large)) {
+        Text(
+            text = "Top Rated",
+            style = SpTypography.HeadlineMedium,
+            color = SpColor.OnBackground,
+            modifier = Modifier
+                .padding(horizontal = SpSpacing.ScreenHorizontal)
+                .testTag("developer_top_rated_header"),
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+        ) {
+            items(
+                items = topGames,
+                key = { "top_${it.id}" },
+            ) { game ->
+                TopRatedGameCard(
+                    game = game,
+                    onClick = { onGameSelected(game.id) },
+                )
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Large))
+    }
+}
+
+@Composable
+internal fun TopRatedGameCard(
+    game: Game,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        modifier = Modifier
+            .width(SpSpacing.CoverMediumWidth)
+            .testTag("developer_top_game_${game.id}")
+            .semantics {
+                contentDescription = "${game.title}, rated ${formatRating(game.rating)}"
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Column {
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.title} cover art",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(topStart = SpSpacing.RadiusLarge, topEnd = SpSpacing.RadiusLarge)),
+                cornerRadius = 0.dp,
+            )
+            Column(
+                modifier = Modifier.padding(SpSpacing.Small),
+            ) {
+                Text(
+                    text = game.title,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+                if (game.rating > 0) {
+                    Spacer(Modifier.height(SpSpacing.XXSmall))
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(10.dp),
+                        )
+                        Text(
+                            text = formatRating(game.rating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// --- (c) Genre Breakdown ---
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun DeveloperGenreBreakdown(
+    genres: List<Pair<String, Int>>,
+    totalGames: Int,
+    selectedGenre: String?,
+    onGenreSelected: (String?) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal),
+    ) {
+        Text(
+            text = "Genres",
+            style = SpTypography.HeadlineMedium,
+            color = SpColor.OnBackground,
+            modifier = Modifier.testTag("developer_genre_header"),
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            // "All" chip
+            SpChip(
+                text = "All ($totalGames)",
+                onClick = { onGenreSelected(null) },
+                isSelected = selectedGenre == null,
+                modifier = Modifier
+                    .testTag("developer_genre_chip_all")
+                    .semantics {
+                        contentDescription = "All, $totalGames games"
+                        role = Role.Button
+                    },
+            )
+
+            genres.forEach { (genre, count) ->
+                val isSelected = genre.equals(selectedGenre, ignoreCase = true)
+                SpChip(
+                    text = "$genre ($count)",
+                    onClick = { onGenreSelected(if (isSelected) null else genre) },
+                    isSelected = isSelected,
+                    modifier = Modifier
+                        .testTag("developer_genre_chip_$genre")
+                        .semantics {
+                            contentDescription = "$genre, $count games"
+                            role = Role.Button
+                        },
+                )
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Large))
+    }
+}
+
+// --- (d) User Stats Card ---
+
+@Composable
+internal fun DeveloperUserStatsCard(
+    userStats: DeveloperDetailUserStats,
+    totalGames: Int,
+    onGameSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal),
+    ) {
+        Text(
+            text = "Your Stats",
+            style = SpTypography.HeadlineMedium,
+            color = SpColor.OnBackground,
+            modifier = Modifier.testTag("developer_user_stats_header"),
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+        SpCard(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("developer_user_stats_card"),
+        ) {
+            Column(
+                modifier = Modifier.padding(SpSpacing.Default),
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                ) {
+                    UserStatItem(
+                        icon = Icons.Filled.Timer,
+                        value = formatPlayTime(userStats.totalPlayTime),
+                        label = "Play time",
+                        modifier = Modifier.testTag("developer_user_stat_playtime"),
+                    )
+                    UserStatItem(
+                        icon = Icons.Filled.SportsEsports,
+                        value = "${userStats.gamesPlayed}/$totalGames",
+                        label = "Played",
+                        modifier = Modifier.testTag("developer_user_stat_played"),
+                    )
+                    UserStatItem(
+                        icon = Icons.Filled.Favorite,
+                        value = "${userStats.favoriteCount}",
+                        label = "Favorites",
+                        modifier = Modifier.testTag("developer_user_stat_favorites"),
+                    )
+                }
+
+                if (userStats.mostPlayedGame != null) {
+                    Spacer(Modifier.height(SpSpacing.Medium))
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                    ) {
+                        Text(
+                            text = "Most played:",
+                            style = SpTypography.LabelMedium,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                        SpCard(
+                            modifier = Modifier
+                                .weight(1f)
+                                .testTag("developer_most_played_game"),
+                            onClick = { onGameSelected(userStats.mostPlayedGame.id) },
+                        ) {
+                            Row(
+                                modifier = Modifier.padding(SpSpacing.Small),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                            ) {
+                                SpCoverArt(
+                                    imageUrl = userStats.mostPlayedGame.coverUrl,
+                                    contentDescription = "${userStats.mostPlayedGame.title} cover",
+                                    modifier = Modifier
+                                        .width(32.dp)
+                                        .height(42.dp)
+                                        .clip(RoundedCornerShape(SpSpacing.RadiusSmall)),
+                                    aspectRatio = 0.75f,
+                                )
+                                Text(
+                                    text = userStats.mostPlayedGame.title,
+                                    style = SpTypography.TitleSmall,
+                                    color = SpColor.OnCard,
+                                    maxLines = 1,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Large))
+    }
+}
+
+@Composable
+internal fun UserStatItem(
+    icon: ImageVector,
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = modifier,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = SpColor.Primary,
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(Modifier.height(SpSpacing.XSmall))
+        Text(
+            text = value,
+            style = SpTypography.TitleLarge,
+            color = SpColor.OnBackground,
+            textAlign = TextAlign.Center,
+        )
+        Text(
+            text = label,
+            style = SpTypography.LabelSmall,
+            color = SpColor.OnBackgroundTertiary,
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+// --- Game Item ---
+
+@Composable
+internal fun DeveloperGameItem(
+    game: Game,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.XSmall,
+            )
+            .testTag("developer_game_${game.id}")
+            .semantics {
+                contentDescription = "${game.title}, ${game.consoleName}"
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SpSpacing.Medium),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+        ) {
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.title} cover art",
+                modifier = Modifier
+                    .width(48.dp)
+                    .height(64.dp)
+                    .clip(RoundedCornerShape(SpSpacing.RadiusSmall)),
+                aspectRatio = 0.75f,
+            )
+
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = game.title,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    Text(
+                        text = game.consoleName,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                    )
+
+                    if (game.rating > 0) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(10.dp),
+                        )
+                        Text(
+                            text = formatRating(game.rating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+// --- (f) Publishers Section ---
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun DeveloperPublishersSection(
+    publishers: List<DeveloperDetailPublisher>,
+    onPublisherSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .padding(top = SpSpacing.Large),
+    ) {
+        Text(
+            text = "Publishers",
+            style = SpTypography.HeadlineMedium,
+            color = SpColor.OnBackground,
+            modifier = Modifier.testTag("developer_publishers_header"),
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            publishers.forEach { publisher ->
+                SpChip(
+                    text = "${publisher.name} (${publisher.count})",
+                    onClick = { onPublisherSelected(publisher.name) },
+                    modifier = Modifier
+                        .testTag("developer_publisher_chip_${publisher.name}")
+                        .semantics {
+                            contentDescription = "${publisher.name}, ${publisher.count} games"
+                            role = Role.Button
+                        },
+                )
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
@@ -13,48 +13,40 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Code
-import androidx.compose.material.icons.filled.Star
-import androidx.compose.material3.Icon
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.unit.dp
-import com.spela.player.domain.model.Game
 import com.spela.player.presentation.ui.components.PlatformBackHandler
-import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpChip
-import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpGameCardSkeleton
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.feature.explore.DeveloperGameItem
+import com.spela.player.presentation.ui.feature.explore.DeveloperGenreBreakdown
+import com.spela.player.presentation.ui.feature.explore.DeveloperHeroBanner
+import com.spela.player.presentation.ui.feature.explore.DeveloperPublishersSection
+import com.spela.player.presentation.ui.feature.explore.DeveloperTopRatedRow
+import com.spela.player.presentation.ui.feature.explore.DeveloperUserStatsCard
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.ExploreViewModel
-import com.spela.player.util.formatRating
+import androidx.compose.material3.Text
 
 @Composable
 fun ExploreDeveloperScreen(
@@ -62,6 +54,7 @@ fun ExploreDeveloperScreen(
     isDeveloper: Boolean = true,
     viewModel: ExploreViewModel,
     onGameSelected: (String) -> Unit,
+    onPublisherSelected: (String) -> Unit = {},
     onBack: () -> Unit,
 ) {
     PlatformBackHandler { onBack() }
@@ -110,90 +103,58 @@ fun ExploreDeveloperScreen(
                 state.detail != null -> {
                     val detail = state.detail!!
                     LazyColumn(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier.fillMaxSize().testTag("developer_detail_content"),
                         contentPadding = PaddingValues(bottom = SpSpacing.XXLarge),
                     ) {
-                        // Stats banner
+                        // (a) Hero Banner
                         item {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(120.dp)
-                                    .background(
-                                        Brush.verticalGradient(
-                                            listOf(
-                                                SpColor.Primary.copy(alpha = 0.3f),
-                                                SpColor.Background,
-                                            ),
-                                        ),
-                                    )
-                                    .testTag("developer_stats_banner"),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                Column(
-                                    horizontalAlignment = Alignment.CenterHorizontally,
-                                ) {
-                                    Text(
-                                        text = detail.name,
-                                        style = SpTypography.DisplaySmall,
-                                        color = SpColor.OnBackground,
-                                    )
-                                    Spacer(Modifier.height(SpSpacing.Small))
-                                    Row(
-                                        verticalAlignment = Alignment.CenterVertically,
-                                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-                                    ) {
-                                        Text(
-                                            text = "${detail.gameCount} games",
-                                            style = SpTypography.BodyMedium,
-                                            color = SpColor.OnBackgroundSecondary,
-                                            modifier = Modifier.testTag("developer_game_count"),
-                                        )
-                                        if (detail.avgRating > 0) {
-                                            Row(
-                                                verticalAlignment = Alignment.CenterVertically,
-                                                horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
-                                            ) {
-                                                Icon(
-                                                    imageVector = Icons.Filled.Star,
-                                                    contentDescription = null,
-                                                    tint = SpColor.Rating,
-                                                    modifier = Modifier.size(14.dp),
-                                                )
-                                                Text(
-                                                    text = formatRating(detail.avgRating),
-                                                    style = SpTypography.BodyMedium,
-                                                    color = SpColor.OnBackgroundSecondary,
-                                                    modifier = Modifier.testTag("developer_avg_rating"),
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
+                            DeveloperHeroBanner(
+                                detail = detail,
+                                modifier = Modifier.testTag("developer_hero_banner"),
+                            )
+                        }
+
+                        // (b) Top Rated Row
+                        if (detail.topGames.isNotEmpty() && detail.gameCount >= 5) {
+                            item {
+                                DeveloperTopRatedRow(
+                                    topGames = detail.topGames,
+                                    onGameSelected = onGameSelected,
+                                    modifier = Modifier.testTag("developer_top_rated_section"),
+                                )
                             }
                         }
 
-                        // Console filter chips
-                        if (detail.consoles.isNotEmpty()) {
+                        // (c) Genre Breakdown
+                        if (detail.genreBreakdown.size >= 2) {
                             item {
-                                DeveloperConsoleFilterRow(
-                                    consoles = detail.consoles,
+                                DeveloperGenreBreakdown(
+                                    genres = detail.genreBreakdown.map { it.name to it.gameCount },
                                     totalGames = detail.gameCount,
-                                    selectedConsole = state.consoleFilter,
-                                    onConsoleSelected = { console ->
-                                        viewModel.setDeveloperConsoleFilter(
-                                            if (console != null && state.consoleFilter == console) null else console,
+                                    selectedGenre = state.genreFilter,
+                                    onGenreSelected = { genre ->
+                                        viewModel.setDeveloperGenreFilter(
+                                            if (genre != null && state.genreFilter == genre) null else genre,
                                         )
                                     },
-                                    modifier = Modifier
-                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
-                                        .testTag("developer_console_filters"),
+                                    modifier = Modifier.testTag("developer_genre_breakdown"),
                                 )
-                                Spacer(Modifier.height(SpSpacing.Large))
                             }
                         }
 
-                        // Games grid
+                        // (d) User Stats Card
+                        if (detail.userStats != null) {
+                            item {
+                                DeveloperUserStatsCard(
+                                    userStats = detail.userStats,
+                                    totalGames = detail.gameCount,
+                                    onGameSelected = onGameSelected,
+                                    modifier = Modifier.testTag("developer_user_stats"),
+                                )
+                            }
+                        }
+
+                        // (e) Games Grouped by Platform
                         val filteredGames = state.filteredGames
                         if (filteredGames.isEmpty() && !state.isLoading) {
                             item {
@@ -212,13 +173,96 @@ fun ExploreDeveloperScreen(
                                 }
                             }
                         } else {
-                            items(
-                                items = filteredGames,
-                                key = { it.id },
-                            ) { game ->
-                                DeveloperGameItem(
-                                    game = game,
-                                    onClick = { onGameSelected(game.id) },
+                            // Group games by platform, ordered by count descending
+                            val platformBreakdown = detail.platformBreakdown
+                                .sortedByDescending { it.count }
+
+                            if (platformBreakdown.isNotEmpty()) {
+                                platformBreakdown.forEach { platform ->
+                                    val platformGames = filteredGames.filter {
+                                        it.consoleName.equals(platform.consoleName, ignoreCase = true)
+                                    }
+                                    if (platformGames.isNotEmpty()) {
+                                        item(key = "platform_header_${platform.consoleId}") {
+                                            DeveloperPlatformHeader(
+                                                consoleName = platform.consoleName,
+                                                gameCount = platformGames.size,
+                                                modifier = Modifier.testTag("developer_platform_header_${platform.consoleId}"),
+                                            )
+                                        }
+                                        items(
+                                            items = platformGames,
+                                            key = { it.id },
+                                        ) { game ->
+                                            DeveloperGameItem(
+                                                game = game,
+                                                onClick = { onGameSelected(game.id) },
+                                            )
+                                        }
+                                    }
+                                }
+                                // Also show games that don't match any platform in breakdown
+                                val knownPlatforms = platformBreakdown.map { it.consoleName.lowercase() }.toSet()
+                                val uncategorized = filteredGames.filter {
+                                    it.consoleName.lowercase() !in knownPlatforms
+                                }
+                                if (uncategorized.isNotEmpty()) {
+                                    item(key = "platform_header_other") {
+                                        DeveloperPlatformHeader(
+                                            consoleName = "Other",
+                                            gameCount = uncategorized.size,
+                                            modifier = Modifier.testTag("developer_platform_header_other"),
+                                        )
+                                    }
+                                    items(
+                                        items = uncategorized,
+                                        key = { "other_${it.id}" },
+                                    ) { game ->
+                                        DeveloperGameItem(
+                                            game = game,
+                                            onClick = { onGameSelected(game.id) },
+                                        )
+                                    }
+                                }
+                            } else {
+                                // Fallback: no platform breakdown, show flat list with console filter
+                                if (detail.consoles.isNotEmpty()) {
+                                    item {
+                                        DeveloperConsoleFilterRow(
+                                            consoles = detail.consoles,
+                                            totalGames = detail.gameCount,
+                                            selectedConsole = state.consoleFilter,
+                                            onConsoleSelected = { console ->
+                                                viewModel.setDeveloperConsoleFilter(
+                                                    if (console != null && state.consoleFilter == console) null else console,
+                                                )
+                                            },
+                                            modifier = Modifier
+                                                .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                                .testTag("developer_console_filters"),
+                                        )
+                                        Spacer(Modifier.height(SpSpacing.Large))
+                                    }
+                                }
+                                items(
+                                    items = filteredGames,
+                                    key = { it.id },
+                                ) { game ->
+                                    DeveloperGameItem(
+                                        game = game,
+                                        onClick = { onGameSelected(game.id) },
+                                    )
+                                }
+                            }
+                        }
+
+                        // (f) Publishers Section
+                        if (detail.publishers.isNotEmpty()) {
+                            item {
+                                DeveloperPublishersSection(
+                                    publishers = detail.publishers,
+                                    onPublisherSelected = onPublisherSelected,
+                                    modifier = Modifier.testTag("developer_publishers_section"),
                                 )
                             }
                         }
@@ -255,6 +299,39 @@ fun ExploreDeveloperScreen(
         )
     }
 }
+
+// --- (e) Platform Group Header ---
+
+@Composable
+private fun DeveloperPlatformHeader(
+    consoleName: String,
+    gameCount: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.Medium,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+        Text(
+            text = consoleName,
+            style = SpTypography.HeadlineSmall,
+            color = SpColor.OnBackground,
+        )
+        Text(
+            text = "$gameCount games",
+            style = SpTypography.BodySmall,
+            color = SpColor.OnBackgroundTertiary,
+        )
+    }
+}
+
+// --- Console Filter Row (fallback when no platform breakdown) ---
 
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
@@ -297,84 +374,6 @@ private fun DeveloperConsoleFilterRow(
                         role = Role.Button
                     },
             )
-        }
-    }
-}
-
-@Composable
-private fun DeveloperGameItem(
-    game: Game,
-    onClick: () -> Unit,
-) {
-    SpCard(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(
-                horizontal = SpSpacing.ScreenHorizontal,
-                vertical = SpSpacing.XSmall,
-            )
-            .testTag("developer_game_${game.id}")
-            .semantics {
-                contentDescription = "${game.title}, ${game.consoleName}"
-                role = Role.Button
-            },
-        onClick = onClick,
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(SpSpacing.Medium),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-        ) {
-            SpCoverArt(
-                imageUrl = game.coverUrl,
-                contentDescription = "${game.title} cover art",
-                modifier = Modifier
-                    .width(48.dp)
-                    .height(64.dp)
-                    .clip(RoundedCornerShape(SpSpacing.RadiusSmall)),
-                aspectRatio = 0.75f,
-            )
-
-            Column(
-                modifier = Modifier.weight(1f),
-            ) {
-                Text(
-                    text = game.title,
-                    style = SpTypography.TitleSmall,
-                    color = SpColor.OnCard,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-
-                Spacer(Modifier.height(SpSpacing.XXSmall))
-
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-                ) {
-                    Text(
-                        text = game.consoleName,
-                        style = SpTypography.LabelSmall,
-                        color = SpColor.OnBackgroundTertiary,
-                    )
-
-                    if (game.rating > 0) {
-                        Icon(
-                            imageVector = Icons.Filled.Star,
-                            contentDescription = null,
-                            tint = SpColor.Rating,
-                            modifier = Modifier.size(10.dp),
-                        )
-                        Text(
-                            text = formatRating(game.rating),
-                            style = SpTypography.LabelSmall,
-                            color = SpColor.OnBackgroundTertiary,
-                        )
-                    }
-                }
-            }
         }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -118,17 +118,23 @@ data class DeveloperDetailState(
     val name: String = "",
     val detail: DeveloperDetail? = null,
     val consoleFilter: String? = null,
+    val genreFilter: String? = null,
     val isLoading: Boolean = false,
     val error: String? = null,
 ) {
     val filteredGames: List<Game>
         get() {
             val games = detail?.games ?: return emptyList()
-            return if (consoleFilter != null) {
-                games.filter { it.consoleName.equals(consoleFilter, ignoreCase = true) }
-            } else {
-                games
+            var result = games
+            if (consoleFilter != null) {
+                result = result.filter { it.consoleName.equals(consoleFilter, ignoreCase = true) }
             }
+            if (genreFilter != null) {
+                result = result.filter { game ->
+                    game.genre?.split(",")?.map { it.trim() }?.any { it.equals(genreFilter, ignoreCase = true) } == true
+                }
+            }
+            return result
         }
 }
 
@@ -551,6 +557,10 @@ class ExploreViewModel(
 
     fun setDeveloperConsoleFilter(abbreviation: String?) {
         _developerDetailState.update { it.copy(consoleFilter = abbreviation) }
+    }
+
+    fun setDeveloperGenreFilter(genre: String?) {
+        _developerDetailState.update { it.copy(genreFilter = genre) }
     }
 
     fun dismissDeveloperDetailError() {

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -62,20 +62,53 @@ type DeveloperListResponse struct {
 
 // DeveloperDetailResponse is the API response for a developer detail page.
 type DeveloperDetailResponse struct {
-	Name      string         `json:"name"`
-	GameCount int            `json:"gameCount"`
-	AvgRating float64        `json:"avgRating"`
-	Consoles  []string       `json:"consoles"`
-	Games     []GameResponse `json:"games"`
+	Name              string              `json:"name"`
+	GameCount         int                 `json:"gameCount"`
+	AvgRating         float64             `json:"avgRating"`
+	Consoles          []string            `json:"consoles"`
+	Games             []GameResponse      `json:"games"`
+	HeroURL           string              `json:"heroUrl,omitempty"`
+	TopGames          []GameResponse      `json:"topGames"`
+	GenreBreakdown    []GenreCount        `json:"genreBreakdown"`
+	PlatformBreakdown []PlatformCount     `json:"platformBreakdown"`
+	UserStats         *EntityUserStats    `json:"userStats,omitempty"`
+	Publishers        []NameCount         `json:"publishers"`
 }
 
 // PublisherDetailResponse is the API response for a publisher detail page.
 type PublisherDetailResponse struct {
-	Name      string         `json:"name"`
-	GameCount int            `json:"gameCount"`
-	AvgRating float64        `json:"avgRating"`
-	Consoles  []string       `json:"consoles"`
-	Games     []GameResponse `json:"games"`
+	Name              string              `json:"name"`
+	GameCount         int                 `json:"gameCount"`
+	AvgRating         float64             `json:"avgRating"`
+	Consoles          []string            `json:"consoles"`
+	Games             []GameResponse      `json:"games"`
+	HeroURL           string              `json:"heroUrl,omitempty"`
+	TopGames          []GameResponse      `json:"topGames"`
+	GenreBreakdown    []GenreCount        `json:"genreBreakdown"`
+	PlatformBreakdown []PlatformCount     `json:"platformBreakdown"`
+	UserStats         *EntityUserStats    `json:"userStats,omitempty"`
+	Developers        []NameCount         `json:"developers"`
+}
+
+// PlatformCount holds a console name/ID and the number of games on that platform.
+type PlatformCount struct {
+	ConsoleName string `json:"consoleName"`
+	ConsoleID   string `json:"consoleId"`
+	Count       int    `json:"count"`
+}
+
+// NameCount holds a name and a count, used for publishers and developers breakdowns.
+type NameCount struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+// EntityUserStats holds user-specific stats for a developer or publisher.
+type EntityUserStats struct {
+	TotalPlayTime  int64         `json:"totalPlayTime"`
+	GamesPlayed    int           `json:"gamesPlayed"`
+	FavoriteCount  int           `json:"favoriteCount"`
+	MostPlayedGame *GameResponse `json:"mostPlayedGame"`
 }
 
 // DeveloperSpotlightResponse is the API response for the featured developer spotlight.

--- a/server/internal/api/explore_handler_developer.go
+++ b/server/internal/api/explore_handler_developer.go
@@ -5,6 +5,7 @@ import (
 	"math"
 	"net/http"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -117,13 +118,42 @@ func (h *ExploreHandler) GetDeveloperDetail(c *gin.Context) {
 		canonicalName = games[0].Developer
 	}
 
+	gameResponses := ToGameResponses(games, h.DB, userID)
+
+	// Hero URL from highest-rated game with hero artwork
+	heroURL := h.findHeroURL(games)
+
+	// Top 8 highest-rated games (only those with rating > 0)
+	topGames := buildTopGames(gameResponses, 8)
+
+	// Genre breakdown
+	genreBreakdown := buildGenreBreakdownFromGames(games)
+
+	// Platform breakdown
+	platformBreakdown := buildPlatformBreakdown(games)
+
+	// Publishers breakdown
+	publishers := buildNameCountBreakdown(games, func(g db.Game) string { return g.Publisher })
+
+	// User stats
+	var userStats *EntityUserStats
+	if userID > 0 {
+		userStats = h.buildEntityUserStats(userID, games, gameResponses)
+	}
+
 	c.Header("Cache-Control", "private, max-age=300")
 	c.JSON(http.StatusOK, DeveloperDetailResponse{
-		Name:      canonicalName,
-		GameCount: len(games),
-		AvgRating: avgRating,
-		Consoles:  consoles,
-		Games:     ToGameResponses(games, h.DB, userID),
+		Name:              canonicalName,
+		GameCount:         len(games),
+		AvgRating:         avgRating,
+		Consoles:          consoles,
+		Games:             gameResponses,
+		HeroURL:           heroURL,
+		TopGames:          topGames,
+		GenreBreakdown:    genreBreakdown,
+		PlatformBreakdown: platformBreakdown,
+		UserStats:         userStats,
+		Publishers:        publishers,
 	})
 }
 
@@ -152,14 +182,244 @@ func (h *ExploreHandler) GetPublisherDetail(c *gin.Context) {
 		canonicalName = games[0].Publisher
 	}
 
+	gameResponses := ToGameResponses(games, h.DB, userID)
+
+	// Hero URL from highest-rated game with hero artwork
+	heroURL := h.findHeroURL(games)
+
+	// Top 8 highest-rated games (only those with rating > 0)
+	topGames := buildTopGames(gameResponses, 8)
+
+	// Genre breakdown
+	genreBreakdown := buildGenreBreakdownFromGames(games)
+
+	// Platform breakdown
+	platformBreakdown := buildPlatformBreakdown(games)
+
+	// Developers breakdown
+	developers := buildNameCountBreakdown(games, func(g db.Game) string { return g.Developer })
+
+	// User stats
+	var userStats *EntityUserStats
+	if userID > 0 {
+		userStats = h.buildEntityUserStats(userID, games, gameResponses)
+	}
+
 	c.Header("Cache-Control", "private, max-age=300")
 	c.JSON(http.StatusOK, PublisherDetailResponse{
-		Name:      canonicalName,
-		GameCount: len(games),
-		AvgRating: avgRating,
-		Consoles:  consoles,
-		Games:     ToGameResponses(games, h.DB, userID),
+		Name:              canonicalName,
+		GameCount:         len(games),
+		AvgRating:         avgRating,
+		Consoles:          consoles,
+		Games:             gameResponses,
+		HeroURL:           heroURL,
+		TopGames:          topGames,
+		GenreBreakdown:    genreBreakdown,
+		PlatformBreakdown: platformBreakdown,
+		UserStats:         userStats,
+		Developers:        developers,
 	})
+}
+
+// findHeroURL returns the hero artwork URL from the highest-rated game that has hero artwork.
+// Games are expected to be sorted by rating DESC already.
+func (h *ExploreHandler) findHeroURL(games []db.Game) string {
+	if len(games) == 0 {
+		return ""
+	}
+	gameIDs := make([]uint, len(games))
+	for i, g := range games {
+		gameIDs[i] = g.ID
+	}
+	var artwork db.GameArtwork
+	if err := h.DB.
+		Joins("JOIN games ON games.id = game_artworks.game_id").
+		Where("game_artworks.game_id IN ? AND game_artworks.hero_url != ''", gameIDs).
+		Order("games.rating DESC").
+		First(&artwork).Error; err == nil {
+		return artwork.HeroURL
+	}
+	return ""
+}
+
+// buildTopGames returns up to limit highest-rated games (only those with rating > 0).
+// gameResponses is expected to be sorted by rating DESC already.
+func buildTopGames(gameResponses []GameResponse, limit int) []GameResponse {
+	var top []GameResponse
+	for _, gr := range gameResponses {
+		if gr.Rating > 0 {
+			top = append(top, gr)
+			if len(top) >= limit {
+				break
+			}
+		}
+	}
+	if top == nil {
+		top = []GameResponse{}
+	}
+	return top
+}
+
+// buildGenreBreakdownFromGames computes genre distribution from a slice of games.
+// Handles comma-separated genre values by splitting and trimming each part.
+func buildGenreBreakdownFromGames(games []db.Game) []GenreCount {
+	genreCounts := make(map[string]int)
+	for _, g := range games {
+		if g.Genre == "" {
+			continue
+		}
+		// Handle comma-separated genres
+		parts := strings.Split(g.Genre, ",")
+		for _, part := range parts {
+			genre := strings.TrimSpace(part)
+			if genre != "" {
+				genreCounts[genre]++
+			}
+		}
+	}
+
+	result := make([]GenreCount, 0, len(genreCounts))
+	for name, count := range genreCounts {
+		result = append(result, GenreCount{Name: name, GameCount: count})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].GameCount != result[j].GameCount {
+			return result[i].GameCount > result[j].GameCount
+		}
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+// buildPlatformBreakdown computes games-per-console from a slice of games.
+func buildPlatformBreakdown(games []db.Game) []PlatformCount {
+	type platformInfo struct {
+		name  string
+		abbr  string
+		count int
+	}
+	platformMap := make(map[uint]*platformInfo)
+	for _, g := range games {
+		if g.Console.ID == 0 {
+			continue
+		}
+		if pi, ok := platformMap[g.Console.ID]; ok {
+			pi.count++
+		} else {
+			platformMap[g.Console.ID] = &platformInfo{
+				name:  g.Console.Name,
+				abbr:  strings.ToLower(g.Console.Abbreviation),
+				count: 1,
+			}
+		}
+	}
+
+	result := make([]PlatformCount, 0, len(platformMap))
+	for _, pi := range platformMap {
+		result = append(result, PlatformCount{
+			ConsoleName: pi.name,
+			ConsoleID:   pi.abbr,
+			Count:       pi.count,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Count != result[j].Count {
+			return result[i].Count > result[j].Count
+		}
+		return result[i].ConsoleName < result[j].ConsoleName
+	})
+	return result
+}
+
+// buildNameCountBreakdown computes a name-count breakdown using a field extractor function.
+func buildNameCountBreakdown(games []db.Game, extractField func(db.Game) string) []NameCount {
+	counts := make(map[string]int)
+	for _, g := range games {
+		name := extractField(g)
+		if name != "" {
+			counts[name]++
+		}
+	}
+
+	result := make([]NameCount, 0, len(counts))
+	for name, count := range counts {
+		result = append(result, NameCount{Name: name, Count: count})
+	}
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].Count != result[j].Count {
+			return result[i].Count > result[j].Count
+		}
+		return result[i].Name < result[j].Name
+	})
+	return result
+}
+
+// buildEntityUserStats computes user-specific stats for a set of games.
+// Returns nil if the user has no play history for any of the games.
+func (h *ExploreHandler) buildEntityUserStats(userID uint, games []db.Game, gameResponses []GameResponse) *EntityUserStats {
+	if len(games) == 0 {
+		return nil
+	}
+
+	gameIDs := make([]uint, len(games))
+	for i, g := range games {
+		gameIDs[i] = g.ID
+	}
+
+	// Get play history for this user across these games
+	var playHistories []db.PlayHistory
+	if err := h.DB.
+		Where("user_id = ? AND game_id IN ? AND deleted_at IS NULL", userID, gameIDs).
+		Find(&playHistories).Error; err != nil {
+		slog.Error("failed to fetch play history for entity stats", "error", err)
+		return nil
+	}
+
+	if len(playHistories) == 0 {
+		return nil
+	}
+
+	// Compute total play time, games played, most played
+	var totalPlayTime int64
+	var mostPlayedGameID uint
+	var mostPlayedTime int64
+	playedGameIDs := make(map[uint]bool)
+
+	for _, ph := range playHistories {
+		totalPlayTime += ph.PlayTime
+		playedGameIDs[ph.GameID] = true
+		if ph.PlayTime > mostPlayedTime {
+			mostPlayedTime = ph.PlayTime
+			mostPlayedGameID = ph.GameID
+		}
+	}
+
+	// Count favorites
+	var favoriteCount int64
+	if err := h.DB.Model(&db.Favorite{}).
+		Where("user_id = ? AND game_id IN ? AND deleted_at IS NULL", userID, gameIDs).
+		Count(&favoriteCount).Error; err != nil {
+		slog.Error("failed to count favorites for entity stats", "error", err)
+	}
+
+	// Find the most-played game response
+	var mostPlayedGame *GameResponse
+	if mostPlayedGameID > 0 {
+		mostPlayedIDStr := strconv.FormatUint(uint64(mostPlayedGameID), 10)
+		for i := range gameResponses {
+			if gameResponses[i].ID == mostPlayedIDStr {
+				mostPlayedGame = &gameResponses[i]
+				break
+			}
+		}
+	}
+
+	return &EntityUserStats{
+		TotalPlayTime:  totalPlayTime,
+		GamesPlayed:    len(playedGameIDs),
+		FavoriteCount:  int(favoriteCount),
+		MostPlayedGame: mostPlayedGame,
+	}
 }
 
 // GetDeveloperSpotlight returns a featured developer with top games and hero art.

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -4257,3 +4257,403 @@ func TestGetCompletionistMap_Unauthenticated(t *testing.T) {
 
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
 }
+
+// --- Developer/Publisher Detail enrichment tests ---
+
+func TestGetDeveloperDetail_HeroURL(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGameWithDev(t, env.database, "NES", "Mega Man 2", 92, "Capcom", "Capcom")
+	game2 := createExploreGameWithDev(t, env.database, "SNES", "Mega Man X", 95, "Capcom", "Capcom")
+
+	// Add hero art to the lower-rated game only
+	env.database.Create(&db.GameArtwork{GameID: game1.ID, HeroURL: "http://hero1.jpg"})
+	// Add hero art to the higher-rated game
+	env.database.Create(&db.GameArtwork{GameID: game2.ID, HeroURL: "http://hero2.jpg"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/Capcom", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// heroUrl should be from the highest-rated game with hero art
+	assert.Equal(t, "http://hero2.jpg", resp.HeroURL)
+}
+
+func TestGetDeveloperDetail_HeroURL_NoArt(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameWithDev(t, env.database, "NES", "Game A", 85, "DevCo", "PubCo")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/DevCo", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Empty(t, resp.HeroURL)
+}
+
+func TestGetDeveloperDetail_TopGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create 10 games, only 8 with rating > 0
+	for i := 0; i < 8; i++ {
+		createExploreGameFull(t, env.database, "NES", fmt.Sprintf("Rated Game %d", i), float64(90-i), "DevTop", "Pub", "Action")
+	}
+	// 2 games with no rating
+	createExploreGameFull(t, env.database, "SNES", "Unrated A", 0, "DevTop", "Pub", "RPG")
+	createExploreGameFull(t, env.database, "SNES", "Unrated B", 0, "DevTop", "Pub", "RPG")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/DevTop", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// topGames should include exactly 8 rated games
+	assert.Len(t, resp.TopGames, 8)
+	// All topGames should have rating > 0
+	for _, g := range resp.TopGames {
+		assert.Greater(t, g.Rating, 0.0)
+	}
+	// games should include all 10
+	assert.Len(t, resp.Games, 10)
+}
+
+func TestGetDeveloperDetail_TopGames_LessThan8(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameFull(t, env.database, "NES", "Only Rated", 85, "SmallDev", "Pub", "Action")
+	createExploreGameFull(t, env.database, "SNES", "Unrated", 0, "SmallDev", "Pub", "RPG")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/SmallDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Len(t, resp.TopGames, 1)
+	assert.Equal(t, "Only Rated", resp.TopGames[0].Title)
+}
+
+func TestGetDeveloperDetail_TopGames_NoRated(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameFull(t, env.database, "NES", "Unrated Only", 0, "NoRateDev", "Pub", "Action")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/NoRateDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Empty(t, resp.TopGames)
+}
+
+func TestGetDeveloperDetail_GenreBreakdown(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameFull(t, env.database, "NES", "Action 1", 85, "GenreDev", "Pub", "Action")
+	createExploreGameFull(t, env.database, "NES", "Action 2", 80, "GenreDev", "Pub", "Action")
+	createExploreGameFull(t, env.database, "SNES", "RPG 1", 90, "GenreDev", "Pub", "RPG")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/GenreDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.GenreBreakdown, 2)
+	// Sorted by count DESC
+	assert.Equal(t, "Action", resp.GenreBreakdown[0].Name)
+	assert.Equal(t, 2, resp.GenreBreakdown[0].GameCount)
+	assert.Equal(t, "RPG", resp.GenreBreakdown[1].Name)
+	assert.Equal(t, 1, resp.GenreBreakdown[1].GameCount)
+}
+
+func TestGetDeveloperDetail_GenreBreakdown_CommaSeparated(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameFull(t, env.database, "NES", "Multi Genre", 85, "CSVDev", "Pub", "Action, RPG")
+	createExploreGameFull(t, env.database, "SNES", "Pure Action", 80, "CSVDev", "Pub", "Action")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/CSVDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.GenreBreakdown, 2)
+	// Action appears in both games
+	assert.Equal(t, "Action", resp.GenreBreakdown[0].Name)
+	assert.Equal(t, 2, resp.GenreBreakdown[0].GameCount)
+	// RPG appears in one game (from comma-separated value)
+	assert.Equal(t, "RPG", resp.GenreBreakdown[1].Name)
+	assert.Equal(t, 1, resp.GenreBreakdown[1].GameCount)
+}
+
+func TestGetDeveloperDetail_GenreBreakdown_EmptyGenres(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameFull(t, env.database, "NES", "No Genre", 85, "NoGenreDev", "Pub", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/NoGenreDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Empty(t, resp.GenreBreakdown)
+}
+
+func TestGetDeveloperDetail_PlatformBreakdown(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameFull(t, env.database, "NES", "NES Game 1", 85, "PlatDev", "Pub", "Action")
+	createExploreGameFull(t, env.database, "NES", "NES Game 2", 80, "PlatDev", "Pub", "Action")
+	createExploreGameFull(t, env.database, "SNES", "SNES Game 1", 90, "PlatDev", "Pub", "RPG")
+	createExploreGameFull(t, env.database, "GBA", "GBA Game 1", 75, "PlatDev", "Pub", "Puzzle")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/PlatDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.PlatformBreakdown, 3)
+	// Sorted by count DESC
+	assert.Equal(t, "nes", resp.PlatformBreakdown[0].ConsoleID)
+	assert.Equal(t, 2, resp.PlatformBreakdown[0].Count)
+	assert.NotEmpty(t, resp.PlatformBreakdown[0].ConsoleName)
+}
+
+func TestGetDeveloperDetail_Publishers(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameFull(t, env.database, "NES", "Game A", 85, "MultiPubDev", "Nintendo", "Action")
+	createExploreGameFull(t, env.database, "SNES", "Game B", 80, "MultiPubDev", "Nintendo", "RPG")
+	createExploreGameFull(t, env.database, "GBA", "Game C", 75, "MultiPubDev", "Capcom", "Action")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/MultiPubDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.Publishers, 2)
+	// Sorted by count DESC
+	assert.Equal(t, "Nintendo", resp.Publishers[0].Name)
+	assert.Equal(t, 2, resp.Publishers[0].Count)
+	assert.Equal(t, "Capcom", resp.Publishers[1].Name)
+	assert.Equal(t, 1, resp.Publishers[1].Count)
+}
+
+func TestGetDeveloperDetail_UserStats(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGameFull(t, env.database, "NES", "Played Game 1", 85, "StatDev", "Pub", "Action")
+	game2 := createExploreGameFull(t, env.database, "SNES", "Played Game 2", 90, "StatDev", "Pub", "RPG")
+	createExploreGameFull(t, env.database, "GBA", "Unplayed Game", 75, "StatDev", "Pub", "Puzzle")
+
+	// Get the user
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+
+	// Create play history
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game1.ID,
+		PlayTime:   3600,
+		LastPlayed: time.Now(),
+	})
+	env.database.Create(&db.PlayHistory{
+		UserID:     user.ID,
+		GameID:     game2.ID,
+		PlayTime:   7200,
+		LastPlayed: time.Now(),
+	})
+
+	// Favorite one game
+	env.database.Create(&db.Favorite{UserID: user.ID, GameID: game1.ID})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/StatDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.NotNil(t, resp.UserStats)
+	assert.Equal(t, int64(10800), resp.UserStats.TotalPlayTime) // 3600 + 7200
+	assert.Equal(t, 2, resp.UserStats.GamesPlayed)
+	assert.Equal(t, 1, resp.UserStats.FavoriteCount)
+	require.NotNil(t, resp.UserStats.MostPlayedGame)
+	assert.Equal(t, "Played Game 2", resp.UserStats.MostPlayedGame.Title) // 7200s > 3600s
+}
+
+func TestGetDeveloperDetail_UserStats_NoPlayHistory(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameFull(t, env.database, "NES", "Game A", 85, "NoPlayDev", "Pub", "Action")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/NoPlayDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// userStats should be nil/omitted when no play history
+	assert.Nil(t, resp.UserStats)
+}
+
+func TestGetDeveloperDetail_NonExistent_EmptyArrays(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/GhostDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "GhostDev", resp.Name)
+	assert.Equal(t, 0, resp.GameCount)
+	assert.Empty(t, resp.Games)
+	assert.Empty(t, resp.TopGames)
+	assert.Empty(t, resp.GenreBreakdown)
+	assert.Empty(t, resp.PlatformBreakdown)
+	assert.Empty(t, resp.Publishers)
+	assert.Nil(t, resp.UserStats)
+	assert.Empty(t, resp.HeroURL)
+}
+
+// --- Publisher Detail enrichment tests ---
+
+func TestGetPublisherDetail_Enriched(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	game1 := createExploreGameFull(t, env.database, "NES", "Pub Game 1", 85, "Dev A", "EnrichPub", "Action")
+	game2 := createExploreGameFull(t, env.database, "SNES", "Pub Game 2", 92, "Dev A", "EnrichPub", "RPG")
+	createExploreGameFull(t, env.database, "GBA", "Pub Game 3", 78, "Dev B", "EnrichPub", "Puzzle")
+
+	// Add hero art to highest-rated
+	env.database.Create(&db.GameArtwork{GameID: game2.ID, HeroURL: "http://pub-hero.jpg"})
+
+	// Get user, add play history
+	var user db.User
+	require.NoError(t, env.database.First(&user).Error)
+	env.database.Create(&db.PlayHistory{UserID: user.ID, GameID: game1.ID, PlayTime: 1800, LastPlayed: time.Now()})
+	env.database.Create(&db.Favorite{UserID: user.ID, GameID: game2.ID})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/publishers/EnrichPub", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PublisherDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Basic fields
+	assert.Equal(t, "EnrichPub", resp.Name)
+	assert.Equal(t, 3, resp.GameCount)
+	assert.Len(t, resp.Games, 3)
+
+	// Hero URL
+	assert.Equal(t, "http://pub-hero.jpg", resp.HeroURL)
+
+	// Top games (all 3 have rating > 0)
+	assert.Len(t, resp.TopGames, 3)
+
+	// Genre breakdown
+	require.Len(t, resp.GenreBreakdown, 3)
+
+	// Platform breakdown
+	require.Len(t, resp.PlatformBreakdown, 3)
+
+	// Developers (publisher detail shows developers)
+	require.Len(t, resp.Developers, 2)
+	assert.Equal(t, "Dev A", resp.Developers[0].Name)
+	assert.Equal(t, 2, resp.Developers[0].Count)
+	assert.Equal(t, "Dev B", resp.Developers[1].Name)
+	assert.Equal(t, 1, resp.Developers[1].Count)
+
+	// User stats
+	require.NotNil(t, resp.UserStats)
+	assert.Equal(t, int64(1800), resp.UserStats.TotalPlayTime)
+	assert.Equal(t, 1, resp.UserStats.GamesPlayed)
+	assert.Equal(t, 1, resp.UserStats.FavoriteCount)
+	require.NotNil(t, resp.UserStats.MostPlayedGame)
+	assert.Equal(t, "Pub Game 1", resp.UserStats.MostPlayedGame.Title)
+}
+
+func TestGetPublisherDetail_NoPlayHistory(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameFull(t, env.database, "NES", "Pub No Play", 85, "Dev", "NoPlayPub", "Action")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/publishers/NoPlayPub", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PublisherDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Nil(t, resp.UserStats)
+}

--- a/web/src/components/ui/filter-chip.test.tsx
+++ b/web/src/components/ui/filter-chip.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { FilterChip } from "./filter-chip";
+
+describe("FilterChip", () => {
+  it("renders label text", () => {
+    render(
+      <FilterChip label="Action" isSelected={false} onClick={vi.fn()} />,
+    );
+    expect(screen.getByRole("button")).toHaveTextContent("Action");
+  });
+
+  it("renders label with count when provided", () => {
+    render(
+      <FilterChip
+        label="RPG"
+        isSelected={false}
+        onClick={vi.fn()}
+        count={12}
+      />,
+    );
+    expect(screen.getByRole("button")).toHaveTextContent("RPG (12)");
+  });
+
+  it("does not render count when omitted", () => {
+    render(
+      <FilterChip label="All" isSelected={true} onClick={vi.fn()} />,
+    );
+    expect(screen.getByRole("button")).toHaveTextContent("All");
+    expect(screen.getByRole("button").textContent).not.toContain("(");
+  });
+
+  it("renders count of zero when explicitly provided", () => {
+    render(
+      <FilterChip
+        label="Empty"
+        isSelected={false}
+        onClick={vi.fn()}
+        count={0}
+      />,
+    );
+    expect(screen.getByRole("button")).toHaveTextContent("Empty (0)");
+  });
+
+  it("applies selected styles when isSelected is true", () => {
+    render(
+      <FilterChip label="Selected" isSelected={true} onClick={vi.fn()} />,
+    );
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("text-brand-400");
+    expect(button.className).toContain("bg-brand-500/15");
+  });
+
+  it("applies unselected styles when isSelected is false", () => {
+    render(
+      <FilterChip label="Unselected" isSelected={false} onClick={vi.fn()} />,
+    );
+    const button = screen.getByRole("button");
+    expect(button.className).toContain("bg-surface-800");
+    expect(button.className).toContain("text-surface-300");
+  });
+
+  it("calls onClick when clicked", async () => {
+    const handleClick = vi.fn();
+    const user = userEvent.setup();
+    render(
+      <FilterChip label="Click me" isSelected={false} onClick={handleClick} />,
+    );
+    await user.click(screen.getByRole("button"));
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/components/ui/filter-chip.tsx
+++ b/web/src/components/ui/filter-chip.tsx
@@ -1,0 +1,30 @@
+import { cn } from "@/lib/cn";
+
+interface FilterChipProps {
+  label: string;
+  isSelected: boolean;
+  onClick: () => void;
+  count?: number;
+}
+
+export function FilterChip({
+  label,
+  isSelected,
+  onClick,
+  count,
+}: FilterChipProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+        isSelected
+          ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
+          : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
+      )}
+    >
+      {label}
+      {count != null && ` (${count})`}
+    </button>
+  );
+}

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -27,3 +27,4 @@ export { StatCard } from "./stat-card";
 export { LeaderboardSkeleton } from "./leaderboard-skeleton";
 export { ConfirmDeleteModal } from "./confirm-delete-modal";
 export { LeaderboardRow } from "./leaderboard-row";
+export { FilterChip } from "./filter-chip";

--- a/web/src/features/explore/components/__tests__/developer-hero-banner.test.tsx
+++ b/web/src/features/explore/components/__tests__/developer-hero-banner.test.tsx
@@ -1,0 +1,149 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { DeveloperHeroBanner } from "@/features/explore/components/developer-hero-banner";
+
+describe("DeveloperHeroBanner", () => {
+  it("renders the developer name as heading", () => {
+    render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={23}
+        avgRating={82.3}
+        consoleCount={3}
+      />,
+    );
+    expect(
+      screen.getByRole("heading", { name: "Capcom", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders avatar with first letter", () => {
+    render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={5}
+        avgRating={0}
+        consoleCount={1}
+      />,
+    );
+    const avatar = screen.getByTestId("developer-avatar");
+    expect(avatar).toHaveTextContent("C");
+  });
+
+  it("renders game count", () => {
+    render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={23}
+        avgRating={0}
+        consoleCount={0}
+      />,
+    );
+    expect(screen.getByTestId("developer-stats")).toHaveTextContent("23 games");
+  });
+
+  it("renders singular game text", () => {
+    render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={1}
+        avgRating={0}
+        consoleCount={0}
+      />,
+    );
+    expect(screen.getByTestId("developer-stats")).toHaveTextContent("1 game");
+  });
+
+  it("renders average rating when > 0", () => {
+    render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={5}
+        avgRating={82.3}
+        consoleCount={1}
+      />,
+    );
+    expect(screen.getByTestId("developer-stats")).toHaveTextContent("82.3");
+  });
+
+  it("hides average rating when zero", () => {
+    render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={5}
+        avgRating={0}
+        consoleCount={1}
+      />,
+    );
+    expect(screen.getByTestId("developer-stats")).not.toHaveTextContent("0.0");
+  });
+
+  it("renders platform count", () => {
+    render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={5}
+        avgRating={0}
+        consoleCount={3}
+      />,
+    );
+    expect(screen.getByTestId("developer-stats")).toHaveTextContent(
+      "3 platforms",
+    );
+  });
+
+  it("renders singular platform text", () => {
+    render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={5}
+        avgRating={0}
+        consoleCount={1}
+      />,
+    );
+    expect(screen.getByTestId("developer-stats")).toHaveTextContent(
+      "1 platform",
+    );
+  });
+
+  it("hides platform count when zero", () => {
+    render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={5}
+        avgRating={0}
+        consoleCount={0}
+      />,
+    );
+    expect(screen.getByTestId("developer-stats")).not.toHaveTextContent(
+      "platform",
+    );
+  });
+
+  it("renders hero image when heroUrl provided", () => {
+    const { container } = render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={5}
+        avgRating={0}
+        consoleCount={1}
+        heroUrl="/images/hero.jpg"
+      />,
+    );
+    const img = container.querySelector("img");
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute("src", "/images/hero.jpg");
+  });
+
+  it("renders gradient fallback when no heroUrl", () => {
+    const { container } = render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={5}
+        avgRating={0}
+        consoleCount={1}
+      />,
+    );
+    expect(container.querySelector("img")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/explore/components/__tests__/developer-stats-card.test.tsx
+++ b/web/src/features/explore/components/__tests__/developer-stats-card.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { DeveloperStatsCard } from "@/features/explore/components/developer-stats-card";
+import type { EntityUserStats, Game } from "@/types/api";
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function renderCard(userStats: EntityUserStats, totalGames = 10) {
+  return render(
+    <MemoryRouter>
+      <DeveloperStatsCard userStats={userStats} totalGames={totalGames} />
+    </MemoryRouter>,
+  );
+}
+
+describe("DeveloperStatsCard", () => {
+  const baseStats: EntityUserStats = {
+    totalPlayTime: 7200,
+    gamesPlayed: 3,
+    favoriteCount: 2,
+    mostPlayedGame: makeGame({
+      id: "42",
+      title: "Mega Man X",
+      coverUrl: "/covers/mmx.jpg",
+      totalPlayTime: 3600,
+    }),
+  };
+
+  it("renders the section heading", () => {
+    renderCard(baseStats);
+    expect(
+      screen.getByRole("heading", { name: "Your Stats" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders total play time", () => {
+    renderCard(baseStats);
+    const card = screen.getByTestId("developer-user-stats");
+    expect(card).toHaveTextContent("2h 0m");
+  });
+
+  it("renders games played fraction", () => {
+    renderCard(baseStats, 10);
+    const card = screen.getByTestId("developer-user-stats");
+    expect(card).toHaveTextContent("3/10");
+  });
+
+  it("renders favorite count", () => {
+    renderCard(baseStats);
+    const card = screen.getByTestId("developer-user-stats");
+    expect(card).toHaveTextContent("2");
+  });
+
+  it("renders most played game name", () => {
+    renderCard(baseStats);
+    // Name appears in both the stat summary and the cover link
+    expect(screen.getAllByText("Mega Man X").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders most played game cover when available", () => {
+    renderCard(baseStats);
+    const mpg = screen.getByTestId("developer-most-played-game");
+    const img = mpg.querySelector("img");
+    expect(img).toHaveAttribute("src", "/covers/mmx.jpg");
+  });
+
+  it("renders without most played game when null", () => {
+    renderCard({
+      ...baseStats,
+      mostPlayedGame: null,
+    });
+    expect(
+      screen.queryByTestId("developer-most-played-game"),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/explore/components/developer-hero-banner.tsx
+++ b/web/src/features/explore/components/developer-hero-banner.tsx
@@ -1,0 +1,100 @@
+import { Star, Gamepad2, Monitor } from "lucide-react";
+
+interface DeveloperHeroBannerProps {
+  name: string;
+  gameCount: number;
+  avgRating: number;
+  consoleCount: number;
+  heroUrl?: string;
+}
+
+/** Generates a deterministic color from a string, used for the avatar circle. */
+function avatarColor(name: string): string {
+  const colors = [
+    "#6366f1", "#8b5cf6", "#ec4899", "#f43f5e",
+    "#f97316", "#eab308", "#22c55e", "#14b8a6",
+    "#06b6d4", "#3b82f6",
+  ];
+  let hash = 0;
+  for (let i = 0; i < name.length; i++) {
+    hash = name.charCodeAt(i) + ((hash << 5) - hash);
+  }
+  return colors[Math.abs(hash) % colors.length];
+}
+
+export function DeveloperHeroBanner({
+  name,
+  gameCount,
+  avgRating,
+  consoleCount,
+  heroUrl,
+}: DeveloperHeroBannerProps) {
+  const color = avatarColor(name);
+
+  return (
+    <div
+      className="relative w-full rounded-2xl overflow-hidden"
+      data-testid="developer-hero-banner"
+    >
+      {/* Background */}
+      {heroUrl ? (
+        <img
+          src={heroUrl}
+          alt=""
+          className="absolute inset-0 w-full h-full object-cover"
+          loading="eager"
+        />
+      ) : (
+        <div
+          className="absolute inset-0"
+          style={{
+            background: `linear-gradient(135deg, ${color}30, ${color}10, transparent)`,
+          }}
+        />
+      )}
+
+      {/* Dark gradient overlay */}
+      <div className="absolute inset-0 bg-gradient-to-t from-black/90 via-black/60 to-black/30 pointer-events-none" />
+
+      {/* Content */}
+      <div className="relative px-6 sm:px-8 py-10 sm:py-14">
+        <div className="flex items-center gap-4 mb-4">
+          {/* Avatar circle */}
+          <div
+            className="flex-shrink-0 flex items-center justify-center w-14 h-14 rounded-full text-2xl font-bold text-white"
+            style={{ backgroundColor: color }}
+            data-testid="developer-avatar"
+          >
+            {name.charAt(0).toUpperCase()}
+          </div>
+          <h1 className="text-3xl sm:text-4xl font-bold text-white">
+            {name}
+          </h1>
+        </div>
+
+        {/* Stats row */}
+        <div
+          className="flex flex-wrap items-center gap-4 text-sm text-white/70"
+          data-testid="developer-stats"
+        >
+          <span className="flex items-center gap-1.5">
+            <Gamepad2 className="h-4 w-4" />
+            {gameCount} {gameCount === 1 ? "game" : "games"}
+          </span>
+          {avgRating > 0 && (
+            <span className="flex items-center gap-1.5">
+              <Star className="h-4 w-4 text-amber-400 fill-amber-400" />
+              {avgRating.toFixed(1)}
+            </span>
+          )}
+          {consoleCount > 0 && (
+            <span className="flex items-center gap-1.5">
+              <Monitor className="h-4 w-4" />
+              {consoleCount} {consoleCount === 1 ? "platform" : "platforms"}
+            </span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/explore/components/developer-stats-card.tsx
+++ b/web/src/features/explore/components/developer-stats-card.tsx
@@ -1,0 +1,104 @@
+import { Link } from "react-router-dom";
+import { Clock, Gamepad2, Heart, Trophy } from "lucide-react";
+import { formatPlayTime } from "@/lib/format";
+import type { EntityUserStats } from "@/types/api";
+
+interface DeveloperStatsCardProps {
+  userStats: EntityUserStats;
+  totalGames: number;
+}
+
+export function DeveloperStatsCard({
+  userStats,
+  totalGames,
+}: DeveloperStatsCardProps) {
+  return (
+    <section data-testid="developer-user-stats">
+      <h2 className="text-xl font-bold text-surface-100 mb-4">Your Stats</h2>
+      <div className="rounded-xl border border-white/[0.06] bg-surface-900/50 p-5">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">
+          {/* Total play time */}
+          <div className="flex items-start gap-3">
+            <div className="flex-shrink-0 p-2 rounded-lg bg-brand-500/10">
+              <Clock className="h-4 w-4 text-brand-400" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-surface-100">
+                {formatPlayTime(userStats.totalPlayTime)}
+              </p>
+              <p className="text-xs text-surface-500">Play time</p>
+            </div>
+          </div>
+
+          {/* Games played */}
+          <div className="flex items-start gap-3">
+            <div className="flex-shrink-0 p-2 rounded-lg bg-emerald-500/10">
+              <Gamepad2 className="h-4 w-4 text-emerald-400" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-surface-100">
+                {userStats.gamesPlayed}/{totalGames}
+              </p>
+              <p className="text-xs text-surface-500">Games played</p>
+            </div>
+          </div>
+
+          {/* Favorites */}
+          <div className="flex items-start gap-3">
+            <div className="flex-shrink-0 p-2 rounded-lg bg-danger-500/10">
+              <Heart className="h-4 w-4 text-danger-500" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-surface-100">
+                {userStats.favoriteCount}
+              </p>
+              <p className="text-xs text-surface-500">Favorites</p>
+            </div>
+          </div>
+
+          {/* Most played */}
+          {userStats.mostPlayedGame && (
+            <div className="flex items-start gap-3">
+              <div className="flex-shrink-0 p-2 rounded-lg bg-amber-500/10">
+                <Trophy className="h-4 w-4 text-amber-400" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-xs text-surface-500">Most played</p>
+                <Link
+                  to={`/games/${userStats.mostPlayedGame.id}`}
+                  className="text-sm font-semibold text-surface-100 hover:text-brand-400 transition-colors truncate block"
+                >
+                  {userStats.mostPlayedGame.title}
+                </Link>
+              </div>
+            </div>
+          )}
+        </div>
+
+        {/* Most played game with cover art */}
+        {userStats.mostPlayedGame?.coverUrl && (
+          <Link
+            to={`/games/${userStats.mostPlayedGame.id}`}
+            className="flex items-center gap-3 mt-3 pt-3 border-t border-white/[0.06] group"
+            data-testid="developer-most-played-game"
+          >
+            <img
+              src={userStats.mostPlayedGame.coverUrl}
+              alt={userStats.mostPlayedGame.title}
+              className="w-10 h-14 rounded-lg object-cover flex-shrink-0"
+              loading="lazy"
+            />
+            <div className="min-w-0">
+              <p className="text-sm font-semibold text-surface-100 group-hover:text-brand-400 transition-colors truncate">
+                {userStats.mostPlayedGame.title}
+              </p>
+              <p className="text-xs text-surface-500">
+                {formatPlayTime(userStats.mostPlayedGame.totalPlayTime)}
+              </p>
+            </div>
+          </Link>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/web/src/pages/__tests__/developer-detail-page.test.tsx
+++ b/web/src/pages/__tests__/developer-detail-page.test.tsx
@@ -57,11 +57,29 @@ const mockDeveloperDetail: DeveloperDetailResponse = {
   avgRating: 88.5,
   consoles: ["SNES", "GBA"],
   games: [
-    makeGame({ id: "1", title: "Mega Man X", consoleName: "SNES", developer: "Capcom" }),
-    makeGame({ id: "2", title: "Mega Man X2", consoleName: "SNES", developer: "Capcom" }),
-    makeGame({ id: "3", title: "Mega Man Zero", consoleName: "GBA", developer: "Capcom" }),
-    makeGame({ id: "4", title: "Street Fighter II", consoleName: "SNES", developer: "Capcom" }),
-    makeGame({ id: "5", title: "Breath of Fire", consoleName: "SNES", developer: "Capcom" }),
+    makeGame({ id: "1", title: "Mega Man X", consoleName: "SNES", genre: "Platformer", developer: "Capcom" }),
+    makeGame({ id: "2", title: "Mega Man X2", consoleName: "SNES", genre: "Platformer", developer: "Capcom" }),
+    makeGame({ id: "3", title: "Mega Man Zero", consoleName: "GBA", genre: "Action", developer: "Capcom" }),
+    makeGame({ id: "4", title: "Street Fighter II", consoleName: "SNES", genre: "Fighting", developer: "Capcom" }),
+    makeGame({ id: "5", title: "Breath of Fire", consoleName: "SNES", genre: "RPG", developer: "Capcom" }),
+  ],
+  topGames: [
+    makeGame({ id: "1", title: "Mega Man X", consoleName: "SNES", rating: 95 }),
+    makeGame({ id: "4", title: "Street Fighter II", consoleName: "SNES", rating: 92 }),
+  ],
+  genreBreakdown: [
+    { name: "Platformer", gameCount: 2 },
+    { name: "Fighting", gameCount: 1 },
+    { name: "RPG", gameCount: 1 },
+    { name: "Action", gameCount: 1 },
+  ],
+  platformBreakdown: [
+    { consoleName: "SNES", consoleId: "snes", count: 4 },
+    { consoleName: "GBA", consoleId: "gba", count: 1 },
+  ],
+  publishers: [
+    { name: "Capcom", count: 4 },
+    { name: "Nintendo", count: 1 },
   ],
 };
 
@@ -99,7 +117,7 @@ describe("DeveloperDetailPage", () => {
     expect(screen.getByTestId("developer-detail-page")).toBeInTheDocument();
   });
 
-  it("renders developer name as heading", () => {
+  it("renders developer name in hero banner heading", () => {
     renderPage();
     expect(
       screen.getByRole("heading", { name: "Capcom", level: 1 }),
@@ -113,12 +131,20 @@ describe("DeveloperDetailPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders stats row with game count and avg rating", () => {
+  it("renders hero banner with stats", () => {
     renderPage();
+    const banner = screen.getByTestId("developer-hero-banner");
+    expect(banner).toBeInTheDocument();
     const stats = screen.getByTestId("developer-stats");
     expect(stats).toHaveTextContent("5 games");
-    expect(stats).toHaveTextContent("Avg rating: 88.5");
-    expect(stats).toHaveTextContent("Consoles: SNES, GBA");
+    expect(stats).toHaveTextContent("88.5");
+    expect(stats).toHaveTextContent("2 platforms");
+  });
+
+  it("renders hero banner avatar with first letter", () => {
+    renderPage();
+    const avatar = screen.getByTestId("developer-avatar");
+    expect(avatar).toHaveTextContent("C");
   });
 
   it("renders console filter chips", () => {
@@ -131,12 +157,13 @@ describe("DeveloperDetailPage", () => {
     expect(buttonTexts).toContainEqual(expect.stringContaining("GBA"));
   });
 
-  it("renders all games in grid", () => {
+  it("renders all games somewhere on page", () => {
     renderPage();
-    expect(screen.getByText("Mega Man X")).toBeInTheDocument();
-    expect(screen.getByText("Mega Man X2")).toBeInTheDocument();
+    // Games may appear in top rated shelf AND platform sections, so use getAllByText
+    expect(screen.getAllByText("Mega Man X").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Mega Man X2").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Mega Man Zero")).toBeInTheDocument();
-    expect(screen.getByText("Street Fighter II")).toBeInTheDocument();
+    expect(screen.getAllByText("Street Fighter II").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Breath of Fire")).toBeInTheDocument();
   });
 
@@ -152,6 +179,7 @@ describe("DeveloperDetailPage", () => {
     expect(gbaButton).toBeDefined();
     await user.click(gbaButton!);
 
+    // When filtering by console, falls back to grid view
     const grid = screen.getByTestId("developer-game-grid");
     const gameLinks = within(grid).getAllByRole("link");
     expect(gameLinks).toHaveLength(1);
@@ -219,6 +247,188 @@ describe("DeveloperDetailPage", () => {
     });
     renderPage();
     const stats = screen.getByTestId("developer-stats");
-    expect(stats).not.toHaveTextContent("Avg rating");
+    expect(stats).not.toHaveTextContent("88.5");
+  });
+
+  // --- Top Rated section ---
+
+  it("shows top rated shelf when >4 games and topGames present", () => {
+    renderPage();
+    expect(screen.getByTestId("shelf-Top Rated")).toBeInTheDocument();
+  });
+
+  it("hides top rated shelf when 4 or fewer games", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        gameCount: 4,
+        topGames: [makeGame({ id: "1", title: "Test" })],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("shelf-Top Rated")).not.toBeInTheDocument();
+  });
+
+  it("hides top rated shelf when topGames is empty", () => {
+    renderPage();
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        topGames: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    // Re-renders with empty topGames
+  });
+
+  // --- Genre Breakdown section ---
+
+  it("shows genre breakdown chips when 2+ genres", () => {
+    renderPage();
+    const section = screen.getByTestId("developer-genre-breakdown");
+    expect(section).toBeInTheDocument();
+    expect(within(section).getByText(/Platformer \(2\)/)).toBeInTheDocument();
+    expect(within(section).getByText(/Fighting \(1\)/)).toBeInTheDocument();
+    expect(within(section).getByText(/RPG \(1\)/)).toBeInTheDocument();
+  });
+
+  it("hides genre breakdown when fewer than 2 genres", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        genreBreakdown: [{ name: "Platformer", gameCount: 5 }],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("developer-genre-breakdown"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters games when clicking a genre chip", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const section = screen.getByTestId("developer-genre-breakdown");
+    const platformerBtn = within(section).getByText(/Platformer \(2\)/);
+    await user.click(platformerBtn);
+
+    // After genre filter, only platformer games remain.
+    // Since all Platformer games are on SNES, we get a grid (single platform = no grouping).
+    const grid = screen.getByTestId("developer-game-grid");
+    // Grid should only contain platformer games
+    const links = within(grid).getAllByRole("link");
+    expect(links).toHaveLength(2);
+    expect(within(grid).getByText("Mega Man X")).toBeInTheDocument();
+    expect(within(grid).getByText("Mega Man X2")).toBeInTheDocument();
+    // Non-platformer games should not be in the grid
+    expect(within(grid).queryByText("Breath of Fire")).not.toBeInTheDocument();
+    expect(
+      within(grid).queryByText("Street Fighter II"),
+    ).not.toBeInTheDocument();
+  });
+
+  // --- Platform sections ---
+
+  it("groups games by platform when multiple platforms present", () => {
+    renderPage();
+    const sections = screen.getByTestId("developer-platform-sections");
+    expect(sections).toBeInTheDocument();
+    expect(
+      screen.getByTestId("platform-section-SNES"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("platform-section-GBA"),
+    ).toBeInTheDocument();
+  });
+
+  it("orders platform sections by count descending", () => {
+    renderPage();
+    const sections = screen.getByTestId("developer-platform-sections");
+    const sectionHeaders = within(sections)
+      .getAllByRole("heading", { level: 2 })
+      .map((h) => h.textContent);
+    // SNES has 4 games, should come first
+    expect(sectionHeaders[0]).toBe("SNES");
+    expect(sectionHeaders[1]).toBe("GBA");
+  });
+
+  // --- Publishers section ---
+
+  it("shows publishers section with clickable chips", () => {
+    renderPage();
+    const section = screen.getByTestId("developer-publishers");
+    expect(section).toBeInTheDocument();
+    const links = within(section).getAllByRole("link");
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveTextContent("Capcom");
+    expect(links[1]).toHaveTextContent("Nintendo");
+  });
+
+  it("hides publishers section when no publishers", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        publishers: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("developer-publishers"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides publishers section when publishers is undefined", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        publishers: undefined,
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("developer-publishers"),
+    ).not.toBeInTheDocument();
+  });
+
+  // --- User Stats section ---
+
+  it("shows user stats card when userStats is present", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        userStats: {
+          totalPlayTime: 14400,
+          gamesPlayed: 3,
+          favoriteCount: 2,
+          mostPlayedGame: makeGame({
+            id: "1",
+            title: "Mega Man X",
+            coverUrl: "/covers/mmx.jpg",
+            totalPlayTime: 7200,
+          }),
+        },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    const card = screen.getByTestId("developer-user-stats");
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveTextContent("Your Stats");
+    expect(card).toHaveTextContent("4h 0m");
+    expect(card).toHaveTextContent("3/5");
+    expect(card).toHaveTextContent("2");
+  });
+
+  it("hides user stats card when userStats is absent", () => {
+    renderPage();
+    expect(
+      screen.queryByTestId("developer-user-stats"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/__tests__/publisher-detail-page.test.tsx
+++ b/web/src/pages/__tests__/publisher-detail-page.test.tsx
@@ -53,14 +53,32 @@ function makeGame(overrides: Partial<Game> = {}): Game {
 
 const mockPublisherDetail: PublisherDetailResponse = {
   name: "Nintendo",
-  gameCount: 4,
+  gameCount: 5,
   avgRating: 92.3,
   consoles: ["NES", "SNES"],
   games: [
-    makeGame({ id: "1", title: "Super Mario World", consoleName: "SNES", publisher: "Nintendo" }),
-    makeGame({ id: "2", title: "Zelda: ALTTP", consoleName: "SNES", publisher: "Nintendo" }),
-    makeGame({ id: "3", title: "Super Mario Bros.", consoleName: "NES", publisher: "Nintendo" }),
-    makeGame({ id: "4", title: "Metroid", consoleName: "NES", publisher: "Nintendo" }),
+    makeGame({ id: "1", title: "Super Mario World", consoleName: "SNES", genre: "Platformer", publisher: "Nintendo" }),
+    makeGame({ id: "2", title: "Zelda: ALTTP", consoleName: "SNES", genre: "RPG", publisher: "Nintendo" }),
+    makeGame({ id: "3", title: "Super Mario Bros.", consoleName: "NES", genre: "Platformer", publisher: "Nintendo" }),
+    makeGame({ id: "4", title: "Metroid", consoleName: "NES", genre: "Action", publisher: "Nintendo" }),
+    makeGame({ id: "5", title: "Kirby's Adventure", consoleName: "NES", genre: "Platformer", publisher: "Nintendo" }),
+  ],
+  topGames: [
+    makeGame({ id: "1", title: "Super Mario World", consoleName: "SNES", rating: 96 }),
+    makeGame({ id: "2", title: "Zelda: ALTTP", consoleName: "SNES", rating: 95 }),
+  ],
+  genreBreakdown: [
+    { name: "Platformer", gameCount: 3 },
+    { name: "RPG", gameCount: 1 },
+    { name: "Action", gameCount: 1 },
+  ],
+  platformBreakdown: [
+    { consoleName: "NES", consoleId: "nes", count: 3 },
+    { consoleName: "SNES", consoleId: "snes", count: 2 },
+  ],
+  developers: [
+    { name: "Nintendo EAD", count: 3 },
+    { name: "Intelligent Systems", count: 1 },
   ],
 };
 
@@ -98,7 +116,7 @@ describe("PublisherDetailPage", () => {
     expect(screen.getByTestId("publisher-detail-page")).toBeInTheDocument();
   });
 
-  it("renders publisher name as heading", () => {
+  it("renders publisher name in hero banner heading", () => {
     renderPage();
     expect(
       screen.getByRole("heading", { name: "Nintendo", level: 1 }),
@@ -112,12 +130,20 @@ describe("PublisherDetailPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("renders stats row with game count and avg rating", () => {
+  it("renders hero banner with stats", () => {
     renderPage();
-    const stats = screen.getByTestId("publisher-stats");
-    expect(stats).toHaveTextContent("4 games");
-    expect(stats).toHaveTextContent("Avg rating: 92.3");
-    expect(stats).toHaveTextContent("Consoles: NES, SNES");
+    const banner = screen.getByTestId("developer-hero-banner");
+    expect(banner).toBeInTheDocument();
+    const stats = screen.getByTestId("developer-stats");
+    expect(stats).toHaveTextContent("5 games");
+    expect(stats).toHaveTextContent("92.3");
+    expect(stats).toHaveTextContent("2 platforms");
+  });
+
+  it("renders hero banner avatar with first letter", () => {
+    renderPage();
+    const avatar = screen.getByTestId("developer-avatar");
+    expect(avatar).toHaveTextContent("N");
   });
 
   it("renders console filter chips", () => {
@@ -130,12 +156,13 @@ describe("PublisherDetailPage", () => {
     expect(buttonTexts).toContainEqual(expect.stringContaining("SNES"));
   });
 
-  it("renders all games in grid", () => {
+  it("renders all games somewhere on page", () => {
     renderPage();
-    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
-    expect(screen.getByText("Zelda: ALTTP")).toBeInTheDocument();
+    expect(screen.getAllByText("Super Mario World").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Zelda: ALTTP").length).toBeGreaterThanOrEqual(1);
     expect(screen.getByText("Super Mario Bros.")).toBeInTheDocument();
     expect(screen.getByText("Metroid")).toBeInTheDocument();
+    expect(screen.getByText("Kirby's Adventure")).toBeInTheDocument();
   });
 
   it("filters games by console", async () => {
@@ -144,18 +171,20 @@ describe("PublisherDetailPage", () => {
 
     const filters = screen.getByTestId("publisher-console-filters");
     const buttons = within(filters).getAllByRole("button");
-    const nesButton = buttons.find(
-      (b) => b.textContent?.trim().startsWith("NES"),
+    const snesButton = buttons.find(
+      (b) => b.textContent?.trim().startsWith("SNES"),
     );
-    expect(nesButton).toBeDefined();
-    await user.click(nesButton!);
+    expect(snesButton).toBeDefined();
+    await user.click(snesButton!);
 
+    // When filtering by console, falls back to grid view
     const grid = screen.getByTestId("publisher-game-grid");
     const gameLinks = within(grid).getAllByRole("link");
     expect(gameLinks).toHaveLength(2);
-    expect(screen.getByText("Super Mario Bros.")).toBeInTheDocument();
-    expect(screen.getByText("Metroid")).toBeInTheDocument();
-    expect(screen.queryByText("Super Mario World")).not.toBeInTheDocument();
+    expect(within(grid).getByText("Super Mario World")).toBeInTheDocument();
+    expect(within(grid).getByText("Zelda: ALTTP")).toBeInTheDocument();
+    // NES games should not be in the grid
+    expect(within(grid).queryByText("Super Mario Bros.")).not.toBeInTheDocument();
   });
 
   it("shows loading skeleton while loading", () => {
@@ -204,7 +233,7 @@ describe("PublisherDetailPage", () => {
       isLoading: false,
     });
     renderPage();
-    const stats = screen.getByTestId("publisher-stats");
+    const stats = screen.getByTestId("developer-stats");
     expect(stats).toHaveTextContent("1 game");
   });
 
@@ -217,7 +246,171 @@ describe("PublisherDetailPage", () => {
       isLoading: false,
     });
     renderPage();
-    const stats = screen.getByTestId("publisher-stats");
-    expect(stats).not.toHaveTextContent("Avg rating");
+    const stats = screen.getByTestId("developer-stats");
+    expect(stats).not.toHaveTextContent("92.3");
+  });
+
+  // --- Top Rated section ---
+
+  it("shows top rated shelf when >4 games and topGames present", () => {
+    renderPage();
+    expect(screen.getByTestId("shelf-Top Rated")).toBeInTheDocument();
+  });
+
+  it("hides top rated shelf when 4 or fewer games", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        gameCount: 4,
+        topGames: [makeGame({ id: "1", title: "Test" })],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByTestId("shelf-Top Rated")).not.toBeInTheDocument();
+  });
+
+  // --- Genre Breakdown section ---
+
+  it("shows genre breakdown chips when 2+ genres", () => {
+    renderPage();
+    const section = screen.getByTestId("publisher-genre-breakdown");
+    expect(section).toBeInTheDocument();
+    expect(within(section).getByText(/Platformer \(3\)/)).toBeInTheDocument();
+    expect(within(section).getByText(/RPG \(1\)/)).toBeInTheDocument();
+    expect(within(section).getByText(/Action \(1\)/)).toBeInTheDocument();
+  });
+
+  it("hides genre breakdown when fewer than 2 genres", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        genreBreakdown: [{ name: "Platformer", gameCount: 5 }],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("publisher-genre-breakdown"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("filters games when clicking a genre chip", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    const section = screen.getByTestId("publisher-genre-breakdown");
+    const platformerBtn = within(section).getByText(/Platformer \(3\)/);
+    await user.click(platformerBtn);
+
+    // After genre filter, platformer games are on NES and SNES, so we get platform grouping
+    // Games may also appear in the top rated shelf, so use getAllByText
+    expect(screen.getAllByText("Super Mario World").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("Super Mario Bros.")).toBeInTheDocument();
+    expect(screen.getByText("Kirby's Adventure")).toBeInTheDocument();
+    // Non-platformer games should be gone from the main section
+    // (Zelda:ALTTP is in top rated shelf but not in filtered platform sections)
+    expect(screen.queryByText("Metroid")).not.toBeInTheDocument();
+  });
+
+  // --- Platform sections ---
+
+  it("groups games by platform when multiple platforms present", () => {
+    renderPage();
+    const sections = screen.getByTestId("publisher-platform-sections");
+    expect(sections).toBeInTheDocument();
+    expect(
+      screen.getByTestId("platform-section-NES"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByTestId("platform-section-SNES"),
+    ).toBeInTheDocument();
+  });
+
+  it("orders platform sections by count descending", () => {
+    renderPage();
+    const sections = screen.getByTestId("publisher-platform-sections");
+    const sectionHeaders = within(sections)
+      .getAllByRole("heading", { level: 2 })
+      .map((h) => h.textContent);
+    // NES has 3 games, should come first
+    expect(sectionHeaders[0]).toBe("NES");
+    expect(sectionHeaders[1]).toBe("SNES");
+  });
+
+  // --- Developers section ---
+
+  it("shows developers section with clickable chips", () => {
+    renderPage();
+    const section = screen.getByTestId("publisher-developers");
+    expect(section).toBeInTheDocument();
+    const links = within(section).getAllByRole("link");
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveTextContent("Nintendo EAD");
+    expect(links[1]).toHaveTextContent("Intelligent Systems");
+  });
+
+  it("hides developers section when no developers", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        developers: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("publisher-developers"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides developers section when developers is undefined", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        developers: undefined,
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("publisher-developers"),
+    ).not.toBeInTheDocument();
+  });
+
+  // --- User Stats section ---
+
+  it("shows user stats card when userStats is present", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        userStats: {
+          totalPlayTime: 14400,
+          gamesPlayed: 3,
+          favoriteCount: 2,
+          mostPlayedGame: makeGame({
+            id: "1",
+            title: "Super Mario World",
+            coverUrl: "/covers/smw.jpg",
+            totalPlayTime: 7200,
+          }),
+        },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    const card = screen.getByTestId("developer-user-stats");
+    expect(card).toBeInTheDocument();
+    expect(card).toHaveTextContent("Your Stats");
+    expect(card).toHaveTextContent("4h 0m");
+    expect(card).toHaveTextContent("3/5");
+    expect(card).toHaveTextContent("2");
+  });
+
+  it("hides user stats card when userStats is absent", () => {
+    renderPage();
+    expect(
+      screen.queryByTestId("developer-user-stats"),
+    ).not.toBeInTheDocument();
   });
 });

--- a/web/src/pages/developer-detail-page.tsx
+++ b/web/src/pages/developer-detail-page.tsx
@@ -1,28 +1,39 @@
 import { useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
-import { BackButton, Skeleton } from "@/components/ui";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { BackButton, Skeleton, Badge, FilterChip } from "@/components/ui";
 import { GameCard } from "@/components/game-card";
 import { GameCardSkeleton } from "@/components/ui";
+import { GameShelf } from "@/features/explore/components/game-shelf";
+import { DeveloperHeroBanner } from "@/features/explore/components/developer-hero-banner";
+import { DeveloperStatsCard } from "@/features/explore/components/developer-stats-card";
 import { useDeveloperDetail } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
-import { cn } from "@/lib/cn";
 import type { Game } from "@/types/api";
 
 function DeveloperPageSkeleton() {
   return (
     <div className="space-y-8" data-testid="developer-detail-skeleton">
-      {/* Title */}
-      <Skeleton className="w-64 h-10" />
-      {/* Stats row */}
-      <Skeleton className="w-96 h-5" />
-      {/* Console chips */}
+      {/* Hero banner skeleton */}
+      <Skeleton className="w-full h-48 rounded-2xl" />
+      {/* Top rated skeleton */}
+      <div>
+        <Skeleton className="w-32 h-7 mb-4" />
+        <div className="flex gap-5 overflow-hidden">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+              <GameCardSkeleton />
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* Genre chips skeleton */}
       <div className="flex gap-2">
-        {Array.from({ length: 4 }, (_, i) => (
-          <Skeleton key={i} className="w-20 h-8 rounded-full" />
+        {Array.from({ length: 5 }, (_, i) => (
+          <Skeleton key={i} className="w-24 h-8 rounded-full" />
         ))}
       </div>
-      {/* Game grid */}
+      {/* Game grid skeleton */}
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-5">
         {Array.from({ length: 12 }, (_, i) => (
           <GameCardSkeleton key={i} />
@@ -39,6 +50,7 @@ export function DeveloperDetailPage() {
   const { data: developer, isLoading } = useDeveloperDetail(name);
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+  const [genreFilter, setGenreFilter] = useState<string | null>(null);
   const [consoleFilter, setConsoleFilter] = useState<string | null>(null);
 
   if (isLoading) {
@@ -65,9 +77,62 @@ export function DeveloperDetailPage() {
     );
   }
 
-  const filteredGames = consoleFilter
-    ? developer.games.filter((g: Game) => g.consoleName === consoleFilter)
-    : developer.games;
+  // Show top rated row when >4 games total and topGames has entries
+  const showTopRated =
+    developer.gameCount > 4 &&
+    developer.topGames &&
+    developer.topGames.length > 0;
+
+  // Show genre breakdown when 2+ genres exist
+  const showGenreBreakdown =
+    developer.genreBreakdown && developer.genreBreakdown.length >= 2;
+
+  // Build platform-grouped games
+  const platformBreakdown = developer.platformBreakdown ?? [];
+  const sortedPlatforms = [...platformBreakdown].sort(
+    (a, b) => b.count - a.count,
+  );
+
+  // Apply genre + console filter to the all-games list
+  let filteredGames = developer.games;
+  if (genreFilter) {
+    filteredGames = filteredGames.filter((g: Game) =>
+      g.genre
+        ?.split(",")
+        .map((s) => s.trim())
+        .includes(genreFilter),
+    );
+  }
+  if (consoleFilter) {
+    filteredGames = filteredGames.filter(
+      (g: Game) => g.consoleName === consoleFilter,
+    );
+  }
+
+  // Group filtered games by platform for display
+  const gamesByPlatform: Record<string, Game[]> = {};
+  for (const game of filteredGames) {
+    const key = game.consoleName;
+    if (!gamesByPlatform[key]) {
+      gamesByPlatform[key] = [];
+    }
+    gamesByPlatform[key].push(game);
+  }
+
+  // Order platform sections by total game count (desc)
+  const platformOrder = sortedPlatforms
+    .map((p) => p.consoleName)
+    .filter((name) => gamesByPlatform[name]?.length);
+
+  // Include any platforms that appear in filtered games but not in platformBreakdown
+  for (const key of Object.keys(gamesByPlatform)) {
+    if (!platformOrder.includes(key)) {
+      platformOrder.push(key);
+    }
+  }
+
+  const showGroupedByPlatform =
+    !consoleFilter && platformOrder.length > 1;
 
   return (
     <div className="max-w-6xl space-y-8" data-testid="developer-detail-page">
@@ -75,19 +140,60 @@ export function DeveloperDetailPage() {
         Back to Explore
       </BackButton>
 
-      {/* Page heading */}
-      <h1 className="text-3xl font-bold text-surface-100">{developer.name}</h1>
+      {/* Hero Banner */}
+      <DeveloperHeroBanner
+        name={developer.name}
+        gameCount={developer.gameCount}
+        avgRating={developer.avgRating}
+        consoleCount={developer.consoles.length}
+        heroUrl={developer.heroUrl}
+      />
 
-      {/* Stats row */}
-      <p className="text-sm text-surface-400" data-testid="developer-stats">
-        {developer.gameCount} {developer.gameCount === 1 ? "game" : "games"}
-        {developer.avgRating > 0 && (
-          <> | Avg rating: {developer.avgRating.toFixed(1)}</>
-        )}
-        {developer.consoles.length > 0 && (
-          <> | Consoles: {developer.consoles.join(", ")}</>
-        )}
-      </p>
+      {/* Top Rated Row */}
+      {showTopRated && (
+        <GameShelf
+          title="Top Rated"
+          games={developer.topGames!}
+          isLoading={false}
+          onToggleFavorite={handleToggleFavorite}
+          onTogglePlayLater={handleTogglePlayLater}
+        />
+      )}
+
+      {/* Genre Breakdown (filter chips) */}
+      {showGenreBreakdown && (
+        <section data-testid="developer-genre-breakdown">
+          <h2 className="text-lg font-bold text-surface-100 mb-3">Genres</h2>
+          <div className="flex flex-wrap gap-2">
+            <FilterChip
+              label="All"
+              isSelected={genreFilter === null}
+              onClick={() => setGenreFilter(null)}
+            />
+            {developer.genreBreakdown!.map((genre) => (
+              <FilterChip
+                key={genre.name}
+                label={genre.name}
+                isSelected={genreFilter === genre.name}
+                onClick={() =>
+                  setGenreFilter(
+                    genreFilter === genre.name ? null : genre.name,
+                  )
+                }
+                count={genre.gameCount}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* User Stats Card */}
+      {developer.userStats && (
+        <DeveloperStatsCard
+          userStats={developer.userStats}
+          totalGames={developer.gameCount}
+        />
+      )}
 
       {/* Console filter chips */}
       {developer.consoles.length > 1 && (
@@ -95,63 +201,114 @@ export function DeveloperDetailPage() {
           className="flex flex-wrap gap-2"
           data-testid="developer-console-filters"
         >
-          <button
+          <FilterChip
+            label="All"
+            isSelected={consoleFilter === null}
             onClick={() => setConsoleFilter(null)}
-            className={cn(
-              "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
-              consoleFilter === null
-                ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
-                : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
-            )}
-          >
-            All ({developer.games.length})
-          </button>
+            count={developer.games.length}
+          />
           {developer.consoles.map((consoleName: string) => {
             const count = developer.games.filter(
               (g: Game) => g.consoleName === consoleName,
             ).length;
             return (
-              <button
+              <FilterChip
                 key={consoleName}
+                label={consoleName}
+                isSelected={consoleFilter === consoleName}
                 onClick={() =>
                   setConsoleFilter(
                     consoleFilter === consoleName ? null : consoleName,
                   )
                 }
-                className={cn(
-                  "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
-                  consoleFilter === consoleName
-                    ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
-                    : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
-                )}
-              >
-                {consoleName} ({count})
-              </button>
+                count={count}
+              />
             );
           })}
         </div>
       )}
 
-      {/* Game grid */}
+      {/* Games grouped by platform (or flat list if only one platform / console filter active) */}
       {filteredGames.length > 0 ? (
-        <div
-          className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-5"
-          data-testid="developer-game-grid"
-        >
-          {filteredGames.map((game: Game) => (
-            <GameCard
-              key={game.id}
-              game={game}
-              showConsoleBadge
-              onToggleFavorite={handleToggleFavorite}
-              onTogglePlayLater={handleTogglePlayLater}
-            />
-          ))}
-        </div>
+        showGroupedByPlatform ? (
+          <div className="space-y-8" data-testid="developer-platform-sections">
+            {platformOrder.map((platformName) => {
+              const platformGames = gamesByPlatform[platformName];
+              if (!platformGames || platformGames.length === 0) return null;
+              return (
+                <section key={platformName} data-testid={`platform-section-${platformName}`}>
+                  <div className="flex items-center gap-2 mb-4">
+                    <h2 className="text-lg font-bold text-surface-100">
+                      {platformName}
+                    </h2>
+                    <Badge variant="default">{platformGames.length}</Badge>
+                  </div>
+                  <div
+                    className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+                    style={{
+                      scrollbarWidth: "none",
+                      msOverflowStyle: "none",
+                    }}
+                  >
+                    {platformGames.map((game: Game) => (
+                      <div
+                        key={game.id}
+                        className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+                      >
+                        <GameCard
+                          game={game}
+                          showConsoleBadge
+                          onToggleFavorite={handleToggleFavorite}
+                          onTogglePlayLater={handleTogglePlayLater}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        ) : (
+          <div
+            className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-5"
+            data-testid="developer-game-grid"
+          >
+            {filteredGames.map((game: Game) => (
+              <GameCard
+                key={game.id}
+                game={game}
+                showConsoleBadge
+                onToggleFavorite={handleToggleFavorite}
+                onTogglePlayLater={handleTogglePlayLater}
+              />
+            ))}
+          </div>
+        )
       ) : (
         <p className="text-surface-400 text-center py-12">
           No games match the selected filter.
         </p>
+      )}
+
+      {/* Publishers Section */}
+      {developer.publishers && developer.publishers.length > 0 && (
+        <section data-testid="developer-publishers">
+          <h2 className="text-lg font-bold text-surface-100 mb-3">
+            Publishers
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {developer.publishers.map((pub) => (
+              <Link
+                key={pub.name}
+                to={`/explore/publishers/${encodeURIComponent(pub.name)}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-surface-700 bg-surface-800 px-3 py-1.5 text-xs font-medium text-surface-300 hover:bg-surface-700 hover:text-surface-100 transition-colors"
+              >
+                {pub.name}
+                <span className="text-surface-500">({pub.count})</span>
+              </Link>
+            ))}
+          </div>
+        </section>
       )}
     </div>
   );

--- a/web/src/pages/publisher-detail-page.tsx
+++ b/web/src/pages/publisher-detail-page.tsx
@@ -1,28 +1,39 @@
 import { useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
-import { BackButton, Skeleton } from "@/components/ui";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import { BackButton, Skeleton, Badge, FilterChip } from "@/components/ui";
 import { GameCard } from "@/components/game-card";
 import { GameCardSkeleton } from "@/components/ui";
+import { GameShelf } from "@/features/explore/components/game-shelf";
+import { DeveloperHeroBanner } from "@/features/explore/components/developer-hero-banner";
+import { DeveloperStatsCard } from "@/features/explore/components/developer-stats-card";
 import { usePublisherDetail } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
-import { cn } from "@/lib/cn";
 import type { Game } from "@/types/api";
 
 function PublisherPageSkeleton() {
   return (
     <div className="space-y-8" data-testid="publisher-detail-skeleton">
-      {/* Title */}
-      <Skeleton className="w-64 h-10" />
-      {/* Stats row */}
-      <Skeleton className="w-96 h-5" />
-      {/* Console chips */}
+      {/* Hero banner skeleton */}
+      <Skeleton className="w-full h-48 rounded-2xl" />
+      {/* Top rated skeleton */}
+      <div>
+        <Skeleton className="w-32 h-7 mb-4" />
+        <div className="flex gap-5 overflow-hidden">
+          {Array.from({ length: 6 }, (_, i) => (
+            <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+              <GameCardSkeleton />
+            </div>
+          ))}
+        </div>
+      </div>
+      {/* Genre chips skeleton */}
       <div className="flex gap-2">
-        {Array.from({ length: 4 }, (_, i) => (
-          <Skeleton key={i} className="w-20 h-8 rounded-full" />
+        {Array.from({ length: 5 }, (_, i) => (
+          <Skeleton key={i} className="w-24 h-8 rounded-full" />
         ))}
       </div>
-      {/* Game grid */}
+      {/* Game grid skeleton */}
       <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-5">
         {Array.from({ length: 12 }, (_, i) => (
           <GameCardSkeleton key={i} />
@@ -39,6 +50,7 @@ export function PublisherDetailPage() {
   const { data: publisher, isLoading } = usePublisherDetail(name);
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+  const [genreFilter, setGenreFilter] = useState<string | null>(null);
   const [consoleFilter, setConsoleFilter] = useState<string | null>(null);
 
   if (isLoading) {
@@ -71,9 +83,62 @@ export function PublisherDetailPage() {
     );
   }
 
-  const filteredGames = consoleFilter
-    ? publisher.games.filter((g: Game) => g.consoleName === consoleFilter)
-    : publisher.games;
+  // Show top rated row when >4 games total and topGames has entries
+  const showTopRated =
+    publisher.gameCount > 4 &&
+    publisher.topGames &&
+    publisher.topGames.length > 0;
+
+  // Show genre breakdown when 2+ genres exist
+  const showGenreBreakdown =
+    publisher.genreBreakdown && publisher.genreBreakdown.length >= 2;
+
+  // Build platform-grouped games
+  const platformBreakdown = publisher.platformBreakdown ?? [];
+  const sortedPlatforms = [...platformBreakdown].sort(
+    (a, b) => b.count - a.count,
+  );
+
+  // Apply genre + console filter to the all-games list
+  let filteredGames = publisher.games;
+  if (genreFilter) {
+    filteredGames = filteredGames.filter((g: Game) =>
+      g.genre
+        ?.split(",")
+        .map((s) => s.trim())
+        .includes(genreFilter),
+    );
+  }
+  if (consoleFilter) {
+    filteredGames = filteredGames.filter(
+      (g: Game) => g.consoleName === consoleFilter,
+    );
+  }
+
+  // Group filtered games by platform for display
+  const gamesByPlatform: Record<string, Game[]> = {};
+  for (const game of filteredGames) {
+    const key = game.consoleName;
+    if (!gamesByPlatform[key]) {
+      gamesByPlatform[key] = [];
+    }
+    gamesByPlatform[key].push(game);
+  }
+
+  // Order platform sections by total game count (desc)
+  const platformOrder = sortedPlatforms
+    .map((p) => p.consoleName)
+    .filter((name) => gamesByPlatform[name]?.length);
+
+  // Include any platforms that appear in filtered games but not in platformBreakdown
+  for (const key of Object.keys(gamesByPlatform)) {
+    if (!platformOrder.includes(key)) {
+      platformOrder.push(key);
+    }
+  }
+
+  const showGroupedByPlatform =
+    !consoleFilter && platformOrder.length > 1;
 
   return (
     <div
@@ -84,19 +149,60 @@ export function PublisherDetailPage() {
         Back to Explore
       </BackButton>
 
-      {/* Page heading */}
-      <h1 className="text-3xl font-bold text-surface-100">{publisher.name}</h1>
+      {/* Hero Banner */}
+      <DeveloperHeroBanner
+        name={publisher.name}
+        gameCount={publisher.gameCount}
+        avgRating={publisher.avgRating}
+        consoleCount={publisher.consoles.length}
+        heroUrl={publisher.heroUrl}
+      />
 
-      {/* Stats row */}
-      <p className="text-sm text-surface-400" data-testid="publisher-stats">
-        {publisher.gameCount} {publisher.gameCount === 1 ? "game" : "games"}
-        {publisher.avgRating > 0 && (
-          <> | Avg rating: {publisher.avgRating.toFixed(1)}</>
-        )}
-        {publisher.consoles.length > 0 && (
-          <> | Consoles: {publisher.consoles.join(", ")}</>
-        )}
-      </p>
+      {/* Top Rated Row */}
+      {showTopRated && (
+        <GameShelf
+          title="Top Rated"
+          games={publisher.topGames!}
+          isLoading={false}
+          onToggleFavorite={handleToggleFavorite}
+          onTogglePlayLater={handleTogglePlayLater}
+        />
+      )}
+
+      {/* Genre Breakdown (filter chips) */}
+      {showGenreBreakdown && (
+        <section data-testid="publisher-genre-breakdown">
+          <h2 className="text-lg font-bold text-surface-100 mb-3">Genres</h2>
+          <div className="flex flex-wrap gap-2">
+            <FilterChip
+              label="All"
+              isSelected={genreFilter === null}
+              onClick={() => setGenreFilter(null)}
+            />
+            {publisher.genreBreakdown!.map((genre) => (
+              <FilterChip
+                key={genre.name}
+                label={genre.name}
+                isSelected={genreFilter === genre.name}
+                onClick={() =>
+                  setGenreFilter(
+                    genreFilter === genre.name ? null : genre.name,
+                  )
+                }
+                count={genre.gameCount}
+              />
+            ))}
+          </div>
+        </section>
+      )}
+
+      {/* User Stats Card */}
+      {publisher.userStats && (
+        <DeveloperStatsCard
+          userStats={publisher.userStats}
+          totalGames={publisher.gameCount}
+        />
+      )}
 
       {/* Console filter chips */}
       {publisher.consoles.length > 1 && (
@@ -104,63 +210,114 @@ export function PublisherDetailPage() {
           className="flex flex-wrap gap-2"
           data-testid="publisher-console-filters"
         >
-          <button
+          <FilterChip
+            label="All"
+            isSelected={consoleFilter === null}
             onClick={() => setConsoleFilter(null)}
-            className={cn(
-              "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
-              consoleFilter === null
-                ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
-                : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
-            )}
-          >
-            All ({publisher.games.length})
-          </button>
+            count={publisher.games.length}
+          />
           {publisher.consoles.map((consoleName: string) => {
             const count = publisher.games.filter(
               (g: Game) => g.consoleName === consoleName,
             ).length;
             return (
-              <button
+              <FilterChip
                 key={consoleName}
+                label={consoleName}
+                isSelected={consoleFilter === consoleName}
                 onClick={() =>
                   setConsoleFilter(
                     consoleFilter === consoleName ? null : consoleName,
                   )
                 }
-                className={cn(
-                  "inline-flex items-center rounded-full border px-3 py-1 text-xs font-medium transition-colors cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
-                  consoleFilter === consoleName
-                    ? "bg-brand-500/15 text-brand-400 border-brand-500/30"
-                    : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
-                )}
-              >
-                {consoleName} ({count})
-              </button>
+                count={count}
+              />
             );
           })}
         </div>
       )}
 
-      {/* Game grid */}
+      {/* Games grouped by platform (or flat list if only one platform / console filter active) */}
       {filteredGames.length > 0 ? (
-        <div
-          className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-5"
-          data-testid="publisher-game-grid"
-        >
-          {filteredGames.map((game: Game) => (
-            <GameCard
-              key={game.id}
-              game={game}
-              showConsoleBadge
-              onToggleFavorite={handleToggleFavorite}
-              onTogglePlayLater={handleTogglePlayLater}
-            />
-          ))}
-        </div>
+        showGroupedByPlatform ? (
+          <div className="space-y-8" data-testid="publisher-platform-sections">
+            {platformOrder.map((platformName) => {
+              const platformGames = gamesByPlatform[platformName];
+              if (!platformGames || platformGames.length === 0) return null;
+              return (
+                <section key={platformName} data-testid={`platform-section-${platformName}`}>
+                  <div className="flex items-center gap-2 mb-4">
+                    <h2 className="text-lg font-bold text-surface-100">
+                      {platformName}
+                    </h2>
+                    <Badge variant="default">{platformGames.length}</Badge>
+                  </div>
+                  <div
+                    className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+                    style={{
+                      scrollbarWidth: "none",
+                      msOverflowStyle: "none",
+                    }}
+                  >
+                    {platformGames.map((game: Game) => (
+                      <div
+                        key={game.id}
+                        className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+                      >
+                        <GameCard
+                          game={game}
+                          showConsoleBadge
+                          onToggleFavorite={handleToggleFavorite}
+                          onTogglePlayLater={handleTogglePlayLater}
+                        />
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              );
+            })}
+          </div>
+        ) : (
+          <div
+            className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-5"
+            data-testid="publisher-game-grid"
+          >
+            {filteredGames.map((game: Game) => (
+              <GameCard
+                key={game.id}
+                game={game}
+                showConsoleBadge
+                onToggleFavorite={handleToggleFavorite}
+                onTogglePlayLater={handleTogglePlayLater}
+              />
+            ))}
+          </div>
+        )
       ) : (
         <p className="text-surface-400 text-center py-12">
           No games match the selected filter.
         </p>
+      )}
+
+      {/* Developers Section */}
+      {publisher.developers && publisher.developers.length > 0 && (
+        <section data-testid="publisher-developers">
+          <h2 className="text-lg font-bold text-surface-100 mb-3">
+            Developers
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {publisher.developers.map((dev) => (
+              <Link
+                key={dev.name}
+                to={`/explore/developers/${encodeURIComponent(dev.name)}`}
+                className="inline-flex items-center gap-1.5 rounded-full border border-surface-700 bg-surface-800 px-3 py-1.5 text-xs font-medium text-surface-300 hover:bg-surface-700 hover:text-surface-100 transition-colors"
+              >
+                {dev.name}
+                <span className="text-surface-500">({dev.count})</span>
+              </Link>
+            ))}
+          </div>
+        </section>
       )}
     </div>
   );

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1093,12 +1093,36 @@ export interface DeveloperListResponse {
   developers: DeveloperSummary[];
 }
 
+export interface PlatformCount {
+  consoleName: string;
+  consoleId: string;
+  count: number;
+}
+
+export interface NameCount {
+  name: string;
+  count: number;
+}
+
+export interface EntityUserStats {
+  totalPlayTime: number;
+  gamesPlayed: number;
+  favoriteCount: number;
+  mostPlayedGame: Game | null;
+}
+
 export interface DeveloperDetailResponse {
   name: string;
   gameCount: number;
   avgRating: number;
   consoles: string[];
   games: Game[];
+  heroUrl?: string;
+  topGames?: Game[];
+  genreBreakdown?: GenreCount[];
+  platformBreakdown?: PlatformCount[];
+  userStats?: EntityUserStats;
+  publishers?: NameCount[];
 }
 
 export interface PublisherDetailResponse {
@@ -1107,6 +1131,12 @@ export interface PublisherDetailResponse {
   avgRating: number;
   consoles: string[];
   games: Game[];
+  heroUrl?: string;
+  topGames?: Game[];
+  genreBreakdown?: GenreCount[];
+  platformBreakdown?: PlatformCount[];
+  userStats?: EntityUserStats;
+  developers?: NameCount[];
 }
 
 export interface DeveloperSpotlightResponse {


### PR DESCRIPTION
## Summary
- Enhance developer/publisher detail API with hero art, top-rated games, genre breakdown, platform breakdown, user stats, and publisher/developer relationships — all derived from existing data
- Redesign both web and player app pages with hero banner, top rated shelf, genre chips with filtering, user stats card, platform-grouped games, and relationship chips
- Extract shared `FilterChip` component (web) and `DeveloperDetailComponents` (player) following shared component discipline
- Update publisher detail page to match the new developer detail layout

## Changes
- **Backend**: 6 new response fields, 15 new tests
- **Web**: 3 new components, 44 new tests across developer + publisher pages
- **Player**: New feature components file, DTO fix, 15 new desktop E2E tests

## Test plan
- [x] Go tests pass (`go test ./...`)
- [x] Web unit tests pass (1159 tests, 111 files)
- [x] Player desktop tests pass (587 tests)
- [x] TypeScript compilation clean
- [x] Code reviewer approved (after fixes for DTO mismatch, genre filter, file extraction)
- [x] UI agent reviewed