### PR TITLE
feat: large library support — variant grouping, filtering, and smart scraping

### DIFF
--- a/design-proposals/large-library-support.md
+++ b/design-proposals/large-library-support.md
@@ -1,0 +1,195 @@
+# Large Library Support
+
+## Problem Statement
+
+When a user adds a complete no-intro ROM collection (all verified), the UI becomes
+unusable — filled with duplicates, betas, prototypes, regional variants, and thousands
+of entries per console. The system was designed for small curated libraries and needs
+to scale gracefully to complete collections.
+
+## Core Problem
+
+The scanner's `GameTitle()` strips all parenthesized tags, so `Super Mario World (USA)`,
+`(Europe)`, `(Japan)`, `(Rev 1)` all become identical "Super Mario World" cards. A no-intro
+SNES set produces 3000+ entries with massive duplication.
+
+## Existing Building Blocks (unused during scan)
+
+- `ExtractRegion()` in `scraper/region.go` — parses region tags from filenames
+- `computePriority()` in `scraper/namematch.go` — ranks variants (clean > revision > beta/proto)
+- `hasPreferredRegion()` in `scraper/namematch.go` — prefers USA/World
+- DAT file parsing in `scraper/datcache.go` — CRC verification and canonical names
+- `Region` field on the `Game` model — exists but only populated by scraper, not scanner
+
+## What Breaks at Scale
+
+| Issue | Severity | Where |
+|---|---|---|
+| All variants show identical title + cover art | Critical | Both platforms |
+| No region/status filters exist | Critical | Both platforms |
+| No way to hide betas, protos, samples | Critical | Both platforms |
+| Pagination renders all 63+ page buttons | High | Web: `pagination.tsx` |
+| Player app loads ALL games into memory per console | High | Player: `ConsoleScreen.kt` |
+| Auto-scrape fires 48 simultaneous requests per page | High | Both platforms |
+| No alphabet quick-jump for sorted lists | Medium | Both platforms |
+| No compact/table view for dense browsing | Medium | Web |
+
+---
+
+## Implementation Phases
+
+### Phase 1 — Foundation (Backend)
+
+Parse no-intro tags at scan time and enable variant grouping in the API.
+
+**Changes:**
+
+1. **Parse filename metadata during scan** — Extract region, revision, and tags
+   (beta/proto/sample/demo/unlicensed) from filenames when creating Game records.
+   Use the existing `ExtractRegion()` function. Add new fields to the Game model:
+   - `Region` — populated at scan time (not just scrape time)
+   - `Tags` — comma-separated: beta, proto, sample, demo, unlicensed, hack, etc.
+   - `Revision` — parsed from `(Rev X)`, `(v1.1)`, etc.
+   - `IsPreRelease` — true for beta/proto/sample/demo
+   - `GroupKey` — normalized title for variant grouping (console-scoped)
+
+2. **Variant grouping** — Add `IsPrimary bool` and `PrimaryGameID *uint` to Game.
+   Post-scan step groups games by `(console_id, group_key)` and elects a primary
+   variant per group using: user region preference > latest revision > has metadata >
+   verified > shortest filename.
+
+3. **API changes** — `GET /api/games` and `GET /api/consoles/:id/games` return only
+   primary variants by default. New query parameters:
+   - `grouped=false` — show all variants
+   - `region=USA,Europe` — filter by region
+   - `hidePreRelease=true` (default) — hide betas/protos/samples
+   - Response includes `variantCount` on each game when grouped
+
+4. **Database indexes** — Add indexes on `(console_id, group_key)`,
+   `(console_id, is_primary)`, `region`, `is_pre_release`.
+
+5. **Backfill migration** — Existing games get their fields populated on startup.
+
+### Phase 2 — Web UI Filters and Fixes
+
+Surface the new backend capabilities in the web frontend.
+
+**Changes:**
+
+1. **Region filter** — Chip picker in the advanced filter panel, populated from
+   distinct regions in the library.
+
+2. **"Hide betas & protos" toggle** — Prominent toggle in the filter bar (not
+   buried in advanced panel). Default ON.
+
+3. **Variant badge on game cards** — When a game has variants, show "N versions"
+   badge. Clicking goes to game detail where variants are listed.
+
+4. **Fix pagination** — Ellipsis-style truncation (1 2 3 ... 61 62 63) instead
+   of rendering all page buttons.
+
+5. **Active filter pills** — Show active filters as dismissible chips above the
+   game grid, visible without opening the advanced panel.
+
+6. **"Best versions only" preset** — One-click button that applies region +
+   release-only + verified filters. Prominently placed.
+
+### Phase 3 — Player App Updates
+
+Bring the player app up to parity with the web for large libraries.
+
+**Changes:**
+
+1. **Server-side pagination** — `GameListViewModel` fetches pages incrementally
+   instead of loading all games at once. Infinite scroll with page loading.
+
+2. **Region filter chips** — Horizontal chip strip for region filtering.
+
+3. **"Hide betas" toggle** — In library controls, default ON.
+
+4. **Variant count on game cards** — Show "N versions" indicator.
+
+5. **Game detail variants section** — List all variants with region, revision,
+   verification status, and file size. User can play any variant.
+
+### Phase 4 — User Preferences and Smart Defaults
+
+Personalization and polish.
+
+**Changes:**
+
+1. **User region preference** — Ordered list of preferred regions (e.g., [USA,
+   Europe, World]). Stored on server, synced across devices. Used by variant
+   grouping to pick the representative.
+
+2. **Admin default settings** — Server-wide defaults for hide pre-release,
+   default region, etc.
+
+3. **Alphabet quick-jump** — A-Z sidebar on game grids (web and player).
+   Clicking jumps to first game starting with that letter. Dim unavailable letters.
+
+4. **Smart scraping** — Scrape one game per variant group, propagate metadata
+   to all variants. Skip pre-release games by default. Prioritize games users
+   have interacted with.
+
+5. **Compact grid / table view** — Denser view modes for power users on web.
+
+### Phase 5 — Polish and Power Features
+
+Nice-to-have improvements.
+
+**Changes:**
+
+1. **Per-user game hiding** — "Hide from library" action on game cards and detail
+   page. Hidden games excluded by default, accessible via "Show hidden" toggle.
+
+2. **Admin bulk hide by pattern** — Pattern-based hide rules (all betas, all
+   Japanese-only, etc.).
+
+3. **Metadata coverage dashboard** — Admin page showing scrape coverage, missing
+   covers, failure rates by console.
+
+4. **"Group by" support** — Group game grid by genre, year, or first letter.
+
+5. **DAT file import** — Upload no-intro DAT files for batch CRC verification
+   and canonical name population.
+
+---
+
+## Key Architecture Decisions
+
+### Variant Grouping: IsPrimary flag on Game model
+
+Add `IsPrimary bool` and `PrimaryGameID *uint` to the existing Game table rather
+than creating a separate GameGroup table. This is the minimal schema change:
+- Existing queries add `WHERE is_primary = true` for default behavior
+- `?grouped=false` removes that filter for power users
+- Self-referential relationship within the same table
+- GORM auto-migration handles the new columns
+
+### GroupKey Computation
+
+`GroupKey = normalize(title) + console_id` where normalize:
+- Strips all parenthesized and bracketed tags (same as current `GameTitle()`)
+- Lowercases
+- Strips articles ("The", "A", "An")
+- Strips accented characters
+- Must match the scraper's `normalizeName()` for consistency
+
+### Primary Variant Election
+
+Priority order for selecting the "best" variant in a group:
+1. User's preferred region (if set)
+2. Server default region (if set), fallback to USA > World > Europe
+3. Latest revision (Rev B > Rev A > no Rev)
+4. Has IGDB metadata / cover art
+5. CRC verified
+6. Not pre-release
+7. Shortest filename (simplest name = cleanest dump)
+
+### Backward Compatibility
+
+- All changes are additive — no data is lost
+- Existing API behavior preserved with `grouped=false`
+- GroupKey and IsPrimary are computed on startup for existing games
+- No breaking changes to the Game response schema (new fields only)

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -319,14 +319,51 @@ class FakeGameRepository : GameRepository {
         else Result.success(games.filter { it.consoleId == consoleId })
     }
 
+    override suspend fun getGamesForConsolePaginated(
+        consoleId: String,
+        page: Int,
+        pageSize: Int,
+        hidePreRelease: Boolean,
+        grouped: Boolean,
+    ): Result<PaginatedResult<Game>> {
+        val filtered = games.filter { it.consoleId == consoleId }
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(PaginatedResult(filtered, filtered.size.toLong(), page, pageSize))
+    }
+
     override suspend fun getAllGames(): Result<List<Game>> {
         return if (shouldFail) Result.failure(Exception("Network error"))
         else Result.success(games)
     }
 
+    override suspend fun getAllGamesPaginated(
+        page: Int,
+        pageSize: Int,
+        hidePreRelease: Boolean,
+        grouped: Boolean,
+    ): Result<PaginatedResult<Game>> {
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(PaginatedResult(games, games.size.toLong(), page, pageSize))
+    }
+
     override suspend fun searchGames(query: String, consoleId: String?, sortBy: String?, sortOrder: String?): Result<List<Game>> {
         return if (shouldFail) Result.failure(Exception("Network error"))
         else Result.success(games.filter { it.title.contains(query, ignoreCase = true) })
+    }
+
+    override suspend fun searchGamesPaginated(
+        query: String,
+        consoleId: String?,
+        sortBy: String?,
+        sortOrder: String?,
+        page: Int,
+        pageSize: Int,
+        hidePreRelease: Boolean,
+        grouped: Boolean,
+    ): Result<PaginatedResult<Game>> {
+        val filtered = games.filter { it.title.contains(query, ignoreCase = true) }
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(PaginatedResult(filtered, filtered.size.toLong(), page, pageSize))
     }
 
     override suspend fun getGameDetail(gameId: String): Result<GameDetail> {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -203,6 +203,8 @@ class SpelaApiClient(
         hidePreRelease: Boolean = true,
         grouped: Boolean = true,
         region: String? = null,
+        page: Int? = null,
+        pageSize: Int? = null,
     ): GameListResponse {
         return client.get("$baseUrl/api/games") {
             parameter("search", query)
@@ -212,6 +214,8 @@ class SpelaApiClient(
             parameter("hidePreRelease", hidePreRelease)
             parameter("grouped", grouped)
             region?.let { parameter("region", it) }
+            page?.let { parameter("page", it) }
+            pageSize?.let { parameter("pageSize", it) }
         }.body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -157,11 +157,17 @@ class SpelaApiClient(
         consoleId: String,
         page: Int? = null,
         pageSize: Int? = null,
+        hidePreRelease: Boolean = true,
+        grouped: Boolean = true,
+        region: String? = null,
     ): GameListResponse {
         return client.get("$baseUrl/api/games") {
             parameter("consoleId", consoleId)
             page?.let { parameter("page", it) }
             pageSize?.let { parameter("pageSize", it) }
+            parameter("hidePreRelease", hidePreRelease)
+            parameter("grouped", grouped)
+            region?.let { parameter("region", it) }
         }.body()
     }
 
@@ -172,6 +178,9 @@ class SpelaApiClient(
         sortOrder: String? = null,
         page: Int? = null,
         pageSize: Int? = null,
+        hidePreRelease: Boolean = true,
+        grouped: Boolean = true,
+        region: String? = null,
     ): GameListResponse {
         return client.get("$baseUrl/api/games") {
             consoleId?.let { parameter("consoleId", it) }
@@ -179,6 +188,9 @@ class SpelaApiClient(
             sortOrder?.let { parameter("sortOrder", it) }
             page?.let { parameter("page", it) }
             pageSize?.let { parameter("pageSize", it) }
+            parameter("hidePreRelease", hidePreRelease)
+            parameter("grouped", grouped)
+            region?.let { parameter("region", it) }
         }.body()
     }
 
@@ -188,12 +200,18 @@ class SpelaApiClient(
         consoleId: String? = null,
         sortBy: String? = null,
         sortOrder: String? = null,
+        hidePreRelease: Boolean = true,
+        grouped: Boolean = true,
+        region: String? = null,
     ): GameListResponse {
         return client.get("$baseUrl/api/games") {
             parameter("search", query)
             consoleId?.let { parameter("consoleId", it) }
             sortBy?.let { parameter("sortBy", it) }
             sortOrder?.let { parameter("sortOrder", it) }
+            parameter("hidePreRelease", hidePreRelease)
+            parameter("grouped", grouped)
+            region?.let { parameter("region", it) }
         }.body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -74,15 +74,33 @@ fun GameDto.toDomain(): Game = Game(
     playable = playable,
     heroUrl = heroUrl,
     logoUrl = logoUrl,
+    revision = revision,
+    tags = tags,
+    isPreRelease = isPreRelease,
+    variantCount = variantCount,
+    groupKey = groupKey,
 )
 
 /**
  * Constructs GameDetail from the enriched GameResponse.
  * screenshotUrls comes directly from the response.
  */
+fun GameVariantDto.toDomain(): GameVariant = GameVariant(
+    id = id,
+    title = title,
+    fileName = fileName,
+    region = region,
+    revision = revision,
+    tags = tags,
+    isPreRelease = isPreRelease,
+    fileSize = fileSize,
+    verificationStatus = verificationStatus,
+)
+
 fun GameDto.toGameDetail(): GameDetail = GameDetail(
     game = toDomain(),
     screenshots = screenshotUrls,
+    variants = variants.map { it.toDomain() },
 )
 
 fun SaveStateDto.toDomain(): SaveState = SaveState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -105,8 +105,27 @@ data class GameDto(
     val playable: Boolean = true,
     val heroUrl: String? = null,
     val logoUrl: String? = null,
+    val revision: String? = null,
+    val tags: String? = null,
+    val isPreRelease: Boolean = false,
+    val variantCount: Int = 0,
+    val groupKey: String? = null,
+    val variants: List<GameVariantDto> = emptyList(),
     val createdAt: String? = null,
     val updatedAt: String? = null,
+)
+
+@Serializable
+data class GameVariantDto(
+    val id: String,
+    val title: String,
+    val fileName: String = "",
+    val region: String? = null,
+    val revision: String? = null,
+    val tags: String? = null,
+    val isPreRelease: Boolean = false,
+    val fileSize: Long = 0,
+    val verificationStatus: String? = null,
 )
 
 /** Wrapper for GET /api/games which returns {data, total, page, pageSize} */

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
@@ -9,6 +9,7 @@ import com.spela.player.domain.model.Console
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameDetail
 import com.spela.player.domain.model.DeveloperGame
+import com.spela.player.domain.model.PaginatedResult
 import com.spela.player.domain.model.SimilarGame
 import com.spela.player.domain.model.TopListGame
 import com.spela.player.domain.model.TopRatedGame
@@ -44,6 +45,32 @@ class GameRepositoryImpl(
         }
     }
 
+    override suspend fun getGamesForConsolePaginated(
+        consoleId: String,
+        page: Int,
+        pageSize: Int,
+        hidePreRelease: Boolean,
+        grouped: Boolean,
+    ): Result<PaginatedResult<Game>> {
+        return runCatching {
+            val response = apiClient.getGamesForConsole(
+                consoleId = consoleId,
+                page = page,
+                pageSize = pageSize,
+                hidePreRelease = hidePreRelease,
+                grouped = grouped,
+            )
+            val games = response.data.map { it.toDomain().resolveImageUrls() }
+            if (page == 1) cacheGames(games)
+            PaginatedResult(
+                data = games,
+                total = response.total,
+                page = response.page,
+                pageSize = response.pageSize,
+            )
+        }
+    }
+
     override suspend fun getAllGames(): Result<List<Game>> {
         return runCatching {
             val games = apiClient.getAllGames().data.map { it.toDomain().resolveImageUrls() }
@@ -52,6 +79,30 @@ class GameRepositoryImpl(
         }.recoverCatching {
             val cached = getAllCachedGames()
             if (cached.isNotEmpty()) cached else throw it
+        }
+    }
+
+    override suspend fun getAllGamesPaginated(
+        page: Int,
+        pageSize: Int,
+        hidePreRelease: Boolean,
+        grouped: Boolean,
+    ): Result<PaginatedResult<Game>> {
+        return runCatching {
+            val response = apiClient.getAllGames(
+                page = page,
+                pageSize = pageSize,
+                hidePreRelease = hidePreRelease,
+                grouped = grouped,
+            )
+            val games = response.data.map { it.toDomain().resolveImageUrls() }
+            if (page == 1) cacheGames(games)
+            PaginatedResult(
+                data = games,
+                total = response.total,
+                page = response.page,
+                pageSize = response.pageSize,
+            )
         }
     }
 
@@ -66,6 +117,35 @@ class GameRepositoryImpl(
         }.recoverCatching {
             val cached = searchCachedGames(query)
             if (cached.isNotEmpty()) cached else throw it
+        }
+    }
+
+    override suspend fun searchGamesPaginated(
+        query: String,
+        consoleId: String?,
+        sortBy: String?,
+        sortOrder: String?,
+        page: Int,
+        pageSize: Int,
+        hidePreRelease: Boolean,
+        grouped: Boolean,
+    ): Result<PaginatedResult<Game>> {
+        return runCatching {
+            val response = apiClient.searchGames(
+                query = query,
+                consoleId = consoleId,
+                sortBy = sortBy,
+                sortOrder = sortOrder,
+                hidePreRelease = hidePreRelease,
+                grouped = grouped,
+            )
+            val games = response.data.map { it.toDomain().resolveImageUrls() }
+            PaginatedResult(
+                data = games,
+                total = response.total,
+                page = response.page,
+                pageSize = response.pageSize,
+            )
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
@@ -138,6 +138,8 @@ class GameRepositoryImpl(
                 sortOrder = sortOrder,
                 hidePreRelease = hidePreRelease,
                 grouped = grouped,
+                page = page,
+                pageSize = pageSize,
             )
             val games = response.data.map { it.toDomain().resolveImageUrls() }
             PaginatedResult(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -3,6 +3,13 @@ package com.spela.player.domain.model
 import kotlinx.datetime.Instant
 import kotlinx.serialization.Serializable
 
+data class PaginatedResult<T>(
+    val data: List<T>,
+    val total: Long,
+    val page: Int,
+    val pageSize: Int,
+)
+
 @Serializable
 data class ServerConnection(
     val id: String,
@@ -80,12 +87,31 @@ data class Game(
     val playable: Boolean = true,
     val heroUrl: String? = null,
     val logoUrl: String? = null,
+    val revision: String? = null,
+    val tags: String? = null,
+    val isPreRelease: Boolean = false,
+    val variantCount: Int = 0,
+    val groupKey: String? = null,
+)
+
+@Serializable
+data class GameVariant(
+    val id: String,
+    val title: String,
+    val fileName: String = "",
+    val region: String? = null,
+    val revision: String? = null,
+    val tags: String? = null,
+    val isPreRelease: Boolean = false,
+    val fileSize: Long = 0,
+    val verificationStatus: String? = null,
 )
 
 @Serializable
 data class GameDetail(
     val game: Game,
     val screenshots: List<String> = emptyList(),
+    val variants: List<GameVariant> = emptyList(),
 )
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/GameRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/GameRepository.kt
@@ -4,6 +4,7 @@ import com.spela.player.domain.model.Console
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameDetail
 import com.spela.player.domain.model.DeveloperGame
+import com.spela.player.domain.model.PaginatedResult
 import com.spela.player.domain.model.SimilarGame
 import com.spela.player.domain.model.TopListGame
 import com.spela.player.domain.model.TopRatedGame
@@ -11,13 +12,36 @@ import com.spela.player.domain.model.TopRatedGame
 interface GameRepository {
     suspend fun getConsoles(): Result<List<Console>>
     suspend fun getGamesForConsole(consoleId: String): Result<List<Game>>
+    suspend fun getGamesForConsolePaginated(
+        consoleId: String,
+        page: Int = 1,
+        pageSize: Int = 50,
+        hidePreRelease: Boolean = true,
+        grouped: Boolean = true,
+    ): Result<PaginatedResult<Game>>
     suspend fun getAllGames(): Result<List<Game>>
+    suspend fun getAllGamesPaginated(
+        page: Int = 1,
+        pageSize: Int = 50,
+        hidePreRelease: Boolean = true,
+        grouped: Boolean = true,
+    ): Result<PaginatedResult<Game>>
     suspend fun searchGames(
         query: String,
         consoleId: String? = null,
         sortBy: String? = null,
         sortOrder: String? = null,
     ): Result<List<Game>>
+    suspend fun searchGamesPaginated(
+        query: String,
+        consoleId: String? = null,
+        sortBy: String? = null,
+        sortOrder: String? = null,
+        page: Int = 1,
+        pageSize: Int = 50,
+        hidePreRelease: Boolean = true,
+        grouped: Boolean = true,
+    ): Result<PaginatedResult<Game>>
     suspend fun getGameDetail(gameId: String): Result<GameDetail>
     suspend fun getRecentGames(): Result<List<Game>>
     suspend fun getFavoriteGames(): Result<List<Game>>

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameListIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameListIntent.kt
@@ -13,4 +13,6 @@ sealed interface GameListIntent {
     data class SetSortBy(val sortBy: String) : GameListIntent
     data class SetSortOrder(val order: String) : GameListIntent
     data object ToggleViewMode : GameListIntent
+    data object LoadMoreGames : GameListIntent
+    data object ToggleHideBetas : GameListIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameListState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameListState.kt
@@ -36,4 +36,10 @@ data class GameListState(
     val topRatedGames: List<TopRatedGame> = emptyList(),
     val isLoadingTopRated: Boolean = false,
     val recentlyAddedGames: List<Game> = emptyList(),
+    val totalGames: Long = 0,
+    val currentPage: Int = 1,
+    val pageSize: Int = 50,
+    val hasMorePages: Boolean = false,
+    val isLoadingMore: Boolean = false,
+    val hideBetas: Boolean = true,
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameGridItem.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameGridItem.kt
@@ -122,8 +122,9 @@ internal fun GameGridItem(
                 }
                 // Variant count badge
                 if (game.variantCount > 1) {
+                    val otherCount = game.variantCount - 1
                     Text(
-                        text = "${game.variantCount} versions",
+                        text = "$otherCount ${if (otherCount == 1) "version" else "versions"}",
                         style = SpTypography.LabelSmall,
                         color = SpColor.OnBackgroundTertiary,
                         modifier = Modifier.padding(top = SpSpacing.XXSmall),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameGridItem.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameGridItem.kt
@@ -120,6 +120,15 @@ internal fun GameGridItem(
                         )
                     }
                 }
+                // Variant count badge
+                if (game.variantCount > 1) {
+                    Text(
+                        text = "${game.variantCount} versions",
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                        modifier = Modifier.padding(top = SpSpacing.XXSmall),
+                    )
+                }
             }
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameLibraryControls.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameLibraryControls.kt
@@ -58,10 +58,12 @@ internal fun GameLibraryControls(
     sortBy: String,
     sortOrder: String,
     viewMode: ViewMode,
+    hideBetas: Boolean = true,
     onFilterByConsole: (String?) -> Unit,
     onSortByChanged: (String) -> Unit,
     onSortOrderChanged: (String) -> Unit,
     onToggleViewMode: () -> Unit,
+    onToggleHideBetas: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     Column(
@@ -90,7 +92,7 @@ internal fun GameLibraryControls(
             }
         }
 
-        // Sort controls + view mode toggle
+        // Sort controls + hide betas + view mode toggle
         Row(
             modifier = Modifier
                 .fillMaxWidth()
@@ -109,6 +111,12 @@ internal fun GameLibraryControls(
                 onToggle = {
                     onSortOrderChanged(if (sortOrder == "asc") "desc" else "asc")
                 },
+            )
+
+            FilterChip(
+                text = "Hide betas",
+                isSelected = hideBetas,
+                onClick = onToggleHideBetas,
             )
 
             ViewModeToggle(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameListRowItem.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameListRowItem.kt
@@ -109,6 +109,14 @@ internal fun GameListRowItem(
                             )
                         }
                     }
+
+                    if (game.variantCount > 1) {
+                        Text(
+                            text = "${game.variantCount} versions",
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
                 }
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameListRowItem.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameListRowItem.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.ui.feature.library
 
+import com.spela.player.util.formatBytes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -87,7 +88,7 @@ internal fun GameListRowItem(
                 ) {
                     if (game.fileSize > 0) {
                         Text(
-                            text = formatFileSize(game.fileSize),
+                            text = formatBytes(game.fileSize),
                             style = SpTypography.LabelSmall,
                             color = SpColor.OnBackgroundTertiary,
                         )
@@ -111,8 +112,9 @@ internal fun GameListRowItem(
                     }
 
                     if (game.variantCount > 1) {
+                        val otherCount = game.variantCount - 1
                         Text(
-                            text = "${game.variantCount} versions",
+                            text = "$otherCount ${if (otherCount == 1) "version" else "versions"}",
                             style = SpTypography.LabelSmall,
                             color = SpColor.OnBackgroundTertiary,
                         )
@@ -121,14 +123,4 @@ internal fun GameListRowItem(
             }
         }
     }
-}
-
-private fun formatFileSize(bytes: Long): String {
-    if (bytes < 1024) return "$bytes B"
-    val kb = bytes / 1024.0
-    if (kb < 1024) return String.format("%.0f KB", kb)
-    val mb = kb / 1024.0
-    if (mb < 1024) return String.format("%.1f MB", mb)
-    val gb = mb / 1024.0
-    return String.format("%.2f GB", gb)
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
@@ -13,26 +13,33 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.state.ViewMode
+import com.spela.player.presentation.ui.components.LocalAnimationsEnabled
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSearchField
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.feature.library.GameLibraryControls
 import com.spela.player.presentation.ui.feature.library.GameListRowItem
+import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
@@ -71,10 +78,12 @@ fun AllGamesScreen(
             sortBy = state.sortBy,
             sortOrder = state.sortOrder,
             viewMode = state.viewMode,
+            hideBetas = state.hideBetas,
             onFilterByConsole = { viewModel.onIntent(GameListIntent.FilterByConsole(it)) },
             onSortByChanged = { viewModel.onIntent(GameListIntent.SetSortBy(it)) },
             onSortOrderChanged = { viewModel.onIntent(GameListIntent.SetSortOrder(it)) },
             onToggleViewMode = { viewModel.onIntent(GameListIntent.ToggleViewMode) },
+            onToggleHideBetas = { viewModel.onIntent(GameListIntent.ToggleHideBetas) },
             modifier = Modifier.padding(vertical = SpSpacing.Small),
         )
 
@@ -105,8 +114,22 @@ fun AllGamesScreen(
                         }
                     }
                 } else if (state.viewMode == ViewMode.GRID) {
+                    val gridState = rememberLazyGridState()
+                    val shouldLoadMore by remember {
+                        derivedStateOf {
+                            val lastVisibleItem = gridState.layoutInfo.visibleItemsInfo.lastOrNull()
+                            lastVisibleItem != null && lastVisibleItem.index >= state.games.size - 6
+                        }
+                    }
+                    LaunchedEffect(shouldLoadMore) {
+                        if (shouldLoadMore && state.hasMorePages && !state.isLoadingMore) {
+                            viewModel.onIntent(GameListIntent.LoadMoreGames)
+                        }
+                    }
+
                     LazyVerticalGrid(
                         columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
+                        state = gridState,
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(
                             horizontal = SpSpacing.ScreenHorizontal,
@@ -122,9 +145,35 @@ fun AllGamesScreen(
                                 onRequestScrape = { viewModel.requestScrapeIfNeeded(it) },
                             )
                         }
+                        if (state.isLoadingMore) {
+                            item {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth().padding(SpSpacing.Medium),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    if (LocalAnimationsEnabled.current) {
+                                        CircularProgressIndicator(color = SpColor.Primary)
+                                    }
+                                }
+                            }
+                        }
                     }
                 } else {
+                    val listState = rememberLazyListState()
+                    val shouldLoadMore by remember {
+                        derivedStateOf {
+                            val lastVisibleItem = listState.layoutInfo.visibleItemsInfo.lastOrNull()
+                            lastVisibleItem != null && lastVisibleItem.index >= state.games.size - 6
+                        }
+                    }
+                    LaunchedEffect(shouldLoadMore) {
+                        if (shouldLoadMore && state.hasMorePages && !state.isLoadingMore) {
+                            viewModel.onIntent(GameListIntent.LoadMoreGames)
+                        }
+                    }
+
                     LazyColumn(
+                        state = listState,
                         modifier = Modifier.fillMaxSize(),
                         contentPadding = PaddingValues(
                             horizontal = SpSpacing.ScreenHorizontal,
@@ -137,6 +186,18 @@ fun AllGamesScreen(
                                 game = game,
                                 onClick = { onGameSelected(game.id) },
                             )
+                        }
+                        if (state.isLoadingMore) {
+                            item {
+                                Box(
+                                    modifier = Modifier.fillMaxWidth().padding(SpSpacing.Medium),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    if (LocalAnimationsEnabled.current) {
+                                        CircularProgressIndicator(color = SpColor.Primary)
+                                    }
+                                }
+                            }
                         }
                     }
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -40,6 +40,7 @@ import com.spela.player.domain.model.BiosMissingFile
 import com.spela.player.domain.model.DownloadState
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameDetail
+import com.spela.player.domain.model.GameVariant
 import com.spela.player.domain.model.NETPLAY_SUPPORTED_CONSOLES
 import com.spela.player.presentation.intent.GameDetailIntent
 import com.spela.player.presentation.state.GameDetailState
@@ -78,6 +79,7 @@ import com.spela.player.presentation.ui.components.GameDetailLayout
 import com.spela.player.presentation.ui.components.GameDetailSkeleton
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
+import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpConfirmDialog
 import com.spela.player.presentation.ui.components.SpConsoleChip
@@ -218,6 +220,7 @@ fun GameDetailScreen(
                         syncState = syncState,
                         onPlayWithLocalSave = onPlayWithLocalSave,
                         onCancelLaunch = onCancelLaunch,
+                        onNavigateToGame = onNavigateToGame,
                     )
 
                     // Series & Franchise links
@@ -558,6 +561,7 @@ private fun GameInfoContent(
     syncState: GameSyncState? = null,
     onPlayWithLocalSave: () -> Unit = {},
     onCancelLaunch: () -> Unit = {},
+    onNavigateToGame: ((String) -> Unit)? = null,
 ) {
     // Title row with trophy icon if achievements exist
     Row(
@@ -866,6 +870,15 @@ private fun GameInfoContent(
 
     // Metadata grid (Developer, Publisher, Released, Genre, Players, Size, Discs)
     MetadataGrid(game = game, onGradient = true)
+
+    // Variants section
+    if (detail.variants.isNotEmpty()) {
+        Spacer(Modifier.height(SpSpacing.XLarge))
+        VariantsSection(
+            variants = detail.variants,
+            onVariantSelected = onNavigateToGame,
+        )
+    }
 }
 
 @Composable
@@ -980,3 +993,75 @@ private val regionFlags = mapOf(
 
 private fun getRegionFlag(region: String): String? =
     regionFlags.entries.firstOrNull { region.contains(it.key, ignoreCase = true) }?.value
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun VariantsSection(
+    variants: List<GameVariant>,
+    onVariantSelected: ((String) -> Unit)?,
+) {
+    SpTitledSection(
+        title = "Versions",
+        includeTopSpacing = false,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            variants.forEach { variant ->
+                SpCard(
+                    onClick = { onVariantSelected?.invoke(variant.id) },
+                    onGradient = true,
+                    cornerRadius = SpSpacing.RadiusMedium,
+                ) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth().padding(SpSpacing.Medium),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                    ) {
+                        Text(
+                            text = variant.title,
+                            style = SpTypography.TitleSmall,
+                            color = SpColor.OnCard,
+                        )
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                            verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                        ) {
+                            variant.region?.takeIf { it.isNotBlank() }?.let { region ->
+                                val flag = getRegionFlag(region)
+                                SpChip(
+                                    text = if (flag != null) "$flag $region" else region,
+                                    onGradient = true,
+                                )
+                            }
+                            variant.revision?.takeIf { it.isNotBlank() }?.let { revision ->
+                                SpChip(text = revision, onGradient = true)
+                            }
+                            if (variant.fileSize > 0) {
+                                SpChip(
+                                    text = formatVariantFileSize(variant.fileSize),
+                                    onGradient = true,
+                                )
+                            }
+                            variant.verificationStatus?.takeIf { it.isNotBlank() }?.let { status ->
+                                SpChip(text = status, onGradient = true)
+                            }
+                            if (variant.isPreRelease) {
+                                SpChip(text = "Pre-release", onGradient = true)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun formatVariantFileSize(bytes: Long): String {
+    if (bytes < 1024) return "$bytes B"
+    val kb = bytes / 1024.0
+    if (kb < 1024) return String.format("%.0f KB", kb)
+    val mb = kb / 1024.0
+    if (mb < 1024) return String.format("%.1f MB", mb)
+    val gb = mb / 1024.0
+    return String.format("%.2f GB", gb)
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.ui.screen
 
+import com.spela.player.util.formatBytes
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -535,7 +536,7 @@ private fun SessionSaveItem(
                         }
                         if (save.fileSize > 0) {
                             if (isNotEmpty()) append(" \u00b7 ")
-                            append(formatFileSize(save.fileSize))
+                            append(formatBytes(save.fileSize))
                         }
                     },
                     style = SpTypography.BodySmall,
@@ -546,13 +547,5 @@ private fun SessionSaveItem(
                 SpChip(text = "Auto", color = SpColor.Primary)
             }
         }
-    }
-}
-
-private fun formatFileSize(bytes: Long): String {
-    return when {
-        bytes < 1024 -> "${bytes}B"
-        bytes < 1024 * 1024 -> "${bytes / 1024}KB"
-        else -> "${bytes / (1024 * 1024)}MB"
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -103,6 +103,8 @@ class GameListViewModel(
             is GameListIntent.SetSortBy -> setSortBy(intent.sortBy)
             is GameListIntent.SetSortOrder -> setSortOrder(intent.order)
             GameListIntent.ToggleViewMode -> toggleViewMode()
+            GameListIntent.LoadMoreGames -> loadMoreGames()
+            GameListIntent.ToggleHideBetas -> toggleHideBetas()
         }
     }
 
@@ -302,22 +304,97 @@ class GameListViewModel(
 
     private fun reloadGames() {
         val current = _state.value
-        _state.update { it.copy(isLoading = true) }
+        _state.update { it.copy(isLoading = true, currentPage = 1) }
         scope.launch(dispatchers.io) {
-            searchGamesUseCase(
+            val repo = gameRepository
+            if (repo != null) {
+                repo.searchGamesPaginated(
+                    query = current.searchQuery,
+                    consoleId = current.selectedConsoleFilter,
+                    sortBy = current.sortBy,
+                    sortOrder = current.sortOrder,
+                    page = 1,
+                    pageSize = current.pageSize,
+                    hidePreRelease = current.hideBetas,
+                ).fold(
+                    onSuccess = { result ->
+                        _state.update {
+                            it.copy(
+                                games = result.data,
+                                totalGames = result.total,
+                                currentPage = result.page,
+                                hasMorePages = result.data.size.toLong() < result.total,
+                                isLoading = false,
+                            )
+                        }
+                    },
+                    onFailure = { error ->
+                        _state.update { it.copy(error = error.message, isLoading = false) }
+                    },
+                )
+            } else {
+                searchGamesUseCase(
+                    query = current.searchQuery,
+                    consoleId = current.selectedConsoleFilter,
+                    sortBy = current.sortBy,
+                    sortOrder = current.sortOrder,
+                ).fold(
+                    onSuccess = { games ->
+                        _state.update {
+                            it.copy(
+                                games = games,
+                                totalGames = games.size.toLong(),
+                                hasMorePages = false,
+                                isLoading = false,
+                            )
+                        }
+                    },
+                    onFailure = { error ->
+                        _state.update { it.copy(error = error.message, isLoading = false) }
+                    },
+                )
+            }
+        }
+    }
+
+    private fun loadMoreGames() {
+        val current = _state.value
+        if (current.isLoadingMore || !current.hasMorePages) return
+        val repo = gameRepository ?: return
+
+        _state.update { it.copy(isLoadingMore = true) }
+        scope.launch(dispatchers.io) {
+            repo.searchGamesPaginated(
                 query = current.searchQuery,
                 consoleId = current.selectedConsoleFilter,
                 sortBy = current.sortBy,
                 sortOrder = current.sortOrder,
+                page = current.currentPage + 1,
+                pageSize = current.pageSize,
+                hidePreRelease = current.hideBetas,
             ).fold(
-                onSuccess = { games ->
-                    _state.update { it.copy(games = games, isLoading = false) }
+                onSuccess = { result ->
+                    _state.update {
+                        val allGames = it.games + result.data
+                        it.copy(
+                            games = allGames,
+                            totalGames = result.total,
+                            currentPage = result.page,
+                            hasMorePages = allGames.size.toLong() < result.total,
+                            isLoadingMore = false,
+                        )
+                    }
                 },
                 onFailure = { error ->
-                    _state.update { it.copy(error = error.message, isLoading = false) }
+                    _state.update { it.copy(error = error.message, isLoadingMore = false) }
                 },
             )
         }
+    }
+
+    private fun toggleHideBetas() {
+        _state.update { it.copy(hideBetas = !it.hideBetas) }
+        reloadGames()
     }
 
     private fun toggleFavorite(gameId: String, isFavorite: Boolean) {

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/GameListViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/GameListViewModelTest.kt
@@ -181,13 +181,50 @@ class FakeGameRepository : GameRepository {
         else Result.success(games.filter { it.consoleId == consoleId })
     }
 
+    override suspend fun getGamesForConsolePaginated(
+        consoleId: String,
+        page: Int,
+        pageSize: Int,
+        hidePreRelease: Boolean,
+        grouped: Boolean,
+    ): Result<PaginatedResult<Game>> {
+        val filtered = games.filter { it.consoleId == consoleId }
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(PaginatedResult(filtered, filtered.size.toLong(), page, pageSize))
+    }
+
     override suspend fun getAllGames(): Result<List<Game>> {
         return if (shouldFail) Result.failure(Exception("Network error")) else Result.success(games)
+    }
+
+    override suspend fun getAllGamesPaginated(
+        page: Int,
+        pageSize: Int,
+        hidePreRelease: Boolean,
+        grouped: Boolean,
+    ): Result<PaginatedResult<Game>> {
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(PaginatedResult(games, games.size.toLong(), page, pageSize))
     }
 
     override suspend fun searchGames(query: String, consoleId: String?, sortBy: String?, sortOrder: String?): Result<List<Game>> {
         return if (shouldFail) Result.failure(Exception("Network error"))
         else Result.success(games.filter { it.title.contains(query, ignoreCase = true) })
+    }
+
+    override suspend fun searchGamesPaginated(
+        query: String,
+        consoleId: String?,
+        sortBy: String?,
+        sortOrder: String?,
+        page: Int,
+        pageSize: Int,
+        hidePreRelease: Boolean,
+        grouped: Boolean,
+    ): Result<PaginatedResult<Game>> {
+        val filtered = games.filter { it.title.contains(query, ignoreCase = true) }
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(PaginatedResult(filtered, filtered.size.toLong(), page, pageSize))
     }
 
     override suspend fun getGameDetail(gameId: String): Result<GameDetail> {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
@@ -199,6 +199,9 @@ class SyncEngineTest {
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
         override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
+        override suspend fun getGamesForConsolePaginated(consoleId: String, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+        override suspend fun getAllGamesPaginated(page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+        override suspend fun searchGamesPaginated(query: String, consoleId: String?, sortBy: String?, sortOrder: String?, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
     }
 
     private class FailingPreferencesRepository : PreferencesRepository {
@@ -235,6 +238,9 @@ class SyncEngineTest {
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
         override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.failure(Exception("fail"))
+        override suspend fun getGamesForConsolePaginated(consoleId: String, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+        override suspend fun getAllGamesPaginated(page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+        override suspend fun searchGamesPaginated(query: String, consoleId: String?, sortBy: String?, sortOrder: String?, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
     }
 
     private class TrackingPreferencesRepository : PreferencesRepository {
@@ -279,5 +285,8 @@ class SyncEngineTest {
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
         override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
+        override suspend fun getGamesForConsolePaginated(consoleId: String, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+        override suspend fun getAllGamesPaginated(page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+        override suspend fun searchGamesPaginated(query: String, consoleId: String?, sortBy: String?, sortOrder: String?, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -362,6 +362,9 @@ class NavigationViewModelTest {
         override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
         override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
         override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
+        override suspend fun getGamesForConsolePaginated(consoleId: String, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+        override suspend fun getAllGamesPaginated(page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+        override suspend fun searchGamesPaginated(query: String, consoleId: String?, sortBy: String?, sortOrder: String?, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
     }
 
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -224,6 +224,9 @@ private class PlayFromSharedSaveTestGameRepository : GameRepository {
     override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
     override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
     override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
+    override suspend fun getGamesForConsolePaginated(consoleId: String, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+    override suspend fun getAllGamesPaginated(page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+    override suspend fun searchGamesPaginated(query: String, consoleId: String?, sortBy: String?, sortOrder: String?, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
 }
 
 private class PlayFromSharedSaveTestRatingRepository : RatingRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
@@ -168,6 +168,9 @@ private class StubGameRepository : GameRepository {
     override suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>> = Result.success(emptyList())
     override suspend fun getDeveloperGames(gameId: String): Result<List<DeveloperGame>> = Result.success(emptyList())
     override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
+    override suspend fun getGamesForConsolePaginated(consoleId: String, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+    override suspend fun getAllGamesPaginated(page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+    override suspend fun searchGamesPaginated(query: String, consoleId: String?, sortBy: String?, sortOrder: String?, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
 }
 
 private class StubRatingRepository : RatingRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
@@ -204,6 +204,9 @@ private class TestGameRepository : GameRepository {
     override suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>> = Result.success(emptyList())
     override suspend fun getDeveloperGames(gameId: String): Result<List<DeveloperGame>> = Result.success(emptyList())
     override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
+    override suspend fun getGamesForConsolePaginated(consoleId: String, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+    override suspend fun getAllGamesPaginated(page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+    override suspend fun searchGamesPaginated(query: String, consoleId: String?, sortBy: String?, sortOrder: String?, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
 }
 
 private class TestRatingRepository : RatingRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -36,6 +36,7 @@ import com.spela.player.domain.model.TopListGame
 import com.spela.player.domain.model.TopRatedGame
 import com.spela.player.domain.model.SimilarGame
 import com.spela.player.domain.model.DeveloperGame
+import com.spela.player.domain.model.PaginatedResult
 import com.spela.player.domain.model.UserPreferences
 import com.spela.player.domain.repository.AchievementsRepository
 import com.spela.player.domain.repository.ChallengeRepository
@@ -185,6 +186,9 @@ class StubGameRepository(private val consoleId: String = "nes") : GameRepository
     override suspend fun getSimilarGames(gameId: String) = Result.success(emptyList<SimilarGame>())
     override suspend fun getDeveloperGames(gameId: String) = Result.success(emptyList<DeveloperGame>())
     override suspend fun getRecentlyAddedGames(): Result<List<Game>> = Result.success(emptyList())
+    override suspend fun getGamesForConsolePaginated(consoleId: String, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+    override suspend fun getAllGamesPaginated(page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
+    override suspend fun searchGamesPaginated(query: String, consoleId: String?, sortBy: String?, sortOrder: String?, page: Int, pageSize: Int, hidePreRelease: Boolean, grouped: Boolean) = Result.success(PaginatedResult<Game>(emptyList(), 0, page, pageSize))
 }
 
 class StubDownloadRepository : DownloadRepository {

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -132,6 +132,11 @@ func main() {
 		slog.Warn("failed to migrate shared sessions", "error", err)
 	}
 
+	// Backfill game metadata (region, tags, grouping) for existing games
+	if err := scanner.BackfillGameMetadata(database); err != nil {
+		slog.Warn("failed to backfill game metadata", "error", err)
+	}
+
 	// Create ES-DE console subdirectories in game dirs
 	if err := scanner.CreateConsoleFolders(database, gameDirs); err != nil {
 		slog.Warn("failed to create console folders", "error", err)

--- a/server/internal/api/admin_handler_settings.go
+++ b/server/internal/api/admin_handler_settings.go
@@ -40,11 +40,13 @@ const secretMaskPlaceholder = "********"
 
 // allowedSettingKeys is the allowlist of setting keys that may be written via the admin API.
 var allowedSettingKeys = map[string]bool{
-	"registration_enabled": true,
-	"igdb_client_id":       true,
-	"igdb_client_secret":   true,
-	"bios_auto_download":   true,
-	"steamgriddb_api_key":  true,
+	"registration_enabled":    true,
+	"igdb_client_id":          true,
+	"igdb_client_secret":      true,
+	"bios_auto_download":      true,
+	"steamgriddb_api_key":     true,
+	"default_region":          true,
+	"hide_pre_release_default": true,
 }
 
 // UpdateSettings updates server settings (admin only).

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -262,6 +262,7 @@ func seedGameForEachConsole(t *testing.T, database *gorm.DB) {
 			FileName:  "test" + c.Abbreviation + ".rom",
 			FilePath:  "/tmp/test" + c.Abbreviation + ".rom",
 			FileSize:  1024,
+			IsPrimary: true,
 		}
 		require.NoError(t, database.Create(&game).Error)
 	}

--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -136,16 +136,21 @@ func (h *ConsoleHandler) ListConsoleGames(c *gin.Context) {
 			}
 		}
 		if len(trimmed) > 0 {
-			regionWhere := h.DB
+			regionWhere := h.DB.Session(&gorm.Session{NewDB: true})
+			countRegionWhere := h.DB.Session(&gorm.Session{NewDB: true})
 			for i, r := range trimmed {
+				cond := "LOWER(region) = LOWER(?) OR region LIKE ? ESCAPE '\\'"
+				args := []interface{}{r, "%" + escapeLikePattern(r) + "%"}
 				if i == 0 {
-					regionWhere = regionWhere.Where("LOWER(region) = LOWER(?) OR region LIKE ? ESCAPE '\\'", r, "%"+escapeLikePattern(r)+"%")
+					regionWhere = regionWhere.Where(cond, args...)
+					countRegionWhere = countRegionWhere.Where(cond, args...)
 				} else {
-					regionWhere = regionWhere.Or("LOWER(region) = LOWER(?) OR region LIKE ? ESCAPE '\\'", r, "%"+escapeLikePattern(r)+"%")
+					regionWhere = regionWhere.Or(cond, args...)
+					countRegionWhere = countRegionWhere.Or(cond, args...)
 				}
 			}
 			query = query.Where(regionWhere)
-			countQuery = countQuery.Where(regionWhere)
+			countQuery = countQuery.Where(countRegionWhere)
 		}
 	}
 

--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -149,6 +149,19 @@ func (h *ConsoleHandler) ListConsoleGames(c *gin.Context) {
 		}
 	}
 
+	// --- Letter filter (alphabet quick-jump) ---
+	if letter := c.Query("letter"); letter != "" {
+		if letter == "#" {
+			query = query.Where("title GLOB '[0-9]*'")
+			countQuery = countQuery.Where("title GLOB '[0-9]*'")
+		} else if len(letter) == 1 && ((letter[0] >= 'A' && letter[0] <= 'Z') || (letter[0] >= 'a' && letter[0] <= 'z')) {
+			upper := strings.ToUpper(letter)
+			lower := strings.ToLower(letter)
+			query = query.Where("title LIKE ? ESCAPE '\\' OR title LIKE ? ESCAPE '\\'", lower+"%", upper+"%")
+			countQuery = countQuery.Where("title LIKE ? ESCAPE '\\' OR title LIKE ? ESCAPE '\\'", lower+"%", upper+"%")
+		}
+	}
+
 	// Search
 	if search := c.Query("search"); search != "" {
 		query = query.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")

--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -80,10 +80,10 @@ func (h *ConsoleHandler) ListConsoles(c *gin.Context) {
 		return
 	}
 
-	// Attach game counts
+	// Attach game counts (only primary, non-pre-release games — matches what users see)
 	for i := range consoles {
 		var count int64
-		h.DB.Model(&db.Game{}).Where("console_id = ?", consoles[i].ID).Count(&count)
+		h.DB.Model(&db.Game{}).Where("console_id = ? AND is_primary = ? AND is_pre_release = ?", consoles[i].ID, true, false).Count(&count)
 		consoles[i].GameCount = int(count)
 	}
 
@@ -109,10 +109,50 @@ func (h *ConsoleHandler) ListConsoleGames(c *gin.Context) {
 	}
 
 	query := h.DB.Where("console_id = ?", console.ID).Preload("Console")
+	countQuery := h.DB.Model(&db.Game{}).Where("console_id = ?", console.ID)
+
+	// --- Variant grouping (default: show only primaries) ---
+	grouped := c.DefaultQuery("grouped", "true")
+	if grouped == "true" {
+		query = query.Where("is_primary = ?", true)
+		countQuery = countQuery.Where("is_primary = ?", true)
+	}
+
+	// --- Hide pre-release (default: hide betas/protos/samples) ---
+	hidePreRelease := c.DefaultQuery("hidePreRelease", "true")
+	if hidePreRelease == "true" {
+		query = query.Where("is_pre_release = ?", false)
+		countQuery = countQuery.Where("is_pre_release = ?", false)
+	}
+
+	// --- Region filter ---
+	if regionFilter := c.Query("region"); regionFilter != "" {
+		regions := strings.Split(regionFilter, ",")
+		var trimmed []string
+		for _, r := range regions {
+			r = strings.TrimSpace(r)
+			if r != "" {
+				trimmed = append(trimmed, r)
+			}
+		}
+		if len(trimmed) > 0 {
+			regionWhere := h.DB
+			for i, r := range trimmed {
+				if i == 0 {
+					regionWhere = regionWhere.Where("LOWER(region) = LOWER(?) OR region LIKE ? ESCAPE '\\'", r, "%"+escapeLikePattern(r)+"%")
+				} else {
+					regionWhere = regionWhere.Or("LOWER(region) = LOWER(?) OR region LIKE ? ESCAPE '\\'", r, "%"+escapeLikePattern(r)+"%")
+				}
+			}
+			query = query.Where(regionWhere)
+			countQuery = countQuery.Where(regionWhere)
+		}
+	}
 
 	// Search
 	if search := c.Query("search"); search != "" {
 		query = query.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")
+		countQuery = countQuery.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")
 	}
 
 	// Sorting
@@ -137,12 +177,7 @@ func (h *ConsoleHandler) ListConsoleGames(c *gin.Context) {
 		perPage = 50
 	}
 
-	// Count with same filters
 	var total int64
-	countQuery := h.DB.Model(&db.Game{}).Where("console_id = ?", console.ID)
-	if search := c.Query("search"); search != "" {
-		countQuery = countQuery.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")
-	}
 	countQuery.Count(&total)
 
 	offset := (page - 1) * perPage

--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -91,6 +91,7 @@ func TestListConsoles_ReturnsConsolesWithGames(t *testing.T) {
 		FileName:  "test.nes",
 		FilePath:  "/tmp/test.nes",
 		FileSize:  1024,
+		IsPrimary: true,
 	}
 	err = database.Create(&game).Error
 	require.NoError(t, err)

--- a/server/internal/api/enrichment_handler_test.go
+++ b/server/internal/api/enrichment_handler_test.go
@@ -46,6 +46,7 @@ func createEnrichTestGame(t *testing.T, database *gorm.DB, title string, rating 
 		FilePath:  "NES/" + title + ".nes",
 		Rating:    rating,
 		ScraperID: fmt.Sprintf("igdb:%d", 1000+int(rating)),
+		IsPrimary: true,
 	}
 	require.NoError(t, database.Create(&game).Error)
 	return game

--- a/server/internal/api/game_filter_test.go
+++ b/server/internal/api/game_filter_test.go
@@ -54,6 +54,7 @@ func createFilterGame(t *testing.T, database *gorm.DB, consoleAbbr, title string
 		Title:     title,
 		FileName:  title + ".rom",
 		FilePath:  consoleAbbr + "/" + title + ".rom",
+		IsPrimary: true,
 	}
 	for _, opt := range opts {
 		opt(&game)

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -72,6 +72,54 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 		countQuery = countQuery.Where("console_id IN ?", consoleIDs)
 	}
 
+	// --- Variant grouping (default: show only primaries) ---
+	grouped := c.DefaultQuery("grouped", "true")
+	if grouped == "true" {
+		query = query.Where("games.is_primary = ?", true)
+		countQuery = countQuery.Where("is_primary = ?", true)
+	}
+
+	// --- Hide pre-release (default: hide betas/protos/samples) ---
+	hidePreRelease := c.DefaultQuery("hidePreRelease", "true")
+	if hidePreRelease == "true" {
+		query = query.Where("games.is_pre_release = ?", false)
+		countQuery = countQuery.Where("is_pre_release = ?", false)
+	}
+
+	// --- Region filter ---
+	if regionFilter := c.Query("region"); regionFilter != "" {
+		regions := strings.Split(regionFilter, ",")
+		var trimmed []string
+		for _, r := range regions {
+			r = strings.TrimSpace(r)
+			if r != "" {
+				trimmed = append(trimmed, r)
+			}
+		}
+		if len(trimmed) > 0 {
+			// Build OR conditions: exact match (case-insensitive) OR substring match
+			// to handle multi-region values like "USA, Europe"
+			regionWhere := h.DB
+			for i, r := range trimmed {
+				if i == 0 {
+					regionWhere = regionWhere.Where("LOWER(games.region) = LOWER(?) OR games.region LIKE ? ESCAPE '\\'", r, "%"+escapeLikePattern(r)+"%")
+				} else {
+					regionWhere = regionWhere.Or("LOWER(games.region) = LOWER(?) OR games.region LIKE ? ESCAPE '\\'", r, "%"+escapeLikePattern(r)+"%")
+				}
+			}
+			query = query.Where(regionWhere)
+			countRegionWhere := h.DB
+			for i, r := range trimmed {
+				if i == 0 {
+					countRegionWhere = countRegionWhere.Where("LOWER(region) = LOWER(?) OR region LIKE ? ESCAPE '\\'", r, "%"+escapeLikePattern(r)+"%")
+				} else {
+					countRegionWhere = countRegionWhere.Or("LOWER(region) = LOWER(?) OR region LIKE ? ESCAPE '\\'", r, "%"+escapeLikePattern(r)+"%")
+				}
+			}
+			countQuery = countQuery.Where(countRegionWhere)
+		}
+	}
+
 	// --- Text search ---
 	if search := c.Query("search"); search != "" {
 		query = query.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")
@@ -270,6 +318,34 @@ func (h *GameHandler) GetGame(c *gin.Context) {
 	userID := getUserID(c)
 	resp := ToGameResponse(game, h.DB, userID)
 	resp.BiosStatus = GetConsoleStatus(h.Storage.BiosDir, game.Console.Abbreviation)
+
+	// Load variants: other games in the same (console_id, group_key) group
+	if game.GroupKey != "" {
+		var variants []db.Game
+		h.DB.Where("console_id = ? AND group_key = ? AND id != ?",
+			game.ConsoleID, game.GroupKey, game.ID).
+			Order("file_name ASC").
+			Find(&variants)
+		if len(variants) > 0 {
+			resp.Variants = make([]VariantResponse, len(variants))
+			for i, v := range variants {
+				resp.Variants[i] = VariantResponse{
+					ID:                 strconv.FormatUint(uint64(v.ID), 10),
+					Title:              v.Title,
+					FileName:           v.FileName,
+					Region:             v.Region,
+					Revision:           v.Revision,
+					Tags:               v.Tags,
+					IsPreRelease:       v.IsPreRelease,
+					FileSize:           v.FileSize,
+					VerificationStatus: v.VerificationStatus,
+				}
+			}
+		}
+		// Set variant count (including this game)
+		resp.VariantCount = len(variants) + 1
+	}
+
 	c.JSON(http.StatusOK, resp)
 }
 

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -120,6 +120,20 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 		}
 	}
 
+	// --- Letter filter (alphabet quick-jump) ---
+	if letter := c.Query("letter"); letter != "" {
+		if letter == "#" {
+			// Non-alpha: match games starting with a digit
+			query = query.Where("title GLOB '[0-9]*'")
+			countQuery = countQuery.Where("title GLOB '[0-9]*'")
+		} else if len(letter) == 1 && ((letter[0] >= 'A' && letter[0] <= 'Z') || (letter[0] >= 'a' && letter[0] <= 'z')) {
+			upper := strings.ToUpper(letter)
+			lower := strings.ToLower(letter)
+			query = query.Where("title LIKE ? ESCAPE '\\' OR title LIKE ? ESCAPE '\\'", lower+"%", upper+"%")
+			countQuery = countQuery.Where("title LIKE ? ESCAPE '\\' OR title LIKE ? ESCAPE '\\'", lower+"%", upper+"%")
+		}
+	}
+
 	// --- Text search ---
 	if search := c.Query("search"); search != "" {
 		query = query.Where("title LIKE ? ESCAPE '\\'", "%"+escapeLikePattern(search)+"%")

--- a/server/internal/api/play_later_handler_test.go
+++ b/server/internal/api/play_later_handler_test.go
@@ -462,8 +462,8 @@ func TestGameResponse_IsInPlayLater_InGamesList(t *testing.T) {
 
 	var console db.Console
 	database.First(&console)
-	game1 := db.Game{ConsoleID: console.ID, Title: "PL List Game 1", FileName: "test1.nes", FilePath: "/tmp/test1.nes", FileSize: 100}
-	game2 := db.Game{ConsoleID: console.ID, Title: "PL List Game 2", FileName: "test2.nes", FilePath: "/tmp/test2.nes", FileSize: 100}
+	game1 := db.Game{ConsoleID: console.ID, Title: "PL List Game 1", FileName: "test1.nes", FilePath: "/tmp/test1.nes", FileSize: 100, IsPrimary: true}
+	game2 := db.Game{ConsoleID: console.ID, Title: "PL List Game 2", FileName: "test2.nes", FilePath: "/tmp/test2.nes", FileSize: 100, IsPrimary: true}
 	database.Create(&game1)
 	database.Create(&game2)
 

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -81,6 +82,12 @@ type GameResponse struct {
 	VerificationStatus  string         `json:"verificationStatus,omitempty"`
 	VerificationTag     string         `json:"verificationTag,omitempty"`
 	Region              string         `json:"region,omitempty"`
+	Revision       string         `json:"revision,omitempty"`
+	Tags           string         `json:"tags,omitempty"`
+	IsPreRelease   bool           `json:"isPreRelease"`
+	VariantCount   int            `json:"variantCount,omitempty"`
+	GroupKey       string         `json:"groupKey,omitempty"`
+	Variants       []VariantResponse `json:"variants,omitempty"`
 	HeroURL        string         `json:"heroUrl,omitempty"`
 	LogoURL        string         `json:"logoUrl,omitempty"`
 	BiosStatus     string         `json:"biosStatus,omitempty"`
@@ -116,6 +123,19 @@ type LanguageSupportResponse struct {
 type AgeRatingResponse struct {
 	Category string `json:"category"`
 	Rating   string `json:"rating"`
+}
+
+// VariantResponse is a simplified game entry for listing variants of a game.
+type VariantResponse struct {
+	ID                 string `json:"id"`
+	Title              string `json:"title"`
+	FileName           string `json:"fileName"`
+	Region             string `json:"region,omitempty"`
+	Revision           string `json:"revision,omitempty"`
+	Tags               string `json:"tags,omitempty"`
+	IsPreRelease       bool   `json:"isPreRelease"`
+	FileSize           int64  `json:"fileSize"`
+	VerificationStatus string `json:"verificationStatus,omitempty"`
 }
 
 // PaginatedResponse wraps a paginated list with standard keys.
@@ -335,6 +355,10 @@ func toGameResponseWithData(g db.Game, data *userGameData) GameResponse {
 		VerificationStatus:  g.VerificationStatus,
 		VerificationTag:     g.VerificationTag,
 		Region:              g.Region,
+		Revision:            g.Revision,
+		Tags:                g.Tags,
+		IsPreRelease:        g.IsPreRelease,
+		GroupKey:            g.GroupKey,
 	}
 
 	// Map release dates
@@ -413,9 +437,67 @@ func ToGameResponses(games []db.Game, database *gorm.DB, userID uint) []GameResp
 
 	data := loadUserGameData(database, userID, gameIDs)
 
+	// Batch-load variant counts for all games in the page.
+	// Group by (console_id, group_key) to count how many games share each key.
+	variantCounts := make(map[string]int) // "consoleID:groupKey" -> count
+	if database != nil && len(games) > 0 {
+		// Collect unique group keys (with console_id) for this page
+		type groupKeyPair struct {
+			ConsoleID uint
+			GroupKey  string
+		}
+		seen := make(map[string]bool)
+		var pairs []groupKeyPair
+		for _, g := range games {
+			if g.GroupKey == "" {
+				continue
+			}
+			key := fmt.Sprintf("%d:%s", g.ConsoleID, g.GroupKey)
+			if !seen[key] {
+				seen[key] = true
+				pairs = append(pairs, groupKeyPair{ConsoleID: g.ConsoleID, GroupKey: g.GroupKey})
+			}
+		}
+
+		if len(pairs) > 0 {
+			type countRow struct {
+				ConsoleID uint
+				GroupKey  string
+				Cnt       int
+			}
+			var rows []countRow
+
+			// Build OR conditions for each (consoleID, groupKey) pair to avoid
+			// the cross-product issue with separate IN clauses.
+			var conditions []string
+			var args []interface{}
+			for _, p := range pairs {
+				conditions = append(conditions, "(console_id = ? AND group_key = ?)")
+				args = append(args, p.ConsoleID, p.GroupKey)
+			}
+
+			database.Model(&db.Game{}).
+				Select("console_id, group_key, COUNT(*) as cnt").
+				Where(strings.Join(conditions, " OR "), args...).
+				Group("console_id, group_key").
+				Find(&rows)
+
+			for _, r := range rows {
+				key := fmt.Sprintf("%d:%s", r.ConsoleID, r.GroupKey)
+				variantCounts[key] = r.Cnt
+			}
+		}
+	}
+
 	result := make([]GameResponse, len(games))
 	for i, g := range games {
 		result[i] = toGameResponseWithData(g, &data)
+		if g.GroupKey != "" {
+			key := fmt.Sprintf("%d:%s", g.ConsoleID, g.GroupKey)
+			if count, ok := variantCounts[key]; ok && count > 1 {
+				result[i].VariantCount = count
+			}
+		}
 	}
 	return result
 }

--- a/server/internal/api/user_handler.go
+++ b/server/internal/api/user_handler.go
@@ -180,6 +180,7 @@ type preferencesResponse struct {
 	SelectedKeyMapping      string                         `json:"selectedKeyMapping"`
 	CustomKeyMapping        map[string]string              `json:"customKeyMapping"`
 	ConsoleKeyMappings      map[string]consoleKeyMappingDTO `json:"consoleKeyMappings"`
+	PreferredRegions        []string                       `json:"preferredRegions"`
 	RALinked                bool                           `json:"raLinked"`
 	RAUsername              string                         `json:"raUsername"`
 	RAHardcoreEnabled       bool                           `json:"raHardcoreEnabled"`
@@ -219,6 +220,8 @@ func (h *UserHandler) GetPreferences(c *gin.Context) {
 		defaultSecondScreenPage = "art"
 	}
 
+	preferredRegions := parsePreferredRegions(user.PreferredRegions)
+
 	var raCred db.RetroAchievementCredential
 	raLinked := h.DB.Where("user_id = ?", uid).First(&raCred).Error == nil
 
@@ -233,10 +236,29 @@ func (h *UserHandler) GetPreferences(c *gin.Context) {
 		SelectedKeyMapping:      selectedKeyMapping,
 		CustomKeyMapping:        customKeyMapping,
 		ConsoleKeyMappings:      consoleKeyMappings,
+		PreferredRegions:        preferredRegions,
 		RALinked:                raLinked,
 		RAUsername:              raCred.RAUsername,
 		RAHardcoreEnabled:       raCred.HardcoreEnabled,
 	})
+}
+
+// parsePreferredRegions splits a comma-separated region string into a slice,
+// trimming whitespace and filtering empty strings. Returns an empty slice (not nil)
+// when the input is empty.
+func parsePreferredRegions(s string) []string {
+	if s == "" {
+		return []string{}
+	}
+	parts := strings.Split(s, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
 }
 
 // UpdatePreferences partially updates the current user's emulation preferences.
@@ -260,6 +282,7 @@ func (h *UserHandler) UpdatePreferences(c *gin.Context) {
 		SelectedKeyMapping      *string                          `json:"selectedKeyMapping"`
 		CustomKeyMapping        map[string]string                `json:"customKeyMapping"`
 		ConsoleKeyMappings      map[string]consoleKeyMappingDTO  `json:"consoleKeyMappings"`
+		PreferredRegions        *[]string                        `json:"preferredRegions"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
@@ -296,6 +319,9 @@ func (h *UserHandler) UpdatePreferences(c *gin.Context) {
 	if req.CustomKeyMapping != nil {
 		b, _ := json.Marshal(req.CustomKeyMapping)
 		user.CustomKeyMapping = string(b)
+	}
+	if req.PreferredRegions != nil {
+		user.PreferredRegions = strings.Join(*req.PreferredRegions, ",")
 	}
 
 	if err := h.DB.Save(&user).Error; err != nil {
@@ -387,6 +413,8 @@ func (h *UserHandler) UpdatePreferences(c *gin.Context) {
 		defaultSecondScreenPage = "art"
 	}
 
+	preferredRegions := parsePreferredRegions(user.PreferredRegions)
+
 	var raCred db.RetroAchievementCredential
 	raLinked := h.DB.Where("user_id = ?", uid).First(&raCred).Error == nil
 
@@ -401,6 +429,7 @@ func (h *UserHandler) UpdatePreferences(c *gin.Context) {
 		SelectedKeyMapping:      selectedKeyMapping,
 		CustomKeyMapping:        customKeyMapping,
 		ConsoleKeyMappings:      consoleKeyMappings,
+		PreferredRegions:        preferredRegions,
 		RALinked:                raLinked,
 		RAUsername:              raCred.RAUsername,
 		RAHardcoreEnabled:       raCred.HardcoreEnabled,

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -40,6 +40,7 @@ type User struct {
 	SelectedKeyMapping  string         `gorm:"size:64;default:arrows-left" json:"selectedKeyMapping"`
 	CustomKeyMapping         string         `gorm:"type:text" json:"customKeyMapping,omitempty"` // JSON: {"0":"z","1":"x",...}
 	DefaultSecondScreenPage string         `gorm:"size:64;default:art" json:"defaultSecondScreenPage"`
+	PreferredRegions         string         `gorm:"size:255" json:"preferredRegions,omitempty"` // comma-separated ordered list, e.g. "USA,Europe,World"
 }
 
 // LoginAttempt tracks failed login attempts per username for account lockout.

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -77,7 +77,7 @@ type Game struct {
 	CreatedAt     time.Time      `json:"createdAt"`
 	UpdatedAt     time.Time      `json:"updatedAt"`
 	DeletedAt     gorm.DeletedAt `gorm:"index" json:"-"`
-	ConsoleID     uint           `gorm:"index;not null" json:"consoleId"`
+	ConsoleID     uint           `gorm:"index;not null;index:idx_console_group_key,priority:1;index:idx_console_is_primary,priority:1" json:"consoleId"`
 	Console       Console        `gorm:"foreignKey:ConsoleID" json:"console,omitempty"`
 	Title         string         `gorm:"size:255;not null" json:"title"`
 	FileName      string         `gorm:"size:512;not null" json:"fileName"`
@@ -113,6 +113,12 @@ type Game struct {
 	VerificationStatus  string         `gorm:"size:32" json:"verificationStatus,omitempty"`
 	VerificationTag     string         `gorm:"size:128" json:"verificationTag,omitempty"`
 	Region              string         `gorm:"size:128" json:"region,omitempty"`
+	Revision            string         `gorm:"size:64" json:"revision,omitempty"`
+	Tags                string         `gorm:"size:255" json:"tags,omitempty"`
+	IsPreRelease        bool           `gorm:"default:false;index:idx_game_is_pre_release" json:"isPreRelease"`
+	GroupKey            string         `gorm:"size:255;index:idx_game_group_key;index:idx_console_group_key,priority:2" json:"groupKey,omitempty"`
+	IsPrimary           bool           `gorm:"default:false;index:idx_game_is_primary;index:idx_console_is_primary,priority:2" json:"isPrimary"`
+	PrimaryGameID       *uint          `json:"primaryGameId,omitempty"`
 	CRC32               string         `gorm:"size:16" json:"-"`
 	Screenshots      []GameScreenshot      `gorm:"foreignKey:GameID" json:"-"`
 	ReleaseDates     []GameReleaseDate     `gorm:"foreignKey:GameID" json:"-"`

--- a/server/internal/scanner/backfill.go
+++ b/server/internal/scanner/backfill.go
@@ -1,0 +1,84 @@
+package scanner
+
+import (
+	"fmt"
+	"log/slog"
+
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// BackfillGameMetadata populates Region, Revision, Tags, IsPreRelease, and GroupKey
+// for existing games that don't have a GroupKey set. This runs on startup to handle
+// games created before the large library support feature was added.
+// After backfilling, it calls GroupAndElectPrimaries to set IsPrimary flags.
+func BackfillGameMetadata(database *gorm.DB) error {
+	// Count games needing backfill
+	var totalNeedingBackfill int64
+	if err := database.Model(&db.Game{}).Where("group_key = '' OR group_key IS NULL").Count(&totalNeedingBackfill).Error; err != nil {
+		return fmt.Errorf("counting games needing backfill: %w", err)
+	}
+
+	if totalNeedingBackfill == 0 {
+		slog.Info("no games need metadata backfill")
+		return nil
+	}
+
+	slog.Info("backfilling game metadata", "total", totalNeedingBackfill)
+
+	// Process in batches of 100
+	const batchSize = 100
+	var processed int64
+
+	for {
+		var games []db.Game
+		if err := database.Where("group_key = '' OR group_key IS NULL").
+			Limit(batchSize).
+			Find(&games).Error; err != nil {
+			return fmt.Errorf("loading games for backfill: %w", err)
+		}
+
+		if len(games) == 0 {
+			break
+		}
+
+		// Accumulate updates in memory, then batch-save in a transaction
+		for i := range games {
+			meta := ParseFilenameMetadata(games[i].FileName)
+			games[i].Revision = meta.Revision
+			games[i].Tags = meta.Tags
+			games[i].IsPreRelease = meta.IsPreRelease
+			games[i].GroupKey = meta.GroupKey
+
+			// Only backfill Region if it's currently empty
+			if games[i].Region == "" && meta.Region != "" {
+				games[i].Region = meta.Region
+			}
+		}
+
+		if err := database.Transaction(func(tx *gorm.DB) error {
+			for i := range games {
+				if err := tx.Save(&games[i]).Error; err != nil {
+					slog.Warn("failed to backfill game metadata",
+						"gameId", games[i].ID, "title", games[i].Title, "error", err)
+				}
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("batch-saving backfilled games: %w", err)
+		}
+
+		processed += int64(len(games))
+		slog.Info("backfilling game metadata progress",
+			"processed", processed, "total", totalNeedingBackfill)
+	}
+
+	slog.Info("game metadata backfill complete", "processed", processed)
+
+	// Run grouping and primary election after backfill
+	if err := GroupAndElectPrimaries(database); err != nil {
+		return fmt.Errorf("electing primaries after backfill: %w", err)
+	}
+
+	return nil
+}

--- a/server/internal/scanner/filename_parser.go
+++ b/server/internal/scanner/filename_parser.go
@@ -1,0 +1,211 @@
+package scanner
+
+import (
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// FilenameMetadata holds structured metadata extracted from a ROM filename.
+type FilenameMetadata struct {
+	Region       string // e.g. "USA", "Japan, Europe"
+	Revision     string // e.g. "Rev 1", "Rev A", "v1.1"
+	Tags         string // comma-separated lowercase, e.g. "beta,unl"
+	IsPreRelease bool   // true when tags contain beta, proto, sample, or demo
+	GroupKey     string // normalized title for variant grouping
+}
+
+// revisionPattern matches revision tags like (Rev 1), (Rev A), (Rev B).
+var revisionPattern = regexp.MustCompile(`(?i)\(Rev\s+([^)]+)\)`)
+
+// versionPattern matches version tags like (v1.0), (v1.1), (v2.0).
+var versionPattern = regexp.MustCompile(`(?i)\(v(\d+\.\d+[^)]*)\)`)
+
+// parenContentPattern extracts the content of each parenthesized group.
+var parenContentPattern = regexp.MustCompile(`\(([^)]*)\)`)
+
+// bracketContentPattern extracts the content of each bracketed group.
+var bracketContentPattern = regexp.MustCompile(`\[([^\]]*)\]`)
+
+// tagKeywords maps lowercase tag keywords to their canonical form.
+// Tags that indicate pre-release status are marked separately.
+var preReleaseTags = map[string]bool{
+	"beta":  true,
+	"proto": true,
+	"sample": true,
+	"demo":  true,
+}
+
+// allKnownTags are tags we extract from filenames.
+var allKnownTags = map[string]string{
+	"beta":            "beta",
+	"proto":           "proto",
+	"prototype":       "proto",
+	"sample":          "sample",
+	"demo":            "demo",
+	"unl":             "unl",
+	"unlicensed":      "unl",
+	"hack":            "hack",
+	"pirate":          "pirate",
+	"virtual console": "virtual console",
+	"switch online":   "switch online",
+}
+
+// Regexes from scraper/namematch.go for normalization, reused here.
+var (
+	fnReParens   = regexp.MustCompile(`\([^)]*\)`)
+	fnReBrackets = regexp.MustCompile(`\[[^\]]*\]`)
+	fnRePunct    = regexp.MustCompile(`[.,'":;!?\-_/\\+]+`)
+	fnReSpaces   = regexp.MustCompile(`\s+`)
+)
+
+// accentMap folds common accented characters to ASCII equivalents.
+var fnAccentMap = map[rune]rune{
+	'à': 'a', 'á': 'a', 'â': 'a', 'ã': 'a', 'ä': 'a', 'å': 'a',
+	'è': 'e', 'é': 'e', 'ê': 'e', 'ë': 'e',
+	'ì': 'i', 'í': 'i', 'î': 'i', 'ï': 'i',
+	'ò': 'o', 'ó': 'o', 'ô': 'o', 'õ': 'o', 'ö': 'o',
+	'ù': 'u', 'ú': 'u', 'û': 'u', 'ü': 'u',
+	'ý': 'y', 'ÿ': 'y',
+	'ñ': 'n', 'ç': 'c',
+	'À': 'a', 'Á': 'a', 'Â': 'a', 'Ã': 'a', 'Ä': 'a', 'Å': 'a',
+	'È': 'e', 'É': 'e', 'Ê': 'e', 'Ë': 'e',
+	'Ì': 'i', 'Í': 'i', 'Î': 'i', 'Ï': 'i',
+	'Ò': 'o', 'Ó': 'o', 'Ô': 'o', 'Õ': 'o', 'Ö': 'o',
+	'Ù': 'u', 'Ú': 'u', 'Û': 'u', 'Ü': 'u',
+	'Ý': 'y',
+	'Ñ': 'n', 'Ç': 'c',
+}
+
+// fnRegionPattern matches parenthesized region tags in No-Intro filenames.
+// Duplicated from scraper/region.go to avoid import cycle (scraper imports scanner).
+var fnRegionPattern = regexp.MustCompile(`\(([^)]*(?:` +
+	`USA|Japan|Europe|World|Korea|Brazil|France|Germany|Spain|Italy|` +
+	`Australia|Netherlands|Sweden|Canada|China|Taiwan|Asia|Russia|` +
+	`UK|En|Ja|Fr|De|Es|It|Pt|Zh|Ko|Nl|Sv|No|Da|Fi|Pl|Ru` +
+	`)[^)]*)\)`)
+
+// extractRegion parses a region tag from a filename.
+// Returns the region string without parentheses, or empty string if none found.
+func extractRegion(filename string) string {
+	match := fnRegionPattern.FindStringSubmatch(filename)
+	if len(match) < 2 {
+		return ""
+	}
+	return match[1]
+}
+
+// ParseFilenameMetadata extracts structured metadata from a ROM filename.
+// Uses no-intro naming conventions: "Game Name (Region) (Rev X) [Tags].ext"
+func ParseFilenameMetadata(filename string) FilenameMetadata {
+	var meta FilenameMetadata
+
+	// Extract region
+	meta.Region = extractRegion(filename)
+
+	// Extract revision
+	if match := revisionPattern.FindStringSubmatch(filename); len(match) >= 2 {
+		meta.Revision = "Rev " + strings.TrimSpace(match[1])
+	} else if match := versionPattern.FindStringSubmatch(filename); len(match) >= 2 {
+		meta.Revision = "v" + strings.TrimSpace(match[1])
+	}
+
+	// Extract tags from parenthesized and bracketed groups
+	var tags []string
+	seen := make(map[string]bool)
+
+	// Check parenthesized groups
+	for _, match := range parenContentPattern.FindAllStringSubmatch(filename, -1) {
+		content := strings.ToLower(strings.TrimSpace(match[1]))
+		for keyword, canonical := range allKnownTags {
+			if strings.Contains(content, keyword) && !seen[canonical] {
+				tags = append(tags, canonical)
+				seen[canonical] = true
+			}
+		}
+	}
+
+	// Check bracketed groups
+	for _, match := range bracketContentPattern.FindAllStringSubmatch(filename, -1) {
+		content := strings.ToLower(strings.TrimSpace(match[1]))
+		for keyword, canonical := range allKnownTags {
+			if strings.Contains(content, keyword) && !seen[canonical] {
+				tags = append(tags, canonical)
+				seen[canonical] = true
+			}
+		}
+	}
+
+	sort.Strings(tags)
+	meta.Tags = strings.Join(tags, ",")
+
+	// Determine pre-release status
+	for _, tag := range tags {
+		if preReleaseTags[tag] {
+			meta.IsPreRelease = true
+			break
+		}
+	}
+
+	// Compute group key: normalized title for variant grouping
+	meta.GroupKey = normalizeGroupKey(filename)
+
+	return meta
+}
+
+// normalizeGroupKey produces a normalized title from a filename for grouping variants.
+// Mirrors the normalization approach from scraper/namematch.go's normalizeName().
+func normalizeGroupKey(filename string) string {
+	// Remove extension
+	name := strings.TrimSuffix(filename, filepath.Ext(filename))
+
+	// Strip (...) and [...] content
+	name = fnReParens.ReplaceAllString(name, "")
+	name = fnReBrackets.ReplaceAllString(name, "")
+
+	// Trim whitespace left over from stripped tags before checking articles
+	name = strings.TrimSpace(name)
+
+	// Handle articles: trailing ", The" / ", A" / ", An"
+	for _, article := range []string{", The", ", A", ", An"} {
+		if strings.HasSuffix(name, article) {
+			name = name[:len(name)-len(article)]
+			break
+		}
+	}
+	// Leading "The " / "A " / "An "
+	for _, article := range []string{"The ", "A ", "An "} {
+		if strings.HasPrefix(name, article) {
+			name = name[len(article):]
+			break
+		}
+	}
+
+	// Fold accented characters
+	var buf strings.Builder
+	buf.Grow(len(name))
+	for _, r := range name {
+		if mapped, ok := fnAccentMap[r]; ok {
+			buf.WriteRune(mapped)
+		} else {
+			buf.WriteRune(r)
+		}
+	}
+	name = buf.String()
+
+	// Lowercase
+	name = strings.ToLower(name)
+
+	// Replace & with "and", strip apostrophes, strip punctuation
+	name = strings.ReplaceAll(name, "&", "and")
+	name = strings.ReplaceAll(name, "'", "")
+	name = strings.ReplaceAll(name, "\u2019", "")
+	name = fnRePunct.ReplaceAllString(name, " ")
+
+	// Collapse whitespace, trim
+	name = fnReSpaces.ReplaceAllString(name, " ")
+	name = strings.TrimSpace(name)
+
+	return name
+}

--- a/server/internal/scanner/filename_parser_test.go
+++ b/server/internal/scanner/filename_parser_test.go
@@ -1,0 +1,271 @@
+package scanner
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseFilenameMetadata(t *testing.T) {
+	tests := []struct {
+		name         string
+		filename     string
+		wantRegion   string
+		wantRevision string
+		wantTags     string
+		wantPreRel   bool
+		wantGroupKey string
+	}{
+		{
+			name:         "standard no-intro USA",
+			filename:     "Super Mario World (USA).sfc",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "super mario world",
+		},
+		{
+			name:         "multi-region",
+			filename:     "Cool Game (USA, Europe).gba",
+			wantRegion:   "USA, Europe",
+			wantRevision: "",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "cool game",
+		},
+		{
+			name:         "revision number",
+			filename:     "Sonic (USA) (Rev 1).sfc",
+			wantRegion:   "USA",
+			wantRevision: "Rev 1",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "sonic",
+		},
+		{
+			name:         "revision letter",
+			filename:     "Game (Japan) (Rev A).sfc",
+			wantRegion:   "Japan",
+			wantRevision: "Rev A",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "game",
+		},
+		{
+			name:         "version tag",
+			filename:     "Game (Japan) (v1.1).sfc",
+			wantRegion:   "Japan",
+			wantRevision: "v1.1",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "game",
+		},
+		{
+			name:         "beta pre-release",
+			filename:     "Mega Man (USA) (Beta).sfc",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "beta",
+			wantPreRel:   true,
+			wantGroupKey: "mega man",
+		},
+		{
+			name:         "proto and unlicensed",
+			filename:     "Game (Japan) (Proto) (Unl).nes",
+			wantRegion:   "Japan",
+			wantRevision: "",
+			wantTags:     "proto,unl",
+			wantPreRel:   true,
+			wantGroupKey: "game",
+		},
+		{
+			name:         "no tags homebrew",
+			filename:     "MyHomebrew.nes",
+			wantRegion:   "",
+			wantRevision: "",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "myhomebrew",
+		},
+		{
+			name:         "unlicensed only not pre-release",
+			filename:     "Game Genie (USA) (Unl).nes",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "unl",
+			wantPreRel:   false,
+			wantGroupKey: "game genie",
+		},
+		{
+			name:         "leading article The stripped",
+			filename:     "The Legend of Zelda (USA).nes",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "legend of zelda",
+		},
+		{
+			name:         "trailing article stripped",
+			filename:     "Legend of Zelda, The (USA).nes",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "legend of zelda",
+		},
+		{
+			name:         "demo is pre-release",
+			filename:     "Cool Demo (Europe) (Demo).gba",
+			wantRegion:   "Europe",
+			wantRevision: "",
+			wantTags:     "demo",
+			wantPreRel:   true,
+			wantGroupKey: "cool demo",
+		},
+		{
+			name:         "sample is pre-release",
+			filename:     "Test Game (USA) (Sample).sfc",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "sample",
+			wantPreRel:   true,
+			wantGroupKey: "test game",
+		},
+		{
+			name:         "world region",
+			filename:     "Tetris (World).gb",
+			wantRegion:   "World",
+			wantRevision: "",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "tetris",
+		},
+		{
+			name:         "hack tag",
+			filename:     "Super Mario World (USA) (Hack).sfc",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "hack",
+			wantPreRel:   false,
+			wantGroupKey: "super mario world",
+		},
+		{
+			name:         "revision and region combined",
+			filename:     "Donkey Kong Country (USA) (Rev B).sfc",
+			wantRegion:   "USA",
+			wantRevision: "Rev B",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "donkey kong country",
+		},
+		{
+			name:         "version with extra digits",
+			filename:     "Pokemon (Japan) (v2.0).gbc",
+			wantRegion:   "Japan",
+			wantRevision: "v2.0",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "pokemon",
+		},
+		{
+			name:         "pirate tag",
+			filename:     "Super Game (USA) (Pirate).nes",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "pirate",
+			wantPreRel:   false,
+			wantGroupKey: "super game",
+		},
+		{
+			name:         "article A stripped",
+			filename:     "A Boy and His Blob (USA).nes",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "boy and his blob",
+		},
+		{
+			name:         "cue file",
+			filename:     "Final Fantasy VII (USA) (Disc 1).cue",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "final fantasy vii",
+		},
+		{
+			name:         "m3u file",
+			filename:     "Chrono Cross (USA).m3u",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "",
+			wantPreRel:   false,
+			wantGroupKey: "chrono cross",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			meta := ParseFilenameMetadata(tt.filename)
+			assert.Equal(t, tt.wantRegion, meta.Region, "Region")
+			assert.Equal(t, tt.wantRevision, meta.Revision, "Revision")
+			assert.Equal(t, tt.wantPreRel, meta.IsPreRelease, "IsPreRelease")
+			assert.Equal(t, tt.wantGroupKey, meta.GroupKey, "GroupKey")
+
+			// Tags may be in different order, so check containment
+			if tt.wantTags == "" {
+				assert.Equal(t, "", meta.Tags, "Tags should be empty")
+			} else {
+				wantParts := splitTags(tt.wantTags)
+				gotParts := splitTags(meta.Tags)
+				assert.ElementsMatch(t, wantParts, gotParts, "Tags")
+			}
+		})
+	}
+}
+
+func TestNormalizeGroupKey(t *testing.T) {
+	tests := []struct {
+		name     string
+		filename string
+		want     string
+	}{
+		{"simple", "Super Mario World.sfc", "super mario world"},
+		{"with tags", "Super Mario World (USA) (Rev 1).sfc", "super mario world"},
+		{"brackets", "Game [!].nes", "game"},
+		{"ampersand", "Chip & Dale.nes", "chip and dale"},
+		{"accented", "Pokémon Blue.gbc", "pokemon blue"},
+		{"leading the", "The Legend of Zelda.nes", "legend of zelda"},
+		{"trailing the", "Legend of Zelda, The.nes", "legend of zelda"},
+		{"leading a", "A Boy and His Blob.nes", "boy and his blob"},
+		{"leading an", "An American Tail.nes", "american tail"},
+		{"punctuation", "Ys III - Wanderers from Ys.sfc", "ys iii wanderers from ys"},
+		{"apostrophe", "Kirby's Dream Land.gb", "kirbys dream land"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := normalizeGroupKey(tt.filename)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+// splitTags splits a comma-separated tag string into a slice.
+func splitTags(tags string) []string {
+	if tags == "" {
+		return nil
+	}
+	parts := make([]string, 0)
+	for _, p := range strings.Split(tags, ",") {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			parts = append(parts, p)
+		}
+	}
+	return parts
+}

--- a/server/internal/scanner/grouping.go
+++ b/server/internal/scanner/grouping.go
@@ -191,22 +191,132 @@ func betterVariant(a, b db.Game) bool {
 	return a.ID < b.ID
 }
 
+// defaultRegionOrder is the default region preference for primary election.
+var defaultRegionOrder = []string{"usa", "world", "europe"}
+
 // regionPriority returns a priority value for a region string.
 // Lower is better. USA=0, World=1, Europe=2, other=3.
 func regionPriority(region string) int {
-	lower := strings.ToLower(region)
+	return regionPriorityWithOrder(region, defaultRegionOrder)
+}
 
-	// Check for USA first (multi-region strings like "USA, Europe" should match)
-	if strings.Contains(lower, "usa") {
-		return 0
+// regionPriorityWithOrder returns a priority value for a region string using
+// a custom region order. Lower is better. Regions not in the order list get
+// the lowest priority (len(order)).
+func regionPriorityWithOrder(region string, order []string) int {
+	lower := strings.ToLower(region)
+	for i, r := range order {
+		if strings.Contains(lower, strings.ToLower(r)) {
+			return i
+		}
 	}
-	if strings.Contains(lower, "world") {
-		return 1
+	return len(order)
+}
+
+// GroupAndElectPrimariesWithRegions groups games by (console_id, group_key) and
+// elects the best variant in each group as primary, using a custom region preference order.
+// If regionOrder is nil or empty, the default order (USA > World > Europe) is used.
+func GroupAndElectPrimariesWithRegions(database *gorm.DB, regionOrder []string) error {
+	if len(regionOrder) == 0 {
+		return GroupAndElectPrimaries(database)
 	}
-	if strings.Contains(lower, "europe") {
-		return 2
+
+	var allGames []db.Game
+	if err := database.Where("group_key != ''").Find(&allGames).Error; err != nil {
+		return fmt.Errorf("loading grouped games: %w", err)
 	}
-	return 3
+
+	type groupKeyType struct {
+		ConsoleID uint
+		GroupKey  string
+	}
+	groups := make(map[groupKeyType][]db.Game)
+	for _, g := range allGames {
+		k := groupKeyType{ConsoleID: g.ConsoleID, GroupKey: g.GroupKey}
+		groups[k] = append(groups[k], g)
+	}
+
+	slog.Info("electing primary variants with custom region order", "groups", len(groups), "regionOrder", regionOrder)
+
+	err := database.Transaction(func(tx *gorm.DB) error {
+		for k, games := range groups {
+			sort.SliceStable(games, func(i, j int) bool {
+				return betterVariantWithRegions(games[i], games[j], regionOrder)
+			})
+
+			primary := games[0]
+
+			if err := tx.Model(&db.Game{}).
+				Where("console_id = ? AND group_key = ?", k.ConsoleID, k.GroupKey).
+				Updates(map[string]interface{}{
+					"is_primary":      false,
+					"primary_game_id": primary.ID,
+				}).Error; err != nil {
+				slog.Warn("failed to clear primary flags",
+					"consoleId", k.ConsoleID, "groupKey", k.GroupKey, "error", err)
+				continue
+			}
+
+			if err := tx.Model(&db.Game{}).
+				Where("id = ?", primary.ID).
+				Updates(map[string]interface{}{
+					"is_primary":      true,
+					"primary_game_id": nil,
+				}).Error; err != nil {
+				slog.Warn("failed to set primary",
+					"consoleId", k.ConsoleID, "groupKey", k.GroupKey, "error", err)
+				continue
+			}
+		}
+
+		if err := tx.Model(&db.Game{}).
+			Where("group_key = '' OR group_key IS NULL").
+			Updates(map[string]interface{}{
+				"is_primary":      true,
+				"primary_game_id": nil,
+			}).Error; err != nil {
+			return fmt.Errorf("setting empty-groupkey games as primary: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("primary election transaction: %w", err)
+	}
+
+	slog.Info("primary variant election with custom regions complete", "groups", len(groups))
+	return nil
+}
+
+// betterVariantWithRegions is like betterVariant but uses a custom region order.
+func betterVariantWithRegions(a, b db.Game, regionOrder []string) bool {
+	if a.IsPreRelease != b.IsPreRelease {
+		return !a.IsPreRelease
+	}
+	aRegion := regionPriorityWithOrder(a.Region, regionOrder)
+	bRegion := regionPriorityWithOrder(b.Region, regionOrder)
+	if aRegion != bRegion {
+		return aRegion < bRegion
+	}
+	aRev := revisionOrder(a.Revision)
+	bRev := revisionOrder(b.Revision)
+	if aRev != bRev {
+		return aRev > bRev
+	}
+	aHasMeta := a.Description != "" || a.CoverURL != ""
+	bHasMeta := b.Description != "" || b.CoverURL != ""
+	if aHasMeta != bHasMeta {
+		return aHasMeta
+	}
+	aVerified := a.VerificationStatus == "verified"
+	bVerified := b.VerificationStatus == "verified"
+	if aVerified != bVerified {
+		return aVerified
+	}
+	if len(a.FileName) != len(b.FileName) {
+		return len(a.FileName) < len(b.FileName)
+	}
+	return a.ID < b.ID
 }
 
 // revisionOrder returns a numeric order for revision strings.

--- a/server/internal/scanner/grouping.go
+++ b/server/internal/scanner/grouping.go
@@ -1,0 +1,277 @@
+package scanner
+
+import (
+	"fmt"
+	"log/slog"
+	"sort"
+	"strings"
+
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// GroupAndElectPrimaries groups games by (console_id, group_key) and elects
+// the best variant in each group as primary.
+// All operations run inside a single transaction to avoid a window where no
+// game is primary.
+func GroupAndElectPrimaries(database *gorm.DB) error {
+	// Load all games with a non-empty group key in one query
+	var allGames []db.Game
+	if err := database.Where("group_key != ''").Find(&allGames).Error; err != nil {
+		return fmt.Errorf("loading grouped games: %w", err)
+	}
+
+	// Group games in memory by (console_id, group_key)
+	type groupKey struct {
+		ConsoleID uint
+		GroupKey  string
+	}
+	groups := make(map[groupKey][]db.Game)
+	for _, g := range allGames {
+		k := groupKey{ConsoleID: g.ConsoleID, GroupKey: g.GroupKey}
+		groups[k] = append(groups[k], g)
+	}
+
+	slog.Info("electing primary variants", "groups", len(groups), "games", len(allGames))
+
+	// Compute primaries in memory, then batch-update in a transaction
+	err := database.Transaction(func(tx *gorm.DB) error {
+		processed := 0
+		for k, games := range groups {
+			// Sort by election priority (stable sort + ID tiebreaker for determinism)
+			sort.SliceStable(games, func(i, j int) bool {
+				return betterVariant(games[i], games[j])
+			})
+
+			primary := games[0]
+
+			// Batch update: set all games in group to non-primary
+			if err := tx.Model(&db.Game{}).
+				Where("console_id = ? AND group_key = ?", k.ConsoleID, k.GroupKey).
+				Updates(map[string]interface{}{
+					"is_primary":      false,
+					"primary_game_id": primary.ID,
+				}).Error; err != nil {
+				slog.Warn("failed to clear primary flags",
+					"consoleId", k.ConsoleID, "groupKey", k.GroupKey, "error", err)
+				continue
+			}
+
+			// Set the winner as primary
+			if err := tx.Model(&db.Game{}).
+				Where("id = ?", primary.ID).
+				Updates(map[string]interface{}{
+					"is_primary":      true,
+					"primary_game_id": nil,
+				}).Error; err != nil {
+				slog.Warn("failed to set primary",
+					"consoleId", k.ConsoleID, "groupKey", k.GroupKey, "error", err)
+				continue
+			}
+
+			processed++
+			if processed%500 == 0 {
+				slog.Info("primary election progress", "processed", processed, "total", len(groups))
+			}
+		}
+
+		// Handle games with empty group key: each is its own primary
+		if err := tx.Model(&db.Game{}).
+			Where("group_key = '' OR group_key IS NULL").
+			Updates(map[string]interface{}{
+				"is_primary":      true,
+				"primary_game_id": nil,
+			}).Error; err != nil {
+			return fmt.Errorf("setting empty-groupkey games as primary: %w", err)
+		}
+
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("primary election transaction: %w", err)
+	}
+
+	slog.Info("primary variant election complete", "groups", len(groups))
+	return nil
+}
+
+// electPrimaryForGroup elects the best variant in a single group and updates the DB.
+// All updates are wrapped in a transaction so there is no window where no game is primary.
+func electPrimaryForGroup(database *gorm.DB, consoleID uint, groupKey string) error {
+	var games []db.Game
+	if err := database.Where("console_id = ? AND group_key = ?", consoleID, groupKey).
+		Find(&games).Error; err != nil {
+		return fmt.Errorf("loading group games: %w", err)
+	}
+
+	if len(games) == 0 {
+		return nil
+	}
+
+	// Sort by election priority (stable sort + ID tiebreaker for determinism)
+	sort.SliceStable(games, func(i, j int) bool {
+		return betterVariant(games[i], games[j])
+	})
+
+	primary := games[0]
+
+	return database.Transaction(func(tx *gorm.DB) error {
+		// Batch update: set all games in group to non-primary
+		if err := tx.Model(&db.Game{}).
+			Where("console_id = ? AND group_key = ?", consoleID, groupKey).
+			Updates(map[string]interface{}{
+				"is_primary":      false,
+				"primary_game_id": primary.ID,
+			}).Error; err != nil {
+			return fmt.Errorf("clearing primary flags: %w", err)
+		}
+
+		// Set the winner as primary
+		if err := tx.Model(&db.Game{}).
+			Where("id = ?", primary.ID).
+			Updates(map[string]interface{}{
+				"is_primary":      true,
+				"primary_game_id": nil,
+			}).Error; err != nil {
+			return fmt.Errorf("setting primary: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// betterVariant returns true if game a is a better variant than game b.
+// Election priority (highest priority first):
+// 1. Not pre-release (IsPreRelease = false beats true)
+// 2. Region preference: USA > World > Europe > other
+// 3. Latest revision (Rev B > Rev A > no revision; v1.1 > v1.0)
+// 4. Has metadata (non-empty Description or CoverURL)
+// 5. CRC verified (VerificationStatus = "verified")
+// 6. Shortest FileName
+func betterVariant(a, b db.Game) bool {
+	// 1. Not pre-release beats pre-release
+	if a.IsPreRelease != b.IsPreRelease {
+		return !a.IsPreRelease
+	}
+
+	// 2. Region preference
+	aRegion := regionPriority(a.Region)
+	bRegion := regionPriority(b.Region)
+	if aRegion != bRegion {
+		return aRegion < bRegion // lower = better
+	}
+
+	// 3. Latest revision
+	aRev := revisionOrder(a.Revision)
+	bRev := revisionOrder(b.Revision)
+	if aRev != bRev {
+		return aRev > bRev // higher = later revision = better
+	}
+
+	// 4. Has metadata
+	aHasMeta := a.Description != "" || a.CoverURL != ""
+	bHasMeta := b.Description != "" || b.CoverURL != ""
+	if aHasMeta != bHasMeta {
+		return aHasMeta
+	}
+
+	// 5. CRC verified
+	aVerified := a.VerificationStatus == "verified"
+	bVerified := b.VerificationStatus == "verified"
+	if aVerified != bVerified {
+		return aVerified
+	}
+
+	// 6. Shortest filename
+	if len(a.FileName) != len(b.FileName) {
+		return len(a.FileName) < len(b.FileName)
+	}
+
+	// 7. Lower ID wins (deterministic tiebreaker)
+	return a.ID < b.ID
+}
+
+// regionPriority returns a priority value for a region string.
+// Lower is better. USA=0, World=1, Europe=2, other=3.
+func regionPriority(region string) int {
+	lower := strings.ToLower(region)
+
+	// Check for USA first (multi-region strings like "USA, Europe" should match)
+	if strings.Contains(lower, "usa") {
+		return 0
+	}
+	if strings.Contains(lower, "world") {
+		return 1
+	}
+	if strings.Contains(lower, "europe") {
+		return 2
+	}
+	return 3
+}
+
+// revisionOrder returns a numeric order for revision strings.
+// Higher is later/better. No revision = 0, Rev A or Rev 1 = ordinal value.
+func revisionOrder(revision string) int {
+	if revision == "" {
+		return 0
+	}
+
+	lower := strings.ToLower(revision)
+
+	// Handle "v1.0", "v1.1", "v2.0" etc.
+	if strings.HasPrefix(lower, "v") {
+		// Parse version: v1.0 -> 100, v1.1 -> 110, v2.0 -> 200
+		parts := strings.SplitN(lower[1:], ".", 2)
+		major := 0
+		minor := 0
+		if len(parts) >= 1 {
+			for _, c := range parts[0] {
+				if c >= '0' && c <= '9' {
+					major = major*10 + int(c-'0')
+				}
+			}
+		}
+		if len(parts) >= 2 {
+			for _, c := range parts[1] {
+				if c >= '0' && c <= '9' {
+					minor = minor*10 + int(c-'0')
+				}
+			}
+		}
+		return major*100 + minor
+	}
+
+	// Handle "Rev A", "Rev B", "Rev 1", "Rev 2"
+	if strings.HasPrefix(lower, "rev ") {
+		rest := strings.TrimSpace(lower[4:])
+		if len(rest) == 0 {
+			return 1
+		}
+		// Single letter: A=1, B=2, etc.
+		if len(rest) == 1 && rest[0] >= 'a' && rest[0] <= 'z' {
+			return int(rest[0]-'a') + 1
+		}
+		// Numeric: 1, 2, etc.
+		val := 0
+		for _, c := range rest {
+			if c >= '0' && c <= '9' {
+				val = val*10 + int(c-'0')
+			}
+		}
+		if val > 0 {
+			return val
+		}
+		return 1
+	}
+
+	return 1
+}
+
+// ReElectPrimaryForGroup re-runs election for a specific (consoleID, groupKey) group.
+// Used when a primary game is removed.
+func ReElectPrimaryForGroup(database *gorm.DB, consoleID uint, groupKey string) error {
+	if groupKey == "" {
+		return nil
+	}
+	return electPrimaryForGroup(database, consoleID, groupKey)
+}

--- a/server/internal/scanner/grouping.go
+++ b/server/internal/scanner/grouping.go
@@ -12,86 +12,91 @@ import (
 
 // GroupAndElectPrimaries groups games by (console_id, group_key) and elects
 // the best variant in each group as primary.
-// All operations run inside a single transaction to avoid a window where no
-// game is primary.
+// Processes one console at a time to bound memory usage for large libraries.
 func GroupAndElectPrimaries(database *gorm.DB) error {
-	// Load all games with a non-empty group key in one query
-	var allGames []db.Game
-	if err := database.Where("group_key != ''").Find(&allGames).Error; err != nil {
-		return fmt.Errorf("loading grouped games: %w", err)
-	}
-
-	// Group games in memory by (console_id, group_key)
-	type groupKey struct {
-		ConsoleID uint
-		GroupKey  string
-	}
-	groups := make(map[groupKey][]db.Game)
-	for _, g := range allGames {
-		k := groupKey{ConsoleID: g.ConsoleID, GroupKey: g.GroupKey}
-		groups[k] = append(groups[k], g)
-	}
-
-	slog.Info("electing primary variants", "groups", len(groups), "games", len(allGames))
-
-	// Compute primaries in memory, then batch-update in a transaction
-	err := database.Transaction(func(tx *gorm.DB) error {
-		processed := 0
-		for k, games := range groups {
-			// Sort by election priority (stable sort + ID tiebreaker for determinism)
-			sort.SliceStable(games, func(i, j int) bool {
-				return betterVariant(games[i], games[j])
-			})
-
-			primary := games[0]
-
-			// Batch update: set all games in group to non-primary
-			if err := tx.Model(&db.Game{}).
-				Where("console_id = ? AND group_key = ?", k.ConsoleID, k.GroupKey).
-				Updates(map[string]interface{}{
-					"is_primary":      false,
-					"primary_game_id": primary.ID,
-				}).Error; err != nil {
-				slog.Warn("failed to clear primary flags",
-					"consoleId", k.ConsoleID, "groupKey", k.GroupKey, "error", err)
-				continue
-			}
-
-			// Set the winner as primary
-			if err := tx.Model(&db.Game{}).
-				Where("id = ?", primary.ID).
-				Updates(map[string]interface{}{
-					"is_primary":      true,
-					"primary_game_id": nil,
-				}).Error; err != nil {
-				slog.Warn("failed to set primary",
-					"consoleId", k.ConsoleID, "groupKey", k.GroupKey, "error", err)
-				continue
-			}
-
-			processed++
-			if processed%500 == 0 {
-				slog.Info("primary election progress", "processed", processed, "total", len(groups))
-			}
-		}
-
-		// Handle games with empty group key: each is its own primary
-		if err := tx.Model(&db.Game{}).
-			Where("group_key = '' OR group_key IS NULL").
-			Updates(map[string]interface{}{
-				"is_primary":      true,
-				"primary_game_id": nil,
-			}).Error; err != nil {
-			return fmt.Errorf("setting empty-groupkey games as primary: %w", err)
-		}
-
-		return nil
+	return groupAndElectWithComparator(database, func(a, b db.Game) bool {
+		return betterVariant(a, b)
 	})
-	if err != nil {
-		return fmt.Errorf("primary election transaction: %w", err)
+}
+
+// groupAndElectWithComparator is the shared implementation for primary election.
+// It processes games one console at a time and uses the given comparator for sorting.
+func groupAndElectWithComparator(database *gorm.DB, less func(a, b db.Game) bool) error {
+	// Get distinct console IDs that have grouped games
+	var consoleIDs []uint
+	if err := database.Model(&db.Game{}).
+		Where("group_key != ''").
+		Distinct("console_id").
+		Pluck("console_id", &consoleIDs).Error; err != nil {
+		return fmt.Errorf("loading console IDs for grouping: %w", err)
 	}
 
-	slog.Info("primary variant election complete", "groups", len(groups))
+	totalGroups := 0
+
+	// Process one console at a time to bound memory
+	for _, cid := range consoleIDs {
+		var games []db.Game
+		if err := database.Where("console_id = ? AND group_key != ''", cid).Find(&games).Error; err != nil {
+			return fmt.Errorf("loading games for console %d: %w", cid, err)
+		}
+
+		// Group by group_key within this console
+		groups := make(map[string][]db.Game)
+		for _, g := range games {
+			groups[g.GroupKey] = append(groups[g.GroupKey], g)
+		}
+
+		err := database.Transaction(func(tx *gorm.DB) error {
+			for gk, gGames := range groups {
+				sort.SliceStable(gGames, func(i, j int) bool {
+					return less(gGames[i], gGames[j])
+				})
+
+				primary := gGames[0]
+
+				if err := tx.Model(&db.Game{}).
+					Where("console_id = ? AND group_key = ?", cid, gk).
+					Updates(map[string]interface{}{
+						"is_primary":      false,
+						"primary_game_id": primary.ID,
+					}).Error; err != nil {
+					slog.Warn("failed to clear primary flags",
+						"consoleId", cid, "groupKey", gk, "error", err)
+					continue
+				}
+
+				if err := tx.Model(&db.Game{}).
+					Where("id = ?", primary.ID).
+					Updates(map[string]interface{}{
+						"is_primary":      true,
+						"primary_game_id": nil,
+					}).Error; err != nil {
+					slog.Warn("failed to set primary",
+						"consoleId", cid, "groupKey", gk, "error", err)
+					continue
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			return fmt.Errorf("primary election for console %d: %w", cid, err)
+		}
+
+		totalGroups += len(groups)
+		slog.Info("primary election progress", "consoleId", cid, "groups", len(groups), "games", len(games))
+	}
+
+	// Handle games with empty group key: each is its own primary
+	if err := database.Model(&db.Game{}).
+		Where("group_key = '' OR group_key IS NULL").
+		Updates(map[string]interface{}{
+			"is_primary":      true,
+			"primary_game_id": nil,
+		}).Error; err != nil {
+		return fmt.Errorf("setting empty-groupkey games as primary: %w", err)
+	}
+
+	slog.Info("primary variant election complete", "groups", totalGroups)
 	return nil
 }
 
@@ -220,72 +225,9 @@ func GroupAndElectPrimariesWithRegions(database *gorm.DB, regionOrder []string) 
 	if len(regionOrder) == 0 {
 		return GroupAndElectPrimaries(database)
 	}
-
-	var allGames []db.Game
-	if err := database.Where("group_key != ''").Find(&allGames).Error; err != nil {
-		return fmt.Errorf("loading grouped games: %w", err)
-	}
-
-	type groupKeyType struct {
-		ConsoleID uint
-		GroupKey  string
-	}
-	groups := make(map[groupKeyType][]db.Game)
-	for _, g := range allGames {
-		k := groupKeyType{ConsoleID: g.ConsoleID, GroupKey: g.GroupKey}
-		groups[k] = append(groups[k], g)
-	}
-
-	slog.Info("electing primary variants with custom region order", "groups", len(groups), "regionOrder", regionOrder)
-
-	err := database.Transaction(func(tx *gorm.DB) error {
-		for k, games := range groups {
-			sort.SliceStable(games, func(i, j int) bool {
-				return betterVariantWithRegions(games[i], games[j], regionOrder)
-			})
-
-			primary := games[0]
-
-			if err := tx.Model(&db.Game{}).
-				Where("console_id = ? AND group_key = ?", k.ConsoleID, k.GroupKey).
-				Updates(map[string]interface{}{
-					"is_primary":      false,
-					"primary_game_id": primary.ID,
-				}).Error; err != nil {
-				slog.Warn("failed to clear primary flags",
-					"consoleId", k.ConsoleID, "groupKey", k.GroupKey, "error", err)
-				continue
-			}
-
-			if err := tx.Model(&db.Game{}).
-				Where("id = ?", primary.ID).
-				Updates(map[string]interface{}{
-					"is_primary":      true,
-					"primary_game_id": nil,
-				}).Error; err != nil {
-				slog.Warn("failed to set primary",
-					"consoleId", k.ConsoleID, "groupKey", k.GroupKey, "error", err)
-				continue
-			}
-		}
-
-		if err := tx.Model(&db.Game{}).
-			Where("group_key = '' OR group_key IS NULL").
-			Updates(map[string]interface{}{
-				"is_primary":      true,
-				"primary_game_id": nil,
-			}).Error; err != nil {
-			return fmt.Errorf("setting empty-groupkey games as primary: %w", err)
-		}
-
-		return nil
+	return groupAndElectWithComparator(database, func(a, b db.Game) bool {
+		return betterVariantWithRegions(a, b, regionOrder)
 	})
-	if err != nil {
-		return fmt.Errorf("primary election transaction: %w", err)
-	}
-
-	slog.Info("primary variant election with custom regions complete", "groups", len(groups))
-	return nil
 }
 
 // betterVariantWithRegions is like betterVariant but uses a custom region order.

--- a/server/internal/scanner/grouping_test.go
+++ b/server/internal/scanner/grouping_test.go
@@ -1,0 +1,264 @@
+package scanner
+
+import (
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBetterVariant(t *testing.T) {
+	tests := []struct {
+		name   string
+		a      db.Game
+		b      db.Game
+		aWins  bool
+	}{
+		{
+			name:  "non-prerelease beats prerelease",
+			a:     db.Game{IsPreRelease: false, FileName: "Game (USA).nes"},
+			b:     db.Game{IsPreRelease: true, FileName: "Game (USA) (Beta).nes"},
+			aWins: true,
+		},
+		{
+			name:  "prerelease loses to non-prerelease",
+			a:     db.Game{IsPreRelease: true, FileName: "Game (USA) (Beta).nes"},
+			b:     db.Game{IsPreRelease: false, FileName: "Game (USA).nes"},
+			aWins: false,
+		},
+		{
+			name:  "USA beats Europe",
+			a:     db.Game{Region: "USA", FileName: "Game (USA).nes"},
+			b:     db.Game{Region: "Europe", FileName: "Game (Europe).nes"},
+			aWins: true,
+		},
+		{
+			name:  "USA beats World",
+			a:     db.Game{Region: "USA", FileName: "Game (USA).nes"},
+			b:     db.Game{Region: "World", FileName: "Game (World).nes"},
+			aWins: true,
+		},
+		{
+			name:  "World beats Europe",
+			a:     db.Game{Region: "World", FileName: "Game (World).nes"},
+			b:     db.Game{Region: "Europe", FileName: "Game (Europe).nes"},
+			aWins: true,
+		},
+		{
+			name:  "Europe beats Japan",
+			a:     db.Game{Region: "Europe", FileName: "Game (Europe).nes"},
+			b:     db.Game{Region: "Japan", FileName: "Game (Japan).nes"},
+			aWins: true,
+		},
+		{
+			name:  "later revision wins",
+			a:     db.Game{Region: "USA", Revision: "Rev B", FileName: "Game (USA) (Rev B).nes"},
+			b:     db.Game{Region: "USA", Revision: "Rev A", FileName: "Game (USA) (Rev A).nes"},
+			aWins: true,
+		},
+		{
+			name:  "revision beats no revision",
+			a:     db.Game{Region: "USA", Revision: "Rev A", FileName: "Game (USA) (Rev A).nes"},
+			b:     db.Game{Region: "USA", Revision: "", FileName: "Game (USA).nes"},
+			aWins: true,
+		},
+		{
+			name:  "version comparison",
+			a:     db.Game{Region: "USA", Revision: "v1.1", FileName: "Game (USA) (v1.1).nes"},
+			b:     db.Game{Region: "USA", Revision: "v1.0", FileName: "Game (USA) (v1.0).nes"},
+			aWins: true,
+		},
+		{
+			name:  "has metadata wins",
+			a:     db.Game{Region: "USA", Description: "A cool game", FileName: "Game (USA).nes"},
+			b:     db.Game{Region: "USA", FileName: "Game (USA).nes"},
+			aWins: true,
+		},
+		{
+			name:  "has cover wins",
+			a:     db.Game{Region: "USA", CoverURL: "http://example.com/cover.png", FileName: "Game (USA).nes"},
+			b:     db.Game{Region: "USA", FileName: "Game (USA).nes"},
+			aWins: true,
+		},
+		{
+			name:  "verified beats unverified",
+			a:     db.Game{Region: "USA", VerificationStatus: "verified", FileName: "Game (USA).nes"},
+			b:     db.Game{Region: "USA", VerificationStatus: "", FileName: "Game (USA).nes"},
+			aWins: true,
+		},
+		{
+			name:  "shorter filename wins as tiebreaker",
+			a:     db.Game{Region: "USA", FileName: "Game (USA).nes"},
+			b:     db.Game{Region: "USA", FileName: "Game (USA) [!].nes"},
+			aWins: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := betterVariant(tt.a, tt.b)
+			assert.Equal(t, tt.aWins, result)
+		})
+	}
+}
+
+func TestRevisionOrder(t *testing.T) {
+	tests := []struct {
+		name     string
+		revision string
+		want     int
+	}{
+		{"empty", "", 0},
+		{"Rev A", "Rev A", 1},
+		{"Rev B", "Rev B", 2},
+		{"Rev 1", "Rev 1", 1},
+		{"Rev 2", "Rev 2", 2},
+		{"v1.0", "v1.0", 100},
+		{"v1.1", "v1.1", 101},
+		{"v2.0", "v2.0", 200},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := revisionOrder(tt.revision)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestRegionPriority(t *testing.T) {
+	tests := []struct {
+		name   string
+		region string
+		want   int
+	}{
+		{"USA", "USA", 0},
+		{"USA, Europe", "USA, Europe", 0},
+		{"World", "World", 1},
+		{"Europe", "Europe", 2},
+		{"Japan", "Japan", 3},
+		{"empty", "", 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := regionPriority(tt.region)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestGroupAndElectPrimaries(t *testing.T) {
+	database := setupTestDB(t)
+
+	// Get NES console
+	var nes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nes).Error)
+
+	// Create games in the same group
+	games := []db.Game{
+		{ConsoleID: nes.ID, Title: "Super Mario Bros", FileName: "Super Mario Bros (USA).nes", FilePath: "nes/Super Mario Bros (USA).nes", GroupKey: "super mario bros", Region: "USA"},
+		{ConsoleID: nes.ID, Title: "Super Mario Bros", FileName: "Super Mario Bros (Europe).nes", FilePath: "nes/Super Mario Bros (Europe).nes", GroupKey: "super mario bros", Region: "Europe"},
+		{ConsoleID: nes.ID, Title: "Super Mario Bros", FileName: "Super Mario Bros (Japan).nes", FilePath: "nes/Super Mario Bros (Japan).nes", GroupKey: "super mario bros", Region: "Japan"},
+		{ConsoleID: nes.ID, Title: "Super Mario Bros", FileName: "Super Mario Bros (USA) (Beta).nes", FilePath: "nes/Super Mario Bros (USA) (Beta).nes", GroupKey: "super mario bros", Region: "USA", IsPreRelease: true, Tags: "beta"},
+	}
+	for i := range games {
+		require.NoError(t, database.Create(&games[i]).Error)
+	}
+
+	// Run election
+	require.NoError(t, GroupAndElectPrimaries(database))
+
+	// Verify: USA non-prerelease should be primary
+	var usaGame db.Game
+	require.NoError(t, database.Where("file_path = ?", "nes/Super Mario Bros (USA).nes").First(&usaGame).Error)
+	assert.True(t, usaGame.IsPrimary, "USA game should be primary")
+	assert.Nil(t, usaGame.PrimaryGameID, "primary game should not point to another game")
+
+	// Verify: Europe should not be primary and should point to USA
+	var europeGame db.Game
+	require.NoError(t, database.Where("file_path = ?", "nes/Super Mario Bros (Europe).nes").First(&europeGame).Error)
+	assert.False(t, europeGame.IsPrimary, "Europe game should not be primary")
+	assert.NotNil(t, europeGame.PrimaryGameID, "non-primary should have PrimaryGameID")
+	assert.Equal(t, usaGame.ID, *europeGame.PrimaryGameID)
+
+	// Verify: Beta should not be primary
+	var betaGame db.Game
+	require.NoError(t, database.Where("file_path = ?", "nes/Super Mario Bros (USA) (Beta).nes").First(&betaGame).Error)
+	assert.False(t, betaGame.IsPrimary, "beta game should not be primary")
+}
+
+func TestGroupAndElectPrimaries_RevisionPreference(t *testing.T) {
+	database := setupTestDB(t)
+
+	var snes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
+
+	games := []db.Game{
+		{ConsoleID: snes.ID, Title: "Donkey Kong Country", FileName: "Donkey Kong Country (USA).sfc", FilePath: "snes/Donkey Kong Country (USA).sfc", GroupKey: "donkey kong country", Region: "USA", Revision: ""},
+		{ConsoleID: snes.ID, Title: "Donkey Kong Country", FileName: "Donkey Kong Country (USA) (Rev A).sfc", FilePath: "snes/Donkey Kong Country (USA) (Rev A).sfc", GroupKey: "donkey kong country", Region: "USA", Revision: "Rev A"},
+		{ConsoleID: snes.ID, Title: "Donkey Kong Country", FileName: "Donkey Kong Country (USA) (Rev B).sfc", FilePath: "snes/Donkey Kong Country (USA) (Rev B).sfc", GroupKey: "donkey kong country", Region: "USA", Revision: "Rev B"},
+	}
+	for i := range games {
+		require.NoError(t, database.Create(&games[i]).Error)
+	}
+
+	require.NoError(t, GroupAndElectPrimaries(database))
+
+	// Rev B should win (latest revision)
+	var revB db.Game
+	require.NoError(t, database.Where("file_path = ?", "snes/Donkey Kong Country (USA) (Rev B).sfc").First(&revB).Error)
+	assert.True(t, revB.IsPrimary, "Rev B should be primary")
+}
+
+func TestGroupAndElectPrimaries_SingleGameGroup(t *testing.T) {
+	database := setupTestDB(t)
+
+	var nes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nes).Error)
+
+	game := db.Game{
+		ConsoleID: nes.ID,
+		Title:     "Unique Game",
+		FileName:  "Unique Game (USA).nes",
+		FilePath:  "nes/Unique Game (USA).nes",
+		GroupKey:  "unique game",
+		Region:    "USA",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	require.NoError(t, GroupAndElectPrimaries(database))
+
+	var result db.Game
+	require.NoError(t, database.First(&result, game.ID).Error)
+	assert.True(t, result.IsPrimary, "single game in group should be primary")
+}
+
+func TestReElectPrimaryForGroup(t *testing.T) {
+	database := setupTestDB(t)
+
+	var nes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nes).Error)
+
+	games := []db.Game{
+		{ConsoleID: nes.ID, Title: "Game", FileName: "Game (USA).nes", FilePath: "nes/Game (USA).nes", GroupKey: "game", Region: "USA", IsPrimary: true},
+		{ConsoleID: nes.ID, Title: "Game", FileName: "Game (Europe).nes", FilePath: "nes/Game (Europe).nes", GroupKey: "game", Region: "Europe", IsPrimary: false, PrimaryGameID: nil},
+	}
+	for i := range games {
+		require.NoError(t, database.Create(&games[i]).Error)
+	}
+	// Set PrimaryGameID on Europe to point to USA
+	database.Model(&games[1]).Update("primary_game_id", games[0].ID)
+
+	// Simulate removing the primary (USA) game
+	database.Unscoped().Delete(&games[0])
+
+	// Re-elect
+	require.NoError(t, ReElectPrimaryForGroup(database, nes.ID, "game"))
+
+	// Europe should now be primary
+	var europeGame db.Game
+	require.NoError(t, database.Where("file_path = ?", "nes/Game (Europe).nes").First(&europeGame).Error)
+	assert.True(t, europeGame.IsPrimary, "Europe game should be elected as new primary")
+}

--- a/server/internal/scanner/grouping_test.go
+++ b/server/internal/scanner/grouping_test.go
@@ -149,6 +149,119 @@ func TestRegionPriority(t *testing.T) {
 	}
 }
 
+func TestRegionPriorityWithOrder(t *testing.T) {
+	tests := []struct {
+		name   string
+		region string
+		order  []string
+		want   int
+	}{
+		{"Europe first - Europe", "Europe", []string{"europe", "usa", "world"}, 0},
+		{"Europe first - USA", "USA", []string{"europe", "usa", "world"}, 1},
+		{"Europe first - World", "World", []string{"europe", "usa", "world"}, 2},
+		{"Europe first - Japan", "Japan", []string{"europe", "usa", "world"}, 3},
+		{"Japan first - Japan", "Japan", []string{"japan", "usa"}, 0},
+		{"Japan first - USA", "USA", []string{"japan", "usa"}, 1},
+		{"Japan first - Europe", "Europe", []string{"japan", "usa"}, 2},
+		{"empty order", "USA", []string{}, 0},
+		{"multi-region matches first", "USA, Europe", []string{"europe", "usa"}, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := regionPriorityWithOrder(tt.region, tt.order)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}
+
+func TestBetterVariantWithRegions(t *testing.T) {
+	europeFirst := []string{"europe", "usa", "world"}
+
+	tests := []struct {
+		name  string
+		a     db.Game
+		b     db.Game
+		aWins bool
+	}{
+		{
+			name:  "Europe wins over USA with Europe-first order",
+			a:     db.Game{Region: "Europe", FileName: "Game (Europe).nes"},
+			b:     db.Game{Region: "USA", FileName: "Game (USA).nes"},
+			aWins: true,
+		},
+		{
+			name:  "USA loses to Europe with Europe-first order",
+			a:     db.Game{Region: "USA", FileName: "Game (USA).nes"},
+			b:     db.Game{Region: "Europe", FileName: "Game (Europe).nes"},
+			aWins: false,
+		},
+		{
+			name:  "non-prerelease still beats prerelease regardless of region order",
+			a:     db.Game{IsPreRelease: false, Region: "USA", FileName: "Game (USA).nes"},
+			b:     db.Game{IsPreRelease: true, Region: "Europe", FileName: "Game (Europe) (Beta).nes"},
+			aWins: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := betterVariantWithRegions(tt.a, tt.b, europeFirst)
+			assert.Equal(t, tt.aWins, result)
+		})
+	}
+}
+
+func TestGroupAndElectPrimariesWithRegions(t *testing.T) {
+	database := setupTestDB(t)
+
+	var nes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nes).Error)
+
+	games := []db.Game{
+		{ConsoleID: nes.ID, Title: "Game", FileName: "Game (USA).nes", FilePath: "nes/Game (USA).nes", GroupKey: "game", Region: "USA"},
+		{ConsoleID: nes.ID, Title: "Game", FileName: "Game (Europe).nes", FilePath: "nes/Game (Europe).nes", GroupKey: "game", Region: "Europe"},
+		{ConsoleID: nes.ID, Title: "Game", FileName: "Game (Japan).nes", FilePath: "nes/Game (Japan).nes", GroupKey: "game", Region: "Japan"},
+	}
+	for i := range games {
+		require.NoError(t, database.Create(&games[i]).Error)
+	}
+
+	// Elect with Europe-first order
+	require.NoError(t, GroupAndElectPrimariesWithRegions(database, []string{"europe", "usa", "world"}))
+
+	// Europe should be primary
+	var europeGame db.Game
+	require.NoError(t, database.Where("file_path = ?", "nes/Game (Europe).nes").First(&europeGame).Error)
+	assert.True(t, europeGame.IsPrimary, "Europe game should be primary with Europe-first order")
+
+	var usaGame db.Game
+	require.NoError(t, database.Where("file_path = ?", "nes/Game (USA).nes").First(&usaGame).Error)
+	assert.False(t, usaGame.IsPrimary, "USA game should not be primary with Europe-first order")
+}
+
+func TestGroupAndElectPrimariesWithRegions_EmptyFallsBack(t *testing.T) {
+	database := setupTestDB(t)
+
+	var nes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nes).Error)
+
+	games := []db.Game{
+		{ConsoleID: nes.ID, Title: "Game", FileName: "Game (USA).nes", FilePath: "nes/Game2 (USA).nes", GroupKey: "game2", Region: "USA"},
+		{ConsoleID: nes.ID, Title: "Game", FileName: "Game (Europe).nes", FilePath: "nes/Game2 (Europe).nes", GroupKey: "game2", Region: "Europe"},
+	}
+	for i := range games {
+		require.NoError(t, database.Create(&games[i]).Error)
+	}
+
+	// Empty region order falls back to default (USA first)
+	require.NoError(t, GroupAndElectPrimariesWithRegions(database, nil))
+
+	var usaGame db.Game
+	require.NoError(t, database.Where("file_path = ?", "nes/Game2 (USA).nes").First(&usaGame).Error)
+	assert.True(t, usaGame.IsPrimary, "USA should be primary with nil region order (default)")
+}
+
 func TestGroupAndElectPrimaries(t *testing.T) {
 	database := setupTestDB(t)
 

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -606,10 +606,20 @@ func (s *Scanner) Scan(onProgress ProgressFunc, consoleFilter ...string) (*ScanR
 					slog.Info("removing missing game", "title", g.Title, "path", g.FilePath)
 					result.RemovedGames++
 				}
+				// If this game was the primary variant for its group,
+				// re-elect a new primary after deletion.
+				wasPrimary := g.IsPrimary
+				removedConsoleID := g.ConsoleID
+				removedGroupKey := g.GroupKey
 				// Hard-delete game and associated discs so the unique index
 				// is freed and future scans can recreate them cleanly.
 				s.DB.Unscoped().Where("game_id = ?", g.ID).Delete(&db.GameDisc{})
 				s.DB.Unscoped().Delete(&g)
+				if wasPrimary && removedGroupKey != "" {
+					if err := ReElectPrimaryForGroup(s.DB, removedConsoleID, removedGroupKey); err != nil {
+						slog.Warn("failed to re-elect primary after game removal", "groupKey", removedGroupKey, "error", err)
+					}
+				}
 			}
 		}
 		if i%100 == 0 {
@@ -625,6 +635,12 @@ func (s *Scanner) Scan(onProgress ProgressFunc, consoleFilter ...string) (*ScanR
 	var count int64
 	s.DB.Model(&db.Game{}).Count(&count)
 	result.TotalGames = int(count)
+
+	// Group variants and elect primary representatives
+	report(ScanProgress{Phase: "grouping", Message: "Grouping variants and electing primaries..."})
+	if err := GroupAndElectPrimaries(s.DB); err != nil {
+		slog.Warn("failed to group and elect primaries", "error", err)
+	}
 
 	slog.Info("scan complete",
 		"new", result.NewGames,
@@ -864,14 +880,21 @@ func (s *Scanner) scanMultiDisc(dir string, consoleMap map[string]*db.Console, f
 			}
 		} else {
 			// Create new game with disc record
-			title := GameTitle(filepath.Base(cuePath))
+			cueBase := filepath.Base(cuePath)
+			title := GameTitle(cueBase)
+			meta := ParseFilenameMetadata(cueBase)
 			game := db.Game{
-				ConsoleID: console.ID,
-				Title:     title,
-				FileName:  filepath.Base(cuePath),
-				FilePath:  relPath,
-				FileSize:  totalSize,
-				DiscCount: 1,
+				ConsoleID:    console.ID,
+				Title:        title,
+				FileName:     cueBase,
+				FilePath:     relPath,
+				FileSize:     totalSize,
+				DiscCount:    1,
+				Region:       meta.Region,
+				Revision:     meta.Revision,
+				Tags:         meta.Tags,
+				IsPreRelease: meta.IsPreRelease,
+				GroupKey:     meta.GroupKey,
 			}
 			if err := s.DB.Create(&game).Error; err != nil {
 				slog.Warn("failed to create .cue game", "path", cuePath, "error", err)
@@ -1013,14 +1036,20 @@ func (s *Scanner) createMultiDiscGame(m3uPath string, discFiles []string, consol
 	// Extract title from the .m3u filename
 	m3uName := filepath.Base(m3uPath)
 	title := GameTitle(m3uName)
+	meta := ParseFilenameMetadata(m3uName)
 
 	game := db.Game{
-		ConsoleID: console.ID,
-		Title:     title,
-		FileName:  m3uName,
-		FilePath:  m3uRelPath,
-		FileSize:  totalSize,
-		DiscCount: len(discFiles),
+		ConsoleID:    console.ID,
+		Title:        title,
+		FileName:     m3uName,
+		FilePath:     m3uRelPath,
+		FileSize:     totalSize,
+		DiscCount:    len(discFiles),
+		Region:       meta.Region,
+		Revision:     meta.Revision,
+		Tags:         meta.Tags,
+		IsPreRelease: meta.IsPreRelease,
+		GroupKey:     meta.GroupKey,
 	}
 	if err := s.DB.Create(&game).Error; err != nil {
 		slog.Warn("failed to create multi-disc game", "path", m3uPath, "error", err)
@@ -1123,12 +1152,18 @@ func (s *Scanner) scanDirectory(dir string, consoleMap map[string]*db.Console, f
 
 		// Create new game entry
 		title := GameTitle(info.Name())
+		meta := ParseFilenameMetadata(info.Name())
 		game := db.Game{
-			ConsoleID: console.ID,
-			Title:     title,
-			FileName:  info.Name(),
-			FilePath:  relPath,
-			FileSize:  info.Size(),
+			ConsoleID:    console.ID,
+			Title:        title,
+			FileName:     info.Name(),
+			FilePath:     relPath,
+			FileSize:     info.Size(),
+			Region:       meta.Region,
+			Revision:     meta.Revision,
+			Tags:         meta.Tags,
+			IsPreRelease: meta.IsPreRelease,
+			GroupKey:     meta.GroupKey,
 		}
 		if err := s.DB.Create(&game).Error; err != nil {
 			slog.Warn("failed to create game entry", "path", relPath, "error", err)

--- a/server/internal/scraper/scraper_batch.go
+++ b/server/internal/scraper/scraper_batch.go
@@ -217,14 +217,67 @@ func (s *Scraper) ScrapeAll(mode string, consoleID uint, onProgress func(ScrapeP
 	successes := 0
 	failures := 0
 	verified := 0
+	// Track groups we've already scraped a primary for, so we can propagate
+	// metadata to other variants in the same group instead of re-scraping.
+	scrapedGroups := make(map[string]uint) // "consoleID:groupKey" -> scraped game ID
 	for i := range games {
-		if err := s.ScrapeGame(&games[i]); err != nil {
-			slog.Warn("failed to scrape game", "game", games[i].Title, "error", err)
+		game := &games[i]
+
+		// Smart scraping: if this game belongs to a variant group, try to
+		// propagate metadata from an already-scraped sibling instead of
+		// hitting external APIs again.
+		if game.GroupKey != "" && mode != "all" {
+			groupID := fmt.Sprintf("%d:%s", game.ConsoleID, game.GroupKey)
+
+			// Check if we've already scraped a game in this group during this run
+			if _, done := scrapedGroups[groupID]; done {
+				if s.propagateGroupMetadata(game) {
+					successes++
+					if onProgress != nil {
+						onProgress(ScrapeProgress{
+							Current:   i + 1,
+							Total:     total,
+							GameName:  game.Title,
+							Successes: successes,
+							Failures:  failures,
+							Verified:  verified,
+						})
+					}
+					continue
+				}
+			}
+
+			// Check if any sibling in the DB already has metadata
+			if s.propagateGroupMetadata(game) {
+				scrapedGroups[groupID] = game.ID
+				successes++
+				if onProgress != nil {
+					onProgress(ScrapeProgress{
+						Current:   i + 1,
+						Total:     total,
+						GameName:  game.Title,
+						Successes: successes,
+						Failures:  failures,
+						Verified:  verified,
+					})
+				}
+				continue
+			}
+		}
+
+		if err := s.ScrapeGame(game); err != nil {
+			slog.Warn("failed to scrape game", "game", game.Title, "error", err)
 			failures++
 		} else {
 			successes++
-			if games[i].VerificationStatus == "verified" {
+			if game.VerificationStatus == "verified" {
 				verified++
+			}
+			// After scraping, propagate to other unscraped variants in the group
+			if game.GroupKey != "" {
+				groupID := fmt.Sprintf("%d:%s", game.ConsoleID, game.GroupKey)
+				scrapedGroups[groupID] = game.ID
+				s.propagateToGroup(game)
 			}
 		}
 
@@ -232,7 +285,7 @@ func (s *Scraper) ScrapeAll(mode string, consoleID uint, onProgress func(ScrapeP
 			onProgress(ScrapeProgress{
 				Current:   i + 1,
 				Total:     total,
-				GameName:  games[i].Title,
+				GameName:  game.Title,
 				Successes: successes,
 				Failures:  failures,
 				Verified:  verified,
@@ -241,4 +294,97 @@ func (s *Scraper) ScrapeAll(mode string, consoleID uint, onProgress func(ScrapeP
 	}
 
 	return successes, total, nil
+}
+
+// propagateGroupMetadata copies metadata from a scraped sibling in the same
+// variant group to the given game. Returns true if metadata was propagated.
+func (s *Scraper) propagateGroupMetadata(game *db.Game) bool {
+	if game.GroupKey == "" {
+		return false
+	}
+
+	// Find a sibling with metadata (has Description or CoverURL and has been scraped)
+	var sibling db.Game
+	err := s.DB.Where("console_id = ? AND group_key = ? AND id != ? AND scraper_id != '' AND scraper_id IS NOT NULL AND (description != '' OR cover_url != '')",
+		game.ConsoleID, game.GroupKey, game.ID).
+		First(&sibling).Error
+	if err != nil {
+		return false
+	}
+
+	// Copy metadata fields that are shared across variants (not file-specific)
+	if game.Description == "" && sibling.Description != "" {
+		game.Description = sibling.Description
+	}
+	if game.CoverURL == "" && sibling.CoverURL != "" {
+		game.CoverURL = sibling.CoverURL
+	}
+	if game.IGDBCoverURL == "" && sibling.IGDBCoverURL != "" {
+		game.IGDBCoverURL = sibling.IGDBCoverURL
+	}
+	if game.LibRetroCoverURL == "" && sibling.LibRetroCoverURL != "" {
+		game.LibRetroCoverURL = sibling.LibRetroCoverURL
+	}
+	if game.Developer == "" && sibling.Developer != "" {
+		game.Developer = sibling.Developer
+	}
+	if game.Publisher == "" && sibling.Publisher != "" {
+		game.Publisher = sibling.Publisher
+	}
+	if game.Genre == "" && sibling.Genre != "" {
+		game.Genre = sibling.Genre
+	}
+	if game.GameModes == "" && sibling.GameModes != "" {
+		game.GameModes = sibling.GameModes
+	}
+	if game.Rating == 0 && sibling.Rating != 0 {
+		game.Rating = sibling.Rating
+	}
+	if game.ReleaseDate == "" && sibling.ReleaseDate != "" {
+		game.ReleaseDate = sibling.ReleaseDate
+	}
+	if game.Players == 0 && sibling.Players != 0 {
+		game.Players = sibling.Players
+	}
+	if game.Storyline == "" && sibling.Storyline != "" {
+		game.Storyline = sibling.Storyline
+	}
+	if game.TotalRating == 0 && sibling.TotalRating != 0 {
+		game.TotalRating = sibling.TotalRating
+	}
+	if game.TotalRatingCount == 0 && sibling.TotalRatingCount != 0 {
+		game.TotalRatingCount = sibling.TotalRatingCount
+	}
+
+	// Mark as propagated (use the sibling's scraper ID with a propagated suffix)
+	if game.ScraperID == "" {
+		game.ScraperID = sibling.ScraperID + ":propagated"
+	}
+
+	game.ScrapeAttempts++
+
+	if err := s.DB.Save(game).Error; err != nil {
+		slog.Warn("failed to save propagated metadata", "game", game.Title, "error", err)
+		return false
+	}
+
+	slog.Info("propagated metadata from group sibling", "game", game.Title, "from", sibling.Title)
+	return true
+}
+
+// propagateToGroup copies metadata from a freshly scraped game to all unscraped
+// siblings in the same variant group.
+func (s *Scraper) propagateToGroup(source *db.Game) {
+	if source.GroupKey == "" {
+		return
+	}
+
+	var siblings []db.Game
+	s.DB.Where("console_id = ? AND group_key = ? AND id != ? AND (scraper_id = '' OR scraper_id IS NULL)",
+		source.ConsoleID, source.GroupKey, source.ID).
+		Find(&siblings)
+
+	for i := range siblings {
+		s.propagateGroupMetadata(&siblings[i])
+	}
 }

--- a/web/src/components/__tests__/alphabet-bar.test.tsx
+++ b/web/src/components/__tests__/alphabet-bar.test.tsx
@@ -1,0 +1,62 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { AlphabetBar } from "../alphabet-bar";
+
+describe("AlphabetBar", () => {
+  it("renders all 27 buttons (# + A-Z)", () => {
+    render(<AlphabetBar onLetterClick={vi.fn()} />);
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(27);
+    expect(buttons[0]).toHaveTextContent("#");
+    expect(buttons[1]).toHaveTextContent("A");
+    expect(buttons[26]).toHaveTextContent("Z");
+  });
+
+  it("calls onLetterClick with the letter when clicked", () => {
+    const onClick = vi.fn();
+    render(<AlphabetBar onLetterClick={onClick} />);
+
+    fireEvent.click(screen.getByLabelText("Jump to M"));
+    expect(onClick).toHaveBeenCalledWith("M");
+  });
+
+  it("calls onLetterClick with undefined when active letter is clicked again", () => {
+    const onClick = vi.fn();
+    render(<AlphabetBar activeLetter="M" onLetterClick={onClick} />);
+
+    fireEvent.click(screen.getByLabelText("Jump to M"));
+    expect(onClick).toHaveBeenCalledWith(undefined);
+  });
+
+  it("highlights the active letter", () => {
+    render(<AlphabetBar activeLetter="A" onLetterClick={vi.fn()} />);
+
+    const aButton = screen.getByLabelText("Jump to A");
+    expect(aButton).toHaveAttribute("aria-pressed", "true");
+
+    const bButton = screen.getByLabelText("Jump to B");
+    expect(bButton).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("renders # button with numbers label", () => {
+    render(<AlphabetBar onLetterClick={vi.fn()} />);
+
+    const hashButton = screen.getByLabelText("Jump to numbers");
+    expect(hashButton).toBeInTheDocument();
+    expect(hashButton).toHaveTextContent("#");
+  });
+
+  it("supports vertical orientation", () => {
+    render(<AlphabetBar orientation="vertical" onLetterClick={vi.fn()} />);
+
+    const nav = screen.getByRole("navigation");
+    expect(nav.className).toContain("flex-col");
+  });
+
+  it("defaults to horizontal orientation", () => {
+    render(<AlphabetBar onLetterClick={vi.fn()} />);
+
+    const nav = screen.getByRole("navigation");
+    expect(nav.className).toContain("flex-wrap");
+  });
+});

--- a/web/src/components/alphabet-bar.tsx
+++ b/web/src/components/alphabet-bar.tsx
@@ -1,0 +1,81 @@
+import { cn } from "@/lib/cn";
+
+const LETTERS = [
+  "#",
+  "A",
+  "B",
+  "C",
+  "D",
+  "E",
+  "F",
+  "G",
+  "H",
+  "I",
+  "J",
+  "K",
+  "L",
+  "M",
+  "N",
+  "O",
+  "P",
+  "Q",
+  "R",
+  "S",
+  "T",
+  "U",
+  "V",
+  "W",
+  "X",
+  "Y",
+  "Z",
+];
+
+interface AlphabetBarProps {
+  activeLetter?: string;
+  onLetterClick: (letter: string | undefined) => void;
+  orientation?: "vertical" | "horizontal";
+}
+
+export function AlphabetBar({
+  activeLetter,
+  onLetterClick,
+  orientation = "horizontal",
+}: AlphabetBarProps) {
+  const isVertical = orientation === "vertical";
+
+  return (
+    <nav
+      aria-label="Alphabet quick-jump"
+      className={cn(
+        "flex gap-0.5",
+        isVertical
+          ? "flex-col items-center"
+          : "flex-wrap items-center justify-center",
+      )}
+    >
+      {LETTERS.map((letter) => {
+        const isActive = activeLetter === letter;
+        return (
+          <button
+            key={letter}
+            type="button"
+            onClick={() => onLetterClick(isActive ? undefined : letter)}
+            className={cn(
+              "flex items-center justify-center text-xs font-medium transition-colors",
+              isVertical
+                ? "h-6 w-6 rounded"
+                : "h-7 min-w-[1.75rem] px-1 rounded-md",
+              isActive
+                ? "bg-brand-500 text-white"
+                : "text-surface-400 hover:text-surface-100 hover:bg-surface-800",
+            )}
+            aria-label={`Jump to ${letter === "#" ? "numbers" : letter}`}
+            aria-pressed={isActive}
+          >
+            {letter}
+          </button>
+        );
+      })}
+    </nav>
+  );
+}

--- a/web/src/components/game-card.tsx
+++ b/web/src/components/game-card.tsx
@@ -106,6 +106,15 @@ export function GameCard({
             <Badge variant="brand">{game.consoleName}</Badge>
           </div>
         )}
+
+        {/* Variant count badge */}
+        {game.variantCount != null && game.variantCount > 1 && (
+          <div className="absolute bottom-2.5 right-2.5 z-10">
+            <span className="inline-flex items-center rounded-full bg-surface-500/80 backdrop-blur-sm px-2 py-0.5 text-[10px] font-medium text-white">
+              {game.variantCount - 1} {game.variantCount === 2 ? "version" : "versions"}
+            </span>
+          </div>
+        )}
       </div>
 
       <div className="px-1 space-y-1">

--- a/web/src/components/pagination.tsx
+++ b/web/src/components/pagination.tsx
@@ -56,7 +56,7 @@ export function Pagination({
   const pages = getPageNumbers(currentPage, pageCount);
 
   return (
-    <div className="flex justify-center items-center gap-1.5 pt-4" data-testid="pagination">
+    <nav className="flex justify-center items-center gap-1.5 pt-4" aria-label="Pagination" data-testid="pagination">
       {/* Previous button */}
       <button
         onClick={() => onPageChange(currentPage - 1)}
@@ -116,6 +116,6 @@ export function Pagination({
       >
         <ChevronRight className="h-4 w-4" />
       </button>
-    </div>
+    </nav>
   );
 }

--- a/web/src/components/pagination.tsx
+++ b/web/src/components/pagination.tsx
@@ -1,3 +1,4 @@
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 interface PaginationProps {
@@ -5,6 +6,42 @@ interface PaginationProps {
   pageSize: number;
   currentPage: number;
   onPageChange: (page: number) => void;
+}
+
+function getPageNumbers(currentPage: number, pageCount: number): (number | "ellipsis")[] {
+  // Show all pages when total is small
+  if (pageCount <= 7) {
+    return Array.from({ length: pageCount }, (_, i) => i + 1);
+  }
+
+  const pages: (number | "ellipsis")[] = [];
+
+  // Always include first page
+  pages.push(1);
+
+  // Calculate window around current page
+  const windowStart = Math.max(2, currentPage - 1);
+  const windowEnd = Math.min(pageCount - 1, currentPage + 1);
+
+  // Add left ellipsis if needed
+  if (windowStart > 2) {
+    pages.push("ellipsis");
+  }
+
+  // Add pages in the window
+  for (let i = windowStart; i <= windowEnd; i++) {
+    pages.push(i);
+  }
+
+  // Add right ellipsis if needed
+  if (windowEnd < pageCount - 1) {
+    pages.push("ellipsis");
+  }
+
+  // Always include last page
+  pages.push(pageCount);
+
+  return pages;
 }
 
 export function Pagination({
@@ -16,23 +53,69 @@ export function Pagination({
   if (total <= pageSize) return null;
 
   const pageCount = Math.ceil(total / pageSize);
+  const pages = getPageNumbers(currentPage, pageCount);
 
   return (
-    <div className="flex justify-center gap-2 pt-4">
-      {Array.from({ length: pageCount }, (_, i) => (
-        <button
-          key={i}
-          onClick={() => onPageChange(i + 1)}
-          className={cn(
-            "h-9 w-9 rounded-lg text-sm font-medium transition-colors",
-            currentPage === i + 1
-              ? "bg-brand-600 text-white"
-              : "bg-surface-900 text-surface-400 hover:text-surface-100 hover:bg-surface-800",
-          )}
-        >
-          {i + 1}
-        </button>
-      ))}
+    <div className="flex justify-center items-center gap-1.5 pt-4" data-testid="pagination">
+      {/* Previous button */}
+      <button
+        onClick={() => onPageChange(currentPage - 1)}
+        disabled={currentPage <= 1}
+        className={cn(
+          "h-9 w-9 rounded-lg text-sm font-medium transition-colors flex items-center justify-center",
+          currentPage <= 1
+            ? "text-surface-600 cursor-not-allowed"
+            : "bg-surface-900 text-surface-400 hover:text-surface-100 hover:bg-surface-800",
+        )}
+        aria-label="Previous page"
+        data-testid="pagination-prev"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
+
+      {/* Page buttons */}
+      {pages.map((page, index) =>
+        page === "ellipsis" ? (
+          <span
+            key={`ellipsis-${index}`}
+            className="h-9 w-9 flex items-center justify-center text-sm text-surface-500"
+            data-testid="pagination-ellipsis"
+          >
+            ...
+          </span>
+        ) : (
+          <button
+            key={page}
+            onClick={() => onPageChange(page)}
+            className={cn(
+              "h-9 w-9 rounded-lg text-sm font-medium transition-colors",
+              currentPage === page
+                ? "bg-brand-600 text-white"
+                : "bg-surface-900 text-surface-400 hover:text-surface-100 hover:bg-surface-800",
+            )}
+            aria-current={currentPage === page ? "page" : undefined}
+            data-testid={`pagination-page-${page}`}
+          >
+            {page}
+          </button>
+        ),
+      )}
+
+      {/* Next button */}
+      <button
+        onClick={() => onPageChange(currentPage + 1)}
+        disabled={currentPage >= pageCount}
+        className={cn(
+          "h-9 w-9 rounded-lg text-sm font-medium transition-colors flex items-center justify-center",
+          currentPage >= pageCount
+            ? "text-surface-600 cursor-not-allowed"
+            : "bg-surface-900 text-surface-400 hover:text-surface-100 hover:bg-surface-800",
+        )}
+        aria-label="Next page"
+        data-testid="pagination-next"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
     </div>
   );
 }

--- a/web/src/features/games/components/active-filter-pills.tsx
+++ b/web/src/features/games/components/active-filter-pills.tsx
@@ -1,0 +1,232 @@
+import { X } from "lucide-react";
+import type { GameFilters, Console } from "@/types/api";
+
+interface FilterPill {
+  key: string;
+  label: string;
+  onDismiss: () => void;
+}
+
+interface ActiveFilterPillsProps {
+  filters: GameFilters;
+  onFiltersChange: (updater: (prev: GameFilters) => GameFilters) => void;
+  consoles?: Console[];
+}
+
+function buildPills(
+  filters: GameFilters,
+  onFiltersChange: ActiveFilterPillsProps["onFiltersChange"],
+  consoles?: Console[],
+): FilterPill[] {
+  const pills: FilterPill[] = [];
+
+  // Console pills
+  for (const c of filters.consoles ?? []) {
+    const consoleName = consoles?.find((con) => con.abbreviation === c)?.name ?? c;
+    pills.push({
+      key: `console-${c}`,
+      label: consoleName,
+      onDismiss: () =>
+        onFiltersChange((f) => ({
+          ...f,
+          consoles: f.consoles?.filter((v) => v !== c),
+          page: 1,
+        })),
+    });
+  }
+
+  // Region pills
+  for (const r of filters.regions ?? []) {
+    pills.push({
+      key: `region-${r}`,
+      label: `Region: ${r}`,
+      onDismiss: () =>
+        onFiltersChange((f) => ({
+          ...f,
+          regions: f.regions?.filter((v) => v !== r),
+          page: 1,
+        })),
+    });
+  }
+
+  // Genre pills
+  for (const g of filters.genres ?? []) {
+    pills.push({
+      key: `genre-${g}`,
+      label: g,
+      onDismiss: () =>
+        onFiltersChange((f) => ({
+          ...f,
+          genres: f.genres?.filter((v) => v !== g),
+          page: 1,
+        })),
+    });
+  }
+
+  // Theme pills
+  for (const t of filters.themes ?? []) {
+    pills.push({
+      key: `theme-${t}`,
+      label: `Theme: ${t}`,
+      onDismiss: () =>
+        onFiltersChange((f) => ({
+          ...f,
+          themes: f.themes?.filter((v) => v !== t),
+          page: 1,
+        })),
+    });
+  }
+
+  // Keyword pills
+  for (const k of filters.keywords ?? []) {
+    pills.push({
+      key: `keyword-${k}`,
+      label: `Keyword: ${k}`,
+      onDismiss: () =>
+        onFiltersChange((f) => ({
+          ...f,
+          keywords: f.keywords?.filter((v) => v !== k),
+          page: 1,
+        })),
+    });
+  }
+
+  // Developer
+  if (filters.developer) {
+    pills.push({
+      key: "developer",
+      label: `Dev: ${filters.developer}`,
+      onDismiss: () =>
+        onFiltersChange((f) => ({ ...f, developer: undefined, page: 1 })),
+    });
+  }
+
+  // Publisher
+  if (filters.publisher) {
+    pills.push({
+      key: "publisher",
+      label: `Pub: ${filters.publisher}`,
+      onDismiss: () =>
+        onFiltersChange((f) => ({ ...f, publisher: undefined, page: 1 })),
+    });
+  }
+
+  // Year range
+  if (filters.yearMin != null || filters.yearMax != null) {
+    const min = filters.yearMin ?? "...";
+    const max = filters.yearMax ?? "...";
+    pills.push({
+      key: "year",
+      label: `Year: ${min}-${max}`,
+      onDismiss: () =>
+        onFiltersChange((f) => ({
+          ...f,
+          yearMin: undefined,
+          yearMax: undefined,
+          page: 1,
+        })),
+    });
+  }
+
+  // Rating range
+  if (filters.ratingMin != null || filters.ratingMax != null) {
+    const min = filters.ratingMin ?? 0;
+    const max = filters.ratingMax ?? 100;
+    pills.push({
+      key: "rating",
+      label: `Rating: ${min}-${max}`,
+      onDismiss: () =>
+        onFiltersChange((f) => ({
+          ...f,
+          ratingMin: undefined,
+          ratingMax: undefined,
+          page: 1,
+        })),
+    });
+  }
+
+  // Play status
+  if (filters.playStatus) {
+    pills.push({
+      key: "playStatus",
+      label: `Status: ${filters.playStatus}`,
+      onDismiss: () =>
+        onFiltersChange((f) => ({ ...f, playStatus: undefined, page: 1 })),
+    });
+  }
+
+  // Show betas (only when hidePreRelease is explicitly false, since default is hidden)
+  if (filters.hidePreRelease === false) {
+    pills.push({
+      key: "hidePreRelease",
+      label: "Showing betas",
+      onDismiss: () =>
+        onFiltersChange((f) => ({
+          ...f,
+          hidePreRelease: undefined,
+          page: 1,
+        })),
+    });
+  }
+
+  // Showing all variants (when grouped is explicitly false)
+  if (filters.grouped === false) {
+    pills.push({
+      key: "grouped",
+      label: "All variants",
+      onDismiss: () =>
+        onFiltersChange((f) => ({
+          ...f,
+          grouped: undefined,
+          page: 1,
+        })),
+    });
+  }
+
+  return pills;
+}
+
+export function ActiveFilterPills({
+  filters,
+  onFiltersChange,
+  consoles,
+}: ActiveFilterPillsProps) {
+  const pills = buildPills(filters, onFiltersChange, consoles);
+
+  if (pills.length === 0) return null;
+
+  const handleClearAll = () => {
+    onFiltersChange((prev) => ({
+      search: prev.search,
+      sortBy: prev.sortBy,
+      sortOrder: prev.sortOrder,
+      page: 1,
+      pageSize: prev.pageSize,
+    }));
+  };
+
+  return (
+    <div className="flex flex-wrap items-center gap-2" data-testid="active-filter-pills">
+      {pills.map((pill) => (
+        <button
+          key={pill.key}
+          onClick={pill.onDismiss}
+          className="inline-flex items-center gap-1.5 rounded-full bg-brand-500/15 text-brand-400 border border-brand-500/30 px-2.5 py-1 text-xs font-medium hover:bg-brand-500/25 transition-colors"
+          data-testid={`filter-pill-${pill.key}`}
+        >
+          {pill.label}
+          <X className="h-3 w-3" />
+        </button>
+      ))}
+      {pills.length >= 2 && (
+        <button
+          onClick={handleClearAll}
+          className="text-xs text-surface-400 hover:text-surface-200 underline underline-offset-2"
+          data-testid="clear-all-filters"
+        >
+          Clear all
+        </button>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/games/components/active-filter-pills.tsx
+++ b/web/src/features/games/components/active-filter-pills.tsx
@@ -213,6 +213,7 @@ export function ActiveFilterPills({
           onClick={pill.onDismiss}
           className="inline-flex items-center gap-1.5 rounded-full bg-brand-500/15 text-brand-400 border border-brand-500/30 px-2.5 py-1 text-xs font-medium hover:bg-brand-500/25 transition-colors"
           data-testid={`filter-pill-${pill.key}`}
+          aria-label={`Remove filter: ${pill.label}`}
         >
           {pill.label}
           <X className="h-3 w-3" />

--- a/web/src/features/games/components/advanced-filter-panel.tsx
+++ b/web/src/features/games/components/advanced-filter-panel.tsx
@@ -221,6 +221,12 @@ export function AdvancedFilterPanel({
     label: c.name,
   }));
 
+  const regionOptions = [
+    "USA", "Europe", "Japan", "World", "Korea", "Brazil",
+    "France", "Germany", "Spain", "Italy", "Australia",
+    "Canada", "China", "Asia",
+  ].map((r) => ({ value: r, label: r }));
+
   const genreOptions = [
     "Action", "Adventure", "RPG", "Platformer", "Puzzle",
     "Racing", "Shooter", "Sports", "Strategy", "Fighting",
@@ -252,6 +258,7 @@ export function AdvancedFilterPanel({
   const filtersToRecord = (f: GameFilters): Record<string, string | number> => {
     const rec: Record<string, string | number> = {};
     if (f.consoles?.length) rec.consoles = f.consoles.join(",");
+    if (f.regions?.length) rec.regions = f.regions.join(",");
     if (f.genres?.length) rec.genres = f.genres.join(",");
     if (f.themes?.length) rec.themes = f.themes.join(",");
     if (f.keywords?.length) rec.keywords = f.keywords.join(",");
@@ -333,6 +340,17 @@ export function AdvancedFilterPanel({
               onFiltersChange((f) => ({ ...f, consoles, page: 1 }))
             }
             testId="console-filter"
+          />
+
+          {/* Region picker */}
+          <ChipPicker
+            label="Regions"
+            options={regionOptions}
+            selected={filters.regions ?? []}
+            onChange={(regions) =>
+              onFiltersChange((f) => ({ ...f, regions, page: 1 }))
+            }
+            testId="region-filter"
           />
 
           {/* Genre picker */}
@@ -548,6 +566,7 @@ export function AdvancedFilterPanel({
 function countActiveFilters(filters: GameFilters): number {
   let count = 0;
   if (filters.consoles?.length) count++;
+  if (filters.regions?.length) count++;
   if (filters.genres?.length) count++;
   if (filters.themes?.length) count++;
   if (filters.keywords?.length) count++;
@@ -570,6 +589,7 @@ export function savedSearchToFilters(
   return {
     ...base,
     consoles: record.consoles ? String(record.consoles).split(",") : undefined,
+    regions: record.regions ? String(record.regions).split(",") : undefined,
     genres: record.genres ? String(record.genres).split(",") : undefined,
     themes: record.themes ? String(record.themes).split(",") : undefined,
     keywords: record.keywords ? String(record.keywords).split(",") : undefined,

--- a/web/src/features/games/components/best-versions-button.tsx
+++ b/web/src/features/games/components/best-versions-button.tsx
@@ -48,6 +48,8 @@ export function BestVersionsButton({
           : "bg-surface-900 border-surface-700 text-surface-300 hover:text-surface-100 hover:border-surface-600",
       )}
       data-testid="best-versions-button"
+      aria-pressed={isActive}
+      aria-label="Best versions only"
     >
       <Sparkles className="h-4 w-4" />
       Best versions

--- a/web/src/features/games/components/best-versions-button.tsx
+++ b/web/src/features/games/components/best-versions-button.tsx
@@ -1,0 +1,56 @@
+import { Sparkles } from "lucide-react";
+import { cn } from "@/lib/cn";
+import type { GameFilters } from "@/types/api";
+
+interface BestVersionsButtonProps {
+  filters: GameFilters;
+  onFiltersChange: (updater: (prev: GameFilters) => GameFilters) => void;
+}
+
+function isBestVersionsActive(filters: GameFilters): boolean {
+  // Active when grouped is default (true/undefined) AND hidePreRelease is default (true/undefined)
+  return filters.grouped !== false && filters.hidePreRelease !== false;
+}
+
+export function BestVersionsButton({
+  filters,
+  onFiltersChange,
+}: BestVersionsButtonProps) {
+  const isActive = isBestVersionsActive(filters);
+
+  const handleClick = () => {
+    if (isActive) {
+      // Turn off: show all variants and betas
+      onFiltersChange((f) => ({
+        ...f,
+        grouped: false,
+        hidePreRelease: false,
+        page: 1,
+      }));
+    } else {
+      // Turn on: grouped and hide pre-release (defaults)
+      onFiltersChange((f) => ({
+        ...f,
+        grouped: undefined,
+        hidePreRelease: undefined,
+        page: 1,
+      }));
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className={cn(
+        "inline-flex items-center gap-1.5 rounded-lg border px-3 py-2.5 text-sm font-medium transition-all",
+        isActive
+          ? "bg-brand-600/20 border-brand-500 text-brand-400"
+          : "bg-surface-900 border-surface-700 text-surface-300 hover:text-surface-100 hover:border-surface-600",
+      )}
+      data-testid="best-versions-button"
+    >
+      <Sparkles className="h-4 w-4" />
+      Best versions
+    </button>
+  );
+}

--- a/web/src/features/games/components/game-list-row.tsx
+++ b/web/src/features/games/components/game-list-row.tsx
@@ -37,6 +37,11 @@ export function GameListRow({ game }: GameListRowProps) {
         )}
       </div>
       {consoleName && <Badge>{consoleName}</Badge>}
+      {game.variantCount != null && game.variantCount > 1 && (
+        <span className="text-xs text-surface-400 whitespace-nowrap">
+          +{game.variantCount - 1} {game.variantCount === 2 ? "version" : "versions"}
+        </span>
+      )}
       <span className="text-xs text-surface-500 w-16 text-right">
         {formatFileSize(game.fileSize)}
       </span>

--- a/web/src/features/games/components/games-filter-bar.tsx
+++ b/web/src/features/games/components/games-filter-bar.tsx
@@ -1,5 +1,5 @@
 import { Grid3X3, List, ArrowUpDown } from "lucide-react";
-import { SearchInput, Select } from "@/components/ui";
+import { SearchInput, Select, Switch } from "@/components/ui";
 import { cn } from "@/lib/cn";
 import type { GameFilters, Console } from "@/types/api";
 
@@ -13,6 +13,7 @@ interface GamesFilterBarProps {
   viewMode: ViewMode;
   onViewModeChange: (mode: ViewMode) => void;
   consoles: Console[] | undefined;
+  showHideBetas?: boolean;
 }
 
 export function GamesFilterBar({
@@ -23,6 +24,7 @@ export function GamesFilterBar({
   viewMode,
   onViewModeChange,
   consoles,
+  showHideBetas = false,
 }: GamesFilterBarProps) {
   const consoleOptions = [
     { value: "", label: "All Consoles" },
@@ -59,6 +61,22 @@ export function GamesFilterBar({
         }
         className="w-44"
       />
+
+      {showHideBetas && (
+        <label className="flex items-center gap-2 text-sm text-surface-300 whitespace-nowrap" data-testid="hide-betas-toggle">
+          <Switch
+            checked={filters.hidePreRelease !== false}
+            onChange={(checked) =>
+              onFiltersChange((f) => ({
+                ...f,
+                hidePreRelease: checked ? undefined : false,
+                page: 1,
+              }))
+            }
+          />
+          Hide betas
+        </label>
+      )}
 
       <Select
         options={sortOptions}

--- a/web/src/hooks/use-games.ts
+++ b/web/src/hooks/use-games.ts
@@ -13,6 +13,7 @@ export function useGames(filters?: GameFilters) {
   if (filters?.themes?.length) params.set("themes", filters.themes.join(","));
   if (filters?.keywords?.length) params.set("keywords", filters.keywords.join(","));
   if (filters?.perspectives?.length) params.set("perspectives", filters.perspectives.join(","));
+  if (filters?.regions?.length) params.set("region", filters.regions.join(","));
   // Text filters
   if (filters?.developer) params.set("developer", filters.developer);
   if (filters?.publisher) params.set("publisher", filters.publisher);
@@ -23,6 +24,9 @@ export function useGames(filters?: GameFilters) {
   if (filters?.ratingMax != null) params.set("ratingMax", String(filters.ratingMax));
   // Play status
   if (filters?.playStatus) params.set("playStatus", filters.playStatus);
+  // Variant grouping / pre-release
+  if (filters?.grouped === false) params.set("grouped", "false");
+  if (filters?.hidePreRelease === false) params.set("hidePreRelease", "false");
   if (filters?.sortBy) params.set("sortBy", filters.sortBy);
   if (filters?.sortOrder) params.set("sortOrder", filters.sortOrder);
   if (filters?.page) params.set("page", String(filters.page));

--- a/web/src/hooks/use-games.ts
+++ b/web/src/hooks/use-games.ts
@@ -27,6 +27,8 @@ export function useGames(filters?: GameFilters) {
   // Variant grouping / pre-release
   if (filters?.grouped === false) params.set("grouped", "false");
   if (filters?.hidePreRelease === false) params.set("hidePreRelease", "false");
+  // Alphabet quick-jump
+  if (filters?.letter) params.set("letter", filters.letter);
   if (filters?.sortBy) params.set("sortBy", filters.sortBy);
   if (filters?.sortOrder) params.set("sortOrder", filters.sortOrder);
   if (filters?.page) params.set("page", String(filters.page));

--- a/web/src/pages/admin/settings-page.test.tsx
+++ b/web/src/pages/admin/settings-page.test.tsx
@@ -300,6 +300,43 @@ describe("AdminSettingsPage - No Game Directories UI", () => {
   });
 });
 
+describe("AdminSettingsPage - Library Defaults", () => {
+  it("renders default region select", () => {
+    renderPage();
+    expect(screen.getByText("Default Region")).toBeInTheDocument();
+  });
+
+  it("renders hide pre-release default toggle", () => {
+    renderPage();
+    expect(screen.getByText("Hide Pre-release by Default")).toBeInTheDocument();
+  });
+
+  it("initializes default region from settings", () => {
+    mockUseServerSettings.mockReturnValue({
+      data: { ...mockSettings, default_region: "Europe" },
+      isLoading: false,
+    });
+    renderPage();
+    const select = screen.getByLabelText("Default Region") as HTMLSelectElement;
+    expect(select.value).toBe("Europe");
+  });
+
+  it("defaults to USA when no default_region setting", () => {
+    renderPage();
+    const select = screen.getByLabelText("Default Region") as HTMLSelectElement;
+    expect(select.value).toBe("USA");
+  });
+
+  it("includes default_region and hide_pre_release_default in save payload", async () => {
+    renderPage();
+    await userEvent.click(screen.getByRole("button", { name: /Save/ }));
+    expect(mockUpdateMutate).toHaveBeenCalledTimes(1);
+    const payload = mockUpdateMutate.mock.calls[0][0] as Record<string, string>;
+    expect(payload).toHaveProperty("default_region", "USA");
+    expect(payload).toHaveProperty("hide_pre_release_default", "true");
+  });
+});
+
 describe("AdminSettingsPage - SteamGridDB env var detection", () => {
   it("shows env-configured message when SteamGridDB is set via env", () => {
     mockUseSteamGridDBStatus.mockReturnValue({

--- a/web/src/pages/admin/settings-page.tsx
+++ b/web/src/pages/admin/settings-page.tsx
@@ -6,6 +6,7 @@ import {
   CardHeader,
   CardContent,
   Input,
+  Select,
   Switch,
 } from "@/components/ui";
 import {
@@ -29,6 +30,8 @@ export function AdminSettingsPage() {
   const [allowRegistration, setAllowRegistration] = useState(true);
   const [scrapeOnScan, setScrapeOnScan] = useState(true);
   const [biosAutoDownload, setBiosAutoDownload] = useState(true);
+  const [defaultRegion, setDefaultRegion] = useState("USA");
+  const [hidePreReleaseDefault, setHidePreReleaseDefault] = useState(true);
   const [igdbClientId, setIgdbClientId] = useState("");
   const [igdbClientSecret, setIgdbClientSecret] = useState("");
   const [steamgriddbApiKey, setSteamgriddbApiKey] = useState("");
@@ -38,6 +41,8 @@ export function AdminSettingsPage() {
       setAllowRegistration(settings["registration_enabled"] !== "false");
       setScrapeOnScan(settings["scrapeOnScan"] !== "false");
       setBiosAutoDownload(settings["bios_auto_download"] !== "false");
+      setDefaultRegion(settings["default_region"] || "USA");
+      setHidePreReleaseDefault(settings["hide_pre_release_default"] !== "false");
       setIgdbClientId(settings["igdb_client_id"] ?? "");
       setIgdbClientSecret(settings["igdb_client_secret"] ?? "");
       setSteamgriddbApiKey(settings["steamgriddb_api_key"] ?? "");
@@ -49,6 +54,8 @@ export function AdminSettingsPage() {
       registration_enabled: String(allowRegistration),
       scrapeOnScan: String(scrapeOnScan),
       bios_auto_download: String(biosAutoDownload),
+      default_region: defaultRegion,
+      hide_pre_release_default: String(hidePreReleaseDefault),
     };
     // Only send IGDB credentials when they're managed via the UI, not env vars
     if (!igdbEnvConfigured) {
@@ -133,6 +140,44 @@ export function AdminSettingsPage() {
             <Switch
               checked={biosAutoDownload}
               onChange={setBiosAutoDownload}
+            />
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <h2 className="text-lg font-semibold text-surface-100">Library Defaults</h2>
+          <p className="text-xs text-surface-500 mt-1">
+            Server-wide defaults for game library display and scraping.
+          </p>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Select
+            id="default-region"
+            label="Default Region"
+            value={defaultRegion}
+            onChange={(e) => setDefaultRegion(e.target.value)}
+            options={[
+              { value: "USA", label: "USA" },
+              { value: "Europe", label: "Europe" },
+              { value: "World", label: "World" },
+              { value: "Japan", label: "Japan" },
+            ]}
+          />
+
+          <div className="flex items-center justify-between">
+            <div>
+              <p className="text-sm font-medium text-surface-200">
+                Hide Pre-release by Default
+              </p>
+              <p className="text-xs text-surface-500">
+                Hide betas, prototypes, and samples in game listings by default
+              </p>
+            </div>
+            <Switch
+              checked={hidePreReleaseDefault}
+              onChange={setHidePreReleaseDefault}
             />
           </div>
         </CardContent>

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -8,6 +8,7 @@ import {
   GameCardSkeleton,
   EmptyState,
   SearchInput,
+  Switch,
 } from "@/components/ui";
 import { ActionsMenu } from "@/components/ui/actions-menu";
 import { useConsoles } from "@/hooks/use-consoles";
@@ -41,6 +42,7 @@ export function ConsoleDetailPage() {
   const [search, setSearch] = useState("");
   const debouncedSearch = useDebouncedValue(search, 300);
   const [page, setPage] = useState(1);
+  const [hideBetas, setHideBetas] = useState(true);
   const { data: biosData } = useBiosStatus();
   const { isAdmin } = useAuth();
   const scanLibrary = useScanLibrary();
@@ -53,6 +55,7 @@ export function ConsoleDetailPage() {
     pageSize: PAGE_SIZE,
     sortBy: "title",
     sortOrder: "asc",
+    hidePreRelease: hideBetas ? undefined : false,
   });
 
   // Find console info from the consoles list
@@ -187,16 +190,28 @@ export function ConsoleDetailPage() {
         />
       )}
 
-      {/* Search */}
-      <SearchInput
-        placeholder={`Search ${consoleName} games...`}
-        value={search}
-        onChange={(e) => {
-          setSearch(e.target.value);
-          setPage(1);
-        }}
-        className="max-w-sm"
-      />
+      {/* Search & filters */}
+      <div className="flex flex-wrap items-center gap-3">
+        <SearchInput
+          placeholder={`Search ${consoleName} games...`}
+          value={search}
+          onChange={(e) => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
+          className="max-w-sm"
+        />
+        <label className="flex items-center gap-2 text-sm text-surface-300 whitespace-nowrap" data-testid="console-hide-betas-toggle">
+          <Switch
+            checked={hideBetas}
+            onChange={(checked) => {
+              setHideBetas(checked);
+              setPage(1);
+            }}
+          />
+          Hide betas
+        </label>
+      </div>
 
       <ConsoleEssentials consoleId={id!} />
       <ConsoleHiddenGems consoleId={id!} />

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -19,6 +19,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { useScanLibrary } from "@/hooks/use-admin";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useToast } from "@/components/ui";
+import { AlphabetBar } from "@/components/alphabet-bar";
 import { BiosWarningBanner } from "@/features/bios/components/bios-warning-banner";
 import {
   ConsoleEssentials,
@@ -43,6 +44,7 @@ export function ConsoleDetailPage() {
   const debouncedSearch = useDebouncedValue(search, 300);
   const [page, setPage] = useState(1);
   const [hideBetas, setHideBetas] = useState(true);
+  const [activeLetter, setActiveLetter] = useState<string | undefined>();
   const { data: biosData } = useBiosStatus();
   const { isAdmin } = useAuth();
   const scanLibrary = useScanLibrary();
@@ -56,6 +58,7 @@ export function ConsoleDetailPage() {
     sortBy: "title",
     sortOrder: "asc",
     hidePreRelease: hideBetas ? undefined : false,
+    letter: activeLetter,
   });
 
   // Find console info from the consoles list
@@ -212,6 +215,14 @@ export function ConsoleDetailPage() {
           Hide betas
         </label>
       </div>
+
+      <AlphabetBar
+        activeLetter={activeLetter}
+        onLetterClick={(letter) => {
+          setActiveLetter(letter);
+          setPage(1);
+        }}
+      />
 
       <ConsoleEssentials consoleId={id!} />
       <ConsoleHiddenGems consoleId={id!} />

--- a/web/src/pages/games-page.tsx
+++ b/web/src/pages/games-page.tsx
@@ -15,6 +15,7 @@ import {
 import { ActiveFilterPills } from "@/features/games/components/active-filter-pills";
 import { BestVersionsButton } from "@/features/games/components/best-versions-button";
 import { GameListRow } from "@/features/games/components/game-list-row";
+import { AlphabetBar } from "@/components/alphabet-bar";
 import { Pagination } from "@/components/pagination";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useThemes, useKeywords } from "@/hooks/use-explore";
@@ -51,6 +52,7 @@ function parseUrlFilters(params: URLSearchParams): Partial<GameFilters> {
   // Only serialize hidePreRelease when explicitly false (default is true/hidden)
   if (params.get("hidePreRelease") === "false") f.hidePreRelease = false;
   if (params.get("grouped") === "false") f.grouped = false;
+  if (params.get("letter")) f.letter = params.get("letter")!;
   const sortBy = params.get("sortBy");
   if (sortBy) f.sortBy = sortBy as GameFilters["sortBy"];
   const sortOrder = params.get("sortOrder");
@@ -77,6 +79,7 @@ function filtersToUrl(filters: GameFilters): URLSearchParams {
   // Only serialize when non-default (false)
   if (filters.hidePreRelease === false) params.set("hidePreRelease", "false");
   if (filters.grouped === false) params.set("grouped", "false");
+  if (filters.letter) params.set("letter", filters.letter);
   if (filters.sortBy && filters.sortBy !== "title") params.set("sortBy", filters.sortBy);
   if (filters.sortOrder && filters.sortOrder !== "asc") params.set("sortOrder", filters.sortOrder);
   if (filters.search) params.set("search", filters.search);
@@ -190,6 +193,13 @@ export function GamesPage() {
         filters={filters}
         onFiltersChange={setFilters}
         consoles={consoles}
+      />
+
+      <AlphabetBar
+        activeLetter={filters.letter}
+        onLetterClick={(letter) =>
+          setFilters((f) => ({ ...f, letter, page: 1 }))
+        }
       />
 
       {/* Content */}

--- a/web/src/pages/games-page.tsx
+++ b/web/src/pages/games-page.tsx
@@ -12,6 +12,8 @@ import {
   AdvancedFilterPanel,
   savedSearchToFilters,
 } from "@/features/games/components/advanced-filter-panel";
+import { ActiveFilterPills } from "@/features/games/components/active-filter-pills";
+import { BestVersionsButton } from "@/features/games/components/best-versions-button";
 import { GameListRow } from "@/features/games/components/game-list-row";
 import { Pagination } from "@/components/pagination";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
@@ -30,6 +32,8 @@ function parseUrlFilters(params: URLSearchParams): Partial<GameFilters> {
   const f: Partial<GameFilters> = {};
   const consoles = params.get("consoles");
   if (consoles) f.consoles = consoles.split(",");
+  const regions = params.get("regions");
+  if (regions) f.regions = regions.split(",");
   const genres = params.get("genres");
   if (genres) f.genres = genres.split(",");
   const themes = params.get("themes");
@@ -44,6 +48,9 @@ function parseUrlFilters(params: URLSearchParams): Partial<GameFilters> {
   if (params.get("ratingMax")) f.ratingMax = Number(params.get("ratingMax"));
   const ps = params.get("playStatus");
   if (ps) f.playStatus = ps as GameFilters["playStatus"];
+  // Only serialize hidePreRelease when explicitly false (default is true/hidden)
+  if (params.get("hidePreRelease") === "false") f.hidePreRelease = false;
+  if (params.get("grouped") === "false") f.grouped = false;
   const sortBy = params.get("sortBy");
   if (sortBy) f.sortBy = sortBy as GameFilters["sortBy"];
   const sortOrder = params.get("sortOrder");
@@ -56,6 +63,7 @@ function parseUrlFilters(params: URLSearchParams): Partial<GameFilters> {
 function filtersToUrl(filters: GameFilters): URLSearchParams {
   const params = new URLSearchParams();
   if (filters.consoles?.length) params.set("consoles", filters.consoles.join(","));
+  if (filters.regions?.length) params.set("regions", filters.regions.join(","));
   if (filters.genres?.length) params.set("genres", filters.genres.join(","));
   if (filters.themes?.length) params.set("themes", filters.themes.join(","));
   if (filters.keywords?.length) params.set("keywords", filters.keywords.join(","));
@@ -66,6 +74,9 @@ function filtersToUrl(filters: GameFilters): URLSearchParams {
   if (filters.ratingMin != null) params.set("ratingMin", String(filters.ratingMin));
   if (filters.ratingMax != null) params.set("ratingMax", String(filters.ratingMax));
   if (filters.playStatus) params.set("playStatus", filters.playStatus);
+  // Only serialize when non-default (false)
+  if (filters.hidePreRelease === false) params.set("hidePreRelease", "false");
+  if (filters.grouped === false) params.set("grouped", "false");
   if (filters.sortBy && filters.sortBy !== "title") params.set("sortBy", filters.sortBy);
   if (filters.sortOrder && filters.sortOrder !== "asc") params.set("sortOrder", filters.sortOrder);
   if (filters.search) params.set("search", filters.search);
@@ -151,21 +162,34 @@ export function GamesPage() {
         viewMode={viewMode}
         onViewModeChange={setViewMode}
         consoles={consoles}
+        showHideBetas
       />
 
-      <AdvancedFilterPanel
+      <div className="flex flex-wrap items-start gap-3">
+        <AdvancedFilterPanel
+          filters={filters}
+          onFiltersChange={setFilters}
+          consoles={consoles}
+          themes={themes}
+          keywords={keywords}
+          savedSearches={savedSearches}
+          onSaveSearch={handleSaveSearch}
+          onDeleteSearch={(id) => deleteSearch.mutate(id)}
+          onApplySearch={handleApplySearch}
+          totalResults={data?.total}
+          isOpen={filtersOpen}
+          onToggle={() => setFiltersOpen((o) => !o)}
+        />
+        <BestVersionsButton
+          filters={filters}
+          onFiltersChange={setFilters}
+        />
+      </div>
+
+      <ActiveFilterPills
         filters={filters}
         onFiltersChange={setFilters}
         consoles={consoles}
-        themes={themes}
-        keywords={keywords}
-        savedSearches={savedSearches}
-        onSaveSearch={handleSaveSearch}
-        onDeleteSearch={(id) => deleteSearch.mutate(id)}
-        onApplySearch={handleApplySearch}
-        totalResults={data?.total}
-        isOpen={filtersOpen}
-        onToggle={() => setFiltersOpen((o) => !o)}
       />
 
       {/* Content */}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -58,6 +58,19 @@ export interface GameDisc {
   fileSize: number;
 }
 
+// GameVariant from backend — represents a variant in the game detail response
+export interface GameVariant {
+  id: string;
+  title: string;
+  fileName: string;
+  region: string;
+  revision: string;
+  tags: string;
+  isPreRelease: boolean;
+  fileSize: number;
+  verificationStatus: string;
+}
+
 // GameResponse from backend responses.go DTO layer
 export interface Game {
   id: string;
@@ -97,6 +110,12 @@ export interface Game {
   verificationStatus?: "verified" | "unverified" | "not_applicable";
   verificationTag?: string;
   region?: string;
+  revision?: string;
+  tags?: string;
+  isPreRelease?: boolean;
+  variantCount?: number;
+  groupKey?: string;
+  variants?: GameVariant[];
   coverAspectRatio: number;
   playable: boolean;
   biosStatus?: "ready" | "missing" | "invalid" | "not_required";
@@ -153,6 +172,7 @@ export interface GameFilters {
   themes?: string[];
   keywords?: string[];
   perspectives?: string[];
+  regions?: string[];
   // Text search filters
   developer?: string;
   publisher?: string;
@@ -163,6 +183,9 @@ export interface GameFilters {
   ratingMax?: number;
   // Play status
   playStatus?: "unplayed" | "played" | "favorited" | "play-later";
+  // Variant grouping / pre-release
+  grouped?: boolean;
+  hidePreRelease?: boolean;
   sortBy?: "title" | "created_at" | "file_size" | "rating" | "release_date";
   sortOrder?: "asc" | "desc";
   page?: number;

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -186,6 +186,8 @@ export interface GameFilters {
   // Variant grouping / pre-release
   grouped?: boolean;
   hidePreRelease?: boolean;
+  // Alphabet quick-jump
+  letter?: string;
   sortBy?: "title" | "created_at" | "file_size" | "rating" | "release_date";
   sortOrder?: "asc" | "desc";
   page?: number;
@@ -240,6 +242,7 @@ export interface UserPreferences {
   selectedKeyMapping: string;
   customKeyMapping: Record<string, string>;
   consoleKeyMappings: Record<string, ConsoleKeyMapping>;
+  preferredRegions: string[];
   raLinked: boolean;
   raUsername: string;
   raHardcoreEnabled: boolean;


### PR DESCRIPTION
## Summary

- **Filename metadata parsing**: Scanner extracts region, revision, tags (beta/proto/sample), and pre-release flag from no-intro ROM filenames at scan time
- **Variant grouping**: Games with the same normalized title on the same console are grouped. One "best" variant is elected primary per group (preferring user region, latest revision, verified, has metadata)
- **API filtering**: Game lists return only primary variants by default. New filters: `region`, `hidePreRelease` (default true), `grouped`, `letter` (alphabet quick-jump)
- **Web UI**: Region filter, "Hide betas" toggle, variant count badges on game cards, ellipsis pagination, active filter pills, "Best versions only" preset, alphabet quick-jump bar, admin library default settings
- **Player app**: Server-side pagination with infinite scroll, variant badges, "Hide betas" filter chip, variants section on game detail, new API query params
- **Smart scraping**: Propagates metadata within variant groups instead of re-scraping duplicates. Tracks verified checksum counts in scrape progress
- **User preferences**: Preferred regions setting synced across devices. Admin default_region and hide_pre_release_default server settings

## Test plan

- [x] Go server: all 11 packages pass (`go test ./...`)
- [x] Web frontend: 1297 Vitest unit tests pass (`npx vitest run`)
- [x] Player desktop: 1031 tests pass (414 shared + 617 desktop E2E)
- [x] TypeScript compiles with zero errors (`npx tsc --noEmit`)
- [ ] Manual test: scan a large no-intro collection and verify grouped view
- [ ] Manual test: verify variant badges and detail page variants section
- [ ] Manual test: verify alphabet quick-jump navigation
- [ ] Manual test: verify smart scraping propagates metadata across variants