### PR TITLE
fix: add missing .lyx extension to ROM modal and setup handler

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -1,15 +1,5 @@
 # Known Issues
 
-## .lyx extension gaps (from PR #161 follow-up)
-
-### Missing .lyx in replace ROM modal (Medium)
-- **File**: `web/src/features/game-detail/components/replace-rom-modal.tsx:35`
-- `.lyx` is not in `ACCEPTED_EXTENSIONS`. Users replacing a Lynx ROM via the UI won't see `.lyx` files in the file picker.
-
-### Missing .lyx in setup handler (Medium)
-- **File**: `server/internal/api/setup_handler.go:206`
-- `.lyx` missing from the `knownExts` map in `countGameFiles()`. The setup page will undercount Lynx ROMs if any use the `.lyx` extension.
-
 ## Console detail page polish (from code review)
 
 ### No focus-visible on "Browse all" links (High - a11y)

--- a/server/internal/api/setup_handler.go
+++ b/server/internal/api/setup_handler.go
@@ -203,7 +203,7 @@ func countGameFiles(dir string) int {
 		".cue": true, ".chd": true, ".zip": true, ".7z": true, ".psx": true,
 		".cso": true, ".pbp": true, ".nsp": true, ".xci": true, ".3ds": true,
 		".cia": true, ".wad": true, ".gcm": true, ".wbfs": true, ".a26": true,
-		".lnx": true, ".pce": true, ".ngp": true, ".ngc": true, ".ws": true,
+		".lnx": true, ".lyx": true, ".pce": true, ".ngp": true, ".ngc": true, ".ws": true,
 		".wsc": true, ".vb": true, ".vec": true, ".col": true, ".sg": true,
 		".gg": true, ".sms": true, ".32x": true,
 	}

--- a/web/src/features/game-detail/components/replace-rom-modal.tsx
+++ b/web/src/features/game-detail/components/replace-rom-modal.tsx
@@ -33,6 +33,7 @@ const ACCEPTED_EXTENSIONS = [
   ".a26",
   ".a78",
   ".lnx",
+  ".lyx",
   ".jag",
   ".col",
   ".sg",


### PR DESCRIPTION
## Summary
- Add `.lyx` to `ACCEPTED_EXTENSIONS` in replace ROM modal so the file picker shows `.lyx` files for Atari Lynx
- Add `.lyx` to `knownExts` in setup handler so the setup wizard correctly counts Lynx ROMs
- Remove resolved items from ISSUES.md

Follow-up to PR #161 which added `.lyx` to the scanner but missed these two hardcoded extension lists.

## Test plan
- [x] Verify `.lyx` appears in both extension lists
- [x] Remove resolved issues from ISSUES.md