### PR TITLE
feat: redesign console page with showcase sections and games browser

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,0 +1,28 @@
+# Known Issues
+
+## .lyx extension gaps (from PR #161 follow-up)
+
+### Missing .lyx in replace ROM modal (Medium)
+- **File**: `web/src/features/game-detail/components/replace-rom-modal.tsx:35`
+- `.lyx` is not in `ACCEPTED_EXTENSIONS`. Users replacing a Lynx ROM via the UI won't see `.lyx` files in the file picker.
+
+### Missing .lyx in setup handler (Medium)
+- **File**: `server/internal/api/setup_handler.go:206`
+- `.lyx` missing from the `knownExts` map in `countGameFiles()`. The setup page will undercount Lynx ROMs if any use the `.lyx` extension.
+
+## Console detail page polish (from code review)
+
+### No focus-visible on "Browse all" links (High - a11y)
+- The "Browse all N games" `<Link>` elements lack `focus-visible` ring styles. Should create a reusable `LinkButton` component or add focus styles matching the `Button` component.
+
+### No loading skeleton for showcase sections (Medium)
+- Large library path: page flashes empty between hero banner and bottom "Browse all" link while showcase data loads. Each showcase component silently returns null when data is undefined.
+
+### Logo onError uses DOM manipulation instead of React state (Medium)
+- `console-detail-page.tsx:127-133` — The `onError` handler performs direct DOM manipulation. Should use `useState` for image error state instead, matching the pattern in `hero-carousel.tsx`.
+
+### BackButton is a button, not a link (Low - codebase-wide)
+- `BackButton` renders a `<button>` with `onClick` navigation instead of a `<Link>`. Right-click/middle-click/status bar preview don't work. Affects 30+ instances across the codebase.
+
+### Showcase components each independently call useConsoleShowcase (Low)
+- Six components each call `useConsoleShowcase(consoleId)`. TanStack Query deduplicates the request, but the parent can't control loading/empty states. Consider lifting the fetch to the parent.

--- a/server/internal/api/explore_handler_console.go
+++ b/server/internal/api/explore_handler_console.go
@@ -39,6 +39,7 @@ type ConsoleShowcaseResponse struct {
 	GenreBreakdown []GenreCount       `json:"genreBreakdown"`
 	TopDevelopers  []DeveloperSummary `json:"topDevelopers"`
 	RecentlyPlayed []GameResponse     `json:"recentlyPlayed"`
+	RecentlyAdded  []GameResponse     `json:"recentlyAdded"`
 }
 
 // ConsoleHighlight is a compact summary of a console for the explore page quick-jump row.
@@ -143,11 +144,22 @@ func (h *ExploreHandler) GetConsoleShowcase(c *gin.Context) {
 		}
 	}
 
-	// Batch-load user game data for all games at once (essentials + hidden gems + recently played)
-	allGames := make([]db.Game, 0, len(essentials)+len(hiddenGems)+len(recentlyPlayed))
+	// --- Recently Added: most recently added games for this console ---
+	var recentlyAdded []db.Game
+	if err := h.DB.Preload("Console").
+		Where("console_id = ? AND deleted_at IS NULL", console.ID).
+		Order("created_at DESC").
+		Limit(10).
+		Find(&recentlyAdded).Error; err != nil {
+		slog.Error("failed to fetch recently added games", "console", abbr, "error", err)
+	}
+
+	// Batch-load user game data for all games at once (essentials + hidden gems + recently played + recently added)
+	allGames := make([]db.Game, 0, len(essentials)+len(hiddenGems)+len(recentlyPlayed)+len(recentlyAdded))
 	allGames = append(allGames, essentials...)
 	allGames = append(allGames, hiddenGems...)
 	allGames = append(allGames, recentlyPlayed...)
+	allGames = append(allGames, recentlyAdded...)
 	allGameIDs := make([]uint, len(allGames))
 	for i, g := range allGames {
 		allGameIDs[i] = g.ID
@@ -170,6 +182,7 @@ func (h *ExploreHandler) GetConsoleShowcase(c *gin.Context) {
 		GenreBreakdown: genreBreakdown,
 		TopDevelopers:  topDevelopers,
 		RecentlyPlayed: toResponses(recentlyPlayed),
+		RecentlyAdded:  toResponses(recentlyAdded),
 	})
 }
 

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -2420,6 +2420,45 @@ func TestGetConsoleShowcase_CaseInsensitive(t *testing.T) {
 	assert.Equal(t, "snes", resp.Console.ID)
 }
 
+func TestGetConsoleShowcase_RecentlyAdded(t *testing.T) {
+	env := setupExploreTestEnv(t)
+
+	now := time.Now()
+
+	// Create 12 games on SNES with different created_at times
+	for i := 0; i < 12; i++ {
+		createExploreGameWithTime(t, env.database, "SNES",
+			fmt.Sprintf("SNES Game %02d", i), 70,
+			now.Add(time.Duration(-i)*time.Hour))
+	}
+
+	// Create a game on NES — should NOT appear in SNES showcase
+	createExploreGameWithTime(t, env.database, "NES", "NES Game", 90, now)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/explore/consoles/snes/showcase", nil)
+	req.Header.Set("Authorization", "Bearer "+env.token)
+	env.router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp ConsoleShowcaseResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+
+	// At most 10 games returned
+	require.Len(t, resp.RecentlyAdded, 10)
+
+	// Games are ordered by created_at DESC (most recent first)
+	assert.Equal(t, "SNES Game 00", resp.RecentlyAdded[0].Title)
+	assert.Equal(t, "SNES Game 01", resp.RecentlyAdded[1].Title)
+	assert.Equal(t, "SNES Game 09", resp.RecentlyAdded[9].Title)
+
+	// NES game should not be in recently added
+	for _, g := range resp.RecentlyAdded {
+		assert.Equal(t, "snes", g.ConsoleID)
+	}
+}
+
 func TestGetConsoleHighlights(t *testing.T) {
 	env := setupExploreTestEnv(t)
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import { RegisterPage } from "@/pages/register-page";
 import { DashboardPage } from "@/pages/dashboard-page";
 import { ConsolesPage } from "@/pages/consoles-page";
 import { ConsoleDetailPage } from "@/pages/console-detail-page";
+import { ConsoleGamesPage } from "@/pages/console-games-page";
 import { GamesPage } from "@/pages/games-page";
 import { GameDetailPage } from "@/pages/game-detail-page";
 import { FavoritesPage } from "@/pages/favorites-page";
@@ -144,6 +145,10 @@ export function App() {
                     <Route
                       path="consoles/:id"
                       element={<ConsoleDetailPage />}
+                    />
+                    <Route
+                      path="consoles/:id/games"
+                      element={<ConsoleGamesPage />}
                     />
                     <Route path="games/:id" element={<GameDetailPage />} />
                     <Route

--- a/web/src/features/explore/components/__tests__/console-showcase-sections.test.tsx
+++ b/web/src/features/explore/components/__tests__/console-showcase-sections.test.tsx
@@ -1,0 +1,173 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  ConsoleRecentlyAdded,
+  ConsoleEssentials,
+} from "../console-showcase-sections";
+import type { Game, ConsoleShowcase, Console } from "@/types/api";
+
+vi.mock("@/hooks/use-explore", () => ({
+  useConsoleShowcase: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-games", () => ({
+  useToggleFavorite: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-play-later", () => ({
+  useTogglePlayLater: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+import { useConsoleShowcase } from "@/hooks/use-explore";
+
+const mockUseConsoleShowcase = useConsoleShowcase as ReturnType<typeof vi.fn>;
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeConsole(overrides: Partial<Console> = {}): Console {
+  return {
+    id: "snes",
+    name: "Super Nintendo",
+    abbreviation: "snes",
+    extensions: [],
+    defaultCore: "",
+    coverAspectRatio: 0.75,
+    colorTheme: "#6366f1",
+    iconUrl: "",
+    logoUrl: "",
+    gameCount: 100,
+    saveStateSupport: true,
+    browserPlayable: false,
+    playable: true,
+    createdAt: "",
+    updatedAt: "",
+    ...overrides,
+  };
+}
+
+function makeShowcase(overrides: Partial<ConsoleShowcase> = {}): ConsoleShowcase {
+  return {
+    console: makeConsole(),
+    essentials: [],
+    hiddenGems: [],
+    recentlyAdded: [],
+    genreBreakdown: [],
+    topDevelopers: [],
+    recentlyPlayed: [],
+    ...overrides,
+  };
+}
+
+function renderComponent(component: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>{component}</MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ConsoleRecentlyAdded", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders recently added games shelf", () => {
+    const games = [
+      makeGame({ id: "1", title: "Super Mario World" }),
+      makeGame({ id: "2", title: "Chrono Trigger" }),
+    ];
+    mockUseConsoleShowcase.mockReturnValue({
+      data: makeShowcase({ recentlyAdded: games }),
+    });
+
+    renderComponent(<ConsoleRecentlyAdded consoleId="snes" />);
+
+    expect(
+      screen.getByRole("heading", { name: "Recently Added", level: 2 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+    expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
+  });
+
+  it("renders nothing when recentlyAdded is empty", () => {
+    mockUseConsoleShowcase.mockReturnValue({
+      data: makeShowcase({ recentlyAdded: [] }),
+    });
+
+    const { container } = renderComponent(
+      <ConsoleRecentlyAdded consoleId="snes" />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders nothing when showcase is undefined", () => {
+    mockUseConsoleShowcase.mockReturnValue({ data: undefined });
+
+    const { container } = renderComponent(
+      <ConsoleRecentlyAdded consoleId="snes" />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+});
+
+describe("ConsoleEssentials", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders essentials games shelf", () => {
+    const games = [makeGame({ id: "1", title: "Zelda" })];
+    mockUseConsoleShowcase.mockReturnValue({
+      data: makeShowcase({ essentials: games }),
+    });
+
+    renderComponent(<ConsoleEssentials consoleId="snes" />);
+
+    expect(
+      screen.getByRole("heading", { name: "Essentials", level: 2 }),
+    ).toBeInTheDocument();
+    expect(screen.getByText("Zelda")).toBeInTheDocument();
+  });
+
+  it("renders nothing when essentials is empty", () => {
+    mockUseConsoleShowcase.mockReturnValue({
+      data: makeShowcase({ essentials: [] }),
+    });
+
+    const { container } = renderComponent(
+      <ConsoleEssentials consoleId="snes" />,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/web/src/features/explore/components/console-showcase-sections.tsx
+++ b/web/src/features/explore/components/console-showcase-sections.tsx
@@ -139,6 +139,26 @@ export function ConsoleTopDevelopers({
   );
 }
 
+export function ConsoleRecentlyAdded({
+  consoleId,
+}: ConsoleShowcaseSectionProps) {
+  const { data: showcase } = useConsoleShowcase(consoleId);
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+
+  if (!showcase || showcase.recentlyAdded.length === 0) return null;
+
+  return (
+    <GameShelf
+      title="Recently Added"
+      games={showcase.recentlyAdded}
+      isLoading={false}
+      onToggleFavorite={handleToggleFavorite}
+      onTogglePlayLater={handleTogglePlayLater}
+    />
+  );
+}
+
 export function ConsoleRecentlyPlayed({
   consoleId,
 }: ConsoleShowcaseSectionProps) {

--- a/web/src/features/games/components/__tests__/advanced-filter-panel.test.tsx
+++ b/web/src/features/games/components/__tests__/advanced-filter-panel.test.tsx
@@ -117,6 +117,16 @@ describe("AdvancedFilterPanel", () => {
     expect(within(consoleFilter).getByText("Game Boy Advance")).toBeInTheDocument();
   });
 
+  it("hides console chips when hideConsoleFilter is true", () => {
+    renderPanel({ hideConsoleFilter: true });
+    expect(screen.queryByTestId("console-filter")).not.toBeInTheDocument();
+  });
+
+  it("shows console chips when hideConsoleFilter is false", () => {
+    renderPanel({ hideConsoleFilter: false });
+    expect(screen.getByTestId("console-filter")).toBeInTheDocument();
+  });
+
   it("toggles console selection", async () => {
     const user = userEvent.setup();
     const onFiltersChange = vi.fn();

--- a/web/src/features/games/components/__tests__/games-filter-bar.test.tsx
+++ b/web/src/features/games/components/__tests__/games-filter-bar.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { GamesFilterBar } from "../games-filter-bar";
+import type { Console } from "@/types/api";
+
+const makeConsole = (abbr: string, name: string): Console => ({
+  id: abbr,
+  name,
+  abbreviation: abbr,
+  extensions: [],
+  defaultCore: "",
+  coverAspectRatio: 0.75,
+  colorTheme: "",
+  iconUrl: "",
+  logoUrl: "",
+  gameCount: 10,
+  saveStateSupport: true,
+  browserPlayable: false,
+  playable: true,
+  createdAt: "",
+  updatedAt: "",
+});
+
+const testConsoles: Console[] = [
+  makeConsole("snes", "Super Nintendo"),
+  makeConsole("nes", "Nintendo"),
+];
+
+function renderBar(overrides: Partial<React.ComponentProps<typeof GamesFilterBar>> = {}) {
+  const defaultProps: React.ComponentProps<typeof GamesFilterBar> = {
+    filters: {},
+    onFiltersChange: vi.fn(),
+    searchValue: "",
+    onSearchChange: vi.fn(),
+    viewMode: "grid" as const,
+    onViewModeChange: vi.fn(),
+    consoles: testConsoles,
+    ...overrides,
+  };
+  return render(<GamesFilterBar {...defaultProps} />);
+}
+
+describe("GamesFilterBar", () => {
+  it("renders console select by default", () => {
+    renderBar();
+    // The "All Consoles" option should be present in the select
+    expect(screen.getByDisplayValue("All Consoles")).toBeInTheDocument();
+  });
+
+  it("hides console select when hideConsoleFilter is true", () => {
+    renderBar({ hideConsoleFilter: true });
+    expect(screen.queryByDisplayValue("All Consoles")).not.toBeInTheDocument();
+  });
+
+  it("shows console select when hideConsoleFilter is false", () => {
+    renderBar({ hideConsoleFilter: false });
+    expect(screen.getByDisplayValue("All Consoles")).toBeInTheDocument();
+  });
+
+  it("renders search input", () => {
+    renderBar();
+    expect(screen.getByPlaceholderText("Search games...")).toBeInTheDocument();
+  });
+
+  it("renders hide betas toggle when showHideBetas is true", () => {
+    renderBar({ showHideBetas: true });
+    expect(screen.getByTestId("hide-betas-toggle")).toBeInTheDocument();
+  });
+
+  it("does not render hide betas toggle by default", () => {
+    renderBar();
+    expect(screen.queryByTestId("hide-betas-toggle")).not.toBeInTheDocument();
+  });
+});

--- a/web/src/features/games/components/advanced-filter-panel.tsx
+++ b/web/src/features/games/components/advanced-filter-panel.tsx
@@ -197,6 +197,7 @@ interface AdvancedFilterPanelProps {
   totalResults?: number;
   isOpen: boolean;
   onToggle: () => void;
+  hideConsoleFilter?: boolean;
 }
 
 export function AdvancedFilterPanel({
@@ -212,6 +213,7 @@ export function AdvancedFilterPanel({
   totalResults,
   isOpen,
   onToggle,
+  hideConsoleFilter = false,
 }: AdvancedFilterPanelProps) {
   const [saveName, setSaveName] = useState("");
   const [showSaveInput, setShowSaveInput] = useState(false);
@@ -332,15 +334,17 @@ export function AdvancedFilterPanel({
           </div>
 
           {/* Console picker */}
-          <ChipPicker
-            label="Consoles"
-            options={consoleOptions}
-            selected={filters.consoles ?? []}
-            onChange={(consoles) =>
-              onFiltersChange((f) => ({ ...f, consoles, page: 1 }))
-            }
-            testId="console-filter"
-          />
+          {!hideConsoleFilter && (
+            <ChipPicker
+              label="Consoles"
+              options={consoleOptions}
+              selected={filters.consoles ?? []}
+              onChange={(consoles) =>
+                onFiltersChange((f) => ({ ...f, consoles, page: 1 }))
+              }
+              testId="console-filter"
+            />
+          )}
 
           {/* Region picker */}
           <ChipPicker

--- a/web/src/features/games/components/games-filter-bar.tsx
+++ b/web/src/features/games/components/games-filter-bar.tsx
@@ -14,6 +14,7 @@ interface GamesFilterBarProps {
   onViewModeChange: (mode: ViewMode) => void;
   consoles: Console[] | undefined;
   showHideBetas?: boolean;
+  hideConsoleFilter?: boolean;
 }
 
 export function GamesFilterBar({
@@ -25,6 +26,7 @@ export function GamesFilterBar({
   onViewModeChange,
   consoles,
   showHideBetas = false,
+  hideConsoleFilter = false,
 }: GamesFilterBarProps) {
   const consoleOptions = [
     { value: "", label: "All Consoles" },
@@ -49,18 +51,20 @@ export function GamesFilterBar({
         />
       </div>
 
-      <Select
-        options={consoleOptions}
-        value={filters.consoleId ?? ""}
-        onChange={(e) =>
-          onFiltersChange((f) => ({
-            ...f,
-            consoleId: e.target.value || undefined,
-            page: 1,
-          }))
-        }
-        className="w-44"
-      />
+      {!hideConsoleFilter && (
+        <Select
+          options={consoleOptions}
+          value={filters.consoleId ?? ""}
+          onChange={(e) =>
+            onFiltersChange((f) => ({
+              ...f,
+              consoleId: e.target.value || undefined,
+              page: 1,
+            }))
+          }
+          className="w-44"
+        />
+      )}
 
       {showHideBetas && (
         <label className="flex items-center gap-2 text-sm text-surface-300 whitespace-nowrap" data-testid="hide-betas-toggle">

--- a/web/src/hooks/use-games.ts
+++ b/web/src/hooks/use-games.ts
@@ -2,7 +2,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api-client";
 import type { Game, GamesResponse, GameFilters, ReplaceROMResponse } from "@/types/api";
 
-export function useGames(filters?: GameFilters) {
+export function useGames(filters?: GameFilters, options?: { enabled?: boolean }) {
   const params = new URLSearchParams();
   if (filters?.search) params.set("search", filters.search);
   if (filters?.consoleId) params.set("consoleId", filters.consoleId);
@@ -40,6 +40,7 @@ export function useGames(filters?: GameFilters) {
     queryKey: ["games", filters],
     queryFn: () =>
       api.get<GamesResponse>(query ? `/games?${query}` : "/games"),
+    enabled: options?.enabled,
   });
 }
 

--- a/web/src/pages/__tests__/console-detail-page.test.tsx
+++ b/web/src/pages/__tests__/console-detail-page.test.tsx
@@ -1,0 +1,248 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ConsoleDetailPage } from "@/pages/console-detail-page";
+import type { Console, Game, GamesResponse } from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-consoles", () => ({
+  useConsoles: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-games", () => ({
+  useGames: vi.fn(),
+  useToggleFavorite: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-play-later", () => ({
+  useTogglePlayLater: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-bios", () => ({
+  useBiosStatus: () => ({ data: undefined }),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ isAdmin: false }),
+}));
+
+vi.mock("@/hooks/use-admin", () => ({
+  useScanLibrary: () => ({ mutate: vi.fn(), isPending: false }),
+}));
+
+vi.mock("@/hooks/use-debounced-value", () => ({
+  useDebouncedValue: (v: string) => v,
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual("@/components/ui");
+  return {
+    ...actual,
+    useToast: () => ({ toast: vi.fn() }),
+  };
+});
+
+vi.mock("@/hooks/use-explore", () => ({
+  useConsoleShowcase: () => ({ data: undefined }),
+}));
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+import { useConsoles } from "@/hooks/use-consoles";
+import { useGames } from "@/hooks/use-games";
+
+const mockUseConsoles = useConsoles as ReturnType<typeof vi.fn>;
+const mockUseGames = useGames as ReturnType<typeof vi.fn>;
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeConsole(overrides: Partial<Console> = {}): Console {
+  return {
+    id: "snes",
+    name: "Super Nintendo",
+    abbreviation: "snes",
+    extensions: [".sfc"],
+    defaultCore: "snes9x",
+    coverAspectRatio: 0.75,
+    colorTheme: "#6366f1",
+    iconUrl: "",
+    logoUrl: "",
+    gameCount: 100,
+    saveStateSupport: true,
+    browserPlayable: false,
+    playable: true,
+    createdAt: "",
+    updatedAt: "",
+    ...overrides,
+  };
+}
+
+function renderPage(consoleId = "snes") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/consoles/${consoleId}`]}>
+        <Routes>
+          <Route
+            path="/consoles/:id"
+            element={<ConsoleDetailPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ConsoleDetailPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseGames.mockReturnValue({
+      data: { data: [], total: 0, page: 1, pageSize: 48 },
+      isLoading: false,
+    });
+  });
+
+  describe("large library (> 24 games)", () => {
+    beforeEach(() => {
+      mockUseConsoles.mockReturnValue({
+        data: [makeConsole({ gameCount: 100 })],
+      });
+    });
+
+    it("renders console name in hero banner", () => {
+      renderPage();
+      expect(
+        screen.getByRole("heading", { name: "Super Nintendo", level: 1 }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders back to consoles button", () => {
+      renderPage();
+      expect(
+        screen.getByRole("button", { name: /back to consoles/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("renders game count in hero banner", () => {
+      renderPage();
+      expect(screen.getByText("100 games")).toBeInTheDocument();
+    });
+
+    it("renders browse all games link at top and bottom", () => {
+      renderPage();
+      const topLink = screen.getByTestId("browse-all-games-link");
+      expect(topLink).toBeInTheDocument();
+      expect(topLink).toHaveTextContent("Browse all 100 games");
+      expect(topLink).toHaveAttribute("href", "/consoles/snes/games");
+
+      const bottomLink = screen.getByTestId("browse-all-games-link-bottom");
+      expect(bottomLink).toBeInTheDocument();
+      expect(bottomLink).toHaveAttribute("href", "/consoles/snes/games");
+    });
+
+    it("does not render inline search input", () => {
+      renderPage();
+      expect(
+        screen.queryByPlaceholderText(/search super nintendo games/i),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("small library (<= 24 games)", () => {
+    const smallGames: GamesResponse = {
+      data: [
+        makeGame({ id: "1", title: "Super Mario World" }),
+        makeGame({ id: "2", title: "Chrono Trigger" }),
+      ],
+      total: 2,
+      page: 1,
+      pageSize: 24,
+    };
+
+    beforeEach(() => {
+      mockUseConsoles.mockReturnValue({
+        data: [makeConsole({ gameCount: 10 })],
+      });
+      mockUseGames.mockReturnValue({
+        data: smallGames,
+        isLoading: false,
+      });
+    });
+
+    it("renders inline search input", () => {
+      renderPage();
+      expect(
+        screen.getByPlaceholderText(/search super nintendo games/i),
+      ).toBeInTheDocument();
+    });
+
+    it("renders game cards inline", () => {
+      renderPage();
+      expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+      expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
+    });
+
+    it("does not render browse all games link", () => {
+      renderPage();
+      expect(screen.queryByTestId("browse-all-games-link")).not.toBeInTheDocument();
+    });
+
+    it("shows loading skeletons while data is loading", () => {
+      mockUseGames.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+      });
+      renderPage();
+      expect(
+        screen.getByPlaceholderText(/search super nintendo games/i),
+      ).toBeInTheDocument();
+      // Should not show empty state or game cards
+      expect(screen.queryByText("No games found")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("empty library", () => {
+    beforeEach(() => {
+      mockUseConsoles.mockReturnValue({
+        data: [makeConsole({ gameCount: 0 })],
+      });
+    });
+
+    it("renders empty state", () => {
+      renderPage();
+      expect(screen.getByText("No games found")).toBeInTheDocument();
+    });
+
+    it("does not render browse all games link", () => {
+      renderPage();
+      expect(screen.queryByTestId("browse-all-games-link")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/web/src/pages/__tests__/console-games-page.test.tsx
+++ b/web/src/pages/__tests__/console-games-page.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { ConsoleGamesPage } from "@/pages/console-games-page";
+import type { Console, Game, GamesResponse } from "@/types/api";
+
+// Mock hooks
+vi.mock("@/hooks/use-consoles", () => ({
+  useConsoles: vi.fn(),
+}));
+
+vi.mock("@/hooks/use-games", () => ({
+  useGames: vi.fn(),
+  useToggleFavorite: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-play-later", () => ({
+  useTogglePlayLater: () => ({ toggle: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-bios", () => ({
+  useBiosStatus: () => ({ data: undefined }),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: () => ({ isAdmin: false }),
+}));
+
+vi.mock("@/hooks/use-debounced-value", () => ({
+  useDebouncedValue: (v: string) => v,
+}));
+
+vi.mock("@/hooks/use-explore", () => ({
+  useThemes: () => ({ data: undefined }),
+  useKeywords: () => ({ data: undefined }),
+}));
+
+vi.mock("@/hooks/use-saved-searches", () => ({
+  useSavedSearches: () => ({ data: undefined }),
+  useCreateSavedSearch: () => ({ mutate: vi.fn() }),
+  useDeleteSavedSearch: () => ({ mutate: vi.fn() }),
+}));
+
+vi.mock("@/hooks/use-auto-scrape", () => ({
+  useAutoScrape: () => ({ ref: { current: null }, isScraping: false }),
+}));
+
+import { useConsoles } from "@/hooks/use-consoles";
+import { useGames } from "@/hooks/use-games";
+
+const mockUseConsoles = useConsoles as ReturnType<typeof vi.fn>;
+const mockUseGames = useGames as ReturnType<typeof vi.fn>;
+
+function makeGame(overrides: Partial<Game> = {}): Game {
+  return {
+    id: "1",
+    title: "Test Game",
+    consoleId: "snes",
+    consoleName: "SNES",
+    fileName: "test.sfc",
+    fileSize: 1024,
+    discCount: 1,
+    screenshotUrls: [],
+    scrapeAttempts: 1,
+    coverAspectRatio: 0.75,
+    playable: true,
+    isFavorite: false,
+    isInPlayLater: false,
+    averageRating: 0,
+    ratingCount: 0,
+    totalPlayTime: 0,
+    createdAt: "2025-01-01T00:00:00Z",
+    updatedAt: "2025-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+const testConsoles: Console[] = [
+  {
+    id: "snes",
+    name: "Super Nintendo",
+    abbreviation: "snes",
+    extensions: [".sfc"],
+    defaultCore: "snes9x",
+    coverAspectRatio: 0.75,
+    colorTheme: "#6366f1",
+    iconUrl: "",
+    logoUrl: "",
+    gameCount: 100,
+    saveStateSupport: true,
+    browserPlayable: false,
+    playable: true,
+    createdAt: "",
+    updatedAt: "",
+  },
+];
+
+const mockGamesResponse: GamesResponse = {
+  data: [
+    makeGame({ id: "1", title: "Super Mario World" }),
+    makeGame({ id: "2", title: "Chrono Trigger" }),
+  ],
+  total: 2,
+  page: 1,
+  pageSize: 48,
+};
+
+function renderPage(consoleId = "snes") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[`/consoles/${consoleId}/games`]}>
+        <Routes>
+          <Route
+            path="/consoles/:id/games"
+            element={<ConsoleGamesPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("ConsoleGamesPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseConsoles.mockReturnValue({ data: testConsoles });
+    mockUseGames.mockReturnValue({
+      data: mockGamesResponse,
+      isLoading: false,
+    });
+  });
+
+  it("renders page with test id", () => {
+    renderPage();
+    expect(screen.getByTestId("console-games-page")).toBeInTheDocument();
+  });
+
+  it("renders console name in heading", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: "Super Nintendo Games", level: 1 }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders back button with console name", () => {
+    renderPage();
+    expect(
+      screen.getByRole("button", { name: /back to super nintendo/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("renders total game count", () => {
+    renderPage();
+    expect(screen.getByText("2 games in your library")).toBeInTheDocument();
+  });
+
+  it("renders game cards", () => {
+    renderPage();
+    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+    expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
+  });
+
+  it("shows empty state when no games", () => {
+    mockUseGames.mockReturnValue({
+      data: { data: [], total: 0, page: 1, pageSize: 48 },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No games found")).toBeInTheDocument();
+  });
+
+  it("renders loading skeletons while loading", () => {
+    mockUseGames.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders search input", () => {
+    renderPage();
+    expect(screen.getByPlaceholderText("Search games...")).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -1,14 +1,20 @@
 import { useState } from "react";
-import { useParams, useNavigate } from "react-router-dom";
-import { Library, Check, Globe, FolderSearch, Loader2 } from "lucide-react";
+import { useParams, useNavigate, Link } from "react-router-dom";
+import {
+  Library,
+  Check,
+  Globe,
+  FolderSearch,
+  ArrowRight,
+} from "lucide-react";
 import { GameCard } from "@/components/game-card";
 import { GameGrid } from "@/components/game-grid";
 import {
   BackButton,
-  GameCardSkeleton,
+  Button,
   EmptyState,
+  GameCardSkeleton,
   SearchInput,
-  Switch,
 } from "@/components/ui";
 import { useConsoles } from "@/hooks/use-consoles";
 import { useGames, useToggleFavorite } from "@/hooks/use-games";
@@ -18,20 +24,19 @@ import { useAuth } from "@/hooks/use-auth";
 import { useScanLibrary } from "@/hooks/use-admin";
 import { useDebouncedValue } from "@/hooks/use-debounced-value";
 import { useToast } from "@/components/ui";
-import { AlphabetBar } from "@/components/alphabet-bar";
 import { BiosWarningBanner } from "@/features/bios/components/bios-warning-banner";
 import {
   ConsoleEssentials,
   ConsoleHiddenGems,
+  ConsoleRecentlyAdded,
   ConsoleGenreBreakdown,
   ConsoleTopDevelopers,
   ConsoleRecentlyPlayed,
 } from "@/features/explore/components/console-showcase-sections";
-import { Pagination } from "@/components/pagination";
 import { getConsoleStyle } from "@/lib/console-metadata";
 import { cn } from "@/lib/cn";
 
-const PAGE_SIZE = 48;
+const SMALL_LIBRARY_THRESHOLD = 24;
 
 export function ConsoleDetailPage() {
   const { id } = useParams<{ id: string }>();
@@ -39,36 +44,37 @@ export function ConsoleDetailPage() {
   const { data: consoles } = useConsoles();
   const { toggle: handleToggleFavorite } = useToggleFavorite();
   const { toggle: handleTogglePlayLater } = useTogglePlayLater();
-  const [search, setSearch] = useState("");
-  const debouncedSearch = useDebouncedValue(search, 300);
-  const [page, setPage] = useState(1);
-  const [hideBetas, setHideBetas] = useState(true);
-  const [activeLetter, setActiveLetter] = useState<string | undefined>();
   const { data: biosData } = useBiosStatus();
   const { isAdmin } = useAuth();
   const scanLibrary = useScanLibrary();
   const { toast } = useToast();
 
-  const { data, isLoading } = useGames({
-    consoleId: id,
-    search: debouncedSearch || undefined,
-    page,
-    pageSize: PAGE_SIZE,
-    sortBy: "title",
-    sortOrder: "asc",
-    hidePreRelease: hideBetas ? undefined : false,
-    letter: activeLetter,
-  });
+  // Small library inline search
+  const [search, setSearch] = useState("");
+  const debouncedSearch = useDebouncedValue(search, 300);
 
   // Find console info from the consoles list
   const console = consoles?.find((c) => c.id === id);
 
   const consoleName = console?.name ?? "Console";
   const consoleAbbr = console?.abbreviation ?? id ?? "";
-  const games = data?.data ?? [];
-  const totalGames = data?.total ?? 0;
+  const gameCount = console?.gameCount ?? 0;
   const style = getConsoleStyle(consoleAbbr);
   const Icon = style.icon;
+
+  const isSmallLibrary = gameCount > 0 && gameCount <= SMALL_LIBRARY_THRESHOLD;
+
+  // Only fetch games for small library inline view
+  const { data: smallLibraryData } = useGames(
+    {
+      consoleId: id,
+      search: debouncedSearch || undefined,
+      pageSize: SMALL_LIBRARY_THRESHOLD,
+      sortBy: "title",
+      sortOrder: "asc",
+    },
+    { enabled: isSmallLibrary },
+  );
 
   const biosConsole = biosData?.consoles.find((c) => c.consoleId === id);
   const showBiosWarning =
@@ -81,7 +87,9 @@ export function ConsoleDetailPage() {
   return (
     <div className="space-y-6">
       {/* Back button */}
-      <BackButton onClick={() => navigate(-1)}>Back to Consoles</BackButton>
+      <BackButton onClick={() => navigate("/consoles")}>
+        Back to Consoles
+      </BackButton>
 
       {/* Console hero banner */}
       <div
@@ -137,7 +145,7 @@ export function ConsoleDetailPage() {
           {/* Metadata row */}
           <div className="flex flex-wrap items-center justify-center gap-3 mt-4">
             <span className="text-sm font-medium text-white/70">
-              {totalGames} {totalGames === 1 ? "game" : "games"}
+              {gameCount} {gameCount === 1 ? "game" : "games"}
             </span>
             {console?.saveStateSupport && (
               <span className="inline-flex items-center gap-1.5 rounded-full bg-white/10 backdrop-blur-sm px-3 py-1 text-xs font-medium text-white/90">
@@ -164,31 +172,16 @@ export function ConsoleDetailPage() {
         />
       )}
 
-      {/* Search & filters */}
-      <div className="flex flex-wrap items-center gap-3">
-        <SearchInput
-          placeholder={`Search ${consoleName} games...`}
-          value={search}
-          onChange={(e) => {
-            setSearch(e.target.value);
-            setPage(1);
-          }}
-          className="max-w-sm"
-        />
-        <label className="flex items-center gap-2 text-sm text-surface-300 whitespace-nowrap" data-testid="console-hide-betas-toggle">
-          <Switch
-            checked={hideBetas}
-            onChange={(checked) => {
-              setHideBetas(checked);
-              setPage(1);
-            }}
-          />
-          Hide betas
-        </label>
-        {isAdmin && (
-          <button
-            className="ml-auto inline-flex items-center gap-2 rounded-lg bg-white/[0.06] px-3 py-2 text-sm font-medium text-surface-300 hover:bg-white/[0.10] hover:text-surface-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed whitespace-nowrap"
-            disabled={scanLibrary.isPending}
+      {/* Admin scan button */}
+      {isAdmin && (
+        <div className="flex">
+          <Button
+            variant="ghost"
+            size="sm"
+            loading={scanLibrary.isPending}
+            icon={<FolderSearch className="h-4 w-4" />}
+            className="ml-auto"
+            data-testid="scan-button"
             onClick={() =>
               scanLibrary.mutate(
                 { console: consoleAbbr },
@@ -204,78 +197,85 @@ export function ConsoleDetailPage() {
               )
             }
           >
-            {scanLibrary.isPending ? (
-              <Loader2 className="h-4 w-4 animate-spin" />
-            ) : (
-              <FolderSearch className="h-4 w-4" />
-            )}
             Scan for new games
-          </button>
-        )}
-      </div>
-
-      <AlphabetBar
-        activeLetter={activeLetter}
-        onLetterClick={(letter) => {
-          setActiveLetter(letter);
-          setPage(1);
-        }}
-      />
-
-      <ConsoleEssentials consoleId={id!} />
-      <ConsoleHiddenGems consoleId={id!} />
-      <ConsoleGenreBreakdown consoleId={id!} />
-      <ConsoleTopDevelopers consoleId={id!} />
-      <ConsoleRecentlyPlayed consoleId={id!} />
-
-      {/* Games heading */}
-      {!isLoading && games.length > 0 && (
-        <h2 className="text-lg font-bold text-surface-100">
-          {totalGames} {totalGames === 1 ? "game" : "games"}
-        </h2>
+          </Button>
+        </div>
       )}
 
-      {/* Games grid */}
-      {isLoading ? (
-        <GameGrid>
-          {Array.from({ length: 12 }, (_, i) => (
-            <GameCardSkeleton
-              key={i}
-              aspectRatio={console?.coverAspectRatio}
-            />
-          ))}
-        </GameGrid>
-      ) : games.length === 0 ? (
+      {/* Content varies by library size */}
+      {gameCount === 0 ? (
         <EmptyState
           icon={Library}
-          title={search.trim() ? "No matching games" : "No games found"}
-          description={
-            search.trim()
-              ? `No games matching "${search.trim()}" for this console.`
-              : "No games have been detected for this console yet."
-          }
+          title="No games found"
+          description="No games have been detected for this console yet."
         />
-      ) : (
-        <GameGrid>
-          {games.map((game) => (
-            <GameCard
-              key={game.id}
-              game={game}
-              aspectRatio={console?.coverAspectRatio}
-              onToggleFavorite={handleToggleFavorite}
-              onTogglePlayLater={handleTogglePlayLater}
+      ) : isSmallLibrary ? (
+        /* Small library: inline game grid */
+        <>
+          <SearchInput
+            placeholder={`Search ${consoleName} games...`}
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="max-w-sm"
+            data-testid="small-library-search"
+          />
+          {smallLibraryData && smallLibraryData.data.length > 0 ? (
+            <GameGrid>
+              {smallLibraryData.data.map((game) => (
+                <GameCard
+                  key={game.id}
+                  game={game}
+                  aspectRatio={console?.coverAspectRatio}
+                  onToggleFavorite={handleToggleFavorite}
+                  onTogglePlayLater={handleTogglePlayLater}
+                />
+              ))}
+            </GameGrid>
+          ) : smallLibraryData ? (
+            <EmptyState
+              icon={Library}
+              title="No matching games"
+              description={`No games matching "${search.trim()}" for this console.`}
             />
-          ))}
-        </GameGrid>
-      )}
+          ) : (
+            <GameGrid>
+              {Array.from({ length: gameCount }, (_, i) => (
+                <GameCardSkeleton
+                  key={i}
+                  aspectRatio={console?.coverAspectRatio}
+                />
+              ))}
+            </GameGrid>
+          )}
+        </>
+      ) : (
+        /* Large library: showcase sections + browse link */
+        <>
+          <Link
+            to={`/consoles/${id}/games`}
+            className="inline-flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white shadow-lg shadow-brand-600/20 hover:bg-brand-500 active:bg-brand-700 transition-all duration-200"
+            data-testid="browse-all-games-link"
+          >
+            Browse all {gameCount} games
+            <ArrowRight className="h-4 w-4" />
+          </Link>
 
-      {data && (
-        <Pagination
-          total={data.total}
-          pageSize={PAGE_SIZE}
-          currentPage={page}
-          onPageChange={setPage}
-        />
+          <ConsoleEssentials consoleId={id!} />
+          <ConsoleHiddenGems consoleId={id!} />
+          <ConsoleGenreBreakdown consoleId={id!} />
+          <ConsoleTopDevelopers consoleId={id!} />
+          <ConsoleRecentlyAdded consoleId={id!} />
+          <ConsoleRecentlyPlayed consoleId={id!} />
+
+          <Link
+            to={`/consoles/${id}/games`}
+            className="inline-flex items-center gap-2 rounded-lg bg-brand-600 px-4 py-2 text-sm font-medium text-white shadow-lg shadow-brand-600/20 hover:bg-brand-500 active:bg-brand-700 transition-all duration-200"
+            data-testid="browse-all-games-link-bottom"
+          >
+            Browse all {gameCount} games
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </>
       )}
     </div>
   );

--- a/web/src/pages/console-games-page.tsx
+++ b/web/src/pages/console-games-page.tsx
@@ -1,0 +1,300 @@
+import { useState, useEffect, useCallback } from "react";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
+import { Library } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameGrid } from "@/components/game-grid";
+import {
+  BackButton,
+  GameCardSkeleton,
+  GameListRowSkeleton,
+  EmptyState,
+} from "@/components/ui";
+import { useConsoles } from "@/hooks/use-consoles";
+import { useGames, useToggleFavorite } from "@/hooks/use-games";
+import { useTogglePlayLater } from "@/hooks/use-play-later";
+import { useBiosStatus } from "@/hooks/use-bios";
+import { useDebouncedValue } from "@/hooks/use-debounced-value";
+import { useThemes, useKeywords } from "@/hooks/use-explore";
+import {
+  useSavedSearches,
+  useCreateSavedSearch,
+  useDeleteSavedSearch,
+} from "@/hooks/use-saved-searches";
+import { GamesFilterBar } from "@/features/games/components/games-filter-bar";
+import {
+  AdvancedFilterPanel,
+  savedSearchToFilters,
+} from "@/features/games/components/advanced-filter-panel";
+import { ActiveFilterPills } from "@/features/games/components/active-filter-pills";
+import { BestVersionsButton } from "@/features/games/components/best-versions-button";
+import { GameListRow } from "@/features/games/components/game-list-row";
+import { AlphabetBar } from "@/components/alphabet-bar";
+import { Pagination } from "@/components/pagination";
+import { BiosWarningBanner } from "@/features/bios/components/bios-warning-banner";
+import { useAuth } from "@/hooks/use-auth";
+import type { GameFilters } from "@/types/api";
+
+type ViewMode = "grid" | "list";
+
+/** Parse URL search params into GameFilters (excluding consoleId) */
+function parseUrlFilters(params: URLSearchParams): Partial<GameFilters> {
+  const f: Partial<GameFilters> = {};
+  const regions = params.get("regions");
+  if (regions) f.regions = regions.split(",");
+  const genres = params.get("genres");
+  if (genres) f.genres = genres.split(",");
+  const themes = params.get("themes");
+  if (themes) f.themes = themes.split(",");
+  const keywords = params.get("keywords");
+  if (keywords) f.keywords = keywords.split(",");
+  if (params.get("developer")) f.developer = params.get("developer")!;
+  if (params.get("publisher")) f.publisher = params.get("publisher")!;
+  if (params.get("yearMin")) f.yearMin = Number(params.get("yearMin"));
+  if (params.get("yearMax")) f.yearMax = Number(params.get("yearMax"));
+  if (params.get("ratingMin")) f.ratingMin = Number(params.get("ratingMin"));
+  if (params.get("ratingMax")) f.ratingMax = Number(params.get("ratingMax"));
+  const ps = params.get("playStatus");
+  if (ps) f.playStatus = ps as GameFilters["playStatus"];
+  if (params.get("hidePreRelease") === "false") f.hidePreRelease = false;
+  if (params.get("grouped") === "false") f.grouped = false;
+  if (params.get("letter")) f.letter = params.get("letter")!;
+  const sortBy = params.get("sortBy");
+  if (sortBy) f.sortBy = sortBy as GameFilters["sortBy"];
+  const sortOrder = params.get("sortOrder");
+  if (sortOrder) f.sortOrder = sortOrder as GameFilters["sortOrder"];
+  if (params.get("search")) f.search = params.get("search")!;
+  return f;
+}
+
+/** Serialize GameFilters to URL search params (excluding consoleId) */
+function filtersToUrl(filters: GameFilters): URLSearchParams {
+  const params = new URLSearchParams();
+  if (filters.regions?.length) params.set("regions", filters.regions.join(","));
+  if (filters.genres?.length) params.set("genres", filters.genres.join(","));
+  if (filters.themes?.length) params.set("themes", filters.themes.join(","));
+  if (filters.keywords?.length) params.set("keywords", filters.keywords.join(","));
+  if (filters.developer) params.set("developer", filters.developer);
+  if (filters.publisher) params.set("publisher", filters.publisher);
+  if (filters.yearMin != null) params.set("yearMin", String(filters.yearMin));
+  if (filters.yearMax != null) params.set("yearMax", String(filters.yearMax));
+  if (filters.ratingMin != null) params.set("ratingMin", String(filters.ratingMin));
+  if (filters.ratingMax != null) params.set("ratingMax", String(filters.ratingMax));
+  if (filters.playStatus) params.set("playStatus", filters.playStatus);
+  if (filters.hidePreRelease === false) params.set("hidePreRelease", "false");
+  if (filters.grouped === false) params.set("grouped", "false");
+  if (filters.letter) params.set("letter", filters.letter);
+  if (filters.sortBy && filters.sortBy !== "title") params.set("sortBy", filters.sortBy);
+  if (filters.sortOrder && filters.sortOrder !== "asc") params.set("sortOrder", filters.sortOrder);
+  if (filters.search) params.set("search", filters.search);
+  return params;
+}
+
+export function ConsoleGamesPage() {
+  const { id } = useParams<{ id: string }>();
+  const navigate = useNavigate();
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [viewMode, setViewMode] = useState<ViewMode>("grid");
+  const [searchInput, setSearchInput] = useState(searchParams.get("search") ?? "");
+  const debouncedSearch = useDebouncedValue(searchInput, 300);
+  const [filtersOpen, setFiltersOpen] = useState(false);
+
+  const { data: consoles } = useConsoles();
+  const { data: themes } = useThemes();
+  const { data: keywords } = useKeywords(50);
+  const { data: savedSearches } = useSavedSearches();
+  const createSearch = useCreateSavedSearch();
+  const deleteSearch = useDeleteSavedSearch();
+  const { toggle: handleToggleFavorite } = useToggleFavorite();
+  const { toggle: handleTogglePlayLater } = useTogglePlayLater();
+  const { data: biosData } = useBiosStatus();
+  const { isAdmin } = useAuth();
+
+  const console = consoles?.find((c) => c.id === id);
+  const consoleName = console?.name ?? "Console";
+
+  // Initialize filters from URL
+  const [filters, setFilters] = useState<GameFilters>(() => ({
+    sortBy: "title",
+    sortOrder: "asc",
+    pageSize: 48,
+    ...parseUrlFilters(searchParams),
+  }));
+
+  // Sync filters to URL (excluding consoleId)
+  useEffect(() => {
+    const params = filtersToUrl({ ...filters, search: debouncedSearch || undefined });
+    const current = searchParams.toString();
+    const next = params.toString();
+    if (current !== next) {
+      setSearchParams(params, { replace: true });
+    }
+  }, [filters, debouncedSearch, searchParams, setSearchParams]);
+
+  // Always lock consoleId to URL param
+  const { data, isLoading } = useGames({
+    ...filters,
+    consoleId: id,
+    search: debouncedSearch || undefined,
+  });
+
+  const handleSaveSearch = useCallback(
+    (name: string, filterRecord: Record<string, string | number>) => {
+      createSearch.mutate({ name, filters: filterRecord });
+    },
+    [createSearch],
+  );
+
+  const handleApplySearch = useCallback(
+    (filterRecord: Record<string, string | number>) => {
+      setFilters((prev) => savedSearchToFilters(filterRecord, prev));
+      if (filterRecord.search) {
+        setSearchInput(String(filterRecord.search));
+      }
+    },
+    [],
+  );
+
+  const games = data?.data ?? [];
+
+  const biosConsole = biosData?.consoles.find((c) => c.consoleId === id);
+  const showBiosWarning =
+    biosConsole?.status === "missing" && biosConsole.biosRequired;
+  const missingBiosFiles =
+    biosConsole?.files
+      .filter((f) => f.status === "missing" && f.required)
+      .map((f) => f.fileName) ?? [];
+
+  return (
+    <div className="space-y-6" data-testid="console-games-page">
+      <BackButton onClick={() => navigate(`/consoles/${id}`)}>
+        {`Back to ${consoleName}`}
+      </BackButton>
+
+      <div>
+        <h1 className="text-3xl font-bold text-surface-100">
+          {consoleName} Games
+        </h1>
+        <p className="mt-1 text-surface-400">
+          {data
+            ? `${data.total} games in your library`
+            : "Browse your game library"}
+        </p>
+      </div>
+
+      {showBiosWarning && (
+        <BiosWarningBanner
+          message={`Missing BIOS: ${consoleName} requires firmware files to play games.`}
+          isAdmin={isAdmin}
+          missingFiles={missingBiosFiles}
+        />
+      )}
+
+      <GamesFilterBar
+        filters={filters}
+        onFiltersChange={setFilters}
+        searchValue={searchInput}
+        onSearchChange={(value) => {
+          setSearchInput(value);
+          setFilters((f) => ({ ...f, page: 1 }));
+        }}
+        viewMode={viewMode}
+        onViewModeChange={setViewMode}
+        consoles={consoles}
+        showHideBetas
+        hideConsoleFilter
+      />
+
+      <div className="flex flex-wrap items-start gap-3">
+        <AdvancedFilterPanel
+          filters={filters}
+          onFiltersChange={setFilters}
+          consoles={consoles}
+          themes={themes}
+          keywords={keywords}
+          savedSearches={savedSearches}
+          onSaveSearch={handleSaveSearch}
+          onDeleteSearch={(deleteId) => deleteSearch.mutate(deleteId)}
+          onApplySearch={handleApplySearch}
+          totalResults={data?.total}
+          isOpen={filtersOpen}
+          onToggle={() => setFiltersOpen((o) => !o)}
+          hideConsoleFilter
+        />
+        <BestVersionsButton
+          filters={filters}
+          onFiltersChange={setFilters}
+        />
+      </div>
+
+      <ActiveFilterPills
+        filters={filters}
+        onFiltersChange={setFilters}
+        consoles={consoles}
+      />
+
+      <AlphabetBar
+        activeLetter={filters.letter}
+        onLetterClick={(letter) =>
+          setFilters((f) => ({ ...f, letter, page: 1 }))
+        }
+      />
+
+      {/* Content */}
+      {isLoading ? (
+        viewMode === "grid" ? (
+          <GameGrid>
+            {Array.from({ length: 18 }, (_, i) => (
+              <GameCardSkeleton
+                key={i}
+                aspectRatio={console?.coverAspectRatio}
+              />
+            ))}
+          </GameGrid>
+        ) : (
+          <div className="space-y-1">
+            {Array.from({ length: 10 }, (_, i) => (
+              <GameListRowSkeleton key={i} />
+            ))}
+          </div>
+        )
+      ) : games.length === 0 ? (
+        <EmptyState
+          icon={Library}
+          title="No games found"
+          description={
+            searchInput
+              ? "No games match your search. Try different keywords."
+              : "No games have been detected for this console yet."
+          }
+        />
+      ) : viewMode === "grid" ? (
+        <GameGrid>
+          {games.map((game) => (
+            <GameCard
+              key={game.id}
+              game={game}
+              aspectRatio={console?.coverAspectRatio}
+              onToggleFavorite={handleToggleFavorite}
+              onTogglePlayLater={handleTogglePlayLater}
+            />
+          ))}
+        </GameGrid>
+      ) : (
+        <div className="space-y-1">
+          {games.map((game) => (
+            <GameListRow key={game.id} game={game} />
+          ))}
+        </div>
+      )}
+
+      {data && (
+        <Pagination
+          total={data.total}
+          pageSize={filters.pageSize ?? 48}
+          currentPage={filters.page ?? 1}
+          onPageChange={(page) => setFilters((f) => ({ ...f, page }))}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1058,6 +1058,7 @@ export interface ConsoleShowcase {
   console: Console;
   essentials: Game[];
   hiddenGems: Game[];
+  recentlyAdded: Game[];
   genreBreakdown: GenreCount[];
   topDevelopers: DeveloperSummary[];
   recentlyPlayed: Game[];


### PR DESCRIPTION
## Summary
- Redesigns `/consoles/:id` to show curated showcase sections (essentials, hidden gems, genre breakdown, top developers, recently added, recently played) for large libraries (>24 games), with "Browse all N games" links at top and bottom
- Adds `/consoles/:id/games` as a dedicated full games browser with filtering, search, alphabet bar, grid/list view, and pagination — mirrors the main Games page but scoped to one console
- Small libraries (≤24 games) show an inline game grid with search directly on the console detail page
- Backend: adds "Recently Added" section to the console showcase API endpoint

## Test plan
- [x] 1353 vitest tests pass (125 files)
- [x] Go API tests pass
- [x] TypeScript compiles with zero errors
- [x] New tests for: ConsoleDetailPage (large/small/empty library), ConsoleGamesPage, GamesFilterBar (hideConsoleFilter), AdvancedFilterPanel (hideConsoleFilter), ConsoleShowcaseSections (recently added), explore handler (recently added API)