### PR TITLE
fix: skip individual scrape when bulk scrape is in progress

### DIFF
--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -633,6 +633,14 @@ func (h *GameHandler) ScrapeIfNeeded(c *gin.Context) {
 		return
 	}
 
+	// If a bulk scrape is already running, don't race with it — the bulk
+	// scrape will get to this game eventually. Concurrent IGDB API calls
+	// from the same account can hit rate limits and cause silent failures.
+	if active, _ := h.Scraper.GetScrapeStatus(); active {
+		c.JSON(http.StatusConflict, gin.H{"status": "bulk_scrape_in_progress"})
+		return
+	}
+
 	// Configure SteamGridDB if API key is set (best-effort artwork)
 	if apiKey := steamGridDBAPIKey(h.DB); apiKey != "" {
 		h.Scraper.ConfigureSteamGridDB(apiKey)


### PR DESCRIPTION
## Summary
- `ScrapeIfNeeded` now checks if a bulk scrape is active and returns 409 instead of racing
- Prevents concurrent IGDB API calls from hitting rate limits and causing silent metadata failures
- Frontend already handles 409 gracefully; game retries once bulk scrape finishes

## Test plan
- [x] Go API tests pass
- [ ] Deploy, trigger bulk scrape, verify individual game scrape returns 409
- [ ] After bulk scrape completes, verify individual scrape works normally