### PR TITLE
feat: add cancel button for running scrape operations

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -266,9 +266,9 @@ func main() {
 					metaScraper.ConfigureSteamGridDB(setting.Value)
 				}
 			}
-			if metaScraper.TryStartScrape() {
+			if scrapeCtx, ok := metaScraper.TryStartScrape(); ok {
 				hub.Broadcast(websocket.Event{Type: "scrape_started", Payload: nil})
-				count, total, scrapeErr := metaScraper.ScrapeAll("new", 0, func(p scraper.ScrapeProgress) {
+				count, total, scrapeErr := metaScraper.ScrapeAll(scrapeCtx, "new", 0, func(p scraper.ScrapeProgress) {
 					metaScraper.SetScrapeProgress(&p)
 					hub.Broadcast(websocket.Event{Type: "scrape_progress", Payload: p})
 				})

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -39,7 +39,8 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 		consoleID = console.ID
 	}
 
-	if !h.Scraper.TryStartScrape() {
+	ctx, ok := h.Scraper.TryStartScrape()
+	if !ok {
 		c.JSON(http.StatusConflict, gin.H{"error": "a scrape operation is already in progress"})
 		return
 	}
@@ -65,11 +66,16 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 	go func() {
 		defer h.Scraper.FinishScrape()
 
-		count, total, err := h.Scraper.ScrapeAll(mode, consoleID, func(p scraper.ScrapeProgress) {
+		count, total, err := h.Scraper.ScrapeAll(ctx, mode, consoleID, func(p scraper.ScrapeProgress) {
 			h.Scraper.SetScrapeProgress(&p)
 			h.Hub.Broadcast(ws.Event{Type: "scrape_progress", Payload: p})
 		})
 		if err != nil {
+			if ctx.Err() != nil {
+				slog.Info("metadata scrape cancelled", "scraped", count, "total", total)
+				h.Hub.Broadcast(ws.Event{Type: "scrape_cancelled", Payload: gin.H{"scraped": count, "total": total}})
+				return
+			}
 			slog.Error("metadata scrape failed", "error", err)
 			h.Hub.Broadcast(ws.Event{Type: "scrape_error", Payload: gin.H{"error": "metadata scrape failed"}})
 			return
@@ -80,6 +86,18 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 	adminID, _ := c.Get("userId")
 	slog.Info("audit: admin triggered scrape", "admin_id", adminID, "mode", mode, "console_id", consoleID)
 	c.JSON(http.StatusAccepted, gin.H{"message": "scrape started in background", "total": total})
+}
+
+// CancelScrape stops the running scrape operation (admin only).
+func (h *AdminHandler) CancelScrape(c *gin.Context) {
+	if !h.Scraper.CancelScrape() {
+		c.JSON(http.StatusConflict, gin.H{"error": "no scrape operation is running"})
+		return
+	}
+
+	adminID, _ := c.Get("userId")
+	slog.Info("audit: admin cancelled scrape", "admin_id", adminID)
+	c.JSON(http.StatusOK, gin.H{"message": "scrape cancellation requested"})
 }
 
 // ScrapeStatus returns the current scrape operation status.

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -581,14 +581,19 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 
 		// Auto-scrape new games if IGDB is configured
 		if result.NewGames > 0 && h.Scraper.IsIGDBConfigured() {
-			if h.Scraper.TryStartScrape() {
+			if scrapeCtx, ok := h.Scraper.TryStartScrape(); ok {
 				h.Hub.Broadcast(ws.Event{Type: "scrape_started", Payload: nil})
-				count, total, scrapeErr := h.Scraper.ScrapeAll("new", 0, func(p scraper.ScrapeProgress) {
+				count, total, scrapeErr := h.Scraper.ScrapeAll(scrapeCtx, "new", 0, func(p scraper.ScrapeProgress) {
 					h.Scraper.SetScrapeProgress(&p)
 					h.Hub.Broadcast(ws.Event{Type: "scrape_progress", Payload: p})
 				})
 				h.Scraper.FinishScrape()
 				if scrapeErr != nil {
+					if scrapeCtx.Err() != nil {
+						slog.Info("auto-scrape cancelled", "scraped", count, "total", total)
+						h.Hub.Broadcast(ws.Event{Type: "scrape_cancelled", Payload: gin.H{"scraped": count, "total": total}})
+						return
+					}
 					slog.Error("auto-scrape after scan failed", "error", scrapeErr)
 					h.Hub.Broadcast(ws.Event{Type: "scrape_error", Payload: gin.H{"error": "auto-scrape failed"}})
 					return

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -508,6 +508,7 @@ func NewRouter(cfg Config) *gin.Engine {
 			admin.GET("/settings", adminHandler.GetSettings)
 			admin.PUT("/settings", adminHandler.UpdateSettings)
 			admin.POST("/scrape", adminHandler.TriggerScrape)
+			admin.DELETE("/scrape", adminHandler.CancelScrape)
 			admin.GET("/scrape/status", adminHandler.ScrapeStatus)
 			admin.POST("/games/:id/scrape", adminHandler.ScrapeGame)
 			admin.GET("/games/:id/covers", adminHandler.GetGameCovers)

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -1,6 +1,7 @@
 package scraper
 
 import (
+	"context"
 	"net/http"
 	"sync"
 	"time"
@@ -25,6 +26,7 @@ type Scraper struct {
 	scrapeMu       sync.Mutex
 	scraping       bool
 	scrapeProgress *ScrapeProgress
+	scrapeCancel   context.CancelFunc
 
 	// Enrichment state tracking
 	enrichMu       sync.Mutex
@@ -53,17 +55,32 @@ func (s *Scraper) IsIGDBConfigured() bool {
 }
 
 // TryStartScrape attempts to acquire the scrape lock.
-// Returns true if the lock was acquired (caller must call FinishScrape when done).
+// Returns a context and true if the lock was acquired. The context is cancelled
+// when CancelScrape is called or when FinishScrape cleans up.
 // Also checks the enrichment lock — scraping and enrichment are mutually exclusive.
-func (s *Scraper) TryStartScrape() bool {
+func (s *Scraper) TryStartScrape() (context.Context, bool) {
 	s.scrapeMu.Lock()
 	defer s.scrapeMu.Unlock()
 	s.enrichMu.Lock()
 	defer s.enrichMu.Unlock()
 	if s.scraping || s.enriching {
-		return false
+		return nil, false
 	}
 	s.scraping = true
+	ctx, cancel := context.WithCancel(context.Background())
+	s.scrapeCancel = cancel
+	return ctx, true
+}
+
+// CancelScrape signals the running scrape to stop gracefully.
+// Returns true if a scrape was running and was cancelled.
+func (s *Scraper) CancelScrape() bool {
+	s.scrapeMu.Lock()
+	defer s.scrapeMu.Unlock()
+	if !s.scraping || s.scrapeCancel == nil {
+		return false
+	}
+	s.scrapeCancel()
 	return true
 }
 
@@ -72,6 +89,10 @@ func (s *Scraper) FinishScrape() {
 	s.scrapeMu.Lock()
 	s.scraping = false
 	s.scrapeProgress = nil
+	if s.scrapeCancel != nil {
+		s.scrapeCancel()
+		s.scrapeCancel = nil
+	}
 	s.scrapeMu.Unlock()
 }
 

--- a/server/internal/scraper/scraper_batch.go
+++ b/server/internal/scraper/scraper_batch.go
@@ -1,6 +1,7 @@
 package scraper
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -195,7 +196,7 @@ type ScrapeProgress struct {
 // If consoleID is non-zero, only games belonging to that console are scraped.
 // If onProgress is non-nil, it is called after each game attempt with the current progress.
 // Returns the number of successes, the total number of games attempted, and any error.
-func (s *Scraper) ScrapeAll(mode string, consoleID uint, onProgress func(ScrapeProgress)) (int, int, error) {
+func (s *Scraper) ScrapeAll(ctx context.Context, mode string, consoleID uint, onProgress func(ScrapeProgress)) (int, int, error) {
 	var games []db.Game
 	q := s.DB.Preload("Console")
 	if consoleID > 0 {
@@ -239,6 +240,12 @@ func (s *Scraper) ScrapeAll(mode string, consoleID uint, onProgress func(ScrapeP
 	// metadata to other variants in the same group instead of re-scraping.
 	scrapedGroups := make(map[string]uint) // "consoleID:groupKey" -> scraped game ID
 	for i := range games {
+		// Check for cancellation before each game
+		if ctx.Err() != nil {
+			slog.Info("scrape cancelled", "completed", i, "total", total)
+			return successes, total, ctx.Err()
+		}
+
 		game := &games[i]
 
 		// Smart scraping: if this game belongs to a variant group, try to

--- a/server/internal/scraper/scraper_igdb_test.go
+++ b/server/internal/scraper/scraper_igdb_test.go
@@ -1,6 +1,7 @@
 package scraper
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
@@ -713,7 +714,7 @@ func TestScrapeAll_DefaultOnlyUnscraped(t *testing.T) {
 		cache:      &nameCache{entries: make(map[string][]nameEntry)},
 	}
 
-	successes, total, err := s.ScrapeAll("", 0, nil)
+	successes, total, err := s.ScrapeAll(context.Background(), "", 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, total, "should only attempt the unscraped game")
 	assert.Equal(t, 1, successes)
@@ -743,7 +744,7 @@ func TestScrapeAll_ForceScrapesAll(t *testing.T) {
 		cache:      &nameCache{entries: make(map[string][]nameEntry)},
 	}
 
-	successes, total, err := s.ScrapeAll("all", 0, nil)
+	successes, total, err := s.ScrapeAll(context.Background(), "all", 0, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 2, total, "force should attempt all games")
 	assert.Equal(t, 2, successes)
@@ -775,7 +776,7 @@ func TestScrapeAll_ConsoleFilter(t *testing.T) {
 	}
 
 	// Scrape only SNES games
-	successes, total, err := s.ScrapeAll("", c1.ID, nil)
+	successes, total, err := s.ScrapeAll(context.Background(), "", c1.ID, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, total, "should only attempt SNES games")
 	assert.Equal(t, 1, successes)
@@ -807,7 +808,7 @@ func TestScrapeAll_ConsoleFilter_AllMode(t *testing.T) {
 	}
 
 	// Scrape all mode but only SNES
-	successes, total, err := s.ScrapeAll("all", c1.ID, nil)
+	successes, total, err := s.ScrapeAll(context.Background(), "all", c1.ID, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, total, "should only attempt SNES games in all mode")
 	assert.Equal(t, 1, successes)
@@ -839,7 +840,7 @@ func TestScrapeAll_ConsoleFilter_FallbackMode(t *testing.T) {
 	}
 
 	// Fallback mode but only NES
-	successes, total, err := s.ScrapeAll("fallback", c2.ID, nil)
+	successes, total, err := s.ScrapeAll(context.Background(), "fallback", c2.ID, nil)
 	require.NoError(t, err)
 	assert.Equal(t, 1, total, "should only attempt NES fallback games")
 	assert.Equal(t, 1, successes)

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -131,6 +131,12 @@ export function useScrapeMetadata() {
   });
 }
 
+export function useCancelScrape() {
+  return useMutation({
+    mutationFn: () => api.delete("/admin/scrape"),
+  });
+}
+
 export function useMetadataMatches() {
   return useQuery({
     queryKey: ["admin", "metadata-matches"],

--- a/web/src/hooks/use-scrape-progress.ts
+++ b/web/src/hooks/use-scrape-progress.ts
@@ -116,6 +116,15 @@ export function useScrapeProgress(): ScrapeProgressState {
   );
 
   useWebSocketEvent(
+    "scrape_cancelled",
+    useCallback((payload: ScrapeCompletePayload) => {
+      setPhase("complete");
+      setSuccesses(payload.scraped);
+      setTotal(payload.total);
+    }, []),
+  );
+
+  useWebSocketEvent(
     "scrape_error",
     useCallback((payload: ScrapeErrorPayload) => {
       setPhase("error");

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -385,4 +385,5 @@ export type ApiDeletePath = WithQuery<
   | `/admin/users/${string}/rate-limit`
   | `/admin/bios/${string}`
   | "/admin/uploads"
+  | "/admin/scrape"
 >;

--- a/web/src/pages/admin/__tests__/scan-page.test.tsx
+++ b/web/src/pages/admin/__tests__/scan-page.test.tsx
@@ -13,6 +13,7 @@ const mockScrapeDismiss = vi.fn();
 vi.mock("@/hooks/use-admin", () => ({
   useScanLibrary: vi.fn(),
   useScrapeMetadata: vi.fn(),
+  useCancelScrape: vi.fn(),
 }));
 
 vi.mock("@/hooks/use-scrape-progress", () => ({
@@ -36,13 +37,14 @@ vi.mock("@/components/ui", async () => {
   };
 });
 
-import { useScanLibrary, useScrapeMetadata } from "@/hooks/use-admin";
+import { useScanLibrary, useScrapeMetadata, useCancelScrape } from "@/hooks/use-admin";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
 import { useScanProgress } from "@/hooks/use-scan-progress";
 import { useConsoles } from "@/hooks/use-consoles";
 
 const mockUseScanLibrary = useScanLibrary as ReturnType<typeof vi.fn>;
 const mockUseScrapeMetadata = useScrapeMetadata as ReturnType<typeof vi.fn>;
+const mockUseCancelScrape = useCancelScrape as ReturnType<typeof vi.fn>;
 const mockUseScrapeProgress = useScrapeProgress as ReturnType<typeof vi.fn>;
 const mockUseScanProgress = useScanProgress as ReturnType<typeof vi.fn>;
 const mockUseConsoles = useConsoles as ReturnType<typeof vi.fn>;
@@ -69,6 +71,10 @@ beforeEach(() => {
   });
   mockUseScrapeMetadata.mockReturnValue({
     mutate: mockScrapeMutate,
+    isPending: false,
+  });
+  mockUseCancelScrape.mockReturnValue({
+    mutate: vi.fn(),
     isPending: false,
   });
   mockUseScanProgress.mockReturnValue({

--- a/web/src/pages/admin/scan-page.tsx
+++ b/web/src/pages/admin/scan-page.tsx
@@ -8,9 +8,10 @@ import {
   Loader2,
   RefreshCw,
   RotateCcw,
+  Square,
 } from "lucide-react";
 import { Button, Card, CardHeader, CardContent, Select } from "@/components/ui";
-import { useScanLibrary, useScrapeMetadata } from "@/hooks/use-admin";
+import { useScanLibrary, useScrapeMetadata, useCancelScrape } from "@/hooks/use-admin";
 import { useToast } from "@/components/ui";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
 import { useScanProgress } from "@/hooks/use-scan-progress";
@@ -176,6 +177,7 @@ function ScanCard() {
 
 function ScrapeCard() {
   const scrapeMetadata = useScrapeMetadata();
+  const cancelScrape = useCancelScrape();
   const scrape = useScrapeProgress();
   const { toast } = useToast();
   const { data: consoles } = useConsoles();
@@ -259,6 +261,25 @@ function ScrapeCard() {
                 </span>
               )}
             </div>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() =>
+                cancelScrape.mutate(undefined, {
+                  onSuccess: () => toast("info", "Cancelling scrape..."),
+                  onError: (err) =>
+                    toast(
+                      "error",
+                      err instanceof Error ? err.message : "Cancel failed",
+                    ),
+                })
+              }
+              loading={cancelScrape.isPending}
+              icon={<Square className="h-3 w-3" />}
+              className="w-full"
+            >
+              Cancel Scrape
+            </Button>
           </div>
         )}
 


### PR DESCRIPTION
## Summary
- Added `DELETE /api/admin/scrape` endpoint to cancel a running scrape
- `ScrapeAll` now accepts `context.Context` and checks for cancellation before each game
- Cancel button appears in the scrape progress panel during active scrapes
- Broadcasts `scrape_cancelled` WebSocket event so the UI transitions to completion state

## Test plan
- [x] All Go tests pass (`go test ./...`)
- [x] All web unit tests pass (including updated scan-page tests)
- [x] TypeScript compiles clean