### PR TITLE
feat: auto-scan library on startup with WebSocket progress

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -132,11 +132,6 @@ func main() {
 		slog.Warn("failed to migrate shared sessions", "error", err)
 	}
 
-	// Backfill game metadata (region, tags, grouping) for existing games
-	if err := scanner.BackfillGameMetadata(database); err != nil {
-		slog.Warn("failed to backfill game metadata", "error", err)
-	}
-
 	// Create ES-DE console subdirectories in game dirs
 	if err := scanner.CreateConsoleFolders(database, gameDirs); err != nil {
 		slog.Warn("failed to create console folders", "error", err)
@@ -203,6 +198,60 @@ func main() {
 		Version:                      version,
 		TestMode:                     testMode,
 	})
+
+	// Auto-scan game library on startup (non-blocking).
+	// Uses the same scan flow as the manual "Scan library" button so progress
+	// is visible in the web UI via WebSocket events.
+	go func() {
+		if !gameScanner.TryStartScan() {
+			slog.Warn("skipping startup scan: scan already in progress")
+			return
+		}
+		defer gameScanner.FinishScan()
+
+		hub.Broadcast(websocket.Event{Type: "scan_started", Payload: nil})
+		result, scanErr := gameScanner.Scan(func(p scanner.ScanProgress) {
+			gameScanner.SetScanProgress(&p)
+			hub.Broadcast(websocket.Event{Type: "scan_progress", Payload: p})
+		})
+		if scanErr != nil {
+			slog.Error("startup library scan failed", "error", scanErr)
+			hub.Broadcast(websocket.Event{Type: "scan_error", Payload: map[string]string{"error": "startup scan failed"}})
+			return
+		}
+
+		hub.Broadcast(websocket.Event{Type: "scan_complete", Payload: map[string]interface{}{
+			"newGames":     result.NewGames,
+			"updatedGames": result.UpdatedGames,
+			"removedGames": result.RemovedGames,
+			"totalGames":   result.TotalGames,
+		}})
+		slog.Info("startup scan complete",
+			"new", result.NewGames,
+			"updated", result.UpdatedGames,
+			"removed", result.RemovedGames,
+			"total", result.TotalGames,
+		)
+
+		// Auto-scrape new games if IGDB is configured
+		if result.NewGames > 0 && metaScraper.IsIGDBConfigured() {
+			if metaScraper.TryStartScrape() {
+				hub.Broadcast(websocket.Event{Type: "scrape_started", Payload: nil})
+				count, total, scrapeErr := metaScraper.ScrapeAll("new", 0, func(p scraper.ScrapeProgress) {
+					metaScraper.SetScrapeProgress(&p)
+					hub.Broadcast(websocket.Event{Type: "scrape_progress", Payload: p})
+				})
+				metaScraper.FinishScrape()
+				if scrapeErr != nil {
+					slog.Error("startup auto-scrape failed", "error", scrapeErr)
+					hub.Broadcast(websocket.Event{Type: "scrape_error", Payload: map[string]string{"error": "auto-scrape failed"}})
+					return
+				}
+				slog.Info("startup auto-scrape complete", "scraped", count, "total", total)
+				hub.Broadcast(websocket.Event{Type: "scrape_complete", Payload: map[string]interface{}{"scraped": count, "total": total}})
+			}
+		}
+	}()
 
 	slog.Info("server listening", "port", port)
 	srv := &http.Server{

--- a/server/internal/scanner/backfill.go
+++ b/server/internal/scanner/backfill.go
@@ -8,11 +8,12 @@ import (
 	"gorm.io/gorm"
 )
 
-// BackfillGameMetadata populates Region, Revision, Tags, IsPreRelease, and GroupKey
-// for existing games that don't have a GroupKey set. This runs on startup to handle
-// games created before the large library support feature was added.
-// After backfilling, it calls GroupAndElectPrimaries to set IsPrimary flags.
-func BackfillGameMetadata(database *gorm.DB) error {
+// BackfillGameMetadataWithProgress populates Region, Revision, Tags, IsPreRelease, and GroupKey
+// for existing games that don't have a GroupKey set. This handles games created before the
+// large library support feature was added.
+// The onProgress callback is called after each batch with (processed, total) counts.
+// It does NOT run GroupAndElectPrimaries — the caller (Scan) handles that separately.
+func BackfillGameMetadataWithProgress(database *gorm.DB, onProgress func(processed, total int64)) error {
 	// Count games needing backfill
 	var totalNeedingBackfill int64
 	if err := database.Model(&db.Game{}).Where("group_key = '' OR group_key IS NULL").Count(&totalNeedingBackfill).Error; err != nil {
@@ -71,14 +72,11 @@ func BackfillGameMetadata(database *gorm.DB) error {
 		processed += int64(len(games))
 		slog.Info("backfilling game metadata progress",
 			"processed", processed, "total", totalNeedingBackfill)
+		if onProgress != nil {
+			onProgress(processed, totalNeedingBackfill)
+		}
 	}
 
 	slog.Info("game metadata backfill complete", "processed", processed)
-
-	// Run grouping and primary election after backfill
-	if err := GroupAndElectPrimaries(database); err != nil {
-		return fmt.Errorf("electing primaries after backfill: %w", err)
-	}
-
 	return nil
 }

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -636,6 +636,19 @@ func (s *Scanner) Scan(onProgress ProgressFunc, consoleFilter ...string) (*ScanR
 	s.DB.Model(&db.Game{}).Count(&count)
 	result.TotalGames = int(count)
 
+	// Backfill metadata for games created before large-library-support
+	report(ScanProgress{Phase: "backfill", Message: "Backfilling game metadata..."})
+	if err := BackfillGameMetadataWithProgress(s.DB, func(processed, total int64) {
+		report(ScanProgress{
+			Phase:   "backfill",
+			Current: int(processed),
+			Total:   int(total),
+			Message: fmt.Sprintf("Backfilling game metadata... (%d/%d)", processed, total),
+		})
+	}); err != nil {
+		slog.Warn("failed to backfill game metadata during scan", "error", err)
+	}
+
 	// Group variants and elect primary representatives
 	report(ScanProgress{Phase: "grouping", Message: "Grouping variants and electing primaries..."})
 	if err := GroupAndElectPrimaries(s.DB); err != nil {


### PR DESCRIPTION
## Summary
- Replace blocking `BackfillGameMetadata` on startup with a non-blocking auto-scan using the same flow as the manual "Scan library" button
- Progress is reported via WebSocket events, visible in the scan page immediately after server starts
- Backfill logic moved into `Scan()` flow (runs before variant grouping) so any scan fixes legacy games
- Auto-scrapes new games if IGDB is configured

## Test plan
- [x] Go tests pass (`go test ./...`)
- [ ] Deploy and verify scan progress appears in web UI on startup
- [ ] Verify manual "Scan library" button still works after startup scan completes