### PR TITLE
feat: save all IGDB genres, game modes, and regional release dates

### DIFF
--- a/server/internal/api/admin_igdb_match_test.go
+++ b/server/internal/api/admin_igdb_match_test.go
@@ -35,7 +35,7 @@ func setupIGDBMatchTestEnv(t *testing.T, tokenServerURL, igdbServerURL string) (
 	require.NoError(t, database.AutoMigrate(
 		&db.User{}, &db.Console{}, &db.Game{}, &db.GameScreenshot{},
 		&db.GameDisc{}, &db.Favorite{}, &db.PlayHistory{}, &db.ServerSetting{},
-		&db.GameRating{}, &db.PlayLaterItem{},
+		&db.GameRating{}, &db.PlayLaterItem{}, &db.GameReleaseDate{},
 	))
 
 	if tokenServerURL != "" {

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -82,6 +82,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.GameArtworkImage{},
 		&db.SavedSearch{},
 		&db.Company{},
+		&db.GameReleaseDate{},
 	)
 	require.NoError(t, err)
 	err = db.SeedConsoles(database)

--- a/server/internal/api/bios_handler_test.go
+++ b/server/internal/api/bios_handler_test.go
@@ -45,7 +45,7 @@ func setupBiosTestEnv(t *testing.T) (*storage.Storage, *gorm.DB, *gin.Engine) {
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	require.NoError(t, err)
-	require.NoError(t, database.AutoMigrate(&db.User{}, &db.Console{}, &db.Game{}))
+	require.NoError(t, database.AutoMigrate(&db.User{}, &db.Console{}, &db.Game{}, &db.GameReleaseDate{}))
 	require.NoError(t, db.SeedConsoles(database))
 
 	gin.SetMode(gin.TestMode)

--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -31,7 +31,7 @@ func setupConsoleTestEnv(t *testing.T) (*gorm.DB, *storage.Storage, *gin.Engine)
 	})
 	require.NoError(t, err)
 
-	err = database.AutoMigrate(&db.Console{}, &db.Game{}, &db.TopRatedGame{})
+	err = database.AutoMigrate(&db.Console{}, &db.Game{}, &db.TopRatedGame{}, &db.GameReleaseDate{})
 	require.NoError(t, err)
 
 	err = db.SeedConsoles(database)
@@ -244,7 +244,7 @@ func setupTopListTestEnv(t *testing.T) (*gorm.DB, *gin.Engine) {
 	})
 	require.NoError(t, err)
 
-	err = database.AutoMigrate(&db.Console{}, &db.Game{}, &db.TopRatedGame{})
+	err = database.AutoMigrate(&db.Console{}, &db.Game{}, &db.TopRatedGame{}, &db.GameReleaseDate{})
 	require.NoError(t, err)
 
 	err = db.SeedConsoles(database)

--- a/server/internal/api/game_discovery_handler_test.go
+++ b/server/internal/api/game_discovery_handler_test.go
@@ -24,7 +24,7 @@ func setupDiscoveryTestEnv(t *testing.T) (*gorm.DB, *gin.Engine) {
 	require.NoError(t, err)
 
 	err = database.AutoMigrate(
-		&db.Console{}, &db.Game{}, &db.SimilarGame{},
+		&db.Console{}, &db.Game{}, &db.SimilarGame{}, &db.GameReleaseDate{},
 	)
 	require.NoError(t, err)
 

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -35,7 +35,7 @@ type GameHandler struct {
 // ListGames returns all games with optional filtering.
 func (h *GameHandler) ListGames(c *gin.Context) {
 	var games []db.Game
-	query := h.DB.Preload("Console").Preload("Discs").Preload("Screenshots")
+	query := h.DB.Preload("Console").Preload("Discs").Preload("Screenshots").Preload("ReleaseDates")
 	countQuery := h.DB.Model(&db.Game{})
 
 	userID := getUserID(c)
@@ -262,7 +262,7 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 func (h *GameHandler) GetGame(c *gin.Context) {
 	id := c.Param("id")
 	var game db.Game
-	if err := h.DB.Preload("Console").Preload("Discs").Preload("Screenshots").First(&game, id).Error; err != nil {
+	if err := h.DB.Preload("Console").Preload("Discs").Preload("Screenshots").Preload("ReleaseDates").First(&game, id).Error; err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "game not found"})
 		return
 	}
@@ -399,7 +399,7 @@ func (h *GameHandler) UpdateMetadata(c *gin.Context) {
 		return
 	}
 
-	h.DB.Preload("Console").Preload("Screenshots").First(&game, game.ID)
+	h.DB.Preload("Console").Preload("Screenshots").Preload("ReleaseDates").First(&game, game.ID)
 	userID := getUserID(c)
 	c.JSON(http.StatusOK, ToGameResponse(game, h.DB, userID))
 }

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -57,9 +57,11 @@ type GameResponse struct {
 	Developer      string         `json:"developer"`
 	Publisher      string         `json:"publisher"`
 	ReleaseDate    string         `json:"releaseDate"`
-	Genre          string         `json:"genre"`
-	Players        int            `json:"players"`
-	Rating         float64        `json:"rating"`
+	Genre          string                `json:"genre"`
+	GameModes      string                `json:"gameModes,omitempty"`
+	Players        int                   `json:"players"`
+	Rating         float64               `json:"rating"`
+	ReleaseDates   []ReleaseDateResponse `json:"releaseDates,omitempty"`
 	Playable            bool           `json:"playable"`
 	CoreOverride        string         `json:"coreOverride,omitempty"`
 	ScraperID           string         `json:"scraperId,omitempty"`
@@ -78,6 +80,13 @@ type GameResponse struct {
 	AverageRating  float64        `json:"averageRating"`
 	RatingCount    int64          `json:"ratingCount"`
 	UserRating     *int           `json:"userRating,omitempty"`
+}
+
+// ReleaseDateResponse represents a regional release date in the API response.
+type ReleaseDateResponse struct {
+	Region   string `json:"region"`
+	Date     string `json:"date"`
+	Platform string `json:"platform,omitempty"`
 }
 
 // PaginatedResponse wraps a paginated list with standard keys.
@@ -278,6 +287,7 @@ func toGameResponseWithData(g db.Game, data *userGameData) GameResponse {
 		Publisher:       g.Publisher,
 		ReleaseDate:    g.ReleaseDate,
 		Genre:          g.Genre,
+		GameModes:      g.GameModes,
 		Players:        g.Players,
 		Rating:         g.Rating,
 		Playable:            g.Console.Playable,
@@ -288,6 +298,18 @@ func toGameResponseWithData(g db.Game, data *userGameData) GameResponse {
 		VerificationStatus:  g.VerificationStatus,
 		VerificationTag:     g.VerificationTag,
 		Region:              g.Region,
+	}
+
+	// Map release dates
+	if len(g.ReleaseDates) > 0 {
+		resp.ReleaseDates = make([]ReleaseDateResponse, len(g.ReleaseDates))
+		for i, rd := range g.ReleaseDates {
+			resp.ReleaseDates[i] = ReleaseDateResponse{
+				Region:   rd.Region,
+				Date:     rd.Date,
+				Platform: rd.Platform,
+			}
+		}
 	}
 
 	if data != nil {

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -166,6 +166,8 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&GameFranchiseGroup{},
 		&GameFranchiseEntry{},
 		&GameArtworkImage{},
+		// Regional release dates
+		&GameReleaseDate{},
 		// Phase 13: Saved Searches
 		&SavedSearch{},
 	)
@@ -532,6 +534,19 @@ func mergeGameData(database *gorm.DB, keeperID, dupID uint) {
 		}
 	}
 
+	// GameReleaseDate — move, skip if keeper already has same region
+	var dupReleaseDates []GameReleaseDate
+	database.Where("game_id = ?", dupID).Find(&dupReleaseDates)
+	for _, rd := range dupReleaseDates {
+		var count int64
+		database.Model(&GameReleaseDate{}).Where("game_id = ? AND region = ?", keeperID, rd.Region).Count(&count)
+		if count == 0 {
+			database.Model(&rd).Update("game_id", keeperID)
+		} else {
+			database.Unscoped().Delete(&rd)
+		}
+	}
+
 	// GameSeriesEntry — update any entries pointing to the duplicate game
 	database.Model(&GameSeriesEntry{}).Where("game_id = ?", dupID).Update("game_id", keeperID)
 
@@ -584,6 +599,9 @@ func mergeGameMetadata(database *gorm.DB, keeper, dup *Game) {
 	}
 	if keeper.Genre == "" && dup.Genre != "" {
 		updates["genre"] = dup.Genre
+	}
+	if keeper.GameModes == "" && dup.GameModes != "" {
+		updates["game_modes"] = dup.GameModes
 	}
 	if keeper.ReleaseDate == "" && dup.ReleaseDate != "" {
 		updates["release_date"] = dup.ReleaseDate

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -91,7 +91,8 @@ type Game struct {
 	Developer     string         `gorm:"size:255" json:"developer,omitempty"`
 	Publisher     string         `gorm:"size:255" json:"publisher,omitempty"`
 	ReleaseDate   string         `gorm:"size:32" json:"releaseDate,omitempty"`
-	Genre         string         `gorm:"size:128" json:"genre,omitempty"`
+	Genre         string         `gorm:"size:512" json:"genre,omitempty"`
+	GameModes     string         `gorm:"size:255" json:"gameModes,omitempty"`
 	Players       int            `json:"players,omitempty"`
 	Rating        float64        `json:"rating,omitempty"`
 	CoreOverride        string         `gorm:"size:128" json:"coreOverride,omitempty"`
@@ -105,7 +106,17 @@ type Game struct {
 	VerificationTag     string         `gorm:"size:128" json:"verificationTag,omitempty"`
 	Region              string         `gorm:"size:128" json:"region,omitempty"`
 	CRC32               string         `gorm:"size:16" json:"-"`
-	Screenshots         []GameScreenshot `gorm:"foreignKey:GameID" json:"-"`
+	Screenshots         []GameScreenshot  `gorm:"foreignKey:GameID" json:"-"`
+	ReleaseDates        []GameReleaseDate `gorm:"foreignKey:GameID" json:"-"`
+}
+
+// GameReleaseDate represents a regional release date for a game.
+type GameReleaseDate struct {
+	ID       uint   `gorm:"primarykey" json:"id"`
+	GameID   uint   `gorm:"uniqueIndex:idx_game_release_region;not null" json:"gameId"`
+	Region   string `gorm:"uniqueIndex:idx_game_release_region;size:64;not null" json:"region"`
+	Date     string `gorm:"size:32" json:"date"`
+	Platform string `gorm:"size:128" json:"platform,omitempty"`
 }
 
 // GameScreenshot represents a single screenshot image for a game.

--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -200,6 +200,51 @@ type Game struct {
 	FirstReleaseDate  int64            `json:"first_release_date"`
 	AggregatedRating  float64          `json:"aggregated_rating"`
 	GameModes         []GameMode       `json:"game_modes"`
+	ReleaseDates      []ReleaseDate    `json:"release_dates"`
+}
+
+// ReleaseDate represents an IGDB release date with region info.
+type ReleaseDate struct {
+	ID       int           `json:"id"`
+	Date     int64         `json:"date"`
+	Region   int           `json:"region"`
+	Human    string        `json:"human"`
+	Platform *ReleasePlatform `json:"platform"`
+}
+
+// ReleasePlatform is the platform info within a release date.
+type ReleasePlatform struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+// RegionName maps IGDB release date region codes to human-readable names.
+// See https://api-docs.igdb.com/#region
+func RegionName(regionCode int) string {
+	switch regionCode {
+	case 1:
+		return "Europe"
+	case 2:
+		return "North America"
+	case 3:
+		return "Australia"
+	case 4:
+		return "New Zealand"
+	case 5:
+		return "Japan"
+	case 6:
+		return "China"
+	case 7:
+		return "Asia"
+	case 8:
+		return "Worldwide"
+	case 9:
+		return "Korea"
+	case 10:
+		return "Brazil"
+	default:
+		return ""
+	}
 }
 
 // Image represents an IGDB image with an image_id for URL construction.
@@ -249,7 +294,7 @@ func (c *Client) SearchGame(name string, platformID int) ([]Game, error) {
 	<-c.rateLimiter
 
 	query := fmt.Sprintf(
-		`search "%s"; fields name,summary,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,game_modes.name; where platforms = (%d); limit 5;`,
+		`search "%s"; fields name,summary,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where platforms = (%d); limit 5;`,
 		escapeQuery(name), platformID,
 	)
 
@@ -309,7 +354,7 @@ func (c *Client) SearchGameExact(name string, platformID int) ([]Game, error) {
 
 	// Case-insensitive exact match using ~ operator
 	query := fmt.Sprintf(
-		`fields name,summary,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,game_modes.name; where name ~ "%s" & platforms = (%d); limit 5;`,
+		`fields name,summary,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where name ~ "%s" & platforms = (%d); limit 5;`,
 		escapeQuery(name), platformID,
 	)
 
@@ -367,7 +412,7 @@ func (c *Client) GetGameByID(igdbID int) (*Game, error) {
 	<-c.rateLimiter
 
 	query := fmt.Sprintf(
-		`fields name,summary,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,game_modes.name; where id = %d; limit 1;`,
+		`fields name,summary,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where id = %d; limit 1;`,
 		igdbID,
 	)
 

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 
@@ -44,8 +45,9 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 		game.ScreenshotURL = ""
 		game.LibRetroCoverURL = ""
 		game.IGDBCoverURL = ""
-		// Delete old normalized screenshots
+		// Delete old normalized screenshots and release dates
 		s.DB.Where("game_id = ?", game.ID).Delete(&db.GameScreenshot{})
+		s.DB.Where("game_id = ?", game.ID).Delete(&db.GameReleaseDate{})
 	}
 
 	// Mark disc-based systems as not applicable for CRC verification
@@ -286,9 +288,22 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 		}
 	}
 
-	// Genre (first genre)
+	// Genre (all genres, comma-separated)
 	if len(match.Genres) > 0 && game.Genre == "" {
-		game.Genre = match.Genres[0].Name
+		names := make([]string, len(match.Genres))
+		for i, g := range match.Genres {
+			names[i] = g.Name
+		}
+		game.Genre = strings.Join(names, ", ")
+	}
+
+	// Game modes (all modes, comma-separated)
+	if len(match.GameModes) > 0 && game.GameModes == "" {
+		modeNames := make([]string, len(match.GameModes))
+		for i, mode := range match.GameModes {
+			modeNames[i] = mode.Name
+		}
+		game.GameModes = strings.Join(modeNames, ", ")
 	}
 
 	// Players: 1 if only single-player, 2 if any multiplayer mode exists
@@ -299,6 +314,30 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 				game.Players = 2
 				break
 			}
+		}
+	}
+
+	// Regional release dates
+	if len(match.ReleaseDates) > 0 {
+		for _, rd := range match.ReleaseDates {
+			regionName := igdb.RegionName(rd.Region)
+			if regionName == "" || rd.Date == 0 {
+				continue
+			}
+			t := time.Unix(rd.Date, 0)
+			platformName := ""
+			if rd.Platform != nil {
+				platformName = rd.Platform.Name
+			}
+			releaseDate := db.GameReleaseDate{
+				GameID:   game.ID,
+				Region:   regionName,
+				Date:     t.Format("2006-01-02"),
+				Platform: platformName,
+			}
+			s.DB.Where("game_id = ? AND region = ?", game.ID, regionName).
+				Assign(releaseDate).
+				FirstOrCreate(&releaseDate)
 		}
 	}
 
@@ -388,11 +427,13 @@ func (s *Scraper) ScrapeGameWithIGDBMatch(game *db.Game, igdbID int) error {
 	game.Developer = ""
 	game.Publisher = ""
 	game.Genre = ""
+	game.GameModes = ""
 	game.Rating = 0
 	game.Players = 0
 	game.ReleaseDate = ""
-	// Delete old IGDB screenshots
+	// Delete old IGDB screenshots and release dates
 	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameScreenshot{})
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameReleaseDate{})
 
 	gameIDStr := strconv.FormatUint(uint64(game.ID), 10)
 

--- a/server/internal/scraper/scraper_igdb_test.go
+++ b/server/internal/scraper/scraper_igdb_test.go
@@ -33,7 +33,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		&db.Console{}, &db.Game{}, &db.GameScreenshot{},
 		&db.GameTheme{}, &db.GameKeyword{}, &db.GamePlayerPerspective{},
 		&db.GameFranchise{}, &db.GameSeries{}, &db.GameSeriesEntry{},
-		&db.GameArtworkImage{},
+		&db.GameArtworkImage{}, &db.GameReleaseDate{},
 	))
 	return database
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -75,6 +75,8 @@ export interface Game {
   publisher?: string;
   releaseDate?: string;
   genre?: string;
+  gameModes?: string;
+  releaseDates?: ReleaseDateInfo[];
   players?: number;
   rating?: number;
   coreOverride?: string;
@@ -96,6 +98,12 @@ export interface Game {
   totalPlayTime: number;
   createdAt: string;
   updatedAt: string;
+}
+
+export interface ReleaseDateInfo {
+  region: string;
+  date: string;
+  platform?: string;
 }
 
 // Backend stores settings as flat key-value pairs


### PR DESCRIPTION
## Summary
- **All genres**: Save all genre names comma-separated instead of only the first
- **Game modes**: New `GameModes` field stores all modes (e.g. "Single player, Co-operative, Split screen")
- **Regional release dates**: New `GameReleaseDate` table with region, date, and platform per entry; IGDB region codes mapped to human-readable names
- Genre field size increased from 128 to 512 to accommodate multiple genres
- Proper cleanup on re-scrape (both normal and admin IGDB match paths)
- Game deduplication handles new data (merge release dates, game modes)
- Web TypeScript types updated with `gameModes` and `releaseDates` fields

## Test plan
- [x] Go build passes
- [x] Scraper tests pass
- [x] DB tests pass
- [x] API tests pass (game endpoints, explore, bios, console, IGDB match)
- [x] Web TypeScript compiles clean (`tsc --noEmit`)
- [x] All 1275 web Vitest tests pass
- [ ] CI passes
- [ ] Re-scrape a game and verify all genres, game modes, and release dates appear in API response