### PR TITLE
feat: save expanded IGDB metadata (storyline, ratings, videos, languages, age ratings)

### DIFF
--- a/server/internal/api/admin_igdb_match_test.go
+++ b/server/internal/api/admin_igdb_match_test.go
@@ -36,6 +36,7 @@ func setupIGDBMatchTestEnv(t *testing.T, tokenServerURL, igdbServerURL string) (
 		&db.User{}, &db.Console{}, &db.Game{}, &db.GameScreenshot{},
 		&db.GameDisc{}, &db.Favorite{}, &db.PlayHistory{}, &db.ServerSetting{},
 		&db.GameRating{}, &db.PlayLaterItem{}, &db.GameReleaseDate{},
+		&db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{},
 	))
 
 	if tokenServerURL != "" {

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -83,6 +83,9 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.SavedSearch{},
 		&db.Company{},
 		&db.GameReleaseDate{},
+		&db.GameVideo{},
+		&db.GameLanguageSupport{},
+		&db.GameAgeRating{},
 	)
 	require.NoError(t, err)
 	err = db.SeedConsoles(database)

--- a/server/internal/api/bios_handler_test.go
+++ b/server/internal/api/bios_handler_test.go
@@ -45,7 +45,7 @@ func setupBiosTestEnv(t *testing.T) (*storage.Storage, *gorm.DB, *gin.Engine) {
 		Logger: logger.Default.LogMode(logger.Silent),
 	})
 	require.NoError(t, err)
-	require.NoError(t, database.AutoMigrate(&db.User{}, &db.Console{}, &db.Game{}, &db.GameReleaseDate{}))
+	require.NoError(t, database.AutoMigrate(&db.User{}, &db.Console{}, &db.Game{}, &db.GameReleaseDate{}, &db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{}))
 	require.NoError(t, db.SeedConsoles(database))
 
 	gin.SetMode(gin.TestMode)

--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -31,7 +31,7 @@ func setupConsoleTestEnv(t *testing.T) (*gorm.DB, *storage.Storage, *gin.Engine)
 	})
 	require.NoError(t, err)
 
-	err = database.AutoMigrate(&db.Console{}, &db.Game{}, &db.TopRatedGame{}, &db.GameReleaseDate{})
+	err = database.AutoMigrate(&db.Console{}, &db.Game{}, &db.TopRatedGame{}, &db.GameReleaseDate{}, &db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{})
 	require.NoError(t, err)
 
 	err = db.SeedConsoles(database)
@@ -244,7 +244,7 @@ func setupTopListTestEnv(t *testing.T) (*gorm.DB, *gin.Engine) {
 	})
 	require.NoError(t, err)
 
-	err = database.AutoMigrate(&db.Console{}, &db.Game{}, &db.TopRatedGame{}, &db.GameReleaseDate{})
+	err = database.AutoMigrate(&db.Console{}, &db.Game{}, &db.TopRatedGame{}, &db.GameReleaseDate{}, &db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{})
 	require.NoError(t, err)
 
 	err = db.SeedConsoles(database)

--- a/server/internal/api/game_discovery_handler_test.go
+++ b/server/internal/api/game_discovery_handler_test.go
@@ -25,6 +25,7 @@ func setupDiscoveryTestEnv(t *testing.T) (*gorm.DB, *gin.Engine) {
 
 	err = database.AutoMigrate(
 		&db.Console{}, &db.Game{}, &db.SimilarGame{}, &db.GameReleaseDate{},
+		&db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{},
 	)
 	require.NoError(t, err)
 

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -262,7 +262,7 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 func (h *GameHandler) GetGame(c *gin.Context) {
 	id := c.Param("id")
 	var game db.Game
-	if err := h.DB.Preload("Console").Preload("Discs").Preload("Screenshots").Preload("ReleaseDates").First(&game, id).Error; err != nil {
+	if err := h.DB.Preload("Console").Preload("Discs").Preload("Screenshots").Preload("ReleaseDates").Preload("Videos").Preload("LanguageSupports").Preload("AgeRatings").First(&game, id).Error; err != nil {
 		c.JSON(http.StatusNotFound, gin.H{"error": "game not found"})
 		return
 	}

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -58,10 +58,21 @@ type GameResponse struct {
 	Publisher      string         `json:"publisher"`
 	ReleaseDate    string         `json:"releaseDate"`
 	Genre          string                `json:"genre"`
-	GameModes      string                `json:"gameModes,omitempty"`
-	Players        int                   `json:"players"`
-	Rating         float64               `json:"rating"`
-	ReleaseDates   []ReleaseDateResponse `json:"releaseDates,omitempty"`
+	GameModes            string                      `json:"gameModes,omitempty"`
+	Storyline            string                      `json:"storyline,omitempty"`
+	TotalRating          float64                     `json:"totalRating,omitempty"`
+	TotalRatingCount     int                         `json:"totalRatingCount,omitempty"`
+	IGDBUserRating       float64                     `json:"igdbUserRating,omitempty"`
+	IGDBUserRatingCount  int                         `json:"igdbUserRatingCount,omitempty"`
+	TimeToBeatHastily    int                         `json:"timeToBeatHastily,omitempty"`
+	TimeToBeatNormally   int                         `json:"timeToBeatNormally,omitempty"`
+	TimeToBeatCompletely int                         `json:"timeToBeatCompletely,omitempty"`
+	Players              int                         `json:"players"`
+	Rating               float64                     `json:"rating"`
+	ReleaseDates         []ReleaseDateResponse       `json:"releaseDates,omitempty"`
+	Videos               []VideoResponse             `json:"videos,omitempty"`
+	LanguageSupports     []LanguageSupportResponse   `json:"languageSupports,omitempty"`
+	AgeRatings           []AgeRatingResponse         `json:"ageRatings,omitempty"`
 	Playable            bool           `json:"playable"`
 	CoreOverride        string         `json:"coreOverride,omitempty"`
 	ScraperID           string         `json:"scraperId,omitempty"`
@@ -87,6 +98,24 @@ type ReleaseDateResponse struct {
 	Region   string `json:"region"`
 	Date     string `json:"date"`
 	Platform string `json:"platform,omitempty"`
+}
+
+// VideoResponse represents a video in the API response.
+type VideoResponse struct {
+	VideoID string `json:"videoId"`
+	Name    string `json:"name,omitempty"`
+}
+
+// LanguageSupportResponse represents a language support entry in the API response.
+type LanguageSupportResponse struct {
+	Language    string `json:"language"`
+	SupportType string `json:"supportType"`
+}
+
+// AgeRatingResponse represents an age rating in the API response.
+type AgeRatingResponse struct {
+	Category string `json:"category"`
+	Rating   string `json:"rating"`
 }
 
 // PaginatedResponse wraps a paginated list with standard keys.
@@ -287,9 +316,17 @@ func toGameResponseWithData(g db.Game, data *userGameData) GameResponse {
 		Publisher:       g.Publisher,
 		ReleaseDate:    g.ReleaseDate,
 		Genre:          g.Genre,
-		GameModes:      g.GameModes,
-		Players:        g.Players,
-		Rating:         g.Rating,
+		GameModes:            g.GameModes,
+		Storyline:            g.Storyline,
+		TotalRating:          g.TotalRating,
+		TotalRatingCount:     g.TotalRatingCount,
+		IGDBUserRating:       g.IGDBUserRating,
+		IGDBUserRatingCount:  g.IGDBUserRatingCount,
+		TimeToBeatHastily:    g.TimeToBeatHastily,
+		TimeToBeatNormally:   g.TimeToBeatNormally,
+		TimeToBeatCompletely: g.TimeToBeatCompletely,
+		Players:              g.Players,
+		Rating:               g.Rating,
 		Playable:            g.Console.Playable,
 		CoreOverride:        g.CoreOverride,
 		ScraperID:           g.ScraperID,
@@ -309,6 +346,30 @@ func toGameResponseWithData(g db.Game, data *userGameData) GameResponse {
 				Date:     rd.Date,
 				Platform: rd.Platform,
 			}
+		}
+	}
+
+	// Map videos
+	if len(g.Videos) > 0 {
+		resp.Videos = make([]VideoResponse, len(g.Videos))
+		for i, v := range g.Videos {
+			resp.Videos[i] = VideoResponse{VideoID: v.VideoID, Name: v.Name}
+		}
+	}
+
+	// Map language supports
+	if len(g.LanguageSupports) > 0 {
+		resp.LanguageSupports = make([]LanguageSupportResponse, len(g.LanguageSupports))
+		for i, ls := range g.LanguageSupports {
+			resp.LanguageSupports[i] = LanguageSupportResponse{Language: ls.Language, SupportType: ls.SupportType}
+		}
+	}
+
+	// Map age ratings
+	if len(g.AgeRatings) > 0 {
+		resp.AgeRatings = make([]AgeRatingResponse, len(g.AgeRatings))
+		for i, ar := range g.AgeRatings {
+			resp.AgeRatings[i] = AgeRatingResponse{Category: ar.Category, Rating: ar.Rating}
 		}
 	}
 

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -168,6 +168,10 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&GameArtworkImage{},
 		// Regional release dates
 		&GameReleaseDate{},
+		// Videos, language supports, age ratings
+		&GameVideo{},
+		&GameLanguageSupport{},
+		&GameAgeRating{},
 		// Phase 13: Saved Searches
 		&SavedSearch{},
 	)
@@ -547,6 +551,45 @@ func mergeGameData(database *gorm.DB, keeperID, dupID uint) {
 		}
 	}
 
+	// GameVideo — move, skip if keeper already has same video
+	var dupVideos []GameVideo
+	database.Where("game_id = ?", dupID).Find(&dupVideos)
+	for _, v := range dupVideos {
+		var count int64
+		database.Model(&GameVideo{}).Where("game_id = ? AND video_id = ?", keeperID, v.VideoID).Count(&count)
+		if count == 0 {
+			database.Model(&v).Update("game_id", keeperID)
+		} else {
+			database.Unscoped().Delete(&v)
+		}
+	}
+
+	// GameLanguageSupport — move, skip if keeper already has same entry
+	var dupLangSupports []GameLanguageSupport
+	database.Where("game_id = ?", dupID).Find(&dupLangSupports)
+	for _, ls := range dupLangSupports {
+		var count int64
+		database.Model(&GameLanguageSupport{}).Where("game_id = ? AND language = ? AND support_type = ?", keeperID, ls.Language, ls.SupportType).Count(&count)
+		if count == 0 {
+			database.Model(&ls).Update("game_id", keeperID)
+		} else {
+			database.Unscoped().Delete(&ls)
+		}
+	}
+
+	// GameAgeRating — move, skip if keeper already has same category
+	var dupAgeRatings []GameAgeRating
+	database.Where("game_id = ?", dupID).Find(&dupAgeRatings)
+	for _, ar := range dupAgeRatings {
+		var count int64
+		database.Model(&GameAgeRating{}).Where("game_id = ? AND category = ?", keeperID, ar.Category).Count(&count)
+		if count == 0 {
+			database.Model(&ar).Update("game_id", keeperID)
+		} else {
+			database.Unscoped().Delete(&ar)
+		}
+	}
+
 	// GameSeriesEntry — update any entries pointing to the duplicate game
 	database.Model(&GameSeriesEntry{}).Where("game_id = ?", dupID).Update("game_id", keeperID)
 
@@ -602,6 +645,30 @@ func mergeGameMetadata(database *gorm.DB, keeper, dup *Game) {
 	}
 	if keeper.GameModes == "" && dup.GameModes != "" {
 		updates["game_modes"] = dup.GameModes
+	}
+	if keeper.Storyline == "" && dup.Storyline != "" {
+		updates["storyline"] = dup.Storyline
+	}
+	if keeper.TotalRating == 0 && dup.TotalRating > 0 {
+		updates["total_rating"] = dup.TotalRating
+	}
+	if keeper.TotalRatingCount == 0 && dup.TotalRatingCount > 0 {
+		updates["total_rating_count"] = dup.TotalRatingCount
+	}
+	if keeper.IGDBUserRating == 0 && dup.IGDBUserRating > 0 {
+		updates["igdb_user_rating"] = dup.IGDBUserRating
+	}
+	if keeper.IGDBUserRatingCount == 0 && dup.IGDBUserRatingCount > 0 {
+		updates["igdb_user_rating_count"] = dup.IGDBUserRatingCount
+	}
+	if keeper.TimeToBeatHastily == 0 && dup.TimeToBeatHastily > 0 {
+		updates["time_to_beat_hastily"] = dup.TimeToBeatHastily
+	}
+	if keeper.TimeToBeatNormally == 0 && dup.TimeToBeatNormally > 0 {
+		updates["time_to_beat_normally"] = dup.TimeToBeatNormally
+	}
+	if keeper.TimeToBeatCompletely == 0 && dup.TimeToBeatCompletely > 0 {
+		updates["time_to_beat_completely"] = dup.TimeToBeatCompletely
 	}
 	if keeper.ReleaseDate == "" && dup.ReleaseDate != "" {
 		updates["release_date"] = dup.ReleaseDate

--- a/server/internal/db/dedup_test.go
+++ b/server/internal/db/dedup_test.go
@@ -25,6 +25,11 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		&GameCollection{}, &CollectionItem{}, &PlayLaterItem{},
 		&SharedSession{}, &NetplaySession{}, &Challenge{},
 		&GameKeyMappingPreference{},
+		&GameTheme{}, &GameKeyword{}, &GamePlayerPerspective{},
+		&GameFranchise{}, &GameArtworkImage{}, &GameReleaseDate{},
+		&GameVideo{}, &GameLanguageSupport{}, &GameAgeRating{},
+		&GameSeries{}, &GameSeriesEntry{},
+		&GameFranchiseGroup{}, &GameFranchiseEntry{},
 	)
 	require.NoError(t, err)
 

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -92,10 +92,18 @@ type Game struct {
 	Publisher     string         `gorm:"size:255" json:"publisher,omitempty"`
 	ReleaseDate   string         `gorm:"size:32" json:"releaseDate,omitempty"`
 	Genre         string         `gorm:"size:512" json:"genre,omitempty"`
-	GameModes     string         `gorm:"size:255" json:"gameModes,omitempty"`
-	Players       int            `json:"players,omitempty"`
-	Rating        float64        `json:"rating,omitempty"`
-	CoreOverride        string         `gorm:"size:128" json:"coreOverride,omitempty"`
+	GameModes            string  `gorm:"size:255" json:"gameModes,omitempty"`
+	Storyline            string  `gorm:"type:text" json:"storyline,omitempty"`
+	TotalRating          float64 `json:"totalRating,omitempty"`
+	TotalRatingCount     int     `json:"totalRatingCount,omitempty"`
+	IGDBUserRating       float64 `json:"igdbUserRating,omitempty"`
+	IGDBUserRatingCount  int     `json:"igdbUserRatingCount,omitempty"`
+	TimeToBeatHastily    int     `json:"timeToBeatHastily,omitempty"`
+	TimeToBeatNormally   int     `json:"timeToBeatNormally,omitempty"`
+	TimeToBeatCompletely int     `json:"timeToBeatCompletely,omitempty"`
+	Players              int     `json:"players,omitempty"`
+	Rating               float64 `json:"rating,omitempty"`
+	CoreOverride         string  `gorm:"size:128" json:"coreOverride,omitempty"`
 	LibRetroCoverURL    string         `gorm:"size:512" json:"-"`
 	IGDBCoverURL        string         `gorm:"size:512" json:"-"`
 	CoverManuallySet    bool           `gorm:"default:false" json:"-"`
@@ -106,8 +114,11 @@ type Game struct {
 	VerificationTag     string         `gorm:"size:128" json:"verificationTag,omitempty"`
 	Region              string         `gorm:"size:128" json:"region,omitempty"`
 	CRC32               string         `gorm:"size:16" json:"-"`
-	Screenshots         []GameScreenshot  `gorm:"foreignKey:GameID" json:"-"`
-	ReleaseDates        []GameReleaseDate `gorm:"foreignKey:GameID" json:"-"`
+	Screenshots      []GameScreenshot      `gorm:"foreignKey:GameID" json:"-"`
+	ReleaseDates     []GameReleaseDate     `gorm:"foreignKey:GameID" json:"-"`
+	Videos           []GameVideo           `gorm:"foreignKey:GameID" json:"-"`
+	LanguageSupports []GameLanguageSupport `gorm:"foreignKey:GameID" json:"-"`
+	AgeRatings       []GameAgeRating       `gorm:"foreignKey:GameID" json:"-"`
 }
 
 // GameReleaseDate represents a regional release date for a game.
@@ -117,6 +128,30 @@ type GameReleaseDate struct {
 	Region   string `gorm:"uniqueIndex:idx_game_release_region;size:64;not null" json:"region"`
 	Date     string `gorm:"size:32" json:"date"`
 	Platform string `gorm:"size:128" json:"platform,omitempty"`
+}
+
+// GameVideo stores a video associated with a game (typically YouTube).
+type GameVideo struct {
+	ID      uint   `gorm:"primarykey" json:"id"`
+	GameID  uint   `gorm:"uniqueIndex:idx_game_video;not null" json:"gameId"`
+	VideoID string `gorm:"uniqueIndex:idx_game_video;size:32;not null" json:"videoId"`
+	Name    string `gorm:"size:512" json:"name"`
+}
+
+// GameLanguageSupport stores a language support entry for a game.
+type GameLanguageSupport struct {
+	ID          uint   `gorm:"primarykey" json:"id"`
+	GameID      uint   `gorm:"uniqueIndex:idx_game_lang_support;not null" json:"gameId"`
+	Language    string `gorm:"uniqueIndex:idx_game_lang_support;size:128;not null" json:"language"`
+	SupportType string `gorm:"uniqueIndex:idx_game_lang_support;size:64;not null" json:"supportType"`
+}
+
+// GameAgeRating stores an age rating classification for a game.
+type GameAgeRating struct {
+	ID       uint   `gorm:"primarykey" json:"id"`
+	GameID   uint   `gorm:"uniqueIndex:idx_game_age_rating;not null" json:"gameId"`
+	Category string `gorm:"uniqueIndex:idx_game_age_rating;size:16;not null" json:"category"`
+	Rating   string `gorm:"size:32;not null" json:"rating"`
 }
 
 // GameScreenshot represents a single screenshot image for a game.

--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -193,14 +193,27 @@ type Game struct {
 	ID                int              `json:"id"`
 	Name              string           `json:"name"`
 	Summary           string           `json:"summary"`
+	Storyline         string           `json:"storyline"`
 	Cover             *Image           `json:"cover"`
 	Screenshots       []Image          `json:"screenshots"`
 	Genres            []Genre          `json:"genres"`
 	InvolvedCompanies []InvolvedCompany `json:"involved_companies"`
 	FirstReleaseDate  int64            `json:"first_release_date"`
 	AggregatedRating  float64          `json:"aggregated_rating"`
+	TotalRating       float64          `json:"total_rating"`
+	TotalRatingCount  int              `json:"total_rating_count"`
+	IGDBRating        float64          `json:"rating"`
+	IGDBRatingCount   int              `json:"rating_count"`
 	GameModes         []GameMode       `json:"game_modes"`
 	ReleaseDates      []ReleaseDate    `json:"release_dates"`
+	TimeToBeat        *TimeToBeat      `json:"time_to_beat"`
+}
+
+// TimeToBeat represents IGDB time-to-beat data in seconds.
+type TimeToBeat struct {
+	Hastily    int `json:"hastily"`
+	Normally   int `json:"normally"`
+	Completely int `json:"completely"`
 }
 
 // ReleaseDate represents an IGDB release date with region info.
@@ -270,6 +283,7 @@ type InvolvedCompany struct {
 type Company struct {
 	ID   int    `json:"id"`
 	Name string `json:"name"`
+	Logo *Image `json:"logo"`
 }
 
 // GameMode represents an IGDB game mode.
@@ -294,7 +308,7 @@ func (c *Client) SearchGame(name string, platformID int) ([]Game, error) {
 	<-c.rateLimiter
 
 	query := fmt.Sprintf(
-		`search "%s"; fields name,summary,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where platforms = (%d); limit 5;`,
+		`search "%s"; fields name,summary,storyline,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.company.logo.image_id,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,total_rating,total_rating_count,rating,rating_count,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human,time_to_beat.hastily,time_to_beat.normally,time_to_beat.completely; where platforms = (%d); limit 5;`,
 		escapeQuery(name), platformID,
 	)
 
@@ -354,7 +368,7 @@ func (c *Client) SearchGameExact(name string, platformID int) ([]Game, error) {
 
 	// Case-insensitive exact match using ~ operator
 	query := fmt.Sprintf(
-		`fields name,summary,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where name ~ "%s" & platforms = (%d); limit 5;`,
+		`fields name,summary,storyline,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.company.logo.image_id,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,total_rating,total_rating_count,rating,rating_count,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human,time_to_beat.hastily,time_to_beat.normally,time_to_beat.completely; where name ~ "%s" & platforms = (%d); limit 5;`,
 		escapeQuery(name), platformID,
 	)
 
@@ -412,7 +426,7 @@ func (c *Client) GetGameByID(igdbID int) (*Game, error) {
 	<-c.rateLimiter
 
 	query := fmt.Sprintf(
-		`fields name,summary,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where id = %d; limit 1;`,
+		`fields name,summary,storyline,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.company.logo.image_id,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,total_rating,total_rating_count,rating,rating_count,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human,time_to_beat.hastily,time_to_beat.normally,time_to_beat.completely; where id = %d; limit 1;`,
 		igdbID,
 	)
 
@@ -865,7 +879,84 @@ type GameEnrichment struct {
 	Franchises         []int                 `json:"franchises"`       // raw franchise IDs
 	CollectionID       *int                  `json:"collection_id"`    // IGDB collection (series) ID, nil if none
 	Artworks           []ArtworkData         `json:"artworks"`
+	Videos             []VideoData           `json:"videos"`
+	LanguageSupports   []LanguageSupportData `json:"language_supports"`
+	AgeRatings         []AgeRatingData       `json:"age_ratings"`
 }
+
+// VideoData holds an IGDB video entry (typically YouTube).
+type VideoData struct {
+	VideoID string `json:"video_id"`
+	Name    string `json:"name"`
+}
+
+// LanguageSupportData holds an IGDB language support entry.
+type LanguageSupportData struct {
+	Language            NameWrapper `json:"language"`
+	LanguageSupportType NameWrapper `json:"language_support_type"`
+}
+
+// NameWrapper is a simple struct for IGDB nested name fields.
+type NameWrapper struct {
+	Name string `json:"name"`
+}
+
+// AgeRatingData holds an IGDB age rating entry.
+type AgeRatingData struct {
+	Category int `json:"category"` // 1=ESRB, 2=PEGI
+	Rating   int `json:"rating"`   // IGDB enum value
+}
+
+// AgeRatingLabel returns a human-readable label for an IGDB age rating.
+func AgeRatingLabel(category, rating int) string {
+	if category == 1 { // ESRB
+		switch rating {
+		case 6:
+			return "RP"
+		case 7:
+			return "EC"
+		case 8:
+			return "E"
+		case 9:
+			return "E10+"
+		case 10:
+			return "T"
+		case 11:
+			return "M"
+		case 12:
+			return "AO"
+		}
+	}
+	if category == 2 { // PEGI
+		switch rating {
+		case 1:
+			return "PEGI 3"
+		case 2:
+			return "PEGI 7"
+		case 3:
+			return "PEGI 12"
+		case 4:
+			return "PEGI 16"
+		case 5:
+			return "PEGI 18"
+		}
+	}
+	return ""
+}
+
+// AgeRatingCategoryName returns the human-readable category name.
+func AgeRatingCategoryName(category int) string {
+	switch category {
+	case 1:
+		return "ESRB"
+	case 2:
+		return "PEGI"
+	default:
+		return ""
+	}
+}
+
+
 
 // EnrichmentNamedItem holds an IGDB entity with an ID and name.
 type EnrichmentNamedItem struct {
@@ -912,7 +1003,7 @@ func (c *Client) GetGameEnrichment(igdbID int) (*GameEnrichment, error) {
 	<-c.rateLimiter
 
 	query := fmt.Sprintf(
-		`fields themes.name,keywords.name,player_perspectives.name,franchises,collection,artworks.image_id,artworks.width,artworks.height; where id = %d; limit 1;`,
+		`fields themes.name,keywords.name,player_perspectives.name,franchises,collection,artworks.image_id,artworks.width,artworks.height,videos.video_id,videos.name,language_supports.language.name,language_supports.language_support_type.name,age_ratings.category,age_ratings.rating; where id = %d; limit 1;`,
 		igdbID,
 	)
 
@@ -955,6 +1046,18 @@ func (c *Client) GetGameEnrichment(igdbID int) (*GameEnrichment, error) {
 			Width   int    `json:"width"`
 			Height  int    `json:"height"`
 		} `json:"artworks"`
+		Videos []struct {
+			VideoID string `json:"video_id"`
+			Name    string `json:"name"`
+		} `json:"videos"`
+		LanguageSupports []struct {
+			Language            NameWrapper `json:"language"`
+			LanguageSupportType NameWrapper `json:"language_support_type"`
+		} `json:"language_supports"`
+		AgeRatings []struct {
+			Category int `json:"category"`
+			Rating   int `json:"rating"`
+		} `json:"age_ratings"`
 	}
 	if err := json.Unmarshal(body, &results); err != nil {
 		return nil, fmt.Errorf("decoding IGDB enrichment response: %w", err)
@@ -981,12 +1084,33 @@ func (c *Client) GetGameEnrichment(igdbID int) (*GameEnrichment, error) {
 			Height:  a.Height,
 		})
 	}
+	for _, v := range r.Videos {
+		enrichment.Videos = append(enrichment.Videos, VideoData{
+			VideoID: v.VideoID,
+			Name:    v.Name,
+		})
+	}
+	for _, ls := range r.LanguageSupports {
+		enrichment.LanguageSupports = append(enrichment.LanguageSupports, LanguageSupportData{
+			Language:            ls.Language,
+			LanguageSupportType: ls.LanguageSupportType,
+		})
+	}
+	for _, ar := range r.AgeRatings {
+		enrichment.AgeRatings = append(enrichment.AgeRatings, AgeRatingData{
+			Category: ar.Category,
+			Rating:   ar.Rating,
+		})
+	}
 
 	slog.Info("IGDB get game enrichment response", "igdbID", igdbID,
 		"themes", len(enrichment.Themes), "keywords", len(enrichment.Keywords),
 		"perspectives", len(enrichment.PlayerPerspectives),
 		"franchises", len(enrichment.Franchises),
-		"artworks", len(enrichment.Artworks))
+		"artworks", len(enrichment.Artworks),
+		"videos", len(enrichment.Videos),
+		"languageSupports", len(enrichment.LanguageSupports),
+		"ageRatings", len(enrichment.AgeRatings))
 
 	return enrichment, nil
 }

--- a/server/internal/scraper/scraper_enrichment.go
+++ b/server/internal/scraper/scraper_enrichment.go
@@ -33,6 +33,9 @@ func (s *Scraper) storeEnrichmentData(game *db.Game, enrichment *igdb.GameEnrich
 	s.DB.Where("game_id = ?", game.ID).Delete(&db.GamePlayerPerspective{})
 	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameFranchise{})
 	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameArtworkImage{})
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameVideo{})
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameLanguageSupport{})
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameAgeRating{})
 
 	// Store themes
 	for _, t := range enrichment.Themes {
@@ -104,6 +107,44 @@ func (s *Scraper) storeEnrichmentData(game *db.Game, enrichment *igdb.GameEnrich
 			IGDBImageID: a.ImageID,
 			Width:       a.Width,
 			Height:      a.Height,
+		})
+	}
+
+	// Store videos
+	for _, v := range enrichment.Videos {
+		if v.VideoID == "" {
+			continue
+		}
+		s.DB.Create(&db.GameVideo{
+			GameID:  game.ID,
+			VideoID: v.VideoID,
+			Name:    v.Name,
+		})
+	}
+
+	// Store language supports
+	for _, ls := range enrichment.LanguageSupports {
+		if ls.Language.Name == "" || ls.LanguageSupportType.Name == "" {
+			continue
+		}
+		s.DB.Create(&db.GameLanguageSupport{
+			GameID:      game.ID,
+			Language:    ls.Language.Name,
+			SupportType: ls.LanguageSupportType.Name,
+		})
+	}
+
+	// Store age ratings
+	for _, ar := range enrichment.AgeRatings {
+		categoryName := igdb.AgeRatingCategoryName(ar.Category)
+		label := igdb.AgeRatingLabel(ar.Category, ar.Rating)
+		if categoryName == "" || label == "" {
+			continue
+		}
+		s.DB.Create(&db.GameAgeRating{
+			GameID:   game.ID,
+			Category: categoryName,
+			Rating:   label,
 		})
 	}
 

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -45,6 +45,15 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 		game.ScreenshotURL = ""
 		game.LibRetroCoverURL = ""
 		game.IGDBCoverURL = ""
+		// Clear IGDB-sourced scalar metadata so new match can overwrite
+		game.Storyline = ""
+		game.TotalRating = 0
+		game.TotalRatingCount = 0
+		game.IGDBUserRating = 0
+		game.IGDBUserRatingCount = 0
+		game.TimeToBeatHastily = 0
+		game.TimeToBeatNormally = 0
+		game.TimeToBeatCompletely = 0
 		// Delete old normalized screenshots and release dates
 		s.DB.Where("game_id = ?", game.ID).Delete(&db.GameScreenshot{})
 		s.DB.Where("game_id = ?", game.ID).Delete(&db.GameReleaseDate{})
@@ -270,21 +279,57 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 	if match.Summary != "" {
 		game.Description = match.Summary
 	}
+	if match.Storyline != "" && game.Storyline == "" {
+		game.Storyline = match.Storyline
+	}
 	if match.AggregatedRating > 0 {
 		game.Rating = match.AggregatedRating
+	}
+	if match.TotalRating > 0 && game.TotalRating == 0 {
+		game.TotalRating = match.TotalRating
+	}
+	if match.TotalRatingCount > 0 && game.TotalRatingCount == 0 {
+		game.TotalRatingCount = match.TotalRatingCount
+	}
+	if match.IGDBRating > 0 && game.IGDBUserRating == 0 {
+		game.IGDBUserRating = match.IGDBRating
+	}
+	if match.IGDBRatingCount > 0 && game.IGDBUserRatingCount == 0 {
+		game.IGDBUserRatingCount = match.IGDBRatingCount
+	}
+	if match.TimeToBeat != nil {
+		if match.TimeToBeat.Hastily > 0 && game.TimeToBeatHastily == 0 {
+			game.TimeToBeatHastily = match.TimeToBeat.Hastily
+		}
+		if match.TimeToBeat.Normally > 0 && game.TimeToBeatNormally == 0 {
+			game.TimeToBeatNormally = match.TimeToBeat.Normally
+		}
+		if match.TimeToBeat.Completely > 0 && game.TimeToBeatCompletely == 0 {
+			game.TimeToBeatCompletely = match.TimeToBeat.Completely
+		}
 	}
 	if match.FirstReleaseDate > 0 {
 		t := time.Unix(match.FirstReleaseDate, 0)
 		game.ReleaseDate = t.Format("2006-01-02")
 	}
 
-	// Extract developer and publisher
+	// Extract developer and publisher, store company logos
 	for _, ic := range match.InvolvedCompanies {
 		if ic.Developer && game.Developer == "" {
 			game.Developer = ic.Company.Name
 		}
 		if ic.Publisher && game.Publisher == "" {
 			game.Publisher = ic.Company.Name
+		}
+		// Store company logo if available
+		if ic.Company.Logo != nil && ic.Company.Logo.ImageID != "" {
+			logoURL := igdb.CompanyLogoURL(ic.Company.Logo.ImageID)
+			var existing db.Company
+			if err := s.DB.Where("igdb_company_id = ?", ic.Company.ID).First(&existing).Error; err == nil {
+				if existing.LogoURL == "" {
+					s.DB.Model(&existing).Update("logo_url", logoURL)
+				}
+			}
 		}
 	}
 
@@ -428,12 +473,23 @@ func (s *Scraper) ScrapeGameWithIGDBMatch(game *db.Game, igdbID int) error {
 	game.Publisher = ""
 	game.Genre = ""
 	game.GameModes = ""
+	game.Storyline = ""
 	game.Rating = 0
+	game.TotalRating = 0
+	game.TotalRatingCount = 0
+	game.IGDBUserRating = 0
+	game.IGDBUserRatingCount = 0
+	game.TimeToBeatHastily = 0
+	game.TimeToBeatNormally = 0
+	game.TimeToBeatCompletely = 0
 	game.Players = 0
 	game.ReleaseDate = ""
-	// Delete old IGDB screenshots and release dates
+	// Delete old IGDB screenshots, release dates, videos, language supports, age ratings
 	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameScreenshot{})
 	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameReleaseDate{})
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameVideo{})
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameLanguageSupport{})
+	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameAgeRating{})
 
 	gameIDStr := strconv.FormatUint(uint64(game.ID), 10)
 

--- a/server/internal/scraper/scraper_igdb_test.go
+++ b/server/internal/scraper/scraper_igdb_test.go
@@ -34,6 +34,7 @@ func setupTestDB(t *testing.T) *gorm.DB {
 		&db.GameTheme{}, &db.GameKeyword{}, &db.GamePlayerPerspective{},
 		&db.GameFranchise{}, &db.GameSeries{}, &db.GameSeriesEntry{},
 		&db.GameArtworkImage{}, &db.GameReleaseDate{},
+		&db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{},
 	))
 	return database
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -76,7 +76,18 @@ export interface Game {
   releaseDate?: string;
   genre?: string;
   gameModes?: string;
+  storyline?: string;
+  totalRating?: number;
+  totalRatingCount?: number;
+  igdbUserRating?: number;
+  igdbUserRatingCount?: number;
+  timeToBeatHastily?: number;
+  timeToBeatNormally?: number;
+  timeToBeatCompletely?: number;
   releaseDates?: ReleaseDateInfo[];
+  videos?: VideoInfo[];
+  languageSupports?: LanguageSupportInfo[];
+  ageRatings?: AgeRatingInfo[];
   players?: number;
   rating?: number;
   coreOverride?: string;
@@ -104,6 +115,21 @@ export interface ReleaseDateInfo {
   region: string;
   date: string;
   platform?: string;
+}
+
+export interface VideoInfo {
+  videoId: string;
+  name?: string;
+}
+
+export interface LanguageSupportInfo {
+  language: string;
+  supportType: string;
+}
+
+export interface AgeRatingInfo {
+  category: string;
+  rating: string;
 }
 
 // Backend stores settings as flat key-value pairs


### PR DESCRIPTION
## Summary
- **Scalar fields**: storyline, total_rating/count, IGDB user rating/count, time-to-beat (hastily/normally/completely)
- **Company logos**: stored on existing `Company` records when available during scrape
- **Videos**: new `GameVideo` table storing YouTube video IDs from IGDB enrichment query
- **Language supports**: new `GameLanguageSupport` table with language + support type (Audio/Subtitles/Interface)
- **Age ratings**: new `GameAgeRating` table with ESRB/PEGI ratings mapped to human-readable labels
- Proper re-scrape cleanup on both normal and admin paths
- Game deduplication handles all new relationship tables and scalar fields
- Videos/languages/age ratings only preloaded on game detail (not list) for performance
- Web TypeScript types updated

## Test plan
- [x] Go build passes
- [x] Scraper + DB tests pass
- [x] API tests pass
- [x] Web TypeScript compiles clean
- [x] All 1275 web Vitest tests pass
- [ ] CI passes
- [ ] Re-scrape a game and verify new fields appear in API response