### PR TITLE
fix: include ROM filename in download URL for EmulatorJS

### DIFF
--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -282,6 +282,7 @@ func NewRouter(cfg Config) *gin.Engine {
 		api.GET("/games", gameHandler.ListGames)
 		api.GET("/games/:id", gameHandler.GetGame)
 		api.GET("/games/:id/download", downloadLimiter.RateLimit(), gameHandler.DownloadGame)
+		api.GET("/games/:id/download/:filename", downloadLimiter.RateLimit(), gameHandler.DownloadGame)
 		api.GET("/games/:id/discs/:discNumber/download", downloadLimiter.RateLimit(), gameHandler.DownloadDisc)
 		api.POST("/games/:id/scrape-if-needed", gameHandler.ScrapeIfNeeded)
 		api.POST("/games/:id/play-time", gameHandler.UpdatePlayTime)

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -271,9 +271,12 @@ export function PlayPage() {
       // For multi-file disc formats (cue+bin), request format=zip since
       // EmulatorJS can extract zip but not tar.
       const isMultiDisc = game!.discCount > 0 && game!.discs && game!.discs.length > 0;
+      // Include the filename in the URL path so EmulatorJS can detect the
+      // file extension (e.g. .gg for Game Gear). Without it, genesis_plus_gx
+      // can't distinguish Game Gear from Genesis ROMs.
       const romUrl = isMultiDisc
         ? `/api/games/${game!.id}/discs/1/download?format=zip${token ? `&token=${encodeURIComponent(token)}` : ""}`
-        : `/api/games/${game!.id}/download${tokenSuffix}`;
+        : `/api/games/${game!.id}/download/${encodeURIComponent(game!.fileName)}${tokenSuffix}`;
 
       // Determine whether to load the save state based on user choice
       const choice = coreMismatchChoiceRef.current;


### PR DESCRIPTION
## Summary
- Game Gear games showed a black screen because EmulatorJS extracts the file extension from the URL path (`/api/games/123/download` → filename `download`, no extension)
- genesis_plus_gx uses the extension to detect Game Gear (.gg) vs Genesis (.md/.bin) — without it, the core can't identify the system
- Now includes the actual filename in the URL: `/api/games/123/download/Game.gg?token=...`
- Added server route alias `/games/:id/download/:filename` (the `:filename` param is ignored server-side, it's purely for EmulatorJS)

## Test plan
- [x] Go tests pass (download handler works with both old and new route)
- [x] Web unit tests pass (1301 tests)
- [ ] Play a Game Gear game in the browser — should no longer show black screen
- [ ] Play a Genesis game — should still work as before
- [ ] Play a NES/SNES game — unaffected (different core)