### PR TITLE
feat: add global search with Cmd+K command palette

### DIFF
--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -181,6 +181,7 @@ func NewRouter(cfg Config) *gin.Engine {
 	savedSearchHandler := &SavedSearchHandler{DB: cfg.DB}
 	enrichmentHandler := &EnrichmentHandler{DB: cfg.DB, Scraper: cfg.Scraper, Hub: cfg.Hub}
 	discoveryHandler := &GameDiscoveryHandler{DB: cfg.DB, Scraper: cfg.Scraper}
+	searchHandler := &SearchHandler{DB: cfg.DB}
 	setupHandler := &SetupHandler{
 		DB:            cfg.DB,
 		JWTSecret:     cfg.JWTSecret,
@@ -231,6 +232,9 @@ func NewRouter(cfg Config) *gin.Engine {
 	api.Use(AuthMiddleware(cfg.JWTSecret, cfg.DB))
 	api.Use(userLimiter.UserRateLimit())
 	{
+		// Search
+		api.GET("/search", searchHandler.Search)
+
 		// Consoles
 		api.GET("/consoles", consoleHandler.ListConsoles)
 		api.GET("/consoles/:id/games", consoleHandler.ListConsoleGames)

--- a/server/internal/api/search_handler.go
+++ b/server/internal/api/search_handler.go
@@ -1,0 +1,529 @@
+package api
+
+import (
+	"log/slog"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// SearchHandler handles the global search endpoint.
+type SearchHandler struct {
+	DB *gorm.DB
+}
+
+// --- Search response types ---
+
+// SearchResponse is the top-level response for the global search endpoint.
+type SearchResponse struct {
+	Games       SearchCategoryResult[SearchGameResult]       `json:"games"`
+	Consoles    SearchCategoryResult[SearchConsoleResult]     `json:"consoles"`
+	Developers  SearchCategoryResult[SearchCompanyResult]     `json:"developers"`
+	Publishers  SearchCategoryResult[SearchCompanyResult]     `json:"publishers"`
+	Collections SearchCategoryResult[SearchCollectionResult]  `json:"collections"`
+	Series      SearchCategoryResult[SearchSeriesResult]      `json:"series"`
+	Franchises  SearchCategoryResult[SearchFranchiseResult]   `json:"franchises"`
+}
+
+// SearchCategoryResult wraps a slice of results with a total count for a single entity type.
+type SearchCategoryResult[T any] struct {
+	Results []T `json:"results"`
+	Total   int `json:"total"`
+}
+
+// SearchGameResult is a game entry in search results.
+type SearchGameResult struct {
+	ID               string  `json:"id"`
+	Title            string  `json:"title"`
+	CoverURL         string  `json:"coverUrl"`
+	ConsoleName      string  `json:"consoleName"`
+	ConsoleID        string  `json:"consoleId"`
+	Developer        string  `json:"developer"`
+	Genre            string  `json:"genre"`
+	CoverAspectRatio float64 `json:"coverAspectRatio"`
+}
+
+// SearchConsoleResult is a console entry in search results.
+type SearchConsoleResult struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	IconURL    string `json:"iconUrl"`
+	GameCount  int    `json:"gameCount"`
+	ColorTheme string `json:"colorTheme"`
+}
+
+// SearchCompanyResult is a developer or publisher entry in search results.
+type SearchCompanyResult struct {
+	Name      string  `json:"name"`
+	GameCount int     `json:"gameCount"`
+	AvgRating float64 `json:"avgRating"`
+}
+
+// SearchCollectionResult is a collection entry in search results.
+type SearchCollectionResult struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	GameCount int    `json:"gameCount"`
+	CoverURL  string `json:"coverUrl"`
+	Username  string `json:"username"`
+}
+
+// SearchSeriesResult is a series entry in search results.
+type SearchSeriesResult struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	TotalGames   int    `json:"totalGames"`
+	LibraryGames int    `json:"libraryGames"`
+}
+
+// SearchFranchiseResult is a franchise entry in search results.
+type SearchFranchiseResult struct {
+	ID           string `json:"id"`
+	Name         string `json:"name"`
+	TotalGames   int    `json:"totalGames"`
+	LibraryGames int    `json:"libraryGames"`
+}
+
+// Search performs a global search across games, consoles, developers, publishers,
+// collections, series, and franchises.
+// GET /api/search?q=<query>&limit=<n>
+func (h *SearchHandler) Search(c *gin.Context) {
+	userID := getUserID(c)
+	query := strings.TrimSpace(c.Query("q"))
+
+	if len(query) < 2 {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "query must be at least 2 characters"})
+		return
+	}
+
+	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "5"))
+	if limit < 1 || limit > 50 {
+		limit = 5
+	}
+
+	escapedQuery := escapeLikePattern(query)
+	likePattern := "%" + escapedQuery + "%"
+
+	// Run all entity queries. SQLite does not benefit from parallel queries
+	// (single-writer, in-memory DBs are connection-scoped), so we run
+	// sequentially to avoid connection-pool issues.
+	games := h.searchGames(likePattern, limit)
+	consoles := h.searchConsoles(likePattern, limit)
+	developers := h.searchDevelopers(likePattern, limit)
+	publishers := h.searchPublishers(likePattern, limit)
+	collections := h.searchCollections(likePattern, limit, userID)
+	series := h.searchSeries(likePattern, limit)
+	franchises := h.searchFranchises(likePattern, limit)
+
+	c.JSON(http.StatusOK, SearchResponse{
+		Games:       games,
+		Consoles:    consoles,
+		Developers:  developers,
+		Publishers:  publishers,
+		Collections: collections,
+		Series:      series,
+		Franchises:  franchises,
+	})
+}
+
+// likeEscape is the ESCAPE clause fragment used in all LIKE queries.
+const likeEscape = " ESCAPE '\\'"
+
+// searchGames searches for games matching the query, excluding soft-deleted entries.
+func (h *SearchHandler) searchGames(likePattern string, limit int) SearchCategoryResult[SearchGameResult] {
+	type gameRow struct {
+		ID          uint
+		Title       string
+		CoverURL    string
+		ConsoleName string
+		ConsoleAbbr string
+		Developer   string
+		Genre       string
+		CoverAspect string
+	}
+
+	likeClause := "games.title LIKE ?" + likeEscape + " AND games.deleted_at IS NULL"
+
+	var total int64
+	h.DB.Model(&db.Game{}).
+		Joins("JOIN consoles ON consoles.id = games.console_id").
+		Where(likeClause, likePattern).
+		Count(&total)
+
+	var rows []gameRow
+	if err := h.DB.
+		Table("games").
+		Select("games.id, games.title, games.cover_url, consoles.name as console_name, consoles.abbreviation as console_abbr, games.developer, games.genre, consoles.cover_aspect").
+		Joins("JOIN consoles ON consoles.id = games.console_id").
+		Where(likeClause, likePattern).
+		Order("games.title ASC").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("search: failed to search games", "error", err)
+		return SearchCategoryResult[SearchGameResult]{Results: []SearchGameResult{}, Total: 0}
+	}
+
+	results := make([]SearchGameResult, len(rows))
+	for i, r := range rows {
+		coverURL := r.CoverURL
+		if coverURL != "" && !strings.HasPrefix(coverURL, "http") {
+			coverURL = "/api/images/" + coverURL
+		}
+		results[i] = SearchGameResult{
+			ID:               strconv.FormatUint(uint64(r.ID), 10),
+			Title:            r.Title,
+			CoverURL:         coverURL,
+			ConsoleName:      r.ConsoleName,
+			ConsoleID:        strings.ToLower(r.ConsoleAbbr),
+			Developer:        r.Developer,
+			Genre:            r.Genre,
+			CoverAspectRatio: parseAspectRatio(r.CoverAspect),
+		}
+	}
+
+	return SearchCategoryResult[SearchGameResult]{Results: results, Total: int(total)}
+}
+
+// searchConsoles searches for consoles matching the query, only returning those with at least 1 game.
+func (h *SearchHandler) searchConsoles(likePattern string, limit int) SearchCategoryResult[SearchConsoleResult] {
+	type consoleRow struct {
+		ID           uint
+		Name         string
+		Abbreviation string
+		ColorTheme   string
+		GameCount    int
+	}
+
+	likeClause := "consoles.name LIKE ?" + likeEscape
+
+	// Build the base query for consoles with games
+	baseQuery := func() *gorm.DB {
+		return h.DB.
+			Table("consoles").
+			Joins("JOIN games ON games.console_id = consoles.id AND games.deleted_at IS NULL").
+			Where(likeClause, likePattern).
+			Group("consoles.id").
+			Having("COUNT(games.id) > 0")
+	}
+
+	// Count total matching consoles
+	type countResult struct {
+		Total int64
+	}
+	var total int64
+	row := baseQuery().Select("COUNT(*) as total").Row()
+	if err := row.Scan(&total); err != nil {
+		// Fallback: count via subquery approach
+		total = 0
+	}
+
+	var rows []consoleRow
+	if err := h.DB.
+		Table("consoles").
+		Select("consoles.id, consoles.name, consoles.abbreviation, consoles.color_theme, COUNT(games.id) as game_count").
+		Joins("JOIN games ON games.console_id = consoles.id AND games.deleted_at IS NULL").
+		Where(likeClause, likePattern).
+		Group("consoles.id").
+		Having("game_count > 0").
+		Order("consoles.name ASC").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("search: failed to search consoles", "error", err)
+		return SearchCategoryResult[SearchConsoleResult]{Results: []SearchConsoleResult{}, Total: 0}
+	}
+
+	// If the Row() scan above failed, fall back to result length (imprecise but functional)
+	if total == 0 && len(rows) > 0 {
+		total = int64(len(rows))
+	}
+
+	results := make([]SearchConsoleResult, len(rows))
+	for i, r := range rows {
+		abbr := strings.ToLower(r.Abbreviation)
+		results[i] = SearchConsoleResult{
+			ID:         abbr,
+			Name:       r.Name,
+			IconURL:    "/api/consoles/" + abbr + "/icon",
+			GameCount:  r.GameCount,
+			ColorTheme: r.ColorTheme,
+		}
+	}
+
+	return SearchCategoryResult[SearchConsoleResult]{Results: results, Total: int(total)}
+}
+
+// searchDevelopers searches for developers matching the query.
+func (h *SearchHandler) searchDevelopers(likePattern string, limit int) SearchCategoryResult[SearchCompanyResult] {
+	type devRow struct {
+		Developer string
+		GameCount int
+		AvgRating float64
+	}
+
+	likeClause := "developer LIKE ?" + likeEscape + " AND developer != '' AND deleted_at IS NULL"
+
+	var total int64
+	h.DB.Model(&db.Game{}).
+		Where(likeClause, likePattern).
+		Select("COUNT(DISTINCT developer)").
+		Scan(&total)
+
+	var rows []devRow
+	if err := h.DB.
+		Table("games").
+		Select("developer, COUNT(*) as game_count, AVG(CASE WHEN "+effectiveRating+" > 0 THEN "+effectiveRating+" ELSE NULL END) as avg_rating").
+		Where(likeClause, likePattern).
+		Group("developer").
+		Order("game_count DESC").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("search: failed to search developers", "error", err)
+		return SearchCategoryResult[SearchCompanyResult]{Results: []SearchCompanyResult{}, Total: 0}
+	}
+
+	results := make([]SearchCompanyResult, len(rows))
+	for i, r := range rows {
+		avgRating := 0.0
+		if r.AvgRating > 0 {
+			avgRating = math.Round(r.AvgRating*10) / 10
+		}
+		results[i] = SearchCompanyResult{
+			Name:      r.Developer,
+			GameCount: r.GameCount,
+			AvgRating: avgRating,
+		}
+	}
+
+	return SearchCategoryResult[SearchCompanyResult]{Results: results, Total: int(total)}
+}
+
+// searchPublishers searches for publishers matching the query.
+func (h *SearchHandler) searchPublishers(likePattern string, limit int) SearchCategoryResult[SearchCompanyResult] {
+	type pubRow struct {
+		Publisher string
+		GameCount int
+		AvgRating float64
+	}
+
+	likeClause := "publisher LIKE ?" + likeEscape + " AND publisher != '' AND deleted_at IS NULL"
+
+	var total int64
+	h.DB.Model(&db.Game{}).
+		Where(likeClause, likePattern).
+		Select("COUNT(DISTINCT publisher)").
+		Scan(&total)
+
+	var rows []pubRow
+	if err := h.DB.
+		Table("games").
+		Select("publisher, COUNT(*) as game_count, AVG(CASE WHEN "+effectiveRating+" > 0 THEN "+effectiveRating+" ELSE NULL END) as avg_rating").
+		Where(likeClause, likePattern).
+		Group("publisher").
+		Order("game_count DESC").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("search: failed to search publishers", "error", err)
+		return SearchCategoryResult[SearchCompanyResult]{Results: []SearchCompanyResult{}, Total: 0}
+	}
+
+	results := make([]SearchCompanyResult, len(rows))
+	for i, r := range rows {
+		avgRating := 0.0
+		if r.AvgRating > 0 {
+			avgRating = math.Round(r.AvgRating*10) / 10
+		}
+		results[i] = SearchCompanyResult{
+			Name:      r.Publisher,
+			GameCount: r.GameCount,
+			AvgRating: avgRating,
+		}
+	}
+
+	return SearchCategoryResult[SearchCompanyResult]{Results: results, Total: int(total)}
+}
+
+// searchCollections searches for collections matching the query.
+// Returns public collections + the authenticated user's own collections.
+func (h *SearchHandler) searchCollections(likePattern string, limit int, userID uint) SearchCategoryResult[SearchCollectionResult] {
+	type colRow struct {
+		ID        uint
+		Name      string
+		UserID    uint
+		Username  string
+		GameCount int
+	}
+
+	likeClause := "game_collections.name LIKE ?" + likeEscape + " AND game_collections.deleted_at IS NULL"
+
+	// Build the visibility-scoped query
+	scopedQuery := func(tx *gorm.DB) *gorm.DB {
+		q := tx.Table("game_collections").
+			Joins("JOIN users ON users.id = game_collections.user_id").
+			Where(likeClause, likePattern)
+		if userID > 0 {
+			q = q.Where("(game_collections.is_public = 1 OR game_collections.user_id = ?)", userID)
+		} else {
+			q = q.Where("game_collections.is_public = 1")
+		}
+		return q
+	}
+
+	var total int64
+	scopedQuery(h.DB).Count(&total)
+
+	var rows []colRow
+	if err := scopedQuery(h.DB).
+		Select(`game_collections.id, game_collections.name, game_collections.user_id,
+			users.username,
+			(SELECT COUNT(*) FROM collection_items WHERE collection_items.collection_id = game_collections.id) as game_count`).
+		Order("game_collections.name ASC").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("search: failed to search collections", "error", err)
+		return SearchCategoryResult[SearchCollectionResult]{Results: []SearchCollectionResult{}, Total: 0}
+	}
+
+	results := make([]SearchCollectionResult, len(rows))
+	for i, r := range rows {
+		// Get cover URL from first game in collection
+		coverURL := ""
+		var firstItem db.CollectionItem
+		if err := h.DB.Where("collection_id = ?", r.ID).Order("position ASC").First(&firstItem).Error; err == nil {
+			var game db.Game
+			if err := h.DB.Select("cover_url").First(&game, firstItem.GameID).Error; err == nil {
+				coverURL = game.CoverURL
+				if coverURL != "" && !strings.HasPrefix(coverURL, "http") {
+					coverURL = "/api/images/" + coverURL
+				}
+			}
+		}
+
+		results[i] = SearchCollectionResult{
+			ID:        strconv.FormatUint(uint64(r.ID), 10),
+			Name:      r.Name,
+			GameCount: r.GameCount,
+			CoverURL:  coverURL,
+			Username:  r.Username,
+		}
+	}
+
+	return SearchCategoryResult[SearchCollectionResult]{Results: results, Total: int(total)}
+}
+
+// searchSeries searches for game series matching the query.
+func (h *SearchHandler) searchSeries(likePattern string, limit int) SearchCategoryResult[SearchSeriesResult] {
+	type seriesRow struct {
+		ID           uint
+		Name         string
+		TotalGames   int
+		LibraryGames int
+	}
+
+	likeClause := "game_series.name LIKE ?" + likeEscape
+
+	// Build the base query
+	baseQuery := func(tx *gorm.DB) *gorm.DB {
+		return tx.
+			Table("game_series").
+			Joins("JOIN game_series_entries ON game_series_entries.series_id = game_series.id").
+			Joins("LEFT JOIN games ON games.id = game_series_entries.game_id").
+			Where(likeClause, likePattern).
+			Group("game_series.id").
+			Having("COUNT(CASE WHEN games.id IS NOT NULL AND games.deleted_at IS NULL THEN 1 END) > 0")
+	}
+
+	// Count total
+	var countRows []seriesRow
+	baseQuery(h.DB).Select("game_series.id").Scan(&countRows)
+	total := int64(len(countRows))
+
+	var rows []seriesRow
+	if err := h.DB.
+		Table("game_series").
+		Select(`game_series.id, game_series.name,
+			COUNT(game_series_entries.id) as total_games,
+			COUNT(CASE WHEN games.id IS NOT NULL AND games.deleted_at IS NULL THEN 1 END) as library_games`).
+		Joins("JOIN game_series_entries ON game_series_entries.series_id = game_series.id").
+		Joins("LEFT JOIN games ON games.id = game_series_entries.game_id").
+		Where(likeClause, likePattern).
+		Group("game_series.id").
+		Having("library_games > 0").
+		Order("library_games DESC").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("search: failed to search series", "error", err)
+		return SearchCategoryResult[SearchSeriesResult]{Results: []SearchSeriesResult{}, Total: 0}
+	}
+
+	results := make([]SearchSeriesResult, len(rows))
+	for i, r := range rows {
+		results[i] = SearchSeriesResult{
+			ID:           strconv.FormatUint(uint64(r.ID), 10),
+			Name:         r.Name,
+			TotalGames:   r.TotalGames,
+			LibraryGames: r.LibraryGames,
+		}
+	}
+
+	return SearchCategoryResult[SearchSeriesResult]{Results: results, Total: int(total)}
+}
+
+// searchFranchises searches for game franchises matching the query.
+func (h *SearchHandler) searchFranchises(likePattern string, limit int) SearchCategoryResult[SearchFranchiseResult] {
+	type franchiseRow struct {
+		ID           uint
+		Name         string
+		TotalGames   int
+		LibraryGames int
+	}
+
+	likeClause := "game_franchise_groups.name LIKE ?" + likeEscape
+
+	// Count total
+	var countRows []franchiseRow
+	h.DB.
+		Table("game_franchise_groups").
+		Select("game_franchise_groups.id").
+		Joins("JOIN game_franchise_entries ON game_franchise_entries.franchise_group_id = game_franchise_groups.id").
+		Joins("LEFT JOIN games ON games.id = game_franchise_entries.game_id").
+		Where(likeClause, likePattern).
+		Group("game_franchise_groups.id").
+		Having("COUNT(CASE WHEN games.id IS NOT NULL AND games.deleted_at IS NULL THEN 1 END) > 0").
+		Scan(&countRows)
+	total := int64(len(countRows))
+
+	var rows []franchiseRow
+	if err := h.DB.
+		Table("game_franchise_groups").
+		Select(`game_franchise_groups.id, game_franchise_groups.name,
+			COUNT(game_franchise_entries.id) as total_games,
+			COUNT(CASE WHEN games.id IS NOT NULL AND games.deleted_at IS NULL THEN 1 END) as library_games`).
+		Joins("JOIN game_franchise_entries ON game_franchise_entries.franchise_group_id = game_franchise_groups.id").
+		Joins("LEFT JOIN games ON games.id = game_franchise_entries.game_id").
+		Where(likeClause, likePattern).
+		Group("game_franchise_groups.id").
+		Having("library_games > 0").
+		Order("library_games DESC").
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("search: failed to search franchises", "error", err)
+		return SearchCategoryResult[SearchFranchiseResult]{Results: []SearchFranchiseResult{}, Total: 0}
+	}
+
+	results := make([]SearchFranchiseResult, len(rows))
+	for i, r := range rows {
+		results[i] = SearchFranchiseResult{
+			ID:           strconv.FormatUint(uint64(r.ID), 10),
+			Name:         r.Name,
+			TotalGames:   r.TotalGames,
+			LibraryGames: r.LibraryGames,
+		}
+	}
+
+	return SearchCategoryResult[SearchFranchiseResult]{Results: results, Total: int(total)}
+}

--- a/server/internal/api/search_handler_test.go
+++ b/server/internal/api/search_handler_test.go
@@ -1,0 +1,428 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	ws "github.com/spela/server/internal/websocket"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+func setupSearchEnv(t *testing.T) (*gorm.DB, http.Handler, string) {
+	t.Helper()
+	database, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+	token := registerAndGetToken(t, router)
+	return database, router, token
+}
+
+// searchGet performs a GET /api/search request and returns the parsed response.
+func searchGet(t *testing.T, router http.Handler, token, url string) (int, SearchResponse) {
+	t.Helper()
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", url, nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	var resp SearchResponse
+	if w.Code == http.StatusOK {
+		require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	}
+	return w.Code, resp
+}
+
+// seedSearchData creates test data across all entity types for search tests.
+func seedSearchData(t *testing.T, database *gorm.DB) {
+	t.Helper()
+
+	// Find SNES and NES console IDs
+	var snes, nes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nes).Error)
+
+	// Create games
+	games := []db.Game{
+		{ConsoleID: snes.ID, Title: "Super Mario World", FileName: "smw.smc", FilePath: "/roms/snes/smw.smc", Developer: "Nintendo", Publisher: "Nintendo", Genre: "Platformer", Rating: 95},
+		{ConsoleID: snes.ID, Title: "Super Metroid", FileName: "sm.smc", FilePath: "/roms/snes/sm.smc", Developer: "Nintendo", Publisher: "Nintendo", Genre: "Action", Rating: 96},
+		{ConsoleID: nes.ID, Title: "Super Mario Bros", FileName: "smb.nes", FilePath: "/roms/nes/smb.nes", Developer: "Nintendo", Publisher: "Nintendo", Genre: "Platformer", Rating: 90},
+		{ConsoleID: snes.ID, Title: "Chrono Trigger", FileName: "ct.smc", FilePath: "/roms/snes/ct.smc", Developer: "Square", Publisher: "Square", Genre: "RPG", Rating: 98},
+		{ConsoleID: nes.ID, Title: "Mega Man 2", FileName: "mm2.nes", FilePath: "/roms/nes/mm2.nes", Developer: "Capcom", Publisher: "Capcom", Genre: "Action", Rating: 85},
+	}
+	for i := range games {
+		require.NoError(t, database.Create(&games[i]).Error)
+	}
+
+	// Create a series
+	series := db.GameSeries{
+		IGDBCollectionID: 100,
+		Name:             "Super Mario Series",
+	}
+	require.NoError(t, database.Create(&series).Error)
+	// Add entries
+	entry1 := db.GameSeriesEntry{SeriesID: series.ID, GameID: &games[0].ID, IGDBGameID: 1001, Name: "Super Mario World"}
+	entry2 := db.GameSeriesEntry{SeriesID: series.ID, GameID: &games[2].ID, IGDBGameID: 1002, Name: "Super Mario Bros"}
+	entry3 := db.GameSeriesEntry{SeriesID: series.ID, GameID: nil, IGDBGameID: 1003, Name: "Super Mario 64"}
+	require.NoError(t, database.Create(&entry1).Error)
+	require.NoError(t, database.Create(&entry2).Error)
+	require.NoError(t, database.Create(&entry3).Error)
+
+	// Create a franchise group
+	franchise := db.GameFranchiseGroup{
+		IGDBFranchiseID: 200,
+		Name:            "Mario Franchise",
+	}
+	require.NoError(t, database.Create(&franchise).Error)
+	fEntry1 := db.GameFranchiseEntry{FranchiseGroupID: franchise.ID, GameID: &games[0].ID, IGDBGameID: 2001, Name: "Super Mario World"}
+	fEntry2 := db.GameFranchiseEntry{FranchiseGroupID: franchise.ID, GameID: nil, IGDBGameID: 2002, Name: "Mario Kart 8"}
+	require.NoError(t, database.Create(&fEntry1).Error)
+	require.NoError(t, database.Create(&fEntry2).Error)
+}
+
+func TestSearch_MultiTypeResults(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+	seedSearchData(t, database)
+
+	// "Super" matches games (Super Mario World, Super Metroid, Super Mario Bros),
+	// the series (Super Mario Series), and developer Nintendo has "Super" games
+	code, resp := searchGet(t, router, token, "/api/search?q=Super")
+	assert.Equal(t, http.StatusOK, code)
+
+	// Games: should find 3 "Super" games
+	assert.Equal(t, 3, resp.Games.Total)
+	assert.Len(t, resp.Games.Results, 3)
+
+	// Verify game fields are populated
+	found := false
+	for _, g := range resp.Games.Results {
+		if g.Title == "Super Mario World" {
+			found = true
+			assert.NotEmpty(t, g.ID)
+			assert.Equal(t, "snes", g.ConsoleID)
+			assert.Equal(t, "Super Nintendo", g.ConsoleName)
+			assert.Equal(t, "Nintendo", g.Developer)
+			assert.Equal(t, "Platformer", g.Genre)
+			break
+		}
+	}
+	assert.True(t, found, "expected to find Super Mario World in results")
+
+	// Series: "Super Mario Series" matches
+	assert.GreaterOrEqual(t, resp.Series.Total, 1)
+	assert.GreaterOrEqual(t, len(resp.Series.Results), 1)
+	assert.Equal(t, "Super Mario Series", resp.Series.Results[0].Name)
+	assert.Equal(t, 3, resp.Series.Results[0].TotalGames)   // 3 entries
+	assert.Equal(t, 2, resp.Series.Results[0].LibraryGames)  // 2 are local
+}
+
+func TestSearch_SingleTypeResults(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+	seedSearchData(t, database)
+
+	// "Chrono" only matches the game "Chrono Trigger"
+	code, resp := searchGet(t, router, token, "/api/search?q=Chrono")
+	assert.Equal(t, http.StatusOK, code)
+
+	assert.Equal(t, 1, resp.Games.Total)
+	assert.Len(t, resp.Games.Results, 1)
+	assert.Equal(t, "Chrono Trigger", resp.Games.Results[0].Title)
+
+	// Other categories should be empty
+	assert.Equal(t, 0, resp.Consoles.Total)
+	assert.Empty(t, resp.Consoles.Results)
+	assert.Equal(t, 0, resp.Series.Total)
+	assert.Empty(t, resp.Series.Results)
+	assert.Equal(t, 0, resp.Franchises.Total)
+	assert.Empty(t, resp.Franchises.Results)
+}
+
+func TestSearch_EmptyResults(t *testing.T) {
+	_, router, token := setupSearchEnv(t)
+
+	code, resp := searchGet(t, router, token, "/api/search?q=zzzznonexistent")
+	assert.Equal(t, http.StatusOK, code)
+
+	assert.Equal(t, 0, resp.Games.Total)
+	assert.Empty(t, resp.Games.Results)
+	assert.Equal(t, 0, resp.Consoles.Total)
+	assert.Empty(t, resp.Consoles.Results)
+	assert.Equal(t, 0, resp.Developers.Total)
+	assert.Empty(t, resp.Developers.Results)
+	assert.Equal(t, 0, resp.Publishers.Total)
+	assert.Empty(t, resp.Publishers.Results)
+	assert.Equal(t, 0, resp.Collections.Total)
+	assert.Empty(t, resp.Collections.Results)
+	assert.Equal(t, 0, resp.Series.Total)
+	assert.Empty(t, resp.Series.Results)
+	assert.Equal(t, 0, resp.Franchises.Total)
+	assert.Empty(t, resp.Franchises.Results)
+}
+
+func TestSearch_ShortQueryRejected(t *testing.T) {
+	_, router, token := setupSearchEnv(t)
+
+	// Single character -> 400
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/search?q=a", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	var errResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &errResp)
+	assert.Contains(t, errResp["error"], "at least 2 characters")
+
+	// Empty query -> 400
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/search?q=", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+
+	// No query parameter -> 400
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/search", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestSearch_CaseInsensitive(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+	seedSearchData(t, database)
+
+	// Lowercase search should find "Super Mario World"
+	code1, resp1 := searchGet(t, router, token, "/api/search?q="+url.QueryEscape("super mario"))
+	assert.Equal(t, http.StatusOK, code1)
+	assert.GreaterOrEqual(t, resp1.Games.Total, 1)
+
+	// Uppercase search should find the same results
+	code2, resp2 := searchGet(t, router, token, "/api/search?q="+url.QueryEscape("SUPER MARIO"))
+	assert.Equal(t, http.StatusOK, code2)
+	assert.Equal(t, resp1.Games.Total, resp2.Games.Total)
+
+	// Mixed case
+	code3, resp3 := searchGet(t, router, token, "/api/search?q="+url.QueryEscape("SuPeR MaRiO"))
+	assert.Equal(t, http.StatusOK, code3)
+	assert.Equal(t, resp1.Games.Total, resp3.Games.Total)
+}
+
+func TestSearch_LimitParameter(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+	seedSearchData(t, database)
+
+	// Default limit should return all matching games (3 "Super" games, limit=5)
+	code, resp := searchGet(t, router, token, "/api/search?q=Super")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, 3, resp.Games.Total)
+	assert.Len(t, resp.Games.Results, 3)
+
+	// Limit to 1 should return 1 result but total stays 3
+	code, resp = searchGet(t, router, token, "/api/search?q=Super&limit=1")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, 3, resp.Games.Total) // total is still 3
+	assert.Len(t, resp.Games.Results, 1)  // only 1 returned
+}
+
+func TestSearch_GamesExcludeSoftDeleted(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+
+	var snes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
+
+	// Create a normal game
+	game1 := db.Game{ConsoleID: snes.ID, Title: "Active Game Zelda", FileName: "zelda.smc", FilePath: "/roms/snes/zelda.smc"}
+	require.NoError(t, database.Create(&game1).Error)
+
+	// Create and soft-delete a game
+	game2 := db.Game{ConsoleID: snes.ID, Title: "Deleted Game Zelda", FileName: "zelda2.smc", FilePath: "/roms/snes/zelda2.smc"}
+	require.NoError(t, database.Create(&game2).Error)
+	require.NoError(t, database.Delete(&game2).Error)
+
+	code, resp := searchGet(t, router, token, "/api/search?q=Zelda")
+	assert.Equal(t, http.StatusOK, code)
+
+	// Only the active game should be returned
+	assert.Equal(t, 1, resp.Games.Total)
+	assert.Len(t, resp.Games.Results, 1)
+	assert.Equal(t, "Active Game Zelda", resp.Games.Results[0].Title)
+}
+
+func TestSearch_Collections_PublicAndOwnPrivate(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+
+	// Get the owner user
+	var owner db.User
+	require.NoError(t, database.First(&owner).Error)
+
+	// Create a second user
+	token2 := createNonOwnerUser(t, router, token, "user2", "user2@test.com", "password123")
+	var user2 db.User
+	require.NoError(t, database.Where("username = ?", "user2").First(&user2).Error)
+
+	// Owner creates a public collection
+	publicCol := db.GameCollection{UserID: owner.ID, Name: "Public Search Collection", IsPublic: true}
+	require.NoError(t, database.Create(&publicCol).Error)
+
+	// Owner creates a private collection
+	ownerPrivateCol := db.GameCollection{UserID: owner.ID, Name: "Private Search Collection", IsPublic: false}
+	require.NoError(t, database.Create(&ownerPrivateCol).Error)
+
+	// User2 creates a private collection
+	user2PrivateCol := db.GameCollection{UserID: user2.ID, Name: "Secret Search Collection", IsPublic: false}
+	require.NoError(t, database.Create(&user2PrivateCol).Error)
+
+	// Owner searching for "Search Collection": should see public + own private
+	code, resp := searchGet(t, router, token, "/api/search?q="+url.QueryEscape("Search Collection"))
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, 2, resp.Collections.Total) // public + owner's private
+	names := make([]string, len(resp.Collections.Results))
+	for i, c := range resp.Collections.Results {
+		names[i] = c.Name
+	}
+	assert.Contains(t, names, "Public Search Collection")
+	assert.Contains(t, names, "Private Search Collection")
+	assert.NotContains(t, names, "Secret Search Collection")
+
+	// User2 searching: should see public + own private
+	code2, resp2 := searchGet(t, router, token2, "/api/search?q="+url.QueryEscape("Search Collection"))
+	assert.Equal(t, http.StatusOK, code2)
+	assert.Equal(t, 2, resp2.Collections.Total) // public + user2's private
+	names2 := make([]string, len(resp2.Collections.Results))
+	for i, c := range resp2.Collections.Results {
+		names2[i] = c.Name
+	}
+	assert.Contains(t, names2, "Public Search Collection")
+	assert.Contains(t, names2, "Secret Search Collection")
+	assert.NotContains(t, names2, "Private Search Collection")
+}
+
+func TestSearch_Consoles_OnlyWithGames(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+
+	// "Nintendo" matches several console names (e.g. "Super Nintendo Entertainment System",
+	// "Nintendo Entertainment System", "Nintendo 64", etc.) but only those with games
+	// should appear.
+	var snes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
+
+	// Add a game to SNES only
+	game := db.Game{ConsoleID: snes.ID, Title: "Test Game", FileName: "test.smc", FilePath: "/roms/snes/test.smc"}
+	require.NoError(t, database.Create(&game).Error)
+
+	code, resp := searchGet(t, router, token, "/api/search?q=Nintendo")
+	assert.Equal(t, http.StatusOK, code)
+
+	// Only SNES should appear (it's the only one with games)
+	// The name contains "Nintendo" (Super Nintendo Entertainment System)
+	for _, c := range resp.Consoles.Results {
+		assert.Greater(t, c.GameCount, 0, "console %s should have games", c.Name)
+	}
+}
+
+func TestSearch_Developers(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+	seedSearchData(t, database)
+
+	// "Nintendo" is the developer for 3 games
+	code, resp := searchGet(t, router, token, "/api/search?q=Nintendo")
+	assert.Equal(t, http.StatusOK, code)
+
+	assert.GreaterOrEqual(t, resp.Developers.Total, 1)
+	found := false
+	for _, d := range resp.Developers.Results {
+		if d.Name == "Nintendo" {
+			found = true
+			assert.Equal(t, 3, d.GameCount)
+			assert.Greater(t, d.AvgRating, 0.0)
+			break
+		}
+	}
+	assert.True(t, found, "expected to find Nintendo in developers")
+}
+
+func TestSearch_Publishers(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+	seedSearchData(t, database)
+
+	// "Capcom" is publisher for 1 game
+	code, resp := searchGet(t, router, token, "/api/search?q=Capcom")
+	assert.Equal(t, http.StatusOK, code)
+
+	assert.GreaterOrEqual(t, resp.Publishers.Total, 1)
+	found := false
+	for _, p := range resp.Publishers.Results {
+		if p.Name == "Capcom" {
+			found = true
+			assert.Equal(t, 1, p.GameCount)
+			break
+		}
+	}
+	assert.True(t, found, "expected to find Capcom in publishers")
+}
+
+func TestSearch_Franchises(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+	seedSearchData(t, database)
+
+	// "Mario Franchise" should be found
+	code, resp := searchGet(t, router, token, "/api/search?q="+url.QueryEscape("Mario Franchise"))
+	assert.Equal(t, http.StatusOK, code)
+
+	assert.GreaterOrEqual(t, resp.Franchises.Total, 1)
+	assert.Equal(t, "Mario Franchise", resp.Franchises.Results[0].Name)
+	assert.Equal(t, 2, resp.Franchises.Results[0].TotalGames)   // 2 entries
+	assert.Equal(t, 1, resp.Franchises.Results[0].LibraryGames)  // 1 has local game
+}
+
+func TestSearch_RequiresAuth(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	cfg.NetplayHub = ws.NewNetplayHub(nil)
+	router := NewRouter(*cfg)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/search?q=test", nil)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestSearch_LimitDefaultsAndBounds(t *testing.T) {
+	database, router, token := setupSearchEnv(t)
+
+	var snes db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
+
+	// Create 10 games to test limit
+	for i := 0; i < 10; i++ {
+		game := db.Game{
+			ConsoleID: snes.ID,
+			Title:     fmt.Sprintf("Limit Test Game %d", i),
+			FileName:  fmt.Sprintf("ltg%d.smc", i),
+			FilePath:  fmt.Sprintf("/roms/snes/ltg%d.smc", i),
+		}
+		require.NoError(t, database.Create(&game).Error)
+	}
+
+	// Default limit=5 should cap results at 5
+	code, resp := searchGet(t, router, token, "/api/search?q="+url.QueryEscape("Limit Test"))
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, 10, resp.Games.Total) // all 10 match
+	assert.Len(t, resp.Games.Results, 5)  // default limit = 5
+
+	// Invalid limit (negative) should fall back to 5
+	code, resp = searchGet(t, router, token, "/api/search?q="+url.QueryEscape("Limit Test")+"&limit=-1")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Len(t, resp.Games.Results, 5)
+
+	// limit=10 should return all
+	code, resp = searchGet(t, router, token, "/api/search?q="+url.QueryEscape("Limit Test")+"&limit=10")
+	assert.Equal(t, http.StatusOK, code)
+	assert.Len(t, resp.Games.Results, 10)
+}

--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -30,6 +30,7 @@ import { useNotifications } from "@/hooks/use-notifications";
 import { useBiosStatus } from "@/hooks/use-bios";
 import { useIgdbStatus } from "@/hooks/use-admin";
 import { useHealth } from "@/hooks/use-health";
+import { SearchPalette } from "@/features/search/components/search-palette";
 
 export function AppLayout() {
   const { user, logout, isAdmin } = useAuth();
@@ -170,6 +171,7 @@ export function AppLayout() {
         mobileOpen={mobileMenuOpen}
         onMobileClose={closeMobileMenu}
         version={health?.version}
+        onSearchClick={() => window.dispatchEvent(new Event("open-search-palette"))}
       />
 
       {/* Content area — left padding on desktop, top padding on mobile */}
@@ -178,6 +180,8 @@ export function AppLayout() {
           <Outlet />
         </main>
       </div>
+
+      <SearchPalette />
     </div>
   );
 }

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useEffect, useRef } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { cn } from "@/lib/cn";
-import { Gamepad2, LogOut } from "lucide-react";
+import { Gamepad2, LogOut, Search } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
 export interface SidebarLinkProps {
@@ -77,9 +77,10 @@ interface SidebarContentProps {
   };
   onLogout?: () => void;
   version?: string;
+  onSearchClick?: () => void;
 }
 
-function SidebarContent({ links, user, onLogout, version }: SidebarContentProps) {
+function SidebarContent({ links, user, onLogout, version, onSearchClick }: SidebarContentProps) {
   return (
     <>
       <div className="flex items-center gap-3 px-5 py-5 border-b border-surface-800/50">
@@ -90,6 +91,22 @@ function SidebarContent({ links, user, onLogout, version }: SidebarContentProps)
           Spela
         </span>
       </div>
+
+      {onSearchClick && (
+        <div className="px-3 pt-3 pb-1">
+          <button
+            onClick={onSearchClick}
+            className="flex items-center gap-3 w-full px-3 py-2.5 rounded-xl text-sm text-surface-400 hover:text-surface-100 hover:bg-surface-800/50 transition-all duration-200 cursor-pointer"
+            aria-label="Open search"
+          >
+            <Search className="h-5 w-5 flex-shrink-0" />
+            <span className="flex-1 text-left">Search...</span>
+            <kbd className="hidden sm:inline-flex items-center rounded border border-surface-700 bg-surface-800 px-1.5 py-0.5 text-xs text-surface-500">
+              ⌘K
+            </kbd>
+          </button>
+        </div>
+      )}
 
       <nav className="flex-1 overflow-y-auto px-3 py-4 space-y-6">
         {links.map((group, i) => (
@@ -149,9 +166,10 @@ interface SidebarProps {
   mobileOpen?: boolean;
   onMobileClose?: () => void;
   version?: string;
+  onSearchClick?: () => void;
 }
 
-export function Sidebar({ links, user, onLogout, mobileOpen, onMobileClose, version }: SidebarProps) {
+export function Sidebar({ links, user, onLogout, mobileOpen, onMobileClose, version, onSearchClick }: SidebarProps) {
   const drawerRef = useRef<HTMLElement>(null);
 
   // Close on Escape key
@@ -180,7 +198,7 @@ export function Sidebar({ links, user, onLogout, mobileOpen, onMobileClose, vers
     <>
       {/* Desktop sidebar — always visible at lg and above */}
       <aside className="hidden lg:flex fixed left-0 top-0 bottom-0 w-64 bg-surface-950 border-r border-surface-800/50 flex-col z-40">
-        <SidebarContent links={links} user={user} onLogout={onLogout} version={version} />
+        <SidebarContent links={links} user={user} onLogout={onLogout} version={version} onSearchClick={onSearchClick} />
       </aside>
 
       {/* Mobile drawer — visible below lg when open */}
@@ -210,7 +228,7 @@ export function Sidebar({ links, user, onLogout, mobileOpen, onMobileClose, vers
               : "-translate-x-full duration-200 ease-in",
           )}
         >
-          <SidebarContent links={links} user={user} onLogout={onLogout} version={version} />
+          <SidebarContent links={links} user={user} onLogout={onLogout} version={version} onSearchClick={() => { onSearchClick?.(); onMobileClose?.(); }} />
         </aside>
       </div>
     </>

--- a/web/src/features/search/components/__tests__/search-palette.test.tsx
+++ b/web/src/features/search/components/__tests__/search-palette.test.tsx
@@ -1,0 +1,326 @@
+import { render, screen, waitFor, act, fireEvent } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SearchPalette } from "../search-palette";
+import type { SearchResults } from "@/hooks/use-search";
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+const mockGet = vi.fn();
+vi.mock("@/lib/api-client", () => ({
+  api: {
+    get: (...args: unknown[]) => mockGet(...args),
+  },
+}));
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+/** Simulate Cmd+K (metaKey) via document keydown. */
+function pressMetaK() {
+  fireEvent.keyDown(document, { key: "k", metaKey: true });
+}
+
+/** Simulate Ctrl+K (ctrlKey) via document keydown. */
+function pressCtrlK() {
+  fireEvent.keyDown(document, { key: "k", ctrlKey: true });
+}
+
+/** Simulate Escape via document keydown. */
+function pressEscape() {
+  fireEvent.keyDown(document, { key: "Escape" });
+}
+
+function emptyResults(): SearchResults {
+  return {
+    games: { results: [], total: 0 },
+    consoles: { results: [], total: 0 },
+    developers: { results: [], total: 0 },
+    publishers: { results: [], total: 0 },
+    collections: { results: [], total: 0 },
+    series: { results: [], total: 0 },
+    franchises: { results: [], total: 0 },
+  };
+}
+
+function resultsWithGames(): SearchResults {
+  return {
+    ...emptyResults(),
+    games: {
+      results: [
+        {
+          id: "game-1",
+          title: "Super Mario World",
+          coverUrl: "/covers/smw.jpg",
+          consoleId: "SNES",
+          consoleName: "Super Nintendo",
+          developer: "Nintendo",
+        },
+        {
+          id: "game-2",
+          title: "Mario Kart 64",
+          consoleId: "N64",
+          consoleName: "Nintendo 64",
+          developer: "Nintendo",
+        },
+      ],
+      total: 5,
+    },
+    developers: {
+      results: [
+        { name: "Nintendo", gameCount: 42, avgRating: 85.3 },
+      ],
+      total: 1,
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.clear();
+  document.body.style.overflow = "";
+});
+
+afterEach(() => {
+  document.body.style.overflow = "";
+});
+
+describe("SearchPalette", () => {
+  describe("opening and closing", () => {
+    it("is not visible by default", () => {
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      expect(screen.queryByTestId("search-palette")).not.toBeInTheDocument();
+    });
+
+    it("opens with Cmd+K", () => {
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      expect(screen.getByTestId("search-palette")).toBeInTheDocument();
+    });
+
+    it("opens with Ctrl+K", () => {
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressCtrlK());
+      expect(screen.getByTestId("search-palette")).toBeInTheDocument();
+    });
+
+    it("opens via custom event (sidebar button)", () => {
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => {
+        window.dispatchEvent(new Event("open-search-palette"));
+      });
+      expect(screen.getByTestId("search-palette")).toBeInTheDocument();
+    });
+
+    it("closes on Escape", () => {
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      expect(screen.getByTestId("search-palette")).toBeInTheDocument();
+      act(() => pressEscape());
+      expect(screen.queryByTestId("search-palette")).not.toBeInTheDocument();
+    });
+
+    it("closes on backdrop click", async () => {
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      const overlay = screen.getByTestId("search-palette");
+      // Click the overlay itself (not the dialog panel inside)
+      await userEvent.click(overlay);
+      expect(screen.queryByTestId("search-palette")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("empty and short query states", () => {
+    it("shows prompt when query is empty and no recent searches", () => {
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      expect(screen.getByText("Start typing to search...")).toBeInTheDocument();
+    });
+
+    it("shows hint when query is less than 2 characters", async () => {
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      await userEvent.type(screen.getByLabelText("Search input"), "a");
+      expect(screen.getByText("Type at least 2 characters")).toBeInTheDocument();
+    });
+  });
+
+  describe("search results", () => {
+    it("displays results grouped by type after typing", async () => {
+      mockGet.mockResolvedValue(resultsWithGames());
+
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      await userEvent.type(screen.getByLabelText("Search input"), "mario");
+
+      await waitFor(() => {
+        expect(screen.getByText("Games")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+      expect(screen.getByText("Mario Kart 64")).toBeInTheDocument();
+      expect(screen.getByText("SNES")).toBeInTheDocument();
+      expect(screen.getByText("N64")).toBeInTheDocument();
+
+      // Developer section
+      expect(screen.getByText("Developers")).toBeInTheDocument();
+    });
+
+    it("shows 'total' count when there are more results than shown", async () => {
+      mockGet.mockResolvedValue(resultsWithGames());
+
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      await userEvent.type(screen.getByLabelText("Search input"), "mario");
+
+      await waitFor(() => {
+        expect(screen.getByText("5 total")).toBeInTheDocument();
+      });
+    });
+
+    it("shows no results message when search returns empty", async () => {
+      mockGet.mockResolvedValue(emptyResults());
+
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      await userEvent.type(screen.getByLabelText("Search input"), "zzzzz");
+
+      await waitFor(() => {
+        expect(screen.getByText(/No results for/)).toBeInTheDocument();
+      });
+    });
+
+    it("navigates and closes when clicking a result", async () => {
+      mockGet.mockResolvedValue(resultsWithGames());
+
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      await userEvent.type(screen.getByLabelText("Search input"), "mario");
+
+      await waitFor(() => {
+        expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByTestId("search-result-game-game-1"));
+
+      expect(mockNavigate).toHaveBeenCalledWith("/games/game-1");
+      // Palette should close
+      expect(screen.queryByTestId("search-palette")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows loading spinner while fetching", async () => {
+      // Never resolve the promise so we stay in loading
+      mockGet.mockReturnValue(new Promise(() => {}));
+
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      await userEvent.type(screen.getByLabelText("Search input"), "mario");
+
+      await waitFor(() => {
+        expect(screen.getAllByTestId("search-loading").length).toBeGreaterThanOrEqual(1);
+      });
+    });
+  });
+
+  describe("recent searches", () => {
+    it("shows recent searches when palette opens with empty query", () => {
+      localStorage.setItem(
+        "spela-recent-searches",
+        JSON.stringify(["zelda", "metroid"]),
+      );
+
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+
+      expect(screen.getByText("Recent searches")).toBeInTheDocument();
+      expect(screen.getByText("zelda")).toBeInTheDocument();
+      expect(screen.getByText("metroid")).toBeInTheDocument();
+    });
+
+    it("removes a recent search when clicking X", async () => {
+      localStorage.setItem(
+        "spela-recent-searches",
+        JSON.stringify(["zelda", "metroid"]),
+      );
+
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+
+      await userEvent.click(screen.getByLabelText("Remove zelda"));
+      expect(screen.queryByText("zelda")).not.toBeInTheDocument();
+      expect(screen.getByText("metroid")).toBeInTheDocument();
+    });
+
+    it("clears all recent searches", async () => {
+      localStorage.setItem(
+        "spela-recent-searches",
+        JSON.stringify(["zelda", "metroid"]),
+      );
+
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+
+      await userEvent.click(screen.getByText("Clear all"));
+      expect(screen.queryByText("zelda")).not.toBeInTheDocument();
+      expect(screen.queryByText("metroid")).not.toBeInTheDocument();
+      expect(screen.getByText("Start typing to search...")).toBeInTheDocument();
+    });
+
+    it("fills search input when clicking a recent search", async () => {
+      localStorage.setItem(
+        "spela-recent-searches",
+        JSON.stringify(["zelda"]),
+      );
+
+      mockGet.mockResolvedValue(emptyResults());
+
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+
+      await userEvent.click(screen.getByText("zelda"));
+
+      const input = screen.getByLabelText("Search input") as HTMLInputElement;
+      expect(input.value).toBe("zelda");
+    });
+
+    it("saves search term when navigating to a result", async () => {
+      mockGet.mockResolvedValue(resultsWithGames());
+
+      render(<SearchPalette />, { wrapper: createWrapper() });
+      act(() => pressMetaK());
+      await userEvent.type(screen.getByLabelText("Search input"), "mario");
+
+      await waitFor(() => {
+        expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+      });
+
+      await userEvent.click(screen.getByTestId("search-result-game-game-1"));
+
+      const stored = JSON.parse(
+        localStorage.getItem("spela-recent-searches") ?? "[]",
+      );
+      expect(stored).toContain("mario");
+    });
+  });
+});

--- a/web/src/features/search/components/search-palette.tsx
+++ b/web/src/features/search/components/search-palette.tsx
@@ -1,0 +1,227 @@
+import { useState, useRef, useEffect, useCallback } from "react";
+import { Search, Loader2, Clock, X } from "lucide-react";
+import { cn } from "@/lib/cn";
+import { useSearch } from "@/hooks/use-search";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useHotkey } from "@/hooks/use-hotkey";
+import { useRecentSearches } from "@/hooks/use-recent-searches";
+import { SearchResultsDisplay } from "./search-results";
+
+export function SearchPalette() {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const debouncedQuery = useDebouncedValue(query.trim(), 250);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const overlayRef = useRef<HTMLDivElement>(null);
+  const { recentSearches, addRecent, removeRecent, clearRecent } =
+    useRecentSearches();
+
+  const { data: results, isLoading, isFetching } = useSearch(debouncedQuery);
+
+  const openPalette = useCallback(() => setOpen(true), []);
+  const closePalette = useCallback(() => {
+    setOpen(false);
+    setQuery("");
+  }, []);
+
+  // Cmd+K / Ctrl+K to open
+  useHotkey("k", openPalette, { meta: true, ctrl: true });
+
+  // Listen for external open requests (e.g. from sidebar search button)
+  useEffect(() => {
+    const handler = () => setOpen(true);
+    window.addEventListener("open-search-palette", handler);
+    return () => window.removeEventListener("open-search-palette", handler);
+  }, []);
+
+  // Auto-focus input when opened
+  useEffect(() => {
+    if (open) {
+      // Small delay to ensure DOM is ready
+      requestAnimationFrame(() => inputRef.current?.focus());
+    }
+  }, [open]);
+
+  // Lock body scroll when open
+  useEffect(() => {
+    if (open) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [open]);
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "Escape") closePalette();
+    };
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [open, closePalette]);
+
+  const handleNavigate = useCallback(
+    (path: string) => {
+      void path;
+      if (query.trim()) {
+        addRecent(query.trim());
+      }
+      closePalette();
+    },
+    [query, addRecent, closePalette],
+  );
+
+  const handleRecentClick = useCallback(
+    (term: string) => {
+      setQuery(term);
+    },
+    [],
+  );
+
+  const hasResults =
+    results &&
+    (results.games.results.length > 0 ||
+      results.consoles.results.length > 0 ||
+      results.developers.results.length > 0 ||
+      results.publishers.results.length > 0 ||
+      results.collections.results.length > 0 ||
+      results.series.results.length > 0 ||
+      results.franchises.results.length > 0);
+
+  if (!open) return null;
+
+  return (
+    <div
+      ref={overlayRef}
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] px-4"
+      onClick={(e) => {
+        if (e.target === overlayRef.current) closePalette();
+      }}
+      data-testid="search-palette"
+    >
+      {/* Backdrop */}
+      <div className="fixed inset-0 bg-black/60 backdrop-blur-sm" />
+
+      {/* Panel */}
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-label="Search"
+        className={cn(
+          "relative w-full max-w-[640px] rounded-2xl bg-surface-900 border border-surface-800 shadow-2xl",
+          "animate-in fade-in zoom-in-95 duration-200",
+        )}
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-3 px-4 border-b border-surface-800">
+          <Search className="h-5 w-5 text-surface-500 flex-shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search games, consoles, developers..."
+            className="flex-1 bg-transparent py-4 text-base text-surface-100 placeholder:text-surface-500 focus:outline-none"
+            aria-label="Search input"
+          />
+          {isFetching && (
+            <Loader2 className="h-4 w-4 text-surface-500 animate-spin flex-shrink-0" data-testid="search-loading" />
+          )}
+          <kbd className="hidden sm:inline-flex items-center gap-0.5 rounded border border-surface-700 bg-surface-800 px-1.5 py-0.5 text-xs text-surface-500">
+            Esc
+          </kbd>
+        </div>
+
+        {/* Content area */}
+        <div className="min-h-[60px]">
+          {/* Empty query — show recent searches or prompt */}
+          {!query.trim() && (
+            <div className="px-4 py-4">
+              {recentSearches.length > 0 ? (
+                <div>
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="text-xs font-semibold uppercase tracking-wider text-surface-500">
+                      Recent searches
+                    </span>
+                    <button
+                      onClick={clearRecent}
+                      className="text-xs text-surface-500 hover:text-surface-300 transition-colors"
+                    >
+                      Clear all
+                    </button>
+                  </div>
+                  <div className="space-y-0.5">
+                    {recentSearches.map((term) => (
+                      <div
+                        key={term}
+                        className="flex items-center gap-2 group"
+                      >
+                        <button
+                          className="flex items-center gap-2 flex-1 px-2 py-1.5 rounded-lg text-sm text-surface-300 hover:bg-surface-800/50 transition-colors text-left"
+                          onClick={() => handleRecentClick(term)}
+                        >
+                          <Clock className="h-3.5 w-3.5 text-surface-500" />
+                          {term}
+                        </button>
+                        <button
+                          onClick={() => removeRecent(term)}
+                          className="p-1 rounded text-surface-600 hover:text-surface-300 opacity-0 group-hover:opacity-100 transition-all"
+                          aria-label={`Remove ${term}`}
+                        >
+                          <X className="h-3.5 w-3.5" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              ) : (
+                <p className="text-sm text-surface-500 text-center py-4">
+                  Start typing to search...
+                </p>
+              )}
+            </div>
+          )}
+
+          {/* Short query hint */}
+          {query.trim().length > 0 && query.trim().length < 2 && (
+            <p className="text-sm text-surface-500 text-center py-6">
+              Type at least 2 characters
+            </p>
+          )}
+
+          {/* Loading state (only show when no existing results and fetching) */}
+          {debouncedQuery.length >= 2 && isLoading && (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-5 w-5 text-surface-500 animate-spin" data-testid="search-loading" />
+            </div>
+          )}
+
+          {/* No results */}
+          {debouncedQuery.length >= 2 &&
+            !isLoading &&
+            results &&
+            !hasResults && (
+              <div className="flex flex-col items-center py-8">
+                <Search className="h-8 w-8 text-surface-600 mb-2" />
+                <p className="text-sm text-surface-500">
+                  No results for &ldquo;{debouncedQuery}&rdquo;
+                </p>
+              </div>
+            )}
+
+          {/* Results */}
+          {results && hasResults && (
+            <SearchResultsDisplay
+              results={results}
+              onNavigate={handleNavigate}
+            />
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/search/components/search-results.tsx
+++ b/web/src/features/search/components/search-results.tsx
@@ -1,0 +1,456 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Code,
+  Building,
+  FolderOpen,
+  Layers,
+  Crown,
+  Star,
+} from "lucide-react";
+import { cn } from "@/lib/cn";
+import type {
+  SearchResults,
+  GameSearchResult,
+  ConsoleSearchResult,
+  DeveloperSearchResult,
+  PublisherSearchResult,
+  CollectionSearchResult,
+  SeriesSearchResult,
+  FranchiseSearchResult,
+} from "@/hooks/use-search";
+
+interface SearchResultsDisplayProps {
+  results: SearchResults;
+  onNavigate: (path: string) => void;
+}
+
+interface ResultSection {
+  key: string;
+  title: string;
+  total: number;
+  items: ResultItem[];
+}
+
+interface ResultItem {
+  id: string;
+  path: string;
+  render: (highlighted: boolean) => React.ReactNode;
+}
+
+function buildSections(results: SearchResults): ResultSection[] {
+  const sections: ResultSection[] = [];
+
+  if (results.games.results.length > 0) {
+    sections.push({
+      key: "games",
+      title: "Games",
+      total: results.games.total,
+      items: results.games.results.map((g) => ({
+        id: `game-${g.id}`,
+        path: `/games/${g.id}`,
+        render: (highlighted: boolean) => <GameRow game={g} highlighted={highlighted} />,
+      })),
+    });
+  }
+
+  if (results.consoles.results.length > 0) {
+    sections.push({
+      key: "consoles",
+      title: "Consoles",
+      total: results.consoles.total,
+      items: results.consoles.results.map((c) => ({
+        id: `console-${c.id}`,
+        path: `/consoles/${c.id}`,
+        render: (highlighted: boolean) => <ConsoleRow console={c} highlighted={highlighted} />,
+      })),
+    });
+  }
+
+  if (results.developers.results.length > 0) {
+    sections.push({
+      key: "developers",
+      title: "Developers",
+      total: results.developers.total,
+      items: results.developers.results.map((d) => ({
+        id: `dev-${d.name}`,
+        path: `/explore/developers/${encodeURIComponent(d.name)}`,
+        render: (highlighted: boolean) => <DeveloperRow developer={d} highlighted={highlighted} />,
+      })),
+    });
+  }
+
+  if (results.publishers.results.length > 0) {
+    sections.push({
+      key: "publishers",
+      title: "Publishers",
+      total: results.publishers.total,
+      items: results.publishers.results.map((p) => ({
+        id: `pub-${p.name}`,
+        path: `/explore/publishers/${encodeURIComponent(p.name)}`,
+        render: (highlighted: boolean) => <PublisherRow publisher={p} highlighted={highlighted} />,
+      })),
+    });
+  }
+
+  if (results.collections.results.length > 0) {
+    sections.push({
+      key: "collections",
+      title: "Collections",
+      total: results.collections.total,
+      items: results.collections.results.map((c) => ({
+        id: `col-${c.id}`,
+        path: `/collections/${c.id}`,
+        render: (highlighted: boolean) => <CollectionRow collection={c} highlighted={highlighted} />,
+      })),
+    });
+  }
+
+  if (results.series.results.length > 0) {
+    sections.push({
+      key: "series",
+      title: "Series",
+      total: results.series.total,
+      items: results.series.results.map((s) => ({
+        id: `series-${s.id}`,
+        path: `/explore/series/${s.id}`,
+        render: (highlighted: boolean) => <SeriesRow series={s} highlighted={highlighted} />,
+      })),
+    });
+  }
+
+  if (results.franchises.results.length > 0) {
+    sections.push({
+      key: "franchises",
+      title: "Franchises",
+      total: results.franchises.total,
+      items: results.franchises.results.map((f) => ({
+        id: `fran-${f.id}`,
+        path: `/explore/franchise/${f.id}`,
+        render: (highlighted: boolean) => <FranchiseRow franchise={f} highlighted={highlighted} />,
+      })),
+    });
+  }
+
+  return sections;
+}
+
+export function SearchResultsDisplay({
+  results,
+  onNavigate,
+}: SearchResultsDisplayProps) {
+  const sections = buildSections(results);
+  const allItems = sections.flatMap((s) => s.items);
+  const [highlightIndex, setHighlightIndex] = useState(-1);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const navigate = useNavigate();
+
+  // Reset highlight when results change
+  useEffect(() => {
+    setHighlightIndex(-1);
+  }, [results]);
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (allItems.length === 0) return;
+
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setHighlightIndex((prev) =>
+          prev < allItems.length - 1 ? prev + 1 : 0,
+        );
+      } else if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setHighlightIndex((prev) =>
+          prev > 0 ? prev - 1 : allItems.length - 1,
+        );
+      } else if (e.key === "Enter" && highlightIndex >= 0) {
+        e.preventDefault();
+        const item = allItems[highlightIndex];
+        if (item) {
+          onNavigate(item.path);
+          navigate(item.path);
+        }
+      }
+    },
+    [allItems, highlightIndex, navigate, onNavigate],
+  );
+
+  useEffect(() => {
+    document.addEventListener("keydown", handleKeyDown);
+    return () => document.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Scroll highlighted item into view
+  useEffect(() => {
+    if (highlightIndex < 0 || !scrollRef.current) return;
+    const el = scrollRef.current.querySelector(
+      `[data-result-index="${highlightIndex}"]`,
+    );
+    if (el && typeof el.scrollIntoView === "function") {
+      el.scrollIntoView({ block: "nearest" });
+    }
+  }, [highlightIndex]);
+
+  if (sections.length === 0) return null;
+
+  let globalIndex = 0;
+
+  return (
+    <div ref={scrollRef} className="overflow-y-auto max-h-[60vh]">
+      {sections.map((section) => (
+        <div key={section.key} className="py-2">
+          <div className="px-4 py-1.5 flex items-center justify-between">
+            <span className="text-xs font-semibold uppercase tracking-wider text-surface-500">
+              {section.title}
+            </span>
+            {section.total > section.items.length && (
+              <span className="text-xs text-surface-500">
+                {section.total} total
+              </span>
+            )}
+          </div>
+          {section.items.map((item) => {
+            const currentIndex = globalIndex++;
+            return (
+              <button
+                key={item.id}
+                data-result-index={currentIndex}
+                data-testid={`search-result-${item.id}`}
+                className="w-full text-left px-4 py-1.5 cursor-pointer"
+                onClick={() => {
+                  onNavigate(item.path);
+                  navigate(item.path);
+                }}
+                onMouseEnter={() => setHighlightIndex(currentIndex)}
+              >
+                {item.render(highlightIndex === currentIndex)}
+              </button>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// --- Individual row components ---
+
+function GameRow({
+  game,
+  highlighted,
+}: {
+  game: GameSearchResult;
+  highlighted: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg px-2 py-1.5 transition-colors",
+        highlighted ? "bg-surface-800" : "hover:bg-surface-800/50",
+      )}
+    >
+      {game.coverUrl ? (
+        <img
+          src={game.coverUrl}
+          alt=""
+          className="h-10 w-8 rounded object-cover flex-shrink-0"
+        />
+      ) : (
+        <div className="h-10 w-8 rounded bg-surface-700 flex-shrink-0" />
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-surface-100 truncate">
+          {game.title}
+        </p>
+        {game.developer && (
+          <p className="text-xs text-surface-500 truncate">{game.developer}</p>
+        )}
+      </div>
+      <span className="text-xs font-medium px-2 py-0.5 rounded bg-surface-800 text-surface-400 uppercase flex-shrink-0">
+        {game.consoleId}
+      </span>
+    </div>
+  );
+}
+
+function ConsoleRow({
+  console: c,
+  highlighted,
+}: {
+  console: ConsoleSearchResult;
+  highlighted: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg px-2 py-1.5 transition-colors",
+        highlighted ? "bg-surface-800" : "hover:bg-surface-800/50",
+      )}
+    >
+      <img
+        src={c.iconUrl}
+        alt=""
+        className="h-6 w-6 flex-shrink-0"
+      />
+      <p className="text-sm font-medium text-surface-100 flex-1 truncate">
+        {c.name}
+      </p>
+      <span className="text-xs text-surface-500">
+        {c.gameCount} {c.gameCount === 1 ? "game" : "games"}
+      </span>
+    </div>
+  );
+}
+
+function DeveloperRow({
+  developer,
+  highlighted,
+}: {
+  developer: DeveloperSearchResult;
+  highlighted: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg px-2 py-1.5 transition-colors",
+        highlighted ? "bg-surface-800" : "hover:bg-surface-800/50",
+      )}
+    >
+      <div className="h-8 w-8 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0">
+        <Code className="h-4 w-4 text-surface-400" />
+      </div>
+      <p className="text-sm font-medium text-surface-100 flex-1 truncate">
+        {developer.name}
+      </p>
+      <span className="text-xs text-surface-500 flex items-center gap-1.5">
+        {developer.gameCount} {developer.gameCount === 1 ? "game" : "games"}
+        {developer.avgRating > 0 && (
+          <>
+            <Star className="h-3 w-3 text-warning-500 fill-warning-500" />
+            {developer.avgRating.toFixed(1)}
+          </>
+        )}
+      </span>
+    </div>
+  );
+}
+
+function PublisherRow({
+  publisher,
+  highlighted,
+}: {
+  publisher: PublisherSearchResult;
+  highlighted: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg px-2 py-1.5 transition-colors",
+        highlighted ? "bg-surface-800" : "hover:bg-surface-800/50",
+      )}
+    >
+      <div className="h-8 w-8 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0">
+        <Building className="h-4 w-4 text-surface-400" />
+      </div>
+      <p className="text-sm font-medium text-surface-100 flex-1 truncate">
+        {publisher.name}
+      </p>
+      <span className="text-xs text-surface-500 flex items-center gap-1.5">
+        {publisher.gameCount} {publisher.gameCount === 1 ? "game" : "games"}
+        {publisher.avgRating > 0 && (
+          <>
+            <Star className="h-3 w-3 text-warning-500 fill-warning-500" />
+            {publisher.avgRating.toFixed(1)}
+          </>
+        )}
+      </span>
+    </div>
+  );
+}
+
+function CollectionRow({
+  collection,
+  highlighted,
+}: {
+  collection: CollectionSearchResult;
+  highlighted: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg px-2 py-1.5 transition-colors",
+        highlighted ? "bg-surface-800" : "hover:bg-surface-800/50",
+      )}
+    >
+      <div className="h-8 w-8 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0">
+        <FolderOpen className="h-4 w-4 text-surface-400" />
+      </div>
+      <div className="min-w-0 flex-1">
+        <p className="text-sm font-medium text-surface-100 truncate">
+          {collection.name}
+        </p>
+        <p className="text-xs text-surface-500 truncate">
+          by {collection.username}
+        </p>
+      </div>
+      <span className="text-xs text-surface-500">
+        {collection.gameCount} {collection.gameCount === 1 ? "game" : "games"}
+      </span>
+    </div>
+  );
+}
+
+function SeriesRow({
+  series,
+  highlighted,
+}: {
+  series: SeriesSearchResult;
+  highlighted: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg px-2 py-1.5 transition-colors",
+        highlighted ? "bg-surface-800" : "hover:bg-surface-800/50",
+      )}
+    >
+      <div className="h-8 w-8 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0">
+        <Layers className="h-4 w-4 text-surface-400" />
+      </div>
+      <p className="text-sm font-medium text-surface-100 flex-1 truncate">
+        {series.name}
+      </p>
+      <span className="text-xs text-surface-500">
+        {series.libraryGames} of {series.totalGames} in library
+      </span>
+    </div>
+  );
+}
+
+function FranchiseRow({
+  franchise,
+  highlighted,
+}: {
+  franchise: FranchiseSearchResult;
+  highlighted: boolean;
+}) {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 rounded-lg px-2 py-1.5 transition-colors",
+        highlighted ? "bg-surface-800" : "hover:bg-surface-800/50",
+      )}
+    >
+      <div className="h-8 w-8 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0">
+        <Crown className="h-4 w-4 text-surface-400" />
+      </div>
+      <p className="text-sm font-medium text-surface-100 flex-1 truncate">
+        {franchise.name}
+      </p>
+      <span className="text-xs text-surface-500">
+        {franchise.libraryGames} of {franchise.totalGames} in library
+      </span>
+    </div>
+  );
+}

--- a/web/src/hooks/use-hotkey.ts
+++ b/web/src/hooks/use-hotkey.ts
@@ -1,0 +1,30 @@
+import { useEffect } from "react";
+
+export function useHotkey(
+  key: string,
+  callback: () => void,
+  options?: { meta?: boolean; ctrl?: boolean },
+) {
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key.toLowerCase() !== key.toLowerCase()) return;
+      const needsMeta = options?.meta ?? false;
+      const needsCtrl = options?.ctrl ?? false;
+
+      // When both meta and ctrl are requested, accept either modifier.
+      // This supports Cmd+K on Mac and Ctrl+K on Windows/Linux.
+      if (needsMeta && needsCtrl) {
+        if (!e.metaKey && !e.ctrlKey) return;
+      } else {
+        if (needsMeta && !e.metaKey) return;
+        if (needsCtrl && !e.ctrlKey) return;
+      }
+
+      e.preventDefault();
+      callback();
+    };
+
+    document.addEventListener("keydown", handler);
+    return () => document.removeEventListener("keydown", handler);
+  }, [key, callback, options?.meta, options?.ctrl]);
+}

--- a/web/src/hooks/use-recent-searches.ts
+++ b/web/src/hooks/use-recent-searches.ts
@@ -1,0 +1,50 @@
+import { useState, useCallback } from "react";
+
+const STORAGE_KEY = "spela-recent-searches";
+const MAX_RECENT = 5;
+
+function loadRecent(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((s): s is string => typeof s === "string").slice(0, MAX_RECENT);
+  } catch {
+    return [];
+  }
+}
+
+function saveRecent(items: string[]) {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items.slice(0, MAX_RECENT)));
+}
+
+export function useRecentSearches() {
+  const [recentSearches, setRecentSearches] = useState<string[]>(loadRecent);
+
+  const addRecent = useCallback((term: string) => {
+    const trimmed = term.trim();
+    if (!trimmed) return;
+    setRecentSearches((prev) => {
+      const filtered = prev.filter((s) => s !== trimmed);
+      const next = [trimmed, ...filtered].slice(0, MAX_RECENT);
+      saveRecent(next);
+      return next;
+    });
+  }, []);
+
+  const removeRecent = useCallback((term: string) => {
+    setRecentSearches((prev) => {
+      const next = prev.filter((s) => s !== term);
+      saveRecent(next);
+      return next;
+    });
+  }, []);
+
+  const clearRecent = useCallback(() => {
+    setRecentSearches([]);
+    localStorage.removeItem(STORAGE_KEY);
+  }, []);
+
+  return { recentSearches, addRecent, removeRecent, clearRecent };
+}

--- a/web/src/hooks/use-search.ts
+++ b/web/src/hooks/use-search.ts
@@ -1,0 +1,74 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+
+export interface GameSearchResult {
+  id: string;
+  title: string;
+  coverUrl?: string;
+  consoleId: string;
+  consoleName: string;
+  developer?: string;
+}
+
+export interface ConsoleSearchResult {
+  id: string;
+  name: string;
+  iconUrl: string;
+  colorTheme: string;
+  gameCount: number;
+}
+
+export interface DeveloperSearchResult {
+  name: string;
+  gameCount: number;
+  avgRating: number;
+}
+
+export interface PublisherSearchResult {
+  name: string;
+  gameCount: number;
+  avgRating: number;
+}
+
+export interface CollectionSearchResult {
+  id: string;
+  name: string;
+  gameCount: number;
+  username: string;
+}
+
+export interface SeriesSearchResult {
+  id: string;
+  name: string;
+  libraryGames: number;
+  totalGames: number;
+}
+
+export interface FranchiseSearchResult {
+  id: string;
+  name: string;
+  libraryGames: number;
+  totalGames: number;
+}
+
+export interface SearchResults {
+  games: { results: GameSearchResult[]; total: number };
+  consoles: { results: ConsoleSearchResult[]; total: number };
+  developers: { results: DeveloperSearchResult[]; total: number };
+  publishers: { results: PublisherSearchResult[]; total: number };
+  collections: { results: CollectionSearchResult[]; total: number };
+  series: { results: SeriesSearchResult[]; total: number };
+  franchises: { results: FranchiseSearchResult[]; total: number };
+}
+
+export function useSearch(query: string) {
+  return useQuery({
+    queryKey: ["search", query],
+    queryFn: () =>
+      api.get<SearchResults>(
+        `/search?q=${encodeURIComponent(query)}&limit=5`,
+      ),
+    enabled: query.length >= 2,
+    staleTime: 30 * 1000,
+  });
+}

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -14,6 +14,9 @@ export type ApiGetPath = WithQuery<
   // Health
   | "/health"
 
+  // Search
+  | "/search"
+
   // Auth
   | "/auth/setup-status"
 


### PR DESCRIPTION
## Summary
- Add global search endpoint (`GET /api/search?q=&limit=`) searching across 7 entity types: games, consoles, developers, publishers, collections, series, and franchises
- Add Cmd+K / Ctrl+K command palette with grouped results, keyboard navigation (arrow keys + Enter), and distinct row designs per entity type
- Add recent searches stored in localStorage, sidebar search button, and search route type registration

## Backend
- `SearchHandler` with 7 entity-specific sub-queries using case-insensitive LIKE matching
- SQL injection protection via `escapeLikePattern` with ESCAPE clause
- Collection visibility scoping (public + own collections)
- 14 backend tests covering all entity types, edge cases, and error handling

## Frontend
- `SearchPalette` component with backdrop blur, auto-focus, and Escape/click-to-close
- `SearchResultsDisplay` with per-type row components (cover art for games, icons for consoles, rating stars for devs/publishers)
- `useHotkey` hook supporting both Cmd+K (Mac) and Ctrl+K (Win/Linux)
- `useRecentSearches` hook with localStorage persistence
- `useSearch` hook with TanStack Query, 250ms debounce, and 30s stale time
- 18 frontend tests covering open/close, results display, recent searches, and navigation

## Test plan
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] All 1319 web tests pass
- [x] All Go tests pass (including 14 new search handler tests)
- [ ] Manual test: Cmd+K opens palette, typing shows results, clicking navigates
- [ ] Manual test: recent searches persist across sessions