### PR TITLE
feat: fetch time-to-beat from dedicated IGDB endpoint

### DIFF
--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -476,6 +476,64 @@ func (c *Client) GetGameByID(igdbID int) (*Game, error) {
 	return &games[0], nil
 }
 
+// GetTimeToBeat fetches time-to-beat data for a game from the separate
+// /v4/game_time_to_beats endpoint. Returns nil if no data exists for the game.
+func (c *Client) GetTimeToBeat(igdbGameID int) (*TimeToBeat, error) {
+	if err := c.authenticate(); err != nil {
+		return nil, fmt.Errorf("IGDB authentication: %w", err)
+	}
+
+	<-c.rateLimiter
+
+	query := fmt.Sprintf(
+		`fields hastily,normally,completely; where game_id = %d; limit 1;`,
+		igdbGameID,
+	)
+
+	slog.Info("IGDB get time to beat request", "igdbGameID", igdbGameID)
+
+	c.mu.Lock()
+	token := c.token.AccessToken
+	c.mu.Unlock()
+
+	req, err := http.NewRequest("POST", igdbAPIBase+"/game_time_to_beats", strings.NewReader(query))
+	if err != nil {
+		return nil, fmt.Errorf("creating IGDB time to beat request: %w", err)
+	}
+	req.Header.Set("Client-ID", c.ClientID)
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	resp, err := c.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("calling IGDB API for time to beat: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading IGDB time to beat response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
+	}
+
+	var results []TimeToBeat
+	if err := json.Unmarshal(body, &results); err != nil {
+		return nil, fmt.Errorf("decoding IGDB time to beat response: %w", err)
+	}
+
+	if len(results) == 0 {
+		slog.Info("IGDB get time to beat: no data", "igdbGameID", igdbGameID)
+		return nil, nil
+	}
+
+	slog.Info("IGDB get time to beat response", "igdbGameID", igdbGameID,
+		"hastily", results[0].Hastily, "normally", results[0].Normally, "completely", results[0].Completely)
+
+	return &results[0], nil
+}
+
 // TopGame represents an IGDB top-rated game result.
 type TopGame struct {
 	ID               int    `json:"id"`

--- a/server/internal/igdb/client_test.go
+++ b/server/internal/igdb/client_test.go
@@ -765,6 +765,125 @@ func TestGetGameByID_APIError(t *testing.T) {
 	assert.Contains(t, err.Error(), "500")
 }
 
+func TestGetTimeToBeat_Success(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "POST", r.Method)
+		assert.Equal(t, "/v4/game_time_to_beats", r.URL.Path)
+		assert.Equal(t, "myid", r.Header.Get("Client-ID"))
+		assert.Equal(t, "Bearer test-token", r.Header.Get("Authorization"))
+
+		json.NewEncoder(w).Encode([]TimeToBeat{
+			{Hastily: 31200, Normally: 111888, Completely: 187200},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	ttb, err := c.GetTimeToBeat(1029)
+	require.NoError(t, err)
+	require.NotNil(t, ttb)
+	assert.Equal(t, 31200, ttb.Hastily)
+	assert.Equal(t, 111888, ttb.Normally)
+	assert.Equal(t, 187200, ttb.Completely)
+}
+
+func TestGetTimeToBeat_NoData(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode([]TimeToBeat{})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	ttb, err := c.GetTimeToBeat(99999)
+	require.NoError(t, err)
+	assert.Nil(t, ttb)
+}
+
+func TestGetTimeToBeat_APIError(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := twitchTokenURL
+	origAPIBase := igdbAPIBase
+	twitchTokenURL = tokenServer.URL
+	igdbAPIBase = igdbServer.URL + "/v4"
+	defer func() {
+		twitchTokenURL = origTokenURL
+		igdbAPIBase = origAPIBase
+	}()
+
+	c := &Client{
+		ClientID:     "myid",
+		ClientSecret: "mysecret",
+		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		rateLimiter:  time.Tick(time.Millisecond),
+	}
+
+	_, err := c.GetTimeToBeat(1234)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "500")
+}
+
 func TestPlatformMapping(t *testing.T) {
 	// Verify key platform mappings exist
 	assert.Equal(t, 18, AbbreviationToIGDBPlatform["NES"])

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -308,15 +308,20 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 	if match.IGDBRatingCount > 0 && game.IGDBUserRatingCount == 0 {
 		game.IGDBUserRatingCount = match.IGDBRatingCount
 	}
-	if match.TimeToBeat != nil {
-		if match.TimeToBeat.Hastily > 0 && game.TimeToBeatHastily == 0 {
-			game.TimeToBeatHastily = match.TimeToBeat.Hastily
-		}
-		if match.TimeToBeat.Normally > 0 && game.TimeToBeatNormally == 0 {
-			game.TimeToBeatNormally = match.TimeToBeat.Normally
-		}
-		if match.TimeToBeat.Completely > 0 && game.TimeToBeatCompletely == 0 {
-			game.TimeToBeatCompletely = match.TimeToBeat.Completely
+	// Fetch time-to-beat from the dedicated endpoint (the inline field was deprecated).
+	if s.IGDBClient != nil && game.TimeToBeatHastily == 0 && game.TimeToBeatNormally == 0 && game.TimeToBeatCompletely == 0 {
+		if ttb, err := s.IGDBClient.GetTimeToBeat(match.ID); err != nil {
+			slog.Warn("failed to fetch time to beat", "igdbID", match.ID, "error", err)
+		} else if ttb != nil {
+			if ttb.Hastily > 0 {
+				game.TimeToBeatHastily = ttb.Hastily
+			}
+			if ttb.Normally > 0 {
+				game.TimeToBeatNormally = ttb.Normally
+			}
+			if ttb.Completely > 0 {
+				game.TimeToBeatCompletely = ttb.Completely
+			}
 		}
 	}
 	if match.FirstReleaseDate > 0 {


### PR DESCRIPTION
## Summary
- IGDB deprecated the inline `time_to_beat` field on the `/games` endpoint
- Added `GetTimeToBeat()` method on the IGDB client that calls the separate `/v4/game_time_to_beats` endpoint
- Wired it into `applyIGDBMatch` so both automatic and manual IGDB scrapes populate time-to-beat data

## Verified locally
- Scraped Zelda OoT → hastily=8h40m, normally=31h4m, completely=52h
- Scraped ALTTP → no data (confirmed missing on IGDB website too)

## Test plan
- [x] Unit tests for `GetTimeToBeat` (success, no data, API error)
- [x] Full `go test ./...` passes
- [x] Verified against real IGDB API locally