### PR TITLE
feat: add statistics and insights to developer/publisher detail pages

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreDeveloperTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreDeveloperTest.kt
@@ -1,6 +1,7 @@
 package com.spela.player.desktop.e2e
 
 import androidx.compose.ui.test.*
+import com.spela.player.domain.model.ActiveYears
 import com.spela.player.domain.model.CompanyInfo
 import com.spela.player.domain.model.DeveloperDetail
 import com.spela.player.domain.model.DeveloperDetailGenreBreakdown
@@ -9,6 +10,9 @@ import com.spela.player.domain.model.DeveloperDetailPublisher
 import com.spela.player.domain.model.DeveloperDetailUserStats
 import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.RatingDistribution
+import com.spela.player.domain.model.TimelineEntry
+import com.spela.player.domain.model.TimelineGame
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.SpScreen
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -350,6 +354,8 @@ class ExploreDeveloperTest {
         )
         advance(harness)
 
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_genre_breakdown"))
         onNodeWithTag("developer_genre_breakdown").assertExists()
         onNodeWithTag("developer_genre_header").assertExists()
         onNodeWithText("Genres").assertExists()
@@ -439,6 +445,8 @@ class ExploreDeveloperTest {
         )
         advance(harness)
 
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_user_stats"))
         onNodeWithTag("developer_user_stats").assertExists()
         onNodeWithTag("developer_user_stats_header").assertExists()
         onNodeWithText("Your Stats").assertExists()
@@ -463,6 +471,8 @@ class ExploreDeveloperTest {
         )
         advance(harness)
 
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_most_played_game"))
         onNodeWithTag("developer_most_played_game").assertExists()
         onNodeWithText("Most played:").assertExists()
     }
@@ -576,7 +586,13 @@ class ExploreDeveloperTest {
 
     private val companyInfoFull = CompanyInfo(
         logoUrl = "https://example.com/capcom-logo.png",
-        description = "Capcom Co., Ltd. is a Japanese video game developer and publisher known for creating multi-million-selling game franchises including Street Fighter, Mega Man, and Resident Evil.",
+        description = "Capcom Co., Ltd. is a Japanese video game developer and publisher headquartered in Osaka, Japan. " +
+            "The company was founded in 1979 and has since become one of the most recognizable names in the video game industry. " +
+            "Capcom is known for creating multi-million-selling game franchises including Street Fighter, Mega Man, Resident Evil, " +
+            "Devil May Cry, Monster Hunter, and Ace Attorney. The company has consistently been at the forefront of gaming innovation, " +
+            "pioneering genres and pushing technical boundaries across multiple console generations. With a catalog spanning decades, " +
+            "Capcom remains one of the most prolific and respected game developers in the world, continuing to produce critically acclaimed " +
+            "titles that resonate with both longtime fans and new players alike.",
         foundedYear = 1979,
         country = "Japan",
         websiteUrl = "https://www.capcom.com",
@@ -667,8 +683,6 @@ class ExploreDeveloperTest {
         onNodeWithTag("developer_company_about_header").assertExists()
         onNodeWithText("About").assertExists()
         onNodeWithTag("developer_company_description").assertExists()
-        onNodeWithTag("developer_company_description_toggle").assertExists()
-        onNodeWithText("Show more").assertExists()
     }
 
     @Test
@@ -742,5 +756,312 @@ class ExploreDeveloperTest {
         advance(harness)
 
         onNodeWithTag("developer_company_description_section").assertDoesNotExist()
+    }
+
+    // --- At a Glance Section ---
+
+    private val detailWithStats = richDeveloperDetail.copy(
+        activeYears = ActiveYears(first = 1987, last = 2003),
+        primaryGenre = "Platformer",
+    )
+
+    @Test
+    fun atAGlanceSectionAlwaysShown() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithStats)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_at_a_glance_section"))
+        onNodeWithTag("developer_at_a_glance_section").assertExists()
+        onNodeWithTag("developer_at_a_glance_header").assertExists()
+        onNodeWithText("At a Glance").assertExists()
+        onNodeWithTag("developer_at_a_glance_row").assertExists()
+    }
+
+    @Test
+    fun atAGlanceShowsGameCount() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithStats)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_glance_games"))
+        onNodeWithTag("developer_glance_games").assertExists()
+        onNodeWithText("8").assertExists()
+    }
+
+    @Test
+    fun atAGlanceShowsActiveYears() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithStats)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_glance_active_years"))
+        onNodeWithTag("developer_glance_active_years").assertExists()
+        onNodeWithText("1987-2003").assertExists()
+    }
+
+    @Test
+    fun atAGlanceShowsPrimaryGenre() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithStats)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_glance_primary_genre"))
+        onNodeWithTag("developer_glance_primary_genre").assertExists()
+        onNodeWithText("Platformer").assertExists()
+    }
+
+    @Test
+    fun atAGlanceHidesActiveYearsWhenNotProvided() = runComposeUiTest {
+        val harness = createHarness()
+        // richDeveloperDetail has no activeYears
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_at_a_glance_section"))
+        onNodeWithTag("developer_glance_active_years").assertDoesNotExist()
+    }
+
+    @Test
+    fun atAGlanceHidesPrimaryGenreWhenNotProvided() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_at_a_glance_section"))
+        onNodeWithTag("developer_glance_primary_genre").assertDoesNotExist()
+    }
+
+    // --- Release Timeline ---
+
+    private val sampleTimeline = listOf(
+        TimelineEntry(
+            year = 1991,
+            games = listOf(
+                TimelineGame(id = "tl-1", title = "Mega Man X", coverUrl = null, rating = 90.0),
+            ),
+        ),
+        TimelineEntry(
+            year = 1993,
+            games = listOf(
+                TimelineGame(id = "tl-2", title = "Street Fighter II Turbo", coverUrl = null, rating = 88.0),
+                TimelineGame(id = "tl-3", title = "Breath of Fire", coverUrl = null, rating = 78.0),
+            ),
+        ),
+    )
+
+    private val detailWithTimeline = richDeveloperDetail.copy(
+        timeline = sampleTimeline,
+    )
+
+    @Test
+    fun timelineSectionShownWhenDataPresent() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithTimeline)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_timeline_section"))
+        onNodeWithTag("developer_timeline_section").assertExists()
+        onNodeWithTag("developer_timeline_header").assertExists()
+        onNodeWithText("Release Timeline").assertExists()
+    }
+
+    @Test
+    fun timelineShowsYearColumns() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithTimeline)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_timeline_section"))
+        onNodeWithTag("developer_timeline_year_1991").assertExists()
+        onNodeWithTag("developer_timeline_year_1993").assertExists()
+    }
+
+    @Test
+    fun timelineShowsGameThumbnails() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithTimeline)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_timeline_section"))
+        onNodeWithTag("developer_timeline_game_tl-1").assertExists()
+        onNodeWithTag("developer_timeline_game_tl-2").assertExists()
+        onNodeWithTag("developer_timeline_game_tl-3").assertExists()
+    }
+
+    @Test
+    fun timelineHiddenWhenEmpty() = runComposeUiTest {
+        val harness = createHarness()
+        // richDeveloperDetail has empty timeline
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_timeline_section").assertDoesNotExist()
+    }
+
+    // --- Rating Distribution ---
+
+    private val sampleRatingDistribution = RatingDistribution(
+        excellent = 5,
+        good = 10,
+        average = 4,
+        poor = 1,
+        unrated = 3,
+    )
+
+    private val detailWithRatingDistribution = richDeveloperDetail.copy(
+        ratingDistribution = sampleRatingDistribution,
+    )
+
+    @Test
+    fun ratingDistributionShownWhenEnoughRatedGames() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithRatingDistribution)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_rating_distribution_section"))
+        onNodeWithTag("developer_rating_distribution_section").assertExists()
+        onNodeWithTag("developer_rating_distribution_header").assertExists()
+        onNodeWithText("Rating Distribution").assertExists()
+        onNodeWithTag("developer_rating_distribution_card").assertExists()
+    }
+
+    @Test
+    fun ratingDistributionShowsAllBars() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithRatingDistribution)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_rating_distribution_card"))
+        onNodeWithTag("developer_rating_bar_excellent").assertExists()
+        onNodeWithTag("developer_rating_bar_good").assertExists()
+        onNodeWithTag("developer_rating_bar_average").assertExists()
+        onNodeWithTag("developer_rating_bar_poor").assertExists()
+        onNodeWithTag("developer_rating_bar_unrated").assertExists()
+    }
+
+    @Test
+    fun ratingDistributionShowsCounts() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailWithRatingDistribution)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_detail_content")
+            .performScrollToNode(hasTestTag("developer_rating_distribution_card"))
+        // Verify the label texts exist
+        onNodeWithText("Excellent").assertExists()
+        onNodeWithText("Good").assertExists()
+        onNodeWithText("Average").assertExists()
+        onNodeWithText("Poor").assertExists()
+        onNodeWithText("Unrated").assertExists()
+    }
+
+    @Test
+    fun ratingDistributionHiddenWhenFewRatedGames() = runComposeUiTest {
+        val harness = createHarness()
+        val fewRatings = RatingDistribution(
+            excellent = 2, good = 1, average = 1, poor = 0, unrated = 5,
+        )
+        val detailFewRatings = richDeveloperDetail.copy(ratingDistribution = fewRatings)
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to detailFewRatings)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_rating_distribution_section").assertDoesNotExist()
+    }
+
+    @Test
+    fun ratingDistributionHiddenWhenNull() = runComposeUiTest {
+        val harness = createHarness()
+        // richDeveloperDetail has null ratingDistribution
+        harness.exploreRepo.developerDetails = mapOf("Capcom" to richDeveloperDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper("Capcom"))
+        )
+        advance(harness)
+
+        onNodeWithTag("developer_rating_distribution_section").assertDoesNotExist()
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -715,6 +715,31 @@ fun CompanyInfoDto.toDomain(): CompanyInfo = CompanyInfo(
     wikipediaUrl = wikipediaUrl,
 )
 
+fun ActiveYearsDto.toDomain(): ActiveYears = ActiveYears(
+    first = first,
+    last = last,
+)
+
+fun RatingDistributionDto.toDomain(): RatingDistribution = RatingDistribution(
+    excellent = excellent,
+    good = good,
+    average = average,
+    poor = poor,
+    unrated = unrated,
+)
+
+fun TimelineGameDto.toDomain(): TimelineGame = TimelineGame(
+    id = id,
+    title = title,
+    coverUrl = coverUrl,
+    rating = rating,
+)
+
+fun TimelineEntryDto.toDomain(): TimelineEntry = TimelineEntry(
+    year = year,
+    games = games.map { it.toDomain() },
+)
+
 fun DeveloperDetailResponseDto.toDomain(): DeveloperDetail = DeveloperDetail(
     name = name,
     gameCount = gameCount,
@@ -728,6 +753,10 @@ fun DeveloperDetailResponseDto.toDomain(): DeveloperDetail = DeveloperDetail(
     userStats = userStats?.toDomain(),
     publishers = publishers.map { it.toDomain() },
     games = games.map { it.toDomain() },
+    activeYears = activeYears?.toDomain(),
+    ratingDistribution = ratingDistribution?.toDomain(),
+    primaryGenre = primaryGenre,
+    timeline = timeline.map { it.toDomain() },
 )
 
 fun DeveloperSpotlightResponseDto.toDomain(): DeveloperSpotlight = DeveloperSpotlight(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1212,6 +1212,35 @@ data class DeveloperDetailPublisherDto(
 )
 
 @Serializable
+data class ActiveYearsDto(
+    val first: Int = 0,
+    val last: Int = 0,
+)
+
+@Serializable
+data class RatingDistributionDto(
+    val excellent: Int = 0,
+    val good: Int = 0,
+    val average: Int = 0,
+    val poor: Int = 0,
+    val unrated: Int = 0,
+)
+
+@Serializable
+data class TimelineGameDto(
+    val id: String = "",
+    val title: String = "",
+    val coverUrl: String? = null,
+    val rating: Double = 0.0,
+)
+
+@Serializable
+data class TimelineEntryDto(
+    val year: Int = 0,
+    val games: List<TimelineGameDto> = emptyList(),
+)
+
+@Serializable
 data class DeveloperDetailResponseDto(
     val name: String,
     val gameCount: Int,
@@ -1225,6 +1254,10 @@ data class DeveloperDetailResponseDto(
     val userStats: DeveloperDetailUserStatsDto? = null,
     val publishers: List<DeveloperDetailPublisherDto> = emptyList(),
     val games: List<GameDto>,
+    val activeYears: ActiveYearsDto? = null,
+    val ratingDistribution: RatingDistributionDto? = null,
+    val primaryGenre: String? = null,
+    val timeline: List<TimelineEntryDto> = emptyList(),
 )
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -165,6 +165,33 @@ data class CompanyInfo(
     val wikipediaUrl: String? = null,
 )
 
+data class ActiveYears(
+    val first: Int,
+    val last: Int,
+)
+
+data class RatingDistribution(
+    val excellent: Int,
+    val good: Int,
+    val average: Int,
+    val poor: Int,
+    val unrated: Int,
+) {
+    val totalRated: Int get() = excellent + good + average + poor
+}
+
+data class TimelineGame(
+    val id: String,
+    val title: String,
+    val coverUrl: String?,
+    val rating: Double,
+)
+
+data class TimelineEntry(
+    val year: Int,
+    val games: List<TimelineGame>,
+)
+
 data class DeveloperDetail(
     val name: String,
     val gameCount: Int,
@@ -178,6 +205,10 @@ data class DeveloperDetail(
     val userStats: DeveloperDetailUserStats? = null,
     val publishers: List<DeveloperDetailPublisher> = emptyList(),
     val games: List<Game>,
+    val activeYears: ActiveYears? = null,
+    val ratingDistribution: RatingDistribution? = null,
+    val primaryGenre: String? = null,
+    val timeline: List<TimelineEntry> = emptyList(),
 )
 
 data class DeveloperSpotlight(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
@@ -3,11 +3,13 @@ package com.spela.player.presentation.ui.feature.explore
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -19,14 +21,20 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CalendarMonth
+import androidx.compose.material.icons.filled.Category
 import androidx.compose.material.icons.filled.Favorite
+import androidx.compose.material.icons.filled.Gamepad
 import androidx.compose.material.icons.filled.SportsEsports
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.filled.TrendingUp
 import androidx.compose.material3.Icon
+import androidx.compose.material3.LinearProgressIndicator
 import androidx.compose.material3.Text
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.runtime.Composable
@@ -38,6 +46,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
@@ -49,11 +58,15 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
+import com.spela.player.domain.model.ActiveYears
 import com.spela.player.domain.model.CompanyInfo
 import com.spela.player.domain.model.DeveloperDetail
 import com.spela.player.domain.model.DeveloperDetailPublisher
 import com.spela.player.domain.model.DeveloperDetailUserStats
 import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.RatingDistribution
+import com.spela.player.domain.model.TimelineEntry
+import com.spela.player.domain.model.TimelineGame
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
@@ -720,5 +733,343 @@ internal fun DeveloperCompanyDescription(
         }
 
         Spacer(Modifier.height(SpSpacing.Large))
+    }
+}
+
+// --- At a Glance Stats Row ---
+
+@Composable
+internal fun DeveloperAtAGlance(
+    detail: DeveloperDetail,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .padding(top = SpSpacing.Large),
+    ) {
+        Text(
+            text = "At a Glance",
+            style = SpTypography.HeadlineMedium,
+            color = SpColor.OnBackground,
+            modifier = Modifier.testTag("developer_at_a_glance_header"),
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .horizontalScroll(rememberScrollState())
+                .testTag("developer_at_a_glance_row"),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+        ) {
+            GlanceStatItem(
+                icon = Icons.Filled.Gamepad,
+                value = "${detail.gameCount}",
+                label = "Games",
+                modifier = Modifier.testTag("developer_glance_games"),
+            )
+
+            val activeYears = detail.activeYears
+            if (activeYears != null && activeYears.first > 0) {
+                val yearRange = if (activeYears.first == activeYears.last) {
+                    "${activeYears.first}"
+                } else {
+                    "${activeYears.first}-${activeYears.last}"
+                }
+                GlanceStatItem(
+                    icon = Icons.Filled.CalendarMonth,
+                    value = yearRange,
+                    label = "Active",
+                    modifier = Modifier.testTag("developer_glance_active_years"),
+                )
+            }
+
+            val primaryGenre = detail.primaryGenre
+            if (!primaryGenre.isNullOrBlank()) {
+                GlanceStatItem(
+                    icon = Icons.Filled.Category,
+                    value = primaryGenre,
+                    label = "Primary genre",
+                    modifier = Modifier.testTag("developer_glance_primary_genre"),
+                )
+            }
+
+            if (detail.consoles.isNotEmpty()) {
+                GlanceStatItem(
+                    icon = Icons.Filled.SportsEsports,
+                    value = "${detail.consoles.size}",
+                    label = "Platforms",
+                    modifier = Modifier.testTag("developer_glance_platforms"),
+                )
+            }
+
+            if (detail.avgRating > 0) {
+                GlanceStatItem(
+                    icon = Icons.Filled.Star,
+                    value = formatRating(detail.avgRating),
+                    label = "Avg rating",
+                    modifier = Modifier.testTag("developer_glance_avg_rating"),
+                )
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Large))
+    }
+}
+
+@Composable
+private fun GlanceStatItem(
+    icon: ImageVector,
+    value: String,
+    label: String,
+    modifier: Modifier = Modifier,
+) {
+    SpCard(
+        modifier = modifier.width(IntrinsicSize.Min),
+    ) {
+        Column(
+            modifier = Modifier.padding(
+                horizontal = SpSpacing.Medium,
+                vertical = SpSpacing.Small,
+            ),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Icon(
+                imageVector = icon,
+                contentDescription = null,
+                tint = SpColor.Primary,
+                modifier = Modifier.size(18.dp),
+            )
+            Spacer(Modifier.height(SpSpacing.XXSmall))
+            Text(
+                text = value,
+                style = SpTypography.TitleSmall,
+                color = SpColor.OnBackground,
+                maxLines = 1,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = label,
+                style = SpTypography.LabelSmall,
+                color = SpColor.OnBackgroundTertiary,
+                maxLines = 1,
+                textAlign = TextAlign.Center,
+            )
+        }
+    }
+}
+
+// --- Release Timeline ---
+
+@Composable
+internal fun DeveloperTimeline(
+    timeline: List<TimelineEntry>,
+    onGameSelected: (String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.padding(top = SpSpacing.Large)) {
+        Text(
+            text = "Release Timeline",
+            style = SpTypography.HeadlineMedium,
+            color = SpColor.OnBackground,
+            modifier = Modifier
+                .padding(horizontal = SpSpacing.ScreenHorizontal)
+                .testTag("developer_timeline_header"),
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+        LazyRow(
+            contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Large),
+            modifier = Modifier.testTag("developer_timeline_row"),
+        ) {
+            items(
+                items = timeline,
+                key = { "timeline_${it.year}" },
+            ) { entry ->
+                TimelineYearColumn(
+                    entry = entry,
+                    onGameSelected = onGameSelected,
+                )
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Large))
+    }
+}
+
+@Composable
+private fun TimelineYearColumn(
+    entry: TimelineEntry,
+    onGameSelected: (String) -> Unit,
+) {
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier.testTag("developer_timeline_year_${entry.year}"),
+    ) {
+        Text(
+            text = "${entry.year}",
+            style = SpTypography.TitleSmall,
+            color = SpColor.Primary,
+        )
+        Spacer(Modifier.height(SpSpacing.Small))
+        entry.games.forEach { game ->
+            TimelineGameThumb(
+                game = game,
+                onClick = { onGameSelected(game.id) },
+            )
+            Spacer(Modifier.height(SpSpacing.XSmall))
+        }
+    }
+}
+
+@Composable
+private fun TimelineGameThumb(
+    game: TimelineGame,
+    onClick: () -> Unit,
+) {
+    SpCard(
+        modifier = Modifier
+            .width(SpSpacing.CoverSmallWidth)
+            .testTag("developer_timeline_game_${game.id}")
+            .semantics {
+                contentDescription = "${game.title}, ${game.rating.toInt()}"
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Column {
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.title} cover",
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(topStart = SpSpacing.RadiusSmall, topEnd = SpSpacing.RadiusSmall)),
+                cornerRadius = 0.dp,
+            )
+            Text(
+                text = game.title,
+                style = SpTypography.LabelSmall,
+                color = SpColor.OnCard,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.padding(SpSpacing.XXSmall),
+            )
+        }
+    }
+}
+
+// --- Rating Distribution ---
+
+@Composable
+internal fun DeveloperRatingDistribution(
+    distribution: RatingDistribution,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = SpSpacing.ScreenHorizontal)
+            .padding(top = SpSpacing.Large),
+    ) {
+        Text(
+            text = "Rating Distribution",
+            style = SpTypography.HeadlineMedium,
+            color = SpColor.OnBackground,
+            modifier = Modifier.testTag("developer_rating_distribution_header"),
+        )
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        SpCard(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("developer_rating_distribution_card"),
+        ) {
+            Column(
+                modifier = Modifier.padding(SpSpacing.Default),
+                verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            ) {
+                val maxCount = maxOf(
+                    distribution.excellent,
+                    distribution.good,
+                    distribution.average,
+                    distribution.poor,
+                    distribution.unrated,
+                    1,
+                )
+                RatingBar(
+                    label = "Excellent",
+                    count = distribution.excellent,
+                    maxCount = maxCount,
+                    color = SpColor.Success,
+                    testTag = "developer_rating_bar_excellent",
+                )
+                RatingBar(
+                    label = "Good",
+                    count = distribution.good,
+                    maxCount = maxCount,
+                    color = SpColor.Rating,
+                    testTag = "developer_rating_bar_good",
+                )
+                RatingBar(
+                    label = "Average",
+                    count = distribution.average,
+                    maxCount = maxCount,
+                    color = SpColor.Warning,
+                    testTag = "developer_rating_bar_average",
+                )
+                RatingBar(
+                    label = "Poor",
+                    count = distribution.poor,
+                    maxCount = maxCount,
+                    color = SpColor.Error,
+                    testTag = "developer_rating_bar_poor",
+                )
+                RatingBar(
+                    label = "Unrated",
+                    count = distribution.unrated,
+                    maxCount = maxCount,
+                    color = SpColor.OnBackgroundTertiary,
+                    testTag = "developer_rating_bar_unrated",
+                )
+            }
+        }
+        Spacer(Modifier.height(SpSpacing.Large))
+    }
+}
+
+@Composable
+private fun RatingBar(
+    label: String,
+    count: Int,
+    maxCount: Int,
+    color: Color,
+    testTag: String,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag(testTag),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        Text(
+            text = label,
+            style = SpTypography.LabelMedium,
+            color = SpColor.OnBackgroundSecondary,
+            modifier = Modifier.width(72.dp),
+        )
+        LinearProgressIndicator(
+            progress = { if (maxCount > 0) count.toFloat() / maxCount else 0f },
+            modifier = Modifier
+                .weight(1f)
+                .height(8.dp)
+                .clip(RoundedCornerShape(4.dp)),
+            color = color,
+            trackColor = SpColor.SurfaceVariant,
+        )
+        Text(
+            text = "$count",
+            style = SpTypography.LabelMedium,
+            color = SpColor.OnBackgroundTertiary,
+            modifier = Modifier.width(28.dp),
+            textAlign = TextAlign.End,
+        )
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
@@ -36,11 +36,14 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.feature.explore.DeveloperAtAGlance
 import com.spela.player.presentation.ui.feature.explore.DeveloperCompanyDescription
 import com.spela.player.presentation.ui.feature.explore.DeveloperGameItem
 import com.spela.player.presentation.ui.feature.explore.DeveloperGenreBreakdown
 import com.spela.player.presentation.ui.feature.explore.DeveloperHeroBanner
 import com.spela.player.presentation.ui.feature.explore.DeveloperPublishersSection
+import com.spela.player.presentation.ui.feature.explore.DeveloperRatingDistribution
+import com.spela.player.presentation.ui.feature.explore.DeveloperTimeline
 import com.spela.player.presentation.ui.feature.explore.DeveloperTopRatedRow
 import com.spela.player.presentation.ui.feature.explore.DeveloperUserStatsCard
 import com.spela.player.presentation.ui.theme.SpColor
@@ -107,7 +110,7 @@ fun ExploreDeveloperScreen(
                         modifier = Modifier.fillMaxSize().testTag("developer_detail_content"),
                         contentPadding = PaddingValues(bottom = SpSpacing.XXLarge),
                     ) {
-                        // (a) Hero Banner
+                        // 1. Hero Banner
                         item {
                             DeveloperHeroBanner(
                                 detail = detail,
@@ -115,7 +118,7 @@ fun ExploreDeveloperScreen(
                             )
                         }
 
-                        // Company Description (below hero banner)
+                        // 2. Company Description (below hero banner)
                         val companyInfo = detail.companyInfo
                         if (companyInfo?.description != null) {
                             item {
@@ -127,7 +130,15 @@ fun ExploreDeveloperScreen(
                             }
                         }
 
-                        // (b) Top Rated Row
+                        // 3. At a Glance stats row
+                        item {
+                            DeveloperAtAGlance(
+                                detail = detail,
+                                modifier = Modifier.testTag("developer_at_a_glance_section"),
+                            )
+                        }
+
+                        // 4. Top Rated Row
                         if (detail.topGames.isNotEmpty() && detail.gameCount >= 5) {
                             item {
                                 DeveloperTopRatedRow(
@@ -138,7 +149,29 @@ fun ExploreDeveloperScreen(
                             }
                         }
 
-                        // (c) Genre Breakdown
+                        // 5. Release Timeline
+                        if (detail.timeline.isNotEmpty()) {
+                            item {
+                                DeveloperTimeline(
+                                    timeline = detail.timeline,
+                                    onGameSelected = onGameSelected,
+                                    modifier = Modifier.testTag("developer_timeline_section"),
+                                )
+                            }
+                        }
+
+                        // 6. Rating Distribution (only shown when 5+ rated games)
+                        val ratingDist = detail.ratingDistribution
+                        if (ratingDist != null && ratingDist.totalRated >= 5) {
+                            item {
+                                DeveloperRatingDistribution(
+                                    distribution = ratingDist,
+                                    modifier = Modifier.testTag("developer_rating_distribution_section"),
+                                )
+                            }
+                        }
+
+                        // 7. Genre Breakdown
                         if (detail.genreBreakdown.size >= 2) {
                             item {
                                 DeveloperGenreBreakdown(
@@ -155,7 +188,7 @@ fun ExploreDeveloperScreen(
                             }
                         }
 
-                        // (d) User Stats Card
+                        // 8. User Stats Card
                         if (detail.userStats != null) {
                             item {
                                 DeveloperUserStatsCard(
@@ -167,7 +200,7 @@ fun ExploreDeveloperScreen(
                             }
                         }
 
-                        // (e) Games Grouped by Platform
+                        // 9. Games Grouped by Platform
                         val filteredGames = state.filteredGames
                         if (filteredGames.isEmpty() && !state.isLoading) {
                             item {
@@ -269,7 +302,7 @@ fun ExploreDeveloperScreen(
                             }
                         }
 
-                        // (f) Publishers Section
+                        // 10. Publishers Section
                         if (detail.publishers.isNotEmpty()) {
                             item {
                                 DeveloperPublishersSection(

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -73,36 +73,73 @@ type CompanyInfo struct {
 	WikipediaURL string `json:"wikipediaUrl,omitempty"`
 }
 
+// ActiveYears represents the first and last release years of a developer/publisher's games.
+type ActiveYears struct {
+	First int `json:"first"`
+	Last  int `json:"last"`
+}
+
+// RatingDistribution holds counts of games in each rating bucket.
+type RatingDistribution struct {
+	Excellent int `json:"excellent"`
+	Good      int `json:"good"`
+	Average   int `json:"average"`
+	Poor      int `json:"poor"`
+	Unrated   int `json:"unrated"`
+}
+
+// TimelineGame is a lightweight game reference used in timeline entries.
+type TimelineGame struct {
+	ID       string  `json:"id"`
+	Title    string  `json:"title"`
+	CoverURL string  `json:"coverUrl"`
+	Rating   float64 `json:"rating"`
+}
+
+// TimelineEntry groups games by release year.
+type TimelineEntry struct {
+	Year  int            `json:"year"`
+	Games []TimelineGame `json:"games"`
+}
+
 // DeveloperDetailResponse is the API response for a developer detail page.
 type DeveloperDetailResponse struct {
-	Name              string              `json:"name"`
-	GameCount         int                 `json:"gameCount"`
-	AvgRating         float64             `json:"avgRating"`
-	Consoles          []string            `json:"consoles"`
-	Games             []GameResponse      `json:"games"`
-	HeroURL           string              `json:"heroUrl,omitempty"`
-	TopGames          []GameResponse      `json:"topGames"`
-	GenreBreakdown    []GenreCount        `json:"genreBreakdown"`
-	PlatformBreakdown []PlatformCount     `json:"platformBreakdown"`
-	UserStats         *EntityUserStats    `json:"userStats,omitempty"`
-	Publishers        []NameCount         `json:"publishers"`
-	CompanyInfo       *CompanyInfo        `json:"companyInfo,omitempty"`
+	Name               string              `json:"name"`
+	GameCount          int                 `json:"gameCount"`
+	AvgRating          float64             `json:"avgRating"`
+	Consoles           []string            `json:"consoles"`
+	Games              []GameResponse      `json:"games"`
+	HeroURL            string              `json:"heroUrl,omitempty"`
+	TopGames           []GameResponse      `json:"topGames"`
+	GenreBreakdown     []GenreCount        `json:"genreBreakdown"`
+	PlatformBreakdown  []PlatformCount     `json:"platformBreakdown"`
+	UserStats          *EntityUserStats    `json:"userStats,omitempty"`
+	Publishers         []NameCount         `json:"publishers"`
+	CompanyInfo        *CompanyInfo        `json:"companyInfo,omitempty"`
+	ActiveYears        *ActiveYears        `json:"activeYears,omitempty"`
+	RatingDistribution RatingDistribution  `json:"ratingDistribution"`
+	PrimaryGenre       string              `json:"primaryGenre,omitempty"`
+	Timeline           []TimelineEntry     `json:"timeline,omitempty"`
 }
 
 // PublisherDetailResponse is the API response for a publisher detail page.
 type PublisherDetailResponse struct {
-	Name              string              `json:"name"`
-	GameCount         int                 `json:"gameCount"`
-	AvgRating         float64             `json:"avgRating"`
-	Consoles          []string            `json:"consoles"`
-	Games             []GameResponse      `json:"games"`
-	HeroURL           string              `json:"heroUrl,omitempty"`
-	TopGames          []GameResponse      `json:"topGames"`
-	GenreBreakdown    []GenreCount        `json:"genreBreakdown"`
-	PlatformBreakdown []PlatformCount     `json:"platformBreakdown"`
-	UserStats         *EntityUserStats    `json:"userStats,omitempty"`
-	Developers        []NameCount         `json:"developers"`
-	CompanyInfo       *CompanyInfo        `json:"companyInfo,omitempty"`
+	Name               string              `json:"name"`
+	GameCount          int                 `json:"gameCount"`
+	AvgRating          float64             `json:"avgRating"`
+	Consoles           []string            `json:"consoles"`
+	Games              []GameResponse      `json:"games"`
+	HeroURL            string              `json:"heroUrl,omitempty"`
+	TopGames           []GameResponse      `json:"topGames"`
+	GenreBreakdown     []GenreCount        `json:"genreBreakdown"`
+	PlatformBreakdown  []PlatformCount     `json:"platformBreakdown"`
+	UserStats          *EntityUserStats    `json:"userStats,omitempty"`
+	Developers         []NameCount         `json:"developers"`
+	CompanyInfo        *CompanyInfo        `json:"companyInfo,omitempty"`
+	ActiveYears        *ActiveYears        `json:"activeYears,omitempty"`
+	RatingDistribution RatingDistribution  `json:"ratingDistribution"`
+	PrimaryGenre       string              `json:"primaryGenre,omitempty"`
+	Timeline           []TimelineEntry     `json:"timeline,omitempty"`
 }
 
 // PlatformCount holds a console name/ID and the number of games on that platform.

--- a/server/internal/api/explore_handler_developer.go
+++ b/server/internal/api/explore_handler_developer.go
@@ -144,20 +144,30 @@ func (h *ExploreHandler) GetDeveloperDetail(c *gin.Context) {
 	// Look up company metadata (lazy-fetched from IGDB)
 	companyInfo := h.lookupCompanyInfo(canonicalName)
 
+	// Statistics fields
+	activeYears := buildActiveYears(games)
+	ratingDist := buildRatingDistribution(games)
+	primaryGenre := buildPrimaryGenre(games)
+	timeline := buildTimeline(games)
+
 	c.Header("Cache-Control", "private, max-age=300")
 	c.JSON(http.StatusOK, DeveloperDetailResponse{
-		Name:              canonicalName,
-		GameCount:         len(games),
-		AvgRating:         avgRating,
-		Consoles:          consoles,
-		Games:             gameResponses,
-		HeroURL:           heroURL,
-		TopGames:          topGames,
-		GenreBreakdown:    genreBreakdown,
-		PlatformBreakdown: platformBreakdown,
-		UserStats:         userStats,
-		Publishers:        publishers,
-		CompanyInfo:       companyInfo,
+		Name:               canonicalName,
+		GameCount:          len(games),
+		AvgRating:          avgRating,
+		Consoles:           consoles,
+		Games:              gameResponses,
+		HeroURL:            heroURL,
+		TopGames:           topGames,
+		GenreBreakdown:     genreBreakdown,
+		PlatformBreakdown:  platformBreakdown,
+		UserStats:          userStats,
+		Publishers:         publishers,
+		CompanyInfo:        companyInfo,
+		ActiveYears:        activeYears,
+		RatingDistribution: ratingDist,
+		PrimaryGenre:       primaryGenre,
+		Timeline:           timeline,
 	})
 }
 
@@ -212,20 +222,30 @@ func (h *ExploreHandler) GetPublisherDetail(c *gin.Context) {
 	// Look up company metadata (lazy-fetched from IGDB)
 	companyInfo := h.lookupCompanyInfo(canonicalName)
 
+	// Statistics fields
+	activeYears := buildActiveYears(games)
+	ratingDist := buildRatingDistribution(games)
+	primaryGenre := buildPrimaryGenre(games)
+	timeline := buildTimeline(games)
+
 	c.Header("Cache-Control", "private, max-age=300")
 	c.JSON(http.StatusOK, PublisherDetailResponse{
-		Name:              canonicalName,
-		GameCount:         len(games),
-		AvgRating:         avgRating,
-		Consoles:          consoles,
-		Games:             gameResponses,
-		HeroURL:           heroURL,
-		TopGames:          topGames,
-		GenreBreakdown:    genreBreakdown,
-		PlatformBreakdown: platformBreakdown,
-		UserStats:         userStats,
-		Developers:        developers,
-		CompanyInfo:       companyInfo,
+		Name:               canonicalName,
+		GameCount:          len(games),
+		AvgRating:          avgRating,
+		Consoles:           consoles,
+		Games:              gameResponses,
+		HeroURL:            heroURL,
+		TopGames:           topGames,
+		GenreBreakdown:     genreBreakdown,
+		PlatformBreakdown:  platformBreakdown,
+		UserStats:          userStats,
+		Developers:         developers,
+		CompanyInfo:        companyInfo,
+		ActiveYears:        activeYears,
+		RatingDistribution: ratingDist,
+		PrimaryGenre:       primaryGenre,
+		Timeline:           timeline,
 	})
 }
 
@@ -516,6 +536,129 @@ func (h *ExploreHandler) GetDeveloperSpotlight(c *gin.Context) {
 		TopGames:  ToGameResponses(topGames, h.DB, userID),
 		HeroURL:   heroURL,
 	})
+}
+
+// parseReleaseYear extracts the year from a release date string (format "2006-01-02").
+// Returns 0 if the string is empty or cannot be parsed.
+func parseReleaseYear(releaseDate string) int {
+	if releaseDate == "" {
+		return 0
+	}
+	t, err := time.Parse("2006-01-02", releaseDate)
+	if err != nil {
+		return 0
+	}
+	return t.Year()
+}
+
+// buildActiveYears computes the first and last release years from a slice of games.
+// Returns nil if no games have valid release dates.
+func buildActiveYears(games []db.Game) *ActiveYears {
+	first := 0
+	last := 0
+	for _, g := range games {
+		year := parseReleaseYear(g.ReleaseDate)
+		if year == 0 {
+			continue
+		}
+		if first == 0 || year < first {
+			first = year
+		}
+		if year > last {
+			last = year
+		}
+	}
+	if first == 0 {
+		return nil
+	}
+	return &ActiveYears{First: first, Last: last}
+}
+
+// buildRatingDistribution computes rating bucket counts from a slice of games.
+// Buckets: excellent (90-100), good (70-89), average (50-69), poor (0-49 excluding 0), unrated (0/no rating).
+func buildRatingDistribution(games []db.Game) RatingDistribution {
+	var dist RatingDistribution
+	for _, g := range games {
+		r := g.Rating
+		switch {
+		case r == 0:
+			dist.Unrated++
+		case r >= 90:
+			dist.Excellent++
+		case r >= 70:
+			dist.Good++
+		case r >= 50:
+			dist.Average++
+		default:
+			dist.Poor++
+		}
+	}
+	return dist
+}
+
+// buildPrimaryGenre returns the genre with the most games, or "" if no games have genre data.
+// Handles comma-separated genre values by splitting and trimming each part.
+func buildPrimaryGenre(games []db.Game) string {
+	genreCounts := make(map[string]int)
+	for _, g := range games {
+		if g.Genre == "" {
+			continue
+		}
+		parts := strings.Split(g.Genre, ",")
+		for _, part := range parts {
+			genre := strings.TrimSpace(part)
+			if genre != "" {
+				genreCounts[genre]++
+			}
+		}
+	}
+	if len(genreCounts) == 0 {
+		return ""
+	}
+	bestGenre := ""
+	bestCount := 0
+	for genre, count := range genreCounts {
+		if count > bestCount || (count == bestCount && genre < bestGenre) {
+			bestGenre = genre
+			bestCount = count
+		}
+	}
+	return bestGenre
+}
+
+// buildTimeline groups games by release year for timeline visualization.
+// Returns nil if fewer than 3 games have release dates or fewer than 2 distinct years.
+func buildTimeline(games []db.Game) []TimelineEntry {
+	yearGames := make(map[int][]TimelineGame)
+	datedCount := 0
+	for _, g := range games {
+		year := parseReleaseYear(g.ReleaseDate)
+		if year == 0 {
+			continue
+		}
+		datedCount++
+		yearGames[year] = append(yearGames[year], TimelineGame{
+			ID:       strconv.FormatUint(uint64(g.ID), 10),
+			Title:    g.Title,
+			CoverURL: g.CoverURL,
+			Rating:   g.Rating,
+		})
+	}
+	if datedCount < 3 || len(yearGames) < 2 {
+		return nil
+	}
+
+	years := make([]int, 0, len(yearGames))
+	for y := range yearGames {
+		years = append(years, y)
+	}
+	sort.Ints(years)
+
+	timeline := make([]TimelineEntry, len(years))
+	for i, y := range years {
+		timeline[i] = TimelineEntry{Year: y, Games: yearGames[y]}
+	}
+	return timeline
 }
 
 // calcRatingAndConsoles computes the average rating and distinct console display names

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -4657,3 +4657,497 @@ func TestGetPublisherDetail_NoPlayHistory(t *testing.T) {
 
 	assert.Nil(t, resp.UserStats)
 }
+
+// --- Phase 3: Statistics Fields tests ---
+
+// createExploreGameComplete creates a game with developer, publisher, genre, rating, and release date.
+func createExploreGameComplete(t *testing.T, database *gorm.DB, consoleAbbr, title string, rating float64, developer, publisher, genre, releaseDate string) db.Game {
+	t.Helper()
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", consoleAbbr).First(&console).Error)
+	game := db.Game{
+		ConsoleID:   console.ID,
+		Title:       title,
+		FileName:    title + ".rom",
+		FilePath:    consoleAbbr + "/" + title + ".rom",
+		Rating:      rating,
+		Genre:       genre,
+		Developer:   developer,
+		Publisher:   publisher,
+		ReleaseDate: releaseDate,
+	}
+	require.NoError(t, database.Create(&game).Error)
+	return game
+}
+
+// --- ActiveYears tests ---
+
+func TestGetDeveloperDetail_ActiveYears(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Early Game", 80, "YearsDev", "Pub", "Action", "1987-03-15")
+	createExploreGameComplete(t, env.database, "SNES", "Mid Game", 85, "YearsDev", "Pub", "Action", "1995-06-20")
+	createExploreGameComplete(t, env.database, "GBA", "Late Game", 90, "YearsDev", "Pub", "Action", "2003-11-10")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/YearsDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.NotNil(t, resp.ActiveYears)
+	assert.Equal(t, 1987, resp.ActiveYears.First)
+	assert.Equal(t, 2003, resp.ActiveYears.Last)
+}
+
+func TestGetDeveloperDetail_ActiveYears_SingleGame(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Only Game", 80, "SingleYearDev", "Pub", "Action", "1991-08-12")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/SingleYearDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.NotNil(t, resp.ActiveYears)
+	assert.Equal(t, 1991, resp.ActiveYears.First)
+	assert.Equal(t, 1991, resp.ActiveYears.Last)
+}
+
+func TestGetDeveloperDetail_ActiveYears_NoDates(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "No Date Game", 80, "NoDateDev", "Pub", "Action", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/NoDateDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Nil(t, resp.ActiveYears)
+}
+
+func TestGetDeveloperDetail_ActiveYears_MixedDates(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Dated Game", 80, "MixDateDev", "Pub", "Action", "1993-05-01")
+	createExploreGameComplete(t, env.database, "SNES", "Undated Game", 85, "MixDateDev", "Pub", "Action", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/MixDateDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.NotNil(t, resp.ActiveYears)
+	assert.Equal(t, 1993, resp.ActiveYears.First)
+	assert.Equal(t, 1993, resp.ActiveYears.Last)
+}
+
+// --- RatingDistribution tests ---
+
+func TestGetDeveloperDetail_RatingDistribution(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Excellent Game", 95, "RatingDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "NES", "Good Game 1", 80, "RatingDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "SNES", "Good Game 2", 75, "RatingDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "SNES", "Average Game", 60, "RatingDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "GBA", "Poor Game", 30, "RatingDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "GBA", "Unrated Game", 0, "RatingDev", "Pub", "Action", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/RatingDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, 1, resp.RatingDistribution.Excellent)
+	assert.Equal(t, 2, resp.RatingDistribution.Good)
+	assert.Equal(t, 1, resp.RatingDistribution.Average)
+	assert.Equal(t, 1, resp.RatingDistribution.Poor)
+	assert.Equal(t, 1, resp.RatingDistribution.Unrated)
+}
+
+func TestGetDeveloperDetail_RatingDistribution_AllUnrated(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Unrated 1", 0, "AllUnratedDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "SNES", "Unrated 2", 0, "AllUnratedDev", "Pub", "Action", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/AllUnratedDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, 0, resp.RatingDistribution.Excellent)
+	assert.Equal(t, 0, resp.RatingDistribution.Good)
+	assert.Equal(t, 0, resp.RatingDistribution.Average)
+	assert.Equal(t, 0, resp.RatingDistribution.Poor)
+	assert.Equal(t, 2, resp.RatingDistribution.Unrated)
+}
+
+func TestGetDeveloperDetail_RatingDistribution_BoundaryValues(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Boundary 90", 90, "BoundaryDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "NES", "Boundary 70", 70, "BoundaryDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "SNES", "Boundary 50", 50, "BoundaryDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "GBA", "Boundary 49", 49, "BoundaryDev", "Pub", "Action", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/BoundaryDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, 1, resp.RatingDistribution.Excellent) // 90 is in excellent
+	assert.Equal(t, 1, resp.RatingDistribution.Good)      // 70 is in good
+	assert.Equal(t, 1, resp.RatingDistribution.Average)    // 50 is in average
+	assert.Equal(t, 1, resp.RatingDistribution.Poor)       // 49 is in poor
+	assert.Equal(t, 0, resp.RatingDistribution.Unrated)
+}
+
+// --- PrimaryGenre tests ---
+
+func TestGetDeveloperDetail_PrimaryGenre(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Action 1", 85, "PGenreDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "NES", "Action 2", 80, "PGenreDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "SNES", "RPG 1", 90, "PGenreDev", "Pub", "RPG", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/PGenreDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "Action", resp.PrimaryGenre)
+}
+
+func TestGetDeveloperDetail_PrimaryGenre_CommaSeparated(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Multi 1", 85, "CSVGenreDev", "Pub", "Action, RPG", "")
+	createExploreGameComplete(t, env.database, "SNES", "Multi 2", 80, "CSVGenreDev", "Pub", "Action", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/CSVGenreDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "Action", resp.PrimaryGenre)
+}
+
+func TestGetDeveloperDetail_PrimaryGenre_NoGenres(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "No Genre", 85, "NoGenrePDev", "Pub", "", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/NoGenrePDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Empty(t, resp.PrimaryGenre)
+}
+
+func TestGetDeveloperDetail_PrimaryGenre_Tie(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Action Game", 85, "TieGenreDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "SNES", "RPG Game", 80, "TieGenreDev", "Pub", "RPG", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/TieGenreDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// On a tie, alphabetically first genre wins
+	assert.Equal(t, "Action", resp.PrimaryGenre)
+}
+
+// --- Timeline tests ---
+
+func TestGetDeveloperDetail_Timeline(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Game 1991a", 80, "TimelineDev", "Pub", "Action", "1991-03-15")
+	createExploreGameComplete(t, env.database, "NES", "Game 1991b", 85, "TimelineDev", "Pub", "Action", "1991-11-20")
+	createExploreGameComplete(t, env.database, "SNES", "Game 1995", 90, "TimelineDev", "Pub", "RPG", "1995-06-01")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/TimelineDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.Timeline, 2)
+	// Sorted by year ascending
+	assert.Equal(t, 1991, resp.Timeline[0].Year)
+	assert.Len(t, resp.Timeline[0].Games, 2)
+	assert.Equal(t, 1995, resp.Timeline[1].Year)
+	assert.Len(t, resp.Timeline[1].Games, 1)
+
+	// Check timeline game fields
+	game := resp.Timeline[1].Games[0]
+	assert.NotEmpty(t, game.ID)
+	assert.Equal(t, "Game 1995", game.Title)
+	assert.Equal(t, 90.0, game.Rating)
+}
+
+func TestGetDeveloperDetail_Timeline_TooFewGames(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// Only 2 games with dates — needs at least 3 for timeline
+	createExploreGameComplete(t, env.database, "NES", "Game A", 80, "FewTimelineDev", "Pub", "Action", "1991-01-01")
+	createExploreGameComplete(t, env.database, "SNES", "Game B", 85, "FewTimelineDev", "Pub", "Action", "1995-01-01")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/FewTimelineDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Nil(t, resp.Timeline)
+}
+
+func TestGetDeveloperDetail_Timeline_SingleYear(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	// 3 games but all same year — needs at least 2 distinct years
+	createExploreGameComplete(t, env.database, "NES", "Game X1", 80, "OneYearDev", "Pub", "Action", "1991-01-01")
+	createExploreGameComplete(t, env.database, "NES", "Game X2", 85, "OneYearDev", "Pub", "Action", "1991-06-15")
+	createExploreGameComplete(t, env.database, "SNES", "Game X3", 90, "OneYearDev", "Pub", "Action", "1991-12-25")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/OneYearDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Nil(t, resp.Timeline)
+}
+
+func TestGetDeveloperDetail_Timeline_NoDates(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "No Date A", 80, "NoDateTimeDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "SNES", "No Date B", 85, "NoDateTimeDev", "Pub", "Action", "")
+	createExploreGameComplete(t, env.database, "GBA", "No Date C", 90, "NoDateTimeDev", "Pub", "Action", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/NoDateTimeDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Nil(t, resp.Timeline)
+}
+
+// --- Publisher statistics fields tests ---
+
+func TestGetPublisherDetail_ActiveYears(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Early Pub Game", 80, "Dev", "YearsPub", "Action", "1989-01-20")
+	createExploreGameComplete(t, env.database, "SNES", "Late Pub Game", 90, "Dev", "YearsPub", "RPG", "2001-07-15")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/publishers/YearsPub", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PublisherDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.NotNil(t, resp.ActiveYears)
+	assert.Equal(t, 1989, resp.ActiveYears.First)
+	assert.Equal(t, 2001, resp.ActiveYears.Last)
+}
+
+func TestGetPublisherDetail_RatingDistribution(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Pub Ex", 92, "Dev", "DistPub", "Action", "")
+	createExploreGameComplete(t, env.database, "SNES", "Pub Good", 75, "Dev", "DistPub", "Action", "")
+	createExploreGameComplete(t, env.database, "GBA", "Pub Unrated", 0, "Dev", "DistPub", "Action", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/publishers/DistPub", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PublisherDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, 1, resp.RatingDistribution.Excellent)
+	assert.Equal(t, 1, resp.RatingDistribution.Good)
+	assert.Equal(t, 0, resp.RatingDistribution.Average)
+	assert.Equal(t, 0, resp.RatingDistribution.Poor)
+	assert.Equal(t, 1, resp.RatingDistribution.Unrated)
+}
+
+func TestGetPublisherDetail_PrimaryGenre(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Pub Plat 1", 80, "Dev", "PGenrePub", "Platformer", "")
+	createExploreGameComplete(t, env.database, "NES", "Pub Plat 2", 85, "Dev", "PGenrePub", "Platformer", "")
+	createExploreGameComplete(t, env.database, "SNES", "Pub RPG", 90, "Dev", "PGenrePub", "RPG", "")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/publishers/PGenrePub", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PublisherDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Equal(t, "Platformer", resp.PrimaryGenre)
+}
+
+func TestGetPublisherDetail_Timeline(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	createExploreGameComplete(t, env.database, "NES", "Pub TL 1a", 80, "Dev", "TimelinePub", "Action", "1990-01-01")
+	createExploreGameComplete(t, env.database, "NES", "Pub TL 1b", 85, "Dev", "TimelinePub", "Action", "1990-06-01")
+	createExploreGameComplete(t, env.database, "SNES", "Pub TL 2", 90, "Dev", "TimelinePub", "RPG", "1997-03-15")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/publishers/TimelinePub", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PublisherDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	require.Len(t, resp.Timeline, 2)
+	assert.Equal(t, 1990, resp.Timeline[0].Year)
+	assert.Len(t, resp.Timeline[0].Games, 2)
+	assert.Equal(t, 1997, resp.Timeline[1].Year)
+	assert.Len(t, resp.Timeline[1].Games, 1)
+}
+
+// --- Non-existent developer/publisher should have sensible defaults ---
+
+func TestGetDeveloperDetail_NonExistent_StatisticsDefaults(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/developers/GhostDev", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp DeveloperDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Nil(t, resp.ActiveYears)
+	assert.Equal(t, 0, resp.RatingDistribution.Excellent)
+	assert.Equal(t, 0, resp.RatingDistribution.Good)
+	assert.Equal(t, 0, resp.RatingDistribution.Average)
+	assert.Equal(t, 0, resp.RatingDistribution.Poor)
+	assert.Equal(t, 0, resp.RatingDistribution.Unrated)
+	assert.Empty(t, resp.PrimaryGenre)
+	assert.Nil(t, resp.Timeline)
+}
+
+func TestGetPublisherDetail_NonExistent_StatisticsDefaults(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/publishers/GhostPub", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp PublisherDetailResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	assert.Nil(t, resp.ActiveYears)
+	assert.Equal(t, 0, resp.RatingDistribution.Excellent)
+	assert.Equal(t, 0, resp.RatingDistribution.Good)
+	assert.Equal(t, 0, resp.RatingDistribution.Average)
+	assert.Equal(t, 0, resp.RatingDistribution.Poor)
+	assert.Equal(t, 0, resp.RatingDistribution.Unrated)
+	assert.Empty(t, resp.PrimaryGenre)
+	assert.Nil(t, resp.Timeline)
+}

--- a/web/src/features/explore/components/__tests__/at-a-glance-row.test.tsx
+++ b/web/src/features/explore/components/__tests__/at-a-glance-row.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { AtAGlanceRow } from "@/features/explore/components/at-a-glance-row";
+
+describe("AtAGlanceRow", () => {
+  it("renders the section with test id", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={10}
+        platformCount={3}
+        avgRating={85}
+      />,
+    );
+    expect(screen.getByTestId("at-a-glance-row")).toBeInTheDocument();
+  });
+
+  it("renders total games pill", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={42}
+        platformCount={2}
+        avgRating={0}
+      />,
+    );
+    const pill = screen.getByTestId("glance-total-games");
+    expect(pill).toHaveTextContent("42");
+    expect(pill).toHaveTextContent("Total games");
+  });
+
+  it("renders active years as range", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={10}
+        activeYears={{ first: 1986, last: 2004 }}
+        platformCount={2}
+        avgRating={0}
+      />,
+    );
+    const pill = screen.getByTestId("glance-active-years");
+    expect(pill).toHaveTextContent("1986");
+    expect(pill).toHaveTextContent("2004");
+    expect(pill).toHaveTextContent("Active years");
+  });
+
+  it("renders active years as single year when first equals last", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={5}
+        activeYears={{ first: 1999, last: 1999 }}
+        platformCount={1}
+        avgRating={0}
+      />,
+    );
+    const pill = screen.getByTestId("glance-active-years");
+    expect(pill).toHaveTextContent("1999");
+  });
+
+  it("hides active years pill when not provided", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={10}
+        platformCount={2}
+        avgRating={80}
+      />,
+    );
+    expect(screen.queryByTestId("glance-active-years")).not.toBeInTheDocument();
+  });
+
+  it("renders primary genre pill", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={10}
+        primaryGenre="Platformer"
+        platformCount={2}
+        avgRating={0}
+      />,
+    );
+    const pill = screen.getByTestId("glance-primary-genre");
+    expect(pill).toHaveTextContent("Platformer");
+    expect(pill).toHaveTextContent("Primary genre");
+  });
+
+  it("hides primary genre pill when not provided", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={10}
+        platformCount={2}
+        avgRating={80}
+      />,
+    );
+    expect(
+      screen.queryByTestId("glance-primary-genre"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("renders platform count pill", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={10}
+        platformCount={5}
+        avgRating={0}
+      />,
+    );
+    const pill = screen.getByTestId("glance-platforms");
+    expect(pill).toHaveTextContent("5");
+    expect(pill).toHaveTextContent("Platforms");
+  });
+
+  it("renders singular platform label for 1 platform", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={10}
+        platformCount={1}
+        avgRating={0}
+      />,
+    );
+    const pill = screen.getByTestId("glance-platforms");
+    expect(pill).toHaveTextContent("1");
+    expect(pill).toHaveTextContent("Platform");
+  });
+
+  it("hides platform pill when count is 0", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={10}
+        platformCount={0}
+        avgRating={80}
+      />,
+    );
+    expect(screen.queryByTestId("glance-platforms")).not.toBeInTheDocument();
+  });
+
+  it("renders avg rating pill when > 0", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={10}
+        platformCount={2}
+        avgRating={88.5}
+      />,
+    );
+    const pill = screen.getByTestId("glance-avg-rating");
+    expect(pill).toHaveTextContent("88.5");
+    expect(pill).toHaveTextContent("Avg rating");
+  });
+
+  it("hides avg rating pill when 0", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={10}
+        platformCount={2}
+        avgRating={0}
+      />,
+    );
+    expect(screen.queryByTestId("glance-avg-rating")).not.toBeInTheDocument();
+  });
+
+  it("renders all pills when all data is provided", () => {
+    render(
+      <AtAGlanceRow
+        gameCount={50}
+        activeYears={{ first: 1985, last: 2010 }}
+        primaryGenre="Action"
+        platformCount={4}
+        avgRating={91.2}
+      />,
+    );
+    expect(screen.getByTestId("glance-total-games")).toBeInTheDocument();
+    expect(screen.getByTestId("glance-active-years")).toBeInTheDocument();
+    expect(screen.getByTestId("glance-primary-genre")).toBeInTheDocument();
+    expect(screen.getByTestId("glance-platforms")).toBeInTheDocument();
+    expect(screen.getByTestId("glance-avg-rating")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/explore/components/__tests__/rating-distribution.test.tsx
+++ b/web/src/features/explore/components/__tests__/rating-distribution.test.tsx
@@ -1,0 +1,124 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { RatingDistribution } from "@/features/explore/components/rating-distribution";
+import type { RatingDistribution as RatingDistributionType } from "@/types/api";
+
+const fullDistribution: RatingDistributionType = {
+  excellent: 10,
+  good: 8,
+  average: 5,
+  poor: 2,
+  unrated: 3,
+};
+
+describe("RatingDistribution", () => {
+  it("renders the section with test id", () => {
+    render(<RatingDistribution distribution={fullDistribution} />);
+    expect(screen.getByTestId("rating-distribution")).toBeInTheDocument();
+  });
+
+  it("renders the heading", () => {
+    render(<RatingDistribution distribution={fullDistribution} />);
+    expect(
+      screen.getByRole("heading", { name: "Rating Distribution" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders all non-zero bars", () => {
+    render(<RatingDistribution distribution={fullDistribution} />);
+    expect(screen.getByTestId("rating-bar-excellent")).toBeInTheDocument();
+    expect(screen.getByTestId("rating-bar-good")).toBeInTheDocument();
+    expect(screen.getByTestId("rating-bar-average")).toBeInTheDocument();
+    expect(screen.getByTestId("rating-bar-poor")).toBeInTheDocument();
+    expect(screen.getByTestId("rating-bar-unrated")).toBeInTheDocument();
+  });
+
+  it("renders labels and counts for each bar", () => {
+    render(<RatingDistribution distribution={fullDistribution} />);
+    const excellent = screen.getByTestId("rating-bar-excellent");
+    expect(excellent).toHaveTextContent("Excellent");
+    expect(excellent).toHaveTextContent("10");
+
+    const good = screen.getByTestId("rating-bar-good");
+    expect(good).toHaveTextContent("Good");
+    expect(good).toHaveTextContent("8");
+
+    const average = screen.getByTestId("rating-bar-average");
+    expect(average).toHaveTextContent("Average");
+    expect(average).toHaveTextContent("5");
+
+    const poor = screen.getByTestId("rating-bar-poor");
+    expect(poor).toHaveTextContent("Poor");
+    expect(poor).toHaveTextContent("2");
+
+    const unrated = screen.getByTestId("rating-bar-unrated");
+    expect(unrated).toHaveTextContent("Unrated");
+    expect(unrated).toHaveTextContent("3");
+  });
+
+  it("hides bars with zero count", () => {
+    render(
+      <RatingDistribution
+        distribution={{
+          excellent: 5,
+          good: 3,
+          average: 0,
+          poor: 0,
+          unrated: 2,
+        }}
+      />,
+    );
+    expect(screen.getByTestId("rating-bar-excellent")).toBeInTheDocument();
+    expect(screen.getByTestId("rating-bar-good")).toBeInTheDocument();
+    expect(
+      screen.queryByTestId("rating-bar-average"),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByTestId("rating-bar-poor")).not.toBeInTheDocument();
+    expect(screen.getByTestId("rating-bar-unrated")).toBeInTheDocument();
+  });
+
+  it("renders nothing when fewer than 5 rated games", () => {
+    const { container } = render(
+      <RatingDistribution
+        distribution={{
+          excellent: 2,
+          good: 1,
+          average: 1,
+          poor: 0,
+          unrated: 10,
+        }}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders when exactly 5 rated games", () => {
+    render(
+      <RatingDistribution
+        distribution={{
+          excellent: 3,
+          good: 2,
+          average: 0,
+          poor: 0,
+          unrated: 0,
+        }}
+      />,
+    );
+    expect(screen.getByTestId("rating-distribution")).toBeInTheDocument();
+  });
+
+  it("renders nothing when all ratings are zero", () => {
+    const { container } = render(
+      <RatingDistribution
+        distribution={{
+          excellent: 0,
+          good: 0,
+          average: 0,
+          poor: 0,
+          unrated: 20,
+        }}
+      />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/web/src/features/explore/components/__tests__/release-timeline.test.tsx
+++ b/web/src/features/explore/components/__tests__/release-timeline.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { ReleaseTimeline } from "@/features/explore/components/release-timeline";
+import type { TimelineEntry } from "@/types/api";
+
+const mockTimeline: TimelineEntry[] = [
+  {
+    year: 1992,
+    games: [
+      { id: "g1", title: "Mega Man X", coverUrl: "/covers/mmx.jpg", rating: 95 },
+      { id: "g2", title: "Street Fighter II", coverUrl: "/covers/sf2.jpg", rating: 90 },
+    ],
+  },
+  {
+    year: 1990,
+    games: [
+      { id: "g3", title: "Final Fight", coverUrl: "/covers/ff.jpg", rating: 80 },
+    ],
+  },
+  {
+    year: 1995,
+    games: [
+      { id: "g4", title: "Mega Man X3", coverUrl: "/covers/mmx3.jpg", rating: 0 },
+    ],
+  },
+];
+
+function renderTimeline(timeline: TimelineEntry[] = mockTimeline) {
+  return render(
+    <MemoryRouter>
+      <ReleaseTimeline timeline={timeline} />
+    </MemoryRouter>,
+  );
+}
+
+describe("ReleaseTimeline", () => {
+  it("renders the section with test id", () => {
+    renderTimeline();
+    expect(screen.getByTestId("release-timeline")).toBeInTheDocument();
+  });
+
+  it("renders the heading", () => {
+    renderTimeline();
+    expect(
+      screen.getByRole("heading", { name: "Release Timeline" }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders year columns sorted ascending", () => {
+    renderTimeline();
+    expect(screen.getByTestId("timeline-year-1990")).toBeInTheDocument();
+    expect(screen.getByTestId("timeline-year-1992")).toBeInTheDocument();
+    expect(screen.getByTestId("timeline-year-1995")).toBeInTheDocument();
+
+    // Check order: 1990 should come before 1992
+    const strip = screen.getByTestId("timeline-strip");
+    const years = strip.querySelectorAll("[data-testid^='timeline-year-']");
+    expect(years[0]).toHaveAttribute("data-testid", "timeline-year-1990");
+    expect(years[1]).toHaveAttribute("data-testid", "timeline-year-1992");
+    expect(years[2]).toHaveAttribute("data-testid", "timeline-year-1995");
+  });
+
+  it("renders year labels", () => {
+    renderTimeline();
+    expect(screen.getByText("1990")).toBeInTheDocument();
+    expect(screen.getByText("1992")).toBeInTheDocument();
+    expect(screen.getByText("1995")).toBeInTheDocument();
+  });
+
+  it("renders game cover images", () => {
+    renderTimeline();
+    expect(screen.getByTestId("timeline-game-g1")).toBeInTheDocument();
+    expect(screen.getByTestId("timeline-game-g2")).toBeInTheDocument();
+    expect(screen.getByTestId("timeline-game-g3")).toBeInTheDocument();
+    expect(screen.getByTestId("timeline-game-g4")).toBeInTheDocument();
+  });
+
+  it("shows tooltip on hover with title and rating", () => {
+    renderTimeline();
+    const cover = screen.getByTestId("timeline-game-g1");
+    // Tooltip should not be visible initially
+    expect(
+      screen.queryByTestId("timeline-tooltip-g1"),
+    ).not.toBeInTheDocument();
+
+    // Hover over the cover's parent (the relative div)
+    fireEvent.mouseEnter(cover.closest("[class*='relative']")!);
+    const tooltip = screen.getByTestId("timeline-tooltip-g1");
+    expect(tooltip).toHaveTextContent("Mega Man X");
+    expect(tooltip).toHaveTextContent("95.0");
+  });
+
+  it("hides tooltip on mouse leave", () => {
+    renderTimeline();
+    const cover = screen.getByTestId("timeline-game-g1");
+    const parent = cover.closest("[class*='relative']")!;
+
+    fireEvent.mouseEnter(parent);
+    expect(screen.getByTestId("timeline-tooltip-g1")).toBeInTheDocument();
+
+    fireEvent.mouseLeave(parent);
+    expect(
+      screen.queryByTestId("timeline-tooltip-g1"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("does not show rating in tooltip when rating is 0", () => {
+    renderTimeline();
+    const cover = screen.getByTestId("timeline-game-g4");
+    const parent = cover.closest("[class*='relative']")!;
+
+    fireEvent.mouseEnter(parent);
+    const tooltip = screen.getByTestId("timeline-tooltip-g4");
+    expect(tooltip).toHaveTextContent("Mega Man X3");
+    // Should not contain a rating value
+    expect(tooltip.querySelectorAll("p")).toHaveLength(1);
+  });
+
+  it("renders nothing when timeline is empty", () => {
+    const { container } = renderTimeline([]);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when timeline is undefined", () => {
+    const { container } = render(
+      <MemoryRouter>
+        <ReleaseTimeline timeline={undefined as unknown as TimelineEntry[]} />
+      </MemoryRouter>,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders game covers as links to game detail pages", () => {
+    renderTimeline();
+    const cover = screen.getByTestId("timeline-game-g1");
+    const link = cover.closest("a");
+    expect(link).toHaveAttribute("href", "/games/g1");
+  });
+});

--- a/web/src/features/explore/components/at-a-glance-row.tsx
+++ b/web/src/features/explore/components/at-a-glance-row.tsx
@@ -1,0 +1,109 @@
+import {
+  Gamepad2,
+  Calendar,
+  Tag,
+  Monitor,
+  Star,
+} from "lucide-react";
+import type { ActiveYears } from "@/types/api";
+
+interface AtAGlanceRowProps {
+  gameCount: number;
+  activeYears?: ActiveYears;
+  primaryGenre?: string;
+  platformCount: number;
+  avgRating: number;
+}
+
+interface StatPillProps {
+  icon: React.ReactNode;
+  label: string;
+  value: string;
+  testId: string;
+}
+
+function StatPill({ icon, label, value, testId }: StatPillProps) {
+  return (
+    <div
+      className="flex items-center gap-2.5 rounded-xl border border-white/[0.06] bg-surface-900/60 px-4 py-2.5"
+      data-testid={testId}
+    >
+      <div className="flex-shrink-0 text-surface-400">{icon}</div>
+      <div className="min-w-0">
+        <p className="text-sm font-semibold text-surface-100 truncate">
+          {value}
+        </p>
+        <p className="text-xs text-surface-500">{label}</p>
+      </div>
+    </div>
+  );
+}
+
+export function AtAGlanceRow({
+  gameCount,
+  activeYears,
+  primaryGenre,
+  platformCount,
+  avgRating,
+}: AtAGlanceRowProps) {
+  const pills: StatPillProps[] = [];
+
+  pills.push({
+    icon: <Gamepad2 className="h-4 w-4" />,
+    label: "Total games",
+    value: String(gameCount),
+    testId: "glance-total-games",
+  });
+
+  if (activeYears) {
+    const yearStr =
+      activeYears.first === activeYears.last
+        ? String(activeYears.first)
+        : `${activeYears.first} \u2013 ${activeYears.last}`;
+    pills.push({
+      icon: <Calendar className="h-4 w-4" />,
+      label: "Active years",
+      value: yearStr,
+      testId: "glance-active-years",
+    });
+  }
+
+  if (primaryGenre) {
+    pills.push({
+      icon: <Tag className="h-4 w-4" />,
+      label: "Primary genre",
+      value: primaryGenre,
+      testId: "glance-primary-genre",
+    });
+  }
+
+  if (platformCount > 0) {
+    pills.push({
+      icon: <Monitor className="h-4 w-4" />,
+      label: platformCount === 1 ? "Platform" : "Platforms",
+      value: String(platformCount),
+      testId: "glance-platforms",
+    });
+  }
+
+  if (avgRating > 0) {
+    pills.push({
+      icon: <Star className="h-4 w-4 text-amber-400 fill-amber-400" />,
+      label: "Avg rating",
+      value: avgRating.toFixed(1),
+      testId: "glance-avg-rating",
+    });
+  }
+
+  if (pills.length === 0) return null;
+
+  return (
+    <section data-testid="at-a-glance-row">
+      <div className="flex flex-wrap gap-3">
+        {pills.map((pill) => (
+          <StatPill key={pill.testId} {...pill} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/web/src/features/explore/components/rating-distribution.tsx
+++ b/web/src/features/explore/components/rating-distribution.tsx
@@ -1,0 +1,97 @@
+import type { RatingDistribution as RatingDistributionType } from "@/types/api";
+
+interface RatingDistributionProps {
+  distribution: RatingDistributionType;
+}
+
+interface BarEntry {
+  label: string;
+  count: number;
+  color: string;
+  testId: string;
+}
+
+export function RatingDistribution({ distribution }: RatingDistributionProps) {
+  // Only show when at least 5 games have ratings
+  const ratedTotal =
+    distribution.excellent +
+    distribution.good +
+    distribution.average +
+    distribution.poor;
+
+  if (ratedTotal < 5) return null;
+
+  const totalWithUnrated = ratedTotal + distribution.unrated;
+
+  const bars: BarEntry[] = [
+    {
+      label: "Excellent",
+      count: distribution.excellent,
+      color: "bg-emerald-500",
+      testId: "rating-bar-excellent",
+    },
+    {
+      label: "Good",
+      count: distribution.good,
+      color: "bg-yellow-500",
+      testId: "rating-bar-good",
+    },
+    {
+      label: "Average",
+      count: distribution.average,
+      color: "bg-orange-500",
+      testId: "rating-bar-average",
+    },
+    {
+      label: "Poor",
+      count: distribution.poor,
+      color: "bg-red-500",
+      testId: "rating-bar-poor",
+    },
+    {
+      label: "Unrated",
+      count: distribution.unrated,
+      color: "bg-surface-600",
+      testId: "rating-bar-unrated",
+    },
+  ];
+
+  // Filter out zero-count bars
+  const visibleBars = bars.filter((b) => b.count > 0);
+
+  return (
+    <section data-testid="rating-distribution">
+      <h2 className="text-lg font-bold text-surface-100 mb-4">
+        Rating Distribution
+      </h2>
+      <div className="space-y-2.5">
+        {visibleBars.map((bar) => {
+          const pct =
+            totalWithUnrated > 0
+              ? (bar.count / totalWithUnrated) * 100
+              : 0;
+          return (
+            <div
+              key={bar.label}
+              className="flex items-center gap-3"
+              data-testid={bar.testId}
+            >
+              <span className="w-20 text-xs text-surface-400 text-right flex-shrink-0">
+                {bar.label}
+              </span>
+              <div className="flex-1 h-5 bg-surface-800 rounded-full overflow-hidden">
+                <div
+                  className={`h-full ${bar.color} rounded-full transition-all duration-300`}
+                  style={{ width: `${Math.max(pct, 1)}%` }}
+                />
+              </div>
+              <span className="w-8 text-xs text-surface-300 font-medium text-right flex-shrink-0">
+                {bar.count}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/web/src/features/explore/components/release-timeline.tsx
+++ b/web/src/features/explore/components/release-timeline.tsx
@@ -1,0 +1,81 @@
+import { useState } from "react";
+import { Link } from "react-router-dom";
+import type { TimelineEntry } from "@/types/api";
+
+interface ReleaseTimelineProps {
+  timeline: TimelineEntry[];
+}
+
+export function ReleaseTimeline({ timeline }: ReleaseTimelineProps) {
+  if (!timeline || timeline.length === 0) return null;
+
+  // Sort entries by year ascending
+  const sorted = [...timeline].sort((a, b) => a.year - b.year);
+
+  return (
+    <section data-testid="release-timeline">
+      <h2 className="text-lg font-bold text-surface-100 mb-4">
+        Release Timeline
+      </h2>
+      <div
+        className="flex gap-6 overflow-x-auto pb-3 scrollbar-hide"
+        style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+        data-testid="timeline-strip"
+      >
+        {sorted.map((entry) => (
+          <TimelineYearColumn key={entry.year} entry={entry} />
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function TimelineYearColumn({ entry }: { entry: TimelineEntry }) {
+  return (
+    <div className="flex-shrink-0 min-w-[100px]" data-testid={`timeline-year-${entry.year}`}>
+      <p className="text-sm font-bold text-surface-200 mb-2">{entry.year}</p>
+      <div className="flex flex-wrap gap-1.5" style={{ maxWidth: "120px" }}>
+        {entry.games.map((game) => (
+          <TimelineCover key={game.id} game={game} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TimelineCover({
+  game,
+}: {
+  game: TimelineEntry["games"][number];
+}) {
+  const [showTooltip, setShowTooltip] = useState(false);
+
+  return (
+    <div
+      className="relative"
+      onMouseEnter={() => setShowTooltip(true)}
+      onMouseLeave={() => setShowTooltip(false)}
+    >
+      <Link to={`/games/${game.id}`}>
+        <img
+          src={game.coverUrl}
+          alt={game.title}
+          className="w-10 h-14 rounded object-cover border border-white/[0.06] hover:border-brand-500/50 transition-colors"
+          loading="lazy"
+          data-testid={`timeline-game-${game.id}`}
+        />
+      </Link>
+      {showTooltip && (
+        <div
+          className="absolute z-20 bottom-full left-1/2 -translate-x-1/2 mb-2 px-2.5 py-1.5 rounded-lg bg-surface-800 border border-white/[0.08] shadow-lg whitespace-nowrap pointer-events-none"
+          data-testid={`timeline-tooltip-${game.id}`}
+        >
+          <p className="text-xs font-medium text-surface-100">{game.title}</p>
+          {game.rating > 0 && (
+            <p className="text-xs text-amber-400">{game.rating.toFixed(1)}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/pages/__tests__/developer-detail-page.test.tsx
+++ b/web/src/pages/__tests__/developer-detail-page.test.tsx
@@ -476,4 +476,149 @@ describe("DeveloperDetailPage", () => {
     expect(logo).toHaveAttribute("src", "/images/companies/capcom-logo.png");
     expect(screen.queryByTestId("developer-avatar")).not.toBeInTheDocument();
   });
+
+  // --- At a Glance section ---
+
+  it("renders at-a-glance row with basic stats", () => {
+    renderPage();
+    const row = screen.getByTestId("at-a-glance-row");
+    expect(row).toBeInTheDocument();
+    expect(screen.getByTestId("glance-total-games")).toHaveTextContent("5");
+    expect(screen.getByTestId("glance-platforms")).toHaveTextContent("2");
+    expect(screen.getByTestId("glance-avg-rating")).toHaveTextContent("88.5");
+  });
+
+  it("renders at-a-glance with active years when provided", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        activeYears: { first: 1987, last: 2003 },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    const pill = screen.getByTestId("glance-active-years");
+    expect(pill).toHaveTextContent("1987");
+    expect(pill).toHaveTextContent("2003");
+  });
+
+  it("renders at-a-glance with primary genre when provided", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        primaryGenre: "Platformer",
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByTestId("glance-primary-genre")).toHaveTextContent(
+      "Platformer",
+    );
+  });
+
+  it("hides active years pill when not provided", () => {
+    renderPage();
+    expect(
+      screen.queryByTestId("glance-active-years"),
+    ).not.toBeInTheDocument();
+  });
+
+  // --- Release Timeline section ---
+
+  it("renders release timeline when timeline data is provided", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        timeline: [
+          {
+            year: 1992,
+            games: [
+              { id: "g1", title: "Mega Man X", coverUrl: "/covers/mmx.jpg", rating: 95 },
+            ],
+          },
+          {
+            year: 1994,
+            games: [
+              { id: "g2", title: "Mega Man X2", coverUrl: "/covers/mmx2.jpg", rating: 88 },
+            ],
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByTestId("release-timeline")).toBeInTheDocument();
+    expect(screen.getByText("1992")).toBeInTheDocument();
+    expect(screen.getByText("1994")).toBeInTheDocument();
+  });
+
+  it("hides release timeline when no timeline data", () => {
+    renderPage();
+    expect(
+      screen.queryByTestId("release-timeline"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides release timeline when timeline is empty", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        timeline: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("release-timeline"),
+    ).not.toBeInTheDocument();
+  });
+
+  // --- Rating Distribution section ---
+
+  it("renders rating distribution when data is provided with 5+ rated games", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        ratingDistribution: {
+          excellent: 3,
+          good: 2,
+          average: 1,
+          poor: 1,
+          unrated: 0,
+        },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByTestId("rating-distribution")).toBeInTheDocument();
+    expect(screen.getByTestId("rating-bar-excellent")).toHaveTextContent("3");
+    expect(screen.getByTestId("rating-bar-good")).toHaveTextContent("2");
+  });
+
+  it("hides rating distribution when not provided", () => {
+    renderPage();
+    expect(
+      screen.queryByTestId("rating-distribution"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides rating distribution when fewer than 5 rated games", () => {
+    mockUseDeveloperDetail.mockReturnValue({
+      data: {
+        ...mockDeveloperDetail,
+        ratingDistribution: {
+          excellent: 2,
+          good: 1,
+          average: 0,
+          poor: 0,
+          unrated: 10,
+        },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("rating-distribution"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/web/src/pages/__tests__/publisher-detail-page.test.tsx
+++ b/web/src/pages/__tests__/publisher-detail-page.test.tsx
@@ -458,4 +458,149 @@ describe("PublisherDetailPage", () => {
     expect(logo).toHaveAttribute("src", "/images/companies/nintendo-logo.png");
     expect(screen.queryByTestId("developer-avatar")).not.toBeInTheDocument();
   });
+
+  // --- At a Glance section ---
+
+  it("renders at-a-glance row with basic stats", () => {
+    renderPage();
+    const row = screen.getByTestId("at-a-glance-row");
+    expect(row).toBeInTheDocument();
+    expect(screen.getByTestId("glance-total-games")).toHaveTextContent("5");
+    expect(screen.getByTestId("glance-platforms")).toHaveTextContent("2");
+    expect(screen.getByTestId("glance-avg-rating")).toHaveTextContent("92.3");
+  });
+
+  it("renders at-a-glance with active years when provided", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        activeYears: { first: 1983, last: 2020 },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    const pill = screen.getByTestId("glance-active-years");
+    expect(pill).toHaveTextContent("1983");
+    expect(pill).toHaveTextContent("2020");
+  });
+
+  it("renders at-a-glance with primary genre when provided", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        primaryGenre: "Platformer",
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByTestId("glance-primary-genre")).toHaveTextContent(
+      "Platformer",
+    );
+  });
+
+  it("hides active years pill when not provided", () => {
+    renderPage();
+    expect(
+      screen.queryByTestId("glance-active-years"),
+    ).not.toBeInTheDocument();
+  });
+
+  // --- Release Timeline section ---
+
+  it("renders release timeline when timeline data is provided", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        timeline: [
+          {
+            year: 1985,
+            games: [
+              { id: "g1", title: "Super Mario Bros.", coverUrl: "/covers/smb.jpg", rating: 93 },
+            ],
+          },
+          {
+            year: 1991,
+            games: [
+              { id: "g2", title: "Super Mario World", coverUrl: "/covers/smw.jpg", rating: 96 },
+            ],
+          },
+        ],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByTestId("release-timeline")).toBeInTheDocument();
+    expect(screen.getByText("1985")).toBeInTheDocument();
+    expect(screen.getByText("1991")).toBeInTheDocument();
+  });
+
+  it("hides release timeline when no timeline data", () => {
+    renderPage();
+    expect(
+      screen.queryByTestId("release-timeline"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides release timeline when timeline is empty", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        timeline: [],
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("release-timeline"),
+    ).not.toBeInTheDocument();
+  });
+
+  // --- Rating Distribution section ---
+
+  it("renders rating distribution when data is provided with 5+ rated games", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        ratingDistribution: {
+          excellent: 4,
+          good: 3,
+          average: 1,
+          poor: 0,
+          unrated: 1,
+        },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByTestId("rating-distribution")).toBeInTheDocument();
+    expect(screen.getByTestId("rating-bar-excellent")).toHaveTextContent("4");
+    expect(screen.getByTestId("rating-bar-good")).toHaveTextContent("3");
+  });
+
+  it("hides rating distribution when not provided", () => {
+    renderPage();
+    expect(
+      screen.queryByTestId("rating-distribution"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides rating distribution when fewer than 5 rated games", () => {
+    mockUsePublisherDetail.mockReturnValue({
+      data: {
+        ...mockPublisherDetail,
+        ratingDistribution: {
+          excellent: 1,
+          good: 2,
+          average: 0,
+          poor: 0,
+          unrated: 15,
+        },
+      },
+      isLoading: false,
+    });
+    renderPage();
+    expect(
+      screen.queryByTestId("rating-distribution"),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/web/src/pages/developer-detail-page.tsx
+++ b/web/src/pages/developer-detail-page.tsx
@@ -7,6 +7,9 @@ import { GameShelf } from "@/features/explore/components/game-shelf";
 import { DeveloperHeroBanner } from "@/features/explore/components/developer-hero-banner";
 import { DeveloperStatsCard } from "@/features/explore/components/developer-stats-card";
 import { CompanyInfoSection } from "@/features/explore/components/company-info-section";
+import { AtAGlanceRow } from "@/features/explore/components/at-a-glance-row";
+import { ReleaseTimeline } from "@/features/explore/components/release-timeline";
+import { RatingDistribution } from "@/features/explore/components/rating-distribution";
 import { useDeveloperDetail } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -156,6 +159,15 @@ export function DeveloperDetailPage() {
         <CompanyInfoSection companyInfo={developer.companyInfo} />
       )}
 
+      {/* At a Glance Stats Row */}
+      <AtAGlanceRow
+        gameCount={developer.gameCount}
+        activeYears={developer.activeYears}
+        primaryGenre={developer.primaryGenre}
+        platformCount={developer.consoles.length}
+        avgRating={developer.avgRating}
+      />
+
       {/* Top Rated Row */}
       {showTopRated && (
         <GameShelf
@@ -165,6 +177,16 @@ export function DeveloperDetailPage() {
           onToggleFavorite={handleToggleFavorite}
           onTogglePlayLater={handleTogglePlayLater}
         />
+      )}
+
+      {/* Release Timeline */}
+      {developer.timeline && developer.timeline.length > 0 && (
+        <ReleaseTimeline timeline={developer.timeline} />
+      )}
+
+      {/* Rating Distribution */}
+      {developer.ratingDistribution && (
+        <RatingDistribution distribution={developer.ratingDistribution} />
       )}
 
       {/* Genre Breakdown (filter chips) */}

--- a/web/src/pages/publisher-detail-page.tsx
+++ b/web/src/pages/publisher-detail-page.tsx
@@ -7,6 +7,9 @@ import { GameShelf } from "@/features/explore/components/game-shelf";
 import { DeveloperHeroBanner } from "@/features/explore/components/developer-hero-banner";
 import { DeveloperStatsCard } from "@/features/explore/components/developer-stats-card";
 import { CompanyInfoSection } from "@/features/explore/components/company-info-section";
+import { AtAGlanceRow } from "@/features/explore/components/at-a-glance-row";
+import { ReleaseTimeline } from "@/features/explore/components/release-timeline";
+import { RatingDistribution } from "@/features/explore/components/rating-distribution";
 import { usePublisherDetail } from "@/hooks/use-explore";
 import { useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -165,6 +168,15 @@ export function PublisherDetailPage() {
         <CompanyInfoSection companyInfo={publisher.companyInfo} />
       )}
 
+      {/* At a Glance Stats Row */}
+      <AtAGlanceRow
+        gameCount={publisher.gameCount}
+        activeYears={publisher.activeYears}
+        primaryGenre={publisher.primaryGenre}
+        platformCount={publisher.consoles.length}
+        avgRating={publisher.avgRating}
+      />
+
       {/* Top Rated Row */}
       {showTopRated && (
         <GameShelf
@@ -174,6 +186,16 @@ export function PublisherDetailPage() {
           onToggleFavorite={handleToggleFavorite}
           onTogglePlayLater={handleTogglePlayLater}
         />
+      )}
+
+      {/* Release Timeline */}
+      {publisher.timeline && publisher.timeline.length > 0 && (
+        <ReleaseTimeline timeline={publisher.timeline} />
+      )}
+
+      {/* Rating Distribution */}
+      {publisher.ratingDistribution && (
+        <RatingDistribution distribution={publisher.ratingDistribution} />
       )}
 
       {/* Genre Breakdown (filter chips) */}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1120,6 +1120,31 @@ export interface CompanyInfo {
   wikipediaUrl?: string;
 }
 
+export interface ActiveYears {
+  first: number;
+  last: number;
+}
+
+export interface RatingDistribution {
+  excellent: number;
+  good: number;
+  average: number;
+  poor: number;
+  unrated: number;
+}
+
+export interface TimelineGame {
+  id: string;
+  title: string;
+  coverUrl: string;
+  rating: number;
+}
+
+export interface TimelineEntry {
+  year: number;
+  games: TimelineGame[];
+}
+
 export interface DeveloperDetailResponse {
   name: string;
   gameCount: number;
@@ -1133,6 +1158,10 @@ export interface DeveloperDetailResponse {
   userStats?: EntityUserStats;
   publishers?: NameCount[];
   companyInfo?: CompanyInfo;
+  activeYears?: ActiveYears;
+  ratingDistribution?: RatingDistribution;
+  primaryGenre?: string;
+  timeline?: TimelineEntry[];
 }
 
 export interface PublisherDetailResponse {
@@ -1148,6 +1177,10 @@ export interface PublisherDetailResponse {
   userStats?: EntityUserStats;
   developers?: NameCount[];
   companyInfo?: CompanyInfo;
+  activeYears?: ActiveYears;
+  ratingDistribution?: RatingDistribution;
+  primaryGenre?: string;
+  timeline?: TimelineEntry[];
 }
 
 export interface DeveloperSpotlightResponse {


### PR DESCRIPTION
## Summary
- Add At a Glance stats row (game count, active years, primary genre, platforms, avg rating)
- Add Release Timeline (horizontal strip of games grouped by year with cover thumbnails)
- Add Rating Distribution bar chart (excellent/good/average/poor/unrated with colored bars)
- Applied consistently to both developer and publisher pages on web and player app

## Changes
- **Backend**: 5 new pure helpers, 20 new tests (active years, rating distribution, primary genre, timeline with thresholds)
- **Web**: 3 new feature components + 32 new tests
- **Player**: 3 new composables + 16 new desktop E2E tests

## Test plan
- [x] Go tests pass (20 new tests)
- [x] Web unit tests pass (1236 tests across 115 files)
- [x] Player desktop tests pass (610 tests)
- [x] TypeScript compilation clean
- [x] Code reviewer approved (after staging fix)
- [x] UI agent approved