### PR TITLE
fix: skip CD audio track .bin files during library scan

### DIFF
--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -253,6 +253,10 @@ var directoryConsoleMap = map[string]string{
 // discPattern matches disc/disk/cd markers in filenames, e.g. "(Disc 1)", "[Disk 2]", "(CD 3)".
 var discPattern = regexp.MustCompile(`(?i)[\(\[]\s*(?:disc|disk|cd)\s*(\d+)\s*[\)\]]`)
 
+// trackPattern matches CD audio track markers in filenames, e.g. "(Track 06)", "(Track 1)".
+// These are companion files referenced by .cue sheets and should not be scanned as standalone games.
+var trackPattern = regexp.MustCompile(`(?i)\(Track\s*\d+\)`)
+
 // consoleNotes contains helpful guidance for console folders where the
 // purpose or correct usage may be ambiguous. These are included in the
 // README.txt files generated inside each console folder.
@@ -576,6 +580,11 @@ func (s *Scanner) Scan(onProgress ProgressFunc, consoleFilter ...string) (*ScanR
 			slog.Warn("error scanning directory", "dir", dir, "error", err)
 		}
 	}
+
+	// Clean up existing Game entries for CD audio track files (e.g. "Game (Track 06).bin")
+	// that were erroneously created as standalone games before the track-file filter was added.
+	removed := s.removeTrackFileGames()
+	result.RemovedGames += removed
 
 	report(ScanProgress{
 		Phase:   "checking_removed",
@@ -953,6 +962,32 @@ func (s *Scanner) identifyConsoleForDir(dir string) string {
 	return ""
 }
 
+// removeTrackFileGames deletes Game entries for CD audio track files (e.g. "Game (Track 06).bin")
+// that were previously created as standalone games. These files are companions to .cue sheets
+// and should never be standalone game entries.
+func (s *Scanner) removeTrackFileGames() int {
+	var games []db.Game
+	if err := s.DB.Where("file_name LIKE '%.bin'").Find(&games).Error; err != nil {
+		slog.Warn("failed to query .bin games for track file cleanup", "error", err)
+		return 0
+	}
+
+	removed := 0
+	for _, g := range games {
+		if trackPattern.MatchString(g.FileName) {
+			slog.Info("removing CD audio track file game entry",
+				"title", g.Title, "fileName", g.FileName, "gameId", g.ID)
+			s.DB.Unscoped().Where("game_id = ?", g.ID).Delete(&db.GameDisc{})
+			s.DB.Unscoped().Delete(&g)
+			removed++
+		}
+	}
+	if removed > 0 {
+		slog.Info("cleaned up CD audio track file entries", "removed", removed)
+	}
+	return removed
+}
+
 // removeOldDiscGames deletes standalone Game records whose FilePath matches a claimed disc file,
 // so they don't coexist with the new multi-disc entry.
 func (s *Scanner) removeOldDiscGames(claimedFiles []string, newM3UPath string, result *ScanResult) {
@@ -1121,6 +1156,14 @@ func (s *Scanner) scanDirectory(dir string, consoleMap map[string]*db.Console, f
 
 		// Skip .m3u files in pass 2 (handled in pass 1)
 		if ext == ".m3u" {
+			return nil
+		}
+
+		// Skip .bin files that are CD audio tracks (e.g. "Game (Track 06).bin").
+		// These are companion files referenced by .cue sheets. When the .cue file
+		// exists, Pass 1 claims them; this catches orphaned track files where the
+		// .cue file is missing or was already handled.
+		if ext == ".bin" && trackPattern.MatchString(info.Name()) {
 			return nil
 		}
 

--- a/server/internal/scanner/scanner_test.go
+++ b/server/internal/scanner/scanner_test.go
@@ -1528,3 +1528,98 @@ func TestScan_DetectsMSXGames(t *testing.T) {
 	database.Model(&db.Game{}).Where("console_id = ?", msx2Console.ID).Count(&msx2Count)
 	assert.Equal(t, int64(1), msx2Count)
 }
+
+func TestScan_SkipsTrackBinFiles(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	psxDir := filepath.Join(dir, "psx")
+	require.NoError(t, os.MkdirAll(psxDir, 0755))
+
+	// Create orphaned CD audio track files (no .cue file present)
+	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "Blam! Machinehead (Japan) (Track 01).bin"), []byte("data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "Blam! Machinehead (Japan) (Track 02).bin"), []byte("audio"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "Blam! Machinehead (Japan) (Track 06).bin"), []byte("audio"), 0644))
+
+	// Also create a legitimate single-file .bin game (no Track pattern)
+	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "Crash Bandicoot (USA).bin"), []byte("game"), 0644))
+
+	s := NewScanner(database, []string{dir})
+	result, err := s.Scan(nil)
+	require.NoError(t, err)
+
+	// Only the legitimate game should be created, track files should be skipped
+	assert.Equal(t, 1, result.NewGames, "only the non-track .bin should be a game")
+	assert.Equal(t, 1, result.TotalGames)
+
+	var games []db.Game
+	database.Find(&games)
+	require.Len(t, games, 1)
+	assert.Equal(t, "Crash Bandicoot", games[0].Title)
+}
+
+func TestScan_CleansUpExistingTrackFileGames(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	psxDir := filepath.Join(dir, "psx")
+	require.NoError(t, os.MkdirAll(psxDir, 0755))
+
+	// Create track files on disk
+	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "Game (Track 01).bin"), []byte("data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(psxDir, "Game (Track 02).bin"), []byte("audio"), 0644))
+
+	// Simulate existing Game entries for track files (created by a prior scanner version)
+	var psxConsole db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "PSX").First(&psxConsole).Error)
+
+	for i := 1; i <= 2; i++ {
+		game := db.Game{
+			ConsoleID: psxConsole.ID,
+			Title:     "Game",
+			FileName:  "Game (Track 0" + string(rune('0'+i)) + ").bin",
+			FilePath:  "psx/Game (Track 0" + string(rune('0'+i)) + ").bin",
+			FileSize:  100,
+		}
+		require.NoError(t, database.Create(&game).Error)
+	}
+
+	var countBefore int64
+	database.Model(&db.Game{}).Count(&countBefore)
+	require.Equal(t, int64(2), countBefore)
+
+	s := NewScanner(database, []string{dir})
+	result, err := s.Scan(nil)
+	require.NoError(t, err)
+
+	// Both track file entries should be cleaned up
+	assert.Equal(t, 2, result.RemovedGames, "track file entries should be removed")
+	assert.Equal(t, 0, result.TotalGames)
+
+	var games []db.Game
+	database.Unscoped().Find(&games)
+	assert.Len(t, games, 0, "track file games should be hard-deleted")
+}
+
+func TestTrackPattern(t *testing.T) {
+	tests := []struct {
+		filename string
+		isTrack  bool
+	}{
+		{"Game (Track 01).bin", true},
+		{"Game (Track 1).bin", true},
+		{"Blam! Machinehead (Japan) (Track 06).bin", true},
+		{"Game (Track 99).bin", true},
+		{"Game (track 3).bin", true},
+		{"Crash Bandicoot (USA).bin", false},
+		{"Super Mario 64 (USA).z64", false},
+		{"Game (Disc 1).bin", false},
+		{"Trackmania.bin", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.filename, func(t *testing.T) {
+			assert.Equal(t, tt.isTrack, trackPattern.MatchString(tt.filename))
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Individual `.bin` track files (e.g. `Game (Track 06).bin`) from disc-based games were being created as standalone Game entries when no corresponding `.cue` file existed
- These are CD audio companion files referenced by `.cue` sheets, not playable games
- Adds `trackPattern` regex to detect `(Track N)` in `.bin` filenames and skip them during scanning
- Cleans up existing orphaned track file Game entries on the next rescan

## Test plan
- [x] `TestTrackPattern` — pattern matches track files, rejects non-track files
- [x] `TestScan_SkipsTrackBinFiles` — orphaned track `.bin` files are not created as games
- [x] `TestScan_CleansUpExistingTrackFileGames` — existing track file Game entries are removed on rescan
- [x] Full scanner test suite passes
- [x] Full Go test suite passes