### PR TITLE
feat: rating fallback, scrape UI improvements, and console page cleanup

### DIFF
--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -92,13 +92,16 @@ func (h *AdminHandler) ScrapeStatus(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, gin.H{
-		"active":    true,
-		"current":   progress.Current,
-		"total":     progress.Total,
-		"gameName":  progress.GameName,
-		"successes": progress.Successes,
-		"failures":  progress.Failures,
-		"verified":  progress.Verified,
+		"active":      true,
+		"current":     progress.Current,
+		"total":       progress.Total,
+		"gameId":      progress.GameID,
+		"gameName":    progress.GameName,
+		"consoleName": progress.ConsoleName,
+		"consoleAbbr": progress.ConsoleAbbr,
+		"successes":   progress.Successes,
+		"failures":    progress.Failures,
+		"verified":    progress.Verified,
 	})
 }
 

--- a/server/internal/api/explore_handler_console.go
+++ b/server/internal/api/explore_handler_console.go
@@ -11,6 +11,18 @@ import (
 	"github.com/spela/server/internal/db"
 )
 
+// effectiveRating is a SQL expression that picks the best available IGDB rating.
+// IGDB stores three rating types:
+//   - rating (aggregated_rating): critics' aggregated score — sparse for retro games
+//   - total_rating: combined critic + user score — much more populated
+//   - igdb_user_rating: user-only score — fallback when neither of the above exists
+//
+// The DB mirrors IGDB 1:1; this expression does the fallback at read time.
+const effectiveRating = "COALESCE(NULLIF(rating, 0), NULLIF(total_rating, 0), NULLIF(igdb_user_rating, 0), 0)"
+
+// effectiveRatingPrefixed is the same but with "games." table prefix for JOINed queries.
+const effectiveRatingPrefixed = "COALESCE(NULLIF(games.rating, 0), NULLIF(games.total_rating, 0), NULLIF(games.igdb_user_rating, 0), 0)"
+
 // --- Phase 8: Console Showcase Pages ---
 
 // GenreCount holds a genre name and the number of games in that genre.
@@ -63,11 +75,15 @@ func (h *ExploreHandler) GetConsoleShowcase(c *gin.Context) {
 	h.DB.Model(&db.Game{}).Where("console_id = ? AND deleted_at IS NULL", console.ID).Count(&gameCount)
 	console.GameCount = int(gameCount)
 
-	// --- Essentials: top 10 by IGDB rating ---
+	// --- Essentials: top 10 by best available IGDB rating ---
+	// Use COALESCE to fall back through rating sources: aggregated_rating (critics)
+	// → total_rating (combined) → igdb_user_rating (user-only). Many retro games
+	// lack critic reviews so aggregated_rating is 0; total_rating is populated
+	// far more often.
 	var essentials []db.Game
 	if err := h.DB.Preload("Console").
-		Where("console_id = ? AND rating > 0 AND deleted_at IS NULL", console.ID).
-		Order("rating DESC").
+		Where("console_id = ? AND "+effectiveRating+" > 0 AND deleted_at IS NULL", console.ID).
+		Order(effectiveRating + " DESC").
 		Limit(10).
 		Find(&essentials).Error; err != nil {
 		slog.Error("failed to fetch console essentials", "console", abbr, "error", err)
@@ -189,7 +205,7 @@ func (h *ExploreHandler) buildConsoleHiddenGems(consoleID uint, excludeIDs []uin
 	query := h.DB.Preload("Console").
 		Joins("LEFT JOIN (SELECT game_id, COALESCE(SUM(play_time), 0) as total_play_time FROM play_histories GROUP BY game_id) ph ON ph.game_id = games.id").
 		Where("games.console_id = ?", consoleID).
-		Where("games.rating >= 70").
+		Where(effectiveRatingPrefixed + " >= 70").
 		Where("games.deleted_at IS NULL")
 
 	if len(excludeIDs) > 0 {
@@ -201,7 +217,7 @@ func (h *ExploreHandler) buildConsoleHiddenGems(consoleID uint, excludeIDs []uin
 	}
 
 	if err := query.
-		Order("games.rating DESC").
+		Order(effectiveRatingPrefixed + " DESC").
 		Limit(10).
 		Find(&games).Error; err != nil {
 		slog.Error("failed to fetch console hidden gems", "error", err)
@@ -250,7 +266,7 @@ func (h *ExploreHandler) buildConsoleTopDevelopers(consoleID uint, consoleName s
 	var rows []devRow
 	if err := h.DB.
 		Table("games").
-		Select("developer, COUNT(*) as game_count, AVG(CASE WHEN rating > 0 THEN rating ELSE NULL END) as avg_rating").
+		Select("developer, COUNT(*) as game_count, AVG(CASE WHEN "+effectiveRating+" > 0 THEN "+effectiveRating+" ELSE NULL END) as avg_rating").
 		Where("console_id = ? AND deleted_at IS NULL AND developer != ''", consoleID).
 		Group("developer").
 		Order("game_count DESC").
@@ -321,11 +337,12 @@ func (h *ExploreHandler) GetConsoleHighlights(c *gin.Context) {
 	var topGameRows []topGameRow
 	if err := h.DB.Raw(`
 		SELECT console_id, game_id FROM (
-			SELECT games.console_id, games.id as game_id, games.rating,
-				ROW_NUMBER() OVER (PARTITION BY games.console_id ORDER BY games.rating DESC) as rn
+			SELECT games.console_id, games.id as game_id,
+				`+effectiveRatingPrefixed+` as eff_rating,
+				ROW_NUMBER() OVER (PARTITION BY games.console_id ORDER BY `+effectiveRatingPrefixed+` DESC) as rn
 			FROM games
 			JOIN game_artworks ON game_artworks.game_id = games.id AND game_artworks.hero_url != ''
-			WHERE games.deleted_at IS NULL AND games.rating > 0
+			WHERE games.deleted_at IS NULL AND `+effectiveRatingPrefixed+` > 0
 		) ranked WHERE rn = 1
 	`).Scan(&topGameRows).Error; err != nil {
 		slog.Error("failed to fetch top games for console highlights", "error", err)

--- a/server/internal/api/explore_handler_featured.go
+++ b/server/internal/api/explore_handler_featured.go
@@ -32,7 +32,7 @@ func (h *ExploreHandler) GetExploreFeatured(c *gin.Context) {
 		Joins("JOIN game_artworks ON game_artworks.game_id = games.id").
 		Where("games.deleted_at IS NULL").
 		Where("game_artworks.hero_url != '' AND game_artworks.logo_url != ''").
-		Order("games.rating DESC").
+		Order(effectiveRatingPrefixed + " DESC").
 		Limit(8).
 		Scan(&rows).Error
 	if err != nil {
@@ -158,8 +158,8 @@ func (h *ExploreHandler) GetExploreRows(c *gin.Context) {
 func (h *ExploreHandler) buildTopRatedRow(userID uint) (*ExploreRowResponse, error) {
 	var games []db.Game
 	if err := h.DB.Preload("Console").
-		Where("rating > 0").
-		Order("rating DESC").
+		Where(effectiveRating + " > 0").
+		Order(effectiveRating + " DESC").
 		Limit(20).
 		Find(&games).Error; err != nil {
 		return nil, err
@@ -241,7 +241,7 @@ func (h *ExploreHandler) buildHiddenGemsRow(userID uint) (*ExploreRowResponse, e
 	var games []db.Game
 	query := h.DB.Preload("Console").
 		Joins("LEFT JOIN (SELECT game_id, COALESCE(SUM(play_time), 0) as total_play_time FROM play_histories GROUP BY game_id) ph ON ph.game_id = games.id").
-		Where("games.rating >= 75").
+		Where(effectiveRatingPrefixed + " >= 75").
 		Where("games.deleted_at IS NULL")
 
 	if threshold > 0 {
@@ -249,7 +249,7 @@ func (h *ExploreHandler) buildHiddenGemsRow(userID uint) (*ExploreRowResponse, e
 	}
 
 	if err := query.
-		Order("games.rating DESC").
+		Order(effectiveRatingPrefixed + " DESC").
 		Limit(20).
 		Find(&games).Error; err != nil {
 		return nil, err

--- a/server/internal/scraper/scraper_batch.go
+++ b/server/internal/scraper/scraper_batch.go
@@ -175,12 +175,15 @@ func (s *Scraper) ConfigureSteamGridDB(apiKey string) {
 
 // ScrapeProgress holds progress information for a bulk scrape operation.
 type ScrapeProgress struct {
-	Current  int    `json:"current"`
-	Total    int    `json:"total"`
-	GameName string `json:"gameName"`
-	Successes int   `json:"successes"`
-	Failures  int   `json:"failures"`
-	Verified  int   `json:"verified"`
+	Current     int    `json:"current"`
+	Total       int    `json:"total"`
+	GameID      uint   `json:"gameId"`
+	GameName    string `json:"gameName"`
+	ConsoleName string `json:"consoleName"`
+	ConsoleAbbr string `json:"consoleAbbr"`
+	Successes   int    `json:"successes"`
+	Failures    int    `json:"failures"`
+	Verified    int    `json:"verified"`
 }
 
 // ScrapeAll fetches metadata for games.
@@ -194,7 +197,7 @@ type ScrapeProgress struct {
 // Returns the number of successes, the total number of games attempted, and any error.
 func (s *Scraper) ScrapeAll(mode string, consoleID uint, onProgress func(ScrapeProgress)) (int, int, error) {
 	var games []db.Game
-	q := s.DB
+	q := s.DB.Preload("Console")
 	if consoleID > 0 {
 		q = q.Where("console_id = ?", consoleID)
 	}
@@ -217,6 +220,21 @@ func (s *Scraper) ScrapeAll(mode string, consoleID uint, onProgress func(ScrapeP
 	successes := 0
 	failures := 0
 	verified := 0
+
+	progress := func(i int, game *db.Game) ScrapeProgress {
+		return ScrapeProgress{
+			Current:     i + 1,
+			Total:       total,
+			GameID:      game.ID,
+			GameName:    game.Title,
+			ConsoleName: game.Console.Name,
+			ConsoleAbbr: game.Console.Abbreviation,
+			Successes:   successes,
+			Failures:    failures,
+			Verified:    verified,
+		}
+	}
+
 	// Track groups we've already scraped a primary for, so we can propagate
 	// metadata to other variants in the same group instead of re-scraping.
 	scrapedGroups := make(map[string]uint) // "consoleID:groupKey" -> scraped game ID
@@ -234,14 +252,7 @@ func (s *Scraper) ScrapeAll(mode string, consoleID uint, onProgress func(ScrapeP
 				if s.propagateGroupMetadata(game) {
 					successes++
 					if onProgress != nil {
-						onProgress(ScrapeProgress{
-							Current:   i + 1,
-							Total:     total,
-							GameName:  game.Title,
-							Successes: successes,
-							Failures:  failures,
-							Verified:  verified,
-						})
+						onProgress(progress(i, game))
 					}
 					continue
 				}
@@ -252,14 +263,7 @@ func (s *Scraper) ScrapeAll(mode string, consoleID uint, onProgress func(ScrapeP
 				scrapedGroups[groupID] = game.ID
 				successes++
 				if onProgress != nil {
-					onProgress(ScrapeProgress{
-						Current:   i + 1,
-						Total:     total,
-						GameName:  game.Title,
-						Successes: successes,
-						Failures:  failures,
-						Verified:  verified,
-					})
+					onProgress(progress(i, game))
 				}
 				continue
 			}
@@ -282,14 +286,7 @@ func (s *Scraper) ScrapeAll(mode string, consoleID uint, onProgress func(ScrapeP
 		}
 
 		if onProgress != nil {
-			onProgress(ScrapeProgress{
-				Current:   i + 1,
-				Total:     total,
-				GameName:  game.Title,
-				Successes: successes,
-				Failures:  failures,
-				Verified:  verified,
-			})
+			onProgress(progress(i, game))
 		}
 	}
 

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -68,10 +68,15 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 	gameIDStr := strconv.FormatUint(uint64(game.ID), 10)
 
 	// --- IGDB (primary metadata + images, when configured) ---
+	igdbAttempted := false
 	if s.IGDBClient != nil && s.IGDBClient.IsConfigured() {
+		igdbAttempted = true
 		if err := s.scrapeIGDB(game, console, gameIDStr); err != nil {
 			slog.Warn("IGDB scrape failed, falling back to LibRetro", "game", game.Title, "error", err)
 		}
+	}
+	if !igdbAttempted {
+		slog.Warn("IGDB not configured, scraping with LibRetro only", "game", game.Title)
 	}
 
 	// --- LibRetro Thumbnails (preferred for box art, fallback for screenshots) ---
@@ -153,7 +158,7 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 		return fmt.Errorf("saving scraped metadata: %w", err)
 	}
 
-	slog.Info("scraped metadata", "game", game.Title, "scraperId", game.ScraperID)
+	slog.Info("scraped metadata", "game", game.Title, "scraperId", game.ScraperID, "rating", game.Rating)
 	return nil
 }
 
@@ -285,6 +290,12 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 	if match.AggregatedRating > 0 {
 		game.Rating = match.AggregatedRating
 	}
+	slog.Info("IGDB rating data",
+		"game", game.Title,
+		"aggregatedRating", match.AggregatedRating,
+		"totalRating", match.TotalRating,
+		"igdbRating", match.IGDBRating,
+	)
 	if match.TotalRating > 0 && game.TotalRating == 0 {
 		game.TotalRating = match.TotalRating
 	}

--- a/server/internal/scraper/scraper_igdb_test.go
+++ b/server/internal/scraper/scraper_igdb_test.go
@@ -162,6 +162,81 @@ func TestScrapeGame_IGDBMetadata(t *testing.T) {
 	}
 }
 
+func TestScrapeGame_IGDBStoresRatings1to1(t *testing.T) {
+	// DB should mirror IGDB 1:1: Rating stores AggregatedRating only,
+	// TotalRating and IGDBUserRating are stored separately.
+	// Read-side queries use fallback logic (COALESCE).
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]igdb.Game{
+			{
+				ID:               100,
+				Name:             "Mega Man 2",
+				Summary:          "Classic NES platformer",
+				AggregatedRating: 0, // no critics rating
+				TotalRating:      88.5,
+				TotalRatingCount: 200,
+				IGDBRating:       90.0,
+				IGDBRatingCount:  150,
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := igdb.TwitchTokenURLForTest()
+	origAPIBase := igdb.IGDBAPIBaseForTest()
+	igdb.SetTwitchTokenURLForTest(tokenServer.URL)
+	igdb.SetIGDBAPIBaseForTest(igdbServer.URL + "/v4")
+	defer func() {
+		igdb.SetTwitchTokenURLForTest(origTokenURL)
+		igdb.SetIGDBAPIBaseForTest(origAPIBase)
+	}()
+
+	database := setupTestDB(t)
+	store := setupTestStorage(t)
+
+	console := db.Console{Abbreviation: "NES", Name: "Nintendo Entertainment System"}
+	require.NoError(t, database.Create(&console).Error)
+
+	game := db.Game{
+		ConsoleID: console.ID,
+		Console:   console,
+		Title:     "Mega Man 2 (USA)",
+		FileName:  "Mega Man 2 (USA).nes",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	igdbClient := igdb.NewClient("test-id", "test-secret")
+	igdbClient.HTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+	s := &Scraper{
+		DB:         database,
+		Storage:    store,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		IGDBClient: igdbClient,
+		DATCache:   NewDATCache(t.TempDir(), &http.Client{Timeout: 5 * time.Second}),
+		cache:      &nameCache{entries: make(map[string][]nameEntry)},
+	}
+
+	err := s.ScrapeGame(&game)
+	require.NoError(t, err)
+
+	// Rating (aggregated_rating) stays 0 — DB mirrors IGDB 1:1
+	assert.InDelta(t, 0, game.Rating, 0.01)
+	// TotalRating and IGDBUserRating stored separately
+	assert.InDelta(t, 88.5, game.TotalRating, 0.01)
+	assert.Equal(t, 200, game.TotalRatingCount)
+	assert.InDelta(t, 90.0, game.IGDBUserRating, 0.01)
+}
+
 func TestScrapeGame_IGDBNoResults_FallsBackToLibRetro(t *testing.T) {
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(map[string]interface{}{

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -214,7 +214,10 @@ export interface ScrapeStatus {
   active: boolean;
   current?: number;
   total?: number;
+  gameId?: number;
   gameName?: string;
+  consoleName?: string;
+  consoleAbbr?: string;
   successes?: number;
   failures?: number;
   verified?: number;

--- a/web/src/hooks/use-scrape-progress.ts
+++ b/web/src/hooks/use-scrape-progress.ts
@@ -5,7 +5,10 @@ import { useScrapeStatus } from "@/hooks/use-admin";
 interface ScrapeProgressPayload {
   current: number;
   total: number;
+  gameId: number;
   gameName: string;
+  consoleName: string;
+  consoleAbbr: string;
   successes: number;
   failures: number;
   verified: number;
@@ -26,7 +29,10 @@ export interface ScrapeProgressState {
   phase: ScrapePhase;
   current: number;
   total: number;
+  gameId: number;
   gameName: string;
+  consoleName: string;
+  consoleAbbr: string;
   successes: number;
   failures: number;
   verified: number;
@@ -40,7 +46,10 @@ export function useScrapeProgress(): ScrapeProgressState {
   const [phase, setPhase] = useState<ScrapePhase>("idle");
   const [current, setCurrent] = useState(0);
   const [total, setTotal] = useState(0);
+  const [gameId, setGameId] = useState(0);
   const [gameName, setGameName] = useState("");
+  const [consoleName, setConsoleName] = useState("");
+  const [consoleAbbr, setConsoleAbbr] = useState("");
   const [successes, setSuccesses] = useState(0);
   const [failures, setFailures] = useState(0);
   const [verified, setVerified] = useState(0);
@@ -54,7 +63,10 @@ export function useScrapeProgress(): ScrapeProgressState {
       setPhase("active");
       setCurrent(initialStatus.current ?? 0);
       setTotal(initialStatus.total ?? 0);
+      setGameId(initialStatus.gameId ?? 0);
       setGameName(initialStatus.gameName ?? "");
+      setConsoleName(initialStatus.consoleName ?? "");
+      setConsoleAbbr(initialStatus.consoleAbbr ?? "");
       setSuccesses(initialStatus.successes ?? 0);
       setFailures(initialStatus.failures ?? 0);
       setVerified(initialStatus.verified ?? 0);
@@ -67,7 +79,10 @@ export function useScrapeProgress(): ScrapeProgressState {
       setPhase("active");
       setCurrent(0);
       setTotal(0);
+      setGameId(0);
       setGameName("");
+      setConsoleName("");
+      setConsoleAbbr("");
       setSuccesses(0);
       setFailures(0);
       setVerified(0);
@@ -81,7 +96,10 @@ export function useScrapeProgress(): ScrapeProgressState {
       setPhase("active");
       setCurrent(payload.current);
       setTotal(payload.total);
+      setGameId(payload.gameId);
       setGameName(payload.gameName);
+      setConsoleName(payload.consoleName);
+      setConsoleAbbr(payload.consoleAbbr);
       setSuccesses(payload.successes);
       setFailures(payload.failures);
       setVerified(payload.verified);
@@ -109,12 +127,15 @@ export function useScrapeProgress(): ScrapeProgressState {
     setPhase("idle");
     setCurrent(0);
     setTotal(0);
+    setGameId(0);
     setGameName("");
+    setConsoleName("");
+    setConsoleAbbr("");
     setSuccesses(0);
     setFailures(0);
     setVerified(0);
     setError(null);
   }, []);
 
-  return { phase, current, total, gameName, successes, failures, verified, error, dismiss };
+  return { phase, current, total, gameId, gameName, consoleName, consoleAbbr, successes, failures, verified, error, dismiss };
 }

--- a/web/src/pages/admin/__tests__/scan-page.test.tsx
+++ b/web/src/pages/admin/__tests__/scan-page.test.tsx
@@ -242,7 +242,10 @@ describe("AdminScanPage", () => {
       phase: "active",
       current: 3,
       total: 10,
+      gameId: 42,
       gameName: "Super Mario Bros.",
+      consoleName: "Nintendo Entertainment System",
+      consoleAbbr: "nes",
       successes: 2,
       failures: 1,
       error: null,
@@ -250,7 +253,12 @@ describe("AdminScanPage", () => {
     });
     renderPage();
     expect(screen.getByText(/Scraping game 3 of 10/)).toBeInTheDocument();
-    expect(screen.getByText("Super Mario Bros.")).toBeInTheDocument();
+    // Game name should be a link to the game detail page
+    const gameLink = screen.getByRole("link", { name: "Super Mario Bros." });
+    expect(gameLink).toBeInTheDocument();
+    expect(gameLink).toHaveAttribute("href", "/games/42");
+    // Console name should be shown
+    expect(screen.getByText("(Nintendo Entertainment System)")).toBeInTheDocument();
     expect(screen.getByText("2 succeeded")).toBeInTheDocument();
     expect(screen.getByText("1 failed")).toBeInTheDocument();
   });

--- a/web/src/pages/admin/scan-page.tsx
+++ b/web/src/pages/admin/scan-page.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import { Link } from "react-router-dom";
 import {
   ScanSearch,
   FolderSearch,
@@ -225,7 +226,21 @@ function ScrapeCard() {
             </div>
             {scrape.gameName && (
               <p className="text-sm text-surface-400 truncate">
-                {scrape.gameName}
+                {scrape.gameId ? (
+                  <Link
+                    to={`/games/${scrape.gameId}`}
+                    className="text-brand-400 hover:text-brand-300 transition-colors"
+                  >
+                    {scrape.gameName}
+                  </Link>
+                ) : (
+                  scrape.gameName
+                )}
+                {scrape.consoleName && (
+                  <span className="text-surface-500 ml-2">
+                    ({scrape.consoleName})
+                  </span>
+                )}
               </p>
             )}
             <ProgressBar value={scrape.current} max={scrape.total} />

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Library, Check, Globe, FolderSearch } from "lucide-react";
+import { Library, Check, Globe, FolderSearch, Loader2 } from "lucide-react";
 import { GameCard } from "@/components/game-card";
 import { GameGrid } from "@/components/game-grid";
 import {
@@ -10,7 +10,6 @@ import {
   SearchInput,
   Switch,
 } from "@/components/ui";
-import { ActionsMenu } from "@/components/ui/actions-menu";
 import { useConsoles } from "@/hooks/use-consoles";
 import { useGames, useToggleFavorite } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
@@ -106,34 +105,6 @@ export function ConsoleDetailPage() {
           )}
         </div>
 
-        {/* Admin actions menu */}
-        {isAdmin && (
-          <div className="absolute right-3 top-3 z-10">
-            <ActionsMenu
-              items={[
-                {
-                  label: "Scan for new games",
-                  icon: <FolderSearch className="h-4 w-4" />,
-                  loading: scanLibrary.isPending,
-                  onClick: () =>
-                    scanLibrary.mutate(
-                      { console: consoleAbbr },
-                      {
-                        onSuccess: () =>
-                          toast("info", `Scan started for ${consoleName}.`),
-                        onError: (err) =>
-                          toast(
-                            "error",
-                            err instanceof Error ? err.message : "Scan failed",
-                          ),
-                      },
-                    ),
-                },
-              ]}
-            />
-          </div>
-        )}
-
         {/* Subtle noise/texture overlay */}
         <div className="absolute inset-0 bg-gradient-to-t from-black/30 via-transparent to-white/[0.04] pointer-events-none" />
 
@@ -214,6 +185,33 @@ export function ConsoleDetailPage() {
           />
           Hide betas
         </label>
+        {isAdmin && (
+          <button
+            className="ml-auto inline-flex items-center gap-2 rounded-lg bg-white/[0.06] px-3 py-2 text-sm font-medium text-surface-300 hover:bg-white/[0.10] hover:text-surface-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
+            disabled={scanLibrary.isPending}
+            onClick={() =>
+              scanLibrary.mutate(
+                { console: consoleAbbr },
+                {
+                  onSuccess: () =>
+                    toast("info", `Scan started for ${consoleName}.`),
+                  onError: (err) =>
+                    toast(
+                      "error",
+                      err instanceof Error ? err.message : "Scan failed",
+                    ),
+                },
+              )
+            }
+          >
+            {scanLibrary.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <FolderSearch className="h-4 w-4" />
+            )}
+            Scan for new games
+          </button>
+        )}
       </div>
 
       <AlphabetBar


### PR DESCRIPTION
## Summary
- **Rating fallback on read side**: Use `COALESCE` to fall back through IGDB rating sources (aggregated → total → user). Many retro games lack critic reviews so `aggregated_rating` is 0 — this ensures Essentials, Hidden Gems, and Top Rated sections populate for far more games. The DB continues to mirror IGDB 1:1 with no write-side fallback.
- **Scrape progress UI**: Game title is now a link to the game detail page during scraping. Console name is shown next to the game being scraped.
- **Console page cleanup**: Moved "Scan for new games" button from the hero banner action menu to the search/filter row (right-aligned) for a cleaner header.
- **Diagnostic logging**: Added IGDB rating data logging during scrape to help diagnose missing ratings.

## Test plan
- [x] Go tests pass (API + scraper)
- [x] Web unit tests pass (1301 tests)
- [x] TypeScript compiles cleanly
- [ ] Verify Essentials/Hidden Gems sections appear on console pages after scraping
- [ ] Verify scrape progress shows game link and console name
- [ ] Verify "Scan for new games" button appears in filter row on console page