### PR TITLE
feat: fix Select disabled styling and add per-console scan

### DIFF
--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -423,7 +423,20 @@ type scanResultResponse struct {
 
 // ScanGames triggers a library scan in the background.
 // Returns 202 immediately; progress is reported via WebSocket events.
+// Pass ?console=<abbreviation> to scan only games for a specific console.
 func (h *GameHandler) ScanGames(c *gin.Context) {
+	consoleAbbrev := c.Query("console")
+
+	// Validate console abbreviation if provided
+	if consoleAbbrev != "" {
+		var con db.Console
+		if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", consoleAbbrev).First(&con).Error; err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unknown console"})
+			return
+		}
+		consoleAbbrev = con.Abbreviation // normalize casing
+	}
+
 	if !h.Scanner.TryStartScan() {
 		c.JSON(http.StatusConflict, gin.H{"error": "a scan is already in progress"})
 		return
@@ -435,10 +448,14 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 	go func() {
 		defer h.Scanner.FinishScan()
 
+		var scanArgs []string
+		if consoleAbbrev != "" {
+			scanArgs = append(scanArgs, consoleAbbrev)
+		}
 		result, err := h.Scanner.Scan(func(p scanner.ScanProgress) {
 			h.Scanner.SetScanProgress(&p)
 			h.Hub.Broadcast(ws.Event{Type: "scan_progress", Payload: p})
-		})
+		}, scanArgs...)
 		if err != nil {
 			slog.Error("game library scan failed", "error", err)
 			h.Hub.Broadcast(ws.Event{Type: "scan_error", Payload: gin.H{"error": "library scan failed"}})

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -504,8 +504,14 @@ type ProgressFunc func(ScanProgress)
 // Scan walks all configured directories and detects ROMs.
 // Uses a two-pass algorithm: first discovers multi-disc games, then scans remaining files.
 // The optional onProgress callback is called at key points to report progress.
-func (s *Scanner) Scan(onProgress ProgressFunc) (*ScanResult, error) {
+// If consoleFilter is non-empty, only games matching that console abbreviation are processed
+// and the removal pass is scoped to that console.
+func (s *Scanner) Scan(onProgress ProgressFunc, consoleFilter ...string) (*ScanResult, error) {
 	result := &ScanResult{}
+	filterAbbrev := ""
+	if len(consoleFilter) > 0 {
+		filterAbbrev = consoleFilter[0]
+	}
 
 	report := func(p ScanProgress) {
 		if onProgress != nil {
@@ -523,6 +529,15 @@ func (s *Scanner) Scan(onProgress ProgressFunc) (*ScanResult, error) {
 	consoleMap := make(map[string]*db.Console)
 	for i := range consoles {
 		consoleMap[consoles[i].Abbreviation] = &consoles[i]
+	}
+
+	// When filtering by console, restrict the map so only that console is processed
+	if filterAbbrev != "" {
+		if con, ok := consoleMap[filterAbbrev]; ok {
+			consoleMap = map[string]*db.Console{filterAbbrev: con}
+		} else {
+			return nil, fmt.Errorf("unknown console: %s", filterAbbrev)
+		}
 	}
 
 	// Track found file paths to detect removed games
@@ -573,7 +588,13 @@ func (s *Scanner) Scan(onProgress ProgressFunc) (*ScanResult, error) {
 	// soft-deleted and the file is still gone, hard-delete it to free the
 	// unique index slot. If the file came back, it was already restored above.
 	var allGames []db.Game
-	if err := s.DB.Unscoped().Find(&allGames).Error; err != nil {
+	gamesQuery := s.DB.Unscoped()
+	if filterAbbrev != "" {
+		if con, ok := consoleMap[filterAbbrev]; ok {
+			gamesQuery = gamesQuery.Where("console_id = ?", con.ID)
+		}
+	}
+	if err := gamesQuery.Find(&allGames).Error; err != nil {
 		return nil, fmt.Errorf("loading existing games: %w", err)
 	}
 	for i, g := range allGames {

--- a/web/src/components/ui/__tests__/select.test.tsx
+++ b/web/src/components/ui/__tests__/select.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Select } from "../select";
+
+const options = [
+  { value: "a", label: "Alpha" },
+  { value: "b", label: "Beta" },
+];
+
+describe("Select", () => {
+  it("renders options", () => {
+    render(<Select options={options} />);
+    expect(screen.getByRole("combobox")).toBeInTheDocument();
+    expect(screen.getAllByRole("option")).toHaveLength(2);
+  });
+
+  it("renders label when provided", () => {
+    render(<Select id="test" label="Pick one" options={options} />);
+    expect(screen.getByText("Pick one")).toBeInTheDocument();
+  });
+
+  it("applies disabled styling when disabled", () => {
+    render(<Select options={options} disabled />);
+    const select = screen.getByRole("combobox");
+    expect(select).toBeDisabled();
+    expect(select.className).toContain("disabled:opacity-50");
+    expect(select.className).toContain("disabled:cursor-not-allowed");
+  });
+});

--- a/web/src/components/ui/dropdown-menu.test.tsx
+++ b/web/src/components/ui/dropdown-menu.test.tsx
@@ -77,6 +77,19 @@ describe("DropdownMenu", () => {
     expect(menu.className).toContain("right-0");
   });
 
+  it("stays open when clicking a disabled item", async () => {
+    render(
+      <DropdownMenu trigger={<button>Open</button>}>
+        <button disabled>Disabled</button>
+      </DropdownMenu>,
+    );
+    await userEvent.click(screen.getByRole("button", { name: "Open" }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: "Disabled" }));
+    expect(screen.getByRole("menu")).toBeInTheDocument();
+  });
+
   it("has role menu on the dropdown panel", async () => {
     render(
       <DropdownMenu trigger={<button>Open</button>}>

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -39,7 +39,11 @@ export function DropdownMenu({
             align === "right" ? "right-0" : "left-0",
             className,
           )}
-          onClick={() => setOpen(false)}
+          onClick={(e) => {
+            const target = e.target as HTMLElement;
+            const button = target.closest("button");
+            if (button && !button.disabled) setOpen(false);
+          }}
         >
           {children}
         </div>

--- a/web/src/components/ui/select.tsx
+++ b/web/src/components/ui/select.tsx
@@ -26,6 +26,7 @@ export const Select = forwardRef<HTMLSelectElement, SelectProps>(
             "transition-all duration-200",
             "focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500",
             "hover:border-surface-600",
+            "disabled:opacity-50 disabled:cursor-not-allowed disabled:hover:border-surface-700",
             className,
           )}
           {...props}

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -84,7 +84,12 @@ export function useScanLibrary() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: () => api.post<Record<string, unknown>>("/admin/games/scan"),
+    mutationFn: (opts?: { console?: string }) => {
+      const path = opts?.console
+        ? (`/admin/games/scan?console=${encodeURIComponent(opts.console)}` as const)
+        : "/admin/games/scan";
+      return api.post<Record<string, unknown>>(path);
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["games"] });
       queryClient.invalidateQueries({ queryKey: ["consoles"] });

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Library, Check, Globe } from "lucide-react";
+import { Library, Check, Globe, FolderSearch } from "lucide-react";
 import { GameCard } from "@/components/game-card";
 import { GameGrid } from "@/components/game-grid";
 import {
@@ -9,12 +9,15 @@ import {
   EmptyState,
   SearchInput,
 } from "@/components/ui";
+import { ActionsMenu } from "@/components/ui/actions-menu";
 import { useConsoles } from "@/hooks/use-consoles";
 import { useGames, useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
 import { useBiosStatus } from "@/hooks/use-bios";
 import { useAuth } from "@/hooks/use-auth";
+import { useScanLibrary } from "@/hooks/use-admin";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useToast } from "@/components/ui";
 import { BiosWarningBanner } from "@/features/bios/components/bios-warning-banner";
 import {
   ConsoleEssentials,
@@ -40,6 +43,8 @@ export function ConsoleDetailPage() {
   const [page, setPage] = useState(1);
   const { data: biosData } = useBiosStatus();
   const { isAdmin } = useAuth();
+  const scanLibrary = useScanLibrary();
+  const { toast } = useToast();
 
   const { data, isLoading } = useGames({
     consoleId: id,
@@ -94,6 +99,34 @@ export function ConsoleDetailPage() {
             <Icon className="h-56 w-56 text-white" />
           )}
         </div>
+
+        {/* Admin actions menu */}
+        {isAdmin && (
+          <div className="absolute right-3 top-3 z-10">
+            <ActionsMenu
+              items={[
+                {
+                  label: "Scan for new games",
+                  icon: <FolderSearch className="h-4 w-4" />,
+                  loading: scanLibrary.isPending,
+                  onClick: () =>
+                    scanLibrary.mutate(
+                      { console: consoleAbbr },
+                      {
+                        onSuccess: () =>
+                          toast("info", `Scan started for ${consoleName}.`),
+                        onError: (err) =>
+                          toast(
+                            "error",
+                            err instanceof Error ? err.message : "Scan failed",
+                          ),
+                      },
+                    ),
+                },
+              ]}
+            />
+          </div>
+        )}
 
         {/* Subtle noise/texture overlay */}
         <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-white/[0.04] pointer-events-none" />


### PR DESCRIPTION
## Summary
- **Select disabled styling**: Added `disabled:opacity-50`, `cursor-not-allowed`, and hover reset so disabled selects are visually distinct (previously relied on browser default which was barely visible)
- **Per-console scan**: New `?console=<abbreviation>` param on the scan endpoint lets admins scan a single console's folder. The scanner restricts its console map to filter both multi-disc and single-file passes, and scopes the removal check to that console only
- **Console detail page admin menu**: Added an ellipsis actions menu (admin-only) in the hero banner with "Scan for new games" — triggers a per-console scan with toast feedback. Game list auto-refreshes on completion via existing WebSocket invalidation
- **Dropdown menu fix**: Menu no longer closes when clicking a disabled/loading item

## Test plan
- [x] New Select component tests (3 tests) — renders, label, disabled styling
- [x] New dropdown menu test — stays open on disabled item click
- [x] All 1289 web tests pass
- [x] TypeScript compiles cleanly
- [x] Go builds cleanly
- [ ] Go tests pass (CI)
- [ ] Player tests pass (CI)