### PR TITLE
feat: add global search to player app

### DIFF
--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -21,6 +21,7 @@ import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.intent.EmulationIntent
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.NavigationViewModel
+import com.spela.player.presentation.navigation.SpScreen
 import com.spela.player.presentation.intent.KeyMappingIntent
 import com.spela.player.presentation.viewmodel.EmulationViewModel
 import com.spela.player.presentation.viewmodel.KeyMappingViewModel
@@ -245,6 +246,13 @@ class MainActivity : ComponentActivity() {
                 navigationViewModel.onIntent(NavigationIntent.NextSection)
                 return true
             }
+            KeyEvent.KEYCODE_BUTTON_SELECT -> {
+                val navState = navigationViewModel.state.value
+                if (navState.currentScreen !is SpScreen.GlobalSearch) {
+                    navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+                }
+                return true
+            }
         }
 
         // Let D-pad and other keys propagate to Compose
@@ -297,6 +305,7 @@ class MainActivity : ComponentActivity() {
             }
             KeyEvent.KEYCODE_BUTTON_B -> return true
             KeyEvent.KEYCODE_BUTTON_L1, KeyEvent.KEYCODE_BUTTON_R1 -> return true
+            KeyEvent.KEYCODE_BUTTON_SELECT -> return true
         }
 
         return super.onKeyUp(keyCode, event)

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreSearchTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreSearchTest.kt
@@ -70,10 +70,10 @@ class ExploreSearchTest {
         ),
     )
 
-    // --- Search chip on Explore screen ---
+    // --- Search bar on Explore screen ---
 
     @Test
-    fun searchChipRendersOnExploreScreen() = runComposeUiTest {
+    fun searchBarRendersOnExploreScreen() = runComposeUiTest {
         val harness = createHarness()
         // Need at least one section so explore screen is not empty
         harness.exploreRepo.featuredSeriesList = listOf(
@@ -87,11 +87,11 @@ class ExploreSearchTest {
         advance(harness)
 
         onNodeWithTag("explore_screen").assertIsDisplayed()
-        onNodeWithTag("explore_search_chip").assertExists()
+        onNodeWithTag("explore_search_bar").assertExists()
     }
 
     @Test
-    fun searchChipNavigatesToSearchScreen() = runComposeUiTest {
+    fun searchBarNavigatesToGlobalSearchScreen() = runComposeUiTest {
         val harness = createHarness()
         harness.exploreRepo.featuredSeriesList = listOf(
             com.spela.player.domain.model.FeaturedSeries(
@@ -103,11 +103,11 @@ class ExploreSearchTest {
         harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
         advance(harness)
 
-        onNodeWithTag("explore_search_chip").performClick()
+        onNodeWithTag("explore_search_bar").performClick()
         advance(harness)
 
         val navState = harness.navigationViewModel.state.value
-        assertEquals("explore_search", navState.currentScreen.route)
+        assertEquals("global_search", navState.currentScreen.route)
     }
 
     // --- Search screen renders ---

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/FranchiseDetailTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/FranchiseDetailTest.kt
@@ -1,0 +1,337 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for Phase 2 Story 7: Franchise Detail Screen.
+ *
+ * Covers:
+ * - Franchise screen renders with hero banner, title, ownership progress
+ * - Console filter chips render and filter games
+ * - Game list shows franchise games
+ * - Navigation from global search franchise result to franchise screen
+ * - Empty state when no games match filter
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class FranchiseDetailTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun ComposeUiTest.searchInputNode(): SemanticsNodeInteraction =
+        onNode(hasSetTextAction() and hasAnyAncestor(hasTestTag("global_search_input")))
+
+    private val sampleFranchiseGames = listOf(
+        SeriesGame(
+            igdbGameId = 2001,
+            name = "Castlevania",
+            inLibrary = true,
+            localGameId = "game-cv1",
+            coverUrl = null,
+            releaseDate = "1986-09-26",
+            rating = 80.0,
+            consoleAbbreviation = "NES",
+            consoleName = "NES",
+            consoleColor = "#dc2626",
+        ),
+        SeriesGame(
+            igdbGameId = 2002,
+            name = "Castlevania: Symphony of the Night",
+            inLibrary = true,
+            localGameId = "game-cv2",
+            coverUrl = null,
+            releaseDate = "1997-03-20",
+            rating = 95.0,
+            consoleAbbreviation = "PS1",
+            consoleName = "PlayStation",
+            consoleColor = "#3b82f6",
+        ),
+        SeriesGame(
+            igdbGameId = 2003,
+            name = "Castlevania: Aria of Sorrow",
+            inLibrary = false,
+            localGameId = null,
+            coverUrl = null,
+            releaseDate = "2003-05-08",
+            rating = 90.0,
+            consoleAbbreviation = "GBA",
+            consoleName = "Game Boy Advance",
+            consoleColor = "#9333ea",
+        ),
+    )
+
+    private val sampleFranchiseConsoles = listOf(
+        SeriesConsole(abbreviation = "NES", name = "NES", color = "#dc2626", gameCount = 1),
+        SeriesConsole(abbreviation = "PS1", name = "PlayStation", color = "#3b82f6", gameCount = 1),
+        SeriesConsole(abbreviation = "GBA", name = "Game Boy Advance", color = "#9333ea", gameCount = 1),
+    )
+
+    private val sampleFranchiseDetail = SeriesDetail(
+        id = "fr1",
+        name = "Castlevania",
+        heroUrl = null,
+        consoles = sampleFranchiseConsoles,
+        libraryGames = 2,
+        totalGames = 3,
+        games = sampleFranchiseGames,
+    )
+
+    // --- Franchise detail screen rendering ---
+
+    @Test
+    fun `franchise screen renders with hero banner, title, and ownership progress`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.franchiseDetails = mapOf("fr1" to sampleFranchiseDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreFranchise("fr1", "Castlevania"))
+        )
+        advance(harness)
+
+        onNodeWithTag("explore_franchise_screen").assertIsDisplayed()
+        onNodeWithTag("franchise_hero_banner").assertIsDisplayed()
+
+        // "Castlevania" appears in both top bar and hero
+        onAllNodesWithText("Castlevania").fetchSemanticsNodes().let {
+            assert(it.isNotEmpty()) { "Expected at least one 'Castlevania' text node" }
+        }
+
+        onNodeWithTag("franchise_ownership_progress").assertIsDisplayed()
+        onNodeWithTag("franchise_ownership_text").assertIsDisplayed()
+        onNodeWithText("You own 2 of 3 games").assertExists()
+    }
+
+    @Test
+    fun `franchise detail shows games in list`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.franchiseDetails = mapOf("fr1" to sampleFranchiseDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreFranchise("fr1", "Castlevania"))
+        )
+        advance(harness)
+
+        onNodeWithTag("franchise_game_2001").assertExists()
+        onNodeWithTag("franchise_game_2002").assertExists()
+        onNodeWithTag("franchise_game_2003").assertExists()
+    }
+
+    // --- Console filter chips ---
+
+    @Test
+    fun `console filter chips render`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.franchiseDetails = mapOf("fr1" to sampleFranchiseDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreFranchise("fr1", "Castlevania"))
+        )
+        advance(harness)
+
+        onNodeWithTag("franchise_console_filters").assertIsDisplayed()
+        onNodeWithTag("franchise_console_chip_all").assertExists()
+        onNodeWithTag("franchise_console_chip_NES").assertExists()
+        onNodeWithTag("franchise_console_chip_PS1").assertExists()
+        onNodeWithTag("franchise_console_chip_GBA").assertExists()
+    }
+
+    @Test
+    fun `console filter filters games`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.franchiseDetails = mapOf("fr1" to sampleFranchiseDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreFranchise("fr1", "Castlevania"))
+        )
+        advance(harness)
+
+        // All 3 games visible initially
+        onNodeWithTag("franchise_game_2001").assertExists()
+        onNodeWithTag("franchise_game_2002").assertExists()
+        onNodeWithTag("franchise_game_2003").assertExists()
+
+        // Click PS1 filter
+        onNodeWithTag("franchise_console_chip_PS1").performClick()
+        advanceQuick(harness)
+
+        // Only PS1 game visible
+        onNodeWithTag("franchise_game_2001").assertDoesNotExist()
+        onNodeWithTag("franchise_game_2002").assertExists()
+        onNodeWithTag("franchise_game_2003").assertDoesNotExist()
+
+        // Click PS1 again to clear filter
+        onNodeWithTag("franchise_console_chip_PS1").performClick()
+        advanceQuick(harness)
+
+        // All games visible again
+        onNodeWithTag("franchise_game_2001").assertExists()
+        onNodeWithTag("franchise_game_2002").assertExists()
+        onNodeWithTag("franchise_game_2003").assertExists()
+    }
+
+    // --- Empty state ---
+
+    @Test
+    fun `empty state shown when no games match filter`() = runComposeUiTest {
+        val harness = createHarness()
+        // Franchise with games on only one console
+        val singleConsoleDetail = SeriesDetail(
+            id = "fr2",
+            name = "Mega Man",
+            heroUrl = null,
+            consoles = listOf(
+                SeriesConsole(abbreviation = "NES", name = "NES", color = "#dc2626", gameCount = 1),
+                SeriesConsole(abbreviation = "SNES", name = "SNES", color = "#9333ea", gameCount = 0),
+            ),
+            libraryGames = 1,
+            totalGames = 1,
+            games = listOf(
+                SeriesGame(
+                    igdbGameId = 3001,
+                    name = "Mega Man 2",
+                    inLibrary = true,
+                    localGameId = "game-mm2",
+                    coverUrl = null,
+                    releaseDate = "1988-12-24",
+                    rating = 88.0,
+                    consoleAbbreviation = "NES",
+                    consoleName = "NES",
+                    consoleColor = "#dc2626",
+                ),
+            ),
+        )
+        harness.exploreRepo.franchiseDetails = mapOf("fr2" to singleConsoleDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreFranchise("fr2", "Mega Man"))
+        )
+        advance(harness)
+
+        // Game should be visible initially
+        onNodeWithTag("franchise_game_3001").assertExists()
+
+        // Filter by SNES (no games on this console)
+        onNodeWithTag("franchise_console_chip_SNES").performClick()
+        advanceQuick(harness)
+
+        // Should show empty state
+        onNodeWithTag("franchise_empty_state").assertExists()
+        onNodeWithTag("franchise_game_3001").assertDoesNotExist()
+    }
+
+    // --- Dimmed treatment for non-library games ---
+
+    @Test
+    fun `non-library games show not in library in content description`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.franchiseDetails = mapOf("fr1" to sampleFranchiseDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreFranchise("fr1", "Castlevania"))
+        )
+        advance(harness)
+
+        // In-library game
+        onNodeWithTag("franchise_game_2001").assertExists()
+
+        // Not-in-library game should indicate as such
+        onNodeWithTag("franchise_game_2003").assertExists()
+        onNodeWithTag("franchise_game_2003")
+            .assertContentDescriptionContains("not in library", substring = true)
+    }
+
+    // --- Navigation from global search ---
+
+    @Test
+    fun `tapping franchise result in global search navigates to franchise screen`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = GlobalSearchResult(
+            franchises = SearchCategory(
+                results = listOf(
+                    SearchFranchiseResult(
+                        id = "fr1",
+                        name = "Castlevania",
+                        totalGames = 8,
+                        libraryGames = 2,
+                    ),
+                ),
+                total = 1,
+            ),
+        )
+        harness.exploreRepo.franchiseDetails = mapOf("fr1" to sampleFranchiseDetail)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("castlevania")
+        advanceFully(harness)
+
+        // Franchise result should be visible
+        onNodeWithTag("search_result_franchise_fr1").assertExists()
+
+        // Click on the franchise result
+        onNodeWithTag("search_result_franchise_fr1").performClick()
+        advance(harness)
+
+        // Should navigate to franchise detail screen
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("explore_franchise/fr1", navState.currentScreen.route)
+    }
+
+    // --- Navigation from game detail franchise chip ---
+
+    @Test
+    fun `franchise link shows on game detail screen`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.gameFranchiseLinks = mapOf(
+            "1" to listOf(
+                GameFranchiseLink(
+                    id = "fr1",
+                    name = "Castlevania",
+                    gameCount = 8,
+                ),
+            ),
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        onNodeWithTag("series_franchise_section").assertExists()
+        onNodeWithText("Part of Castlevania", substring = true).assertExists()
+    }
+
+    // --- Loading state ---
+
+    @Test
+    fun `franchise detail shows loading skeleton while fetching`() = runComposeUiTest {
+        val harness = createHarness()
+        // Do not provide franchise details so it stays in loading state / error
+        // since the repository will fail with "Franchise not found"
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.ExploreFranchise("fr_unknown", "Unknown"))
+        )
+        advance(harness)
+
+        // When franchise is not found, the error state is shown
+        onNodeWithTag("franchise_error_state").assertExists()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GlobalSearchTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GlobalSearchTest.kt
@@ -1,0 +1,528 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for the Global Search feature.
+ *
+ * Covers:
+ * - Screen states (placeholder, hint, loading, results, no results, error)
+ * - Search behavior (typing triggers search, clearing resets, debouncing)
+ * - Navigation from search results to detail screens
+ * - Entry points (Explore search bar, Home search icon)
+ * - Advanced filters chip visibility
+ * - Edge cases (whitespace-only query, categories with no results hidden)
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class GlobalSearchTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    /**
+     * SpTextField wraps an OutlinedTextField in a Column; the testTag "global_search_input"
+     * is on the Column, but performTextInput requires the node with SetTextAction
+     * (the OutlinedTextField). This helper finds the editable text field inside the wrapper.
+     */
+    private fun ComposeUiTest.searchInputNode(): SemanticsNodeInteraction =
+        onNode(hasSetTextAction() and hasAnyAncestor(hasTestTag("global_search_input")))
+
+    private fun fullSearchResult() = GlobalSearchResult(
+        games = SearchCategory(
+            results = listOf(
+                SearchGameResult(
+                    id = "g1",
+                    title = "Super Mario World",
+                    consoleName = "SNES",
+                    consoleId = "snes",
+                    developer = "Nintendo",
+                    coverUrl = null,
+                ),
+                SearchGameResult(
+                    id = "g2",
+                    title = "Castlevania",
+                    consoleName = "NES",
+                    consoleId = "nes",
+                    developer = "Konami",
+                    coverUrl = null,
+                ),
+            ),
+            total = 2,
+        ),
+        consoles = SearchCategory(
+            results = listOf(
+                SearchConsoleResult(id = "snes", name = "Super Nintendo", gameCount = 15),
+            ),
+            total = 1,
+        ),
+        developers = SearchCategory(
+            results = listOf(
+                SearchDeveloperResult(name = "Nintendo", gameCount = 20, avgRating = 90.0),
+            ),
+            total = 1,
+        ),
+        publishers = SearchCategory(
+            results = listOf(
+                SearchPublisherResult(name = "Konami", gameCount = 10, avgRating = 85.0),
+            ),
+            total = 1,
+        ),
+        collections = SearchCategory(
+            results = listOf(
+                SearchCollectionResult(
+                    id = "col1",
+                    name = "Best Platformers",
+                    gameCount = 5,
+                    username = "player",
+                ),
+            ),
+            total = 1,
+        ),
+        series = SearchCategory(
+            results = listOf(
+                SearchSeriesResult(id = "ser1", name = "Mario", totalGames = 10, libraryGames = 3),
+            ),
+            total = 1,
+        ),
+        franchises = SearchCategory(
+            results = listOf(
+                SearchFranchiseResult(id = "fr1", name = "Castlevania", totalGames = 8, libraryGames = 2),
+            ),
+            total = 1,
+        ),
+    )
+
+    // --- Screen states ---
+
+    @Test
+    fun `search screen shows placeholder when input is empty`() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        onNodeWithTag("global_search_screen").assertIsDisplayed()
+        onNodeWithTag("search_placeholder").assertIsDisplayed()
+    }
+
+    @Test
+    fun `search screen shows hint when query has fewer than 2 characters`() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("a")
+        advanceQuick(harness)
+
+        onNodeWithTag("search_hint").assertIsDisplayed()
+    }
+
+    @Test
+    fun `search screen shows loading skeleton while fetching`() = runComposeUiTest {
+        val harness = createHarness()
+        // Configure a long delay so loading state is visible
+        harness.searchRepo.delayMs = 10_000
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        // Only advance the dispatcher enough to trigger the debounce (250ms) but not
+        // complete the long delay. The search job should be in progress.
+        advanceQuick(harness)
+
+        // The loading skeleton should be displayed
+        onNodeWithTag("search_loading").assertIsDisplayed()
+    }
+
+    @Test
+    fun `search screen shows results with all 7 categories`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // Results list should be visible
+        val resultsList = onNodeWithTag("search_results_list")
+        resultsList.assertIsDisplayed()
+
+        // Game results (visible at top)
+        onNodeWithTag("search_result_game_g1").assertExists()
+        onNodeWithTag("search_result_game_g2").assertExists()
+
+        // Console results
+        onNodeWithTag("search_result_console_snes").assertExists()
+
+        // Developer results - may need scroll
+        resultsList.performScrollToNode(hasTestTag("search_result_developer_Nintendo"))
+        onNodeWithTag("search_result_developer_Nintendo").assertExists()
+
+        // Publisher results - may need scroll
+        resultsList.performScrollToNode(hasTestTag("search_result_publisher_Konami"))
+        onNodeWithTag("search_result_publisher_Konami").assertExists()
+
+        // Collection results - may need scroll
+        resultsList.performScrollToNode(hasTestTag("search_result_collection_col1"))
+        onNodeWithTag("search_result_collection_col1").assertExists()
+
+        // Series results - may need scroll
+        resultsList.performScrollToNode(hasTestTag("search_result_series_ser1"))
+        onNodeWithTag("search_result_series_ser1").assertExists()
+
+        // Franchise results - may need scroll
+        resultsList.performScrollToNode(hasTestTag("search_result_franchise_fr1"))
+        onNodeWithTag("search_result_franchise_fr1").assertExists()
+    }
+
+    @Test
+    fun `search screen shows no results state`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = GlobalSearchResult() // empty result
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("zzzzzznotfound")
+        advanceFully(harness)
+
+        onNodeWithTag("search_no_results").assertIsDisplayed()
+    }
+
+    @Test
+    fun `search screen shows error snackbar on failure`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.shouldFail = true
+        harness.searchRepo.errorMessage = "Network error"
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        // Drive the search directly via the ViewModel (bypasses text field focus issues)
+        harness.globalSearchViewModel.updateQuery("mario")
+
+        // Advance enough for the 250ms debounce + repository call to complete
+        mainClock.autoAdvance = false
+        harness.testDispatcher.scheduler.advanceTimeBy(2_000)
+        harness.testDispatcher.scheduler.runCurrent()
+        mainClock.advanceTimeBy(2_000)
+        mainClock.autoAdvance = true
+
+        // Verify the error state was set on the view model
+        val state = harness.globalSearchViewModel.state.value
+        assertEquals("Network error", state.error)
+    }
+
+    // --- Search behavior ---
+
+    @Test
+    fun `typing 2 or more characters triggers search`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("ma")
+        advanceFully(harness)
+
+        // Search should have been called
+        assertEquals("ma", harness.searchRepo.lastQuery)
+        assertEquals(true, harness.searchRepo.callCount > 0)
+
+        // Results should be displayed
+        onNodeWithTag("search_results_list").assertIsDisplayed()
+    }
+
+    @Test
+    fun `clearing search returns to placeholder`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        // Type and get results
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+        onNodeWithTag("search_results_list").assertIsDisplayed()
+
+        // Clear via the clear button
+        onNodeWithTag("search_clear_button").performClick()
+        advanceQuick(harness)
+
+        // Should return to placeholder
+        onNodeWithTag("search_placeholder").assertIsDisplayed()
+    }
+
+    @Test
+    fun `game results show correct data with title and console name`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // Game result should have content description with title and console name
+        onNodeWithTag("search_result_game_g1").assertExists()
+        onNodeWithTag("search_result_game_g1")
+            .assertContentDescriptionContains("Super Mario World", substring = true)
+        onNodeWithTag("search_result_game_g1")
+            .assertContentDescriptionContains("SNES", substring = true)
+    }
+
+    @Test
+    fun `console results show name and game count`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("super")
+        advanceFully(harness)
+
+        onNodeWithTag("search_result_console_snes").assertExists()
+        onNodeWithTag("search_result_console_snes")
+            .assertContentDescriptionContains("Super Nintendo", substring = true)
+        onNodeWithTag("search_result_console_snes")
+            .assertContentDescriptionContains("15 games", substring = true)
+    }
+
+    // --- Navigation from results ---
+
+    @Test
+    fun `tapping game result navigates to game detail`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        onNodeWithTag("search_result_game_g1").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("game/g1", navState.currentScreen.route)
+    }
+
+    @Test
+    fun `tapping console result navigates to console screen`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("super")
+        advanceFully(harness)
+
+        onNodeWithTag("search_result_console_snes").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("console/snes", navState.currentScreen.route)
+    }
+
+    @Test
+    fun `tapping developer result navigates to developer explore`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("nint")
+        advanceFully(harness)
+
+        onNodeWithTag("search_result_developer_Nintendo").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("explore_developer/Nintendo", navState.currentScreen.route)
+    }
+
+    @Test
+    fun `tapping collection result navigates to collection detail`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("platform")
+        advanceFully(harness)
+
+        // Collection items may be below the visible area in the LazyColumn
+        onNodeWithTag("search_results_list")
+            .performScrollToNode(hasTestTag("search_result_collection_col1"))
+        onNodeWithTag("search_result_collection_col1").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("collection/col1", navState.currentScreen.route)
+    }
+
+    @Test
+    fun `tapping series result navigates to series explore`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // Series items may be below the visible area in the LazyColumn
+        onNodeWithTag("search_results_list")
+            .performScrollToNode(hasTestTag("search_result_series_ser1"))
+        onNodeWithTag("search_result_series_ser1").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("explore_series/ser1", navState.currentScreen.route)
+    }
+
+    // --- Entry points ---
+
+    @Test
+    fun `search bar on explore tab navigates to global search`() = runComposeUiTest {
+        val harness = createHarness()
+        // Need at least one section so explore screen is not empty
+        harness.exploreRepo.featuredSeriesList = listOf(
+            FeaturedSeries(
+                id = "s1", name = "Mario", libraryGames = 1, totalGames = 3, consoleCount = 1, heroUrl = null,
+            ),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
+        advance(harness)
+
+        // The search bar entry point uses contentDescription
+        onNodeWithContentDescription("Search games, consoles, developers").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("global_search", navState.currentScreen.route)
+    }
+
+    @Test
+    fun `search icon on home screen navigates to global search`() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        advance(harness)
+
+        // The search icon button uses contentDescription = "Search"
+        onNodeWithContentDescription("Search").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("global_search", navState.currentScreen.route)
+    }
+
+    // --- Advanced filters ---
+
+    @Test
+    fun `advanced filters chip is visible on search screen`() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        onNodeWithTag("global_search_advanced_filters").assertIsDisplayed()
+    }
+
+    // --- Edge cases ---
+
+    @Test
+    fun `whitespace-only query shows hint state`() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("   ")
+        advanceQuick(harness)
+
+        onNodeWithTag("search_hint").assertIsDisplayed()
+    }
+
+    @Test
+    fun `categories with no results are not shown`() = runComposeUiTest {
+        val harness = createHarness()
+        // Only games category has results
+        harness.searchRepo.searchResult = GlobalSearchResult(
+            games = SearchCategory(
+                results = listOf(
+                    SearchGameResult(
+                        id = "g1",
+                        title = "Super Mario World",
+                        consoleName = "SNES",
+                        consoleId = "snes",
+                    ),
+                ),
+                total = 1,
+            ),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // Game result should be visible
+        onNodeWithTag("search_result_game_g1").assertExists()
+
+        // Other categories should not have any result items
+        onNodeWithTag("search_result_console_snes").assertDoesNotExist()
+        onNodeWithTag("search_result_developer_Nintendo").assertDoesNotExist()
+        onNodeWithTag("search_result_publisher_Konami").assertDoesNotExist()
+        onNodeWithTag("search_result_collection_col1").assertDoesNotExist()
+        onNodeWithTag("search_result_series_ser1").assertDoesNotExist()
+        onNodeWithTag("search_result_franchise_fr1").assertDoesNotExist()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GlobalSearchTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GlobalSearchTest.kt
@@ -370,6 +370,9 @@ class GlobalSearchTest {
         searchInputNode().performTextInput("nint")
         advanceFully(harness)
 
+        // Developer results may be below the visible area due to quick results section
+        onNodeWithTag("search_results_list")
+            .performScrollToNode(hasTestTag("search_result_developer_Nintendo"))
         onNodeWithTag("search_result_developer_Nintendo").performClick()
         advance(harness)
 
@@ -472,6 +475,165 @@ class GlobalSearchTest {
         advance(harness)
 
         onNodeWithTag("global_search_advanced_filters").assertIsDisplayed()
+    }
+
+    // --- Quick results / autocomplete ---
+
+    @Test
+    fun `quick results section shown when search has results`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        onNodeWithTag("quick_results_section").assertIsDisplayed()
+    }
+
+    @Test
+    fun `quick results section not shown when no results`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = GlobalSearchResult() // empty
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("zzzznotfound")
+        advanceFully(harness)
+
+        onNodeWithTag("quick_results_section").assertDoesNotExist()
+    }
+
+    @Test
+    fun `quick results shows correct number of items capped at 5`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // fullSearchResult() has 2 games + 1 console + 1 developer + 1 publisher = 5
+        // (collections, series, franchises are lower priority and don't fit in cap of 5)
+        onNodeWithTag("quick_result_game_g1").assertExists()
+        onNodeWithTag("quick_result_game_g2").assertExists()
+        onNodeWithTag("quick_result_console_snes").assertExists()
+        onNodeWithTag("quick_result_developer_Nintendo").assertExists()
+        onNodeWithTag("quick_result_publisher_Konami").assertExists()
+
+        // Verify the state has exactly 5 suggestions
+        val state = harness.globalSearchViewModel.state.value
+        assertEquals(5, state.suggestions.size)
+    }
+
+    @Test
+    fun `quick results prioritizes games as first items`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // The suggestion order should be: games first, then console, developer, publisher
+        val suggestions = harness.globalSearchViewModel.state.value.suggestions
+        assertEquals("Game", suggestions[0].type)
+        assertEquals("Game", suggestions[1].type)
+        assertEquals("Console", suggestions[2].type)
+        assertEquals("Developer", suggestions[3].type)
+        assertEquals("Publisher", suggestions[4].type)
+    }
+
+    @Test
+    fun `tapping quick result game navigates to game detail`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        onNodeWithTag("quick_result_game_g1").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("game/g1", navState.currentScreen.route)
+    }
+
+    @Test
+    fun `tapping quick result console navigates to console screen`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        onNodeWithTag("quick_result_console_snes").performClick()
+        advance(harness)
+
+        val navState = harness.navigationViewModel.state.value
+        assertEquals("console/snes", navState.currentScreen.route)
+    }
+
+    @Test
+    fun `quick results not shown on empty hint state`() = runComposeUiTest {
+        val harness = createHarness()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        // Empty state (placeholder) - no quick results
+        onNodeWithTag("quick_results_section").assertDoesNotExist()
+
+        // Single character (hint state) - no quick results
+        searchInputNode().performTextInput("a")
+        advanceQuick(harness)
+
+        onNodeWithTag("search_hint").assertIsDisplayed()
+        onNodeWithTag("quick_results_section").assertDoesNotExist()
+    }
+
+    @Test
+    fun `quick result type badges show correct category names`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // Each quick result item has contentDescription = "${name}, ${type}"
+        // Verify the type badge text is present via content descriptions
+        onNodeWithTag("quick_result_game_g1")
+            .assertContentDescriptionContains("Game", substring = true)
+        onNodeWithTag("quick_result_console_snes")
+            .assertContentDescriptionContains("Console", substring = true)
+        onNodeWithTag("quick_result_developer_Nintendo")
+            .assertContentDescriptionContains("Developer", substring = true)
+        onNodeWithTag("quick_result_publisher_Konami")
+            .assertContentDescriptionContains("Publisher", substring = true)
     }
 
     // --- Edge cases ---

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GlobalSearchTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GlobalSearchTest.kt
@@ -257,7 +257,7 @@ class GlobalSearchTest {
     }
 
     @Test
-    fun `clearing search returns to placeholder`() = runComposeUiTest {
+    fun `clearing search returns to recent searches when recents exist`() = runComposeUiTest {
         val harness = createHarness()
         harness.searchRepo.searchResult = fullSearchResult()
 
@@ -265,7 +265,7 @@ class GlobalSearchTest {
         harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
         advance(harness)
 
-        // Type and get results
+        // Type and get results — this saves "mario" as a recent search
         searchInputNode().performTextInput("mario")
         advanceFully(harness)
         onNodeWithTag("search_results_list").assertIsDisplayed()
@@ -274,8 +274,9 @@ class GlobalSearchTest {
         onNodeWithTag("search_clear_button").performClick()
         advanceQuick(harness)
 
-        // Should return to placeholder
-        onNodeWithTag("search_placeholder").assertIsDisplayed()
+        // Should show recent searches (the query was saved as a recent)
+        onNodeWithTag("search_results_list").assertDoesNotExist()
+        onNodeWithTag("recent_searches_section").assertIsDisplayed()
     }
 
     @Test

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/RecentSearchTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/RecentSearchTest.kt
@@ -1,0 +1,239 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Desktop E2E tests for Phase 2 Story 6: Recent Searches.
+ *
+ * Covers:
+ * - Recent searches section shown when query is empty and recents exist
+ * - Tapping a recent search fills query and triggers search
+ * - Remove button removes individual recent search
+ * - "Clear all" clears all recent searches
+ * - Recent searches hidden when no recents exist
+ * - Recent searches hidden when query has text
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class RecentSearchTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    /**
+     * Populate recent searches on the fake repo and force the ViewModel to reload.
+     *
+     * The GlobalSearchViewModel reads recent searches in its init block (before
+     * the test can set up data). Calling clearSearch() re-reads from the repo.
+     */
+    private fun SpelaTestHarness.setRecentSearches(queries: List<String>) {
+        searchRepo.storedRecentSearches = queries.toMutableList()
+        globalSearchViewModel.clearSearch()
+    }
+
+    private fun ComposeUiTest.searchInputNode(): SemanticsNodeInteraction =
+        onNode(hasSetTextAction() and hasAnyAncestor(hasTestTag("global_search_input")))
+
+    private fun fullSearchResult() = GlobalSearchResult(
+        games = SearchCategory(
+            results = listOf(
+                SearchGameResult(
+                    id = "g1",
+                    title = "Super Mario World",
+                    consoleName = "SNES",
+                    consoleId = "snes",
+                    developer = "Nintendo",
+                    coverUrl = null,
+                ),
+            ),
+            total = 1,
+        ),
+    )
+
+    // --- Recent searches section visibility ---
+
+    @Test
+    fun `recent searches section shown when query is empty and recents exist`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setRecentSearches(listOf("mario", "zelda", "metroid"))
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        onNodeWithTag("recent_searches_section").assertIsDisplayed()
+        onNodeWithTag("recent_search_item_mario").assertIsDisplayed()
+        onNodeWithTag("recent_search_item_zelda").assertIsDisplayed()
+        onNodeWithTag("recent_search_item_metroid").assertIsDisplayed()
+    }
+
+    @Test
+    fun `recent searches section hidden when no recents exist`() = runComposeUiTest {
+        val harness = createHarness()
+        // No recent searches set — default is empty
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        onNodeWithTag("recent_searches_section").assertDoesNotExist()
+        // Should show placeholder instead
+        onNodeWithTag("search_placeholder").assertIsDisplayed()
+    }
+
+    @Test
+    fun `recent searches section hidden when query has text`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setRecentSearches(listOf("mario", "zelda"))
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        // Initially, recent searches should be visible
+        onNodeWithTag("recent_searches_section").assertIsDisplayed()
+
+        // Type a query
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // Recent searches section should be hidden
+        onNodeWithTag("recent_searches_section").assertDoesNotExist()
+    }
+
+    // --- Interacting with recent searches ---
+
+    @Test
+    fun `tapping a recent search fills query and triggers search`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setRecentSearches(listOf("mario", "zelda"))
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        // Tap the "mario" recent search
+        onNodeWithTag("recent_search_item_mario").performClick()
+        advanceFully(harness)
+
+        // The query should be updated
+        val state = harness.globalSearchViewModel.state.value
+        assertEquals("mario", state.query)
+
+        // Search should have been triggered
+        assertEquals("mario", harness.searchRepo.lastQuery)
+        assert(harness.searchRepo.callCount > 0) { "Search should have been called" }
+
+        // Results should be displayed
+        onNodeWithTag("search_results_list").assertIsDisplayed()
+    }
+
+    @Test
+    fun `remove button removes individual recent search`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setRecentSearches(listOf("mario", "zelda", "metroid"))
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        // All three should be visible
+        onNodeWithTag("recent_search_item_mario").assertIsDisplayed()
+        onNodeWithTag("recent_search_item_zelda").assertIsDisplayed()
+        onNodeWithTag("recent_search_item_metroid").assertIsDisplayed()
+
+        // Remove "zelda"
+        onNodeWithTag("recent_search_remove_zelda").performClick()
+        advanceQuick(harness)
+
+        // "zelda" should be gone, others remain
+        onNodeWithTag("recent_search_item_mario").assertIsDisplayed()
+        onNodeWithTag("recent_search_item_zelda").assertDoesNotExist()
+        onNodeWithTag("recent_search_item_metroid").assertIsDisplayed()
+
+        // Verify the underlying store was updated
+        assertEquals(listOf("mario", "metroid"), harness.searchRepo.storedRecentSearches)
+    }
+
+    @Test
+    fun `clear all clears all recent searches`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setRecentSearches(listOf("mario", "zelda", "metroid"))
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        // Recent searches should be visible
+        onNodeWithTag("recent_searches_section").assertIsDisplayed()
+
+        // Tap "Clear all"
+        onNodeWithTag("recent_searches_clear_all").performClick()
+        advanceQuick(harness)
+
+        // Recent searches section should be hidden
+        onNodeWithTag("recent_searches_section").assertDoesNotExist()
+
+        // Should show placeholder since query is empty and no recents
+        onNodeWithTag("search_placeholder").assertIsDisplayed()
+
+        // Verify underlying store is empty
+        assertEquals(emptyList<String>(), harness.searchRepo.storedRecentSearches)
+    }
+
+    @Test
+    fun `recent searches show up to 5 items`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setRecentSearches(listOf("mario", "zelda", "metroid", "kirby", "pokemon"))
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        onNodeWithTag("recent_search_item_mario").assertExists()
+        onNodeWithTag("recent_search_item_zelda").assertExists()
+        onNodeWithTag("recent_search_item_metroid").assertExists()
+        onNodeWithTag("recent_search_item_kirby").assertExists()
+        onNodeWithTag("recent_search_item_pokemon").assertExists()
+    }
+
+    @Test
+    fun `recent searches reappear after clearing search`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.setRecentSearches(listOf("mario"))
+        harness.searchRepo.searchResult = fullSearchResult()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        // Recent searches visible initially
+        onNodeWithTag("recent_searches_section").assertIsDisplayed()
+
+        // Type a query to trigger search
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // Recent searches gone, results shown
+        onNodeWithTag("recent_searches_section").assertDoesNotExist()
+        onNodeWithTag("search_results_list").assertIsDisplayed()
+
+        // Clear the search via the clear button
+        onNodeWithTag("search_clear_button").performClick()
+        advanceQuick(harness)
+
+        // Recent searches should reappear (now with "mario" still in the list)
+        onNodeWithTag("recent_searches_section").assertIsDisplayed()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SearchSeeMoreTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SearchSeeMoreTest.kt
@@ -1,0 +1,245 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+/**
+ * Desktop E2E tests for Phase 2 Story 8: "See More" / "Show Less".
+ *
+ * Covers:
+ * - "See all X" text shown when total > displayed count
+ * - "See all" not shown when total <= displayed count
+ * - Tapping "See all" expands the category
+ * - "Show less" shown after expanding
+ * - Tapping "Show less" collapses back
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class SearchSeeMoreTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun ComposeUiTest.searchInputNode(): SemanticsNodeInteraction =
+        onNode(hasSetTextAction() and hasAnyAncestor(hasTestTag("global_search_input")))
+
+    /**
+     * Search result where games total (10) > displayed (2), so "See all 10" should show.
+     * Consoles has total == displayed count (1), so "See all" should NOT show.
+     */
+    private fun searchResultWithMoreGames() = GlobalSearchResult(
+        games = SearchCategory(
+            results = listOf(
+                SearchGameResult(
+                    id = "g1",
+                    title = "Super Mario World",
+                    consoleName = "SNES",
+                    consoleId = "snes",
+                    developer = "Nintendo",
+                    coverUrl = null,
+                ),
+                SearchGameResult(
+                    id = "g2",
+                    title = "Super Mario Bros.",
+                    consoleName = "NES",
+                    consoleId = "nes",
+                    developer = "Nintendo",
+                    coverUrl = null,
+                ),
+            ),
+            total = 10, // More than the 2 displayed
+        ),
+        consoles = SearchCategory(
+            results = listOf(
+                SearchConsoleResult(id = "snes", name = "Super Nintendo", gameCount = 15),
+            ),
+            total = 1, // Same as displayed count
+        ),
+    )
+
+    /**
+     * Expanded search result with limit=50 — more games returned.
+     */
+    private fun expandedSearchResult() = GlobalSearchResult(
+        games = SearchCategory(
+            results = listOf(
+                SearchGameResult(id = "g1", title = "Super Mario World", consoleName = "SNES", consoleId = "snes", coverUrl = null),
+                SearchGameResult(id = "g2", title = "Super Mario Bros.", consoleName = "NES", consoleId = "nes", coverUrl = null),
+                SearchGameResult(id = "g3", title = "Super Mario 64", consoleName = "N64", consoleId = "n64", coverUrl = null),
+                SearchGameResult(id = "g4", title = "Super Mario Sunshine", consoleName = "GCN", consoleId = "gcn", coverUrl = null),
+                SearchGameResult(id = "g5", title = "Super Mario Galaxy", consoleName = "Wii", consoleId = "wii", coverUrl = null),
+                SearchGameResult(id = "g6", title = "Super Mario Land", consoleName = "GB", consoleId = "gb", coverUrl = null),
+                SearchGameResult(id = "g7", title = "Super Mario RPG", consoleName = "SNES", consoleId = "snes", coverUrl = null),
+            ),
+            total = 10,
+        ),
+        consoles = SearchCategory(
+            results = listOf(
+                SearchConsoleResult(id = "snes", name = "Super Nintendo", gameCount = 15),
+            ),
+            total = 1,
+        ),
+    )
+
+    // --- "See all" visibility ---
+
+    @Test
+    fun `see all shown when total is greater than displayed count`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = searchResultWithMoreGames()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // "See all 10" should be visible for Games (total 10 > displayed 2)
+        onNodeWithTag("search_section_see_all_Games").assertExists()
+    }
+
+    @Test
+    fun `see all not shown when total equals displayed count`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = searchResultWithMoreGames()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // Consoles has total == 1 == displayed count, so "See all" should NOT show
+        onNodeWithTag("search_section_see_all_Consoles").assertDoesNotExist()
+    }
+
+    @Test
+    fun `see all not shown when total is less than or equal to displayed count`() = runComposeUiTest {
+        val harness = createHarness()
+        // All counts match displayed
+        harness.searchRepo.searchResult = GlobalSearchResult(
+            games = SearchCategory(
+                results = listOf(
+                    SearchGameResult(
+                        id = "g1",
+                        title = "Super Mario World",
+                        consoleName = "SNES",
+                        consoleId = "snes",
+                        coverUrl = null,
+                    ),
+                ),
+                total = 1,
+            ),
+        )
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        onNodeWithTag("search_section_see_all_Games").assertDoesNotExist()
+    }
+
+    // --- Expand / Collapse ---
+
+    @Test
+    fun `tapping see all expands category and shows more results`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = searchResultWithMoreGames()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // Initially only 2 game results
+        onNodeWithTag("search_result_game_g1").assertExists()
+        onNodeWithTag("search_result_game_g2").assertExists()
+        onNodeWithTag("search_result_game_g3").assertDoesNotExist()
+
+        // Tap "See all 10"
+        onNodeWithTag("search_section_see_all_Games").performClick()
+
+        // The expanded search will be fetched — set the result for the second call
+        harness.searchRepo.searchResult = expandedSearchResult()
+        advanceFully(harness)
+
+        // Verify the category is in expanded state on the ViewModel
+        val state = harness.globalSearchViewModel.state.value
+        assertTrue(state.expandedCategories.contains("Games"))
+    }
+
+    @Test
+    fun `show less shown after expanding category`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = searchResultWithMoreGames()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // "See all" should be visible before expanding
+        onNodeWithTag("search_section_see_all_Games").assertExists()
+        onNodeWithTag("search_section_show_less_Games").assertDoesNotExist()
+
+        // Tap "See all"
+        onNodeWithTag("search_section_see_all_Games").performClick()
+
+        harness.searchRepo.searchResult = expandedSearchResult()
+        advanceFully(harness)
+
+        // After expanding, "Show less" should be visible
+        onNodeWithTag("search_section_show_less_Games").assertExists()
+        onNodeWithTag("search_section_see_all_Games").assertDoesNotExist()
+    }
+
+    @Test
+    fun `tapping show less collapses category back`() = runComposeUiTest {
+        val harness = createHarness()
+        harness.searchRepo.searchResult = searchResultWithMoreGames()
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.GlobalSearch))
+        advance(harness)
+
+        searchInputNode().performTextInput("mario")
+        advanceFully(harness)
+
+        // Expand the category
+        onNodeWithTag("search_section_see_all_Games").performClick()
+        harness.searchRepo.searchResult = expandedSearchResult()
+        advanceFully(harness)
+
+        // "Show less" should be visible
+        onNodeWithTag("search_section_show_less_Games").assertExists()
+
+        // Click "Show less"
+        onNodeWithTag("search_section_show_less_Games").performClick()
+        advanceQuick(harness)
+
+        // Category should be collapsed
+        val state = harness.globalSearchViewModel.state.value
+        assertTrue(!state.expandedCategories.contains("Games"))
+
+        // "See all" should reappear
+        onNodeWithTag("search_section_see_all_Games").assertExists()
+        onNodeWithTag("search_section_show_less_Games").assertDoesNotExist()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -107,6 +107,7 @@ class SpelaTestHarness(
     val cheatRepo = FakeCheatRepository()
     val sessionRepo = FakeSessionRepository()
     val exploreRepo = FakeExploreRepository()
+    val searchRepo = FakeSearchRepository()
 
     private val scrapeService = com.spela.player.data.remote.ScrapeService(fakeApiClient, dispatchers, scope)
 
@@ -348,6 +349,12 @@ class SpelaTestHarness(
         scope = scope,
     )
 
+    val globalSearchViewModel = GlobalSearchViewModel(
+        searchRepository = searchRepo,
+        dispatchers = dispatchers,
+        scope = scope,
+    )
+
     @Composable
     fun App() {
         androidx.compose.runtime.CompositionLocalProvider(
@@ -381,6 +388,7 @@ class SpelaTestHarness(
             topListsViewModel = topListsViewModel,
             exploreViewModel = exploreViewModel,
             gamepadPortManager = gamepadPortManager,
+            globalSearchViewModel = globalSearchViewModel,
         )
         }
     }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1371,6 +1371,7 @@ class FakeExploreRepository : ExploreRepository {
     var keywordGames: Map<String, List<Game>> = emptyMap()
     var featuredSeriesList: List<FeaturedSeries> = emptyList()
     var seriesDetails: Map<String, SeriesDetail> = emptyMap()
+    var franchiseDetails: Map<String, SeriesDetail> = emptyMap()
     var gameSeriesLinks: Map<String, List<GameSeriesLink>> = emptyMap()
     var gameFranchiseLinks: Map<String, List<GameFranchiseLink>> = emptyMap()
     var moodsList: List<MoodDefinition> = emptyList()
@@ -1441,6 +1442,14 @@ class FakeExploreRepository : ExploreRepository {
             val detail = seriesDetails[id]
             if (detail != null) Result.success(detail)
             else Result.failure(Exception("Series not found"))
+        }
+
+    override suspend fun getFranchiseDetail(id: String): Result<SeriesDetail> =
+        if (shouldFail) Result.failure(Exception("Failed to load franchise detail"))
+        else {
+            val detail = franchiseDetails[id]
+            if (detail != null) Result.success(detail)
+            else Result.failure(Exception("Franchise not found"))
         }
 
     override suspend fun getGameSeries(gameId: String): Result<List<GameSeriesLink>> =
@@ -1661,6 +1670,7 @@ class FakeSearchRepository : SearchRepository {
     var delayMs: Long = 0
     var lastQuery: String? = null
     var callCount: Int = 0
+    var storedRecentSearches: MutableList<String> = mutableListOf()
 
     override suspend fun globalSearch(query: String, limit: Int): Result<GlobalSearchResult> {
         lastQuery = query
@@ -1670,6 +1680,26 @@ class FakeSearchRepository : SearchRepository {
         }
         return if (shouldFail) Result.failure(Exception(errorMessage))
         else Result.success(searchResult)
+    }
+
+    override fun getRecentSearches(): List<String> = storedRecentSearches.toList()
+
+    override fun addRecentSearch(query: String) {
+        val trimmed = query.trim()
+        if (trimmed.isBlank()) return
+        storedRecentSearches.remove(trimmed)
+        storedRecentSearches.add(0, trimmed)
+        if (storedRecentSearches.size > 5) {
+            storedRecentSearches.subList(5, storedRecentSearches.size).clear()
+        }
+    }
+
+    override fun removeRecentSearch(query: String) {
+        storedRecentSearches.remove(query)
+    }
+
+    override fun clearRecentSearches() {
+        storedRecentSearches.clear()
     }
 }
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1654,6 +1654,25 @@ class FakeExploreRepository : ExploreRepository {
         if (shouldFail) Result.failure(Exception("Failed")) else Result.success(completionistMapData)
 }
 
+class FakeSearchRepository : SearchRepository {
+    var searchResult: GlobalSearchResult = GlobalSearchResult()
+    var shouldFail: Boolean = false
+    var errorMessage: String = "Search failed"
+    var delayMs: Long = 0
+    var lastQuery: String? = null
+    var callCount: Int = 0
+
+    override suspend fun globalSearch(query: String, limit: Int): Result<GlobalSearchResult> {
+        lastQuery = query
+        callCount++
+        if (delayMs > 0) {
+            kotlinx.coroutines.delay(delayMs)
+        }
+        return if (shouldFail) Result.failure(Exception(errorMessage))
+        else Result.success(searchResult)
+    }
+}
+
 class FakeCheatRepository : CheatRepository {
     var cheats: MutableList<Cheat> = mutableListOf()
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -468,6 +468,15 @@ class SpelaApiClient(
     }
 
     /** Returns games filtered by multi-faceted criteria */
+    // Global Search
+
+    suspend fun globalSearch(query: String, limit: Int = 5): GlobalSearchResponseDto {
+        return client.get("$baseUrl/api/search") {
+            parameter("q", query)
+            parameter("limit", limit)
+        }.body()
+    }
+
     suspend fun getFilteredGames(
         filters: Map<String, String>,
         page: Int? = null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -310,6 +310,11 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/series/$id").body()
     }
 
+    /** Returns detail for a specific franchise */
+    suspend fun getFranchiseDetail(id: String): SeriesDetailDto {
+        return client.get("$baseUrl/api/franchises/$id").body()
+    }
+
     /** Returns series links for a game */
     suspend fun getGameSeries(gameId: String): List<GameSeriesLinkDto> {
         return client.get("$baseUrl/api/games/$gameId/series").body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -989,3 +989,89 @@ fun CompletionistMapResponseDto.toDomain() = CompletionistMap(
     totalPlayed = totalPlayed,
     overallPct = overallPct,
 )
+
+// --- Global Search mappers ---
+
+fun GlobalSearchGameResultDto.toDomain() = SearchGameResult(
+    id = id,
+    title = title,
+    coverUrl = coverUrl,
+    consoleName = consoleName,
+    consoleId = consoleId,
+    developer = developer,
+    genre = genre,
+    coverAspectRatio = coverAspectRatio.toFloat(),
+)
+
+fun GlobalSearchConsoleResultDto.toDomain() = SearchConsoleResult(
+    id = id,
+    name = name,
+    iconUrl = iconUrl,
+    gameCount = gameCount,
+    colorTheme = colorTheme,
+)
+
+fun GlobalSearchDeveloperResultDto.toDomain() = SearchDeveloperResult(
+    name = name,
+    gameCount = gameCount,
+    avgRating = avgRating,
+)
+
+fun GlobalSearchPublisherResultDto.toDomain() = SearchPublisherResult(
+    name = name,
+    gameCount = gameCount,
+    avgRating = avgRating,
+)
+
+fun GlobalSearchCollectionResultDto.toDomain() = SearchCollectionResult(
+    id = id,
+    name = name,
+    gameCount = gameCount,
+    coverUrl = coverUrl,
+    username = username,
+)
+
+fun GlobalSearchSeriesResultDto.toDomain() = SearchSeriesResult(
+    id = id,
+    name = name,
+    totalGames = totalGames,
+    libraryGames = libraryGames,
+)
+
+fun GlobalSearchFranchiseResultDto.toDomain() = SearchFranchiseResult(
+    id = id,
+    name = name,
+    totalGames = totalGames,
+    libraryGames = libraryGames,
+)
+
+fun GlobalSearchResponseDto.toDomain() = GlobalSearchResult(
+    games = SearchCategory(
+        results = games.results.map { it.toDomain() },
+        total = games.total,
+    ),
+    consoles = SearchCategory(
+        results = consoles.results.map { it.toDomain() },
+        total = consoles.total,
+    ),
+    developers = SearchCategory(
+        results = developers.results.map { it.toDomain() },
+        total = developers.total,
+    ),
+    publishers = SearchCategory(
+        results = publishers.results.map { it.toDomain() },
+        total = publishers.total,
+    ),
+    collections = SearchCategory(
+        results = collections.results.map { it.toDomain() },
+        total = collections.total,
+    ),
+    series = SearchCategory(
+        results = series.results.map { it.toDomain() },
+        total = series.total,
+    ),
+    franchises = SearchCategory(
+        results = franchises.results.map { it.toDomain() },
+        total = franchises.total,
+    ),
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1634,3 +1634,82 @@ data class CompletionistMapResponseDto(
     val totalPlayed: Int,
     val overallPct: Int,
 )
+
+// --- Global Search ---
+
+@Serializable
+data class GlobalSearchGameResultDto(
+    val id: String,
+    val title: String,
+    val coverUrl: String? = null,
+    val consoleName: String = "",
+    val consoleId: String = "",
+    val developer: String? = null,
+    val genre: String? = null,
+    val coverAspectRatio: Double = 0.75,
+)
+
+@Serializable
+data class GlobalSearchConsoleResultDto(
+    val id: String,
+    val name: String,
+    val iconUrl: String = "",
+    val gameCount: Int = 0,
+    val colorTheme: String = "#6366f1",
+)
+
+@Serializable
+data class GlobalSearchDeveloperResultDto(
+    val name: String,
+    val gameCount: Int = 0,
+    val avgRating: Double = 0.0,
+)
+
+@Serializable
+data class GlobalSearchPublisherResultDto(
+    val name: String,
+    val gameCount: Int = 0,
+    val avgRating: Double = 0.0,
+)
+
+@Serializable
+data class GlobalSearchCollectionResultDto(
+    val id: String,
+    val name: String,
+    val gameCount: Int = 0,
+    val coverUrl: String? = null,
+    val username: String = "",
+)
+
+@Serializable
+data class GlobalSearchSeriesResultDto(
+    val id: String,
+    val name: String,
+    val totalGames: Int = 0,
+    val libraryGames: Int = 0,
+)
+
+@Serializable
+data class GlobalSearchFranchiseResultDto(
+    val id: String,
+    val name: String,
+    val totalGames: Int = 0,
+    val libraryGames: Int = 0,
+)
+
+@Serializable
+data class GlobalSearchCategoryDto<T>(
+    val results: List<T> = emptyList(),
+    val total: Int = 0,
+)
+
+@Serializable
+data class GlobalSearchResponseDto(
+    val games: GlobalSearchCategoryDto<GlobalSearchGameResultDto> = GlobalSearchCategoryDto(),
+    val consoles: GlobalSearchCategoryDto<GlobalSearchConsoleResultDto> = GlobalSearchCategoryDto(),
+    val developers: GlobalSearchCategoryDto<GlobalSearchDeveloperResultDto> = GlobalSearchCategoryDto(),
+    val publishers: GlobalSearchCategoryDto<GlobalSearchPublisherResultDto> = GlobalSearchCategoryDto(),
+    val collections: GlobalSearchCategoryDto<GlobalSearchCollectionResultDto> = GlobalSearchCategoryDto(),
+    val series: GlobalSearchCategoryDto<GlobalSearchSeriesResultDto> = GlobalSearchCategoryDto(),
+    val franchises: GlobalSearchCategoryDto<GlobalSearchFranchiseResultDto> = GlobalSearchCategoryDto(),
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -117,6 +117,18 @@ class ExploreRepositoryImpl(
         )
     }
 
+    override suspend fun getFranchiseDetail(id: String): Result<SeriesDetail> = runCatching {
+        val dto = apiClient.getFranchiseDetail(id)
+        dto.toDomain().copy(
+            heroUrl = apiClient.resolveUrl(dto.heroUrl),
+            games = dto.games.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                )
+            },
+        )
+    }
+
     override suspend fun getGameSeries(gameId: String): Result<List<GameSeriesLink>> = runCatching {
         apiClient.getGameSeries(gameId).map { it.toDomain() }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SearchRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SearchRepositoryImpl.kt
@@ -1,13 +1,19 @@
 package com.spela.player.data.repository
 
+import com.spela.player.data.local.SpelaDatabase
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.GlobalSearchResult
 import com.spela.player.domain.repository.SearchRepository
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 class SearchRepositoryImpl(
     private val apiClient: SpelaApiClient,
+    private val database: SpelaDatabase,
 ) : SearchRepository {
+
+    private val json = Json { ignoreUnknownKeys = true }
 
     override suspend fun globalSearch(query: String, limit: Int): Result<GlobalSearchResult> = runCatching {
         val dto = apiClient.globalSearch(query, limit)
@@ -30,5 +36,49 @@ class SearchRepositoryImpl(
                 },
             ),
         )
+    }
+
+    override fun getRecentSearches(): List<String> {
+        val raw = database.spelaDatabaseQueries
+            .getDeviceSetting(RECENT_SEARCHES_KEY)
+            .executeAsOneOrNull() ?: return emptyList()
+        return runCatching {
+            json.decodeFromString<List<String>>(raw)
+        }.getOrDefault(emptyList())
+    }
+
+    override fun addRecentSearch(query: String) {
+        val trimmed = query.trim()
+        if (trimmed.isBlank()) return
+        val current = getRecentSearches().toMutableList()
+        current.remove(trimmed)
+        current.add(0, trimmed)
+        val capped = current.take(MAX_RECENT_SEARCHES)
+        database.spelaDatabaseQueries.insertDeviceSetting(
+            RECENT_SEARCHES_KEY,
+            json.encodeToString(capped),
+        )
+    }
+
+    override fun removeRecentSearch(query: String) {
+        val current = getRecentSearches().toMutableList()
+        current.remove(query)
+        if (current.isEmpty()) {
+            database.spelaDatabaseQueries.deleteDeviceSetting(RECENT_SEARCHES_KEY)
+        } else {
+            database.spelaDatabaseQueries.insertDeviceSetting(
+                RECENT_SEARCHES_KEY,
+                json.encodeToString(current),
+            )
+        }
+    }
+
+    override fun clearRecentSearches() {
+        database.spelaDatabaseQueries.deleteDeviceSetting(RECENT_SEARCHES_KEY)
+    }
+
+    companion object {
+        private const val RECENT_SEARCHES_KEY = "recent_searches"
+        private const val MAX_RECENT_SEARCHES = 5
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SearchRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SearchRepositoryImpl.kt
@@ -1,0 +1,34 @@
+package com.spela.player.data.repository
+
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.dto.toDomain
+import com.spela.player.domain.model.GlobalSearchResult
+import com.spela.player.domain.repository.SearchRepository
+
+class SearchRepositoryImpl(
+    private val apiClient: SpelaApiClient,
+) : SearchRepository {
+
+    override suspend fun globalSearch(query: String, limit: Int): Result<GlobalSearchResult> = runCatching {
+        val dto = apiClient.globalSearch(query, limit)
+        val result = dto.toDomain()
+        // Resolve image URLs for games and consoles
+        result.copy(
+            games = result.games.copy(
+                results = result.games.results.map { game ->
+                    game.copy(coverUrl = apiClient.resolveUrl(game.coverUrl))
+                },
+            ),
+            consoles = result.consoles.copy(
+                results = result.consoles.results.map { console ->
+                    console.copy(iconUrl = apiClient.resolveUrl(console.iconUrl) ?: "")
+                },
+            ),
+            collections = result.collections.copy(
+                results = result.collections.results.map { collection ->
+                    collection.copy(coverUrl = apiClient.resolveUrl(collection.coverUrl))
+                },
+            ),
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -70,7 +70,7 @@ val commonModule = module {
     single<CheatRepository> { CheatRepositoryImpl(get(), get()) }
     single<SessionRepository> { SessionRepositoryImpl(get()) }
     single<ExploreRepository> { ExploreRepositoryImpl(get()) }
-    single<SearchRepository> { SearchRepositoryImpl(get()) }
+    single<SearchRepository> { SearchRepositoryImpl(get(), get()) }
     single { BiosRepository(get(), get()) }
     single { GamepadPortManager(get()) }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -70,6 +70,7 @@ val commonModule = module {
     single<CheatRepository> { CheatRepositoryImpl(get(), get()) }
     single<SessionRepository> { SessionRepositoryImpl(get()) }
     single<ExploreRepository> { ExploreRepositoryImpl(get()) }
+    single<SearchRepository> { SearchRepositoryImpl(get()) }
     single { BiosRepository(get(), get()) }
     single { GamepadPortManager(get()) }
 
@@ -331,6 +332,14 @@ val commonModule = module {
     factory {
         ExploreViewModel(
             exploreRepository = get(),
+            dispatchers = get(),
+            scope = get(),
+        )
+    }
+
+    factory {
+        GlobalSearchViewModel(
+            searchRepository = get(),
             dispatchers = get(),
             scope = get(),
         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/SearchModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/SearchModels.kt
@@ -1,0 +1,78 @@
+package com.spela.player.domain.model
+
+data class GlobalSearchResult(
+    val games: SearchCategory<SearchGameResult> = SearchCategory(),
+    val consoles: SearchCategory<SearchConsoleResult> = SearchCategory(),
+    val developers: SearchCategory<SearchDeveloperResult> = SearchCategory(),
+    val publishers: SearchCategory<SearchPublisherResult> = SearchCategory(),
+    val collections: SearchCategory<SearchCollectionResult> = SearchCategory(),
+    val series: SearchCategory<SearchSeriesResult> = SearchCategory(),
+    val franchises: SearchCategory<SearchFranchiseResult> = SearchCategory(),
+) {
+    val isEmpty: Boolean
+        get() = games.results.isEmpty() &&
+                consoles.results.isEmpty() &&
+                developers.results.isEmpty() &&
+                publishers.results.isEmpty() &&
+                collections.results.isEmpty() &&
+                series.results.isEmpty() &&
+                franchises.results.isEmpty()
+}
+
+data class SearchCategory<T>(
+    val results: List<T> = emptyList(),
+    val total: Int = 0,
+)
+
+data class SearchGameResult(
+    val id: String,
+    val title: String,
+    val coverUrl: String? = null,
+    val consoleName: String = "",
+    val consoleId: String = "",
+    val developer: String? = null,
+    val genre: String? = null,
+    val coverAspectRatio: Float = 0.75f,
+)
+
+data class SearchConsoleResult(
+    val id: String,
+    val name: String,
+    val iconUrl: String = "",
+    val gameCount: Int = 0,
+    val colorTheme: String = "#6366f1",
+)
+
+data class SearchDeveloperResult(
+    val name: String,
+    val gameCount: Int = 0,
+    val avgRating: Double = 0.0,
+)
+
+data class SearchPublisherResult(
+    val name: String,
+    val gameCount: Int = 0,
+    val avgRating: Double = 0.0,
+)
+
+data class SearchCollectionResult(
+    val id: String,
+    val name: String,
+    val gameCount: Int = 0,
+    val coverUrl: String? = null,
+    val username: String = "",
+)
+
+data class SearchSeriesResult(
+    val id: String,
+    val name: String,
+    val totalGames: Int = 0,
+    val libraryGames: Int = 0,
+)
+
+data class SearchFranchiseResult(
+    val id: String,
+    val name: String,
+    val totalGames: Int = 0,
+    val libraryGames: Int = 0,
+)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/SearchModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/SearchModels.kt
@@ -76,3 +76,31 @@ data class SearchFranchiseResult(
     val totalGames: Int = 0,
     val libraryGames: Int = 0,
 )
+
+data class SearchSuggestion(
+    val id: String,
+    val name: String,
+    val subtitle: String = "",
+    val imageUrl: String? = null,
+    val navigationType: SuggestionNavigationType,
+) {
+    val type: String get() = when (navigationType) {
+        is SuggestionNavigationType.Game -> "Game"
+        is SuggestionNavigationType.Console -> "Console"
+        is SuggestionNavigationType.Developer -> "Developer"
+        is SuggestionNavigationType.Publisher -> "Publisher"
+        is SuggestionNavigationType.Collection -> "Collection"
+        is SuggestionNavigationType.Series -> "Series"
+        is SuggestionNavigationType.Franchise -> "Franchise"
+    }
+}
+
+sealed class SuggestionNavigationType {
+    data class Game(val id: String) : SuggestionNavigationType()
+    data class Console(val id: String) : SuggestionNavigationType()
+    data class Developer(val name: String) : SuggestionNavigationType()
+    data class Publisher(val name: String) : SuggestionNavigationType()
+    data class Collection(val id: String) : SuggestionNavigationType()
+    data class Series(val id: String, val name: String) : SuggestionNavigationType()
+    data class Franchise(val id: String, val name: String) : SuggestionNavigationType()
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -46,6 +46,7 @@ interface ExploreRepository {
     suspend fun getKeywordGames(keywordId: String, page: Int = 1, pageSize: Int = 20): Result<List<Game>>
     suspend fun getFeaturedSeries(): Result<List<FeaturedSeries>>
     suspend fun getSeriesDetail(id: String): Result<SeriesDetail>
+    suspend fun getFranchiseDetail(id: String): Result<SeriesDetail>
     suspend fun getGameSeries(gameId: String): Result<List<GameSeriesLink>>
     suspend fun getGameFranchises(gameId: String): Result<List<GameFranchiseLink>>
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SearchRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SearchRepository.kt
@@ -4,4 +4,9 @@ import com.spela.player.domain.model.GlobalSearchResult
 
 interface SearchRepository {
     suspend fun globalSearch(query: String, limit: Int = 5): Result<GlobalSearchResult>
+
+    fun getRecentSearches(): List<String>
+    fun addRecentSearch(query: String)
+    fun removeRecentSearch(query: String)
+    fun clearRecentSearches()
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SearchRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SearchRepository.kt
@@ -1,0 +1,7 @@
+package com.spela.player.domain.repository
+
+import com.spela.player.domain.model.GlobalSearchResult
+
+interface SearchRepository {
+    suspend fun globalSearch(query: String, limit: Int = 5): Result<GlobalSearchResult>
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
@@ -25,6 +25,7 @@ import com.spela.player.presentation.viewmodel.ChallengeDetailViewModel
 import com.spela.player.presentation.viewmodel.ChallengeListViewModel
 import com.spela.player.presentation.viewmodel.CollectionsViewModel
 import com.spela.player.presentation.viewmodel.SocialViewModel
+import com.spela.player.presentation.viewmodel.GlobalSearchViewModel
 import com.spela.player.presentation.viewmodel.StatsViewModel
 import com.spela.player.libretro.GamepadPortManager
 import org.koin.compose.koinInject
@@ -60,6 +61,7 @@ fun App() {
     val sessionDetailViewModel: SessionDetailViewModel = koinInject()
     val navigationEventBus: NavigationEventBus = koinInject()
     val gamepadPortManager: GamepadPortManager = koinInject()
+    val globalSearchViewModel: GlobalSearchViewModel = koinInject()
 
     SpelaApp(
         navigationViewModel = navigationViewModel,
@@ -87,5 +89,6 @@ fun App() {
         sessionDetailViewModel = sessionDetailViewModel,
         navigationEventBus = navigationEventBus,
         gamepadPortManager = gamepadPortManager,
+        globalSearchViewModel = globalSearchViewModel,
     )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
@@ -191,6 +191,7 @@ class NavigationViewModel(
             is SpScreen.ExploreTheme,
             is SpScreen.ExploreKeyword,
             is SpScreen.ExploreSeries,
+            is SpScreen.ExploreFranchise,
             is SpScreen.ExploreMood,
             is SpScreen.ExploreDeveloper,
             is SpScreen.ExplorePublisher,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -32,6 +32,7 @@ sealed class SpScreen(val route: String) {
     data class ExploreTheme(val themeId: String, val themeName: String) : SpScreen("explore_theme/$themeId")
     data class ExploreKeyword(val keywordId: String, val keywordName: String) : SpScreen("explore_keyword/$keywordId")
     data class ExploreSeries(val seriesId: String, val seriesName: String) : SpScreen("explore_series/$seriesId")
+    data class ExploreFranchise(val franchiseId: String, val franchiseName: String) : SpScreen("explore_franchise/$franchiseId")
 
     data class ExploreMood(val moodId: String, val moodName: String) : SpScreen("explore_mood/$moodId")
     data class ExploreDeveloper(val name: String) : SpScreen("explore_developer/$name")

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -39,6 +39,7 @@ sealed class SpScreen(val route: String) {
     data object ExploreGallery : SpScreen("explore_gallery")
     data object ExploreSearch : SpScreen("explore_search")
     data object ExploreWizard : SpScreen("explore_wizard")
+    data object GlobalSearch : SpScreen("global_search")
 }
 
 data class NavigationState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -105,6 +105,7 @@ import com.spela.player.presentation.ui.screen.ExploreKeywordScreen
 import com.spela.player.presentation.ui.screen.ExploreMoodScreen
 import com.spela.player.presentation.ui.screen.ExploreScreen
 import com.spela.player.presentation.ui.screen.ExploreSeriesScreen
+import com.spela.player.presentation.ui.screen.ExploreFranchiseScreen
 import com.spela.player.presentation.ui.screen.ExploreSearchScreen
 import com.spela.player.presentation.ui.screen.GlobalSearchScreen
 import com.spela.player.presentation.ui.screen.ExploreWizardScreen
@@ -613,6 +614,24 @@ fun SpelaApp(
                                 }
                             }
 
+                            is SpScreen.ExploreFranchise -> {
+                                if (exploreViewModel != null) {
+                                    ExploreFranchiseScreen(
+                                        franchiseId = screen.franchiseId,
+                                        franchiseName = screen.franchiseName,
+                                        viewModel = exploreViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
                             is SpScreen.ExploreMood -> {
                                 if (exploreViewModel != null) {
                                     ExploreMoodScreen(
@@ -739,7 +758,7 @@ fun SpelaApp(
                                         },
                                         onFranchiseSelected = { franchiseId, franchiseName ->
                                             navigationViewModel.onIntent(
-                                                NavigationIntent.NavigateTo(SpScreen.ExploreSeries(franchiseId, franchiseName))
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreFranchise(franchiseId, franchiseName))
                                             )
                                         },
                                         onAdvancedFiltersSelected = {
@@ -904,6 +923,11 @@ fun SpelaApp(
                                     onNavigateToSeries = { seriesId, seriesName ->
                                         navigationViewModel.onIntent(
                                             NavigationIntent.NavigateTo(SpScreen.ExploreSeries(seriesId, seriesName))
+                                        )
+                                    },
+                                    onNavigateToFranchise = { franchiseId, franchiseName ->
+                                        navigationViewModel.onIntent(
+                                            NavigationIntent.NavigateTo(SpScreen.ExploreFranchise(franchiseId, franchiseName))
                                         )
                                     },
                                 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -33,6 +33,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyEventType
+import androidx.compose.ui.input.key.isCtrlPressed
+import androidx.compose.ui.input.key.isMetaPressed
+import androidx.compose.ui.input.key.key
+import androidx.compose.ui.input.key.onPreviewKeyEvent
+import androidx.compose.ui.input.key.type
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.graphics.Color
@@ -99,6 +106,7 @@ import com.spela.player.presentation.ui.screen.ExploreMoodScreen
 import com.spela.player.presentation.ui.screen.ExploreScreen
 import com.spela.player.presentation.ui.screen.ExploreSeriesScreen
 import com.spela.player.presentation.ui.screen.ExploreSearchScreen
+import com.spela.player.presentation.ui.screen.GlobalSearchScreen
 import com.spela.player.presentation.ui.screen.ExploreWizardScreen
 import com.spela.player.presentation.ui.screen.ExploreThemeScreen
 import com.spela.player.presentation.ui.screen.TopListsScreen
@@ -128,6 +136,7 @@ import com.spela.player.presentation.viewmodel.NetplayViewModel
 import com.spela.player.presentation.viewmodel.ChallengeDetailViewModel
 import com.spela.player.presentation.viewmodel.ChallengeListViewModel
 import com.spela.player.presentation.viewmodel.ExploreViewModel
+import com.spela.player.presentation.viewmodel.GlobalSearchViewModel
 import com.spela.player.presentation.viewmodel.CollectionsViewModel
 import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
 import com.spela.player.presentation.viewmodel.SocialViewModel
@@ -166,6 +175,7 @@ fun SpelaApp(
     exploreViewModel: ExploreViewModel? = null,
     navigationEventBus: NavigationEventBus? = null,
     gamepadPortManager: GamepadPortManager? = null,
+    globalSearchViewModel: GlobalSearchViewModel? = null,
 ) {
     val currentTheme by settingsViewModel.selectedTheme.collectAsState()
 
@@ -256,6 +266,23 @@ fun SpelaApp(
             modifier = Modifier
                 .fillMaxSize()
                 .background(SpColor.Background)
+                .onPreviewKeyEvent { keyEvent ->
+                    // Cmd+K (macOS) / Ctrl+K (Windows/Linux) opens global search
+                    if (keyEvent.type == KeyEventType.KeyDown &&
+                        keyEvent.key == Key.K &&
+                        (keyEvent.isMetaPressed || keyEvent.isCtrlPressed) &&
+                        !navState.showInGameOverlay
+                    ) {
+                        if (navState.currentScreen !is SpScreen.GlobalSearch) {
+                            navigationViewModel.onIntent(
+                                NavigationIntent.NavigateTo(SpScreen.GlobalSearch)
+                            )
+                        }
+                        true
+                    } else {
+                        false
+                    }
+                }
                 .pointerInput(Unit) {
                     awaitPointerEventScope {
                         while (true) {
@@ -447,6 +474,11 @@ fun SpelaApp(
                                             NavigationIntent.NavigateTo(SpScreen.UserProfile(userId))
                                         )
                                     },
+                                    onSearchSelected = {
+                                        navigationViewModel.onIntent(
+                                            NavigationIntent.NavigateTo(SpScreen.GlobalSearch)
+                                        )
+                                    },
                                     hasActiveDownloads = downloadsState.activeDownloads.isNotEmpty(),
                                     activeNetplaySessions = activeNetplaySessions,
                                 )
@@ -507,6 +539,11 @@ fun SpelaApp(
                                                     NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
                                                 )
                                             }
+                                        },
+                                        onGlobalSearchSelected = {
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GlobalSearch)
+                                            )
                                         },
                                         onSearchSelected = {
                                             navigationViewModel.onIntent(
@@ -657,6 +694,57 @@ fun SpelaApp(
                                         onGameSelected = { gameId ->
                                             navigationViewModel.onIntent(
                                                 NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onBack = {
+                                            navigationViewModel.onIntent(NavigationIntent.GoBack)
+                                        },
+                                    )
+                                }
+                            }
+
+                            is SpScreen.GlobalSearch -> {
+                                if (globalSearchViewModel != null) {
+                                    GlobalSearchScreen(
+                                        viewModel = globalSearchViewModel,
+                                        onGameSelected = { gameId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                            )
+                                        },
+                                        onConsoleSelected = { consoleId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.Console(consoleId))
+                                            )
+                                        },
+                                        onDeveloperSelected = { name ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper(name))
+                                            )
+                                        },
+                                        onPublisherSelected = { name ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExplorePublisher(name))
+                                            )
+                                        },
+                                        onCollectionSelected = { collectionId ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.CollectionDetail(collectionId))
+                                            )
+                                        },
+                                        onSeriesSelected = { seriesId, seriesName ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreSeries(seriesId, seriesName))
+                                            )
+                                        },
+                                        onFranchiseSelected = { franchiseId, franchiseName ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreSeries(franchiseId, franchiseName))
+                                            )
+                                        },
+                                        onAdvancedFiltersSelected = {
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExploreSearch)
                                             )
                                         },
                                         onBack = {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
@@ -1,0 +1,409 @@
+package com.spela.player.presentation.ui.feature.explore
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.filled.VideoLibrary
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.SeriesConsole
+import com.spela.player.domain.model.SeriesDetail
+import com.spela.player.domain.model.SeriesGame
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpGameCardSkeleton
+import com.spela.player.presentation.ui.components.SpProgressBar
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.formatRating
+
+/**
+ * Shared content composable for series and franchise detail screens.
+ *
+ * @param detail The loaded detail data, or null if not yet loaded.
+ * @param filteredGames The list of games after applying the console filter.
+ * @param consoleFilter The currently selected console filter abbreviation, or null for "All".
+ * @param isLoading Whether data is currently loading.
+ * @param error An error message to display, or null.
+ * @param title The display name shown in the top bar.
+ * @param groupLabel A label used for test tag prefixes and display text (e.g., "series" or "franchise").
+ * @param onGameSelected Called when a game is tapped.
+ * @param onBack Called when the back button is tapped.
+ * @param onConsoleFilterSelected Called when a console filter chip is tapped.
+ * @param onDismissError Called when the error snackbar is dismissed.
+ */
+@Composable
+fun ExploreGroupDetailContent(
+    detail: SeriesDetail?,
+    filteredGames: List<SeriesGame>,
+    consoleFilter: String?,
+    isLoading: Boolean,
+    error: String?,
+    title: String,
+    groupLabel: String,
+    onGameSelected: (String) -> Unit,
+    onBack: () -> Unit,
+    onConsoleFilterSelected: (String?) -> Unit,
+    onDismissError: () -> Unit,
+) {
+    Box(modifier = Modifier.fillMaxSize().testTag("explore_${groupLabel}_screen")) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = title,
+                showBack = true,
+                onBack = onBack,
+            )
+
+            when {
+                isLoading && detail == null -> {
+                    // Loading skeleton
+                    Column(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(SpSpacing.ScreenHorizontal)
+                            .testTag("${groupLabel}_detail_loading"),
+                    ) {
+                        Spacer(Modifier.height(SpSpacing.Large))
+                        repeat(4) {
+                            SpGameCardSkeleton(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(bottom = SpSpacing.Medium),
+                            )
+                        }
+                    }
+                }
+
+                detail != null -> {
+                    LazyColumn(
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(bottom = SpSpacing.XXLarge),
+                    ) {
+                        // Hero banner with gradient
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(160.dp)
+                                    .background(
+                                        Brush.verticalGradient(
+                                            listOf(
+                                                SpColor.Primary.copy(alpha = 0.3f),
+                                                SpColor.Background,
+                                            ),
+                                        ),
+                                    )
+                                    .testTag("${groupLabel}_hero_banner"),
+                                contentAlignment = Alignment.Center,
+                            ) {
+                                Text(
+                                    text = detail.name,
+                                    style = SpTypography.DisplaySmall,
+                                    color = SpColor.OnBackground,
+                                )
+                            }
+                        }
+
+                        // Ownership progress
+                        item {
+                            Column(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                    .testTag("${groupLabel}_ownership_progress"),
+                            ) {
+                                val progress = if (detail.totalGames > 0) {
+                                    detail.libraryGames.toFloat() / detail.totalGames.toFloat()
+                                } else 0f
+
+                                Text(
+                                    text = "You own ${detail.libraryGames} of ${detail.totalGames} games",
+                                    style = SpTypography.BodyMedium,
+                                    color = SpColor.OnBackgroundSecondary,
+                                    modifier = Modifier.testTag("${groupLabel}_ownership_text"),
+                                )
+                                Spacer(Modifier.height(SpSpacing.Small))
+                                SpProgressBar(
+                                    progress = progress,
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                                Spacer(Modifier.height(SpSpacing.Large))
+                            }
+                        }
+
+                        // Console filter badges
+                        if (detail.consoles.isNotEmpty()) {
+                            item {
+                                ConsoleFilterRow(
+                                    consoles = detail.consoles,
+                                    totalGames = detail.totalGames,
+                                    selectedAbbreviation = consoleFilter,
+                                    onConsoleSelected = onConsoleFilterSelected,
+                                    testTagPrefix = groupLabel,
+                                    modifier = Modifier
+                                        .padding(horizontal = SpSpacing.ScreenHorizontal)
+                                        .testTag("${groupLabel}_console_filters"),
+                                )
+                                Spacer(Modifier.height(SpSpacing.Large))
+                            }
+                        }
+
+                        // Timeline of games
+                        if (filteredGames.isEmpty() && !isLoading) {
+                            item {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(SpSpacing.XXLarge),
+                                    contentAlignment = Alignment.Center,
+                                ) {
+                                    SpEmptyState(
+                                        icon = Icons.Filled.VideoLibrary,
+                                        title = "No games found",
+                                        message = "No games match the selected filter.",
+                                        modifier = Modifier.testTag("${groupLabel}_empty_state"),
+                                    )
+                                }
+                            }
+                        } else {
+                            items(
+                                items = filteredGames,
+                                key = { it.igdbGameId },
+                            ) { game ->
+                                TimelineItem(
+                                    game = game,
+                                    testTagPrefix = groupLabel,
+                                    onClick = if (game.inLibrary && game.localGameId != null) {
+                                        { onGameSelected(game.localGameId) }
+                                    } else null,
+                                )
+                            }
+                        }
+                    }
+                }
+
+                else -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.VideoLibrary,
+                            title = "${groupLabel.replaceFirstChar { it.uppercase() }} not found",
+                            message = "Could not load ${groupLabel} details.",
+                            modifier = Modifier.testTag("${groupLabel}_error_state"),
+                        )
+                    }
+                }
+            }
+        }
+
+        SpSnackbar(
+            data = error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = onDismissError,
+                )
+            },
+            onDismiss = onDismissError,
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun ConsoleFilterRow(
+    consoles: List<SeriesConsole>,
+    totalGames: Int,
+    selectedAbbreviation: String?,
+    onConsoleSelected: (String?) -> Unit,
+    testTagPrefix: String,
+    modifier: Modifier = Modifier,
+) {
+    FlowRow(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        // "All" chip
+        SpChip(
+            text = "All ($totalGames)",
+            onClick = { onConsoleSelected(null) },
+            isSelected = selectedAbbreviation == null,
+            modifier = Modifier
+                .testTag("${testTagPrefix}_console_chip_all")
+                .semantics {
+                    contentDescription = "All, $totalGames games"
+                    role = Role.Button
+                },
+        )
+
+        consoles.forEach { console ->
+            val isSelected = console.abbreviation == selectedAbbreviation
+
+            SpChip(
+                text = "${console.name} (${console.gameCount})",
+                onClick = { onConsoleSelected(console.abbreviation) },
+                isSelected = isSelected,
+                modifier = Modifier
+                    .testTag("${testTagPrefix}_console_chip_${console.abbreviation}")
+                    .semantics {
+                        contentDescription = "${console.name}, ${console.gameCount} games"
+                        role = Role.Button
+                    },
+            )
+        }
+    }
+}
+
+@Composable
+internal fun TimelineItem(
+    game: SeriesGame,
+    testTagPrefix: String,
+    onClick: (() -> Unit)?,
+) {
+    val itemAlpha = if (game.inLibrary) 1f else 0.5f
+
+    SpCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.XSmall,
+            )
+            .alpha(itemAlpha)
+            .testTag("${testTagPrefix}_game_${game.igdbGameId}")
+            .semantics {
+                contentDescription = buildString {
+                    append(game.name)
+                    game.consoleName?.let { append(", $it") }
+                    game.releaseDate?.let { append(", $it") }
+                    if (!game.inLibrary) append(", not in library")
+                }
+                role = Role.Button
+            },
+        onClick = onClick,
+    ) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SpSpacing.Medium),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+        ) {
+            // Cover art
+            SpCoverArt(
+                imageUrl = game.coverUrl,
+                contentDescription = "${game.name} cover art",
+                modifier = Modifier
+                    .width(48.dp)
+                    .height(64.dp)
+                    .clip(RoundedCornerShape(SpSpacing.RadiusSmall)),
+                aspectRatio = 0.75f,
+            )
+
+            // Game info
+            Column(
+                modifier = Modifier.weight(1f),
+            ) {
+                Text(
+                    text = game.name,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                )
+
+                Spacer(Modifier.height(SpSpacing.XXSmall))
+
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    game.consoleName?.let { consoleName ->
+                        Text(
+                            text = consoleName,
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+
+                    game.releaseDate?.take(4)?.let { year ->
+                        Text(
+                            text = year,
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+
+                    if (game.rating > 0) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(SpSpacing.IconXSmall),
+                        )
+                        Text(
+                            text = formatRating(game.rating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                }
+
+                if (!game.inLibrary) {
+                    Spacer(Modifier.height(SpSpacing.XXSmall))
+                    Text(
+                        text = "Not in library",
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                    )
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SeriesFranchiseSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SeriesFranchiseSection.kt
@@ -27,6 +27,7 @@ fun SeriesFranchiseSection(
     series: List<GameSeriesLink>,
     franchises: List<GameFranchiseLink>,
     onSeriesSelected: ((seriesId: String, seriesName: String) -> Unit)? = null,
+    onFranchiseSelected: ((franchiseId: String, franchiseName: String) -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     if (series.isEmpty() && franchises.isEmpty()) return
@@ -54,6 +55,9 @@ fun SeriesFranchiseSection(
             franchises.forEach { franchiseLink ->
                 SpChip(
                     text = "Part of ${franchiseLink.name} (${franchiseLink.gameCount} games)",
+                    onClick = if (onFranchiseSelected != null) {
+                        { onFranchiseSelected(franchiseLink.id, franchiseLink.name) }
+                    } else null,
                     color = SpColor.Accent,
                     onGradient = true,
                     modifier = Modifier.testTag("franchise_link_${franchiseLink.id}"),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/QuickResultsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/QuickResultsSection.kt
@@ -1,0 +1,245 @@
+package com.spela.player.presentation.ui.feature.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Gamepad
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.spela.player.domain.model.SearchSuggestion
+import com.spela.player.domain.model.SuggestionNavigationType
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.gamepad.spFocusRing
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+@Composable
+fun QuickResultsSection(
+    suggestions: List<SearchSuggestion>,
+    onGameSelected: (String) -> Unit,
+    onConsoleSelected: (String) -> Unit,
+    onDeveloperSelected: (String) -> Unit,
+    onPublisherSelected: (String) -> Unit,
+    onCollectionSelected: (String) -> Unit,
+    onSeriesSelected: (String, String) -> Unit,
+    onFranchiseSelected: (String, String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("quick_results_section"),
+    ) {
+        // Section header
+        Text(
+            text = "Quick results",
+            style = SpTypography.TitleMedium,
+            color = SpColor.OnBackgroundTertiary,
+            modifier = Modifier
+                .padding(
+                    horizontal = SpSpacing.ScreenHorizontal,
+                    vertical = SpSpacing.Small,
+                ),
+        )
+
+        suggestions.forEach { suggestion ->
+            QuickResultItem(
+                suggestion = suggestion,
+                onClick = {
+                    dispatchNavigation(
+                        navigationType = suggestion.navigationType,
+                        onGameSelected = onGameSelected,
+                        onConsoleSelected = onConsoleSelected,
+                        onDeveloperSelected = onDeveloperSelected,
+                        onPublisherSelected = onPublisherSelected,
+                        onCollectionSelected = onCollectionSelected,
+                        onSeriesSelected = onSeriesSelected,
+                        onFranchiseSelected = onFranchiseSelected,
+                    )
+                },
+            )
+        }
+    }
+}
+
+@Composable
+private fun QuickResultItem(
+    suggestion: SearchSuggestion,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clickable(onClick = onClick)
+            .focusable()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.Small,
+            )
+            .testTag("quick_result_${suggestion.type.lowercase()}_${suggestion.id}")
+            .semantics {
+                contentDescription = "${suggestion.name}, ${suggestion.type}"
+                role = Role.Button
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        // Thumbnail / icon
+        QuickResultThumbnail(suggestion = suggestion)
+
+        // Name and subtitle
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = suggestion.name,
+                style = SpTypography.TitleSmall,
+                color = SpColor.OnBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            if (suggestion.subtitle.isNotBlank()) {
+                Text(
+                    text = suggestion.subtitle,
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
+            }
+        }
+
+        // Type badge
+        TypeBadge(type = suggestion.type)
+    }
+}
+
+@Composable
+private fun QuickResultThumbnail(
+    suggestion: SearchSuggestion,
+    modifier: Modifier = Modifier,
+) {
+    val isGame = suggestion.navigationType is SuggestionNavigationType.Game
+
+    if (isGame && suggestion.imageUrl != null) {
+        SpCoverArt(
+            imageUrl = suggestion.imageUrl,
+            contentDescription = "${suggestion.name} cover",
+            modifier = modifier
+                .width(SpSpacing.IconXLarge)
+                .height(43.dp), // 32dp * 4/3 aspect ratio
+            aspectRatio = 0.75f,
+            cornerRadius = SpSpacing.RadiusSmall,
+        )
+    } else {
+        Box(
+            modifier = modifier
+                .size(SpSpacing.IconXLarge)
+                .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
+                .background(SpColor.SurfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            val isConsole = suggestion.navigationType is SuggestionNavigationType.Console
+            val isCollection = suggestion.navigationType is SuggestionNavigationType.Collection
+
+            when {
+                isConsole && !suggestion.imageUrl.isNullOrBlank() -> {
+                    AsyncImage(
+                        model = suggestion.imageUrl,
+                        contentDescription = null,
+                        modifier = Modifier.size(SpSpacing.IconDefault),
+                    )
+                }
+                isCollection -> {
+                    Icon(
+                        imageVector = Icons.Filled.Folder,
+                        contentDescription = null,
+                        tint = SpColor.OnBackgroundSecondary,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+                isConsole -> {
+                    Icon(
+                        imageVector = Icons.Filled.Gamepad,
+                        contentDescription = null,
+                        tint = SpColor.OnBackgroundSecondary,
+                        modifier = Modifier.size(18.dp),
+                    )
+                }
+                else -> {
+                    Text(
+                        text = suggestion.name.take(2).uppercase(),
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundSecondary,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun TypeBadge(
+    type: String,
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = type,
+        style = SpTypography.LabelSmall,
+        color = SpColor.Primary,
+        modifier = modifier
+            .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
+            .background(SpColor.PrimaryContainer)
+            .padding(
+                horizontal = SpSpacing.Small,
+                vertical = SpSpacing.XXSmall,
+            ),
+    )
+}
+
+private fun dispatchNavigation(
+    navigationType: SuggestionNavigationType,
+    onGameSelected: (String) -> Unit,
+    onConsoleSelected: (String) -> Unit,
+    onDeveloperSelected: (String) -> Unit,
+    onPublisherSelected: (String) -> Unit,
+    onCollectionSelected: (String) -> Unit,
+    onSeriesSelected: (String, String) -> Unit,
+    onFranchiseSelected: (String, String) -> Unit,
+) {
+    when (navigationType) {
+        is SuggestionNavigationType.Game -> onGameSelected(navigationType.id)
+        is SuggestionNavigationType.Console -> onConsoleSelected(navigationType.id)
+        is SuggestionNavigationType.Developer -> onDeveloperSelected(navigationType.name)
+        is SuggestionNavigationType.Publisher -> onPublisherSelected(navigationType.name)
+        is SuggestionNavigationType.Collection -> onCollectionSelected(navigationType.id)
+        is SuggestionNavigationType.Series -> onSeriesSelected(navigationType.id, navigationType.name)
+        is SuggestionNavigationType.Franchise -> onFranchiseSelected(navigationType.id, navigationType.name)
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/RecentSearchesSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/RecentSearchesSection.kt
@@ -1,0 +1,149 @@
+package com.spela.player.presentation.ui.feature.search
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.History
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.gamepad.spFocusRing
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+@Composable
+fun RecentSearchesSection(
+    recentSearches: List<String>,
+    onRecentSearchSelected: (String) -> Unit,
+    onRemoveRecentSearch: (String) -> Unit,
+    onClearAll: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .testTag("recent_searches_section"),
+    ) {
+        // Header row
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(
+                    horizontal = SpSpacing.ScreenHorizontal,
+                    vertical = SpSpacing.Small,
+                ),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = "Recent searches",
+                style = SpTypography.TitleMedium,
+                color = SpColor.OnBackground,
+                modifier = Modifier.weight(1f),
+            )
+            Text(
+                text = "Clear all",
+                style = SpTypography.LabelSmall,
+                color = SpColor.Primary,
+                modifier = Modifier
+                    .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusSmall))
+                    .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
+                    .clickable(onClick = onClearAll)
+                    .focusable()
+                    .padding(
+                        horizontal = SpSpacing.Small,
+                        vertical = SpSpacing.XSmall,
+                    )
+                    .testTag("recent_searches_clear_all"),
+            )
+        }
+
+        // Recent search items
+        recentSearches.forEach { query ->
+            RecentSearchItem(
+                query = query,
+                onClick = { onRecentSearchSelected(query) },
+                onRemove = { onRemoveRecentSearch(query) },
+            )
+        }
+
+        Spacer(Modifier.height(SpSpacing.Medium))
+    }
+}
+
+@Composable
+private fun RecentSearchItem(
+    query: String,
+    onClick: () -> Unit,
+    onRemove: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clickable(onClick = onClick)
+            .focusable()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.Small,
+            )
+            .testTag("recent_search_item_$query")
+            .semantics {
+                contentDescription = "Recent search: $query"
+                role = Role.Button
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        Icon(
+            imageVector = Icons.Filled.History,
+            contentDescription = null,
+            tint = SpColor.OnBackgroundTertiary,
+            modifier = Modifier.size(SpSpacing.IconDefault),
+        )
+        Text(
+            text = query,
+            style = SpTypography.BodyMedium,
+            color = SpColor.OnBackground,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
+            modifier = Modifier.weight(1f),
+        )
+        IconButton(
+            onClick = onRemove,
+            modifier = Modifier
+                .size(SpSpacing.IconXLarge)
+                .testTag("recent_search_remove_$query"),
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Close,
+                contentDescription = "Remove $query",
+                tint = SpColor.OnBackgroundTertiary,
+                modifier = Modifier.size(16.dp),
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultSections.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultSections.kt
@@ -50,6 +50,9 @@ fun SearchSectionHeader(
     title: String,
     total: Int,
     displayedCount: Int,
+    isExpanded: Boolean = false,
+    onSeeAll: (() -> Unit)? = null,
+    onShowLess: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     Row(
@@ -67,12 +70,48 @@ fun SearchSectionHeader(
             color = SpColor.OnBackground,
             modifier = Modifier.weight(1f),
         )
-        if (total > displayedCount) {
-            Text(
-                text = "$total total",
-                style = SpTypography.LabelSmall,
-                color = SpColor.OnBackgroundTertiary,
-            )
+        when {
+            isExpanded && onShowLess != null -> {
+                Text(
+                    text = "Show less",
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.Primary,
+                    modifier = Modifier
+                        .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusSmall))
+                        .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
+                        .clickable(onClick = onShowLess)
+                        .focusable()
+                        .padding(
+                            horizontal = SpSpacing.Small,
+                            vertical = SpSpacing.XSmall,
+                        )
+                        .testTag("search_section_show_less_$title"),
+                )
+            }
+            total > displayedCount && onSeeAll != null -> {
+                Text(
+                    text = "See all $total",
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.Primary,
+                    modifier = Modifier
+                        .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusSmall))
+                        .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
+                        .clickable(onClick = onSeeAll)
+                        .focusable()
+                        .padding(
+                            horizontal = SpSpacing.Small,
+                            vertical = SpSpacing.XSmall,
+                        )
+                        .testTag("search_section_see_all_$title"),
+                )
+            }
+            total > displayedCount -> {
+                Text(
+                    text = "$total total",
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
+                )
+            }
         }
     }
 }
@@ -275,7 +314,7 @@ fun CompanySearchResultItem(
                         imageVector = Icons.Filled.Star,
                         contentDescription = null,
                         tint = SpColor.Rating,
-                        modifier = Modifier.size(10.dp),
+                        modifier = Modifier.size(SpSpacing.IconXSmall),
                     )
                     Text(
                         text = formatRating(avgRating),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultSections.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultSections.kt
@@ -1,0 +1,500 @@
+package com.spela.player.presentation.ui.feature.search
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Folder
+import androidx.compose.material.icons.filled.Gamepad
+import androidx.compose.material.icons.filled.Star
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.spela.player.domain.model.SearchCollectionResult
+import com.spela.player.domain.model.SearchConsoleResult
+import com.spela.player.domain.model.SearchFranchiseResult
+import com.spela.player.domain.model.SearchGameResult
+import com.spela.player.domain.model.SearchSeriesResult
+import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpShimmer
+import com.spela.player.presentation.ui.gamepad.spFocusRing
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.formatRating
+
+@Composable
+fun SearchSectionHeader(
+    title: String,
+    total: Int,
+    displayedCount: Int,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.Small,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            style = SpTypography.TitleMedium,
+            color = SpColor.OnBackground,
+            modifier = Modifier.weight(1f),
+        )
+        if (total > displayedCount) {
+            Text(
+                text = "$total total",
+                style = SpTypography.LabelSmall,
+                color = SpColor.OnBackgroundTertiary,
+            )
+        }
+    }
+}
+
+@Composable
+fun GameSearchResultItem(
+    game: SearchGameResult,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clickable(onClick = onClick)
+            .focusable()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.Small,
+            )
+            .testTag("search_result_game_${game.id}")
+            .semantics {
+                contentDescription = "${game.title}, ${game.consoleName}"
+                role = Role.Button
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        SpCoverArt(
+            imageUrl = game.coverUrl,
+            contentDescription = "${game.title} cover",
+            modifier = Modifier
+                .width(40.dp)
+                .height(54.dp),
+            aspectRatio = game.coverAspectRatio,
+            cornerRadius = SpSpacing.RadiusSmall,
+        )
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = game.title,
+                style = SpTypography.TitleSmall,
+                color = SpColor.OnBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+            ) {
+                Text(
+                    text = game.consoleName,
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.Primary,
+                    maxLines = 1,
+                )
+                if (!game.developer.isNullOrBlank()) {
+                    Text(
+                        text = "\u00B7",
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                    )
+                    Text(
+                        text = game.developer,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ConsoleSearchResultItem(
+    console: SearchConsoleResult,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clickable(onClick = onClick)
+            .focusable()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.Small,
+            )
+            .testTag("search_result_console_${console.id}")
+            .semantics {
+                contentDescription = "${console.name}, ${console.gameCount} games"
+                role = Role.Button
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
+                .background(SpColor.SurfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (console.iconUrl.isNotBlank()) {
+                AsyncImage(
+                    model = console.iconUrl,
+                    contentDescription = null,
+                    modifier = Modifier.size(24.dp),
+                )
+            } else {
+                Icon(
+                    imageVector = Icons.Filled.Gamepad,
+                    contentDescription = null,
+                    tint = SpColor.OnBackgroundSecondary,
+                    modifier = Modifier.size(24.dp),
+                )
+            }
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = console.name,
+                style = SpTypography.TitleSmall,
+                color = SpColor.OnBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = "${console.gameCount} games",
+                style = SpTypography.LabelSmall,
+                color = SpColor.OnBackgroundTertiary,
+            )
+        }
+    }
+}
+
+@Composable
+fun CompanySearchResultItem(
+    name: String,
+    gameCount: Int,
+    avgRating: Double,
+    label: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clickable(onClick = onClick)
+            .focusable()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.Small,
+            )
+            .testTag("search_result_${label.lowercase()}_$name")
+            .semantics {
+                contentDescription = "$name, $gameCount games"
+                role = Role.Button
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
+                .background(SpColor.SurfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = name.take(2).uppercase(),
+                style = SpTypography.LabelMedium,
+                color = SpColor.OnBackgroundSecondary,
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = name,
+                style = SpTypography.TitleSmall,
+                color = SpColor.OnBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+            ) {
+                Text(
+                    text = "$gameCount games",
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
+                )
+                if (avgRating > 0) {
+                    Icon(
+                        imageVector = Icons.Filled.Star,
+                        contentDescription = null,
+                        tint = SpColor.Rating,
+                        modifier = Modifier.size(10.dp),
+                    )
+                    Text(
+                        text = formatRating(avgRating),
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun CollectionSearchResultItem(
+    collection: SearchCollectionResult,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clickable(onClick = onClick)
+            .focusable()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.Small,
+            )
+            .testTag("search_result_collection_${collection.id}")
+            .semantics {
+                contentDescription = "${collection.name}, ${collection.gameCount} games"
+                role = Role.Button
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
+                .background(SpColor.SurfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector = Icons.Filled.Folder,
+                contentDescription = null,
+                tint = SpColor.OnBackgroundSecondary,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = collection.name,
+                style = SpTypography.TitleSmall,
+                color = SpColor.OnBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+            ) {
+                Text(
+                    text = collection.username,
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.Primary,
+                )
+                Text(
+                    text = "\u00B7 ${collection.gameCount} games",
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+fun GroupSearchResultItem(
+    name: String,
+    subtitle: String,
+    avatarText: String,
+    testTagPrefix: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
+            .clickable(onClick = onClick)
+            .focusable()
+            .padding(
+                horizontal = SpSpacing.ScreenHorizontal,
+                vertical = SpSpacing.Small,
+            )
+            .testTag("search_result_${testTagPrefix}")
+            .semantics {
+                contentDescription = "$name, $subtitle"
+                role = Role.Button
+            },
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(40.dp)
+                .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
+                .background(SpColor.SurfaceVariant),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = avatarText,
+                style = SpTypography.LabelMedium,
+                color = SpColor.OnBackgroundSecondary,
+            )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = name,
+                style = SpTypography.TitleSmall,
+                color = SpColor.OnBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Text(
+                text = subtitle,
+                style = SpTypography.LabelSmall,
+                color = SpColor.OnBackgroundTertiary,
+            )
+        }
+    }
+}
+
+@Composable
+fun SeriesSearchResultItem(
+    series: SearchSeriesResult,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    GroupSearchResultItem(
+        name = series.name,
+        subtitle = "${series.libraryGames} of ${series.totalGames} in library",
+        avatarText = series.name.take(2).uppercase(),
+        testTagPrefix = "series_${series.id}",
+        onClick = onClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun FranchiseSearchResultItem(
+    franchise: SearchFranchiseResult,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    GroupSearchResultItem(
+        name = franchise.name,
+        subtitle = "${franchise.libraryGames} of ${franchise.totalGames} in library",
+        avatarText = franchise.name.take(2).uppercase(),
+        testTagPrefix = "franchise_${franchise.id}",
+        onClick = onClick,
+        modifier = modifier,
+    )
+}
+
+@Composable
+fun SearchResultSkeleton(
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = SpSpacing.ScreenHorizontal),
+    ) {
+        // Mimic a section header
+        SpShimmer(width = 80.dp, height = 16.dp)
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        // Mimic several result rows
+        repeat(4) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = SpSpacing.Small),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+            ) {
+                SpShimmer(width = 40.dp, height = 54.dp)
+                Column(modifier = Modifier.weight(1f)) {
+                    SpShimmer(width = 160.dp, height = 14.dp)
+                    Spacer(Modifier.height(SpSpacing.XSmall))
+                    SpShimmer(width = 100.dp, height = 12.dp)
+                }
+            }
+        }
+
+        Spacer(Modifier.height(SpSpacing.Large))
+
+        // Second section
+        SpShimmer(width = 100.dp, height = 16.dp)
+        Spacer(Modifier.height(SpSpacing.Medium))
+
+        repeat(3) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(vertical = SpSpacing.Small),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+            ) {
+                SpShimmer(width = 40.dp, height = 40.dp)
+                Column(modifier = Modifier.weight(1f)) {
+                    SpShimmer(width = 140.dp, height = 14.dp)
+                    Spacer(Modifier.height(SpSpacing.XSmall))
+                    SpShimmer(width = 80.dp, height = 12.dp)
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultsList.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultsList.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -16,6 +17,7 @@ import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.GlobalSearchResult
 import com.spela.player.domain.model.SearchCategory
+import com.spela.player.domain.model.SearchSuggestion
 import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.theme.SpSpacing
 
@@ -33,6 +35,7 @@ private object SearchCategoryNames {
 fun SearchResultsList(
     results: GlobalSearchResult,
     isLoading: Boolean,
+    suggestions: List<SearchSuggestion> = emptyList(),
     expandedCategories: Set<String> = emptySet(),
     expandedResults: GlobalSearchResult? = null,
     onExpandCategory: (String) -> Unit = {},
@@ -82,224 +85,166 @@ fun SearchResultsList(
             }
         }
 
-        // Games section
-        val gamesExpanded = SearchCategoryNames.GAMES in expandedCategories
-        val gamesCategory = resolveCategory(
+        // Quick results section
+        if (suggestions.isNotEmpty()) {
+            item(key = "quick_results") {
+                QuickResultsSection(
+                    suggestions = suggestions,
+                    onGameSelected = onGameSelected,
+                    onConsoleSelected = onConsoleSelected,
+                    onDeveloperSelected = onDeveloperSelected,
+                    onPublisherSelected = onPublisherSelected,
+                    onCollectionSelected = onCollectionSelected,
+                    onSeriesSelected = onSeriesSelected,
+                    onFranchiseSelected = onFranchiseSelected,
+                )
+            }
+        }
+
+        // Category sections
+        searchSection(
+            name = SearchCategoryNames.GAMES,
             category = results.games,
             expandedCategory = expandedResults?.games,
-            isExpanded = gamesExpanded,
-        )
-        if (gamesCategory.results.isNotEmpty()) {
-            item {
-                SearchSectionHeader(
-                    title = SearchCategoryNames.GAMES,
-                    total = gamesCategory.total,
-                    displayedCount = gamesCategory.results.size,
-                    isExpanded = gamesExpanded,
-                    onSeeAll = { onExpandCategory(SearchCategoryNames.GAMES) },
-                    onShowLess = { onCollapseCategory(SearchCategoryNames.GAMES) },
-                )
-            }
-            items(
-                count = gamesCategory.results.size,
-                key = { "game_${gamesCategory.results[it].id}" },
-            ) { index ->
-                val game = gamesCategory.results[index]
-                GameSearchResultItem(
-                    game = game,
-                    onClick = { onGameSelected(game.id) },
-                )
-            }
+            expandedCategories = expandedCategories,
+            onExpand = onExpandCategory,
+            onCollapse = onCollapseCategory,
+            itemKey = { "game_${it.id}" },
+        ) { game ->
+            GameSearchResultItem(game = game, onClick = { onGameSelected(game.id) })
         }
 
-        // Consoles section
-        val consolesExpanded = SearchCategoryNames.CONSOLES in expandedCategories
-        val consolesCategory = resolveCategory(
+        searchSection(
+            name = SearchCategoryNames.CONSOLES,
             category = results.consoles,
             expandedCategory = expandedResults?.consoles,
-            isExpanded = consolesExpanded,
-        )
-        if (consolesCategory.results.isNotEmpty()) {
-            item {
-                SearchSectionHeader(
-                    title = SearchCategoryNames.CONSOLES,
-                    total = consolesCategory.total,
-                    displayedCount = consolesCategory.results.size,
-                    isExpanded = consolesExpanded,
-                    onSeeAll = { onExpandCategory(SearchCategoryNames.CONSOLES) },
-                    onShowLess = { onCollapseCategory(SearchCategoryNames.CONSOLES) },
-                )
-            }
-            items(
-                count = consolesCategory.results.size,
-                key = { "console_${consolesCategory.results[it].id}" },
-            ) { index ->
-                val console = consolesCategory.results[index]
-                ConsoleSearchResultItem(
-                    console = console,
-                    onClick = { onConsoleSelected(console.id) },
-                )
-            }
+            expandedCategories = expandedCategories,
+            onExpand = onExpandCategory,
+            onCollapse = onCollapseCategory,
+            itemKey = { "console_${it.id}" },
+        ) { console ->
+            ConsoleSearchResultItem(console = console, onClick = { onConsoleSelected(console.id) })
         }
 
-        // Developers section
-        val developersExpanded = SearchCategoryNames.DEVELOPERS in expandedCategories
-        val developersCategory = resolveCategory(
+        searchSection(
+            name = SearchCategoryNames.DEVELOPERS,
             category = results.developers,
             expandedCategory = expandedResults?.developers,
-            isExpanded = developersExpanded,
-        )
-        if (developersCategory.results.isNotEmpty()) {
-            item {
-                SearchSectionHeader(
-                    title = SearchCategoryNames.DEVELOPERS,
-                    total = developersCategory.total,
-                    displayedCount = developersCategory.results.size,
-                    isExpanded = developersExpanded,
-                    onSeeAll = { onExpandCategory(SearchCategoryNames.DEVELOPERS) },
-                    onShowLess = { onCollapseCategory(SearchCategoryNames.DEVELOPERS) },
-                )
-            }
-            items(
-                count = developersCategory.results.size,
-                key = { "developer_${developersCategory.results[it].name}" },
-            ) { index ->
-                val developer = developersCategory.results[index]
-                CompanySearchResultItem(
-                    name = developer.name,
-                    gameCount = developer.gameCount,
-                    avgRating = developer.avgRating,
-                    label = "Developer",
-                    onClick = { onDeveloperSelected(developer.name) },
-                )
-            }
+            expandedCategories = expandedCategories,
+            onExpand = onExpandCategory,
+            onCollapse = onCollapseCategory,
+            itemKey = { "developer_${it.name}" },
+        ) { developer ->
+            CompanySearchResultItem(
+                name = developer.name,
+                gameCount = developer.gameCount,
+                avgRating = developer.avgRating,
+                label = "Developer",
+                onClick = { onDeveloperSelected(developer.name) },
+            )
         }
 
-        // Publishers section
-        val publishersExpanded = SearchCategoryNames.PUBLISHERS in expandedCategories
-        val publishersCategory = resolveCategory(
+        searchSection(
+            name = SearchCategoryNames.PUBLISHERS,
             category = results.publishers,
             expandedCategory = expandedResults?.publishers,
-            isExpanded = publishersExpanded,
-        )
-        if (publishersCategory.results.isNotEmpty()) {
-            item {
-                SearchSectionHeader(
-                    title = SearchCategoryNames.PUBLISHERS,
-                    total = publishersCategory.total,
-                    displayedCount = publishersCategory.results.size,
-                    isExpanded = publishersExpanded,
-                    onSeeAll = { onExpandCategory(SearchCategoryNames.PUBLISHERS) },
-                    onShowLess = { onCollapseCategory(SearchCategoryNames.PUBLISHERS) },
-                )
-            }
-            items(
-                count = publishersCategory.results.size,
-                key = { "publisher_${publishersCategory.results[it].name}" },
-            ) { index ->
-                val publisher = publishersCategory.results[index]
-                CompanySearchResultItem(
-                    name = publisher.name,
-                    gameCount = publisher.gameCount,
-                    avgRating = publisher.avgRating,
-                    label = "Publisher",
-                    onClick = { onPublisherSelected(publisher.name) },
-                )
-            }
+            expandedCategories = expandedCategories,
+            onExpand = onExpandCategory,
+            onCollapse = onCollapseCategory,
+            itemKey = { "publisher_${it.name}" },
+        ) { publisher ->
+            CompanySearchResultItem(
+                name = publisher.name,
+                gameCount = publisher.gameCount,
+                avgRating = publisher.avgRating,
+                label = "Publisher",
+                onClick = { onPublisherSelected(publisher.name) },
+            )
         }
 
-        // Collections section
-        val collectionsExpanded = SearchCategoryNames.COLLECTIONS in expandedCategories
-        val collectionsCategory = resolveCategory(
+        searchSection(
+            name = SearchCategoryNames.COLLECTIONS,
             category = results.collections,
             expandedCategory = expandedResults?.collections,
-            isExpanded = collectionsExpanded,
-        )
-        if (collectionsCategory.results.isNotEmpty()) {
-            item {
-                SearchSectionHeader(
-                    title = SearchCategoryNames.COLLECTIONS,
-                    total = collectionsCategory.total,
-                    displayedCount = collectionsCategory.results.size,
-                    isExpanded = collectionsExpanded,
-                    onSeeAll = { onExpandCategory(SearchCategoryNames.COLLECTIONS) },
-                    onShowLess = { onCollapseCategory(SearchCategoryNames.COLLECTIONS) },
-                )
-            }
-            items(
-                count = collectionsCategory.results.size,
-                key = { "collection_${collectionsCategory.results[it].id}" },
-            ) { index ->
-                val collection = collectionsCategory.results[index]
-                CollectionSearchResultItem(
-                    collection = collection,
-                    onClick = { onCollectionSelected(collection.id) },
-                )
-            }
+            expandedCategories = expandedCategories,
+            onExpand = onExpandCategory,
+            onCollapse = onCollapseCategory,
+            itemKey = { "collection_${it.id}" },
+        ) { collection ->
+            CollectionSearchResultItem(
+                collection = collection,
+                onClick = { onCollectionSelected(collection.id) },
+            )
         }
 
-        // Series section
-        val seriesExpanded = SearchCategoryNames.SERIES in expandedCategories
-        val seriesCategory = resolveCategory(
+        searchSection(
+            name = SearchCategoryNames.SERIES,
             category = results.series,
             expandedCategory = expandedResults?.series,
-            isExpanded = seriesExpanded,
-        )
-        if (seriesCategory.results.isNotEmpty()) {
-            item {
-                SearchSectionHeader(
-                    title = SearchCategoryNames.SERIES,
-                    total = seriesCategory.total,
-                    displayedCount = seriesCategory.results.size,
-                    isExpanded = seriesExpanded,
-                    onSeeAll = { onExpandCategory(SearchCategoryNames.SERIES) },
-                    onShowLess = { onCollapseCategory(SearchCategoryNames.SERIES) },
-                )
-            }
-            items(
-                count = seriesCategory.results.size,
-                key = { "series_${seriesCategory.results[it].id}" },
-            ) { index ->
-                val series = seriesCategory.results[index]
-                SeriesSearchResultItem(
-                    series = series,
-                    onClick = { onSeriesSelected(series.id, series.name) },
-                )
-            }
+            expandedCategories = expandedCategories,
+            onExpand = onExpandCategory,
+            onCollapse = onCollapseCategory,
+            itemKey = { "series_${it.id}" },
+        ) { series ->
+            SeriesSearchResultItem(
+                series = series,
+                onClick = { onSeriesSelected(series.id, series.name) },
+            )
         }
 
-        // Franchises section
-        val franchisesExpanded = SearchCategoryNames.FRANCHISES in expandedCategories
-        val franchisesCategory = resolveCategory(
+        searchSection(
+            name = SearchCategoryNames.FRANCHISES,
             category = results.franchises,
             expandedCategory = expandedResults?.franchises,
-            isExpanded = franchisesExpanded,
-        )
-        if (franchisesCategory.results.isNotEmpty()) {
-            item {
-                SearchSectionHeader(
-                    title = SearchCategoryNames.FRANCHISES,
-                    total = franchisesCategory.total,
-                    displayedCount = franchisesCategory.results.size,
-                    isExpanded = franchisesExpanded,
-                    onSeeAll = { onExpandCategory(SearchCategoryNames.FRANCHISES) },
-                    onShowLess = { onCollapseCategory(SearchCategoryNames.FRANCHISES) },
-                )
-            }
-            items(
-                count = franchisesCategory.results.size,
-                key = { "franchise_${franchisesCategory.results[it].id}" },
-            ) { index ->
-                val franchise = franchisesCategory.results[index]
-                FranchiseSearchResultItem(
-                    franchise = franchise,
-                    onClick = { onFranchiseSelected(franchise.id, franchise.name) },
-                )
-            }
+            expandedCategories = expandedCategories,
+            onExpand = onExpandCategory,
+            onCollapse = onCollapseCategory,
+            itemKey = { "franchise_${it.id}" },
+        ) { franchise ->
+            FranchiseSearchResultItem(
+                franchise = franchise,
+                onClick = { onFranchiseSelected(franchise.id, franchise.name) },
+            )
         }
 
         // Bottom spacer
         item { Spacer(Modifier.height(SpSpacing.XLarge)) }
+    }
+}
+
+/**
+ * Adds a search section (header + items) to the LazyColumn if the category
+ * has results. Handles expand/collapse resolution via [resolveCategory].
+ */
+private fun <T> LazyListScope.searchSection(
+    name: String,
+    category: SearchCategory<T>,
+    expandedCategory: SearchCategory<T>?,
+    expandedCategories: Set<String>,
+    onExpand: (String) -> Unit,
+    onCollapse: (String) -> Unit,
+    itemKey: (T) -> String,
+    itemContent: @Composable (T) -> Unit,
+) {
+    val isExpanded = name in expandedCategories
+    val resolved = resolveCategory(category, expandedCategory, isExpanded)
+    if (resolved.results.isEmpty()) return
+
+    item {
+        SearchSectionHeader(
+            title = name,
+            total = resolved.total,
+            displayedCount = resolved.results.size,
+            isExpanded = isExpanded,
+            onSeeAll = { onExpand(name) },
+            onShowLess = { onCollapse(name) },
+        )
+    }
+    items(
+        count = resolved.results.size,
+        key = { itemKey(resolved.results[it]) },
+    ) { index ->
+        itemContent(resolved.results[index])
     }
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultsList.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultsList.kt
@@ -1,0 +1,213 @@
+package com.spela.player.presentation.ui.feature.search
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.GlobalSearchResult
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+
+@Composable
+fun SearchResultsList(
+    results: GlobalSearchResult,
+    isLoading: Boolean,
+    onGameSelected: (String) -> Unit,
+    onConsoleSelected: (String) -> Unit,
+    onDeveloperSelected: (String) -> Unit,
+    onPublisherSelected: (String) -> Unit,
+    onCollectionSelected: (String) -> Unit,
+    onSeriesSelected: (String, String) -> Unit,
+    onFranchiseSelected: (String, String) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        modifier = modifier
+            .fillMaxSize()
+            .testTag("search_results_list"),
+    ) {
+        // Loading indicator at top when re-searching
+        if (isLoading) {
+            item {
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = SpSpacing.Small),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(
+                        color = SpColor.Primary,
+                        modifier = Modifier.size(20.dp),
+                        strokeWidth = 2.dp,
+                    )
+                }
+            }
+        }
+
+        // Games section
+        if (results.games.results.isNotEmpty()) {
+            item {
+                SearchSectionHeader(
+                    title = "Games",
+                    total = results.games.total,
+                    displayedCount = results.games.results.size,
+                )
+            }
+            items(
+                count = results.games.results.size,
+                key = { "game_${results.games.results[it].id}" },
+            ) { index ->
+                val game = results.games.results[index]
+                GameSearchResultItem(
+                    game = game,
+                    onClick = { onGameSelected(game.id) },
+                )
+            }
+        }
+
+        // Consoles section
+        if (results.consoles.results.isNotEmpty()) {
+            item {
+                SearchSectionHeader(
+                    title = "Consoles",
+                    total = results.consoles.total,
+                    displayedCount = results.consoles.results.size,
+                )
+            }
+            items(
+                count = results.consoles.results.size,
+                key = { "console_${results.consoles.results[it].id}" },
+            ) { index ->
+                val console = results.consoles.results[index]
+                ConsoleSearchResultItem(
+                    console = console,
+                    onClick = { onConsoleSelected(console.id) },
+                )
+            }
+        }
+
+        // Developers section
+        if (results.developers.results.isNotEmpty()) {
+            item {
+                SearchSectionHeader(
+                    title = "Developers",
+                    total = results.developers.total,
+                    displayedCount = results.developers.results.size,
+                )
+            }
+            items(
+                count = results.developers.results.size,
+                key = { "developer_${results.developers.results[it].name}" },
+            ) { index ->
+                val developer = results.developers.results[index]
+                CompanySearchResultItem(
+                    name = developer.name,
+                    gameCount = developer.gameCount,
+                    avgRating = developer.avgRating,
+                    label = "Developer",
+                    onClick = { onDeveloperSelected(developer.name) },
+                )
+            }
+        }
+
+        // Publishers section
+        if (results.publishers.results.isNotEmpty()) {
+            item {
+                SearchSectionHeader(
+                    title = "Publishers",
+                    total = results.publishers.total,
+                    displayedCount = results.publishers.results.size,
+                )
+            }
+            items(
+                count = results.publishers.results.size,
+                key = { "publisher_${results.publishers.results[it].name}" },
+            ) { index ->
+                val publisher = results.publishers.results[index]
+                CompanySearchResultItem(
+                    name = publisher.name,
+                    gameCount = publisher.gameCount,
+                    avgRating = publisher.avgRating,
+                    label = "Publisher",
+                    onClick = { onPublisherSelected(publisher.name) },
+                )
+            }
+        }
+
+        // Collections section
+        if (results.collections.results.isNotEmpty()) {
+            item {
+                SearchSectionHeader(
+                    title = "Collections",
+                    total = results.collections.total,
+                    displayedCount = results.collections.results.size,
+                )
+            }
+            items(
+                count = results.collections.results.size,
+                key = { "collection_${results.collections.results[it].id}" },
+            ) { index ->
+                val collection = results.collections.results[index]
+                CollectionSearchResultItem(
+                    collection = collection,
+                    onClick = { onCollectionSelected(collection.id) },
+                )
+            }
+        }
+
+        // Series section
+        if (results.series.results.isNotEmpty()) {
+            item {
+                SearchSectionHeader(
+                    title = "Series",
+                    total = results.series.total,
+                    displayedCount = results.series.results.size,
+                )
+            }
+            items(
+                count = results.series.results.size,
+                key = { "series_${results.series.results[it].id}" },
+            ) { index ->
+                val series = results.series.results[index]
+                SeriesSearchResultItem(
+                    series = series,
+                    onClick = { onSeriesSelected(series.id, series.name) },
+                )
+            }
+        }
+
+        // Franchises section
+        if (results.franchises.results.isNotEmpty()) {
+            item {
+                SearchSectionHeader(
+                    title = "Franchises",
+                    total = results.franchises.total,
+                    displayedCount = results.franchises.results.size,
+                )
+            }
+            items(
+                count = results.franchises.results.size,
+                key = { "franchise_${results.franchises.results[it].id}" },
+            ) { index ->
+                val franchise = results.franchises.results[index]
+                FranchiseSearchResultItem(
+                    franchise = franchise,
+                    onClick = { onFranchiseSelected(franchise.id, franchise.name) },
+                )
+            }
+        }
+
+        // Bottom spacer
+        item { Spacer(Modifier.height(SpSpacing.XLarge)) }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultsList.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultsList.kt
@@ -1,27 +1,42 @@
 package com.spela.player.presentation.ui.feature.search
 
-import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.GlobalSearchResult
-import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.domain.model.SearchCategory
+import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.theme.SpSpacing
+
+private object SearchCategoryNames {
+    const val GAMES = "Games"
+    const val CONSOLES = "Consoles"
+    const val DEVELOPERS = "Developers"
+    const val PUBLISHERS = "Publishers"
+    const val COLLECTIONS = "Collections"
+    const val SERIES = "Series"
+    const val FRANCHISES = "Franchises"
+}
 
 @Composable
 fun SearchResultsList(
     results: GlobalSearchResult,
     isLoading: Boolean,
+    expandedCategories: Set<String> = emptySet(),
+    expandedResults: GlobalSearchResult? = null,
+    onExpandCategory: (String) -> Unit = {},
+    onCollapseCategory: (String) -> Unit = {},
     onGameSelected: (String) -> Unit,
     onConsoleSelected: (String) -> Unit,
     onDeveloperSelected: (String) -> Unit,
@@ -36,38 +51,60 @@ fun SearchResultsList(
             .fillMaxSize()
             .testTag("search_results_list"),
     ) {
-        // Loading indicator at top when re-searching
+        // Loading skeleton at top when re-searching
         if (isLoading) {
             item {
-                Box(
+                Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(vertical = SpSpacing.Small),
-                    contentAlignment = Alignment.Center,
+                        .padding(
+                            horizontal = SpSpacing.ScreenHorizontal,
+                            vertical = SpSpacing.Small,
+                        ),
                 ) {
-                    CircularProgressIndicator(
-                        color = SpColor.Primary,
-                        modifier = Modifier.size(20.dp),
-                        strokeWidth = 2.dp,
-                    )
+                    repeat(3) {
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = SpSpacing.Small),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                        ) {
+                            SpShimmer(width = 40.dp, height = 40.dp)
+                            Column(modifier = Modifier.weight(1f)) {
+                                SpShimmer(width = 140.dp, height = 14.dp)
+                                Spacer(Modifier.height(SpSpacing.XSmall))
+                                SpShimmer(width = 80.dp, height = 12.dp)
+                            }
+                        }
+                    }
                 }
             }
         }
 
         // Games section
-        if (results.games.results.isNotEmpty()) {
+        val gamesExpanded = SearchCategoryNames.GAMES in expandedCategories
+        val gamesCategory = resolveCategory(
+            category = results.games,
+            expandedCategory = expandedResults?.games,
+            isExpanded = gamesExpanded,
+        )
+        if (gamesCategory.results.isNotEmpty()) {
             item {
                 SearchSectionHeader(
-                    title = "Games",
-                    total = results.games.total,
-                    displayedCount = results.games.results.size,
+                    title = SearchCategoryNames.GAMES,
+                    total = gamesCategory.total,
+                    displayedCount = gamesCategory.results.size,
+                    isExpanded = gamesExpanded,
+                    onSeeAll = { onExpandCategory(SearchCategoryNames.GAMES) },
+                    onShowLess = { onCollapseCategory(SearchCategoryNames.GAMES) },
                 )
             }
             items(
-                count = results.games.results.size,
-                key = { "game_${results.games.results[it].id}" },
+                count = gamesCategory.results.size,
+                key = { "game_${gamesCategory.results[it].id}" },
             ) { index ->
-                val game = results.games.results[index]
+                val game = gamesCategory.results[index]
                 GameSearchResultItem(
                     game = game,
                     onClick = { onGameSelected(game.id) },
@@ -76,19 +113,28 @@ fun SearchResultsList(
         }
 
         // Consoles section
-        if (results.consoles.results.isNotEmpty()) {
+        val consolesExpanded = SearchCategoryNames.CONSOLES in expandedCategories
+        val consolesCategory = resolveCategory(
+            category = results.consoles,
+            expandedCategory = expandedResults?.consoles,
+            isExpanded = consolesExpanded,
+        )
+        if (consolesCategory.results.isNotEmpty()) {
             item {
                 SearchSectionHeader(
-                    title = "Consoles",
-                    total = results.consoles.total,
-                    displayedCount = results.consoles.results.size,
+                    title = SearchCategoryNames.CONSOLES,
+                    total = consolesCategory.total,
+                    displayedCount = consolesCategory.results.size,
+                    isExpanded = consolesExpanded,
+                    onSeeAll = { onExpandCategory(SearchCategoryNames.CONSOLES) },
+                    onShowLess = { onCollapseCategory(SearchCategoryNames.CONSOLES) },
                 )
             }
             items(
-                count = results.consoles.results.size,
-                key = { "console_${results.consoles.results[it].id}" },
+                count = consolesCategory.results.size,
+                key = { "console_${consolesCategory.results[it].id}" },
             ) { index ->
-                val console = results.consoles.results[index]
+                val console = consolesCategory.results[index]
                 ConsoleSearchResultItem(
                     console = console,
                     onClick = { onConsoleSelected(console.id) },
@@ -97,19 +143,28 @@ fun SearchResultsList(
         }
 
         // Developers section
-        if (results.developers.results.isNotEmpty()) {
+        val developersExpanded = SearchCategoryNames.DEVELOPERS in expandedCategories
+        val developersCategory = resolveCategory(
+            category = results.developers,
+            expandedCategory = expandedResults?.developers,
+            isExpanded = developersExpanded,
+        )
+        if (developersCategory.results.isNotEmpty()) {
             item {
                 SearchSectionHeader(
-                    title = "Developers",
-                    total = results.developers.total,
-                    displayedCount = results.developers.results.size,
+                    title = SearchCategoryNames.DEVELOPERS,
+                    total = developersCategory.total,
+                    displayedCount = developersCategory.results.size,
+                    isExpanded = developersExpanded,
+                    onSeeAll = { onExpandCategory(SearchCategoryNames.DEVELOPERS) },
+                    onShowLess = { onCollapseCategory(SearchCategoryNames.DEVELOPERS) },
                 )
             }
             items(
-                count = results.developers.results.size,
-                key = { "developer_${results.developers.results[it].name}" },
+                count = developersCategory.results.size,
+                key = { "developer_${developersCategory.results[it].name}" },
             ) { index ->
-                val developer = results.developers.results[index]
+                val developer = developersCategory.results[index]
                 CompanySearchResultItem(
                     name = developer.name,
                     gameCount = developer.gameCount,
@@ -121,19 +176,28 @@ fun SearchResultsList(
         }
 
         // Publishers section
-        if (results.publishers.results.isNotEmpty()) {
+        val publishersExpanded = SearchCategoryNames.PUBLISHERS in expandedCategories
+        val publishersCategory = resolveCategory(
+            category = results.publishers,
+            expandedCategory = expandedResults?.publishers,
+            isExpanded = publishersExpanded,
+        )
+        if (publishersCategory.results.isNotEmpty()) {
             item {
                 SearchSectionHeader(
-                    title = "Publishers",
-                    total = results.publishers.total,
-                    displayedCount = results.publishers.results.size,
+                    title = SearchCategoryNames.PUBLISHERS,
+                    total = publishersCategory.total,
+                    displayedCount = publishersCategory.results.size,
+                    isExpanded = publishersExpanded,
+                    onSeeAll = { onExpandCategory(SearchCategoryNames.PUBLISHERS) },
+                    onShowLess = { onCollapseCategory(SearchCategoryNames.PUBLISHERS) },
                 )
             }
             items(
-                count = results.publishers.results.size,
-                key = { "publisher_${results.publishers.results[it].name}" },
+                count = publishersCategory.results.size,
+                key = { "publisher_${publishersCategory.results[it].name}" },
             ) { index ->
-                val publisher = results.publishers.results[index]
+                val publisher = publishersCategory.results[index]
                 CompanySearchResultItem(
                     name = publisher.name,
                     gameCount = publisher.gameCount,
@@ -145,19 +209,28 @@ fun SearchResultsList(
         }
 
         // Collections section
-        if (results.collections.results.isNotEmpty()) {
+        val collectionsExpanded = SearchCategoryNames.COLLECTIONS in expandedCategories
+        val collectionsCategory = resolveCategory(
+            category = results.collections,
+            expandedCategory = expandedResults?.collections,
+            isExpanded = collectionsExpanded,
+        )
+        if (collectionsCategory.results.isNotEmpty()) {
             item {
                 SearchSectionHeader(
-                    title = "Collections",
-                    total = results.collections.total,
-                    displayedCount = results.collections.results.size,
+                    title = SearchCategoryNames.COLLECTIONS,
+                    total = collectionsCategory.total,
+                    displayedCount = collectionsCategory.results.size,
+                    isExpanded = collectionsExpanded,
+                    onSeeAll = { onExpandCategory(SearchCategoryNames.COLLECTIONS) },
+                    onShowLess = { onCollapseCategory(SearchCategoryNames.COLLECTIONS) },
                 )
             }
             items(
-                count = results.collections.results.size,
-                key = { "collection_${results.collections.results[it].id}" },
+                count = collectionsCategory.results.size,
+                key = { "collection_${collectionsCategory.results[it].id}" },
             ) { index ->
-                val collection = results.collections.results[index]
+                val collection = collectionsCategory.results[index]
                 CollectionSearchResultItem(
                     collection = collection,
                     onClick = { onCollectionSelected(collection.id) },
@@ -166,19 +239,28 @@ fun SearchResultsList(
         }
 
         // Series section
-        if (results.series.results.isNotEmpty()) {
+        val seriesExpanded = SearchCategoryNames.SERIES in expandedCategories
+        val seriesCategory = resolveCategory(
+            category = results.series,
+            expandedCategory = expandedResults?.series,
+            isExpanded = seriesExpanded,
+        )
+        if (seriesCategory.results.isNotEmpty()) {
             item {
                 SearchSectionHeader(
-                    title = "Series",
-                    total = results.series.total,
-                    displayedCount = results.series.results.size,
+                    title = SearchCategoryNames.SERIES,
+                    total = seriesCategory.total,
+                    displayedCount = seriesCategory.results.size,
+                    isExpanded = seriesExpanded,
+                    onSeeAll = { onExpandCategory(SearchCategoryNames.SERIES) },
+                    onShowLess = { onCollapseCategory(SearchCategoryNames.SERIES) },
                 )
             }
             items(
-                count = results.series.results.size,
-                key = { "series_${results.series.results[it].id}" },
+                count = seriesCategory.results.size,
+                key = { "series_${seriesCategory.results[it].id}" },
             ) { index ->
-                val series = results.series.results[index]
+                val series = seriesCategory.results[index]
                 SeriesSearchResultItem(
                     series = series,
                     onClick = { onSeriesSelected(series.id, series.name) },
@@ -187,19 +269,28 @@ fun SearchResultsList(
         }
 
         // Franchises section
-        if (results.franchises.results.isNotEmpty()) {
+        val franchisesExpanded = SearchCategoryNames.FRANCHISES in expandedCategories
+        val franchisesCategory = resolveCategory(
+            category = results.franchises,
+            expandedCategory = expandedResults?.franchises,
+            isExpanded = franchisesExpanded,
+        )
+        if (franchisesCategory.results.isNotEmpty()) {
             item {
                 SearchSectionHeader(
-                    title = "Franchises",
-                    total = results.franchises.total,
-                    displayedCount = results.franchises.results.size,
+                    title = SearchCategoryNames.FRANCHISES,
+                    total = franchisesCategory.total,
+                    displayedCount = franchisesCategory.results.size,
+                    isExpanded = franchisesExpanded,
+                    onSeeAll = { onExpandCategory(SearchCategoryNames.FRANCHISES) },
+                    onShowLess = { onCollapseCategory(SearchCategoryNames.FRANCHISES) },
                 )
             }
             items(
-                count = results.franchises.results.size,
-                key = { "franchise_${results.franchises.results[it].id}" },
+                count = franchisesCategory.results.size,
+                key = { "franchise_${franchisesCategory.results[it].id}" },
             ) { index ->
-                val franchise = results.franchises.results[index]
+                val franchise = franchisesCategory.results[index]
                 FranchiseSearchResultItem(
                     franchise = franchise,
                     onClick = { onFranchiseSelected(franchise.id, franchise.name) },
@@ -209,5 +300,22 @@ fun SearchResultsList(
 
         // Bottom spacer
         item { Spacer(Modifier.height(SpSpacing.XLarge)) }
+    }
+}
+
+/**
+ * Resolves which category data to display. When a category is expanded
+ * and expanded results are available, use those. Otherwise use the
+ * default (limit=5) results.
+ */
+private fun <T> resolveCategory(
+    category: SearchCategory<T>,
+    expandedCategory: SearchCategory<T>?,
+    isExpanded: Boolean,
+): SearchCategory<T> {
+    return if (isExpanded && expandedCategory != null) {
+        expandedCategory
+    } else {
+        category
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreFranchiseScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreFranchiseScreen.kt
@@ -9,19 +9,19 @@ import com.spela.player.presentation.ui.feature.explore.ExploreGroupDetailConten
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 
 @Composable
-fun ExploreSeriesScreen(
-    seriesId: String,
-    seriesName: String,
+fun ExploreFranchiseScreen(
+    franchiseId: String,
+    franchiseName: String,
     viewModel: ExploreViewModel,
     onGameSelected: (String) -> Unit,
     onBack: () -> Unit,
 ) {
     PlatformBackHandler { onBack() }
 
-    val state by viewModel.seriesDetailState.collectAsState()
+    val state by viewModel.franchiseDetailState.collectAsState()
 
-    LaunchedEffect(seriesId) {
-        viewModel.loadSeriesDetail(seriesId, seriesName)
+    LaunchedEffect(franchiseId) {
+        viewModel.loadFranchiseDetail(franchiseId, franchiseName)
     }
 
     ExploreGroupDetailContent(
@@ -30,15 +30,15 @@ fun ExploreSeriesScreen(
         consoleFilter = state.consoleFilter,
         isLoading = state.isLoading,
         error = state.error,
-        title = seriesName,
-        groupLabel = "series",
+        title = franchiseName,
+        groupLabel = "franchise",
         onGameSelected = onGameSelected,
         onBack = onBack,
         onConsoleFilterSelected = { abbreviation ->
-            viewModel.setSeriesConsoleFilter(
+            viewModel.setFranchiseConsoleFilter(
                 if (abbreviation != null && state.consoleFilter == abbreviation) null else abbreviation,
             )
         },
-        onDismissError = { viewModel.dismissSeriesDetailError() },
+        onDismissError = { viewModel.dismissFranchiseDetailError() },
     )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -1,17 +1,25 @@
 package com.spela.player.presentation.ui.screen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Explore
 import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -19,10 +27,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.material3.Icon
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
-import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.gamepad.spFocusRing
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -66,6 +79,7 @@ import com.spela.player.presentation.ui.feature.explore.WildFeaturesSection
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 
 @Composable
@@ -83,6 +97,7 @@ fun ExploreScreen(
     onGallerySelected: (() -> Unit)? = null,
     onSurpriseMe: (() -> Unit)? = null,
     onWizardSelected: (() -> Unit)? = null,
+    onGlobalSearchSelected: (() -> Unit)? = null,
     onSearchSelected: (() -> Unit)? = null,
 ) {
     val state by viewModel.state.collectAsState()
@@ -143,25 +158,16 @@ fun ExploreScreen(
                         }
                     }
 
-                    // Advanced search entry point
+                    // Global search entry point — tappable search bar
                     item {
-                        SpChip(
-                            text = "Advanced Search & Filters",
-                            onClick = { onSearchSelected?.invoke() },
-                            leadingIcon = {
-                                Icon(
-                                    imageVector = Icons.Filled.Search,
-                                    contentDescription = null,
-                                    tint = SpColor.OnBackgroundSecondary,
-                                    modifier = Modifier.height(16.dp),
-                                )
-                            },
+                        SearchBarEntryPoint(
+                            onClick = { onGlobalSearchSelected?.invoke() },
                             modifier = Modifier
                                 .padding(
                                     horizontal = SpSpacing.ScreenHorizontal,
                                     vertical = SpSpacing.Small,
                                 )
-                                .testTag("explore_search_chip"),
+                                .testTag("explore_search_bar"),
                         )
                     }
 
@@ -771,6 +777,43 @@ fun ExploreScreen(
             },
             onDismiss = { viewModel.dismissError() },
             modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}
+
+@Composable
+private fun SearchBarEntryPoint(
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val shape = RoundedCornerShape(SpSpacing.RadiusLarge)
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .spFocusRing(shape = shape)
+            .clip(shape)
+            .background(SpColor.SurfaceVariant)
+            .border(1.dp, SpColor.Divider, shape)
+            .clickable(onClick = onClick)
+            .focusable()
+            .padding(horizontal = SpSpacing.Default, vertical = 14.dp)
+            .semantics {
+                contentDescription = "Search games, consoles, developers"
+                role = Role.Button
+            },
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = Icons.Filled.Search,
+            contentDescription = null,
+            tint = SpColor.OnBackgroundTertiary,
+            modifier = Modifier.size(20.dp),
+        )
+        Spacer(Modifier.size(SpSpacing.Small))
+        Text(
+            text = "Search games, consoles, developers...",
+            style = SpTypography.BodyMedium,
+            color = SpColor.OnBackgroundTertiary,
         )
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -117,6 +117,7 @@ fun GameDetailScreen(
     onNavigateToGame: ((gameId: String) -> Unit)? = null,
     onNavigateToUser: ((userId: String) -> Unit)? = null,
     onNavigateToSeries: ((seriesId: String, seriesName: String) -> Unit)? = null,
+    onNavigateToFranchise: ((franchiseId: String, franchiseName: String) -> Unit)? = null,
     syncState: GameSyncState? = null,
     onPlayWithLocalSave: () -> Unit = {},
     onCancelLaunch: () -> Unit = {},
@@ -230,6 +231,7 @@ fun GameDetailScreen(
                             series = state.gameSeries,
                             franchises = state.gameFranchises,
                             onSeriesSelected = onNavigateToSeries,
+                            onFranchiseSelected = onNavigateToFranchise,
                         )
                     }
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalSearchScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalSearchScreen.kt
@@ -200,6 +200,7 @@ fun GlobalSearchScreen(
                     SearchResultsList(
                         results = state.results!!,
                         isLoading = state.isLoading,
+                        suggestions = state.suggestions,
                         expandedCategories = state.expandedCategories,
                         expandedResults = state.expandedResults,
                         onExpandCategory = { viewModel.expandCategory(it) },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalSearchScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalSearchScreen.kt
@@ -1,0 +1,219 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.TravelExplore
+import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTextField
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.feature.search.SearchResultSkeleton
+import com.spela.player.presentation.ui.feature.search.SearchResultsList
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.viewmodel.GlobalSearchViewModel
+
+@Composable
+fun GlobalSearchScreen(
+    viewModel: GlobalSearchViewModel,
+    onGameSelected: (String) -> Unit,
+    onConsoleSelected: (String) -> Unit,
+    onDeveloperSelected: (String) -> Unit,
+    onPublisherSelected: (String) -> Unit,
+    onCollectionSelected: (String) -> Unit,
+    onSeriesSelected: (String, String) -> Unit,
+    onFranchiseSelected: (String, String) -> Unit,
+    onAdvancedFiltersSelected: () -> Unit,
+    onBack: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val state by viewModel.state.collectAsState()
+    val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .testTag("global_search_screen"),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+        ) {
+            SpTopBar(
+                title = "Search",
+                showBack = true,
+                onBack = onBack,
+            )
+
+            // Search input
+            SpTextField(
+                value = state.query,
+                onValueChange = { viewModel.updateQuery(it) },
+                placeholder = "Search games, consoles, developers...",
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Filled.Search,
+                        contentDescription = null,
+                        tint = SpColor.OnBackgroundSecondary,
+                    )
+                },
+                trailingIcon = if (state.query.isNotEmpty()) {
+                    {
+                        IconButton(
+                            onClick = { viewModel.clearSearch() },
+                            modifier = Modifier.testTag("search_clear_button"),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Close,
+                                contentDescription = "Clear search",
+                                tint = SpColor.OnBackgroundSecondary,
+                            )
+                        }
+                    }
+                } else null,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                    .focusRequester(focusRequester)
+                    .testTag("global_search_input"),
+            )
+
+            Spacer(Modifier.height(SpSpacing.Small))
+
+            // Advanced Filters chip (Story 5)
+            SpChip(
+                text = "Advanced Filters",
+                onClick = onAdvancedFiltersSelected,
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Filled.Tune,
+                        contentDescription = null,
+                        tint = SpColor.OnBackgroundSecondary,
+                        modifier = Modifier.size(16.dp),
+                    )
+                },
+                modifier = Modifier
+                    .padding(horizontal = SpSpacing.ScreenHorizontal)
+                    .testTag("global_search_advanced_filters"),
+            )
+
+            Spacer(Modifier.height(SpSpacing.Small))
+
+            // Content area
+            when {
+                state.showPlaceholder -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.TravelExplore,
+                            title = "Find anything",
+                            message = "Search across games, consoles, developers, publishers, collections, series, and franchises.",
+                            modifier = Modifier.testTag("search_placeholder"),
+                        )
+                    }
+                }
+
+                state.showHint -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.Search,
+                            title = "Type at least 2 characters",
+                            message = "Search across games, consoles, developers, and more.",
+                            modifier = Modifier.testTag("search_hint"),
+                        )
+                    }
+                }
+
+                state.isLoading && !state.hasResults -> {
+                    SearchResultSkeleton(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(top = SpSpacing.Default)
+                            .testTag("search_loading"),
+                    )
+                }
+
+                state.showNoResults -> {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.Search,
+                            title = "No results found",
+                            message = "Try a different search term or use Advanced Filters for more options.",
+                            modifier = Modifier.testTag("search_no_results"),
+                        )
+                    }
+                }
+
+                state.hasResults -> {
+                    SearchResultsList(
+                        results = state.results!!,
+                        isLoading = state.isLoading,
+                        onGameSelected = onGameSelected,
+                        onConsoleSelected = onConsoleSelected,
+                        onDeveloperSelected = onDeveloperSelected,
+                        onPublisherSelected = onPublisherSelected,
+                        onCollectionSelected = onCollectionSelected,
+                        onSeriesSelected = onSeriesSelected,
+                        onFranchiseSelected = onFranchiseSelected,
+                    )
+                }
+            }
+        }
+
+        // Error snackbar
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.dismissError() },
+                )
+            },
+            onDismiss = { viewModel.dismissError() },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalSearchScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalSearchScreen.kt
@@ -35,6 +35,7 @@ import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTextField
 import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.feature.search.RecentSearchesSection
 import com.spela.player.presentation.ui.feature.search.SearchResultSkeleton
 import com.spela.player.presentation.ui.feature.search.SearchResultsList
 import com.spela.player.presentation.ui.theme.SpColor
@@ -135,6 +136,15 @@ fun GlobalSearchScreen(
 
             // Content area
             when {
+                state.showRecentSearches -> {
+                    RecentSearchesSection(
+                        recentSearches = state.recentSearches,
+                        onRecentSearchSelected = { viewModel.selectRecentSearch(it) },
+                        onRemoveRecentSearch = { viewModel.removeRecentSearch(it) },
+                        onClearAll = { viewModel.clearRecentSearches() },
+                    )
+                }
+
                 state.showPlaceholder -> {
                     Box(
                         modifier = Modifier.fillMaxSize(),
@@ -190,6 +200,10 @@ fun GlobalSearchScreen(
                     SearchResultsList(
                         results = state.results!!,
                         isLoading = state.isLoading,
+                        expandedCategories = state.expandedCategories,
+                        expandedResults = state.expandedResults,
+                        onExpandCategory = { viewModel.expandCategory(it) },
+                        onCollapseCategory = { viewModel.collapseCategory(it) },
                         onGameSelected = onGameSelected,
                         onConsoleSelected = onConsoleSelected,
                         onDeveloperSelected = onDeveloperSelected,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.material.icons.filled.Favorite
 import androidx.compose.material.icons.filled.History
 import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.PlayArrow
+import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.NewReleases
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.filled.WatchLater
@@ -108,6 +109,7 @@ fun HomeScreen(
     onChallengeSelected: (String) -> Unit = {},
     onNetplaySessionSelected: (String) -> Unit = {},
     onUserSelected: (String) -> Unit = {},
+    onSearchSelected: () -> Unit = {},
     hasActiveDownloads: Boolean = false,
     activeNetplaySessions: List<NetplaySession> = emptyList(),
 ) {
@@ -206,6 +208,11 @@ fun HomeScreen(
                                         style = SpTypography.HeadlineMedium,
                                         color = SpColor.OnBackground,
                                         modifier = Modifier.weight(1f),
+                                    )
+                                    SpIconButton(
+                                        icon = Icons.Filled.Search,
+                                        contentDescription = "Search",
+                                        onClick = onSearchSelected,
                                     )
                                     if (hasActiveDownloads) {
                                         SpIconButton(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -207,6 +207,26 @@ data class SeriesDetailState(
         }
 }
 
+data class FranchiseDetailState(
+    val franchiseId: String = "",
+    val franchiseName: String = "",
+    val detail: SeriesDetail? = null,
+    val consoleFilter: String? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+) {
+    val filteredGames: List<com.spela.player.domain.model.SeriesGame>
+        get() {
+            val games = detail?.games ?: return emptyList()
+            val filtered = if (consoleFilter != null) {
+                games.filter { it.consoleAbbreviation == consoleFilter }
+            } else {
+                games
+            }
+            return filtered.sortedWith(compareBy(nullsLast()) { it.releaseDate })
+        }
+}
+
 
 private const val GALLERY_PAGE_SIZE = 40
 class ExploreViewModel(
@@ -226,6 +246,8 @@ class ExploreViewModel(
     private val _seriesDetailState = MutableStateFlow(SeriesDetailState())
     val seriesDetailState: StateFlow<SeriesDetailState> = _seriesDetailState.asStateFlow()
 
+    private val _franchiseDetailState = MutableStateFlow(FranchiseDetailState())
+    val franchiseDetailState: StateFlow<FranchiseDetailState> = _franchiseDetailState.asStateFlow()
 
     private val _moodDetailState = MutableStateFlow(MoodDetailState())
     val moodDetailState: StateFlow<MoodDetailState> = _moodDetailState.asStateFlow()
@@ -258,6 +280,7 @@ class ExploreViewModel(
     private var keywordDetailJob: Job? = null
     private var featuredSeriesJob: Job? = null
     private var seriesDetailJob: Job? = null
+    private var franchiseDetailJob: Job? = null
 
     private var moodsJob: Job? = null
     private var moodDetailJob: Job? = null
@@ -361,6 +384,31 @@ class ExploreViewModel(
 
     fun dismissSeriesDetailError() {
         _seriesDetailState.update { it.copy(error = null) }
+    }
+
+    fun loadFranchiseDetail(franchiseId: String, franchiseName: String) {
+        franchiseDetailJob?.cancel()
+        _franchiseDetailState.update {
+            FranchiseDetailState(franchiseId = franchiseId, franchiseName = franchiseName, isLoading = true)
+        }
+        franchiseDetailJob = scope.launch(dispatchers.io) {
+            exploreRepository.getFranchiseDetail(franchiseId).fold(
+                onSuccess = { detail ->
+                    _franchiseDetailState.update { it.copy(detail = detail, isLoading = false) }
+                },
+                onFailure = { error ->
+                    _franchiseDetailState.update { it.copy(isLoading = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun setFranchiseConsoleFilter(abbreviation: String?) {
+        _franchiseDetailState.update { it.copy(consoleFilter = abbreviation) }
+    }
+
+    fun dismissFranchiseDetailError() {
+        _franchiseDetailState.update { it.copy(error = null) }
     }
 
     private fun loadFeatured() {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GlobalSearchViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GlobalSearchViewModel.kt
@@ -1,6 +1,8 @@
 package com.spela.player.presentation.viewmodel
 
 import com.spela.player.domain.model.GlobalSearchResult
+import com.spela.player.domain.model.SearchSuggestion
+import com.spela.player.domain.model.SuggestionNavigationType
 import com.spela.player.domain.repository.SearchRepository
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
@@ -15,6 +17,7 @@ import kotlinx.coroutines.launch
 data class GlobalSearchState(
     val query: String = "",
     val results: GlobalSearchResult? = null,
+    val suggestions: List<SearchSuggestion> = emptyList(),
     val isLoading: Boolean = false,
     val error: String? = null,
     val recentSearches: List<String> = emptyList(),
@@ -56,7 +59,7 @@ class GlobalSearchViewModel(
 
         val trimmed = query.trim()
         if (trimmed.length < 2) {
-            _state.update { it.copy(results = null, isLoading = false) }
+            _state.update { it.copy(results = null, suggestions = emptyList(), isLoading = false) }
             return
         }
 
@@ -70,7 +73,9 @@ class GlobalSearchViewModel(
                     _state.update {
                         it.copy(
                             results = result,
+                            suggestions = computeSuggestions(result),
                             isLoading = false,
+                            error = null,
                             recentSearches = searchRepository.getRecentSearches(),
                         )
                     }
@@ -140,6 +145,103 @@ class GlobalSearchViewModel(
         scope.launch(dispatchers.io) {
             val recents = searchRepository.getRecentSearches()
             _state.update { it.copy(recentSearches = recents) }
+        }
+    }
+
+    private companion object {
+        const val SUGGESTION_CAP = 5
+
+        fun computeSuggestions(result: GlobalSearchResult): List<SearchSuggestion> {
+            val items = mutableListOf<SearchSuggestion>()
+
+            // Priority 1: Up to 2 games
+            result.games.results.take(2).forEach { game ->
+                items.add(
+                    SearchSuggestion(
+                        id = game.id,
+                        name = game.title,
+                        subtitle = game.consoleName,
+                        imageUrl = game.coverUrl,
+                        navigationType = SuggestionNavigationType.Game(game.id),
+                    )
+                )
+            }
+
+            // Priority 2: Up to 1 console
+            result.consoles.results.take(1).forEach { console ->
+                items.add(
+                    SearchSuggestion(
+                        id = console.id,
+                        name = console.name,
+                        subtitle = "${console.gameCount} games",
+                        imageUrl = console.iconUrl.ifBlank { null },
+                        navigationType = SuggestionNavigationType.Console(console.id),
+                    )
+                )
+            }
+
+            // Priority 3: Up to 1 developer
+            result.developers.results.take(1).forEach { dev ->
+                items.add(
+                    SearchSuggestion(
+                        id = dev.name,
+                        name = dev.name,
+                        subtitle = "${dev.gameCount} games",
+                        navigationType = SuggestionNavigationType.Developer(dev.name),
+                    )
+                )
+            }
+
+            // Priority 4: Up to 1 publisher
+            result.publishers.results.take(1).forEach { pub ->
+                items.add(
+                    SearchSuggestion(
+                        id = pub.name,
+                        name = pub.name,
+                        subtitle = "${pub.gameCount} games",
+                        navigationType = SuggestionNavigationType.Publisher(pub.name),
+                    )
+                )
+            }
+
+            // Priority 5: Up to 1 collection
+            result.collections.results.take(1).forEach { coll ->
+                items.add(
+                    SearchSuggestion(
+                        id = coll.id,
+                        name = coll.name,
+                        subtitle = "${coll.gameCount} games",
+                        imageUrl = coll.coverUrl,
+                        navigationType = SuggestionNavigationType.Collection(coll.id),
+                    )
+                )
+            }
+
+            // Priority 6: Up to 1 series
+            result.series.results.take(1).forEach { s ->
+                items.add(
+                    SearchSuggestion(
+                        id = s.id,
+                        name = s.name,
+                        subtitle = "${s.libraryGames}/${s.totalGames} games in library",
+                        navigationType = SuggestionNavigationType.Series(s.id, s.name),
+                    )
+                )
+            }
+
+            // Priority 7: Up to 1 franchise
+            result.franchises.results.take(1).forEach { f ->
+                items.add(
+                    SearchSuggestion(
+                        id = f.id,
+                        name = f.name,
+                        subtitle = "${f.libraryGames}/${f.totalGames} games in library",
+                        navigationType = SuggestionNavigationType.Franchise(f.id, f.name),
+                    )
+                )
+            }
+
+            return items.take(SUGGESTION_CAP)
         }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GlobalSearchViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GlobalSearchViewModel.kt
@@ -1,0 +1,145 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.domain.model.GlobalSearchResult
+import com.spela.player.domain.repository.SearchRepository
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class GlobalSearchState(
+    val query: String = "",
+    val results: GlobalSearchResult? = null,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+    val recentSearches: List<String> = emptyList(),
+    val expandedCategories: Set<String> = emptySet(),
+    val expandedResults: GlobalSearchResult? = null,
+) {
+    val hasResults: Boolean get() = results != null && !results.isEmpty
+    val showHint: Boolean get() = query.trim().length < 2 && query.isNotEmpty() && !isLoading && results == null
+    val showNoResults: Boolean get() = query.trim().length >= 2 && !isLoading && results != null && results.isEmpty
+    val showPlaceholder: Boolean get() = query.isEmpty() && !isLoading && results == null && recentSearches.isEmpty()
+    val showRecentSearches: Boolean get() = query.isEmpty() && recentSearches.isNotEmpty()
+}
+
+class GlobalSearchViewModel(
+    private val searchRepository: SearchRepository,
+    private val dispatchers: DispatcherProvider,
+    private val scope: CoroutineScope,
+) {
+    private val _state = MutableStateFlow(GlobalSearchState())
+    val state: StateFlow<GlobalSearchState> = _state.asStateFlow()
+
+    private var searchJob: Job? = null
+
+    init {
+        loadRecentSearches()
+    }
+
+    fun updateQuery(query: String) {
+        _state.update {
+            it.copy(
+                query = query,
+                error = null,
+                expandedCategories = emptySet(),
+                expandedResults = null,
+            )
+        }
+
+        searchJob?.cancel()
+
+        val trimmed = query.trim()
+        if (trimmed.length < 2) {
+            _state.update { it.copy(results = null, isLoading = false) }
+            return
+        }
+
+        _state.update { it.copy(isLoading = true) }
+
+        searchJob = scope.launch(dispatchers.io) {
+            delay(250) // debounce
+            searchRepository.globalSearch(trimmed).fold(
+                onSuccess = { result ->
+                    searchRepository.addRecentSearch(trimmed)
+                    _state.update {
+                        it.copy(
+                            results = result,
+                            isLoading = false,
+                            recentSearches = searchRepository.getRecentSearches(),
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoading = false, error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun clearSearch() {
+        searchJob?.cancel()
+        _state.update {
+            GlobalSearchState(recentSearches = searchRepository.getRecentSearches())
+        }
+    }
+
+    fun dismissError() {
+        _state.update { it.copy(error = null) }
+    }
+
+    fun selectRecentSearch(query: String) {
+        _state.update { it.copy(query = query) }
+        updateQuery(query)
+    }
+
+    fun removeRecentSearch(query: String) {
+        scope.launch(dispatchers.io) {
+            searchRepository.removeRecentSearch(query)
+            val recents = searchRepository.getRecentSearches()
+            _state.update { it.copy(recentSearches = recents) }
+        }
+    }
+
+    fun clearRecentSearches() {
+        scope.launch(dispatchers.io) {
+            searchRepository.clearRecentSearches()
+            _state.update { it.copy(recentSearches = emptyList()) }
+        }
+    }
+
+    fun expandCategory(category: String) {
+        val current = _state.value
+        val newExpanded = current.expandedCategories + category
+        _state.update { it.copy(expandedCategories = newExpanded) }
+
+        // Re-fetch with higher limit if not already done
+        if (current.expandedResults == null) {
+            scope.launch(dispatchers.io) {
+                val trimmed = current.query.trim()
+                searchRepository.globalSearch(trimmed, limit = 50).fold(
+                    onSuccess = { result ->
+                        _state.update { it.copy(expandedResults = result) }
+                    },
+                    onFailure = { /* Keep showing original results */ },
+                )
+            }
+        }
+    }
+
+    fun collapseCategory(category: String) {
+        _state.update { it.copy(expandedCategories = it.expandedCategories - category) }
+    }
+
+    private fun loadRecentSearches() {
+        scope.launch(dispatchers.io) {
+            val recents = searchRepository.getRecentSearches()
+            _state.update { it.copy(recentSearches = recents) }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/FormatUtils.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/FormatUtils.kt
@@ -35,5 +35,9 @@ fun formatBytes(bytes: Long): String {
         value /= 1024
         unitIndex++
     }
-    return "%.1f %s".format(value, units[unitIndex])
+    return if (value == value.toLong().toDouble()) {
+        "${value.toLong()} ${units[unitIndex]}"
+    } else {
+        "%.1f %s".format(value, units[unitIndex])
+    }
 }


### PR DESCRIPTION
## Summary
- **Phase 1**: Global search screen with debounced multi-category search (games, consoles, developers, publishers, collections, series, franchises). Entry points from Explore tab search bar, Home screen icon, and Cmd+K/Ctrl+K on desktop.
- **Phase 2**: Recent searches (persisted locally), franchise detail screen (shared composable with series), "See all" / "Show less" for expandable result categories.
- **Phase 3**: Gamepad Select button shortcut to open search on Android, quick results section with top 5 suggestions at the top of search results.
- **Bug fix**: `formatBytes()` now omits decimal for whole numbers ("128 KB" not "128.0 KB").

## Test plan
- [x] 51 new desktop E2E tests covering all search states, navigation, recent searches, franchise detail, "see more", and quick results
- [x] Full desktop test suite passes (668 tests, 0 failures)
- [ ] Manual test on Android device (gamepad Select button opens search)
- [ ] Manual test on desktop (Cmd+K opens search)