### PR TITLE
fix: invalidate game detail cache during batch scrape

### DIFF
--- a/web/src/hooks/__tests__/use-game-scraped-listener.test.ts
+++ b/web/src/hooks/__tests__/use-game-scraped-listener.test.ts
@@ -4,7 +4,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createElement } from "react";
 import { useGameScrapedListener } from "../use-game-scraped-listener";
 
-// Capture the game_scraped handler
+// Capture the event handlers
 const wsHandlers: Record<string, (payload: unknown) => void> = {};
 
 vi.mock("@/hooks/use-websocket", () => ({
@@ -82,17 +82,53 @@ describe("useGameScrapedListener", () => {
       wsHandlers["game_scraped"](scraped);
     });
 
-    // Game query should be updated with scraped data
-    const updatedGame = queryClient.getQueryData(["game", "42"]);
-    expect(updatedGame).toMatchObject({
-      coverUrl: "https://example.com/cover.jpg",
-      description: "A great game",
-      scrapeAttempts: 1,
-    });
-
-    // Cheats query must still be an array — this was the bug
+    // Cheats query must still be an array — this was the original bug
     const updatedCheats = queryClient.getQueryData(["game", "42", "cheats"]);
     expect(Array.isArray(updatedCheats)).toBe(true);
     expect(updatedCheats).toEqual(cheats);
+  });
+
+  it("invalidates game query on scrape_progress during batch scrape", () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    // Pre-populate the game query
+    queryClient.setQueryData(["game", "42"], makeGame());
+
+    renderHook(() => useGameScrapedListener(), { wrapper });
+
+    // Simulate batch scrape progress event
+    act(() => {
+      wsHandlers["scrape_progress"]({
+        current: 5,
+        total: 100,
+        gameId: 42,
+        gameName: "Test Game",
+        consoleName: "NES",
+        consoleAbbr: "nes",
+        successes: 4,
+        failures: 0,
+        verified: 0,
+      });
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["game", "42"],
+      exact: true,
+    });
+  });
+
+  it("ignores scrape_progress without gameId", () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useGameScrapedListener(), { wrapper });
+
+    act(() => {
+      wsHandlers["scrape_progress"]({
+        current: 0,
+        total: 100,
+      });
+    });
+
+    expect(invalidateSpy).not.toHaveBeenCalled();
   });
 });

--- a/web/src/hooks/use-game-scraped-listener.ts
+++ b/web/src/hooks/use-game-scraped-listener.ts
@@ -1,3 +1,4 @@
+import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
@@ -8,38 +9,12 @@ import type {
   MostPlayedGamesResponse,
 } from "@/types/api";
 
-/** Fields that come from scraping — everything else is user-specific and must be preserved */
-const SCRAPE_FIELDS = [
-  "coverUrl",
-  "description",
-  "developer",
-  "publisher",
-  "releaseDate",
-  "genre",
-  "players",
-  "rating",
-  "scraperId",
-  "scrapeAttempts",
-  "screenshotUrls",
-  "updatedAt",
-] as const;
-
-function mergeScrapedData(cached: Game, scraped: Game): Game {
-  const merged = { ...cached };
-  for (const key of SCRAPE_FIELDS) {
-    if (key in scraped) {
-      (merged as Record<string, unknown>)[key] = scraped[key];
-    }
-  }
-  return merged;
-}
-
 function updateGameInArray(games: Game[], scraped: Game): Game[] {
   let changed = false;
   const result = games.map((g) => {
     if (g.id === scraped.id) {
       changed = true;
-      return mergeScrapedData(g, scraped);
+      return { ...g, ...scraped };
     }
     return g;
   });
@@ -49,18 +24,19 @@ function updateGameInArray(games: Game[], scraped: Game): Game[] {
 export function useGameScrapedListener() {
   const queryClient = useQueryClient();
 
+  // Handle individual game scrape events (single scrape via admin).
+  // The payload is a full Game response, so we can replace cached data directly.
   useWebSocketEvent("game_scraped", (payload: Game) => {
     const scraped = payload;
     if (!scraped?.id) return;
 
-    // Update single game query: ["game", id] (exact to avoid clobbering
-    // sub-queries like ["game", id, "cheats"])
-    queryClient.setQueriesData<Game>(
-      { queryKey: ["game", scraped.id], exact: true },
-      (old) => (old ? mergeScrapedData(old, scraped) : old),
-    );
+    // Invalidate single game query so it re-fetches with user-specific data
+    queryClient.invalidateQueries({
+      queryKey: ["game", scraped.id],
+      exact: true,
+    });
 
-    // Update paginated games: ["games", ...] → GamesResponse
+    // Optimistically update list queries with the scraped data (covers, etc.)
     queryClient.setQueriesData<GamesResponse>(
       { queryKey: ["games"] },
       (old) => {
@@ -70,7 +46,6 @@ export function useGameScrapedListener() {
       },
     );
 
-    // Update console games: ["consoles", consoleId, "games"] → Game[]
     queryClient.setQueriesData<Game[]>(
       { queryKey: ["consoles"] },
       (old) => {
@@ -79,7 +54,6 @@ export function useGameScrapedListener() {
       },
     );
 
-    // Update collection details: ["collection", id] → CollectionDetail
     queryClient.setQueriesData<CollectionDetail>(
       { queryKey: ["collection"] },
       (old) => {
@@ -89,7 +63,6 @@ export function useGameScrapedListener() {
       },
     );
 
-    // Update most-played games: ["most-played-games"] → MostPlayedGamesResponse
     queryClient.setQueriesData<MostPlayedGamesResponse>(
       { queryKey: ["most-played-games"] },
       (old) => {
@@ -98,7 +71,7 @@ export function useGameScrapedListener() {
         const updated = old.games.map((entry: MostPlayedGame) => {
           if (entry.game.id === scraped.id) {
             changed = true;
-            return { ...entry, game: mergeScrapedData(entry.game, scraped) };
+            return { ...entry, game: { ...entry.game, ...scraped } };
           }
           return entry;
         });
@@ -106,4 +79,20 @@ export function useGameScrapedListener() {
       },
     );
   });
+
+  // Handle batch scrape progress — invalidate the game query for each game
+  // as it's scraped so the detail page refreshes automatically.
+  const handleScrapeProgress = useCallback(
+    (payload: { gameId?: number }) => {
+      if (!payload?.gameId) return;
+      const gameId = String(payload.gameId);
+      queryClient.invalidateQueries({
+        queryKey: ["game", gameId],
+        exact: true,
+      });
+    },
+    [queryClient],
+  );
+
+  useWebSocketEvent("scrape_progress", handleScrapeProgress);
 }


### PR DESCRIPTION
## Summary
- Listen to `scrape_progress` WebSocket events and invalidate `["game", gameId]` query so the game detail page auto-refreshes during batch scrape
- Replace fragile `SCRAPE_FIELDS` merge approach with simple query invalidation — no more missing fields when new IGDB data is added
- For `game_scraped` (single scrape), invalidate instead of merging so all fields are always fresh

## Problem
When batch-scraping 12,000+ games, viewing a game detail page showed no IGDB data even after that game was scraped. The batch scrape only broadcast `scrape_progress` events, which the game detail cache didn't listen to. The existing `game_scraped` handler also used an incomplete field list that missed newer IGDB fields.

## Test plan
- [x] All 1321 web tests pass
- [x] 3 listener tests (sub-query protection, progress invalidation, missing gameId guard)