### PR TITLE
feat: warn when game library is read-only on ROM upload page

### DIFF
--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -531,6 +531,7 @@ func NewRouter(cfg Config) *gin.Engine {
 			admin.GET("/enrich-metadata/status", enrichmentHandler.EnrichMetadataStatus)
 
 			// ROM uploads
+			admin.GET("/uploads/writable", uploadHandler.CheckWritable)
 			admin.POST("/uploads", uploadHandler.UploadROMs)
 			admin.GET("/uploads", uploadHandler.ListUploads)
 			admin.POST("/uploads/:id/console", uploadHandler.SetConsole)

--- a/server/internal/api/upload_handler.go
+++ b/server/internal/api/upload_handler.go
@@ -171,6 +171,24 @@ func detectConsole(database *gorm.DB, ext string) (*uint, bool) {
 	return nil, false
 }
 
+// CheckWritable checks whether the game library directory is writable.
+// GET /api/admin/uploads/writable
+func (h *UploadHandler) CheckWritable(c *gin.Context) {
+	gameDir := h.GameDirs[0]
+	tmpPath := filepath.Join(gameDir, ".spela-write-test")
+	f, err := os.Create(tmpPath)
+	if err != nil {
+		c.JSON(http.StatusOK, gin.H{
+			"writable": false,
+			"reason":   "Game library directory is read-only",
+		})
+		return
+	}
+	f.Close()
+	os.Remove(tmpPath)
+	c.JSON(http.StatusOK, gin.H{"writable": true})
+}
+
 // UploadROMs handles multipart file uploads of ROM files to the staging area.
 // Zip files are automatically extracted and individual ROMs inside are staged.
 // POST /api/admin/uploads

--- a/server/internal/api/upload_handler.go
+++ b/server/internal/api/upload_handler.go
@@ -185,7 +185,7 @@ func (h *UploadHandler) CheckWritable(c *gin.Context) {
 		return
 	}
 	f.Close()
-	os.Remove(tmpPath)
+	defer os.Remove(tmpPath)
 	c.JSON(http.StatusOK, gin.H{"writable": true})
 }
 

--- a/server/internal/api/upload_handler_test.go
+++ b/server/internal/api/upload_handler_test.go
@@ -1582,3 +1582,46 @@ func matchesTempZipPattern(name string) bool {
 	matched, _ := filepath.Match("upload-*.zip", name)
 	return matched
 }
+
+func TestCheckWritable_WritableDir(t *testing.T) {
+	env := setupUploadTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/uploads/writable", nil)
+	req.Header.Set("Authorization", "Bearer "+env.adminToken)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	assert.Equal(t, true, result["writable"])
+	assert.Nil(t, result["reason"])
+}
+
+func TestCheckWritable_ReadonlyDir(t *testing.T) {
+	env := setupUploadTestEnv(t)
+
+	// Make the game directory read-only
+	readonlyDir := filepath.Join(t.TempDir(), "readonly-games")
+	require.NoError(t, os.MkdirAll(readonlyDir, 0555))
+	t.Cleanup(func() {
+		os.Chmod(readonlyDir, 0755)
+	})
+	env.cfg.GameDirs = []string{readonlyDir}
+
+	router := NewRouter(*env.cfg)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/admin/uploads/writable", nil)
+	req.Header.Set("Authorization", "Bearer "+env.adminToken)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+	assert.Equal(t, false, result["writable"])
+	assert.Equal(t, "Game library directory is read-only", result["reason"])
+}

--- a/web/src/features/upload/components/drop-zone.tsx
+++ b/web/src/features/upload/components/drop-zone.tsx
@@ -14,6 +14,7 @@ export function DropZone({ onFiles, isUploading }: DropZoneProps) {
   function handleDrop(e: React.DragEvent) {
     e.preventDefault();
     setIsDragOver(false);
+    if (isUploading) return;
     if (e.dataTransfer.files.length > 0) {
       onFiles(Array.from(e.dataTransfer.files));
     }
@@ -29,6 +30,7 @@ export function DropZone({ onFiles, isUploading }: DropZoneProps) {
   }
 
   function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    if (isUploading) return;
     if (e.target.files && e.target.files.length > 0) {
       onFiles(Array.from(e.target.files));
       e.target.value = "";

--- a/web/src/hooks/use-uploads.ts
+++ b/web/src/hooks/use-uploads.ts
@@ -2,6 +2,16 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
 import type { StagedUpload, Game } from "@/types/api";
 
+export function useUploadWritable() {
+  return useQuery({
+    queryKey: ["admin", "uploads", "writable"],
+    queryFn: () =>
+      api.get<{ writable: boolean; reason?: string }>(
+        "/admin/uploads/writable",
+      ),
+  });
+}
+
 export function useStagedUploads() {
   return useQuery({
     queryKey: ["admin", "uploads"],

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -210,6 +210,7 @@ export type ApiGetPath = WithQuery<
   | "/admin/steamgriddb/status"
   | "/admin/cheats/stats"
   | "/admin/uploads"
+  | "/admin/uploads/writable"
   | "/admin/core-compatibility"
 
   // WebSocket

--- a/web/src/pages/admin/__tests__/upload-roms-page.test.tsx
+++ b/web/src/pages/admin/__tests__/upload-roms-page.test.tsx
@@ -1,0 +1,159 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { UploadRomsPage } from "../upload-roms-page";
+
+const mockUploadMutate = vi.fn();
+
+vi.mock("@/hooks/use-uploads", () => ({
+  useUploadWritable: vi.fn(),
+  useStagedUploads: vi.fn(),
+  useUploadRoms: vi.fn(),
+  useScrapeAllUploads: vi.fn(),
+  useAcceptUpload: vi.fn(),
+  useRejectUpload: vi.fn(),
+  useAcceptAllUploads: vi.fn(),
+  useRejectAllUploads: vi.fn(),
+  useClearStaging: vi.fn(),
+  useSetUploadConsole: vi.fn(),
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual =
+    await vi.importActual<Record<string, unknown>>("@/components/ui");
+  return {
+    ...actual,
+    useToast: () => ({ toast: vi.fn() }),
+  };
+});
+
+import {
+  useUploadWritable,
+  useStagedUploads,
+  useUploadRoms,
+  useScrapeAllUploads,
+  useAcceptUpload,
+  useRejectUpload,
+  useAcceptAllUploads,
+  useRejectAllUploads,
+  useClearStaging,
+  useSetUploadConsole,
+} from "@/hooks/use-uploads";
+
+const mockUseUploadWritable = useUploadWritable as ReturnType<typeof vi.fn>;
+const mockUseStagedUploads = useStagedUploads as ReturnType<typeof vi.fn>;
+const mockUseUploadRoms = useUploadRoms as ReturnType<typeof vi.fn>;
+const mockUseScrapeAllUploads = useScrapeAllUploads as ReturnType<typeof vi.fn>;
+const mockUseAcceptUpload = useAcceptUpload as ReturnType<typeof vi.fn>;
+const mockUseRejectUpload = useRejectUpload as ReturnType<typeof vi.fn>;
+const mockUseAcceptAllUploads = useAcceptAllUploads as ReturnType<typeof vi.fn>;
+const mockUseRejectAllUploads = useRejectAllUploads as ReturnType<typeof vi.fn>;
+const mockUseClearStaging = useClearStaging as ReturnType<typeof vi.fn>;
+const mockUseSetUploadConsole = useSetUploadConsole as ReturnType<typeof vi.fn>;
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <UploadRomsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+function setupDefaultMocks() {
+  mockUseUploadWritable.mockReturnValue({
+    data: { writable: true },
+  });
+  mockUseStagedUploads.mockReturnValue({
+    data: [],
+    isLoading: false,
+  });
+  mockUseUploadRoms.mockReturnValue({
+    mutateAsync: mockUploadMutate,
+    isPending: false,
+  });
+  mockUseScrapeAllUploads.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  mockUseAcceptUpload.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  mockUseRejectUpload.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  mockUseAcceptAllUploads.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  mockUseRejectAllUploads.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  mockUseClearStaging.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+  mockUseSetUploadConsole.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  setupDefaultMocks();
+});
+
+describe("UploadRomsPage", () => {
+  it("renders page heading and drop zone when writable", () => {
+    renderPage();
+    expect(screen.getByText("Upload ROMs")).toBeInTheDocument();
+    expect(screen.getByTestId("upload-drop-zone")).toBeInTheDocument();
+    expect(screen.queryByTestId("readonly-warning")).not.toBeInTheDocument();
+  });
+
+  it("shows readonly warning when library is not writable", () => {
+    mockUseUploadWritable.mockReturnValue({
+      data: { writable: false, reason: "Game library directory is read-only" },
+    });
+    renderPage();
+    expect(screen.getByTestId("readonly-warning")).toBeInTheDocument();
+    expect(screen.getByText("Uploads unavailable")).toBeInTheDocument();
+    expect(
+      screen.getByText(/Game library directory is read-only/),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Contact your server administrator/),
+    ).toBeInTheDocument();
+  });
+
+  it("disables upload when library is not writable", () => {
+    mockUseUploadWritable.mockReturnValue({
+      data: { writable: false, reason: "Game library directory is read-only" },
+    });
+    renderPage();
+    const selectButton = screen.getByRole("button", { name: /Select Files/ });
+    expect(selectButton).toBeDisabled();
+  });
+
+  it("does not show readonly warning when writable data is still loading", () => {
+    mockUseUploadWritable.mockReturnValue({
+      data: undefined,
+    });
+    renderPage();
+    expect(screen.queryByTestId("readonly-warning")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no staged uploads", () => {
+    renderPage();
+    expect(screen.getByText("No staged uploads")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/admin/__tests__/upload-roms-page.test.tsx
+++ b/web/src/pages/admin/__tests__/upload-roms-page.test.tsx
@@ -131,7 +131,7 @@ describe("UploadRomsPage", () => {
       screen.getByText(/Game library directory is read-only/),
     ).toBeInTheDocument();
     expect(
-      screen.getByText(/Contact your server administrator/),
+      screen.getByText(/Check that the game library directory/),
     ).toBeInTheDocument();
   });
 

--- a/web/src/pages/admin/upload-roms-page.tsx
+++ b/web/src/pages/admin/upload-roms-page.tsx
@@ -218,15 +218,18 @@ export function UploadRomsPage() {
 
       {isReadonly && (
         <div
-          className="flex items-start gap-3 rounded-xl border border-warning-700/50 bg-warning-900/30 p-4"
+          role="alert"
+          className="flex items-start gap-3 rounded-xl border border-warning-500/30 bg-warning-500/10 p-4"
           data-testid="readonly-warning"
         >
-          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-warning-300" />
-          <div className="text-sm text-warning-300">
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-warning-400" />
+          <div className="text-sm text-warning-400">
             <p className="font-medium">Uploads unavailable</p>
-            <p className="mt-1">
-              Game library directory is read-only. Contact your server
-              administrator to fix directory permissions.
+            <p className="mt-1 text-warning-500">
+              {writable?.reason ||
+                "Game library directory is read-only."}{" "}
+              Check that the game library directory exists and has write
+              permissions.
             </p>
           </div>
         </div>

--- a/web/src/pages/admin/upload-roms-page.tsx
+++ b/web/src/pages/admin/upload-roms-page.tsx
@@ -1,5 +1,6 @@
 import { useState, useCallback } from "react";
 import {
+  AlertTriangle,
   CheckCheck,
   XCircle,
   Trash2,
@@ -12,6 +13,7 @@ import { useToast } from "@/components/ui";
 import {
   useStagedUploads,
   useUploadRoms,
+  useUploadWritable,
   useScrapeAllUploads,
   useAcceptUpload,
   useRejectUpload,
@@ -29,6 +31,8 @@ import { StagedUploadCard } from "@/features/upload/components/staged-upload-car
 
 export function UploadRomsPage() {
   const { toast } = useToast();
+  const { data: writable } = useUploadWritable();
+  const isReadonly = writable?.writable === false;
   const { data: uploads, isLoading: isLoadingUploads } = useStagedUploads();
   const uploadRoms = useUploadRoms();
   const scrapeAll = useScrapeAllUploads();
@@ -212,7 +216,26 @@ export function UploadRomsPage() {
         </p>
       </div>
 
-      <DropZone onFiles={handleFiles} isUploading={uploadRoms.isPending} />
+      {isReadonly && (
+        <div
+          className="flex items-start gap-3 rounded-xl border border-warning-700/50 bg-warning-900/30 p-4"
+          data-testid="readonly-warning"
+        >
+          <AlertTriangle className="mt-0.5 h-5 w-5 shrink-0 text-warning-300" />
+          <div className="text-sm text-warning-300">
+            <p className="font-medium">Uploads unavailable</p>
+            <p className="mt-1">
+              Game library directory is read-only. Contact your server
+              administrator to fix directory permissions.
+            </p>
+          </div>
+        </div>
+      )}
+
+      <DropZone
+        onFiles={handleFiles}
+        isUploading={uploadRoms.isPending || isReadonly}
+      />
 
       <UploadProgress files={fileStatuses} />
 


### PR DESCRIPTION
## Summary
- Adds a `GET /admin/uploads/writable` endpoint that checks if the game library directory is writable by creating/removing a temp file
- Shows a warning banner on the ROM upload page when the library is read-only, with actionable guidance for admins
- Disables the upload drop zone (both button and drag-and-drop) when read-only
- Gracefully degrades: if the writable check fails or is still loading, uploads remain enabled

## Test plan
- [x] Backend: `TestCheckWritable_WritableDir` and `TestCheckWritable_ReadonlyDir` pass
- [x] Frontend: 5 unit tests covering writable, readonly, loading, and empty states
- [x] Drop zone blocks both drag-and-drop and file selection when disabled
- [x] Warning uses `role="alert"` for screen reader accessibility
- [x] Warning displays server-provided reason when available