### PR TITLE
feat: add per-console scraping with console filter

### DIFF
--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -17,6 +17,7 @@ import (
 // Only one scrape can run at a time; concurrent requests are rejected.
 // Pass ?mode=all to re-scrape all games, ?mode=fallback to re-scrape
 // games that only have LibRetro metadata. Default scrapes unscraped games only.
+// Pass ?console=<abbreviation> to scrape only games for a specific console.
 // Legacy ?force=true is equivalent to ?mode=all.
 func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 	h.tryConfigureIGDB()
@@ -27,6 +28,17 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 		mode = "all"
 	}
 
+	// Resolve optional console filter
+	var consoleID uint
+	if abbr := c.Query("console"); abbr != "" {
+		var console db.Console
+		if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", abbr).First(&console).Error; err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unknown console: " + abbr})
+			return
+		}
+		consoleID = console.ID
+	}
+
 	if !h.Scraper.TryStartScrape() {
 		c.JSON(http.StatusConflict, gin.H{"error": "a scrape operation is already in progress"})
 		return
@@ -35,13 +47,17 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 	// Count matching games before launching the goroutine so we can
 	// return the total in the HTTP response for immediate user feedback.
 	var total int64
+	q := h.DB.Model(&db.Game{})
+	if consoleID > 0 {
+		q = q.Where("console_id = ?", consoleID)
+	}
 	switch mode {
 	case "all":
-		h.DB.Model(&db.Game{}).Count(&total)
+		q.Count(&total)
 	case "fallback":
-		h.DB.Model(&db.Game{}).Where("scraper_id = 'libretro'").Count(&total)
+		q.Where("scraper_id = 'libretro'").Count(&total)
 	default:
-		h.DB.Model(&db.Game{}).Where("scraper_id = '' OR scraper_id IS NULL").Count(&total)
+		q.Where("scraper_id = '' OR scraper_id IS NULL").Count(&total)
 	}
 
 	h.Hub.Broadcast(ws.Event{Type: "scrape_started", Payload: nil})
@@ -49,7 +65,7 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 	go func() {
 		defer h.Scraper.FinishScrape()
 
-		count, total, err := h.Scraper.ScrapeAll(mode, func(p scraper.ScrapeProgress) {
+		count, total, err := h.Scraper.ScrapeAll(mode, consoleID, func(p scraper.ScrapeProgress) {
 			h.Scraper.SetScrapeProgress(&p)
 			h.Hub.Broadcast(ws.Event{Type: "scrape_progress", Payload: p})
 		})
@@ -62,7 +78,7 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 	}()
 
 	adminID, _ := c.Get("userId")
-	slog.Info("audit: admin triggered scrape", "admin_id", adminID, "mode", mode)
+	slog.Info("audit: admin triggered scrape", "admin_id", adminID, "mode", mode, "console_id", consoleID)
 	c.JSON(http.StatusAccepted, gin.H{"message": "scrape started in background", "total": total})
 }
 

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -33,7 +33,7 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 	if abbr := c.Query("console"); abbr != "" {
 		var console db.Console
 		if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", abbr).First(&console).Error; err != nil {
-			c.JSON(http.StatusBadRequest, gin.H{"error": "unknown console: " + abbr})
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unknown console"})
 			return
 		}
 		consoleID = console.ID

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -476,7 +476,7 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 		if result.NewGames > 0 && h.Scraper.IsIGDBConfigured() {
 			if h.Scraper.TryStartScrape() {
 				h.Hub.Broadcast(ws.Event{Type: "scrape_started", Payload: nil})
-				count, total, scrapeErr := h.Scraper.ScrapeAll("new", func(p scraper.ScrapeProgress) {
+				count, total, scrapeErr := h.Scraper.ScrapeAll("new", 0, func(p scraper.ScrapeProgress) {
 					h.Scraper.SetScrapeProgress(&p)
 					h.Hub.Broadcast(ws.Event{Type: "scrape_progress", Payload: p})
 				})

--- a/server/internal/scraper/scraper_batch.go
+++ b/server/internal/scraper/scraper_batch.go
@@ -188,21 +188,26 @@ type ScrapeProgress struct {
 //   - "all": re-scrape every game
 //   - "fallback": re-scrape games that were only scraped via LibRetro fallback (no IGDB match)
 //
+// If consoleID is non-zero, only games belonging to that console are scraped.
 // If onProgress is non-nil, it is called after each game attempt with the current progress.
 // Returns the number of successes, the total number of games attempted, and any error.
-func (s *Scraper) ScrapeAll(mode string, onProgress func(ScrapeProgress)) (int, int, error) {
+func (s *Scraper) ScrapeAll(mode string, consoleID uint, onProgress func(ScrapeProgress)) (int, int, error) {
 	var games []db.Game
+	q := s.DB
+	if consoleID > 0 {
+		q = q.Where("console_id = ?", consoleID)
+	}
 	switch mode {
 	case "all":
-		if err := s.DB.Find(&games).Error; err != nil {
+		if err := q.Find(&games).Error; err != nil {
 			return 0, 0, fmt.Errorf("loading all games: %w", err)
 		}
 	case "fallback":
-		if err := s.DB.Where("scraper_id = 'libretro'").Find(&games).Error; err != nil {
+		if err := q.Where("scraper_id = 'libretro'").Find(&games).Error; err != nil {
 			return 0, 0, fmt.Errorf("loading fallback-scraped games: %w", err)
 		}
 	default:
-		if err := s.DB.Where("scraper_id = '' OR scraper_id IS NULL").Find(&games).Error; err != nil {
+		if err := q.Where("scraper_id = '' OR scraper_id IS NULL").Find(&games).Error; err != nil {
 			return 0, 0, fmt.Errorf("loading unscraped games: %w", err)
 		}
 	}

--- a/server/internal/scraper/scraper_igdb_test.go
+++ b/server/internal/scraper/scraper_igdb_test.go
@@ -638,7 +638,7 @@ func TestScrapeAll_DefaultOnlyUnscraped(t *testing.T) {
 		cache:      &nameCache{entries: make(map[string][]nameEntry)},
 	}
 
-	successes, total, err := s.ScrapeAll("", nil)
+	successes, total, err := s.ScrapeAll("", 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, total, "should only attempt the unscraped game")
 	assert.Equal(t, 1, successes)
@@ -668,10 +668,106 @@ func TestScrapeAll_ForceScrapesAll(t *testing.T) {
 		cache:      &nameCache{entries: make(map[string][]nameEntry)},
 	}
 
-	successes, total, err := s.ScrapeAll("all", nil)
+	successes, total, err := s.ScrapeAll("all", 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 2, total, "force should attempt all games")
 	assert.Equal(t, 2, successes)
+}
+
+func TestScrapeAll_ConsoleFilter(t *testing.T) {
+	database := setupTestDB(t)
+	store := setupTestStorage(t)
+
+	c1 := db.Console{Abbreviation: "snes", Name: "SNES"}
+	c2 := db.Console{Abbreviation: "nes", Name: "NES"}
+	require.NoError(t, database.Create(&c1).Error)
+	require.NoError(t, database.Create(&c2).Error)
+
+	romDir := t.TempDir()
+
+	// One unscraped game per console
+	g1 := db.Game{ConsoleID: c1.ID, Console: c1, Title: "SNES Game", FileName: "snes.rom", FilePath: filepath.Join(romDir, "snes.rom")}
+	g2 := db.Game{ConsoleID: c2.ID, Console: c2, Title: "NES Game", FileName: "nes.rom", FilePath: filepath.Join(romDir, "nes.rom")}
+	require.NoError(t, database.Create(&g1).Error)
+	require.NoError(t, database.Create(&g2).Error)
+
+	s := &Scraper{
+		DB:         database,
+		Storage:    store,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		DATCache:   NewDATCache(t.TempDir(), &http.Client{Timeout: 5 * time.Second}),
+		cache:      &nameCache{entries: make(map[string][]nameEntry)},
+	}
+
+	// Scrape only SNES games
+	successes, total, err := s.ScrapeAll("", c1.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "should only attempt SNES games")
+	assert.Equal(t, 1, successes)
+}
+
+func TestScrapeAll_ConsoleFilter_AllMode(t *testing.T) {
+	database := setupTestDB(t)
+	store := setupTestStorage(t)
+
+	c1 := db.Console{Abbreviation: "snes", Name: "SNES"}
+	c2 := db.Console{Abbreviation: "nes", Name: "NES"}
+	require.NoError(t, database.Create(&c1).Error)
+	require.NoError(t, database.Create(&c2).Error)
+
+	romDir := t.TempDir()
+
+	// Both games already scraped
+	g1 := db.Game{ConsoleID: c1.ID, Console: c1, Title: "SNES Game", FileName: "snes.rom", FilePath: filepath.Join(romDir, "snes.rom"), ScraperID: "igdb:1"}
+	g2 := db.Game{ConsoleID: c2.ID, Console: c2, Title: "NES Game", FileName: "nes.rom", FilePath: filepath.Join(romDir, "nes.rom"), ScraperID: "igdb:2"}
+	require.NoError(t, database.Create(&g1).Error)
+	require.NoError(t, database.Create(&g2).Error)
+
+	s := &Scraper{
+		DB:         database,
+		Storage:    store,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		DATCache:   NewDATCache(t.TempDir(), &http.Client{Timeout: 5 * time.Second}),
+		cache:      &nameCache{entries: make(map[string][]nameEntry)},
+	}
+
+	// Scrape all mode but only SNES
+	successes, total, err := s.ScrapeAll("all", c1.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "should only attempt SNES games in all mode")
+	assert.Equal(t, 1, successes)
+}
+
+func TestScrapeAll_ConsoleFilter_FallbackMode(t *testing.T) {
+	database := setupTestDB(t)
+	store := setupTestStorage(t)
+
+	c1 := db.Console{Abbreviation: "snes", Name: "SNES"}
+	c2 := db.Console{Abbreviation: "nes", Name: "NES"}
+	require.NoError(t, database.Create(&c1).Error)
+	require.NoError(t, database.Create(&c2).Error)
+
+	romDir := t.TempDir()
+
+	// SNES game with libretro fallback, NES game with libretro fallback
+	g1 := db.Game{ConsoleID: c1.ID, Console: c1, Title: "SNES Game", FileName: "snes.rom", FilePath: filepath.Join(romDir, "snes.rom"), ScraperID: "libretro"}
+	g2 := db.Game{ConsoleID: c2.ID, Console: c2, Title: "NES Game", FileName: "nes.rom", FilePath: filepath.Join(romDir, "nes.rom"), ScraperID: "libretro"}
+	require.NoError(t, database.Create(&g1).Error)
+	require.NoError(t, database.Create(&g2).Error)
+
+	s := &Scraper{
+		DB:         database,
+		Storage:    store,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		DATCache:   NewDATCache(t.TempDir(), &http.Client{Timeout: 5 * time.Second}),
+		cache:      &nameCache{entries: make(map[string][]nameEntry)},
+	}
+
+	// Fallback mode but only NES
+	successes, total, err := s.ScrapeAll("fallback", c2.ID, nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, total, "should only attempt NES fallback games")
+	assert.Equal(t, 1, successes)
 }
 
 func TestScrapeGameWithIGDBMatch_Success(t *testing.T) {

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -104,10 +104,21 @@ export function useScrapeMetadata() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (mode: ScrapeMode = "new") =>
-      api.post<ScrapeStartResponse>(
-        mode !== "new" ? `/admin/scrape?mode=${mode}` : "/admin/scrape",
-      ),
+    mutationFn: ({
+      mode = "new",
+      console,
+    }: {
+      mode?: ScrapeMode;
+      console?: string;
+    }) => {
+      const params = new URLSearchParams();
+      if (mode !== "new") params.set("mode", mode);
+      if (console) params.set("console", console);
+      const qs = params.toString();
+      return api.post<ScrapeStartResponse>(
+        qs ? `/admin/scrape?${qs}` : "/admin/scrape",
+      );
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["games"] });
       queryClient.invalidateQueries({ queryKey: ["game"] });

--- a/web/src/pages/admin/__tests__/scan-page.test.tsx
+++ b/web/src/pages/admin/__tests__/scan-page.test.tsx
@@ -23,6 +23,10 @@ vi.mock("@/hooks/use-scan-progress", () => ({
   useScanProgress: vi.fn(),
 }));
 
+vi.mock("@/hooks/use-consoles", () => ({
+  useConsoles: vi.fn(),
+}));
+
 vi.mock("@/components/ui", async () => {
   const actual =
     await vi.importActual<Record<string, unknown>>("@/components/ui");
@@ -35,11 +39,13 @@ vi.mock("@/components/ui", async () => {
 import { useScanLibrary, useScrapeMetadata } from "@/hooks/use-admin";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
 import { useScanProgress } from "@/hooks/use-scan-progress";
+import { useConsoles } from "@/hooks/use-consoles";
 
 const mockUseScanLibrary = useScanLibrary as ReturnType<typeof vi.fn>;
 const mockUseScrapeMetadata = useScrapeMetadata as ReturnType<typeof vi.fn>;
 const mockUseScrapeProgress = useScrapeProgress as ReturnType<typeof vi.fn>;
 const mockUseScanProgress = useScanProgress as ReturnType<typeof vi.fn>;
+const mockUseConsoles = useConsoles as ReturnType<typeof vi.fn>;
 
 function renderPage() {
   const queryClient = new QueryClient({
@@ -83,6 +89,13 @@ beforeEach(() => {
     failures: 0,
     error: null,
     dismiss: mockScrapeDismiss,
+  });
+  mockUseConsoles.mockReturnValue({
+    data: [
+      { id: 1, name: "Super Nintendo", abbreviation: "snes" },
+      { id: 2, name: "Nintendo Entertainment System", abbreviation: "nes" },
+      { id: 3, name: "Game Boy Advance", abbreviation: "gba" },
+    ],
   });
 });
 
@@ -132,7 +145,7 @@ describe("AdminScanPage", () => {
       screen.getByRole("button", { name: /Scrape New Games/ }),
     );
     expect(mockScrapeMutate).toHaveBeenCalledWith(
-      "new",
+      { mode: "new", console: undefined },
       expect.any(Object),
     );
   });
@@ -143,7 +156,7 @@ describe("AdminScanPage", () => {
       screen.getByRole("button", { name: /Rescrape Fallback Only/ }),
     );
     expect(mockScrapeMutate).toHaveBeenCalledWith(
-      "fallback",
+      { mode: "fallback", console: undefined },
       expect.any(Object),
     );
   });
@@ -154,7 +167,7 @@ describe("AdminScanPage", () => {
       screen.getByRole("button", { name: /Rescrape All Games/ }),
     );
     expect(mockScrapeMutate).toHaveBeenCalledWith(
-      "all",
+      { mode: "all", console: undefined },
       expect.any(Object),
     );
   });
@@ -376,5 +389,46 @@ describe("AdminScanPage", () => {
     renderPage();
     expect(screen.getByText("No unscraped games found")).toBeInTheDocument();
     expect(screen.queryByText(/\d+ scraped/)).not.toBeInTheDocument();
+  });
+
+  it("renders console filter dropdown with sorted consoles", () => {
+    renderPage();
+    const select = screen.getByLabelText("Console filter");
+    expect(select).toBeInTheDocument();
+    const options = select.querySelectorAll("option");
+    // "All consoles" + 3 consoles
+    expect(options).toHaveLength(4);
+    // Sorted alphabetically: GBA, NES, SNES
+    expect(options[1].textContent).toBe("Game Boy Advance");
+    expect(options[2].textContent).toBe("Nintendo Entertainment System");
+    expect(options[3].textContent).toBe("Super Nintendo");
+  });
+
+  it("passes selected console to scrape mutation", async () => {
+    renderPage();
+    const select = screen.getByLabelText("Console filter");
+    await userEvent.selectOptions(select, "snes");
+    await userEvent.click(
+      screen.getByRole("button", { name: /Scrape New Games/ }),
+    );
+    expect(mockScrapeMutate).toHaveBeenCalledWith(
+      { mode: "new", console: "snes" },
+      expect.any(Object),
+    );
+  });
+
+  it("disables console filter when scrape is active", () => {
+    mockUseScrapeProgress.mockReturnValue({
+      phase: "active",
+      current: 1,
+      total: 5,
+      gameName: "Test Game",
+      successes: 0,
+      failures: 0,
+      error: null,
+      dismiss: mockScrapeDismiss,
+    });
+    renderPage();
+    expect(screen.getByLabelText("Console filter")).toBeDisabled();
   });
 });

--- a/web/src/pages/admin/scan-page.tsx
+++ b/web/src/pages/admin/scan-page.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import {
   ScanSearch,
   FolderSearch,
@@ -12,6 +13,7 @@ import { useScanLibrary, useScrapeMetadata } from "@/hooks/use-admin";
 import { useToast } from "@/components/ui";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
 import { useScanProgress } from "@/hooks/use-scan-progress";
+import { useConsoles } from "@/hooks/use-consoles";
 
 function ProgressBar({ value, max }: { value: number; max: number }) {
   const pct = max > 0 ? Math.round((value / max) * 100) : 0;
@@ -175,10 +177,14 @@ function ScrapeCard() {
   const scrapeMetadata = useScrapeMetadata();
   const scrape = useScrapeProgress();
   const { toast } = useToast();
+  const { data: consoles } = useConsoles();
+  const [selectedConsole, setSelectedConsole] = useState("");
 
   const isActive = scrape.phase === "active";
   const isComplete = scrape.phase === "complete";
   const isError = scrape.phase === "error";
+
+  const consoleParam = selectedConsole || undefined;
 
   return (
     <Card>
@@ -193,6 +199,32 @@ function ScrapeCard() {
           Fetch cover art, descriptions, and other metadata for games that are
           missing information.
         </p>
+
+        <div>
+          <label
+            htmlFor="console-filter"
+            className="block text-xs font-medium text-surface-400 mb-1"
+          >
+            Console filter
+          </label>
+          <select
+            id="console-filter"
+            value={selectedConsole}
+            onChange={(e) => setSelectedConsole(e.target.value)}
+            disabled={isActive}
+            className="w-full rounded-lg border border-surface-600 bg-surface-800 px-3 py-2 text-sm text-surface-200 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50"
+          >
+            <option value="">All consoles</option>
+            {consoles
+              ?.slice()
+              .sort((a, b) => a.name.localeCompare(b.name))
+              .map((c) => (
+                <option key={c.abbreviation} value={c.abbreviation}>
+                  {c.name}
+                </option>
+              ))}
+          </select>
+        </div>
 
         {isActive && (
           <div className="rounded-xl bg-surface-800/50 p-4 space-y-3">
@@ -277,22 +309,25 @@ function ScrapeCard() {
         <div className="flex flex-col gap-2">
           <Button
             onClick={() =>
-              scrapeMetadata.mutate("new", {
-                onSuccess: (data) => {
-                  const n = data.total;
-                  toast(
-                    n === 0 ? "info" : "success",
-                    n === 0
-                      ? "No unscraped games found"
-                      : `Scraping ${n} game${n === 1 ? "" : "s"}...`,
-                  );
+              scrapeMetadata.mutate(
+                { mode: "new", console: consoleParam },
+                {
+                  onSuccess: (data) => {
+                    const n = data.total;
+                    toast(
+                      n === 0 ? "info" : "success",
+                      n === 0
+                        ? "No unscraped games found"
+                        : `Scraping ${n} game${n === 1 ? "" : "s"}...`,
+                    );
+                  },
+                  onError: (err) =>
+                    toast(
+                      "error",
+                      err instanceof Error ? err.message : "Scrape failed",
+                    ),
                 },
-                onError: (err) =>
-                  toast(
-                    "error",
-                    err instanceof Error ? err.message : "Scrape failed",
-                  ),
-              })
+              )
             }
             loading={scrapeMetadata.isPending}
             disabled={isActive}
@@ -304,22 +339,25 @@ function ScrapeCard() {
           </Button>
           <Button
             onClick={() =>
-              scrapeMetadata.mutate("fallback", {
-                onSuccess: (data) => {
-                  const n = data.total;
-                  toast(
-                    n === 0 ? "info" : "success",
-                    n === 0
-                      ? "No fallback-only games found"
-                      : `Re-scraping ${n} game${n === 1 ? "" : "s"}...`,
-                  );
+              scrapeMetadata.mutate(
+                { mode: "fallback", console: consoleParam },
+                {
+                  onSuccess: (data) => {
+                    const n = data.total;
+                    toast(
+                      n === 0 ? "info" : "success",
+                      n === 0
+                        ? "No fallback-only games found"
+                        : `Re-scraping ${n} game${n === 1 ? "" : "s"}...`,
+                    );
+                  },
+                  onError: (err) =>
+                    toast(
+                      "error",
+                      err instanceof Error ? err.message : "Scrape failed",
+                    ),
                 },
-                onError: (err) =>
-                  toast(
-                    "error",
-                    err instanceof Error ? err.message : "Scrape failed",
-                  ),
-              })
+              )
             }
             loading={scrapeMetadata.isPending}
             disabled={isActive}
@@ -331,22 +369,25 @@ function ScrapeCard() {
           </Button>
           <Button
             onClick={() =>
-              scrapeMetadata.mutate("all", {
-                onSuccess: (data) => {
-                  const n = data.total;
-                  toast(
-                    n === 0 ? "info" : "success",
-                    n === 0
-                      ? "No games found to scrape"
-                      : `Re-scraping ${n} game${n === 1 ? "" : "s"}...`,
-                  );
+              scrapeMetadata.mutate(
+                { mode: "all", console: consoleParam },
+                {
+                  onSuccess: (data) => {
+                    const n = data.total;
+                    toast(
+                      n === 0 ? "info" : "success",
+                      n === 0
+                        ? "No games found to scrape"
+                        : `Re-scraping ${n} game${n === 1 ? "" : "s"}...`,
+                    );
+                  },
+                  onError: (err) =>
+                    toast(
+                      "error",
+                      err instanceof Error ? err.message : "Scrape failed",
+                    ),
                 },
-                onError: (err) =>
-                  toast(
-                    "error",
-                    err instanceof Error ? err.message : "Scrape failed",
-                  ),
-              })
+              )
             }
             loading={scrapeMetadata.isPending}
             disabled={isActive}

--- a/web/src/pages/admin/scan-page.tsx
+++ b/web/src/pages/admin/scan-page.tsx
@@ -8,7 +8,7 @@ import {
   RefreshCw,
   RotateCcw,
 } from "lucide-react";
-import { Button, Card, CardHeader, CardContent } from "@/components/ui";
+import { Button, Card, CardHeader, CardContent, Select } from "@/components/ui";
 import { useScanLibrary, useScrapeMetadata } from "@/hooks/use-admin";
 import { useToast } from "@/components/ui";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
@@ -200,31 +200,20 @@ function ScrapeCard() {
           missing information.
         </p>
 
-        <div>
-          <label
-            htmlFor="console-filter"
-            className="block text-xs font-medium text-surface-400 mb-1"
-          >
-            Console filter
-          </label>
-          <select
-            id="console-filter"
-            value={selectedConsole}
-            onChange={(e) => setSelectedConsole(e.target.value)}
-            disabled={isActive}
-            className="w-full rounded-lg border border-surface-600 bg-surface-800 px-3 py-2 text-sm text-surface-200 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:opacity-50"
-          >
-            <option value="">All consoles</option>
-            {consoles
+        <Select
+          id="console-filter"
+          label="Console filter"
+          value={selectedConsole}
+          onChange={(e) => setSelectedConsole(e.target.value)}
+          disabled={isActive}
+          options={[
+            { value: "", label: "All consoles" },
+            ...(consoles
               ?.slice()
               .sort((a, b) => a.name.localeCompare(b.name))
-              .map((c) => (
-                <option key={c.abbreviation} value={c.abbreviation}>
-                  {c.name}
-                </option>
-              ))}
-          </select>
-        </div>
+              .map((c) => ({ value: c.abbreviation, label: c.name })) ?? []),
+          ]}
+        />
 
         {isActive && (
           <div className="rounded-xl bg-surface-800/50 p-4 space-y-3">


### PR DESCRIPTION
## Summary
- Adds `?console=<abbreviation>` query parameter to the scrape endpoint to filter scraping to a single console
- Adds a console filter dropdown (using shared `Select` component) in the Scrape Metadata card on the admin scan page
- All three scrape modes (new, fallback, all) support the console filter
- Console lookup is case-insensitive

## Test plan
- [x] Backend: 3 new tests for console filtering across new, all, and fallback modes
- [x] Backend: existing scrape tests updated and passing (consoleID=0 for all consoles)
- [x] Frontend: 3 new tests for console dropdown rendering, selection, and disabled state
- [x] Frontend: existing mutation tests updated to new object parameter format
- [x] Invalid console abbreviation returns 400 without acquiring the scrape lock