### PR TITLE
feat: add IGDB company data to developer/publisher detail pages

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreDeveloperTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreDeveloperTest.kt
@@ -1,6 +1,7 @@
 package com.spela.player.desktop.e2e
 
 import androidx.compose.ui.test.*
+import com.spela.player.domain.model.CompanyInfo
 import com.spela.player.domain.model.DeveloperDetail
 import com.spela.player.domain.model.DeveloperDetailGenreBreakdown
 import com.spela.player.domain.model.DeveloperDetailPlatformBreakdown
@@ -569,5 +570,177 @@ class ExploreDeveloperTest {
         advance(harness)
 
         onNodeWithTag("developer_publishers_section").assertDoesNotExist()
+    }
+
+    // --- Company Info: Logo ---
+
+    private val companyInfoFull = CompanyInfo(
+        logoUrl = "https://example.com/capcom-logo.png",
+        description = "Capcom Co., Ltd. is a Japanese video game developer and publisher known for creating multi-million-selling game franchises including Street Fighter, Mega Man, and Resident Evil.",
+        foundedYear = 1979,
+        country = "Japan",
+        websiteUrl = "https://www.capcom.com",
+        wikipediaUrl = "https://en.wikipedia.org/wiki/Capcom",
+    )
+
+    private val detailWithCompanyInfo = richDeveloperDetail.copy(
+        companyInfo = companyInfoFull,
+    )
+
+    private val detailWithLogoOnly = sampleDeveloperDetail.copy(
+        companyInfo = CompanyInfo(
+            logoUrl = "https://example.com/square-logo.png",
+        ),
+    )
+
+    private val detailWithDescriptionOnly = sampleDeveloperDetail.copy(
+        companyInfo = CompanyInfo(
+            description = "Square was a Japanese video game company.",
+            foundedYear = 1986,
+            country = "Japan",
+        ),
+    )
+
+    @Test
+    fun companyLogoShownWhenAvailable() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithCompanyInfo)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_hero_banner").assertExists()
+        onNodeWithTag("developer_company_logo").assertExists()
+        onNodeWithTag("developer_letter_avatar").assertDoesNotExist()
+    }
+
+    @Test
+    fun letterAvatarFallbackWhenNoLogo() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Square" to sampleDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Square"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_hero_banner").assertExists()
+        onNodeWithTag("developer_letter_avatar").assertExists()
+        onNodeWithTag("developer_company_logo").assertDoesNotExist()
+    }
+
+    @Test
+    fun letterAvatarShownWhenCompanyInfoHasNoLogo() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Square" to detailWithDescriptionOnly)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Square"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_letter_avatar").assertExists()
+        onNodeWithTag("developer_company_logo").assertDoesNotExist()
+    }
+
+    // --- Company Info: Description Section ---
+
+    @Test
+    fun companyDescriptionSectionShown() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithCompanyInfo)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_company_description_section"))
+        onNodeWithTag("developer_company_description_section").assertExists()
+        onNodeWithTag("developer_company_about_header").assertExists()
+        onNodeWithText("About").assertExists()
+        onNodeWithTag("developer_company_description").assertExists()
+        onNodeWithTag("developer_company_description_toggle").assertExists()
+        onNodeWithText("Show more").assertExists()
+    }
+
+    @Test
+    fun companyDescriptionToggleExpandsAndCollapses() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithCompanyInfo)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_company_description_toggle"))
+
+        // Initially shows "Show more"
+        onNodeWithText("Show more").assertExists()
+
+        // Click to expand
+        onNodeWithTag("developer_company_description_toggle").performClick()
+        advanceQuick(harness)
+        onNodeWithText("Show less").assertExists()
+
+        // Click to collapse
+        onNodeWithTag("developer_company_description_toggle").performClick()
+        advanceQuick(harness)
+        onNodeWithText("Show more").assertExists()
+    }
+
+    @Test
+    fun companyMetadataShowsFoundedYearAndCountry() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithCompanyInfo)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_company_metadata"))
+        onNodeWithTag("developer_company_metadata").assertExists()
+        onNodeWithText("Founded 1979 \u2014 Japan").assertExists()
+    }
+
+    @Test
+    fun companyDescriptionHiddenWhenNoDescription() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Square" to detailWithLogoOnly)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Square"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_company_description_section").assertDoesNotExist()
+    }
+
+    @Test
+    fun companyDescriptionHiddenWhenNoCompanyInfo() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Square" to sampleDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Square"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_company_description_section").assertDoesNotExist()
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -706,12 +706,22 @@ fun DeveloperDetailPublisherDto.toDomain(): DeveloperDetailPublisher = Developer
     count = count,
 )
 
+fun CompanyInfoDto.toDomain(): CompanyInfo = CompanyInfo(
+    logoUrl = logoUrl,
+    description = description,
+    foundedYear = foundedYear,
+    country = country,
+    websiteUrl = websiteUrl,
+    wikipediaUrl = wikipediaUrl,
+)
+
 fun DeveloperDetailResponseDto.toDomain(): DeveloperDetail = DeveloperDetail(
     name = name,
     gameCount = gameCount,
     avgRating = avgRating,
     consoles = consoles,
     heroUrl = heroUrl,
+    companyInfo = companyInfo?.toDomain(),
     topGames = topGames.map { it.toDomain() },
     genreBreakdown = genreBreakdown.map { it.toDeveloperGenreBreakdown() },
     platformBreakdown = platformBreakdown.map { it.toDomain() },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1168,6 +1168,16 @@ data class PlayersLikeYouResponseDto(
 // Developer / Publisher
 
 @Serializable
+data class CompanyInfoDto(
+    val logoUrl: String? = null,
+    val description: String? = null,
+    val foundedYear: Int? = null,
+    val country: String? = null,
+    val websiteUrl: String? = null,
+    val wikipediaUrl: String? = null,
+)
+
+@Serializable
 data class DeveloperSummaryDto(
     val name: String,
     val gameCount: Int,
@@ -1208,6 +1218,7 @@ data class DeveloperDetailResponseDto(
     val avgRating: Double,
     val consoles: List<String>,
     val heroUrl: String? = null,
+    val companyInfo: CompanyInfoDto? = null,
     val topGames: List<GameDto> = emptyList(),
     val genreBreakdown: List<GenreCountDto> = emptyList(),
     val platformBreakdown: List<DeveloperDetailPlatformBreakdownDto> = emptyList(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -422,6 +422,11 @@ class ExploreRepositoryImpl(
     private fun resolveEntityDetail(dto: DeveloperDetailResponseDto): DeveloperDetail =
         dto.toDomain().copy(
             heroUrl = apiClient.resolveUrl(dto.heroUrl),
+            companyInfo = dto.companyInfo?.let { info ->
+                info.toDomain().copy(
+                    logoUrl = apiClient.resolveUrl(info.logoUrl),
+                )
+            },
             topGames = dto.topGames.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -156,12 +156,22 @@ data class DeveloperDetailPublisher(
     val count: Int,
 )
 
+data class CompanyInfo(
+    val logoUrl: String? = null,
+    val description: String? = null,
+    val foundedYear: Int? = null,
+    val country: String? = null,
+    val websiteUrl: String? = null,
+    val wikipediaUrl: String? = null,
+)
+
 data class DeveloperDetail(
     val name: String,
     val gameCount: Int,
     val avgRating: Double,
     val consoles: List<String>,
     val heroUrl: String? = null,
+    val companyInfo: CompanyInfo? = null,
     val topGames: List<Game> = emptyList(),
     val genreBreakdown: List<DeveloperDetailGenreBreakdown> = emptyList(),
     val platformBreakdown: List<DeveloperDetailPlatformBreakdown> = emptyList(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
@@ -1,6 +1,8 @@
 package com.spela.player.presentation.ui.feature.explore
 
+import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -26,12 +28,18 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Timer
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -40,6 +48,8 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import com.spela.player.domain.model.CompanyInfo
 import com.spela.player.domain.model.DeveloperDetail
 import com.spela.player.domain.model.DeveloperDetailPublisher
 import com.spela.player.domain.model.DeveloperDetailUserStats
@@ -99,18 +109,28 @@ internal fun DeveloperHeroBanner(
                 verticalAlignment = Alignment.CenterVertically,
                 horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
             ) {
-                // Avatar (first letter)
-                Box(
-                    modifier = Modifier
-                        .size(48.dp)
-                        .clip(CircleShape)
-                        .background(SpColor.Primary.copy(alpha = 0.6f)),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    Text(
-                        text = detail.name.take(1).uppercase(),
-                        style = SpTypography.HeadlineMedium,
-                        color = SpColor.OnPrimary,
+                // Company logo or letter avatar fallback
+                val logoUrl = detail.companyInfo?.logoUrl
+                if (logoUrl != null) {
+                    SubcomposeAsyncImage(
+                        model = logoUrl,
+                        contentDescription = "${detail.name} logo",
+                        modifier = Modifier
+                            .size(48.dp)
+                            .clip(CircleShape)
+                            .testTag("developer_company_logo"),
+                        contentScale = ContentScale.Fit,
+                        loading = {
+                            LetterAvatar(detail.name)
+                        },
+                        error = {
+                            LetterAvatar(detail.name)
+                        },
+                    )
+                } else {
+                    LetterAvatar(
+                        name = detail.name,
+                        modifier = Modifier.testTag("developer_letter_avatar"),
                     )
                 }
 
@@ -576,5 +596,129 @@ internal fun DeveloperPublishersSection(
                 )
             }
         }
+    }
+}
+
+// --- Letter Avatar (extracted for reuse) ---
+
+@Composable
+private fun LetterAvatar(
+    name: String,
+    modifier: Modifier = Modifier,
+) {
+    Box(
+        modifier = modifier
+            .size(48.dp)
+            .clip(CircleShape)
+            .background(SpColor.Primary.copy(alpha = 0.6f)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = name.take(1).uppercase(),
+            style = SpTypography.HeadlineMedium,
+            color = SpColor.OnPrimary,
+        )
+    }
+}
+
+// --- Company Description Section ---
+
+@Composable
+internal fun DeveloperCompanyDescription(
+    companyInfo: CompanyInfo,
+    modifier: Modifier = Modifier,
+) {
+    val description = companyInfo.description ?: return
+
+    var expanded by remember { mutableStateOf(false) }
+    var hasVisualOverflow by remember { mutableStateOf(false) }
+    val uriHandler = LocalUriHandler.current
+
+    Column(
+        modifier = modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal),
+    ) {
+        Text(
+            text = "About",
+            style = SpTypography.HeadlineMedium,
+            color = SpColor.OnBackground,
+            modifier = Modifier.testTag("developer_company_about_header"),
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        Column(
+            modifier = Modifier.animateContentSize(),
+        ) {
+            Text(
+                text = description,
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundSecondary,
+                maxLines = if (expanded) Int.MAX_VALUE else 3,
+                overflow = TextOverflow.Ellipsis,
+                onTextLayout = { result ->
+                    if (!expanded) hasVisualOverflow = result.hasVisualOverflow
+                },
+                modifier = Modifier.testTag("developer_company_description"),
+            )
+
+            if (hasVisualOverflow || expanded) {
+                Spacer(Modifier.height(SpSpacing.XSmall))
+
+                Text(
+                    text = if (expanded) "Show less" else "Show more",
+                    style = SpTypography.LabelMedium,
+                    color = SpColor.Primary,
+                    modifier = Modifier
+                        .clickable { expanded = !expanded }
+                        .testTag("developer_company_description_toggle"),
+                )
+            }
+        }
+
+        // Metadata line: "Founded {year} — {country}"
+        val metaParts = buildList {
+            companyInfo.foundedYear?.let { add("Founded $it") }
+            companyInfo.country?.let { add(it) }
+        }
+        if (metaParts.isNotEmpty()) {
+            Spacer(Modifier.height(SpSpacing.Medium))
+            Text(
+                text = metaParts.joinToString(" \u2014 "),
+                style = SpTypography.LabelMedium,
+                color = SpColor.OnBackgroundTertiary,
+                modifier = Modifier.testTag("developer_company_metadata"),
+            )
+        }
+
+        // External links
+        val websiteUrl = companyInfo.websiteUrl
+        val wikipediaUrl = companyInfo.wikipediaUrl
+        if (!websiteUrl.isNullOrBlank() || !wikipediaUrl.isNullOrBlank()) {
+            Spacer(Modifier.height(SpSpacing.Medium))
+            Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium)) {
+                if (!websiteUrl.isNullOrBlank()) {
+                    Text(
+                        text = "Website",
+                        style = SpTypography.LabelMedium,
+                        color = SpColor.Primary,
+                        modifier = Modifier
+                            .clickable { uriHandler.openUri(websiteUrl) }
+                            .testTag("developer_company_website_link"),
+                    )
+                }
+                if (!wikipediaUrl.isNullOrBlank()) {
+                    Text(
+                        text = "Wikipedia",
+                        style = SpTypography.LabelMedium,
+                        color = SpColor.Primary,
+                        modifier = Modifier
+                            .clickable { uriHandler.openUri(wikipediaUrl) }
+                            .testTag("developer_company_wikipedia_link"),
+                    )
+                }
+            }
+        }
+
+        Spacer(Modifier.height(SpSpacing.Large))
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
@@ -36,6 +36,7 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.feature.explore.DeveloperCompanyDescription
 import com.spela.player.presentation.ui.feature.explore.DeveloperGameItem
 import com.spela.player.presentation.ui.feature.explore.DeveloperGenreBreakdown
 import com.spela.player.presentation.ui.feature.explore.DeveloperHeroBanner
@@ -112,6 +113,18 @@ fun ExploreDeveloperScreen(
                                 detail = detail,
                                 modifier = Modifier.testTag("developer_hero_banner"),
                             )
+                        }
+
+                        // Company Description (below hero banner)
+                        val companyInfo = detail.companyInfo
+                        if (companyInfo?.description != null) {
+                            item {
+                                Spacer(Modifier.height(SpSpacing.Large))
+                                DeveloperCompanyDescription(
+                                    companyInfo = companyInfo,
+                                    modifier = Modifier.testTag("developer_company_description_section"),
+                                )
+                            }
                         }
 
                         // (b) Top Rated Row

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -81,6 +81,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.GameFranchiseEntry{},
 		&db.GameArtworkImage{},
 		&db.SavedSearch{},
+		&db.Company{},
 	)
 	require.NoError(t, err)
 	err = db.SeedConsoles(database)

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -1,12 +1,14 @@
 package api
 
 import (
+	"github.com/spela/server/internal/igdb"
 	"gorm.io/gorm"
 )
 
 // ExploreHandler handles explore page endpoints.
 type ExploreHandler struct {
-	DB *gorm.DB
+	DB         *gorm.DB
+	IGDBClient *igdb.Client
 }
 
 // FeaturedGameResponse is the API response for a featured game in the hero carousel.
@@ -60,6 +62,17 @@ type DeveloperListResponse struct {
 	Developers []DeveloperSummary `json:"developers"`
 }
 
+// CompanyInfo holds optional rich metadata for a developer or publisher,
+// sourced from IGDB company data.
+type CompanyInfo struct {
+	LogoURL      string `json:"logoUrl,omitempty"`
+	Description  string `json:"description,omitempty"`
+	FoundedYear  int    `json:"foundedYear,omitempty"`
+	Country      string `json:"country,omitempty"`
+	WebsiteURL   string `json:"websiteUrl,omitempty"`
+	WikipediaURL string `json:"wikipediaUrl,omitempty"`
+}
+
 // DeveloperDetailResponse is the API response for a developer detail page.
 type DeveloperDetailResponse struct {
 	Name              string              `json:"name"`
@@ -73,6 +86,7 @@ type DeveloperDetailResponse struct {
 	PlatformBreakdown []PlatformCount     `json:"platformBreakdown"`
 	UserStats         *EntityUserStats    `json:"userStats,omitempty"`
 	Publishers        []NameCount         `json:"publishers"`
+	CompanyInfo       *CompanyInfo        `json:"companyInfo,omitempty"`
 }
 
 // PublisherDetailResponse is the API response for a publisher detail page.
@@ -88,6 +102,7 @@ type PublisherDetailResponse struct {
 	PlatformBreakdown []PlatformCount     `json:"platformBreakdown"`
 	UserStats         *EntityUserStats    `json:"userStats,omitempty"`
 	Developers        []NameCount         `json:"developers"`
+	CompanyInfo       *CompanyInfo        `json:"companyInfo,omitempty"`
 }
 
 // PlatformCount holds a console name/ID and the number of games on that platform.

--- a/server/internal/api/explore_handler_company.go
+++ b/server/internal/api/explore_handler_company.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/igdb"
+	"gorm.io/gorm"
+)
+
+// lookupCompanyInfo looks up company metadata by name. If a Company record
+// exists in the database, it is returned immediately. If not, a background
+// fetch from IGDB is triggered (lazy fetching) and the current request
+// returns without company data. If the record is older than 30 days, a
+// background refresh is triggered.
+func (h *ExploreHandler) lookupCompanyInfo(name string) *CompanyInfo {
+	if name == "" {
+		return nil
+	}
+
+	var company db.Company
+	if err := h.DB.Where("LOWER(name) = LOWER(?)", name).First(&company).Error; err != nil {
+		// No record found — trigger background fetch if IGDB is configured
+		h.triggerCompanyFetch(name)
+		return nil
+	}
+
+	// Check if the record is stale (older than 30 days) — refresh in background
+	if time.Since(company.UpdatedAt) > 30*24*time.Hour {
+		h.triggerCompanyFetch(name)
+	}
+
+	return companyToInfo(&company)
+}
+
+// companyToInfo converts a db.Company record to a CompanyInfo response.
+func companyToInfo(company *db.Company) *CompanyInfo {
+	if company == nil {
+		return nil
+	}
+
+	info := &CompanyInfo{
+		LogoURL:      company.LogoURL,
+		Description:  company.Description,
+		FoundedYear:  company.FoundedYear,
+		Country:      igdb.CountryName(company.Country),
+		WebsiteURL:   company.WebsiteURL,
+		WikipediaURL: company.WikipediaURL,
+	}
+
+	// Only return non-empty info
+	if info.LogoURL == "" && info.Description == "" && info.FoundedYear == 0 &&
+		info.Country == "" && info.WebsiteURL == "" && info.WikipediaURL == "" {
+		return nil
+	}
+
+	return info
+}
+
+// triggerCompanyFetch starts a background goroutine to fetch company data
+// from IGDB and store it in the database.
+func (h *ExploreHandler) triggerCompanyFetch(name string) {
+	if h.IGDBClient == nil || !h.IGDBClient.IsConfigured() {
+		return
+	}
+
+	go func() {
+		detail, err := h.IGDBClient.SearchCompanyByName(name)
+		if err != nil {
+			slog.Warn("background company fetch failed", "name", name, "error", err)
+			return
+		}
+		if detail == nil {
+			slog.Debug("company not found on IGDB", "name", name)
+			return
+		}
+
+		storeCompanyDetail(h.DB, detail)
+	}()
+}
+
+// storeCompanyDetail creates or updates a Company record from IGDB data.
+func storeCompanyDetail(database *gorm.DB, detail *igdb.CompanyDetail) {
+	if detail == nil {
+		return
+	}
+
+	logoURL := igdb.CompanyLogoURL(detail.LogoImageID)
+
+	// Extract founding year from start_date Unix timestamp
+	foundedYear := 0
+	if detail.StartDate > 0 {
+		foundedYear = time.Unix(detail.StartDate, 0).Year()
+	}
+
+	var existing db.Company
+	if err := database.Where("igdb_company_id = ?", detail.ID).First(&existing).Error; err != nil {
+		// Create new
+		company := db.Company{
+			IGDBCompanyID: detail.ID,
+			Name:          detail.Name,
+			Description:   detail.Description,
+			LogoURL:       logoURL,
+			Country:       detail.Country,
+			FoundedYear:   foundedYear,
+			WebsiteURL:    detail.WebsiteURL,
+			WikipediaURL:  detail.WikipediaURL,
+		}
+		if err := database.Create(&company).Error; err != nil {
+			slog.Warn("failed to create company record", "name", detail.Name, "error", err)
+		} else {
+			slog.Info("stored company metadata", "name", detail.Name, "igdbId", detail.ID)
+		}
+	} else {
+		// Update existing
+		updates := map[string]interface{}{
+			"name":          detail.Name,
+			"description":   detail.Description,
+			"logo_url":      logoURL,
+			"country":       detail.Country,
+			"founded_year":  foundedYear,
+			"website_url":   detail.WebsiteURL,
+			"wikipedia_url": detail.WikipediaURL,
+		}
+		if err := database.Model(&existing).Updates(updates).Error; err != nil {
+			slog.Warn("failed to update company record", "name", detail.Name, "error", err)
+		}
+	}
+}

--- a/server/internal/api/explore_handler_company_test.go
+++ b/server/internal/api/explore_handler_company_test.go
@@ -1,0 +1,204 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetDeveloperDetail_WithCompanyInfo(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create a game with a developer
+	game := createExploreGame(t, env.database, "NES", "Super Mario Bros", 90.0)
+	env.database.Model(&game).Update("developer", "Nintendo")
+
+	// Create a Company record in the DB
+	company := db.Company{
+		IGDBCompanyID: 421,
+		Name:          "Nintendo",
+		Description:   "Nintendo Co., Ltd. is a Japanese video game company.",
+		LogoURL:       "https://images.igdb.com/igdb/image/upload/t_logo_med/cl_nintendo.png",
+		Country:       392,
+		FoundedYear:   1889,
+		WebsiteURL:    "https://www.nintendo.com",
+		WikipediaURL:  "https://en.wikipedia.org/wiki/Nintendo",
+	}
+	require.NoError(t, env.database.Create(&company).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/Nintendo", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "Nintendo", resp.Name)
+	assert.Equal(t, 1, resp.GameCount)
+
+	// Verify company info is included
+	require.NotNil(t, resp.CompanyInfo)
+	assert.Equal(t, "https://images.igdb.com/igdb/image/upload/t_logo_med/cl_nintendo.png", resp.CompanyInfo.LogoURL)
+	assert.Equal(t, "Nintendo Co., Ltd. is a Japanese video game company.", resp.CompanyInfo.Description)
+	assert.Equal(t, 1889, resp.CompanyInfo.FoundedYear)
+	assert.Equal(t, "Japan", resp.CompanyInfo.Country)
+	assert.Equal(t, "https://www.nintendo.com", resp.CompanyInfo.WebsiteURL)
+	assert.Equal(t, "https://en.wikipedia.org/wiki/Nintendo", resp.CompanyInfo.WikipediaURL)
+}
+
+func TestGetDeveloperDetail_WithoutCompanyInfo(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create a game with a developer but no Company record
+	game := createExploreGame(t, env.database, "NES", "Some Game", 85.0)
+	env.database.Model(&game).Update("developer", "UnknownStudio")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/UnknownStudio", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "UnknownStudio", resp.Name)
+	// CompanyInfo should be nil when no Company record exists
+	assert.Nil(t, resp.CompanyInfo)
+}
+
+func TestGetPublisherDetail_WithCompanyInfo(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create a game with a publisher
+	game := createExploreGame(t, env.database, "SNES", "Mega Man X", 92.0)
+	env.database.Model(&game).Update("publisher", "Capcom")
+
+	// Create a Company record
+	company := db.Company{
+		IGDBCompanyID: 12,
+		Name:          "Capcom",
+		Description:   "A Japanese game developer and publisher.",
+		LogoURL:       "https://images.igdb.com/igdb/image/upload/t_logo_med/cl_capcom.png",
+		Country:       392,
+		FoundedYear:   1983,
+		WebsiteURL:    "https://www.capcom.com",
+	}
+	require.NoError(t, env.database.Create(&company).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/publishers/Capcom", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PublisherDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "Capcom", resp.Name)
+
+	require.NotNil(t, resp.CompanyInfo)
+	assert.Equal(t, "A Japanese game developer and publisher.", resp.CompanyInfo.Description)
+	assert.Equal(t, 1983, resp.CompanyInfo.FoundedYear)
+	assert.Equal(t, "Japan", resp.CompanyInfo.Country)
+}
+
+func TestGetDeveloperDetail_CaseInsensitiveCompanyLookup(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Create a game with lowercase developer name
+	game := createExploreGame(t, env.database, "NES", "Test Game", 80.0)
+	env.database.Model(&game).Update("developer", "nintendo")
+
+	// Company record with proper casing
+	company := db.Company{
+		IGDBCompanyID: 421,
+		Name:          "Nintendo",
+		Description:   "The house of Mario.",
+		FoundedYear:   1889,
+		Country:       392,
+	}
+	require.NoError(t, env.database.Create(&company).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/nintendo", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Company lookup should work despite case mismatch
+	require.NotNil(t, resp.CompanyInfo)
+	assert.Equal(t, "The house of Mario.", resp.CompanyInfo.Description)
+	assert.Equal(t, "Japan", resp.CompanyInfo.Country)
+}
+
+func TestCompanyToInfo_EmptyCompany(t *testing.T) {
+	// A company with no useful data should return nil
+	company := &db.Company{
+		IGDBCompanyID: 1,
+		Name:          "Empty Co",
+	}
+	info := companyToInfo(company)
+	assert.Nil(t, info)
+}
+
+func TestCompanyToInfo_NilCompany(t *testing.T) {
+	info := companyToInfo(nil)
+	assert.Nil(t, info)
+}
+
+func TestCompanyToInfo_PartialData(t *testing.T) {
+	company := &db.Company{
+		IGDBCompanyID: 1,
+		Name:          "Partial Co",
+		Description:   "Some description",
+		Country:       840,
+	}
+	info := companyToInfo(company)
+	require.NotNil(t, info)
+	assert.Equal(t, "Some description", info.Description)
+	assert.Equal(t, "United States", info.Country)
+	assert.Empty(t, info.LogoURL)
+	assert.Empty(t, info.WebsiteURL)
+	assert.Equal(t, 0, info.FoundedYear)
+}
+
+func TestCompanyToInfo_UnknownCountryCode(t *testing.T) {
+	company := &db.Company{
+		IGDBCompanyID: 1,
+		Name:          "Mystery Co",
+		Description:   "From an unknown land",
+		Country:       999, // unknown code
+	}
+	info := companyToInfo(company)
+	require.NotNil(t, info)
+	assert.Equal(t, "From an unknown land", info.Description)
+	assert.Empty(t, info.Country) // unknown code returns ""
+}
+
+// setupExploreCompanyTestEnv creates a test env with a scraper that has no IGDB client
+// (which is the typical test scenario).
+func setupExploreCompanyTestEnv(t *testing.T) *exploreTestEnv {
+	t.Helper()
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+	return &exploreTestEnv{
+		database: database,
+		router:   router,
+		token:    token,
+	}
+}

--- a/server/internal/api/explore_handler_developer.go
+++ b/server/internal/api/explore_handler_developer.go
@@ -141,6 +141,9 @@ func (h *ExploreHandler) GetDeveloperDetail(c *gin.Context) {
 		userStats = h.buildEntityUserStats(userID, games, gameResponses)
 	}
 
+	// Look up company metadata (lazy-fetched from IGDB)
+	companyInfo := h.lookupCompanyInfo(canonicalName)
+
 	c.Header("Cache-Control", "private, max-age=300")
 	c.JSON(http.StatusOK, DeveloperDetailResponse{
 		Name:              canonicalName,
@@ -154,6 +157,7 @@ func (h *ExploreHandler) GetDeveloperDetail(c *gin.Context) {
 		PlatformBreakdown: platformBreakdown,
 		UserStats:         userStats,
 		Publishers:        publishers,
+		CompanyInfo:       companyInfo,
 	})
 }
 
@@ -205,6 +209,9 @@ func (h *ExploreHandler) GetPublisherDetail(c *gin.Context) {
 		userStats = h.buildEntityUserStats(userID, games, gameResponses)
 	}
 
+	// Look up company metadata (lazy-fetched from IGDB)
+	companyInfo := h.lookupCompanyInfo(canonicalName)
+
 	c.Header("Cache-Control", "private, max-age=300")
 	c.JSON(http.StatusOK, PublisherDetailResponse{
 		Name:              canonicalName,
@@ -218,6 +225,7 @@ func (h *ExploreHandler) GetPublisherDetail(c *gin.Context) {
 		PlatformBreakdown: platformBreakdown,
 		UserStats:         userStats,
 		Developers:        developers,
+		CompanyInfo:       companyInfo,
 	})
 }
 

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/auth"
 	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/igdb"
 	"github.com/spela/server/internal/retroachievements"
 	"github.com/spela/server/internal/scanner"
 	"github.com/spela/server/internal/scraper"
@@ -172,7 +173,11 @@ func NewRouter(cfg Config) *gin.Engine {
 	challengeHandler.AttemptRateLimitSeconds = cfg.ChallengeAttemptRateLimitSec
 	sessionHandler := &SessionHandler{DB: cfg.DB, Storage: cfg.Storage}
 	artworkHandler := &ArtworkHandler{DB: cfg.DB}
-	exploreHandler := &ExploreHandler{DB: cfg.DB}
+	var igdbClient *igdb.Client
+	if cfg.Scraper != nil {
+		igdbClient = cfg.Scraper.IGDBClient
+	}
+	exploreHandler := &ExploreHandler{DB: cfg.DB, IGDBClient: igdbClient}
 	savedSearchHandler := &SavedSearchHandler{DB: cfg.DB}
 	enrichmentHandler := &EnrichmentHandler{DB: cfg.DB, Scraper: cfg.Scraper, Hub: cfg.Hub}
 	discoveryHandler := &GameDiscoveryHandler{DB: cfg.DB, Scraper: cfg.Scraper}

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -154,6 +154,8 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&SessionCheatSetting{},
 		&DailyPlayActivity{},
 		&GameArtwork{},
+		// Company metadata
+		&Company{},
 		// Phase 2 Explore: IGDB enrichment
 		&GameTheme{},
 		&GameKeyword{},

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -636,6 +636,21 @@ type GameArtwork struct {
 	UpdatedAt     time.Time `json:"updatedAt"`
 }
 
+// Company represents an IGDB game development/publishing company with metadata.
+type Company struct {
+	ID            uint      `gorm:"primarykey" json:"id"`
+	IGDBCompanyID int       `gorm:"uniqueIndex" json:"igdbCompanyId"`
+	Name          string    `gorm:"index" json:"name"`
+	Description   string    `gorm:"type:text" json:"description,omitempty"`
+	LogoURL       string    `gorm:"size:512" json:"logoUrl,omitempty"`
+	Country       int       `json:"country,omitempty"`
+	FoundedYear   int       `json:"foundedYear,omitempty"`
+	WebsiteURL    string    `gorm:"size:512" json:"websiteUrl,omitempty"`
+	WikipediaURL  string    `gorm:"size:512" json:"wikipediaUrl,omitempty"`
+	CreatedAt     time.Time `json:"createdAt"`
+	UpdatedAt     time.Time `json:"updatedAt"`
+}
+
 // --- Phase 2 Explore: IGDB Enrichment models ---
 
 // GameTheme stores an IGDB theme associated with a game (e.g., "Fantasy", "Sci-Fi").

--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -590,6 +590,226 @@ func (c *Client) GetSimilarGames(igdbGameID int) ([]SimilarGame, error) {
 	return games, nil
 }
 
+// CompanyDetail holds extended metadata about a company from IGDB.
+type CompanyDetail struct {
+	ID           int    `json:"id"`
+	Name         string `json:"name"`
+	Description  string `json:"description"`
+	LogoImageID  string `json:"logo_image_id"`
+	Country      int    `json:"country"`
+	StartDate    int64  `json:"start_date"`     // Unix timestamp
+	WebsiteURL   string `json:"website_url"`    // official website
+	WikipediaURL string `json:"wikipedia_url"`
+}
+
+// CompanyLogoURL constructs a full logo URL from an image_id.
+func CompanyLogoURL(imageID string) string {
+	if imageID == "" {
+		return ""
+	}
+	return fmt.Sprintf("%s/t_logo_med/%s.png", igdbImageBase, imageID)
+}
+
+// GetCompanyByID fetches detailed company information from IGDB by company ID.
+// Returns name, description, logo, country, founding date, and websites.
+// Returns nil, nil if the company is not found.
+func (c *Client) GetCompanyByID(igdbID int) (*CompanyDetail, error) {
+	if err := c.authenticate(); err != nil {
+		return nil, fmt.Errorf("IGDB authentication: %w", err)
+	}
+
+	<-c.rateLimiter
+
+	query := fmt.Sprintf(
+		`fields name,description,logo.image_id,country,start_date,websites.url,websites.category; where id = %d; limit 1;`,
+		igdbID,
+	)
+
+	slog.Info("IGDB get company request", "igdbID", igdbID)
+
+	c.mu.Lock()
+	token := c.token.AccessToken
+	c.mu.Unlock()
+
+	req, err := http.NewRequest("POST", igdbAPIBase+"/companies", strings.NewReader(query))
+	if err != nil {
+		return nil, fmt.Errorf("creating IGDB company request: %w", err)
+	}
+	req.Header.Set("Client-ID", c.ClientID)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling IGDB API for company: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading IGDB company response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var results []struct {
+		ID          int    `json:"id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Logo        *struct {
+			ImageID string `json:"image_id"`
+		} `json:"logo"`
+		Country   int   `json:"country"`
+		StartDate int64 `json:"start_date"`
+		Websites  []struct {
+			URL      string `json:"url"`
+			Category int    `json:"category"`
+		} `json:"websites"`
+	}
+	if err := json.Unmarshal(body, &results); err != nil {
+		return nil, fmt.Errorf("decoding IGDB company response: %w", err)
+	}
+
+	if len(results) == 0 {
+		slog.Info("IGDB get company: not found", "igdbID", igdbID)
+		return nil, nil
+	}
+
+	r := results[0]
+	detail := &CompanyDetail{
+		ID:          r.ID,
+		Name:        r.Name,
+		Description: r.Description,
+		Country:     r.Country,
+		StartDate:   r.StartDate,
+	}
+
+	if r.Logo != nil {
+		detail.LogoImageID = r.Logo.ImageID
+	}
+
+	// Extract official website (category 1) and Wikipedia (category 3)
+	for _, w := range r.Websites {
+		switch w.Category {
+		case 1:
+			if detail.WebsiteURL == "" {
+				detail.WebsiteURL = w.URL
+			}
+		case 3:
+			if detail.WikipediaURL == "" {
+				detail.WikipediaURL = w.URL
+			}
+		}
+	}
+
+	slog.Info("IGDB get company response", "igdbID", igdbID, "name", detail.Name)
+	return detail, nil
+}
+
+// SearchCompanyByName searches IGDB for companies matching the given name.
+// Returns the first exact match (case-insensitive) or nil if not found.
+func (c *Client) SearchCompanyByName(name string) (*CompanyDetail, error) {
+	if err := c.authenticate(); err != nil {
+		return nil, fmt.Errorf("IGDB authentication: %w", err)
+	}
+
+	<-c.rateLimiter
+
+	query := fmt.Sprintf(
+		`fields name,description,logo.image_id,country,start_date,websites.url,websites.category; where name ~ "%s"; limit 5;`,
+		escapeQuery(name),
+	)
+
+	slog.Info("IGDB search company by name request", "name", name)
+
+	c.mu.Lock()
+	token := c.token.AccessToken
+	c.mu.Unlock()
+
+	req, err := http.NewRequest("POST", igdbAPIBase+"/companies", strings.NewReader(query))
+	if err != nil {
+		return nil, fmt.Errorf("creating IGDB company search request: %w", err)
+	}
+	req.Header.Set("Client-ID", c.ClientID)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling IGDB API for company search: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading IGDB company search response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var results []struct {
+		ID          int    `json:"id"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+		Logo        *struct {
+			ImageID string `json:"image_id"`
+		} `json:"logo"`
+		Country   int   `json:"country"`
+		StartDate int64 `json:"start_date"`
+		Websites  []struct {
+			URL      string `json:"url"`
+			Category int    `json:"category"`
+		} `json:"websites"`
+	}
+	if err := json.Unmarshal(body, &results); err != nil {
+		return nil, fmt.Errorf("decoding IGDB company search response: %w", err)
+	}
+
+	if len(results) == 0 {
+		slog.Info("IGDB search company by name: not found", "name", name)
+		return nil, nil
+	}
+
+	// Pick the first result (case-insensitive exact match preferred)
+	r := results[0]
+	for _, candidate := range results {
+		if strings.EqualFold(candidate.Name, name) {
+			r = candidate
+			break
+		}
+	}
+
+	detail := &CompanyDetail{
+		ID:          r.ID,
+		Name:        r.Name,
+		Description: r.Description,
+		Country:     r.Country,
+		StartDate:   r.StartDate,
+	}
+
+	if r.Logo != nil {
+		detail.LogoImageID = r.Logo.ImageID
+	}
+
+	for _, w := range r.Websites {
+		switch w.Category {
+		case 1:
+			if detail.WebsiteURL == "" {
+				detail.WebsiteURL = w.URL
+			}
+		case 3:
+			if detail.WikipediaURL == "" {
+				detail.WikipediaURL = w.URL
+			}
+		}
+	}
+
+	slog.Info("IGDB search company by name response", "name", name, "matchedName", detail.Name, "igdbID", detail.ID)
+	return detail, nil
+}
+
 // --- Enrichment types for Phase 2 Explore ---
 
 // GameEnrichment holds extended metadata fetched from IGDB for a single game.

--- a/server/internal/igdb/company_client_test.go
+++ b/server/internal/igdb/company_client_test.go
@@ -1,0 +1,311 @@
+package igdb
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetCompanyByID_Success(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/v4/companies", r.URL.Path)
+		assert.Equal(t, "myid", r.Header.Get("Client-ID"))
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{
+				"id":          421,
+				"name":        "Nintendo",
+				"description": "Nintendo Co., Ltd. is a Japanese video game company.",
+				"logo":        map[string]interface{}{"image_id": "cl_nintendo"},
+				"country":     392,
+				"start_date":  -2208988800, // 1889
+				"websites": []map[string]interface{}{
+					{"url": "https://www.nintendo.com", "category": 1},
+					{"url": "https://en.wikipedia.org/wiki/Nintendo", "category": 3},
+					{"url": "https://twitter.com/NintendoAmerica", "category": 5},
+				},
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	detail, err := c.GetCompanyByID(421)
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+
+	assert.Equal(t, 421, detail.ID)
+	assert.Equal(t, "Nintendo", detail.Name)
+	assert.Equal(t, "Nintendo Co., Ltd. is a Japanese video game company.", detail.Description)
+	assert.Equal(t, "cl_nintendo", detail.LogoImageID)
+	assert.Equal(t, 392, detail.Country)
+	assert.Equal(t, int64(-2208988800), detail.StartDate)
+	assert.Equal(t, "https://www.nintendo.com", detail.WebsiteURL)
+	assert.Equal(t, "https://en.wikipedia.org/wiki/Nintendo", detail.WikipediaURL)
+}
+
+func TestGetCompanyByID_NotFound(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	detail, err := c.GetCompanyByID(99999)
+	require.NoError(t, err)
+	assert.Nil(t, detail)
+}
+
+func TestGetCompanyByID_APIError(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	_, err := c.GetCompanyByID(421)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
+func TestGetCompanyByID_NoLogo(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{
+				"id":      100,
+				"name":    "Small Studio",
+				"country": 840,
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	detail, err := c.GetCompanyByID(100)
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+
+	assert.Equal(t, "Small Studio", detail.Name)
+	assert.Empty(t, detail.LogoImageID)
+	assert.Equal(t, 840, detail.Country)
+	assert.Empty(t, detail.WebsiteURL)
+}
+
+func TestSearchCompanyByName_Success(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/v4/companies", r.URL.Path)
+
+		json.NewEncoder(w).Encode([]map[string]interface{}{
+			{
+				"id":          999,
+				"name":        "capcom co",
+				"description": "Not the right one",
+			},
+			{
+				"id":          12,
+				"name":        "Capcom",
+				"description": "A Japanese game developer and publisher.",
+				"logo":        map[string]interface{}{"image_id": "cl_capcom"},
+				"country":     392,
+				"start_date":  488332800,
+				"websites": []map[string]interface{}{
+					{"url": "https://www.capcom.com", "category": 1},
+				},
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	detail, err := c.SearchCompanyByName("Capcom")
+	require.NoError(t, err)
+	require.NotNil(t, detail)
+
+	// Should pick the exact name match "Capcom" instead of "capcom co"
+	assert.Equal(t, 12, detail.ID)
+	assert.Equal(t, "Capcom", detail.Name)
+	assert.Equal(t, "A Japanese game developer and publisher.", detail.Description)
+	assert.Equal(t, "cl_capcom", detail.LogoImageID)
+	assert.Equal(t, 392, detail.Country)
+	assert.Equal(t, "https://www.capcom.com", detail.WebsiteURL)
+}
+
+func TestSearchCompanyByName_NotFound(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]map[string]interface{}{})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	detail, err := c.SearchCompanyByName("Nonexistent Studio XYZ")
+	require.NoError(t, err)
+	assert.Nil(t, detail)
+}
+
+func TestCompanyLogoURL(t *testing.T) {
+	tests := []struct {
+		imageID  string
+		expected string
+	}{
+		{"cl_nintendo", "https://images.igdb.com/igdb/image/upload/t_logo_med/cl_nintendo.png"},
+		{"cl_capcom", "https://images.igdb.com/igdb/image/upload/t_logo_med/cl_capcom.png"},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.imageID, func(t *testing.T) {
+			assert.Equal(t, tt.expected, CompanyLogoURL(tt.imageID))
+		})
+	}
+}

--- a/server/internal/igdb/country.go
+++ b/server/internal/igdb/country.go
@@ -1,0 +1,50 @@
+package igdb
+
+// CountryCodeToName maps ISO 3166-1 numeric country codes used by IGDB
+// to human-readable country names. Only the ~20 most common game
+// development countries are included; unknown codes return "".
+var CountryCodeToName = map[int]string{
+	36:  "Australia",
+	40:  "Austria",
+	56:  "Belgium",
+	76:  "Brazil",
+	124: "Canada",
+	156: "China",
+	203: "Czech Republic",
+	208: "Denmark",
+	246: "Finland",
+	250: "France",
+	276: "Germany",
+	344: "Hong Kong",
+	356: "India",
+	380: "Italy",
+	392: "Japan",
+	410: "South Korea",
+	484: "Mexico",
+	528: "Netherlands",
+	554: "New Zealand",
+	578: "Norway",
+	616: "Poland",
+	620: "Portugal",
+	643: "Russia",
+	702: "Singapore",
+	710: "South Africa",
+	724: "Spain",
+	752: "Sweden",
+	756: "Switzerland",
+	158: "Taiwan",
+	764: "Thailand",
+	792: "Turkey",
+	804: "Ukraine",
+	826: "United Kingdom",
+	840: "United States",
+}
+
+// CountryName returns the country name for an IGDB country code,
+// or an empty string if the code is unknown or zero.
+func CountryName(code int) string {
+	if code == 0 {
+		return ""
+	}
+	return CountryCodeToName[code]
+}

--- a/server/internal/igdb/country_test.go
+++ b/server/internal/igdb/country_test.go
@@ -1,0 +1,39 @@
+package igdb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCountryName(t *testing.T) {
+	tests := []struct {
+		name     string
+		code     int
+		expected string
+	}{
+		{"Japan", 392, "Japan"},
+		{"United States", 840, "United States"},
+		{"United Kingdom", 826, "United Kingdom"},
+		{"Sweden", 752, "Sweden"},
+		{"Canada", 124, "Canada"},
+		{"France", 250, "France"},
+		{"Germany", 276, "Germany"},
+		{"zero code", 0, ""},
+		{"unknown code", 999, ""},
+		{"negative code", -1, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, CountryName(tt.code))
+		})
+	}
+}
+
+func TestCountryCodeToName_Coverage(t *testing.T) {
+	// Verify all entries in the map return non-empty names
+	for code, name := range CountryCodeToName {
+		assert.NotEmpty(t, name, "code %d should have a non-empty name", code)
+		assert.Equal(t, name, CountryName(code))
+	}
+}

--- a/web/src/features/explore/components/__tests__/company-info-section.test.tsx
+++ b/web/src/features/explore/components/__tests__/company-info-section.test.tsx
@@ -1,0 +1,186 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect } from "vitest";
+import { CompanyInfoSection } from "@/features/explore/components/company-info-section";
+import type { CompanyInfo } from "@/types/api";
+
+const fullCompanyInfo: CompanyInfo = {
+  logoUrl: "/images/companies/capcom-logo.png",
+  description:
+    "Capcom Co., Ltd. is a Japanese video game developer and publisher known for creating multi-million-selling game franchises including Street Fighter, Mega Man, Resident Evil, Devil May Cry, Monster Hunter, and Ace Attorney. Founded in 1979, the company is headquartered in Osaka, Japan and has become one of the most recognized names in gaming worldwide with a reputation for high-quality action games.",
+  foundedYear: 1979,
+  country: "Japan",
+  websiteUrl: "https://www.capcom.com",
+  wikipediaUrl: "https://en.wikipedia.org/wiki/Capcom",
+};
+
+describe("CompanyInfoSection", () => {
+  it("renders the section when company info has content", () => {
+    render(<CompanyInfoSection companyInfo={fullCompanyInfo} />);
+    expect(screen.getByTestId("company-info-section")).toBeInTheDocument();
+  });
+
+  it("renders nothing when company info has no meaningful data", () => {
+    const { container } = render(
+      <CompanyInfoSection companyInfo={{ logoUrl: "/logo.png" }} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  // --- Description ---
+
+  it("renders description text", () => {
+    render(<CompanyInfoSection companyInfo={fullCompanyInfo} />);
+    expect(screen.getByTestId("company-description")).toBeInTheDocument();
+    expect(screen.getByTestId("company-description-text")).toHaveTextContent(
+      "Capcom Co., Ltd.",
+    );
+  });
+
+  it("shows description collapsed by default with line-clamp", () => {
+    render(<CompanyInfoSection companyInfo={fullCompanyInfo} />);
+    const text = screen.getByTestId("company-description-text");
+    expect(text.className).toContain("line-clamp-3");
+  });
+
+  it("expands description when 'Show more' is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CompanyInfoSection companyInfo={fullCompanyInfo} />);
+
+    const toggle = screen.getByTestId("company-description-toggle");
+    expect(toggle).toHaveTextContent("Show more");
+
+    await user.click(toggle);
+
+    const text = screen.getByTestId("company-description-text");
+    expect(text.className).not.toContain("line-clamp-3");
+    expect(toggle).toHaveTextContent("Show less");
+  });
+
+  it("collapses description when 'Show less' is clicked", async () => {
+    const user = userEvent.setup();
+    render(<CompanyInfoSection companyInfo={fullCompanyInfo} />);
+
+    const toggle = screen.getByTestId("company-description-toggle");
+    await user.click(toggle); // expand
+    await user.click(toggle); // collapse
+
+    const text = screen.getByTestId("company-description-text");
+    expect(text.className).toContain("line-clamp-3");
+    expect(toggle).toHaveTextContent("Show more");
+  });
+
+  it("hides toggle for short descriptions", () => {
+    render(
+      <CompanyInfoSection
+        companyInfo={{ description: "A short description." }}
+      />,
+    );
+    expect(screen.getByTestId("company-description")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("company-description-toggle"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides description section when no description", () => {
+    render(
+      <CompanyInfoSection
+        companyInfo={{ foundedYear: 1979, country: "Japan" }}
+      />,
+    );
+    expect(
+      screen.queryByTestId("company-description"),
+    ).not.toBeInTheDocument();
+  });
+
+  // --- Metadata ---
+
+  it("renders founded year and country", () => {
+    render(<CompanyInfoSection companyInfo={fullCompanyInfo} />);
+    const meta = screen.getByTestId("company-metadata");
+    expect(meta).toHaveTextContent("Founded 1979 \u2014 Japan");
+  });
+
+  it("renders only founded year when country is missing", () => {
+    render(
+      <CompanyInfoSection companyInfo={{ foundedYear: 1985 }} />,
+    );
+    const meta = screen.getByTestId("company-metadata");
+    expect(meta).toHaveTextContent("Founded 1985");
+    expect(meta).not.toHaveTextContent("\u2014");
+  });
+
+  it("renders only country when founded year is missing", () => {
+    render(
+      <CompanyInfoSection companyInfo={{ country: "Japan" }} />,
+    );
+    const meta = screen.getByTestId("company-metadata");
+    expect(meta).toHaveTextContent("Japan");
+    expect(meta).not.toHaveTextContent("Founded");
+  });
+
+  it("hides metadata when neither year nor country is present", () => {
+    render(
+      <CompanyInfoSection
+        companyInfo={{ description: "Some description that is long enough to be useful." }}
+      />,
+    );
+    expect(
+      screen.queryByTestId("company-metadata"),
+    ).not.toBeInTheDocument();
+  });
+
+  // --- Links ---
+
+  it("renders website link", () => {
+    render(<CompanyInfoSection companyInfo={fullCompanyInfo} />);
+    const link = screen.getByTestId("company-website-link");
+    expect(link).toHaveAttribute("href", "https://www.capcom.com");
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveTextContent("Website");
+  });
+
+  it("renders wikipedia link", () => {
+    render(<CompanyInfoSection companyInfo={fullCompanyInfo} />);
+    const link = screen.getByTestId("company-wikipedia-link");
+    expect(link).toHaveAttribute(
+      "href",
+      "https://en.wikipedia.org/wiki/Capcom",
+    );
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveTextContent("Wikipedia");
+  });
+
+  it("hides links section when no URLs provided", () => {
+    render(
+      <CompanyInfoSection
+        companyInfo={{ foundedYear: 1979, country: "Japan" }}
+      />,
+    );
+    expect(screen.queryByTestId("company-links")).not.toBeInTheDocument();
+  });
+
+  it("renders only website link when wikipedia is missing", () => {
+    render(
+      <CompanyInfoSection
+        companyInfo={{ websiteUrl: "https://example.com" }}
+      />,
+    );
+    expect(screen.getByTestId("company-website-link")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("company-wikipedia-link"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders only wikipedia link when website is missing", () => {
+    render(
+      <CompanyInfoSection
+        companyInfo={{ wikipediaUrl: "https://en.wikipedia.org/wiki/Test" }}
+      />,
+    );
+    expect(
+      screen.queryByTestId("company-website-link"),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId("company-wikipedia-link")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/explore/components/__tests__/developer-hero-banner.test.tsx
+++ b/web/src/features/explore/components/__tests__/developer-hero-banner.test.tsx
@@ -146,4 +146,34 @@ describe("DeveloperHeroBanner", () => {
     );
     expect(container.querySelector("img")).not.toBeInTheDocument();
   });
+
+  it("renders company logo instead of letter avatar when logoUrl provided", () => {
+    render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={5}
+        avgRating={0}
+        consoleCount={1}
+        logoUrl="/images/companies/capcom-logo.png"
+      />,
+    );
+    const logo = screen.getByTestId("developer-logo");
+    expect(logo).toBeInTheDocument();
+    expect(logo).toHaveAttribute("src", "/images/companies/capcom-logo.png");
+    expect(logo).toHaveAttribute("alt", "Capcom logo");
+    expect(screen.queryByTestId("developer-avatar")).not.toBeInTheDocument();
+  });
+
+  it("renders letter avatar when logoUrl is not provided", () => {
+    render(
+      <DeveloperHeroBanner
+        name="Capcom"
+        gameCount={5}
+        avgRating={0}
+        consoleCount={1}
+      />,
+    );
+    expect(screen.getByTestId("developer-avatar")).toBeInTheDocument();
+    expect(screen.queryByTestId("developer-logo")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/features/explore/components/company-info-section.tsx
+++ b/web/src/features/explore/components/company-info-section.tsx
@@ -1,0 +1,103 @@
+import { useState } from "react";
+import { Globe, BookOpen, ChevronDown, ChevronUp } from "lucide-react";
+import type { CompanyInfo } from "@/types/api";
+
+interface CompanyInfoSectionProps {
+  companyInfo: CompanyInfo;
+}
+
+export function CompanyInfoSection({ companyInfo }: CompanyInfoSectionProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const hasDescription = !!companyInfo.description;
+  const hasMetadata = !!companyInfo.foundedYear || !!companyInfo.country;
+  const hasLinks = !!companyInfo.websiteUrl || !!companyInfo.wikipediaUrl;
+
+  if (!hasDescription && !hasMetadata && !hasLinks) {
+    return null;
+  }
+
+  return (
+    <section data-testid="company-info-section" className="space-y-3">
+      {/* Description */}
+      {hasDescription && (
+        <div data-testid="company-description">
+          <div
+            className={`text-sm text-surface-300 leading-relaxed ${
+              !isExpanded ? "line-clamp-3" : ""
+            }`}
+            data-testid="company-description-text"
+          >
+            {companyInfo.description}
+          </div>
+          {/* Only show toggle if description is long enough to be clamped */}
+          {companyInfo.description!.length > 200 && (
+            <button
+              type="button"
+              onClick={() => setIsExpanded(!isExpanded)}
+              className="mt-1 flex items-center gap-1 text-xs font-medium text-primary-400 hover:text-primary-300 transition-colors"
+              data-testid="company-description-toggle"
+            >
+              {isExpanded ? (
+                <>
+                  Show less <ChevronUp className="h-3 w-3" />
+                </>
+              ) : (
+                <>
+                  Show more <ChevronDown className="h-3 w-3" />
+                </>
+              )}
+            </button>
+          )}
+        </div>
+      )}
+
+      {/* Metadata line */}
+      {hasMetadata && (
+        <p
+          className="text-xs text-surface-400"
+          data-testid="company-metadata"
+        >
+          {companyInfo.foundedYear && companyInfo.country
+            ? `Founded ${companyInfo.foundedYear} \u2014 ${companyInfo.country}`
+            : companyInfo.foundedYear
+              ? `Founded ${companyInfo.foundedYear}`
+              : companyInfo.country}
+        </p>
+      )}
+
+      {/* Links */}
+      {hasLinks && (
+        <div
+          className="flex items-center gap-3"
+          data-testid="company-links"
+        >
+          {companyInfo.websiteUrl && (
+            <a
+              href={companyInfo.websiteUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-surface-400 hover:text-surface-200 transition-colors"
+              data-testid="company-website-link"
+            >
+              <Globe className="h-3.5 w-3.5" />
+              Website
+            </a>
+          )}
+          {companyInfo.wikipediaUrl && (
+            <a
+              href={companyInfo.wikipediaUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-1 text-xs text-surface-400 hover:text-surface-200 transition-colors"
+              data-testid="company-wikipedia-link"
+            >
+              <BookOpen className="h-3.5 w-3.5" />
+              Wikipedia
+            </a>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/features/explore/components/developer-hero-banner.tsx
+++ b/web/src/features/explore/components/developer-hero-banner.tsx
@@ -6,6 +6,7 @@ interface DeveloperHeroBannerProps {
   avgRating: number;
   consoleCount: number;
   heroUrl?: string;
+  logoUrl?: string;
 }
 
 /** Generates a deterministic color from a string, used for the avatar circle. */
@@ -28,6 +29,7 @@ export function DeveloperHeroBanner({
   avgRating,
   consoleCount,
   heroUrl,
+  logoUrl,
 }: DeveloperHeroBannerProps) {
   const color = avatarColor(name);
 
@@ -59,14 +61,23 @@ export function DeveloperHeroBanner({
       {/* Content */}
       <div className="relative px-6 sm:px-8 py-10 sm:py-14">
         <div className="flex items-center gap-4 mb-4">
-          {/* Avatar circle */}
-          <div
-            className="flex-shrink-0 flex items-center justify-center w-14 h-14 rounded-full text-2xl font-bold text-white"
-            style={{ backgroundColor: color }}
-            data-testid="developer-avatar"
-          >
-            {name.charAt(0).toUpperCase()}
-          </div>
+          {/* Avatar / Logo */}
+          {logoUrl ? (
+            <img
+              src={logoUrl}
+              alt={`${name} logo`}
+              className="flex-shrink-0 w-16 h-16 object-contain rounded-lg"
+              data-testid="developer-logo"
+            />
+          ) : (
+            <div
+              className="flex-shrink-0 flex items-center justify-center w-14 h-14 rounded-full text-2xl font-bold text-white"
+              style={{ backgroundColor: color }}
+              data-testid="developer-avatar"
+            >
+              {name.charAt(0).toUpperCase()}
+            </div>
+          )}
           <h1 className="text-3xl sm:text-4xl font-bold text-white">
             {name}
           </h1>

--- a/web/src/pages/__tests__/developer-detail-page.test.tsx
+++ b/web/src/pages/__tests__/developer-detail-page.test.tsx
@@ -431,4 +431,49 @@ describe("DeveloperDetailPage", () => {
       screen.queryByTestId("developer-user-stats"),
     ).not.toBeInTheDocument();
   });
+
+  // --- Company Info section ---
+
+  it("shows company info section when companyInfo is present", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        companyInfo: {
+          description: "A famous game developer.",
+          foundedYear: 1979,
+          country: "Japan",
+          websiteUrl: "https://www.capcom.com",
+        },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByTestId("company-info-section")).toBeInTheDocument();
+    expect(screen.getByTestId("company-metadata")).toHaveTextContent(
+      "Founded 1979",
+    );
+  });
+
+  it("hides company info section when companyInfo is absent", () => {
+    renderPage();
+    expect(
+      screen.queryByTestId("company-info-section"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("passes logoUrl to hero banner when companyInfo has logo", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        companyInfo: {
+          logoUrl: "/images/companies/capcom-logo.png",
+        },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    const logo = screen.getByTestId("developer-logo");
+    expect(logo).toHaveAttribute("src", "/images/companies/capcom-logo.png");
+    expect(screen.queryByTestId("developer-avatar")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/pages/__tests__/publisher-detail-page.test.tsx
+++ b/web/src/pages/__tests__/publisher-detail-page.test.tsx
@@ -413,4 +413,49 @@ describe("PublisherDetailPage", () => {
       screen.queryByTestId("developer-user-stats"),
     ).not.toBeInTheDocument();
   });
+
+  // --- Company Info section ---
+
+  it("shows company info section when companyInfo is present", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        companyInfo: {
+          description: "A famous game publisher.",
+          foundedYear: 1889,
+          country: "Japan",
+          wikipediaUrl: "https://en.wikipedia.org/wiki/Nintendo",
+        },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByTestId("company-info-section")).toBeInTheDocument();
+    expect(screen.getByTestId("company-metadata")).toHaveTextContent(
+      "Founded 1889",
+    );
+  });
+
+  it("hides company info section when companyInfo is absent", () => {
+    renderPage();
+    expect(
+      screen.queryByTestId("company-info-section"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("passes logoUrl to hero banner when companyInfo has logo", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        companyInfo: {
+          logoUrl: "/images/companies/nintendo-logo.png",
+        },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    const logo = screen.getByTestId("developer-logo");
+    expect(logo).toHaveAttribute("src", "/images/companies/nintendo-logo.png");
+    expect(screen.queryByTestId("developer-avatar")).not.toBeInTheDocument();
+  });
 });

--- a/web/src/pages/developer-detail-page.tsx
+++ b/web/src/pages/developer-detail-page.tsx
@@ -6,6 +6,7 @@ import { GameCardSkeleton } from "@/components/ui";
 import { GameShelf } from "@/features/explore/components/game-shelf";
 import { DeveloperHeroBanner } from "@/features/explore/components/developer-hero-banner";
 import { DeveloperStatsCard } from "@/features/explore/components/developer-stats-card";
+import { CompanyInfoSection } from "@/features/explore/components/company-info-section";
 import { useDeveloperDetail } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -147,7 +148,13 @@ export function DeveloperDetailPage() {
         avgRating={developer.avgRating}
         consoleCount={developer.consoles.length}
         heroUrl={developer.heroUrl}
+        logoUrl={developer.companyInfo?.logoUrl}
       />
+
+      {/* Company Info */}
+      {developer.companyInfo && (
+        <CompanyInfoSection companyInfo={developer.companyInfo} />
+      )}
 
       {/* Top Rated Row */}
       {showTopRated && (

--- a/web/src/pages/publisher-detail-page.tsx
+++ b/web/src/pages/publisher-detail-page.tsx
@@ -6,6 +6,7 @@ import { GameCardSkeleton } from "@/components/ui";
 import { GameShelf } from "@/features/explore/components/game-shelf";
 import { DeveloperHeroBanner } from "@/features/explore/components/developer-hero-banner";
 import { DeveloperStatsCard } from "@/features/explore/components/developer-stats-card";
+import { CompanyInfoSection } from "@/features/explore/components/company-info-section";
 import { usePublisherDetail } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -156,7 +157,13 @@ export function PublisherDetailPage() {
         avgRating={publisher.avgRating}
         consoleCount={publisher.consoles.length}
         heroUrl={publisher.heroUrl}
+        logoUrl={publisher.companyInfo?.logoUrl}
       />
+
+      {/* Company Info */}
+      {publisher.companyInfo && (
+        <CompanyInfoSection companyInfo={publisher.companyInfo} />
+      )}
 
       {/* Top Rated Row */}
       {showTopRated && (

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1111,6 +1111,15 @@ export interface EntityUserStats {
   mostPlayedGame: Game | null;
 }
 
+export interface CompanyInfo {
+  logoUrl?: string;
+  description?: string;
+  foundedYear?: number;
+  country?: string;
+  websiteUrl?: string;
+  wikipediaUrl?: string;
+}
+
 export interface DeveloperDetailResponse {
   name: string;
   gameCount: number;
@@ -1123,6 +1132,7 @@ export interface DeveloperDetailResponse {
   platformBreakdown?: PlatformCount[];
   userStats?: EntityUserStats;
   publishers?: NameCount[];
+  companyInfo?: CompanyInfo;
 }
 
 export interface PublisherDetailResponse {
@@ -1137,6 +1147,7 @@ export interface PublisherDetailResponse {
   platformBreakdown?: PlatformCount[];
   userStats?: EntityUserStats;
   developers?: NameCount[];
+  companyInfo?: CompanyInfo;
 }
 
 export interface DeveloperSpotlightResponse {


### PR DESCRIPTION
## Summary
- Add lazy-fetched IGDB company metadata (logo, description, country, founding year, website/Wikipedia links) to developer and publisher detail pages
- New `Company` database model with automatic IGDB enrichment on first page visit
- Company logo replaces letter avatar in hero banner when available
- Collapsible description section with founding metadata and external links
- Applied consistently across web and player app

## Changes
- **Backend**: New Company model, IGDB client extensions, lazy fetch with 30-day refresh, country code mapping
- **Web**: CompanyInfoSection component, hero banner logo support, 20 new tests
- **Player**: DeveloperCompanyDescription composable with overflow detection, external links, 8 new tests

## Test plan
- [x] Go tests pass (including new company and IGDB client tests)
- [x] Web unit tests pass (1184 tests across 112 files)
- [x] Player desktop tests pass (595 tests)
- [x] TypeScript compilation clean
- [x] Code reviewer approved
- [x] UI agent review findings addressed (show more toggle + external links)