### PR TITLE
feat: make library scan async with WebSocket progress

### DIFF
--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -421,54 +421,66 @@ type scanResultResponse struct {
 	AutoScraping bool              `json:"autoScraping"`
 }
 
-// ScanGames triggers a library scan.
+// ScanGames triggers a library scan in the background.
+// Returns 202 immediately; progress is reported via WebSocket events.
 func (h *GameHandler) ScanGames(c *gin.Context) {
-	h.Hub.Broadcast(ws.Event{Type: "scan_started", Payload: nil})
-
-	result, err := h.Scanner.Scan()
-	if err != nil {
-		slog.Error("game library scan failed", "error", err)
-		h.Hub.Broadcast(ws.Event{Type: "scan_error", Payload: gin.H{"error": "library scan failed"}})
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "scan failed"})
+	if !h.Scanner.TryStartScan() {
+		c.JSON(http.StatusConflict, gin.H{"error": "a scan is already in progress"})
 		return
 	}
 
-	// Build response with new game summaries
-	resp := scanResultResponse{
-		NewGames:     result.NewGames,
-		UpdatedGames: result.UpdatedGames,
-		RemovedGames: result.RemovedGames,
-		TotalGames:   result.TotalGames,
-	}
+	h.Hub.Broadcast(ws.Event{Type: "scan_started", Payload: nil})
+	c.JSON(http.StatusAccepted, gin.H{"message": "scan started in background"})
 
-	if len(result.NewGameIDs) > 0 {
-		var newGames []db.Game
-		h.DB.Preload("Console").Where("id IN ?", result.NewGameIDs).Find(&newGames)
-		for _, g := range newGames {
-			resp.NewGamesList = append(resp.NewGamesList, scanGameSummary{
-				ID:          strconv.FormatUint(uint64(g.ID), 10),
-				Title:       g.Title,
-				ConsoleName: g.Console.Name,
-			})
+	go func() {
+		defer h.Scanner.FinishScan()
+
+		result, err := h.Scanner.Scan(func(p scanner.ScanProgress) {
+			h.Scanner.SetScanProgress(&p)
+			h.Hub.Broadcast(ws.Event{Type: "scan_progress", Payload: p})
+		})
+		if err != nil {
+			slog.Error("game library scan failed", "error", err)
+			h.Hub.Broadcast(ws.Event{Type: "scan_error", Payload: gin.H{"error": "library scan failed"}})
+			return
 		}
-	}
 
-	// Configure SteamGridDB if API key is set (best-effort artwork during auto-scrape)
-	if apiKey := steamGridDBAPIKey(h.DB); apiKey != "" {
-		h.Scraper.ConfigureSteamGridDB(apiKey)
-	}
+		// Build response with new game summaries
+		resp := scanResultResponse{
+			NewGames:     result.NewGames,
+			UpdatedGames: result.UpdatedGames,
+			RemovedGames: result.RemovedGames,
+			TotalGames:   result.TotalGames,
+		}
 
-	// Auto-scrape new games if IGDB is configured
-	if result.NewGames > 0 && h.Scraper.IsIGDBConfigured() {
-		if h.Scraper.TryStartScrape() {
-			resp.AutoScraping = true
-			h.Hub.Broadcast(ws.Event{Type: "scrape_started", Payload: nil})
-			go func() {
-				defer h.Scraper.FinishScrape()
+		if len(result.NewGameIDs) > 0 {
+			var newGames []db.Game
+			h.DB.Preload("Console").Where("id IN ?", result.NewGameIDs).Find(&newGames)
+			for _, g := range newGames {
+				resp.NewGamesList = append(resp.NewGamesList, scanGameSummary{
+					ID:          strconv.FormatUint(uint64(g.ID), 10),
+					Title:       g.Title,
+					ConsoleName: g.Console.Name,
+				})
+			}
+		}
+
+		h.Hub.Broadcast(ws.Event{Type: "scan_complete", Payload: resp})
+
+		// Configure SteamGridDB if API key is set (best-effort artwork during auto-scrape)
+		if apiKey := steamGridDBAPIKey(h.DB); apiKey != "" {
+			h.Scraper.ConfigureSteamGridDB(apiKey)
+		}
+
+		// Auto-scrape new games if IGDB is configured
+		if result.NewGames > 0 && h.Scraper.IsIGDBConfigured() {
+			if h.Scraper.TryStartScrape() {
+				h.Hub.Broadcast(ws.Event{Type: "scrape_started", Payload: nil})
 				count, total, scrapeErr := h.Scraper.ScrapeAll("new", func(p scraper.ScrapeProgress) {
 					h.Scraper.SetScrapeProgress(&p)
 					h.Hub.Broadcast(ws.Event{Type: "scrape_progress", Payload: p})
 				})
+				h.Scraper.FinishScrape()
 				if scrapeErr != nil {
 					slog.Error("auto-scrape after scan failed", "error", scrapeErr)
 					h.Hub.Broadcast(ws.Event{Type: "scrape_error", Payload: gin.H{"error": "auto-scrape failed"}})
@@ -476,12 +488,27 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 				}
 				slog.Info("auto-scrape after scan complete", "scraped", count, "total", total)
 				h.Hub.Broadcast(ws.Event{Type: "scrape_complete", Payload: gin.H{"scraped": count, "total": total}})
-			}()
+			}
 		}
+	}()
+}
+
+// ScanStatus returns the current scan operation status.
+func (h *GameHandler) ScanStatus(c *gin.Context) {
+	active, progress := h.Scanner.GetScanStatus()
+
+	if !active || progress == nil {
+		c.JSON(http.StatusOK, gin.H{"active": active})
+		return
 	}
 
-	h.Hub.Broadcast(ws.Event{Type: "scan_complete", Payload: resp})
-	c.JSON(http.StatusOK, resp)
+	c.JSON(http.StatusOK, gin.H{
+		"active":  true,
+		"phase":   progress.Phase,
+		"current": progress.Current,
+		"total":   progress.Total,
+		"message": progress.Message,
+	})
 }
 
 // ScrapeIfNeeded triggers an async scrape for a game that has never been scraped.

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -493,6 +493,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		{
 			admin.POST("/games/:id/metadata", gameHandler.UpdateMetadata)
 			admin.POST("/games/scan", gameHandler.ScanGames)
+			admin.GET("/games/scan/status", gameHandler.ScanStatus)
 			admin.GET("/users", adminHandler.ListUsers)
 			admin.POST("/users", adminHandler.CreateUser)
 			admin.PUT("/users/:id", adminHandler.UpdateUser)

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -9,16 +9,29 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/storage"
 	"gorm.io/gorm"
 )
 
+// ScanProgress holds the current state of an in-progress scan.
+type ScanProgress struct {
+	Phase   string `json:"phase"`   // "discovering" or "checking_removed"
+	Current int    `json:"current"` // files/games processed so far
+	Total   int    `json:"total"`   // total expected (0 if unknown)
+	Message string `json:"message"` // human-readable status
+}
+
 // Scanner detects ROMs in configured directories and maps them to consoles.
 type Scanner struct {
 	DB       *gorm.DB
 	GameDirs []string
+
+	mu       sync.Mutex
+	scanning bool
+	progress *ScanProgress
 }
 
 // NewScanner creates a new game scanner.
@@ -27,6 +40,45 @@ func NewScanner(database *gorm.DB, gameDirs []string) *Scanner {
 		DB:       database,
 		GameDirs: gameDirs,
 	}
+}
+
+// TryStartScan attempts to acquire the scan lock.
+// Returns true if acquired (caller must call FinishScan when done).
+func (s *Scanner) TryStartScan() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.scanning {
+		return false
+	}
+	s.scanning = true
+	s.progress = nil
+	return true
+}
+
+// FinishScan releases the scan lock and clears progress.
+func (s *Scanner) FinishScan() {
+	s.mu.Lock()
+	s.scanning = false
+	s.progress = nil
+	s.mu.Unlock()
+}
+
+// SetScanProgress updates the current scan progress.
+func (s *Scanner) SetScanProgress(p *ScanProgress) {
+	s.mu.Lock()
+	s.progress = p
+	s.mu.Unlock()
+}
+
+// GetScanStatus returns whether a scan is active and the current progress.
+func (s *Scanner) GetScanStatus() (bool, *ScanProgress) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.progress == nil {
+		return s.scanning, nil
+	}
+	p := *s.progress
+	return s.scanning, &p
 }
 
 // ConsoleExtMap maps file extensions to console abbreviations.
@@ -325,10 +377,22 @@ type discGroupKey struct {
 	Title string
 }
 
+// ProgressFunc is a callback for reporting scan progress.
+type ProgressFunc func(ScanProgress)
+
 // Scan walks all configured directories and detects ROMs.
 // Uses a two-pass algorithm: first discovers multi-disc games, then scans remaining files.
-func (s *Scanner) Scan() (*ScanResult, error) {
+// The optional onProgress callback is called at key points to report progress.
+func (s *Scanner) Scan(onProgress ProgressFunc) (*ScanResult, error) {
 	result := &ScanResult{}
+
+	report := func(p ScanProgress) {
+		if onProgress != nil {
+			onProgress(p)
+		}
+	}
+
+	report(ScanProgress{Phase: "discovering", Message: "Loading console definitions..."})
 
 	// Load all consoles into a map by abbreviation
 	var consoles []db.Console
@@ -347,11 +411,18 @@ func (s *Scanner) Scan() (*ScanResult, error) {
 	claimedPaths := make(map[string]bool)
 
 	// Pass 1: Multi-disc discovery
+	report(ScanProgress{Phase: "discovering", Message: "Scanning for multi-disc games..."})
 	for _, dir := range s.GameDirs {
 		if err := s.scanMultiDisc(dir, consoleMap, foundPaths, claimedPaths, result); err != nil {
 			slog.Warn("error in multi-disc scan", "dir", dir, "error", err)
 		}
 	}
+
+	report(ScanProgress{
+		Phase:   "discovering",
+		Current: result.NewGames,
+		Message: fmt.Sprintf("Scanning game directories... (%d new so far)", result.NewGames),
+	})
 
 	// Pass 2: Normal single-disc scan, skipping claimed paths
 	for _, dir := range s.GameDirs {
@@ -359,6 +430,12 @@ func (s *Scanner) Scan() (*ScanResult, error) {
 			slog.Warn("error scanning directory", "dir", dir, "error", err)
 		}
 	}
+
+	report(ScanProgress{
+		Phase:   "checking_removed",
+		Current: result.NewGames,
+		Message: "Checking for removed games...",
+	})
 
 	// Remove games whose files no longer exist.
 	// Use Unscoped to include soft-deleted games — if a game was previously
@@ -368,7 +445,7 @@ func (s *Scanner) Scan() (*ScanResult, error) {
 	if err := s.DB.Unscoped().Find(&allGames).Error; err != nil {
 		return nil, fmt.Errorf("loading existing games: %w", err)
 	}
-	for _, g := range allGames {
+	for i, g := range allGames {
 		if !foundPaths[g.FilePath] {
 			// Resolve relative path to absolute for filesystem check
 			absPath, resolveErr := storage.ResolveGamePath(g.FilePath, s.GameDirs)
@@ -382,6 +459,14 @@ func (s *Scanner) Scan() (*ScanResult, error) {
 				s.DB.Unscoped().Where("game_id = ?", g.ID).Delete(&db.GameDisc{})
 				s.DB.Unscoped().Delete(&g)
 			}
+		}
+		if i%100 == 0 {
+			report(ScanProgress{
+				Phase:   "checking_removed",
+				Current: i,
+				Total:   len(allGames),
+				Message: fmt.Sprintf("Checking for removed games... (%d/%d)", i, len(allGames)),
+			})
 		}
 	}
 

--- a/server/internal/scanner/scanner_test.go
+++ b/server/internal/scanner/scanner_test.go
@@ -79,7 +79,7 @@ func TestScan_EmptyDirectory(t *testing.T) {
 	dir := t.TempDir()
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result.NewGames)
 	assert.Equal(t, 0, result.TotalGames)
@@ -100,7 +100,7 @@ func TestScan_DetectsROMs(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(snesDir, "Chrono Trigger.sfc"), []byte("fake snes rom"), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 3, result.NewGames)
 	assert.Equal(t, 3, result.TotalGames)
@@ -128,11 +128,11 @@ func TestScan_RescanDoesNotDuplicate(t *testing.T) {
 
 	s := NewScanner(database, []string{dir})
 
-	result1, err := s.Scan()
+	result1, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result1.NewGames)
 
-	result2, err := s.Scan()
+	result2, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result2.NewGames)
 	assert.Equal(t, 1, result2.TotalGames)
@@ -187,7 +187,7 @@ func TestScan_IgnoresNonROMFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(nesDir, "game.nfo"), []byte("info"), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.NewGames)
 	assert.Equal(t, 1, result.TotalGames)
@@ -266,13 +266,13 @@ func TestScan_RemovesMissingGames(t *testing.T) {
 	require.NoError(t, os.WriteFile(romPath, []byte("rom"), 0644))
 
 	s := NewScanner(database, []string{dir})
-	_, err := s.Scan()
+	_, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	// Delete the ROM file
 	require.NoError(t, os.Remove(romPath))
 
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.RemovedGames)
 	assert.Equal(t, 0, result.TotalGames)
@@ -301,7 +301,7 @@ func TestScanSkipsBiosDirectory(t *testing.T) {
 	}
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	// Only the NES ROM should be detected, not BIOS files
@@ -325,7 +325,7 @@ func TestScanRejectsWrongExtensionInConsoleDir(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(nesDir, "wrong.bin"), []byte("not nes"), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	// Only .nes and .fds should be detected, not .bin
@@ -443,7 +443,7 @@ func TestScan_M3UMultiDisc(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "Final Fantasy VII.m3u"), []byte(m3uContent), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, result.NewGames, "should create exactly 1 game")
@@ -478,7 +478,7 @@ func TestScan_PatternMultiDisc(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "Game (Disc 2).cue"), []byte("FILE \"game_d2.bin\" BINARY\n"), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 1, result.NewGames, "should create exactly 1 game from disc pattern")
@@ -506,7 +506,7 @@ func TestScan_SingleDiscNotGrouped(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "Crash Bandicoot.iso"), []byte("iso data"), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	var games []db.Game
@@ -539,7 +539,7 @@ func TestScan_M3UClaimsFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "MyGame.m3u"), []byte(m3uContent), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	// The .cue files should be claimed by the .m3u, not creating separate games
@@ -592,7 +592,7 @@ func TestScan_RescanUpgradesOldEntries(t *testing.T) {
 	// Now scan — disc pattern detects the group, creates multi-disc game,
 	// and should remove the old standalone entries
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	var games []db.Game
@@ -617,7 +617,7 @@ func TestScan_PSPCHDSetsAchievementsWarning(t *testing.T) {
 	})
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.NewGames)
 
@@ -640,7 +640,7 @@ func TestScan_PSPCHDCreateCDNoWarning(t *testing.T) {
 	})
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.NewGames)
 
@@ -659,7 +659,7 @@ func TestScan_PSPISONoWarning(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(pspDir, "Crisis Core.iso"), []byte("fake iso"), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.NewGames)
 
@@ -678,7 +678,7 @@ func TestScan_PSPCSOSetsWarning(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(pspDir, "Patapon.cso"), []byte("fake cso"), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.NewGames)
 
@@ -705,7 +705,7 @@ func TestScan_NonPSPCHDNoWarning(t *testing.T) {
 	})
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result.NewGames)
 
@@ -759,7 +759,7 @@ func TestScan_RescanCreatesDiscRecordsForExistingGame(t *testing.T) {
 
 	// Scan — should detect the existing game and backfill disc records
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, result.NewGames, "should not create a new game")
@@ -781,7 +781,7 @@ func TestScan_RescanCreatesDiscRecordsForExistingGame(t *testing.T) {
 	assert.Greater(t, updatedGame.FileSize, int64(0), "file size should be updated")
 
 	// Rescan should be idempotent — no duplicate disc records
-	_, err = s.Scan()
+	_, err = s.Scan(nil)
 	require.NoError(t, err)
 
 	var discsAfterRescan []db.GameDisc
@@ -804,7 +804,7 @@ func TestScan_Deterministic_RemoveAndRestore(t *testing.T) {
 	s := NewScanner(database, []string{dir})
 
 	// Scan 1: game appears
-	r1, err := s.Scan()
+	r1, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, r1.NewGames)
 	assert.Equal(t, 1, r1.TotalGames)
@@ -816,7 +816,7 @@ func TestScan_Deterministic_RemoveAndRestore(t *testing.T) {
 	require.NoError(t, os.Remove(romPath))
 
 	// Scan 2: game is removed
-	r2, err := s.Scan()
+	r2, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, r2.RemovedGames)
 	assert.Equal(t, 0, r2.TotalGames)
@@ -830,7 +830,7 @@ func TestScan_Deterministic_RemoveAndRestore(t *testing.T) {
 	require.NoError(t, os.WriteFile(romPath, []byte("rom data"), 0644))
 
 	// Scan 3: game reappears as new
-	r3, err := s.Scan()
+	r3, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, r3.NewGames)
 	assert.Equal(t, 1, r3.TotalGames)
@@ -874,7 +874,7 @@ func TestScan_Deterministic_MultiDisc_RemoveAndRestore(t *testing.T) {
 	s := NewScanner(database, []string{dir})
 
 	// Scan 1: game + discs created
-	r1, err := s.Scan()
+	r1, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, r1.NewGames)
 
@@ -888,7 +888,7 @@ func TestScan_Deterministic_MultiDisc_RemoveAndRestore(t *testing.T) {
 	removeDiscFiles()
 
 	// Scan 2: game removed
-	r2, err := s.Scan()
+	r2, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, r2.RemovedGames)
 	assert.Equal(t, 0, r2.TotalGames)
@@ -904,7 +904,7 @@ func TestScan_Deterministic_MultiDisc_RemoveAndRestore(t *testing.T) {
 	writeDiscFiles()
 
 	// Scan 3: game + discs recreated
-	r3, err := s.Scan()
+	r3, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, r3.NewGames)
 	assert.Equal(t, 1, r3.TotalGames)
@@ -937,12 +937,12 @@ func TestScan_RescanIdempotent_MultiDisc(t *testing.T) {
 
 	s := NewScanner(database, []string{dir})
 
-	result1, err := s.Scan()
+	result1, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, result1.NewGames)
 	assert.Equal(t, 1, result1.TotalGames)
 
-	result2, err := s.Scan()
+	result2, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result2.NewGames, "rescan should not create duplicates")
 	assert.Equal(t, 1, result2.TotalGames)
@@ -971,7 +971,7 @@ func TestScan_StandaloneCueBin(t *testing.T) {
 	require.NoError(t, os.WriteFile(cuePath, []byte(cueContent), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	// Should create exactly 1 game (the .cue), NOT 2 (one for .cue, one for .bin)
@@ -993,7 +993,7 @@ func TestScan_StandaloneCueBin(t *testing.T) {
 	assert.Equal(t, "Crash Bandicoot.cue", discs[0].FileName)
 
 	// Rescan should be idempotent
-	result2, err := s.Scan()
+	result2, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result2.NewGames, "rescan should not create duplicates")
 	assert.Equal(t, 1, result2.TotalGames)
@@ -1034,7 +1034,7 @@ func TestScan_StandaloneCueBin_CleansUpOldBinEntry(t *testing.T) {
 	require.Equal(t, int64(1), countBefore)
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	// The old .bin entry should be removed and replaced by the .cue entry
@@ -1090,7 +1090,7 @@ func TestScan_StandaloneCueBin_CleansUpBinWhenCueExists(t *testing.T) {
 	require.Equal(t, int64(2), countBefore)
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	// Only the .cue game should remain; the .bin entry should be cleaned up
@@ -1133,7 +1133,7 @@ func TestScan_StandaloneCueBin_BackfillDiscRecord(t *testing.T) {
 	require.NoError(t, database.Create(&existingGame).Error)
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	assert.Equal(t, 0, result.NewGames, "should not create a new game")
@@ -1204,7 +1204,7 @@ func TestScan_StandaloneGdiBin(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(dcDir, "Sonic Adventure.gdi"), []byte(gdiContent), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 
 	// Should create exactly 1 game — the .gdi — not separate entries for track files
@@ -1232,7 +1232,7 @@ func TestScan_StandaloneGdiBin(t *testing.T) {
 	assert.Equal(t, "Sonic Adventure.gdi", discs[0].FileName)
 
 	// Rescan should be idempotent
-	result2, err := s.Scan()
+	result2, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 0, result2.NewGames, "rescan should not create duplicates")
 	assert.Equal(t, 1, result2.TotalGames)
@@ -1320,7 +1320,7 @@ func TestScan_NonPlayableConsoles(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(x360Dir, "Halo 3.xex"), []byte("fake xex"), 0644))
 
 	s := NewScanner(database, []string{dir})
-	result, err := s.Scan()
+	result, err := s.Scan(nil)
 	require.NoError(t, err)
 	assert.Equal(t, 4, result.NewGames)
 	assert.Equal(t, 4, result.TotalGames)

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -210,6 +210,21 @@ export function useScrapeStatus() {
   });
 }
 
+export interface ScanStatus {
+  active: boolean;
+  phase?: string;
+  current?: number;
+  total?: number;
+  message?: string;
+}
+
+export function useScanStatus() {
+  return useQuery({
+    queryKey: ["admin", "scan-status"],
+    queryFn: () => api.get<ScanStatus>("/admin/games/scan/status"),
+  });
+}
+
 export interface CoverOption {
   source: "libretro" | "igdb" | "custom" | "libretro-regional";
   url: string;

--- a/web/src/hooks/use-scan-progress.ts
+++ b/web/src/hooks/use-scan-progress.ts
@@ -1,0 +1,114 @@
+import { useState, useCallback, useEffect } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useWebSocketEvent } from "@/hooks/use-websocket";
+import { useScanStatus } from "@/hooks/use-admin";
+
+interface ScanProgressPayload {
+  phase: string;
+  current: number;
+  total: number;
+  message: string;
+}
+
+interface ScanCompletePayload {
+  newGames: number;
+  updatedGames: number;
+  removedGames: number;
+  totalGames: number;
+  newGamesList?: { id: string; title: string; consoleName: string }[];
+}
+
+interface ScanErrorPayload {
+  error: string;
+}
+
+export type ScanPhase = "idle" | "active" | "complete" | "error";
+
+export interface ScanProgressState {
+  phase: ScanPhase;
+  message: string;
+  current: number;
+  total: number;
+  result: ScanCompletePayload | null;
+  error: string | null;
+  dismiss: () => void;
+}
+
+export function useScanProgress(): ScanProgressState {
+  const { data: initialStatus } = useScanStatus();
+  const queryClient = useQueryClient();
+
+  const [phase, setPhase] = useState<ScanPhase>("idle");
+  const [message, setMessage] = useState("");
+  const [current, setCurrent] = useState(0);
+  const [total, setTotal] = useState(0);
+  const [result, setResult] = useState<ScanCompletePayload | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [initialized, setInitialized] = useState(false);
+
+  useEffect(() => {
+    if (!initialStatus || initialized) return;
+    setInitialized(true);
+    if (initialStatus.active) {
+      setPhase("active");
+      setMessage(initialStatus.message ?? "Scanning...");
+      setCurrent(initialStatus.current ?? 0);
+      setTotal(initialStatus.total ?? 0);
+    }
+  }, [initialStatus, initialized]);
+
+  useWebSocketEvent(
+    "scan_started",
+    useCallback(() => {
+      setPhase("active");
+      setMessage("Starting scan...");
+      setCurrent(0);
+      setTotal(0);
+      setResult(null);
+      setError(null);
+    }, []),
+  );
+
+  useWebSocketEvent(
+    "scan_progress",
+    useCallback((payload: ScanProgressPayload) => {
+      setPhase("active");
+      setMessage(payload.message);
+      setCurrent(payload.current);
+      setTotal(payload.total);
+    }, []),
+  );
+
+  useWebSocketEvent(
+    "scan_complete",
+    useCallback(
+      (payload: ScanCompletePayload) => {
+        setPhase("complete");
+        setResult(payload);
+        queryClient.invalidateQueries({ queryKey: ["games"] });
+        queryClient.invalidateQueries({ queryKey: ["consoles"] });
+        queryClient.invalidateQueries({ queryKey: ["admin", "stats"] });
+      },
+      [queryClient],
+    ),
+  );
+
+  useWebSocketEvent(
+    "scan_error",
+    useCallback((payload: ScanErrorPayload) => {
+      setPhase("error");
+      setError(payload.error);
+    }, []),
+  );
+
+  const dismiss = useCallback(() => {
+    setPhase("idle");
+    setMessage("");
+    setCurrent(0);
+    setTotal(0);
+    setResult(null);
+    setError(null);
+  }, []);
+
+  return { phase, message, current, total, result, error, dismiss };
+}

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -202,6 +202,7 @@ export type ApiGetPath = WithQuery<
   | "/admin/settings"
   | "/admin/stats"
   | "/admin/scrape/status"
+  | "/admin/games/scan/status"
   | `/admin/games/${string}/covers`
   | `/admin/games/${string}/igdb-search`
   | "/admin/metadata-matches"

--- a/web/src/pages/admin/__tests__/scan-page.test.tsx
+++ b/web/src/pages/admin/__tests__/scan-page.test.tsx
@@ -7,7 +7,8 @@ import { AdminScanPage } from "../scan-page";
 
 const mockScanMutate = vi.fn();
 const mockScrapeMutate = vi.fn();
-const mockDismiss = vi.fn();
+const mockScanDismiss = vi.fn();
+const mockScrapeDismiss = vi.fn();
 
 vi.mock("@/hooks/use-admin", () => ({
   useScanLibrary: vi.fn(),
@@ -16,6 +17,10 @@ vi.mock("@/hooks/use-admin", () => ({
 
 vi.mock("@/hooks/use-scrape-progress", () => ({
   useScrapeProgress: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-scan-progress", () => ({
+  useScanProgress: vi.fn(),
 }));
 
 vi.mock("@/components/ui", async () => {
@@ -29,10 +34,12 @@ vi.mock("@/components/ui", async () => {
 
 import { useScanLibrary, useScrapeMetadata } from "@/hooks/use-admin";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
+import { useScanProgress } from "@/hooks/use-scan-progress";
 
 const mockUseScanLibrary = useScanLibrary as ReturnType<typeof vi.fn>;
 const mockUseScrapeMetadata = useScrapeMetadata as ReturnType<typeof vi.fn>;
 const mockUseScrapeProgress = useScrapeProgress as ReturnType<typeof vi.fn>;
+const mockUseScanProgress = useScanProgress as ReturnType<typeof vi.fn>;
 
 function renderPage() {
   const queryClient = new QueryClient({
@@ -58,6 +65,15 @@ beforeEach(() => {
     mutate: mockScrapeMutate,
     isPending: false,
   });
+  mockUseScanProgress.mockReturnValue({
+    phase: "idle",
+    message: "",
+    current: 0,
+    total: 0,
+    result: null,
+    error: null,
+    dismiss: mockScanDismiss,
+  });
   mockUseScrapeProgress.mockReturnValue({
     phase: "idle",
     current: 0,
@@ -66,7 +82,7 @@ beforeEach(() => {
     successes: 0,
     failures: 0,
     error: null,
-    dismiss: mockDismiss,
+    dismiss: mockScrapeDismiss,
   });
 });
 
@@ -143,23 +159,47 @@ describe("AdminScanPage", () => {
     );
   });
 
-  it("shows scanning indicator when scan is pending", () => {
-    mockUseScanLibrary.mockReturnValue({
-      mutate: mockScanMutate,
-      isPending: true,
-      data: undefined,
+  it("shows scanning progress when scan is active", () => {
+    mockUseScanProgress.mockReturnValue({
+      phase: "active",
+      message: "Scanning game directories... (12 new so far)",
+      current: 12,
+      total: 0,
+      result: null,
+      error: null,
+      dismiss: mockScanDismiss,
     });
     renderPage();
     expect(
-      screen.getByText("Scanning game directories..."),
+      screen.getByText("Scanning game directories... (12 new so far)"),
     ).toBeInTheDocument();
   });
 
+  it("disables Start Scan button when scan is active", () => {
+    mockUseScanProgress.mockReturnValue({
+      phase: "active",
+      message: "Scanning...",
+      current: 0,
+      total: 0,
+      result: null,
+      error: null,
+      dismiss: mockScanDismiss,
+    });
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /Start Scan/ }),
+    ).toBeDisabled();
+  });
+
   it("shows scan results when scan completes", () => {
-    mockUseScanLibrary.mockReturnValue({
-      mutate: mockScanMutate,
-      isPending: false,
-      data: { totalGames: 42, newGames: 5, updatedGames: 3, removedGames: 1 },
+    mockUseScanProgress.mockReturnValue({
+      phase: "complete",
+      message: "",
+      current: 0,
+      total: 0,
+      result: { totalGames: 42, newGames: 5, updatedGames: 3, removedGames: 1 },
+      error: null,
+      dismiss: mockScanDismiss,
     });
     renderPage();
     expect(screen.getByText("Scan complete")).toBeInTheDocument();
@@ -167,6 +207,21 @@ describe("AdminScanPage", () => {
     expect(screen.getByText("5")).toBeInTheDocument();
     expect(screen.getByText("3")).toBeInTheDocument();
     expect(screen.getByText("1")).toBeInTheDocument();
+  });
+
+  it("shows scan error state", () => {
+    mockUseScanProgress.mockReturnValue({
+      phase: "error",
+      message: "",
+      current: 0,
+      total: 0,
+      result: null,
+      error: "library scan failed",
+      dismiss: mockScanDismiss,
+    });
+    renderPage();
+    expect(screen.getByText("Scan failed")).toBeInTheDocument();
+    expect(screen.getByText("library scan failed")).toBeInTheDocument();
   });
 
   it("shows active scrape progress panel", () => {
@@ -178,7 +233,7 @@ describe("AdminScanPage", () => {
       successes: 2,
       failures: 1,
       error: null,
-      dismiss: mockDismiss,
+      dismiss: mockScrapeDismiss,
     });
     renderPage();
     expect(screen.getByText(/Scraping game 3 of 10/)).toBeInTheDocument();
@@ -196,7 +251,7 @@ describe("AdminScanPage", () => {
       successes: 0,
       failures: 0,
       error: null,
-      dismiss: mockDismiss,
+      dismiss: mockScrapeDismiss,
     });
     renderPage();
     expect(
@@ -216,7 +271,7 @@ describe("AdminScanPage", () => {
       successes: 8,
       failures: 2,
       error: null,
-      dismiss: mockDismiss,
+      dismiss: mockScrapeDismiss,
     });
     renderPage();
     expect(screen.getByText("Scraping complete")).toBeInTheDocument();
@@ -224,7 +279,7 @@ describe("AdminScanPage", () => {
     expect(screen.getByText("2 failed")).toBeInTheDocument();
   });
 
-  it("shows dismiss button on completion and calls dismiss", async () => {
+  it("shows dismiss button on scrape completion and calls dismiss", async () => {
     mockUseScrapeProgress.mockReturnValue({
       phase: "complete",
       current: 10,
@@ -233,16 +288,16 @@ describe("AdminScanPage", () => {
       successes: 10,
       failures: 0,
       error: null,
-      dismiss: mockDismiss,
+      dismiss: mockScrapeDismiss,
     });
     renderPage();
-    const dismissButton = screen.getByRole("button", { name: /Dismiss/ });
-    expect(dismissButton).toBeInTheDocument();
-    await userEvent.click(dismissButton);
-    expect(mockDismiss).toHaveBeenCalled();
+    const dismissButtons = screen.getAllByRole("button", { name: /Dismiss/ });
+    expect(dismissButtons.length).toBeGreaterThan(0);
+    await userEvent.click(dismissButtons[0]);
+    expect(mockScrapeDismiss).toHaveBeenCalled();
   });
 
-  it("shows error state with error message", () => {
+  it("shows scrape error state with error message", () => {
     mockUseScrapeProgress.mockReturnValue({
       phase: "error",
       current: 0,
@@ -251,14 +306,14 @@ describe("AdminScanPage", () => {
       successes: 0,
       failures: 0,
       error: "IGDB rate limit exceeded",
-      dismiss: mockDismiss,
+      dismiss: mockScrapeDismiss,
     });
     renderPage();
     expect(screen.getByText("Scraping failed")).toBeInTheDocument();
     expect(screen.getByText("IGDB rate limit exceeded")).toBeInTheDocument();
   });
 
-  it("shows dismiss button on error and calls dismiss", async () => {
+  it("shows dismiss button on scrape error and calls dismiss", async () => {
     mockUseScrapeProgress.mockReturnValue({
       phase: "error",
       current: 0,
@@ -267,12 +322,12 @@ describe("AdminScanPage", () => {
       successes: 0,
       failures: 0,
       error: "Some error",
-      dismiss: mockDismiss,
+      dismiss: mockScrapeDismiss,
     });
     renderPage();
-    const dismissButton = screen.getByRole("button", { name: /Dismiss/ });
-    await userEvent.click(dismissButton);
-    expect(mockDismiss).toHaveBeenCalled();
+    const dismissButtons = screen.getAllByRole("button", { name: /Dismiss/ });
+    await userEvent.click(dismissButtons[0]);
+    expect(mockScrapeDismiss).toHaveBeenCalled();
   });
 
   it("does not show failures count when there are zero failures during active scrape", () => {
@@ -284,7 +339,7 @@ describe("AdminScanPage", () => {
       successes: 3,
       failures: 0,
       error: null,
-      dismiss: mockDismiss,
+      dismiss: mockScrapeDismiss,
     });
     renderPage();
     expect(screen.getByText("3 succeeded")).toBeInTheDocument();
@@ -300,7 +355,7 @@ describe("AdminScanPage", () => {
       successes: 10,
       failures: 0,
       error: null,
-      dismiss: mockDismiss,
+      dismiss: mockScrapeDismiss,
     });
     renderPage();
     expect(screen.getByText("10 scraped")).toBeInTheDocument();
@@ -316,7 +371,7 @@ describe("AdminScanPage", () => {
       successes: 0,
       failures: 0,
       error: null,
-      dismiss: mockDismiss,
+      dismiss: mockScrapeDismiss,
     });
     renderPage();
     expect(screen.getByText("No unscraped games found")).toBeInTheDocument();

--- a/web/src/pages/admin/scan-page.tsx
+++ b/web/src/pages/admin/scan-page.tsx
@@ -11,21 +11,7 @@ import { Button, Card, CardHeader, CardContent } from "@/components/ui";
 import { useScanLibrary, useScrapeMetadata } from "@/hooks/use-admin";
 import { useToast } from "@/components/ui";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
-
-interface ScanGameSummary {
-  id: string;
-  title: string;
-  consoleName: string;
-}
-
-interface ScanResult {
-  newGames?: number;
-  updatedGames?: number;
-  removedGames?: number;
-  totalGames?: number;
-  newGamesList?: ScanGameSummary[];
-  autoScraping?: boolean;
-}
+import { useScanProgress } from "@/hooks/use-scan-progress";
 
 function ProgressBar({ value, max }: { value: number; max: number }) {
   const pct = max > 0 ? Math.round((value / max) * 100) : 0;
@@ -36,6 +22,152 @@ function ProgressBar({ value, max }: { value: number; max: number }) {
         style={{ width: `${pct}%` }}
       />
     </div>
+  );
+}
+
+function ScanCard() {
+  const scanLibrary = useScanLibrary();
+  const scan = useScanProgress();
+  const { toast } = useToast();
+
+  const isActive = scan.phase === "active";
+  const isComplete = scan.phase === "complete";
+  const isError = scan.phase === "error";
+
+  return (
+    <Card>
+      <CardHeader>
+        <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+          <FolderSearch className="h-5 w-5 text-brand-400" />
+          Scan for Games
+        </h2>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-surface-400">
+          Scan configured game directories for new ROMs. Previously detected
+          games will not be duplicated.
+        </p>
+
+        {isActive && (
+          <div className="rounded-xl bg-surface-800/50 p-4 space-y-3">
+            <div className="flex items-center gap-2 text-sm">
+              <Loader2 className="h-4 w-4 animate-spin text-brand-400" />
+              <span className="text-surface-200">{scan.message}</span>
+            </div>
+            {scan.total > 0 && (
+              <ProgressBar value={scan.current} max={scan.total} />
+            )}
+          </div>
+        )}
+
+        {isComplete && scan.result && (
+          <div className="rounded-xl bg-surface-800/50 p-4 space-y-3">
+            <div className="flex items-center gap-2 text-sm">
+              <CheckCircle className="h-4 w-4 text-success-500" />
+              <span className="text-surface-200">Scan complete</span>
+            </div>
+            <div className="grid grid-cols-2 gap-2 text-sm">
+              {scan.result.totalGames !== undefined && (
+                <div>
+                  <p className="text-surface-500">Total games</p>
+                  <p className="text-surface-100 font-semibold">
+                    {scan.result.totalGames}
+                  </p>
+                </div>
+              )}
+              {scan.result.newGames !== undefined && (
+                <div>
+                  <p className="text-surface-500">New games</p>
+                  <p className="text-surface-100 font-semibold">
+                    {scan.result.newGames}
+                  </p>
+                </div>
+              )}
+              {scan.result.updatedGames !== undefined && (
+                <div>
+                  <p className="text-surface-500">Updated</p>
+                  <p className="text-surface-100 font-semibold">
+                    {scan.result.updatedGames}
+                  </p>
+                </div>
+              )}
+              {scan.result.removedGames !== undefined && (
+                <div>
+                  <p className="text-surface-500">Removed</p>
+                  <p className="text-surface-100 font-semibold">
+                    {scan.result.removedGames}
+                  </p>
+                </div>
+              )}
+            </div>
+            {scan.result.newGamesList && scan.result.newGamesList.length > 0 && (
+              <div className="mt-2">
+                <p className="text-xs font-medium text-surface-400 mb-1.5">
+                  New games found:
+                </p>
+                <ul className="space-y-1 max-h-48 overflow-y-auto text-sm">
+                  {scan.result.newGamesList.map((g) => (
+                    <li
+                      key={g.id}
+                      className="flex items-center justify-between text-surface-200"
+                    >
+                      <span className="truncate">{g.title}</span>
+                      <span className="text-xs text-surface-500 ml-2 shrink-0">
+                        {g.consoleName}
+                      </span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={scan.dismiss}
+              className="w-full"
+            >
+              Dismiss
+            </Button>
+          </div>
+        )}
+
+        {isError && (
+          <div className="rounded-xl bg-error-900/30 border border-error-700/50 p-4 space-y-3">
+            <div className="flex items-center gap-2 text-sm">
+              <AlertCircle className="h-4 w-4 text-error-400" />
+              <span className="text-error-300">Scan failed</span>
+            </div>
+            <p className="text-sm text-error-400">{scan.error}</p>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={scan.dismiss}
+              className="w-full"
+            >
+              Dismiss
+            </Button>
+          </div>
+        )}
+
+        <Button
+          onClick={() =>
+            scanLibrary.mutate(undefined, {
+              onError: (err) =>
+                toast(
+                  "error",
+                  err instanceof Error ? err.message : "Scan failed",
+                ),
+            })
+          }
+          loading={scanLibrary.isPending}
+          disabled={isActive}
+          icon={<FolderSearch className="h-4 w-4" />}
+          className="w-full"
+        >
+          Start Scan
+        </Button>
+      </CardContent>
+    </Card>
   );
 }
 
@@ -231,11 +363,6 @@ function ScrapeCard() {
 }
 
 export function AdminScanPage() {
-  const scanLibrary = useScanLibrary();
-  const { toast } = useToast();
-
-  const scanResult = scanLibrary.data as ScanResult | undefined;
-
   return (
     <div className="space-y-6 max-w-3xl">
       <div>
@@ -246,118 +373,7 @@ export function AdminScanPage() {
       </div>
 
       <div className="grid gap-5 md:grid-cols-2">
-        <Card>
-          <CardHeader>
-            <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
-              <FolderSearch className="h-5 w-5 text-brand-400" />
-              Scan for Games
-            </h2>
-          </CardHeader>
-          <CardContent className="space-y-4">
-            <p className="text-sm text-surface-400">
-              Scan configured game directories for new ROMs. Previously detected
-              games will not be duplicated.
-            </p>
-
-            {scanLibrary.isPending && (
-              <div className="rounded-xl bg-surface-800/50 p-4">
-                <div className="flex items-center gap-2 text-sm">
-                  <Loader2 className="h-4 w-4 animate-spin text-brand-400" />
-                  <span className="text-surface-200">
-                    Scanning game directories...
-                  </span>
-                </div>
-              </div>
-            )}
-
-            {scanResult && (
-              <div className="rounded-xl bg-surface-800/50 p-4 space-y-3">
-                <div className="flex items-center gap-2 text-sm">
-                  <CheckCircle className="h-4 w-4 text-success-500" />
-                  <span className="text-surface-200">Scan complete</span>
-                </div>
-                <div className="grid grid-cols-2 gap-2 text-sm">
-                  {scanResult.totalGames !== undefined && (
-                    <div>
-                      <p className="text-surface-500">Total games</p>
-                      <p className="text-surface-100 font-semibold">
-                        {scanResult.totalGames}
-                      </p>
-                    </div>
-                  )}
-                  {scanResult.newGames !== undefined && (
-                    <div>
-                      <p className="text-surface-500">New games</p>
-                      <p className="text-surface-100 font-semibold">
-                        {scanResult.newGames}
-                      </p>
-                    </div>
-                  )}
-                  {scanResult.updatedGames !== undefined && (
-                    <div>
-                      <p className="text-surface-500">Updated</p>
-                      <p className="text-surface-100 font-semibold">
-                        {scanResult.updatedGames}
-                      </p>
-                    </div>
-                  )}
-                  {scanResult.removedGames !== undefined && (
-                    <div>
-                      <p className="text-surface-500">Removed</p>
-                      <p className="text-surface-100 font-semibold">
-                        {scanResult.removedGames}
-                      </p>
-                    </div>
-                  )}
-                </div>
-                {scanResult.autoScraping && (
-                  <p className="text-xs text-brand-400">
-                    Auto-scraping new games...
-                  </p>
-                )}
-                {scanResult.newGamesList &&
-                  scanResult.newGamesList.length > 0 && (
-                    <div className="mt-2">
-                      <p className="text-xs font-medium text-surface-400 mb-1.5">
-                        New games found:
-                      </p>
-                      <ul className="space-y-1 max-h-48 overflow-y-auto text-sm">
-                        {scanResult.newGamesList.map((g) => (
-                          <li
-                            key={g.id}
-                            className="flex items-center justify-between text-surface-200"
-                          >
-                            <span className="truncate">{g.title}</span>
-                            <span className="text-xs text-surface-500 ml-2 shrink-0">
-                              {g.consoleName}
-                            </span>
-                          </li>
-                        ))}
-                      </ul>
-                    </div>
-                  )}
-              </div>
-            )}
-
-            <Button
-              onClick={() =>
-                scanLibrary.mutate(undefined, {
-                  onError: (err) =>
-                    toast(
-                      "error",
-                      err instanceof Error ? err.message : "Scan failed",
-                    ),
-                })
-              }
-              loading={scanLibrary.isPending}
-              icon={<FolderSearch className="h-4 w-4" />}
-              className="w-full"
-            >
-              Start Scan
-            </Button>
-          </CardContent>
-        </Card>
-
+        <ScanCard />
         <ScrapeCard />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Scan endpoint (`POST /admin/games/scan`) now returns 202 immediately and runs in the background
- Progress is broadcast via WebSocket events (`scan_started`, `scan_progress`, `scan_complete`, `scan_error`)
- New `GET /admin/games/scan/status` endpoint for reconnection (matches the existing scrape status pattern)
- New `useScanProgress` hook mirrors `useScrapeProgress` — navigate away, come back, progress persists
- Concurrent scan requests are rejected with 409 Conflict
- Auto-scrape still runs automatically after scan completes (also in background)

Fixes the HTTP timeout issue when scanning libraries with thousands of games.

## Test plan
- [x] Go server builds cleanly
- [x] All scanner tests pass (37 tests)
- [x] TypeScript compiles cleanly
- [x] All web unit tests pass (117 files, 1277 tests)
- [ ] CI passes
- [ ] Manual: start scan with large library, navigate away, come back — progress visible