### PR TITLE
fix: add games heading to web console detail page

### DIFF
--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -171,6 +171,13 @@ export function ConsoleDetailPage() {
       <ConsoleTopDevelopers consoleId={id!} />
       <ConsoleRecentlyPlayed consoleId={id!} />
 
+      {/* Games heading */}
+      {!isLoading && games.length > 0 && (
+        <h2 className="text-lg font-bold text-surface-100">
+          {totalGames} {totalGames === 1 ? "game" : "games"}
+        </h2>
+      )}
+
       {/* Games grid */}
       {isLoading ? (
         <GameGrid>


### PR DESCRIPTION
## Summary
- Add "{count} games" heading above the games grid on the web console detail page
- Matches the player app which already shows this heading with a sort dropdown

## Test plan
- [x] TypeScript compilation clean
- Visual check: heading appears above games grid, hidden during loading and when no games