### PR TITLE
feat: add Replace ROM endpoint and game detail UI

### DIFF
--- a/server/internal/api/game_handler_replace.go
+++ b/server/internal/api/game_handler_replace.go
@@ -1,0 +1,258 @@
+package api
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/scanner"
+	"github.com/spela/server/internal/scraper"
+	"github.com/spela/server/internal/storage"
+)
+
+// ReplaceROMResult holds the verification result from a ROM replacement.
+type ReplaceROMResult struct {
+	Verified       bool   `json:"verified"`
+	CRC32          string `json:"crc32"`
+	CanonicalName  string `json:"canonicalName,omitempty"`
+	PreviousStatus string `json:"previousStatus"`
+	PreviousCRC32  string `json:"previousCrc32"`
+}
+
+// ReplaceROMResponse is the API response for a ROM replacement.
+type ReplaceROMResponse struct {
+	Game              GameResponse     `json:"game"`
+	ReplacementResult ReplaceROMResult `json:"replacementResult"`
+}
+
+// ReplaceROM replaces a game's ROM file with a new one, re-verifying against DAT files.
+// PUT /api/admin/games/:id/replace-rom
+func (h *GameHandler) ReplaceROM(c *gin.Context) {
+	id := c.Param("id")
+	var game db.Game
+	if err := h.DB.Preload("Console").First(&game, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "game not found"})
+		return
+	}
+
+	// Accept the uploaded file
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxROMUploadSize)
+	file, header, err := c.Request.FormFile("file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "file required in 'file' field"})
+		return
+	}
+	defer file.Close()
+
+	ext := strings.ToLower(filepath.Ext(header.Filename))
+
+	// Write uploaded file to a temp location
+	tmpDir := os.TempDir()
+	tmpFile, err := os.CreateTemp(tmpDir, "replace-rom-*"+ext)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create temp file"})
+		return
+	}
+	tmpPath := tmpFile.Name()
+	defer os.Remove(tmpPath)
+
+	written, err := io.Copy(tmpFile, file)
+	tmpFile.Close()
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to write uploaded file"})
+		return
+	}
+
+	// If zip, extract the first ROM file
+	var romPath string
+	var romExt string
+	var romSize int64
+	var extractedTmpPath string
+
+	if ext == ".zip" {
+		extractedPath, extractedExt, extractedSize, extractErr := extractFirstROMFromZip(tmpPath, maxROMUploadSize)
+		if extractErr != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": extractErr.Error()})
+			return
+		}
+		romPath = extractedPath
+		romExt = extractedExt
+		romSize = extractedSize
+		extractedTmpPath = extractedPath
+		defer os.Remove(extractedTmpPath)
+	} else {
+		// Validate extension is a recognized ROM type
+		if !scanner.RomExtensions[ext] {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unrecognized ROM file extension: " + ext})
+			return
+		}
+		romPath = tmpPath
+		romExt = ext
+		romSize = written
+	}
+
+	// Compute CRC32 of the new ROM
+	crc, err := scraper.ComputeFileCRC32(romPath)
+	if err != nil {
+		slog.Warn("failed to compute CRC32 for replacement ROM", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to compute CRC32"})
+		return
+	}
+
+	// Save previous state for response
+	previousStatus := game.VerificationStatus
+	previousCRC32 := game.CRC32
+
+	// Verify against DAT files
+	verified := false
+	canonicalName := ""
+	newVerificationStatus := "unverified"
+
+	if h.Scraper != nil && h.Scraper.DATCache != nil {
+		consoleAbbrev := game.Console.Abbreviation
+
+		if scraper.DiscBasedSystems[consoleAbbrev] {
+			// Try Redump DAT for disc-based systems
+			newVerificationStatus = "not_applicable"
+			if idx, err := h.Scraper.DATCache.GetRedumpIndex(consoleAbbrev); err == nil && idx != nil {
+				if entry, ok := idx.LookupCRC(crc); ok {
+					verified = true
+					canonicalName = entry.ROMName
+					newVerificationStatus = "verified"
+				}
+			}
+		} else {
+			// Try No-Intro DAT for cartridge-based systems
+			if idx, err := h.Scraper.DATCache.GetIndex(consoleAbbrev); err == nil && idx != nil {
+				if entry, ok := idx.LookupCRC(crc); ok {
+					verified = true
+					canonicalName = entry.ROMName
+					newVerificationStatus = "verified"
+				}
+			}
+		}
+	}
+
+	// Resolve the current ROM path on disk
+	oldAbsPath, err := storage.ResolveGamePath(game.FilePath, h.GameDirs)
+	if err != nil {
+		slog.Warn("could not resolve existing game file path", "filePath", game.FilePath, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to locate existing ROM file"})
+		return
+	}
+
+	// Determine the target filename and path
+	targetDir := filepath.Dir(oldAbsPath)
+	targetName := game.FileName
+	if verified && canonicalName != "" {
+		// Use canonical name with proper extension
+		targetName = canonicalName
+		if filepath.Ext(canonicalName) == "" {
+			targetName = canonicalName + romExt
+		}
+	}
+	targetPath := filepath.Join(targetDir, targetName)
+
+	// Copy new ROM to target location
+	if err := copyFile(romPath, targetPath); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to write replacement ROM"})
+		return
+	}
+
+	// Update game record in DB before removing old file to avoid inconsistent state
+	game.CRC32 = crc
+	game.VerificationStatus = newVerificationStatus
+	game.FileName = targetName
+	game.FilePath = filepath.Join(game.Console.FolderName, targetName)
+	game.FileSize = romSize
+
+	if err := h.DB.Save(&game).Error; err != nil {
+		// DB save failed — remove the new file if it differs from old to avoid orphans
+		if targetPath != oldAbsPath {
+			os.Remove(targetPath)
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update game record"})
+		return
+	}
+
+	// Remove old file if target path changed (rename case)
+	if targetPath != oldAbsPath {
+		if err := os.Remove(oldAbsPath); err != nil {
+			slog.Warn("failed to remove old ROM file after replacement", "path", oldAbsPath, "error", err)
+		}
+	}
+
+	// Reload with associations for the response
+	h.DB.Preload("Console").Preload("Discs").Preload("Screenshots").First(&game, game.ID)
+	userID := getUserID(c)
+
+	c.JSON(http.StatusOK, ReplaceROMResponse{
+		Game: ToGameResponse(game, h.DB, userID),
+		ReplacementResult: ReplaceROMResult{
+			Verified:       verified,
+			CRC32:          crc,
+			CanonicalName:  canonicalName,
+			PreviousStatus: previousStatus,
+			PreviousCRC32:  previousCRC32,
+		},
+	})
+}
+
+// extractFirstROMFromZip opens a zip archive and extracts the first recognized ROM file
+// to a temporary location. Returns the path, extension, size, and any error.
+// maxSize limits the decompressed output to prevent zip bomb attacks.
+func extractFirstROMFromZip(zipPath string, maxSize int64) (string, string, int64, error) {
+	r, err := zip.OpenReader(zipPath)
+	if err != nil {
+		return "", "", 0, fmt.Errorf("failed to open zip file: %w", err)
+	}
+	defer r.Close()
+
+	for _, zf := range r.File {
+		if zf.FileInfo().IsDir() {
+			continue
+		}
+
+		ext := strings.ToLower(filepath.Ext(zf.Name))
+		if !scanner.RomExtensions[ext] {
+			continue
+		}
+
+		// Found a ROM file — extract it
+		zfReader, err := zf.Open()
+		if err != nil {
+			return "", "", 0, fmt.Errorf("failed to open zip entry %s: %w", zf.Name, err)
+		}
+
+		tmpFile, err := os.CreateTemp("", "replace-rom-zip-*"+ext)
+		if err != nil {
+			zfReader.Close()
+			return "", "", 0, fmt.Errorf("failed to create temp file for extraction: %w", err)
+		}
+
+		// Use LimitedReader to prevent zip bomb decompression attacks
+		limited := &io.LimitedReader{R: zfReader, N: maxSize + 1}
+		written, err := io.Copy(tmpFile, limited)
+		tmpFile.Close()
+		zfReader.Close()
+		if err != nil {
+			os.Remove(tmpFile.Name())
+			return "", "", 0, fmt.Errorf("failed to extract zip entry %s: %w", zf.Name, err)
+		}
+		if written > maxSize {
+			os.Remove(tmpFile.Name())
+			return "", "", 0, fmt.Errorf("extracted ROM exceeds maximum size limit")
+		}
+
+		return tmpFile.Name(), ext, written, nil
+	}
+
+	return "", "", 0, fmt.Errorf("no recognized ROM file found in zip archive")
+}

--- a/server/internal/api/game_handler_replace_test.go
+++ b/server/internal/api/game_handler_replace_test.go
@@ -1,0 +1,359 @@
+package api
+
+import (
+	"archive/zip"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spela/server/internal/auth"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/scraper"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// replaceROMTestEnv holds the test environment for replace ROM tests.
+type replaceROMTestEnv struct {
+	db         *gorm.DB
+	cfg        *Config
+	router     http.Handler
+	adminToken string
+	gameDir    string
+}
+
+func setupReplaceROMTestEnv(t *testing.T) *replaceROMTestEnv {
+	t.Helper()
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+
+	// Create admin user
+	user := db.User{
+		Username:     "replaceadmin",
+		Email:        "replaceadmin@test.com",
+		PasswordHash: "unused",
+		Role:         "owner",
+	}
+	require.NoError(t, database.Create(&user).Error)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	require.NoError(t, err)
+
+	router := NewRouter(*cfg)
+
+	return &replaceROMTestEnv{
+		db:         database,
+		cfg:        cfg,
+		router:     router,
+		adminToken: token,
+		gameDir:    cfg.GameDirs[0],
+	}
+}
+
+// createTestGameWithROM creates a game record and its ROM file on disk.
+func createTestGameWithROM(t *testing.T, env *replaceROMTestEnv, consoleAbbrev, title, fileName string, romContent []byte) db.Game {
+	t.Helper()
+
+	var console db.Console
+	require.NoError(t, env.db.Where("abbreviation = ?", consoleAbbrev).First(&console).Error)
+
+	// Create the ROM file on disk
+	consoleDir := filepath.Join(env.gameDir, console.FolderName)
+	require.NoError(t, os.MkdirAll(consoleDir, 0755))
+	romPath := filepath.Join(consoleDir, fileName)
+	require.NoError(t, os.WriteFile(romPath, romContent, 0644))
+
+	// Compute CRC for the original file
+	crc, err := scraper.ComputeFileCRC32(romPath)
+	require.NoError(t, err)
+
+	game := db.Game{
+		ConsoleID:          console.ID,
+		Title:              title,
+		FileName:           fileName,
+		FilePath:           filepath.Join(console.FolderName, fileName),
+		FileSize:           int64(len(romContent)),
+		CRC32:              crc,
+		VerificationStatus: "unverified",
+	}
+	require.NoError(t, env.db.Create(&game).Error)
+	return game
+}
+
+// replaceROM sends a PUT request to replace a game's ROM file.
+func replaceROM(t *testing.T, env *replaceROMTestEnv, gameID uint, fileName string, fileContent []byte) *httptest.ResponseRecorder {
+	t.Helper()
+
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", fileName)
+	require.NoError(t, err)
+	_, err = part.Write(fileContent)
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	w := httptest.NewRecorder()
+	url := fmt.Sprintf("/api/admin/games/%d/replace-rom", gameID)
+	req := httptest.NewRequest("PUT", url, body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+env.adminToken)
+	env.router.ServeHTTP(w, req)
+	return w
+}
+
+func TestReplaceROM_Success(t *testing.T) {
+	env := setupReplaceROMTestEnv(t)
+
+	// Create a game with an initial ROM
+	originalContent := []byte("original rom data")
+	game := createTestGameWithROM(t, env, "NES", "Test Game", "test.nes", originalContent)
+	originalCRC := game.CRC32
+
+	// Replace with new ROM content
+	newContent := []byte("new rom data that is different")
+	w := replaceROM(t, env, game.ID, "replacement.nes", newContent)
+
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp ReplaceROMResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Verify response structure
+	assert.NotEmpty(t, resp.ReplacementResult.CRC32)
+	assert.NotEqual(t, originalCRC, resp.ReplacementResult.CRC32)
+	assert.Equal(t, "unverified", resp.ReplacementResult.PreviousStatus)
+	assert.Equal(t, originalCRC, resp.ReplacementResult.PreviousCRC32)
+
+	// Verify game record was updated
+	var updatedGame db.Game
+	require.NoError(t, env.db.First(&updatedGame, game.ID).Error)
+	assert.Equal(t, resp.ReplacementResult.CRC32, updatedGame.CRC32)
+	assert.Equal(t, int64(len(newContent)), updatedGame.FileSize)
+}
+
+func TestReplaceROM_CRC32Updated(t *testing.T) {
+	env := setupReplaceROMTestEnv(t)
+
+	originalContent := []byte("original nes rom")
+	game := createTestGameWithROM(t, env, "NES", "CRC Test", "crc_test.nes", originalContent)
+
+	// Compute expected CRC of new content
+	newContent := []byte("completely different rom content for crc check")
+	tmpFile, err := os.CreateTemp("", "crc-test-*.nes")
+	require.NoError(t, err)
+	_, err = tmpFile.Write(newContent)
+	require.NoError(t, err)
+	tmpFile.Close()
+	defer os.Remove(tmpFile.Name())
+	expectedCRC, err := scraper.ComputeFileCRC32(tmpFile.Name())
+	require.NoError(t, err)
+
+	w := replaceROM(t, env, game.ID, "new_crc.nes", newContent)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp ReplaceROMResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// CRC in response should match expected
+	assert.Equal(t, expectedCRC, resp.ReplacementResult.CRC32)
+
+	// DB record should have the new CRC
+	var updatedGame db.Game
+	require.NoError(t, env.db.First(&updatedGame, game.ID).Error)
+	assert.Equal(t, expectedCRC, updatedGame.CRC32)
+}
+
+func TestReplaceROM_FileSizeUpdated(t *testing.T) {
+	env := setupReplaceROMTestEnv(t)
+
+	originalContent := []byte("short")
+	game := createTestGameWithROM(t, env, "SNES", "Size Test", "size_test.sfc", originalContent)
+
+	newContent := []byte("this is a much longer piece of content that represents the new ROM file")
+	w := replaceROM(t, env, game.ID, "bigger.sfc", newContent)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var updatedGame db.Game
+	require.NoError(t, env.db.First(&updatedGame, game.ID).Error)
+	assert.Equal(t, int64(len(newContent)), updatedGame.FileSize)
+}
+
+func TestReplaceROM_GameNotFound(t *testing.T) {
+	env := setupReplaceROMTestEnv(t)
+
+	w := replaceROM(t, env, 99999, "test.nes", []byte("rom data"))
+	assert.Equal(t, http.StatusNotFound, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, "game not found", resp["error"])
+}
+
+func TestReplaceROM_InvalidExtension(t *testing.T) {
+	env := setupReplaceROMTestEnv(t)
+
+	originalContent := []byte("original rom")
+	game := createTestGameWithROM(t, env, "NES", "Ext Test", "ext_test.nes", originalContent)
+
+	w := replaceROM(t, env, game.ID, "readme.txt", []byte("not a rom"))
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Contains(t, resp["error"], "unrecognized ROM file extension")
+}
+
+func TestReplaceROM_ZipWithROM(t *testing.T) {
+	env := setupReplaceROMTestEnv(t)
+
+	originalContent := []byte("original nes rom data")
+	game := createTestGameWithROM(t, env, "NES", "Zip Test", "zip_test.nes", originalContent)
+
+	// Create a zip file containing a NES ROM
+	romContent := []byte("zipped rom content for NES")
+	zipBuf := &bytes.Buffer{}
+	zw := zip.NewWriter(zipBuf)
+	zfWriter, err := zw.Create("inner_game.nes")
+	require.NoError(t, err)
+	_, err = zfWriter.Write(romContent)
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	w := replaceROM(t, env, game.ID, "game_bundle.zip", zipBuf.Bytes())
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp ReplaceROMResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// CRC should be of the extracted ROM content, not the zip
+	assert.NotEmpty(t, resp.ReplacementResult.CRC32)
+
+	// File size should match the extracted ROM, not the zip
+	var updatedGame db.Game
+	require.NoError(t, env.db.First(&updatedGame, game.ID).Error)
+	assert.Equal(t, int64(len(romContent)), updatedGame.FileSize)
+}
+
+func TestReplaceROM_ZipNoROMs(t *testing.T) {
+	env := setupReplaceROMTestEnv(t)
+
+	originalContent := []byte("original rom")
+	game := createTestGameWithROM(t, env, "NES", "Empty Zip", "empty_zip_test.nes", originalContent)
+
+	// Create a zip file with no ROM files
+	zipBuf := &bytes.Buffer{}
+	zw := zip.NewWriter(zipBuf)
+	zfWriter, err := zw.Create("readme.txt")
+	require.NoError(t, err)
+	_, err = zfWriter.Write([]byte("just a readme"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+
+	w := replaceROM(t, env, game.ID, "no_roms.zip", zipBuf.Bytes())
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var resp map[string]string
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Contains(t, resp["error"], "no recognized ROM file")
+}
+
+func TestReplaceROM_PreservesMetadata(t *testing.T) {
+	env := setupReplaceROMTestEnv(t)
+
+	originalContent := []byte("original rom")
+	game := createTestGameWithROM(t, env, "NES", "Metadata Preserve", "meta_test.nes", originalContent)
+
+	// Add metadata to the game
+	game.Description = "A great game"
+	game.Developer = "Test Dev"
+	game.Publisher = "Test Pub"
+	game.Genre = "Action"
+	game.Rating = 85.5
+	game.CoverURL = "https://example.com/cover.jpg"
+	require.NoError(t, env.db.Save(&game).Error)
+
+	// Replace ROM
+	newContent := []byte("replacement rom data")
+	w := replaceROM(t, env, game.ID, "new.nes", newContent)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	// Verify metadata is preserved
+	var updatedGame db.Game
+	require.NoError(t, env.db.First(&updatedGame, game.ID).Error)
+	assert.Equal(t, "A great game", updatedGame.Description)
+	assert.Equal(t, "Test Dev", updatedGame.Developer)
+	assert.Equal(t, "Test Pub", updatedGame.Publisher)
+	assert.Equal(t, "Action", updatedGame.Genre)
+	assert.Equal(t, 85.5, updatedGame.Rating)
+	assert.Equal(t, "https://example.com/cover.jpg", updatedGame.CoverURL)
+
+	// But CRC and file size should be updated
+	assert.Equal(t, int64(len(newContent)), updatedGame.FileSize)
+	assert.NotEqual(t, game.CRC32, updatedGame.CRC32)
+}
+
+func TestReplaceROM_UnverifiedStaysUnverified(t *testing.T) {
+	env := setupReplaceROMTestEnv(t)
+
+	// No DAT files loaded, so verification will not happen
+	originalContent := []byte("original rom")
+	game := createTestGameWithROM(t, env, "NES", "Unverified Test", "unverified_test.nes", originalContent)
+
+	newContent := []byte("new unverified rom")
+	w := replaceROM(t, env, game.ID, "new.nes", newContent)
+	assert.Equal(t, http.StatusOK, w.Code, w.Body.String())
+
+	var resp ReplaceROMResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// Without DAT files, ROM should remain unverified
+	assert.False(t, resp.ReplacementResult.Verified)
+	assert.Equal(t, "unverified", resp.ReplacementResult.PreviousStatus)
+
+	var updatedGame db.Game
+	require.NoError(t, env.db.First(&updatedGame, game.ID).Error)
+	assert.Equal(t, "unverified", updatedGame.VerificationStatus)
+}
+
+func TestReplaceROM_RequiresAdmin(t *testing.T) {
+	env := setupReplaceROMTestEnv(t)
+
+	originalContent := []byte("original rom")
+	game := createTestGameWithROM(t, env, "NES", "Auth Test", "auth_test.nes", originalContent)
+
+	// Create a non-admin user
+	user := db.User{
+		Username:     "regularuser",
+		Email:        "regular@test.com",
+		PasswordHash: "unused",
+		Role:         "user",
+	}
+	require.NoError(t, env.db.Create(&user).Error)
+	userToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	require.NoError(t, err)
+
+	// Try to replace ROM as non-admin
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreateFormFile("file", "new.nes")
+	require.NoError(t, err)
+	_, err = part.Write([]byte("new rom data"))
+	require.NoError(t, err)
+	require.NoError(t, writer.Close())
+
+	w := httptest.NewRecorder()
+	url := fmt.Sprintf("/api/admin/games/%d/replace-rom", game.ID)
+	req := httptest.NewRequest("PUT", url, body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+userToken)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -520,6 +520,7 @@ func NewRouter(cfg Config) *gin.Engine {
 			admin.POST("/bios/download", biosHandler.TriggerDownload)
 			admin.DELETE("/bios/:filename", biosHandler.DeleteBiosFile)
 			admin.PUT("/games/:id/verification-tag", gameHandler.UpdateVerificationTag)
+			admin.PUT("/games/:id/replace-rom", uploadLimiter.RateLimit(), gameHandler.ReplaceROM)
 			admin.POST("/cheats/import", adminHandler.TriggerCheatImport)
 			admin.GET("/cheats/stats", adminHandler.GetCheatStats)
 			admin.GET("/core-compatibility", adminHandler.GetCoreCompatibility)

--- a/web/src/features/game-detail/components/__tests__/replace-rom-modal.test.tsx
+++ b/web/src/features/game-detail/components/__tests__/replace-rom-modal.test.tsx
@@ -1,0 +1,306 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { ReplaceRomModal } from "../replace-rom-modal";
+
+const mockMutate = vi.fn();
+const mockReset = vi.fn();
+
+vi.mock("@/hooks/use-games", () => ({
+  useReplaceRom: vi.fn(() => ({
+    mutate: mockMutate,
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: mockReset,
+  })),
+}));
+
+import { useReplaceRom } from "@/hooks/use-games";
+
+const mockUseReplaceRom = useReplaceRom as ReturnType<typeof vi.fn>;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+const defaultProps = {
+  gameId: "game-1",
+  open: true,
+  onClose: vi.fn(),
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseReplaceRom.mockReturnValue({
+    mutate: mockMutate,
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: mockReset,
+  });
+});
+
+describe("ReplaceRomModal", () => {
+  it("renders modal with drop zone when open", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ReplaceRomModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.getByRole("dialog", { name: "Replace ROM" }),
+    ).toBeInTheDocument();
+    expect(screen.getByTestId("drop-zone")).toBeInTheDocument();
+    expect(
+      screen.getByText("Drop a ROM file here or click to browse"),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render when closed", () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ReplaceRomModal {...defaultProps} open={false} />
+      </Wrapper>,
+    );
+
+    expect(
+      screen.queryByRole("dialog", { name: "Replace ROM" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("triggers upload when a file is selected via input", async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ReplaceRomModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    const file = new File(["rom content"], "game.nes", {
+      type: "application/octet-stream",
+    });
+    const input = screen.getByTestId("file-input");
+
+    await userEvent.upload(input, file);
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { gameId: "game-1", file },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+      }),
+    );
+  });
+
+  it("shows success state when ROM is verified", async () => {
+    // Simulate a successful upload with verified result
+    mockMutate.mockImplementation((_args: unknown, opts: { onSuccess: (data: unknown) => void }) => {
+      opts.onSuccess({
+        replacementResult: {
+          verified: true,
+          crc32: "ABCD1234",
+          canonicalName: "Super Mario Bros (USA).nes",
+          previousStatus: "unverified",
+          previousCrc32: "00000000",
+        },
+      });
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ReplaceRomModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    const file = new File(["rom content"], "mario.nes", {
+      type: "application/octet-stream",
+    });
+    const input = screen.getByTestId("file-input");
+    await userEvent.upload(input, file);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("replace-result")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("ROM Verified")).toBeInTheDocument();
+    expect(screen.getByText("Verified")).toBeInTheDocument();
+    expect(
+      screen.getByText("Super Mario Bros (USA).nes"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("CRC32: ABCD1234")).toBeInTheDocument();
+  });
+
+  it("shows warning state when ROM is unverified", async () => {
+    mockMutate.mockImplementation((_args: unknown, opts: { onSuccess: (data: unknown) => void }) => {
+      opts.onSuccess({
+        replacementResult: {
+          verified: false,
+          crc32: "DEADBEEF",
+          previousStatus: "unverified",
+          previousCrc32: "00000000",
+        },
+      });
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ReplaceRomModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    const file = new File(["rom content"], "hack.nes", {
+      type: "application/octet-stream",
+    });
+    const input = screen.getByTestId("file-input");
+    await userEvent.upload(input, file);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("replace-result")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("ROM Replaced")).toBeInTheDocument();
+    expect(screen.getByText("Unverified")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "ROM replaced but does not match any known verified dump",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.getByText("CRC32: DEADBEEF")).toBeInTheDocument();
+  });
+
+  it("shows uploading state during upload", () => {
+    mockUseReplaceRom.mockReturnValue({
+      mutate: mockMutate,
+      isPending: true,
+      isError: false,
+      error: null,
+      reset: mockReset,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ReplaceRomModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByTestId("upload-progress")).toBeInTheDocument();
+  });
+
+  it("shows error state on upload failure", () => {
+    mockUseReplaceRom.mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+      isError: true,
+      error: new Error("File too large"),
+      reset: mockReset,
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ReplaceRomModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    expect(screen.getByTestId("upload-error")).toBeInTheDocument();
+    expect(screen.getByText("File too large")).toBeInTheDocument();
+  });
+
+  it("close button works in result view", async () => {
+    const onClose = vi.fn();
+    mockMutate.mockImplementation((_args: unknown, opts: { onSuccess: (data: unknown) => void }) => {
+      opts.onSuccess({
+        replacementResult: {
+          verified: true,
+          crc32: "ABCD1234",
+          previousStatus: "unverified",
+          previousCrc32: "00000000",
+        },
+      });
+    });
+
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ReplaceRomModal {...defaultProps} onClose={onClose} />
+      </Wrapper>,
+    );
+
+    const file = new File(["rom content"], "game.nes", {
+      type: "application/octet-stream",
+    });
+    const input = screen.getByTestId("file-input");
+    await userEvent.upload(input, file);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("replace-result")).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByText("Close"));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it("rejects invalid file extensions with feedback via drag-and-drop", async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ReplaceRomModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    const file = new File(["not a rom"], "readme.txt", {
+      type: "text/plain",
+    });
+    const dropZone = screen.getByTestId("drop-zone");
+
+    // Simulate drag-and-drop which bypasses the accept attribute
+    const dropEvent = new Event("drop", { bubbles: true });
+    Object.defineProperty(dropEvent, "dataTransfer", {
+      value: { files: [file] },
+    });
+    Object.defineProperty(dropEvent, "preventDefault", {
+      value: vi.fn(),
+    });
+    dropZone.dispatchEvent(dropEvent);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("validation-error")).toBeInTheDocument();
+    });
+    expect(mockMutate).not.toHaveBeenCalled();
+    expect(screen.getByText(/unsupported file type/i)).toBeInTheDocument();
+  });
+
+  it("accepts .zip files", async () => {
+    const Wrapper = createWrapper();
+    render(
+      <Wrapper>
+        <ReplaceRomModal {...defaultProps} />
+      </Wrapper>,
+    );
+
+    const file = new File(["zip content"], "game.zip", {
+      type: "application/zip",
+    });
+    const input = screen.getByTestId("file-input");
+    await userEvent.upload(input, file);
+
+    expect(mockMutate).toHaveBeenCalled();
+  });
+});

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -16,6 +16,7 @@ import {
   Search,
   Download,
   Monitor,
+  Replace,
 } from "lucide-react";
 import { Button, Badge, ActionsMenu } from "@/components/ui";
 import { VerificationBadge } from "./verification-badge";
@@ -48,6 +49,7 @@ interface GameHeroProps {
   onAddToCollection?: () => void;
   onFixMatch?: () => void;
   onDownloadRom?: () => void;
+  onReplaceRom?: () => void;
 }
 
 export function GameHero({
@@ -68,6 +70,7 @@ export function GameHero({
   onAddToCollection,
   onFixMatch,
   onDownloadRom,
+  onReplaceRom,
 }: GameHeroProps) {
   const [showCoverModal, setShowCoverModal] = useState(false);
   const consoleName = game.consoleName ?? "";
@@ -123,6 +126,15 @@ export function GameHero({
             label: "Fix Match",
             icon: <Search className="h-4 w-4" />,
             onClick: onFixMatch,
+          },
+        ]
+      : []),
+    ...(onReplaceRom
+      ? [
+          {
+            label: "Replace ROM",
+            icon: <Replace className="h-4 w-4" />,
+            onClick: onReplaceRom,
           },
         ]
       : []),

--- a/web/src/features/game-detail/components/replace-rom-modal.tsx
+++ b/web/src/features/game-detail/components/replace-rom-modal.tsx
@@ -1,0 +1,269 @@
+import { useState, useRef } from "react";
+import { CheckCircle2, AlertTriangle, Upload, FileUp } from "lucide-react";
+import { Modal, Button, Badge } from "@/components/ui";
+import { useReplaceRom } from "@/hooks/use-games";
+import { formatFileSize } from "@/lib/format";
+import { cn } from "@/lib/cn";
+import type { ReplaceROMResult } from "@/types/api";
+
+const ACCEPTED_EXTENSIONS = [
+  ".zip",
+  ".nes",
+  ".sfc",
+  ".smc",
+  ".gba",
+  ".gb",
+  ".gbc",
+  ".md",
+  ".gen",
+  ".n64",
+  ".z64",
+  ".v64",
+  ".nds",
+  ".iso",
+  ".bin",
+  ".cue",
+  ".img",
+  ".chd",
+  ".pce",
+  ".ngp",
+  ".ngc",
+  ".ws",
+  ".wsc",
+  ".a26",
+  ".a78",
+  ".lnx",
+  ".jag",
+  ".col",
+  ".sg",
+  ".gg",
+  ".sms",
+  ".32x",
+  ".vec",
+];
+
+const ACCEPT_STRING = ACCEPTED_EXTENSIONS.join(",");
+
+interface ReplaceRomModalProps {
+  gameId: string;
+  open: boolean;
+  onClose: () => void;
+}
+
+export function ReplaceRomModal({
+  gameId,
+  open,
+  onClose,
+}: ReplaceRomModalProps) {
+  const [dragOver, setDragOver] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [result, setResult] = useState<ReplaceROMResult | null>(null);
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const replaceRom = useReplaceRom();
+
+  function handleClose() {
+    setSelectedFile(null);
+    setResult(null);
+    setDragOver(false);
+    setValidationError(null);
+    replaceRom.reset();
+    onClose();
+  }
+
+  function isValidFile(file: File): boolean {
+    const name = file.name.toLowerCase();
+    return ACCEPTED_EXTENSIONS.some((ext) => name.endsWith(ext));
+  }
+
+  function handleFile(file: File) {
+    if (!isValidFile(file)) {
+      setValidationError(
+        `Unsupported file type. Expected a ROM file (.nes, .sfc, .gba, .zip, etc.)`,
+      );
+      return;
+    }
+    setValidationError(null);
+    setSelectedFile(file);
+    setResult(null);
+    replaceRom.mutate(
+      { gameId, file },
+      {
+        onSuccess: (data) => {
+          setResult(data.replacementResult);
+        },
+      },
+    );
+  }
+
+  function handleDrop(e: React.DragEvent) {
+    e.preventDefault();
+    setDragOver(false);
+    const file = e.dataTransfer.files[0];
+    if (file) handleFile(file);
+  }
+
+  function handleDragOver(e: React.DragEvent) {
+    e.preventDefault();
+    setDragOver(true);
+  }
+
+  function handleDragLeave(e: React.DragEvent) {
+    e.preventDefault();
+    setDragOver(false);
+  }
+
+  function handleInputChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (file) handleFile(file);
+    // Reset the input so the same file can be re-selected
+    e.target.value = "";
+  }
+
+  const isUploading = replaceRom.isPending;
+  const isError = replaceRom.isError;
+  const errorMessage =
+    replaceRom.error instanceof Error
+      ? replaceRom.error.message
+      : "Upload failed";
+
+  return (
+    <Modal open={open} onClose={handleClose} title="Replace ROM" size="sm">
+      {result ? (
+        <ResultView result={result} onClose={handleClose} />
+      ) : (
+        <div className="space-y-4">
+          {/* Drop zone */}
+          <button
+            type="button"
+            data-testid="drop-zone"
+            aria-label="Select ROM file to upload"
+            className={cn(
+              "w-full rounded-2xl border-2 border-dashed p-8 text-center transition-colors cursor-pointer",
+              "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500",
+              dragOver
+                ? "border-brand-500 bg-brand-500/5"
+                : "border-surface-700 hover:border-surface-500 bg-surface-800/50",
+              isUploading && "pointer-events-none opacity-60",
+            )}
+            onClick={() => fileInputRef.current?.click()}
+            onDrop={handleDrop}
+            onDragOver={handleDragOver}
+            onDragLeave={handleDragLeave}
+          >
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              accept={ACCEPT_STRING}
+              onChange={handleInputChange}
+              data-testid="file-input"
+            />
+            {isUploading ? (
+              <div className="space-y-3">
+                <FileUp className="h-10 w-10 mx-auto text-brand-400 animate-pulse" />
+                <p className="text-sm font-medium text-surface-200">
+                  Uploading {selectedFile?.name}...
+                </p>
+                <p className="text-xs text-surface-400">
+                  {selectedFile && formatFileSize(selectedFile.size)}
+                </p>
+                <div
+                  className="mx-auto w-48 h-1.5 rounded-full bg-surface-700 overflow-hidden"
+                  data-testid="upload-progress"
+                >
+                  <div className="h-full rounded-full bg-brand-500 animate-pulse" style={{ width: "100%" }} />
+                </div>
+              </div>
+            ) : (
+              <div className="space-y-3">
+                <Upload className="h-10 w-10 mx-auto text-surface-500" />
+                <div>
+                  <p className="text-sm font-medium text-surface-200">
+                    Drop a ROM file here or click to browse
+                  </p>
+                  <p className="text-xs text-surface-500 mt-1">
+                    Supports .zip, .nes, .sfc, .smc, .gba, .gb, .gbc, .md, and
+                    more
+                  </p>
+                </div>
+              </div>
+            )}
+          </button>
+
+          {validationError && (
+            <div
+              className="flex items-center gap-2 rounded-lg bg-warning-500/10 border border-warning-500/20 px-4 py-3 text-sm text-warning-400"
+              data-testid="validation-error"
+              role="alert"
+            >
+              <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+              {validationError}
+            </div>
+          )}
+
+          {isError && (
+            <div
+              className="flex items-center gap-2 rounded-lg bg-danger-500/10 border border-danger-500/20 px-4 py-3 text-sm text-danger-400"
+              data-testid="upload-error"
+              role="alert"
+            >
+              <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+              {errorMessage}
+            </div>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function ResultView({
+  result,
+  onClose,
+}: {
+  result: ReplaceROMResult;
+  onClose: () => void;
+}) {
+  return (
+    <div className="space-y-4" data-testid="replace-result">
+      {result.verified ? (
+        <div className="flex flex-col items-center gap-3 py-2">
+          <CheckCircle2 className="h-12 w-12 text-success-500" />
+          <p className="text-lg font-semibold text-surface-100">
+            ROM Verified
+          </p>
+          <Badge variant="success">Verified</Badge>
+          {result.canonicalName && (
+            <p className="text-sm text-surface-300 text-center">
+              {result.canonicalName}
+            </p>
+          )}
+          <p className="text-xs text-surface-500 font-mono">
+            CRC32: {result.crc32}
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col items-center gap-3 py-2">
+          <AlertTriangle className="h-12 w-12 text-warning-500" />
+          <p className="text-lg font-semibold text-surface-100">
+            ROM Replaced
+          </p>
+          <Badge variant="warning">Unverified</Badge>
+          <p className="text-sm text-surface-400 text-center">
+            ROM replaced but does not match any known verified dump
+          </p>
+          <p className="text-xs text-surface-500 font-mono">
+            CRC32: {result.crc32}
+          </p>
+        </div>
+      )}
+
+      <div className="flex justify-center pt-2">
+        <Button variant="primary" size="sm" onClick={onClose}>
+          Close
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/use-games.ts
+++ b/web/src/hooks/use-games.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
-import type { Game, GamesResponse, GameFilters } from "@/types/api";
+import type { Game, GamesResponse, GameFilters, ReplaceROMResponse } from "@/types/api";
 
 export function useGames(filters?: GameFilters) {
   const params = new URLSearchParams();
@@ -92,6 +92,25 @@ export function useScrapeIfNeeded() {
   return useMutation({
     mutationFn: (gameId: string) =>
       api.post(`/games/${gameId}/scrape-if-needed`),
+  });
+}
+
+export function useReplaceRom() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ gameId, file }: { gameId: string; file: File }) => {
+      const formData = new FormData();
+      formData.append("file", file);
+      return api.uploadPut<ReplaceROMResponse>(
+        `/admin/games/${gameId}/replace-rom`,
+        formData,
+      );
+    },
+    onSuccess: (_data, { gameId }) => {
+      queryClient.invalidateQueries({ queryKey: ["game", gameId] });
+      queryClient.invalidateQueries({ queryKey: ["games"] });
+    },
   });
 }
 

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -140,6 +140,9 @@ export const api = {
   upload: <T>(path: ApiPostPath, formData: FormData) =>
     request<T>(path, { method: "POST", body: formData }),
 
+  uploadPut: <T>(path: ApiPutPath, formData: FormData) =>
+    request<T>(path, { method: "PUT", body: formData }),
+
   setTokens,
   clearTokens,
   getAccessToken,

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -335,6 +335,7 @@ export type ApiPutPath = WithQuery<
   | "/admin/settings"
   | `/admin/games/${string}/covers`
   | `/admin/games/${string}/verification-tag`
+  | `/admin/games/${string}/replace-rom`
 >;
 
 // ── DELETE ────────────────────────────────────────────────────────────────────

--- a/web/src/pages/__tests__/game-detail-page.test.tsx
+++ b/web/src/pages/__tests__/game-detail-page.test.tsx
@@ -8,6 +8,13 @@ vi.mock("@/hooks/use-games", () => ({
   useGame: vi.fn(),
   useToggleFavorite: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
   useScrapeIfNeeded: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useReplaceRom: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+    reset: vi.fn(),
+  })),
 }));
 
 vi.mock("@/hooks/use-play-later", () => ({

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -39,6 +39,7 @@ import { useGameSeries, useGameFranchises } from "@/hooks/use-explore";
 import { useBiosStatus } from "@/hooks/use-bios";
 import { BiosWarningBanner } from "@/features/bios/components/bios-warning-banner";
 import { ScrapeMatchModal } from "@/features/game-detail/components/scrape-match-modal";
+import { ReplaceRomModal } from "@/features/game-detail/components/replace-rom-modal";
 import { api } from "@/lib/api-client";
 import type { Collection } from "@/types/api";
 
@@ -123,6 +124,7 @@ export function GameDetailPage() {
   const hasAchievements = (gameAchievements?.achievements?.length ?? 0) > 0;
   const [showCollectionPicker, setShowCollectionPicker] = useState(false);
   const [showScrapeMatch, setShowScrapeMatch] = useState(false);
+  const [showReplaceRom, setShowReplaceRom] = useState(false);
 
   useEffect(() => {
     if (game && game.scrapeAttempts === 0) {
@@ -212,6 +214,11 @@ export function GameDetailPage() {
             : undefined
         }
         onDownloadRom={!isPlayable ? handleDownloadRom : undefined}
+        onReplaceRom={
+          isAdmin && game.verificationStatus !== "verified"
+            ? () => setShowReplaceRom(true)
+            : undefined
+        }
       />
 
       <ScrapeMatchModal
@@ -221,6 +228,12 @@ export function GameDetailPage() {
         currentScraperId={game.scraperId}
         open={showScrapeMatch}
         onClose={() => setShowScrapeMatch(false)}
+      />
+
+      <ReplaceRomModal
+        gameId={game.id}
+        open={showReplaceRom}
+        onClose={() => setShowReplaceRom(false)}
       />
 
       <CollectionPickerModal

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -823,6 +823,21 @@ export interface CompleteAttemptResponse {
   isNewBest: boolean;
 }
 
+// --- Replace ROM ---
+
+export interface ReplaceROMResult {
+  verified: boolean;
+  crc32: string;
+  canonicalName?: string;
+  previousStatus: string;
+  previousCrc32: string;
+}
+
+export interface ReplaceROMResponse {
+  game: Game;
+  replacementResult: ReplaceROMResult;
+}
+
 // --- Staged Uploads ---
 
 export type StagedUploadStatus =


### PR DESCRIPTION
## Summary
- Adds `PUT /api/admin/games/:id/replace-rom` endpoint that accepts ROM uploads (including ZIP), computes CRC32, verifies against No-Intro/Redump DATs, and replaces the file on disk
- Adds "Replace ROM" action in the game detail page actions menu for admin users viewing unverified games
- Opens a drag-and-drop modal that uploads the file and shows verification results (verified/unverified with CRC32 and canonical name)

### Backend
- ZIP extraction with zip bomb protection (LimitedReader)
- Upload rate limiting consistent with other upload endpoints  
- File-then-DB update ordering to prevent inconsistent state on failures
- 10 unit tests covering success, CRC updates, file size, 404, invalid extensions, ZIP handling, metadata preservation, and auth

### Web
- `ReplaceRomModal` with accessible drop zone, upload progress, validation error feedback, and result states
- `useReplaceRom` mutation hook with cache invalidation
- 10 unit tests covering all modal states and interactions

## Test plan
- [x] Backend: 10 tests pass (`go test ./internal/api/ -run Replace`)
- [x] Web: 10 modal tests + 1 game-detail-page test pass
- [x] Full web suite: 1275 tests pass (117 files)
- [x] Full Go suite: all tests pass
- [x] TypeScript compiles clean
- [x] Code reviewed
- [x] UX reviewed