### PR TITLE
feat: add console folder READMEs, MSX1/MSX2, and missing scanner mappings

### DIFF
--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -804,6 +804,8 @@ func SeedConsoles(db *gorm.DB) error {
 		{Name: "Commodore 64", Abbreviation: "C64", Extensions: ".d64,.t64,.prg,.crt", DefaultCore: "vice_x64", EmulatorJSCore: "vice_x64", FolderName: "c64", ColorTheme: "#6c5eb5", SaveStateSupport: true, Playable: true},
 		{Name: "DOS", Abbreviation: "DOS", Extensions: ".exe,.com,.bat,.conf", DefaultCore: "dosbox_pure", EmulatorJSCore: "dosbox_pure", FolderName: "dos", ColorTheme: "#000000", SaveStateSupport: true, Playable: true},
 		{Name: "Commodore Amiga", Abbreviation: "AMIGA", Extensions: ".adf,.hdf,.lha", DefaultCore: "puae", EmulatorJSCore: "", FolderName: "amiga", ColorTheme: "#6c5eb5", SaveStateSupport: true, Playable: true},
+		{Name: "MSX", Abbreviation: "MSX1", Extensions: ".rom,.mx1,.dsk,.cas", DefaultCore: "bluemsx", EmulatorJSCore: "", FolderName: "msx1", ColorTheme: "#4a86c8", SaveStateSupport: true, Playable: true},
+		{Name: "MSX2", Abbreviation: "MSX2", Extensions: ".rom,.mx2,.dsk,.cas", DefaultCore: "bluemsx", EmulatorJSCore: "", FolderName: "msx2", ColorTheme: "#4a86c8", SaveStateSupport: true, Playable: true},
 		// Non-playable consoles (external emulators only)
 		{Name: "PlayStation 3", Abbreviation: "PS3", Extensions: ".iso,.bin,.pkg", DefaultCore: "", EmulatorJSCore: "", FolderName: "ps3", ColorTheme: "#003087", CoverAspect: "8:11", SaveStateSupport: false, Playable: false},
 		{Name: "PlayStation 4", Abbreviation: "PS4", Extensions: ".pkg", DefaultCore: "", EmulatorJSCore: "", FolderName: "ps4", ColorTheme: "#003087", CoverAspect: "8:11", SaveStateSupport: false, Playable: false},

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -121,6 +121,21 @@ var ConsoleExtMap = map[string]string{
 	".xci":  "NSW",
 	".mx1":  "MSX1",
 	".mx2":  "MSX2",
+	".gg":   "GG",
+	".vb":   "VB",
+	".vboy": "VB",
+	".lnx":  "LYNX",
+	".ngp":  "NGP",
+	".ngc":  "NGP",
+	".ws":   "WS",
+	".wsc":  "WS",
+	".col":  "CV",
+	".min":  "PKMN",
+	".j64":  "JAG",
+	".jag":  "JAG",
+	".32x":  "32X",
+	".a52":  "A52",
+	".a78":  "A78",
 }
 
 // RomExtensions is the set of file extensions recognized as ROM/disc files.
@@ -262,13 +277,15 @@ var consoleNotes = map[string]string{
 func ConsoleReadmeContent(c db.Console) string {
 	var b strings.Builder
 	b.WriteString(c.Name)
+	headerLen := len(c.Name)
 	if c.Abbreviation != "" {
 		b.WriteString(" (")
 		b.WriteString(c.Abbreviation)
 		b.WriteString(")")
+		headerLen += len(c.Abbreviation) + 3 // " (" + ")"
 	}
 	b.WriteString("\n")
-	b.WriteString(strings.Repeat("=", len(c.Name)+len(c.Abbreviation)+3))
+	b.WriteString(strings.Repeat("=", headerLen))
 	b.WriteString("\n\n")
 
 	if c.Extensions != "" {

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -119,6 +119,8 @@ var ConsoleExtMap = map[string]string{
 	".wux":  "WIIU",
 	".nsp":  "NSW",
 	".xci":  "NSW",
+	".mx1":  "MSX1",
+	".mx2":  "MSX2",
 }
 
 // RomExtensions is the set of file extensions recognized as ROM/disc files.
@@ -144,6 +146,19 @@ var RomExtensions = map[string]bool{
 	".pkg": true, ".xex": true, ".god": true, ".wbfs": true,
 	".rpx": true, ".wud": true, ".wux": true,
 	".nsp": true, ".xci": true, ".xvd": true,
+	".mx1": true, ".mx2": true, ".cas": true,
+	".rom": true, ".dsk": true,
+	".vb": true, ".vboy": true,
+	".lnx": true,
+	".ngp": true, ".ngc": true,
+	".ws": true, ".wsc": true,
+	".col": true,
+	".d64": true, ".t64": true, ".prg": true, ".crt": true,
+	".exe": true, ".com": true, ".bat": true, ".conf": true,
+	".adf": true, ".hdf": true, ".lha": true,
+	".min": true,
+	".j64": true, ".jag": true,
+	".32x": true,
 }
 
 // directoryConsoleMap maps directory names to console abbreviations.
@@ -193,14 +208,96 @@ var directoryConsoleMap = map[string]string{
 	"wii":          "WII",
 	"wiiu":         "WIIU",
 	"switch":       "NSW",
+	"msx1":         "MSX1",
+	"msx":          "MSX1",
+	"msx2":         "MSX2",
+	"sega32x":      "32X",
+	"32x":          "32X",
+	"gamegear":     "GG",
+	"gg":           "GG",
+	"virtualboy":   "VB",
+	"vb":           "VB",
+	"atari5200":    "A52",
+	"a52":          "A52",
+	"atari7800":    "A78",
+	"a78":          "A78",
+	"atarilynx":    "LYNX",
+	"lynx":         "LYNX",
+	"atarijaguar":  "JAG",
+	"jag":          "JAG",
+	"ngp":          "NGP",
+	"wonderswan":   "WS",
+	"ws":           "WS",
+	"colecovision": "CV",
+	"pokemonmini":  "PKMN",
+	"c64":          "C64",
+	"dos":          "DOS",
+	"amiga":        "AMIGA",
 }
 
 // discPattern matches disc/disk/cd markers in filenames, e.g. "(Disc 1)", "[Disk 2]", "(CD 3)".
 var discPattern = regexp.MustCompile(`(?i)[\(\[]\s*(?:disc|disk|cd)\s*(\d+)\s*[\)\]]`)
 
+// consoleNotes contains helpful guidance for console folders where the
+// purpose or correct usage may be ambiguous. These are included in the
+// README.txt files generated inside each console folder.
+var consoleNotes = map[string]string{
+	"NEOGEO": "This is for Neo Geo AES/MVS arcade ROMs (not Neo Geo Pocket).\nNeo Geo Pocket ROMs go in the 'ngp' folder.",
+	"NGP":    "This is for both Neo Geo Pocket AND Neo Geo Pocket Color ROMs.\nFile extensions: .ngp (Neo Geo Pocket), .ngc (Neo Geo Pocket Color).",
+	"WS":     "This is for both WonderSwan AND WonderSwan Color ROMs.\nFile extensions: .ws (WonderSwan), .wsc (WonderSwan Color).",
+	"PCE":    "This is for TurboGrafx-16 / PC Engine ROMs.\nThis is NOT the same system as PC-FX (which has its own 'pcfx' folder).",
+	"PCFX":   "This is for NEC PC-FX disc images.\nThis is NOT the same system as TurboGrafx-16/PC Engine (which uses the 'tg16' folder).",
+	"A78":    "Prefer .a78 files over .bin when both are available.\nThe .a78 format includes a header that helps the emulator identify the game correctly.",
+	"A26":    "Prefer .a26 files over .bin when both are available.",
+	"A52":    "Prefer .a52 files over .bin when both are available.",
+	"GEN":    "Prefer .md or .gen files over .bin when both are available.\nThe .bin format is ambiguous and could be mistaken for other systems.",
+	"MSX1":   "This is for MSX (first generation) ROMs.\nMSX2 ROMs go in the 'msx2' folder.\nUse .mx1 for MSX1-specific ROMs, or .rom/.dsk for generic MSX media.",
+	"MSX2":   "This is for MSX2 (and MSX2+) ROMs.\nOriginal MSX ROMs go in the 'msx1' folder.\nUse .mx2 for MSX2-specific ROMs, or .rom/.dsk for generic MSX media.",
+	"GB":     "This is for original Game Boy ROMs only (.gb).\nGame Boy Color ROMs go in the 'gbc' folder.",
+	"GBC":    "This is for Game Boy Color ROMs (.gbc).\nOriginal Game Boy ROMs go in the 'gb' folder.",
+}
+
+// ConsoleReadmeContent generates the content for a README.txt file
+// placed inside a console folder to help users understand what ROMs belong there.
+func ConsoleReadmeContent(c db.Console) string {
+	var b strings.Builder
+	b.WriteString(c.Name)
+	if c.Abbreviation != "" {
+		b.WriteString(" (")
+		b.WriteString(c.Abbreviation)
+		b.WriteString(")")
+	}
+	b.WriteString("\n")
+	b.WriteString(strings.Repeat("=", len(c.Name)+len(c.Abbreviation)+3))
+	b.WriteString("\n\n")
+
+	if c.Extensions != "" {
+		b.WriteString("Supported file extensions: ")
+		b.WriteString(c.Extensions)
+		b.WriteString("\n\n")
+	}
+
+	if note, ok := consoleNotes[c.Abbreviation]; ok {
+		b.WriteString("Notes:\n")
+		for _, line := range strings.Split(note, "\n") {
+			b.WriteString("  ")
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	b.WriteString("Place your ROM files in this folder. They will be detected\n")
+	b.WriteString("automatically when you run a library scan.\n")
+
+	return b.String()
+}
+
 // CreateConsoleFolders creates ES-DE standard console subdirectories in each game directory.
 // It loads console definitions from the DB and creates a subfolder per console using FolderName.
-// The operation is idempotent — existing directories and files are not affected.
+// Each folder gets a README.txt explaining what ROMs belong there.
+// The operation is idempotent — existing directories are not affected, but README.txt
+// files are updated on every run to keep them current.
 func CreateConsoleFolders(database *gorm.DB, gameDirs []string) error {
 	var consoles []db.Console
 	if err := database.Find(&consoles).Error; err != nil {
@@ -216,6 +313,13 @@ func CreateConsoleFolders(database *gorm.DB, gameDirs []string) error {
 			if err := os.MkdirAll(path, 0755); err != nil {
 				return fmt.Errorf("creating folder %s: %w", path, err)
 			}
+
+			readmePath := filepath.Join(path, "README.txt")
+			content := ConsoleReadmeContent(c)
+			if err := os.WriteFile(readmePath, []byte(content), 0644); err != nil {
+				slog.Warn("failed to write README.txt", "path", readmePath, "error", err)
+			}
+
 			slog.Info("ensured console folder", "path", path)
 		}
 	}

--- a/server/internal/scanner/scanner_test.go
+++ b/server/internal/scanner/scanner_test.go
@@ -204,6 +204,7 @@ func TestCreateConsoleFolders_CreatesExpectedDirs(t *testing.T) {
 		"nes", "snes", "gb", "gbc", "gba", "n64", "nds",
 		"mastersystem", "genesis", "saturn", "psx", "psp",
 		"neogeo", "arcade", "tg16", "atari2600",
+		"msx1", "msx2",
 	}
 	for _, folder := range expectedFolders {
 		info, err := os.Stat(filepath.Join(dir, folder))
@@ -1338,4 +1339,192 @@ func TestScan_NonPlayableConsoles(t *testing.T) {
 	verifyConsole("NSW", 1)
 	verifyConsole("WII", 1)
 	verifyConsole("X360", 1)
+}
+
+func TestIdentifyConsole_MSXExtensions(t *testing.T) {
+	s := &Scanner{}
+	tests := []struct {
+		name string
+		path string
+		ext  string
+		want string
+	}{
+		{"MSX1 by .mx1 extension", "/games/some/game.mx1", ".mx1", "MSX1"},
+		{"MSX2 by .mx2 extension", "/games/some/game.mx2", ".mx2", "MSX2"},
+		{"MSX1 by directory", "/games/msx1/game.rom", ".rom", "MSX1"},
+		{"MSX1 by msx directory", "/games/msx/game.rom", ".rom", "MSX1"},
+		{"MSX2 by directory", "/games/msx2/game.rom", ".rom", "MSX2"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.identifyConsole(tt.path, tt.ext)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestIdentifyConsole_NewDirectoryMappings(t *testing.T) {
+	s := &Scanner{}
+	tests := []struct {
+		name string
+		path string
+		ext  string
+		want string
+	}{
+		{"32x by sega32x dir", "/games/sega32x/game.bin", ".bin", "32X"},
+		{"32x by 32x dir", "/games/32x/game.bin", ".bin", "32X"},
+		{"Game Gear by gamegear dir", "/games/gamegear/game.gg", ".gg", "GG"},
+		{"Game Gear by gg dir", "/games/gg/game.gg", ".gg", "GG"},
+		{"Virtual Boy by virtualboy dir", "/games/virtualboy/game.vb", ".vb", "VB"},
+		{"Virtual Boy by vb dir", "/games/vb/game.vb", ".vb", "VB"},
+		{"Lynx by atarilynx dir", "/games/atarilynx/game.lnx", ".lnx", "LYNX"},
+		{"Lynx by lynx dir", "/games/lynx/game.lnx", ".lnx", "LYNX"},
+		{"NGP by ngp dir", "/games/ngp/game.ngp", ".ngp", "NGP"},
+		{"WonderSwan by wonderswan dir", "/games/wonderswan/game.ws", ".ws", "WS"},
+		{"WonderSwan by ws dir", "/games/ws/game.ws", ".ws", "WS"},
+		{"ColecoVision by colecovision dir", "/games/colecovision/game.col", ".col", "CV"},
+		{"C64 by c64 dir", "/games/c64/game.d64", ".d64", "C64"},
+		{"DOS by dos dir", "/games/dos/game.exe", ".exe", "DOS"},
+		{"Amiga by amiga dir", "/games/amiga/game.adf", ".adf", "AMIGA"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := s.identifyConsole(tt.path, tt.ext)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestCreateConsoleFolders_WritesREADME(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	err := CreateConsoleFolders(database, []string{dir})
+	require.NoError(t, err)
+
+	// Check that README.txt exists in the NES folder
+	readmePath := filepath.Join(dir, "nes", "README.txt")
+	data, err := os.ReadFile(readmePath)
+	require.NoError(t, err, "README.txt should exist in nes folder")
+	content := string(data)
+
+	assert.Contains(t, content, "Nintendo Entertainment System")
+	assert.Contains(t, content, ".nes")
+	assert.Contains(t, content, "Place your ROM files in this folder")
+}
+
+func TestCreateConsoleFolders_READMEIncludesNotes(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	err := CreateConsoleFolders(database, []string{dir})
+	require.NoError(t, err)
+
+	// Neo Geo should have a note about Neo Geo Pocket
+	data, err := os.ReadFile(filepath.Join(dir, "neogeo", "README.txt"))
+	require.NoError(t, err)
+	content := string(data)
+	assert.Contains(t, content, "Neo Geo Pocket")
+	assert.Contains(t, content, "ngp")
+
+	// WonderSwan should mention WonderSwan Color
+	data, err = os.ReadFile(filepath.Join(dir, "wonderswan", "README.txt"))
+	require.NoError(t, err)
+	content = string(data)
+	assert.Contains(t, content, "WonderSwan Color")
+
+	// TG16 should clarify it's not PC-FX
+	data, err = os.ReadFile(filepath.Join(dir, "tg16", "README.txt"))
+	require.NoError(t, err)
+	content = string(data)
+	assert.Contains(t, content, "NOT the same system as PC-FX")
+}
+
+func TestCreateConsoleFolders_PreservesExistingROMs(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	// Pre-create a folder with a ROM and a custom README
+	nesDir := filepath.Join(dir, "nes")
+	require.NoError(t, os.MkdirAll(nesDir, 0755))
+	romPath := filepath.Join(nesDir, "Mario.nes")
+	require.NoError(t, os.WriteFile(romPath, []byte("fake rom"), 0644))
+
+	err := CreateConsoleFolders(database, []string{dir})
+	require.NoError(t, err)
+
+	// ROM should be untouched
+	data, err := os.ReadFile(romPath)
+	require.NoError(t, err)
+	assert.Equal(t, "fake rom", string(data))
+
+	// README.txt should have been written
+	readmeData, err := os.ReadFile(filepath.Join(nesDir, "README.txt"))
+	require.NoError(t, err)
+	assert.Contains(t, string(readmeData), "Nintendo Entertainment System")
+}
+
+func TestConsoleReadmeContent(t *testing.T) {
+	tests := []struct {
+		name    string
+		console db.Console
+		want    []string
+	}{
+		{
+			name:    "basic console",
+			console: db.Console{Name: "Nintendo Entertainment System", Abbreviation: "NES", Extensions: ".nes,.fds"},
+			want:    []string{"Nintendo Entertainment System (NES)", ".nes,.fds", "Place your ROM files"},
+		},
+		{
+			name:    "console with notes",
+			console: db.Console{Name: "Neo Geo", Abbreviation: "NEOGEO", Extensions: ".zip"},
+			want:    []string{"Neo Geo (NEOGEO)", "Neo Geo Pocket", "ngp"},
+		},
+		{
+			name:    "MSX1 with notes",
+			console: db.Console{Name: "MSX", Abbreviation: "MSX1", Extensions: ".rom,.mx1,.dsk,.cas"},
+			want:    []string{"MSX (MSX1)", "msx2", ".mx1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			content := ConsoleReadmeContent(tt.console)
+			for _, w := range tt.want {
+				assert.Contains(t, content, w)
+			}
+		})
+	}
+}
+
+func TestScan_DetectsMSXGames(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	msx1Dir := filepath.Join(dir, "msx1")
+	require.NoError(t, os.MkdirAll(msx1Dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(msx1Dir, "Penguin Adventure.mx1"), []byte("rom"), 0644))
+
+	msx2Dir := filepath.Join(dir, "msx2")
+	require.NoError(t, os.MkdirAll(msx2Dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(msx2Dir, "Space Manbow.mx2"), []byte("rom"), 0644))
+
+	s := NewScanner(database, []string{dir})
+	result, err := s.Scan(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.NewGames)
+
+	var msx1Console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "MSX1").First(&msx1Console).Error)
+	var msx1Count int64
+	database.Model(&db.Game{}).Where("console_id = ?", msx1Console.ID).Count(&msx1Count)
+	assert.Equal(t, int64(1), msx1Count)
+
+	var msx2Console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "MSX2").First(&msx2Console).Error)
+	var msx2Count int64
+	database.Model(&db.Game{}).Where("console_id = ?", msx2Console.ID).Count(&msx2Count)
+	assert.Equal(t, int64(1), msx2Count)
 }


### PR DESCRIPTION
## Summary
- Generate README.txt in each console folder explaining what ROMs belong there, with notes for ambiguous consoles (Neo Geo vs NGP, TG16 vs PC-FX, WonderSwan Color, GB vs GBC, MSX1 vs MSX2, etc.)
- Add MSX and MSX2 as new playable consoles using the blueMSX core
- Add 20+ missing directory-to-console mappings and 15+ unambiguous extension-to-console mappings so games in folders like `gamegear/`, `virtualboy/`, `ngp/`, `wonderswan/`, `c64/`, etc. are properly detected

## Test plan
- [x] All 80+ scanner tests pass including 7 new tests
- [x] Full `go test ./...` passes with no regressions
- [ ] Verify README.txt files appear in console folders after server startup
- [ ] Verify MSX ROMs in msx1/msx2 folders are detected by scan