### PR TITLE
feat: add ROM hack support with patch application and admin UI

### DIFF
--- a/design-proposals/rom-hacks-minimal-stories.md
+++ b/design-proposals/rom-hacks-minimal-stories.md
@@ -1,0 +1,182 @@
+# ROM Hacks -- Minimal Feature Set
+
+## Context
+
+Spela already handles pre-patched ROMs. If someone drops a patched ROM file into
+their games folder, the scanner picks it up, the `[hack]` tag is parsed from the
+filename, and it groups with the original game via the variant system (same
+normalized GroupKey). It can be played like any other game.
+
+The gaps are:
+
+1. Hacks look identical to regional variants in the UI -- there is no visual
+   distinction between "Super Mario Bros (Europe)" and "Super Mario Bros [hack]".
+2. There is no way to create a standalone game entry for a total conversion
+   (e.g. a hack that is effectively a new game and deserves its own library entry).
+3. Admins cannot upload a patch file and have the server apply it to a base ROM --
+   they must patch manually and drop the result into the games directory.
+
+This proposal addresses all three gaps with the smallest possible feature set.
+No RHDN integration, no archive.org downloads, no on-demand patching, no patch
+metadata database.
+
+## How It Works
+
+The admin uploads a patch file (.ips, .bps, .ups, .xdelta) and selects a base
+ROM. The server applies the patch **once** at upload time and stores the
+resulting ROM file permanently. The patch is a tool, not runtime state -- the
+output is a normal ROM file that the system treats like any other game. Save
+states, netplay, achievements, and all existing features work automatically.
+
+The admin chooses one of two outcomes:
+
+- **Variant**: the patched ROM becomes a variant of the base game, with a label
+  (e.g. "English Translation", "Bugfix v1.2"). It appears in a "ROM Hacks"
+  sub-section on the base game's detail page, separate from regional variants.
+- **Standalone game**: the patched ROM becomes its own game entry with a "Based
+  on [parent game]" link. The admin provides a title and can later set cover art
+  and description via existing metadata editing.
+
+---
+
+## Stories
+
+### Story 1: Separate hacks from regional variants in the variants section
+
+**As a** player
+**I want to** see ROM hacks listed separately from regional variants on the game detail page
+**So that** I can quickly find translations and hack variants without them being mixed in with USA/Europe/Japan versions.
+
+**Acceptance criteria:**
+- [ ] On the game detail page, variants with the `hack` tag are displayed in a "ROM Hacks" sub-section, separate from other variants
+- [ ] Regional/revision variants without the `hack` tag are displayed in a "Versions" sub-section (the existing behavior, just with a heading)
+- [ ] If there are no hack variants, the "ROM Hacks" sub-section is hidden
+- [ ] If there are no regional variants, the "Versions" sub-section is hidden
+- [ ] Hack variants still show region, revision, and file size chips where applicable
+- [ ] This applies to both the web frontend and the player app
+
+**Notes:**
+- The `tags` field on `VariantResponse` already contains `"hack"` when parsed from `[hack]` in the filename -- this is a pure UI change
+- The player app already has a `VariantsSection` composable that renders all variants in a single list titled "Versions" -- split it into two lists
+
+---
+
+### Story 2: Server-side patch application endpoint
+
+**As a** server admin
+**I want to** upload a patch file and have the server apply it to a base ROM
+**So that** I do not have to manually patch ROMs on my own machine before adding them to the library.
+
+**Acceptance criteria:**
+- [ ] New admin endpoint `POST /api/admin/rom-hacks` accepts a multipart form with: patch file, base game ID, output mode ("variant" or "standalone"), label/title
+- [ ] The server applies the patch to the base game's ROM file using the appropriate patching algorithm based on file extension (.ips, .bps, .ups, .xdelta)
+- [ ] The patched ROM file is written to the games directory with a descriptive filename
+- [ ] If the patch fails to apply (corrupt file, wrong base ROM, unsupported format), the endpoint returns a clear error message
+- [ ] The endpoint returns the created game's ID on success
+- [ ] Supported patch formats: IPS, BPS, UPS, xdelta
+
+**Notes:**
+- Use existing Go libraries for patch application where available; for IPS the format is simple enough to implement directly
+- The patch file itself can be discarded after successful application
+- The patched ROM filename should include the label/title to be human-readable in the filesystem
+
+---
+
+### Story 3: Create ROM hack as a variant of the base game
+
+**As a** server admin
+**I want to** create a patched ROM that appears as a variant of the base game
+**So that** translations, bugfixes, and minor hacks are grouped with the original game rather than cluttering the library as separate entries.
+
+**Acceptance criteria:**
+- [ ] When the admin selects "variant" mode, the patched ROM is created as a new game entry with the same `GroupKey` and `ConsoleID` as the base game
+- [ ] The variant's `tags` field includes `"hack"`
+- [ ] The variant inherits the base game's metadata (description, cover art, developer, publisher, genre, release date) so it is not a blank entry
+- [ ] The admin-provided label (e.g. "English Translation") is stored and visible in the variant's title or as a tag
+- [ ] The variant appears in the "ROM Hacks" sub-section on the base game's detail page (per Story 1)
+- [ ] The variant is playable immediately after creation
+
+**Notes:**
+- The variant should not become the primary game in the group -- the election algorithm should deprioritize hack-tagged games
+- Consider whether to add the label to the title (e.g. "Super Mario Bros [English Translation]") or as a separate display field
+
+---
+
+### Story 4: Create ROM hack as a standalone game
+
+**As a** server admin
+**I want to** create a patched ROM that appears as its own game in the library
+**So that** total conversions and major hacks that are effectively new games get their own library entry with a custom title, cover, and description.
+
+**Acceptance criteria:**
+- [ ] When the admin selects "standalone" mode, the patched ROM is created as a new game entry with a unique `GroupKey` (not grouped with the base game)
+- [ ] The admin provides a title for the new game entry
+- [ ] The new game entry has a `ParentGameID` field linking it to the base game
+- [ ] The standalone hack is listed in the library like any other game
+- [ ] The admin can later edit the game's metadata (cover art, description) using the existing metadata editing flow
+- [ ] The standalone hack is playable immediately after creation
+
+**Notes:**
+- A new nullable `ParentGameID` field on the `Game` model stores the relationship
+- The standalone hack inherits the base game's `ConsoleID` but gets its own `GroupKey`
+
+---
+
+### Story 5: "Based on" display for standalone ROM hacks
+
+**As a** player
+**I want to** see which game a standalone ROM hack is based on
+**So that** I understand the hack's origin and can navigate to the original game.
+
+**Acceptance criteria:**
+- [ ] Standalone hack game entries show "Based on [parent game title]" on their detail page, with the parent title as a clickable link
+- [ ] Clicking the parent game link navigates to the parent game's detail page
+- [ ] The parent game's detail page shows a "ROM Hacks" section listing standalone hacks based on it (title, cover thumbnail, link)
+- [ ] If the parent game is deleted, the "Based on" link is hidden gracefully (not a broken link)
+- [ ] This applies to both the web frontend and the player app
+
+**Notes:**
+- The API game detail response needs a new `parentGame` field with `{ id, title, coverUrl }` when `ParentGameID` is set
+- The API game detail response needs a new `romHacks` array listing standalone games where `ParentGameID` points to this game
+- On the parent's detail page, the "ROM Hacks" section is distinct from the variants-based "ROM Hacks" sub-section in Story 1 -- this one lists standalone games, the other lists hack-tagged variants
+
+---
+
+### Story 6: Admin "Add ROM Hack" page in the web UI
+
+**As a** server admin
+**I want to** a dedicated page in the admin panel for creating ROM hacks
+**So that** I can easily select a base game, upload a patch, and choose how to treat the result.
+
+**Acceptance criteria:**
+- [ ] A new "Add ROM Hack" page is accessible from the admin navigation
+- [ ] The page has a game search/picker to select the base game (with cover art preview)
+- [ ] The page has a file upload input for the patch file, restricted to supported extensions (.ips, .bps, .ups, .xdelta)
+- [ ] The page has a mode selector: "Add as variant" or "Create standalone game"
+- [ ] In variant mode, the admin provides a label (e.g. "English Translation")
+- [ ] In standalone mode, the admin provides a game title
+- [ ] A "Create" button submits the form and shows a progress/loading state while the patch is being applied
+- [ ] On success, the admin is navigated to the resulting game's detail page
+- [ ] On error, the error message is displayed clearly (e.g. "Patch failed: CRC mismatch")
+
+**Notes:**
+- Reuse the existing `GamePicker` component (`web/src/components/game-picker.tsx`) for base game selection
+- The existing admin upload page (`upload-roms-page.tsx`) can serve as a reference for the file upload UX pattern
+
+---
+
+### Story 7: Player app support for "Based on" and "ROM Hacks" sections
+
+**As a** player (using the native player app)
+**I want to** see the "Based on" link and "ROM Hacks" section on game detail screens
+**So that** I can discover and navigate between original games and their standalone hacks.
+
+**Acceptance criteria:**
+- [ ] The player app's game detail screen shows "Based on [parent game title]" when the game has a parent, with a tap target that navigates to the parent game
+- [ ] The player app's game detail screen shows a "ROM Hacks" section listing standalone hacks based on this game, each tappable to navigate to the hack's detail page
+- [ ] The "ROM Hacks" section is hidden when there are no standalone hacks
+- [ ] No other player app changes are needed -- standalone hacks are regular game entries that work with downloads, saves, and all existing features
+
+**Notes:**
+- The player app's `GameDetail` model and DTO mappers need to include the new `parentGame` and `romHacks` fields from the API
+- Standalone ROM hacks are regular game entries from the player app's perspective -- they download, save, and play through the existing code paths

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -100,10 +100,24 @@ fun GameVariantDto.toDomain(): GameVariant = GameVariant(
     verificationStatus = verificationStatus,
 )
 
+fun ParentGameDto.toDomain(): ParentGame = ParentGame(
+    id = id,
+    title = title,
+    coverUrl = coverUrl,
+)
+
+fun RomHackGameDto.toDomain(): RomHackGame = RomHackGame(
+    id = id,
+    title = title,
+    coverUrl = coverUrl,
+)
+
 fun GameDto.toGameDetail(): GameDetail = GameDetail(
     game = toDomain(),
     screenshots = screenshotUrls,
     variants = variants.map { it.toDomain() },
+    parentGame = parentGame?.toDomain(),
+    romHacks = romHacks.map { it.toDomain() },
 )
 
 fun SaveStateDto.toDomain(): SaveState = SaveState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -111,6 +111,8 @@ data class GameDto(
     val variantCount: Int = 0,
     val groupKey: String? = null,
     val variants: List<GameVariantDto> = emptyList(),
+    val parentGame: ParentGameDto? = null,
+    val romHacks: List<RomHackGameDto> = emptyList(),
     val timeToBeatHastily: Int = 0,
     val timeToBeatNormally: Int = 0,
     val timeToBeatCompletely: Int = 0,
@@ -129,6 +131,22 @@ data class GameVariantDto(
     val isPreRelease: Boolean = false,
     val fileSize: Long = 0,
     val verificationStatus: String? = null,
+)
+
+/** Minimal reference to a parent game for standalone ROM hacks. */
+@Serializable
+data class ParentGameDto(
+    val id: String,
+    val title: String,
+    val coverUrl: String? = null,
+)
+
+/** Minimal reference to a standalone ROM hack based on a game. */
+@Serializable
+data class RomHackGameDto(
+    val id: String,
+    val title: String,
+    val coverUrl: String? = null,
 )
 
 /** Wrapper for GET /api/games which returns {data, total, page, pageSize} */

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -110,11 +110,29 @@ data class GameVariant(
     val verificationStatus: String? = null,
 )
 
+/** Minimal reference to a parent game for standalone ROM hacks. */
+@Serializable
+data class ParentGame(
+    val id: String,
+    val title: String,
+    val coverUrl: String? = null,
+)
+
+/** Minimal reference to a standalone ROM hack based on a game. */
+@Serializable
+data class RomHackGame(
+    val id: String,
+    val title: String,
+    val coverUrl: String? = null,
+)
+
 @Serializable
 data class GameDetail(
     val game: Game,
     val screenshots: List<String> = emptyList(),
     val variants: List<GameVariant> = emptyList(),
+    val parentGame: ParentGame? = null,
+    val romHacks: List<RomHackGame> = emptyList(),
 )
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -35,12 +35,15 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.BiosMissingFile
 import com.spela.player.domain.model.DownloadState
 import com.spela.player.domain.model.Game
 import com.spela.player.domain.model.GameDetail
 import com.spela.player.domain.model.GameVariant
+import com.spela.player.domain.model.ParentGame
+import com.spela.player.domain.model.RomHackGame
 import com.spela.player.domain.model.NETPLAY_SUPPORTED_CONSOLES
 import com.spela.player.presentation.intent.GameDetailIntent
 import com.spela.player.presentation.state.GameDetailState
@@ -883,12 +886,47 @@ private fun GameInfoContent(
     // Metadata grid (Developer, Publisher, Released, Genre, Players, Size, Discs)
     MetadataGrid(game = game, onGradient = true)
 
-    // Variants section
-    if (detail.variants.isNotEmpty()) {
+    // Variants section -- split into Versions (non-hack) and ROM Hacks (hack-tagged)
+    val versionVariants = detail.variants.filter { variant ->
+        variant.tags?.split(",")?.map { it.trim().lowercase() }?.contains("hack") != true
+    }
+    val hackVariants = detail.variants.filter { variant ->
+        variant.tags?.split(",")?.map { it.trim().lowercase() }?.contains("hack") == true
+    }
+
+    if (versionVariants.isNotEmpty()) {
         Spacer(Modifier.height(SpSpacing.XLarge))
         VariantsSection(
-            variants = detail.variants,
+            title = "Versions",
+            variants = versionVariants,
             onVariantSelected = onNavigateToGame,
+        )
+    }
+
+    if (hackVariants.isNotEmpty()) {
+        Spacer(Modifier.height(SpSpacing.XLarge))
+        VariantsSection(
+            title = "ROM Hacks",
+            variants = hackVariants,
+            onVariantSelected = onNavigateToGame,
+        )
+    }
+
+    // "Based on" section for standalone ROM hacks
+    detail.parentGame?.let { parent ->
+        Spacer(Modifier.height(SpSpacing.XLarge))
+        BasedOnSection(
+            parentGame = parent,
+            onNavigateToGame = onNavigateToGame,
+        )
+    }
+
+    // Standalone ROM Hacks section
+    if (detail.romHacks.isNotEmpty()) {
+        Spacer(Modifier.height(SpSpacing.XLarge))
+        RomHacksSection(
+            romHacks = detail.romHacks,
+            onNavigateToGame = onNavigateToGame,
         )
     }
 }
@@ -1009,11 +1047,12 @@ private fun getRegionFlag(region: String): String? =
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun VariantsSection(
+    title: String,
     variants: List<GameVariant>,
     onVariantSelected: ((String) -> Unit)?,
 ) {
     SpTitledSection(
-        title = "Versions",
+        title = title,
         includeTopSpacing = false,
     ) {
         Column(
@@ -1076,4 +1115,84 @@ private fun formatVariantFileSize(bytes: Long): String {
     if (mb < 1024) return String.format("%.1f MB", mb)
     val gb = mb / 1024.0
     return String.format("%.2f GB", gb)
+}
+
+@Composable
+private fun BasedOnSection(
+    parentGame: ParentGame,
+    onNavigateToGame: ((String) -> Unit)?,
+) {
+    SpTitledSection(
+        title = "Based on",
+        includeTopSpacing = false,
+    ) {
+        SpCard(
+            onClick = { onNavigateToGame?.invoke(parentGame.id) },
+            onGradient = true,
+            cornerRadius = SpSpacing.RadiusMedium,
+        ) {
+            Row(
+                modifier = Modifier.fillMaxWidth().padding(SpSpacing.Medium),
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                SpCoverArt(
+                    imageUrl = parentGame.coverUrl,
+                    contentDescription = "${parentGame.title} cover art",
+                    modifier = Modifier.size(width = SpSpacing.CoverSmallWidth, height = SpSpacing.CoverSmallHeight),
+                )
+                Text(
+                    text = parentGame.title,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 2,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun RomHacksSection(
+    romHacks: List<RomHackGame>,
+    onNavigateToGame: ((String) -> Unit)?,
+) {
+    SpTitledSection(
+        title = "ROM Hacks",
+        includeTopSpacing = false,
+    ) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            romHacks.forEach { hack ->
+                SpCard(
+                    onClick = { onNavigateToGame?.invoke(hack.id) },
+                    onGradient = true,
+                    cornerRadius = SpSpacing.RadiusMedium,
+                ) {
+                    Row(
+                        modifier = Modifier.fillMaxWidth().padding(SpSpacing.Medium),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        SpCoverArt(
+                            imageUrl = hack.coverUrl,
+                            contentDescription = "${hack.title} cover art",
+                            modifier = Modifier.size(width = SpSpacing.CoverSmallWidth, height = SpSpacing.CoverSmallHeight),
+                        )
+                        Text(
+                            text = hack.title,
+                            style = SpTypography.TitleSmall,
+                            color = SpColor.OnCard,
+                            maxLines = 2,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                }
+            }
+        }
+    }
 }

--- a/server/internal/api/admin_handler_romhacks.go
+++ b/server/internal/api/admin_handler_romhacks.go
@@ -1,0 +1,257 @@
+package api
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/patcher"
+	"github.com/spela/server/internal/scanner"
+	"github.com/spela/server/internal/storage"
+	"gorm.io/gorm"
+)
+
+// RomHackHandler handles ROM hack creation endpoints.
+type RomHackHandler struct {
+	DB       *gorm.DB
+	GameDirs []string
+}
+
+// maxPatchUploadSize limits patch file uploads to 100 MB.
+const maxPatchUploadSize = 100 << 20
+
+// CreateRomHack applies a patch file to a base game's ROM and creates a new game entry.
+// POST /api/admin/rom-hacks
+func (h *RomHackHandler) CreateRomHack(c *gin.Context) {
+	c.Request.Body = http.MaxBytesReader(c.Writer, c.Request.Body, maxPatchUploadSize)
+
+	// Parse form data
+	baseGameID := c.PostForm("base_game_id")
+	if baseGameID == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "base_game_id is required"})
+		return
+	}
+	if _, err := strconv.ParseUint(baseGameID, 10, 64); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "base_game_id must be a valid numeric ID"})
+		return
+	}
+
+	mode := c.PostForm("mode")
+	if mode != "variant" && mode != "standalone" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "mode must be 'variant' or 'standalone'"})
+		return
+	}
+
+	label := c.PostForm("label")
+	title := c.PostForm("title")
+
+	if mode == "variant" && label == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "label is required for variant mode"})
+		return
+	}
+	if mode == "standalone" && title == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "title is required for standalone mode"})
+		return
+	}
+
+	// Read patch file
+	patchFile, patchHeader, err := c.Request.FormFile("patch_file")
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "patch_file is required"})
+		return
+	}
+	defer patchFile.Close()
+
+	// Validate patch extension
+	patchExt := strings.ToLower(filepath.Ext(patchHeader.Filename))
+	supportedExts := map[string]bool{".ips": true, ".bps": true, ".ups": true, ".xdelta": true, ".vcdiff": true}
+	if !supportedExts[patchExt] {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported patch format: " + patchExt + "; supported: .ips, .bps, .ups, .xdelta"})
+		return
+	}
+
+	patchData, err := io.ReadAll(patchFile)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "failed to read patch file"})
+		return
+	}
+
+	// Load base game
+	var baseGame db.Game
+	if err := h.DB.Preload("Console").First(&baseGame, baseGameID).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "base game not found"})
+		return
+	}
+
+	// Read the base game's ROM file
+	romAbsPath, err := storage.ResolveGamePath(baseGame.FilePath, h.GameDirs)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "base game ROM file not found on disk"})
+		return
+	}
+
+	romData, err := os.ReadFile(romAbsPath)
+	if err != nil {
+		slog.Warn("failed to read base ROM", "path", romAbsPath, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to read base game ROM"})
+		return
+	}
+
+	// Apply the patch
+	patchedData, err := patcher.Apply(romData, patchData, patchHeader.Filename)
+	if err != nil {
+		slog.Info("patch application failed", "baseGame", baseGame.Title, "patchFile", patchHeader.Filename, "error", err)
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("patch failed: %s", err)})
+		return
+	}
+
+	// Generate descriptive filename for the patched ROM
+	romExt := filepath.Ext(baseGame.FileName)
+	var patchedFileName string
+	if mode == "variant" {
+		// e.g. "Super Mario Bros [English Translation].nes"
+		baseName := strings.TrimSuffix(baseGame.FileName, romExt)
+		patchedFileName = baseName + " [" + label + "]" + romExt
+	} else {
+		// e.g. "My Cool Hack.nes"
+		patchedFileName = sanitizePatchedFilename(title) + romExt
+	}
+
+	// Write the patched ROM to the games directory
+	targetDir := filepath.Join(h.GameDirs[0], baseGame.Console.FolderName)
+	if err := os.MkdirAll(targetDir, 0755); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create target directory"})
+		return
+	}
+
+	targetPath := filepath.Join(targetDir, patchedFileName)
+
+	// Avoid overwriting existing files
+	if _, err := os.Stat(targetPath); err == nil {
+		c.JSON(http.StatusConflict, gin.H{"error": "a ROM file with this name already exists: " + patchedFileName})
+		return
+	}
+
+	if err := os.WriteFile(targetPath, patchedData, 0644); err != nil {
+		slog.Warn("failed to write patched ROM", "path", targetPath, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to write patched ROM file"})
+		return
+	}
+
+	// Create the game record
+	relPath := filepath.Join(baseGame.Console.FolderName, patchedFileName)
+
+	var newGame db.Game
+	if mode == "variant" {
+		// Variant: same GroupKey and ConsoleID, tagged with "hack"
+		variantTitle := baseGame.Title + " [" + label + "]"
+
+		tags := "hack"
+		if baseGame.Tags != "" {
+			// Merge existing tags with "hack" if not already present
+			existingTags := strings.Split(baseGame.Tags, ",")
+			hasHack := false
+			for _, t := range existingTags {
+				if strings.TrimSpace(t) == "hack" {
+					hasHack = true
+					break
+				}
+			}
+			if !hasHack {
+				tags = baseGame.Tags + ",hack"
+			} else {
+				tags = baseGame.Tags
+			}
+		}
+
+		newGame = db.Game{
+			ConsoleID:   baseGame.ConsoleID,
+			Title:       variantTitle,
+			FileName:    patchedFileName,
+			FilePath:    relPath,
+			FileSize:    int64(len(patchedData)),
+			Description: baseGame.Description,
+			CoverURL:    baseGame.CoverURL,
+			Developer:   baseGame.Developer,
+			Publisher:   baseGame.Publisher,
+			ReleaseDate: baseGame.ReleaseDate,
+			Genre:       baseGame.Genre,
+			GroupKey:    baseGame.GroupKey,
+			Tags:        tags,
+			Region:      baseGame.Region,
+		}
+	} else {
+		// Standalone: unique GroupKey, own title, ParentGameID set
+		parentID := baseGame.ID
+		groupKey := scanner.NormalizeGroupKey(title)
+
+		newGame = db.Game{
+			ConsoleID:    baseGame.ConsoleID,
+			Title:        title,
+			FileName:     patchedFileName,
+			FilePath:     relPath,
+			FileSize:     int64(len(patchedData)),
+			GroupKey:     groupKey,
+			ParentGameID: &parentID,
+			IsPrimary:    true,
+		}
+	}
+
+	if err := h.DB.Create(&newGame).Error; err != nil {
+		// Clean up the file we wrote
+		os.Remove(targetPath)
+		slog.Warn("failed to create game record for ROM hack", "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to create game record"})
+		return
+	}
+
+	// For variants, re-elect primary in the group to ensure the hack doesn't
+	// accidentally become primary (betterVariant deprioritizes hack-tagged games
+	// via shorter filenames, but let's be explicit).
+	if mode == "variant" && baseGame.GroupKey != "" {
+		if err := scanner.ReElectPrimaryForGroup(h.DB, baseGame.ConsoleID, baseGame.GroupKey); err != nil {
+			slog.Warn("failed to re-elect primary after ROM hack creation", "error", err)
+		}
+	}
+
+	slog.Info("ROM hack created",
+		"mode", mode,
+		"baseGame", baseGame.Title,
+		"newGameID", newGame.ID,
+		"newTitle", newGame.Title,
+	)
+
+	c.JSON(http.StatusCreated, gin.H{
+		"id":    strconv.FormatUint(uint64(newGame.ID), 10),
+		"title": newGame.Title,
+	})
+}
+
+// sanitizePatchedFilename creates a safe filename from a title.
+func sanitizePatchedFilename(title string) string {
+	// Replace characters that are problematic in filenames
+	replacer := strings.NewReplacer(
+		"/", "-",
+		"\\", "-",
+		":", "-",
+		"*", "",
+		"?", "",
+		"\"", "",
+		"<", "",
+		">", "",
+		"|", "",
+	)
+	safe := replacer.Replace(title)
+	safe = strings.TrimSpace(safe)
+	if safe == "" {
+		safe = "rom-hack"
+	}
+	return safe
+}

--- a/server/internal/api/admin_handler_romhacks_test.go
+++ b/server/internal/api/admin_handler_romhacks_test.go
@@ -1,0 +1,513 @@
+package api
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/json"
+	"hash/crc32"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	"github.com/spela/server/internal/auth"
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// romHackTestEnv holds the test environment for ROM hack handler tests.
+type romHackTestEnv struct {
+	db         *gorm.DB
+	cfg        *Config
+	adminToken string
+	tmpDir     string
+	baseGame   db.Game
+}
+
+func setupRomHackTestEnv(t *testing.T) *romHackTestEnv {
+	t.Helper()
+	database, cfg := setupTestEnv(t)
+
+	// Create admin user
+	user := db.User{
+		Username:     "romhackadmin",
+		Email:        "romhackadmin@test.com",
+		PasswordHash: "unused",
+		Role:         "owner",
+	}
+	require.NoError(t, database.Create(&user).Error)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	require.NoError(t, err)
+
+	// Find a console
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
+
+	// Create the console folder and base ROM file
+	consoleDir := filepath.Join(cfg.GameDirs[0], console.FolderName)
+	require.NoError(t, os.MkdirAll(consoleDir, 0755))
+
+	romData := []byte("Hello, World! This is a test ROM file for patching.")
+	romFilename := "Super Mario Bros (USA).nes"
+	romPath := filepath.Join(consoleDir, romFilename)
+	require.NoError(t, os.WriteFile(romPath, romData, 0644))
+
+	// Create base game record
+	baseGame := db.Game{
+		ConsoleID:   console.ID,
+		Title:       "Super Mario Bros",
+		FileName:    romFilename,
+		FilePath:    filepath.Join(console.FolderName, romFilename),
+		FileSize:    int64(len(romData)),
+		Description: "A classic platformer",
+		CoverURL:    "covers/smb.png",
+		Developer:   "Nintendo",
+		Publisher:   "Nintendo",
+		Genre:       "Platformer",
+		GroupKey:     "super mario bros",
+		IsPrimary:   true,
+		Region:      "USA",
+	}
+	require.NoError(t, database.Create(&baseGame).Error)
+
+	return &romHackTestEnv{
+		db:         database,
+		cfg:        cfg,
+		adminToken: token,
+		tmpDir:     cfg.GameDirs[0],
+		baseGame:   baseGame,
+	}
+}
+
+// buildTestIPSPatch creates a valid IPS patch that replaces bytes at the given offset.
+func buildTestIPSPatch(offset int, data []byte) []byte {
+	var patch []byte
+	patch = append(patch, []byte("PATCH")...)
+	// 3-byte offset
+	patch = append(patch, byte(offset>>16), byte(offset>>8), byte(offset))
+	// 2-byte size
+	size := make([]byte, 2)
+	binary.BigEndian.PutUint16(size, uint16(len(data)))
+	patch = append(patch, size...)
+	patch = append(patch, data...)
+	patch = append(patch, []byte("EOF")...)
+	return patch
+}
+
+// buildTestBPSPatch creates a minimal valid BPS patch that transforms source into target.
+func buildTestBPSPatch(source, target []byte) []byte {
+	encodeVLQ := func(value uint64) []byte {
+		var result []byte
+		for {
+			x := byte(value & 0x7F)
+			value >>= 7
+			if value == 0 {
+				result = append(result, x|0x80)
+				return result
+			}
+			result = append(result, x)
+			value--
+		}
+	}
+	writeLE32 := func(v uint32) []byte {
+		return []byte{byte(v), byte(v >> 8), byte(v >> 16), byte(v >> 24)}
+	}
+
+	var patch []byte
+	patch = append(patch, []byte("BPS1")...)
+	patch = append(patch, encodeVLQ(uint64(len(source)))...)
+	patch = append(patch, encodeVLQ(uint64(len(target)))...)
+	patch = append(patch, encodeVLQ(0)...) // no metadata
+
+	// TargetRead action for all target data
+	actionData := uint64(len(target)-1)<<2 | 1
+	patch = append(patch, encodeVLQ(actionData)...)
+	patch = append(patch, target...)
+
+	// Footer
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(source))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(target))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(patch))...)
+
+	return patch
+}
+
+func createRomHackRequest(t *testing.T, token string, fields map[string]string, patchFilename string, patchData []byte) *http.Request {
+	t.Helper()
+	body := &bytes.Buffer{}
+	writer := multipart.NewWriter(body)
+
+	for key, value := range fields {
+		require.NoError(t, writer.WriteField(key, value))
+	}
+
+	part, err := writer.CreateFormFile("patch_file", patchFilename)
+	require.NoError(t, err)
+	_, err = part.Write(patchData)
+	require.NoError(t, err)
+
+	require.NoError(t, writer.Close())
+
+	req := httptest.NewRequest("POST", "/api/admin/rom-hacks", body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("Authorization", "Bearer "+token)
+	return req
+}
+
+func TestCreateRomHack_VariantMode(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	// Create an IPS patch
+	patch := buildTestIPSPatch(0, []byte("Patched"))
+
+	req := createRomHackRequest(t, env.adminToken, map[string]string{
+		"base_game_id": strconv.FormatUint(uint64(env.baseGame.ID), 10),
+		"mode":         "variant",
+		"label":        "English Translation",
+	}, "translation.ips", patch)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["id"])
+	assert.Equal(t, "Super Mario Bros [English Translation]", resp["title"])
+
+	// Verify the game record
+	gameID, _ := strconv.ParseUint(resp["id"].(string), 10, 64)
+	var game db.Game
+	require.NoError(t, env.db.First(&game, gameID).Error)
+	assert.Equal(t, env.baseGame.ConsoleID, game.ConsoleID)
+	assert.Equal(t, env.baseGame.GroupKey, game.GroupKey)
+	assert.Contains(t, game.Tags, "hack")
+	assert.Equal(t, "Super Mario Bros [English Translation]", game.Title)
+	assert.Equal(t, env.baseGame.Description, game.Description)
+	assert.Equal(t, env.baseGame.CoverURL, game.CoverURL)
+	assert.Equal(t, env.baseGame.Developer, game.Developer)
+	assert.Nil(t, game.ParentGameID) // variants don't have ParentGameID
+
+	// Verify the patched ROM file exists on disk
+	romPath := filepath.Join(env.tmpDir, game.FilePath)
+	_, err := os.Stat(romPath)
+	assert.NoError(t, err)
+
+	// Verify patched content
+	content, err := os.ReadFile(romPath)
+	require.NoError(t, err)
+	assert.Equal(t, byte('P'), content[0])
+	assert.Equal(t, byte('a'), content[1])
+}
+
+func TestCreateRomHack_StandaloneMode(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	// Create an IPS patch
+	patch := buildTestIPSPatch(0, []byte("Patched"))
+
+	req := createRomHackRequest(t, env.adminToken, map[string]string{
+		"base_game_id": strconv.FormatUint(uint64(env.baseGame.ID), 10),
+		"mode":         "standalone",
+		"title":        "My Cool ROM Hack",
+	}, "hack.ips", patch)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.NotEmpty(t, resp["id"])
+	assert.Equal(t, "My Cool ROM Hack", resp["title"])
+
+	// Verify the game record
+	gameID, _ := strconv.ParseUint(resp["id"].(string), 10, 64)
+	var game db.Game
+	require.NoError(t, env.db.First(&game, gameID).Error)
+	assert.Equal(t, env.baseGame.ConsoleID, game.ConsoleID)
+	assert.NotEqual(t, env.baseGame.GroupKey, game.GroupKey) // standalone gets its own group key
+	assert.Equal(t, "My Cool ROM Hack", game.Title)
+	assert.NotNil(t, game.ParentGameID)
+	assert.Equal(t, env.baseGame.ID, *game.ParentGameID)
+	assert.True(t, game.IsPrimary)
+
+	// Verify the patched ROM file exists
+	romPath := filepath.Join(env.tmpDir, game.FilePath)
+	_, err := os.Stat(romPath)
+	assert.NoError(t, err)
+}
+
+func TestCreateRomHack_BPSPatch(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	// Read the actual ROM data to build a BPS patch
+	romPath := filepath.Join(env.tmpDir, env.baseGame.FilePath)
+	romData, err := os.ReadFile(romPath)
+	require.NoError(t, err)
+
+	// Create target data
+	target := make([]byte, len(romData))
+	copy(target, romData)
+	copy(target, []byte("BPS Patched!"))
+
+	patch := buildTestBPSPatch(romData, target)
+
+	req := createRomHackRequest(t, env.adminToken, map[string]string{
+		"base_game_id": strconv.FormatUint(uint64(env.baseGame.ID), 10),
+		"mode":         "standalone",
+		"title":        "BPS Hack",
+	}, "hack.bps", patch)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusCreated, w.Code, "body: %s", w.Body.String())
+
+	// Verify patched content
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	gameID, _ := strconv.ParseUint(resp["id"].(string), 10, 64)
+	var game db.Game
+	require.NoError(t, env.db.First(&game, gameID).Error)
+
+	patchedRomPath := filepath.Join(env.tmpDir, game.FilePath)
+	patchedContent, err := os.ReadFile(patchedRomPath)
+	require.NoError(t, err)
+	assert.Equal(t, target, patchedContent)
+}
+
+func TestCreateRomHack_MissingBaseGameID(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	patch := buildTestIPSPatch(0, []byte("X"))
+
+	req := createRomHackRequest(t, env.adminToken, map[string]string{
+		"mode":  "variant",
+		"label": "Test",
+	}, "patch.ips", patch)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "base_game_id")
+}
+
+func TestCreateRomHack_InvalidMode(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	patch := buildTestIPSPatch(0, []byte("X"))
+
+	req := createRomHackRequest(t, env.adminToken, map[string]string{
+		"base_game_id": strconv.FormatUint(uint64(env.baseGame.ID), 10),
+		"mode":         "invalid",
+	}, "patch.ips", patch)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "mode must be")
+}
+
+func TestCreateRomHack_MissingLabel(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	patch := buildTestIPSPatch(0, []byte("X"))
+
+	req := createRomHackRequest(t, env.adminToken, map[string]string{
+		"base_game_id": strconv.FormatUint(uint64(env.baseGame.ID), 10),
+		"mode":         "variant",
+	}, "patch.ips", patch)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "label is required")
+}
+
+func TestCreateRomHack_MissingTitle(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	patch := buildTestIPSPatch(0, []byte("X"))
+
+	req := createRomHackRequest(t, env.adminToken, map[string]string{
+		"base_game_id": strconv.FormatUint(uint64(env.baseGame.ID), 10),
+		"mode":         "standalone",
+	}, "patch.ips", patch)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "title is required")
+}
+
+func TestCreateRomHack_UnsupportedFormat(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	req := createRomHackRequest(t, env.adminToken, map[string]string{
+		"base_game_id": strconv.FormatUint(uint64(env.baseGame.ID), 10),
+		"mode":         "standalone",
+		"title":        "Test",
+	}, "patch.xyz", []byte("data"))
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Contains(t, w.Body.String(), "unsupported patch format")
+}
+
+func TestCreateRomHack_BaseGameNotFound(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	patch := buildTestIPSPatch(0, []byte("X"))
+
+	req := createRomHackRequest(t, env.adminToken, map[string]string{
+		"base_game_id": "99999",
+		"mode":         "standalone",
+		"title":        "Test",
+	}, "patch.ips", patch)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestCreateRomHack_NonAdminDenied(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	// Create a regular user
+	user := db.User{
+		Username:     "regularuser",
+		Email:        "regular@test.com",
+		PasswordHash: "unused",
+		Role:         "user",
+	}
+	require.NoError(t, env.db.Create(&user).Error)
+	userToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	require.NoError(t, err)
+
+	patch := buildTestIPSPatch(0, []byte("X"))
+
+	req := createRomHackRequest(t, userToken, map[string]string{
+		"base_game_id": strconv.FormatUint(uint64(env.baseGame.ID), 10),
+		"mode":         "standalone",
+		"title":        "Test",
+	}, "patch.ips", patch)
+
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestGetGame_ParentGameAndRomHacks(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	// Create a standalone ROM hack that references the base game
+	parentID := env.baseGame.ID
+
+	var console db.Console
+	require.NoError(t, env.db.Where("abbreviation = ?", "NES").First(&console).Error)
+
+	hackGame := db.Game{
+		ConsoleID:    console.ID,
+		Title:        "Hack Game",
+		FileName:     "hack.nes",
+		FilePath:     filepath.Join(console.FolderName, "hack.nes"),
+		FileSize:     100,
+		GroupKey:      "hack game",
+		ParentGameID: &parentID,
+		IsPrimary:    true,
+		CoverURL:     "covers/hack.png",
+	}
+	require.NoError(t, env.db.Create(&hackGame).Error)
+
+	// Write a dummy ROM for the hack
+	hackRomDir := filepath.Join(env.tmpDir, console.FolderName)
+	require.NoError(t, os.WriteFile(filepath.Join(hackRomDir, "hack.nes"), []byte("hack rom"), 0644))
+
+	// Get the base game detail — should include romHacks
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.FormatUint(uint64(env.baseGame.ID), 10), nil)
+	req.Header.Set("Authorization", "Bearer "+env.adminToken)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var baseResp GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &baseResp))
+	assert.Nil(t, baseResp.ParentGame) // base game has no parent
+	require.Len(t, baseResp.RomHacks, 1)
+	assert.Equal(t, strconv.FormatUint(uint64(hackGame.ID), 10), baseResp.RomHacks[0].ID)
+	assert.Equal(t, "Hack Game", baseResp.RomHacks[0].Title)
+
+	// Get the hack game detail — should include parentGame
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/games/"+strconv.FormatUint(uint64(hackGame.ID), 10), nil)
+	req.Header.Set("Authorization", "Bearer "+env.adminToken)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var hackResp GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &hackResp))
+	require.NotNil(t, hackResp.ParentGame)
+	assert.Equal(t, strconv.FormatUint(uint64(env.baseGame.ID), 10), hackResp.ParentGame.ID)
+	assert.Equal(t, "Super Mario Bros", hackResp.ParentGame.Title)
+	assert.Empty(t, hackResp.RomHacks) // hack has no child hacks
+}
+
+func TestGetGame_DeletedParentGraceful(t *testing.T) {
+	env := setupRomHackTestEnv(t)
+	router := NewRouter(*env.cfg)
+
+	// Create a standalone hack with a non-existent parent ID
+	nonExistentID := uint(99999)
+	var console db.Console
+	require.NoError(t, env.db.Where("abbreviation = ?", "NES").First(&console).Error)
+
+	hackGame := db.Game{
+		ConsoleID:    console.ID,
+		Title:        "Orphan Hack",
+		FileName:     "orphan.nes",
+		FilePath:     filepath.Join(console.FolderName, "orphan.nes"),
+		FileSize:     100,
+		GroupKey:      "orphan hack",
+		ParentGameID: &nonExistentID,
+		IsPrimary:    true,
+	}
+	require.NoError(t, env.db.Create(&hackGame).Error)
+
+	// Write a dummy ROM
+	hackRomDir := filepath.Join(env.tmpDir, console.FolderName)
+	require.NoError(t, os.WriteFile(filepath.Join(hackRomDir, "orphan.nes"), []byte("orphan"), 0644))
+
+	// Get the hack game detail — parentGame should be nil (graceful)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.FormatUint(uint64(hackGame.ID), 10), nil)
+	req.Header.Set("Authorization", "Bearer "+env.adminToken)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var resp GameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Nil(t, resp.ParentGame) // parent not found, should be nil gracefully
+}

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -360,6 +360,35 @@ func (h *GameHandler) GetGame(c *gin.Context) {
 		resp.VariantCount = len(variants) + 1
 	}
 
+	// Load parent game reference (for standalone ROM hacks)
+	if game.ParentGameID != nil {
+		var parent db.Game
+		if err := h.DB.Select("id", "title", "cover_url").First(&parent, *game.ParentGameID).Error; err == nil {
+			resp.ParentGame = &ParentGameResponse{
+				ID:       strconv.FormatUint(uint64(parent.ID), 10),
+				Title:    parent.Title,
+				CoverURL: resolveImageURL(parent.CoverURL),
+			}
+		}
+	}
+
+	// Load standalone ROM hacks based on this game
+	var romHacks []db.Game
+	h.DB.Select("id", "title", "cover_url").
+		Where("parent_game_id = ?", game.ID).
+		Order("title ASC").
+		Find(&romHacks)
+	if len(romHacks) > 0 {
+		resp.RomHacks = make([]RomHackGameResponse, len(romHacks))
+		for i, rh := range romHacks {
+			resp.RomHacks[i] = RomHackGameResponse{
+				ID:       strconv.FormatUint(uint64(rh.ID), 10),
+				Title:    rh.Title,
+				CoverURL: resolveImageURL(rh.CoverURL),
+			}
+		}
+	}
+
 	c.JSON(http.StatusOK, resp)
 }
 

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -88,6 +88,8 @@ type GameResponse struct {
 	VariantCount   int            `json:"variantCount,omitempty"`
 	GroupKey       string         `json:"groupKey,omitempty"`
 	Variants       []VariantResponse `json:"variants,omitempty"`
+	ParentGame     *ParentGameResponse  `json:"parentGame,omitempty"`
+	RomHacks       []RomHackGameResponse `json:"romHacks,omitempty"`
 	HeroURL        string         `json:"heroUrl,omitempty"`
 	LogoURL        string         `json:"logoUrl,omitempty"`
 	BiosStatus     string         `json:"biosStatus,omitempty"`
@@ -136,6 +138,20 @@ type VariantResponse struct {
 	IsPreRelease       bool   `json:"isPreRelease"`
 	FileSize           int64  `json:"fileSize"`
 	VerificationStatus string `json:"verificationStatus,omitempty"`
+}
+
+// ParentGameResponse is a minimal reference to a parent game for standalone ROM hacks.
+type ParentGameResponse struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	CoverURL string `json:"coverUrl,omitempty"`
+}
+
+// RomHackGameResponse is a minimal reference to a standalone ROM hack.
+type RomHackGameResponse struct {
+	ID       string `json:"id"`
+	Title    string `json:"title"`
+	CoverURL string `json:"coverUrl,omitempty"`
 }
 
 // PaginatedResponse wraps a paginated list with standard keys.

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -189,6 +189,10 @@ func NewRouter(cfg Config) *gin.Engine {
 		GameDirs:      cfg.GameDirs,
 		Storage:       cfg.Storage,
 	}
+	romHackHandler := &RomHackHandler{
+		DB:       cfg.DB,
+		GameDirs: cfg.GameDirs,
+	}
 	stagingDir := filepath.Join(cfg.GameDirs[0], "staging")
 	uploadHandler := &UploadHandler{
 		DB:         cfg.DB,
@@ -532,6 +536,9 @@ func NewRouter(cfg Config) *gin.Engine {
 			admin.POST("/cheats/import", adminHandler.TriggerCheatImport)
 			admin.GET("/cheats/stats", adminHandler.GetCheatStats)
 			admin.GET("/core-compatibility", adminHandler.GetCoreCompatibility)
+
+			// ROM hacks
+			admin.POST("/rom-hacks", uploadLimiter.RateLimit(), romHackHandler.CreateRomHack)
 
 			// Enrichment backfill
 			admin.POST("/enrich-metadata", enrichmentHandler.TriggerEnrichMetadata)

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -120,6 +120,7 @@ type Game struct {
 	GroupKey            string         `gorm:"size:255;index:idx_game_group_key;index:idx_console_group_key,priority:2" json:"groupKey,omitempty"`
 	IsPrimary           bool           `gorm:"default:false;index:idx_game_is_primary;index:idx_console_is_primary,priority:2" json:"isPrimary"`
 	PrimaryGameID       *uint          `json:"primaryGameId,omitempty"`
+	ParentGameID        *uint          `gorm:"index:idx_game_parent" json:"parentGameId,omitempty"` // links standalone ROM hacks to their base game
 	CRC32               string         `gorm:"size:16" json:"-"`
 	Screenshots      []GameScreenshot      `gorm:"foreignKey:GameID" json:"-"`
 	ReleaseDates     []GameReleaseDate     `gorm:"foreignKey:GameID" json:"-"`

--- a/server/internal/patcher/bps.go
+++ b/server/internal/patcher/bps.go
@@ -1,0 +1,177 @@
+package patcher
+
+import (
+	"fmt"
+	"hash/crc32"
+)
+
+// BPS format specification:
+// Header: "BPS1" (4 bytes)
+// Source size: variable-length encoded
+// Target size: variable-length encoded
+// Metadata size: variable-length encoded
+// Metadata: (metadata size bytes)
+// Actions (until 12 bytes before end):
+//   Each action: data (variable-length encoded)
+//     action type = data & 3
+//     length = (data >> 2) + 1
+//     0 = SourceRead, 1 = TargetRead, 2 = SourceCopy, 3 = TargetCopy
+// Footer (last 12 bytes):
+//   Source CRC32 (4 bytes, little-endian)
+//   Target CRC32 (4 bytes, little-endian)
+//   Patch CRC32  (4 bytes, little-endian, covers everything before it)
+
+const bpsHeader = "BPS1"
+
+// ApplyBPS applies a BPS patch to ROM data with CRC32 verification.
+func ApplyBPS(romData, patchData []byte) ([]byte, error) {
+	if len(patchData) < 16 {
+		return nil, fmt.Errorf("BPS patch too short")
+	}
+
+	// Verify patch CRC32 (covers everything except the last 4 bytes)
+	patchCRC := readLE32(patchData[len(patchData)-4:])
+	actualPatchCRC := crc32.ChecksumIEEE(patchData[:len(patchData)-4])
+	if patchCRC != actualPatchCRC {
+		return nil, fmt.Errorf("BPS patch CRC32 mismatch: expected %08x, got %08x", patchCRC, actualPatchCRC)
+	}
+
+	// Verify header
+	if string(patchData[:4]) != bpsHeader {
+		return nil, fmt.Errorf("invalid BPS header: expected %q, got %q", bpsHeader, string(patchData[:4]))
+	}
+
+	pos := 4
+
+	// Read source size
+	sourceSize, n := decodeVLQ(patchData[pos:])
+	pos += n
+
+	// Verify source size matches
+	if int(sourceSize) != len(romData) {
+		return nil, fmt.Errorf("BPS source size mismatch: patch expects %d bytes, ROM is %d bytes", sourceSize, len(romData))
+	}
+
+	// Read target size
+	targetSize, n := decodeVLQ(patchData[pos:])
+	pos += n
+
+	// Read and skip metadata
+	metadataSize, n := decodeVLQ(patchData[pos:])
+	pos += n
+	pos += int(metadataSize)
+
+	// Verify source CRC32
+	sourceCRC := readLE32(patchData[len(patchData)-12:])
+	actualSourceCRC := crc32.ChecksumIEEE(romData)
+	if sourceCRC != actualSourceCRC {
+		return nil, fmt.Errorf("BPS source CRC32 mismatch: expected %08x, got %08x (wrong base ROM?)", sourceCRC, actualSourceCRC)
+	}
+
+	// Validate target size
+	if targetSize > MaxOutputSize {
+		return nil, fmt.Errorf("BPS target size %d exceeds maximum allowed size (%d bytes)", targetSize, MaxOutputSize)
+	}
+
+	// Create target buffer
+	target := make([]byte, targetSize)
+	targetPos := 0
+
+	sourceRelOffset := 0
+	targetRelOffset := 0
+
+	// Process actions (stop 12 bytes before end = 3 CRC32 values)
+	endPos := len(patchData) - 12
+	for pos < endPos {
+		data, n := decodeVLQ(patchData[pos:])
+		pos += n
+
+		actionType := data & 3
+		length := int((data >> 2) + 1)
+
+		switch actionType {
+		case 0: // SourceRead
+			for i := 0; i < length; i++ {
+				if targetPos < len(target) && targetPos < len(romData) {
+					target[targetPos] = romData[targetPos]
+				}
+				targetPos++
+			}
+
+		case 1: // TargetRead
+			if pos+length > endPos {
+				return nil, fmt.Errorf("BPS patch truncated during TargetRead at offset %d", pos)
+			}
+			if targetPos+length > len(target) {
+				return nil, fmt.Errorf("BPS TargetRead would write past end of target buffer at offset %d", targetPos)
+			}
+			copy(target[targetPos:targetPos+length], patchData[pos:pos+length])
+			pos += length
+			targetPos += length
+
+		case 2: // SourceCopy
+			offset, n := decodeSignedVLQ(patchData[pos:])
+			pos += n
+			sourceRelOffset += offset
+			for i := 0; i < length; i++ {
+				if targetPos < len(target) && sourceRelOffset >= 0 && sourceRelOffset < len(romData) {
+					target[targetPos] = romData[sourceRelOffset]
+				}
+				sourceRelOffset++
+				targetPos++
+			}
+
+		case 3: // TargetCopy
+			offset, n := decodeSignedVLQ(patchData[pos:])
+			pos += n
+			targetRelOffset += offset
+			for i := 0; i < length; i++ {
+				if targetPos < len(target) && targetRelOffset >= 0 && targetRelOffset < len(target) {
+					target[targetPos] = target[targetRelOffset]
+				}
+				targetRelOffset++
+				targetPos++
+			}
+		}
+	}
+
+	// Verify target CRC32
+	targetCRC := readLE32(patchData[len(patchData)-8:])
+	actualTargetCRC := crc32.ChecksumIEEE(target)
+	if targetCRC != actualTargetCRC {
+		return nil, fmt.Errorf("BPS target CRC32 mismatch: expected %08x, got %08x", targetCRC, actualTargetCRC)
+	}
+
+	return target, nil
+}
+
+// decodeVLQ decodes a variable-length quantity from BPS/UPS format.
+// Returns the value and the number of bytes consumed.
+func decodeVLQ(data []byte) (uint64, int) {
+	var value uint64
+	shift := uint(0)
+	for i, b := range data {
+		value += uint64(b&0x7F) << shift
+		if b&0x80 != 0 {
+			return value, i + 1
+		}
+		value += 1 << (shift + 7)
+		shift += 7
+	}
+	return value, len(data)
+}
+
+// decodeSignedVLQ decodes a signed variable-length quantity.
+// The lowest bit indicates sign (1 = negative).
+func decodeSignedVLQ(data []byte) (int, int) {
+	value, n := decodeVLQ(data)
+	if value&1 != 0 {
+		return -int(value >> 1) - 1, n
+	}
+	return int(value >> 1), n
+}
+
+// readLE32 reads a 32-bit little-endian value.
+func readLE32(data []byte) uint32 {
+	return uint32(data[0]) | uint32(data[1])<<8 | uint32(data[2])<<16 | uint32(data[3])<<24
+}

--- a/server/internal/patcher/bps_test.go
+++ b/server/internal/patcher/bps_test.go
@@ -1,0 +1,179 @@
+package patcher
+
+import (
+	"hash/crc32"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// encodeVLQ encodes a value using BPS/UPS variable-length encoding.
+func encodeVLQ(value uint64) []byte {
+	var result []byte
+	for {
+		x := byte(value & 0x7F)
+		value >>= 7
+		if value == 0 {
+			result = append(result, x|0x80)
+			return result
+		}
+		result = append(result, x)
+		value--
+	}
+}
+
+// encodeSignedVLQ encodes a signed value for BPS SourceCopy/TargetCopy offsets.
+func encodeSignedVLQ(value int) []byte {
+	if value < 0 {
+		return encodeVLQ(uint64((-value-1)*2 + 1))
+	}
+	return encodeVLQ(uint64(value * 2))
+}
+
+// writeLE32 writes a 32-bit value in little-endian.
+func writeLE32(v uint32) []byte {
+	return []byte{byte(v), byte(v >> 8), byte(v >> 16), byte(v >> 24)}
+}
+
+// buildBPSPatch creates a minimal valid BPS patch that transforms source into target
+// using TargetRead actions (the simplest approach for testing).
+func buildBPSPatch(source, target []byte) []byte {
+	var patch []byte
+	patch = append(patch, []byte("BPS1")...)
+	patch = append(patch, encodeVLQ(uint64(len(source)))...)
+	patch = append(patch, encodeVLQ(uint64(len(target)))...)
+	patch = append(patch, encodeVLQ(0)...) // no metadata
+
+	// Single TargetRead action for all target data
+	// action type 1 (TargetRead), length = len(target)
+	// data = (length-1) << 2 | 1
+	actionData := uint64(len(target)-1)<<2 | 1
+	patch = append(patch, encodeVLQ(actionData)...)
+	patch = append(patch, target...)
+
+	// Footer: source CRC32, target CRC32, patch CRC32
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(source))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(target))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(patch))...)
+
+	return patch
+}
+
+func TestApplyBPS_Simple(t *testing.T) {
+	source := []byte("Hello, World!")
+	target := []byte("Hello, Go!!!")
+
+	patch := buildBPSPatch(source, target)
+
+	result, err := ApplyBPS(source, patch)
+	require.NoError(t, err)
+	assert.Equal(t, target, result)
+}
+
+func TestApplyBPS_DifferentSizes(t *testing.T) {
+	source := []byte("Short")
+	target := []byte("A much longer target string here")
+
+	patch := buildBPSPatch(source, target)
+
+	result, err := ApplyBPS(source, patch)
+	require.NoError(t, err)
+	assert.Equal(t, target, result)
+}
+
+func TestApplyBPS_InvalidHeader(t *testing.T) {
+	source := []byte("test")
+	// Build a patch with wrong header but valid CRC so header check is reached
+	patch := []byte("XXXX")
+	patch = append(patch, encodeVLQ(4)...)  // source size
+	patch = append(patch, encodeVLQ(4)...)  // target size
+	patch = append(patch, encodeVLQ(0)...)  // metadata size
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(source))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(source))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(patch))...)
+
+	_, err := ApplyBPS(source, patch)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid BPS header")
+}
+
+func TestApplyBPS_WrongSourceCRC(t *testing.T) {
+	source := []byte("Hello, World!")
+	target := []byte("Hello, Go!!!")
+
+	patch := buildBPSPatch(source, target)
+
+	// Use a different source
+	wrongSource := []byte("Wrong source!!")
+	_, err := ApplyBPS(wrongSource, patch)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "source size mismatch")
+}
+
+func TestApplyBPS_CorruptPatchCRC(t *testing.T) {
+	source := []byte("Hello, World!")
+	target := []byte("Hello, Go!!!")
+
+	patch := buildBPSPatch(source, target)
+	// Corrupt the last byte (patch CRC)
+	patch[len(patch)-1] ^= 0xFF
+
+	_, err := ApplyBPS(source, patch)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "patch CRC32 mismatch")
+}
+
+func TestApplyBPS_TooShort(t *testing.T) {
+	source := []byte("test")
+	patch := []byte("BPS1")
+
+	_, err := ApplyBPS(source, patch)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestApplyBPS_SourceRead(t *testing.T) {
+	// Build a BPS patch using SourceRead action (copies from source at same position)
+	source := []byte("ABCDEFGH")
+	target := []byte("ABCDEFGH") // same content
+
+	var patch []byte
+	patch = append(patch, []byte("BPS1")...)
+	patch = append(patch, encodeVLQ(uint64(len(source)))...)
+	patch = append(patch, encodeVLQ(uint64(len(target)))...)
+	patch = append(patch, encodeVLQ(0)...) // no metadata
+
+	// SourceRead for all bytes: action type 0, length = 8
+	actionData := uint64(len(target)-1)<<2 | 0
+	patch = append(patch, encodeVLQ(actionData)...)
+
+	// Footer
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(source))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(target))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(patch))...)
+
+	result, err := ApplyBPS(source, patch)
+	require.NoError(t, err)
+	assert.Equal(t, target, result)
+}
+
+func TestVLQRoundtrip(t *testing.T) {
+	tests := []uint64{0, 1, 127, 128, 255, 256, 1000, 65535, 16777215}
+	for _, v := range tests {
+		encoded := encodeVLQ(v)
+		decoded, n := decodeVLQ(encoded)
+		assert.Equal(t, v, decoded, "value %d", v)
+		assert.Equal(t, len(encoded), n, "bytes consumed for value %d", v)
+	}
+}
+
+func TestSignedVLQRoundtrip(t *testing.T) {
+	tests := []int{0, 1, -1, 127, -128, 1000, -1000}
+	for _, v := range tests {
+		encoded := encodeSignedVLQ(v)
+		decoded, n := decodeSignedVLQ(encoded)
+		assert.Equal(t, v, decoded, "value %d", v)
+		assert.Equal(t, len(encoded), n, "bytes consumed for value %d", v)
+	}
+}

--- a/server/internal/patcher/ips.go
+++ b/server/internal/patcher/ips.go
@@ -1,0 +1,189 @@
+package patcher
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// IPS format specification:
+// Header: "PATCH" (5 bytes)
+// Records: [offset(3 bytes)][size(2 bytes)][data(size bytes)]
+//   If size == 0 (RLE): [rle_size(2 bytes)][rle_value(1 byte)]
+// EOF marker: "EOF" (3 bytes) at offset position
+//
+// IPS32 extends offsets to 4 bytes and uses "IPS32" header / "EEOF" marker.
+
+const (
+	ipsHeader = "PATCH"
+	ipsEOF    = "EOF"
+
+	ips32Header = "IPS32"
+	ips32EOF    = "EEOF"
+)
+
+// ApplyIPS applies an IPS or IPS32 patch to ROM data.
+func ApplyIPS(romData, patchData []byte) ([]byte, error) {
+	if len(patchData) < 5 {
+		return nil, fmt.Errorf("IPS patch too short")
+	}
+
+	header := string(patchData[:5])
+	switch header {
+	case ipsHeader:
+		return applyIPSStandard(romData, patchData)
+	case ips32Header:
+		return applyIPS32(romData, patchData)
+	default:
+		return nil, fmt.Errorf("invalid IPS header: expected %q or %q, got %q", ipsHeader, ips32Header, header)
+	}
+}
+
+func applyIPSStandard(romData, patchData []byte) ([]byte, error) {
+	result := make([]byte, len(romData))
+	copy(result, romData)
+
+	pos := 5 // skip "PATCH"
+	for {
+		if pos+3 > len(patchData) {
+			return nil, fmt.Errorf("IPS patch truncated at offset %d", pos)
+		}
+
+		// Check for EOF marker
+		if string(patchData[pos:pos+3]) == ipsEOF {
+			break
+		}
+
+		// Read 3-byte offset
+		offset := int(patchData[pos])<<16 | int(patchData[pos+1])<<8 | int(patchData[pos+2])
+		pos += 3
+
+		if pos+2 > len(patchData) {
+			return nil, fmt.Errorf("IPS patch truncated reading size at offset %d", pos)
+		}
+
+		// Read 2-byte size
+		size := int(binary.BigEndian.Uint16(patchData[pos : pos+2]))
+		pos += 2
+
+		if size == 0 {
+			// RLE record
+			if pos+3 > len(patchData) {
+				return nil, fmt.Errorf("IPS patch truncated reading RLE at offset %d", pos)
+			}
+			rleSize := int(binary.BigEndian.Uint16(patchData[pos : pos+2]))
+			pos += 2
+			rleValue := patchData[pos]
+			pos++
+
+			// Expand result if needed
+			if offset+rleSize > MaxOutputSize {
+				return nil, fmt.Errorf("IPS patch output would exceed maximum size (%d bytes)", MaxOutputSize)
+			}
+			if offset+rleSize > len(result) {
+				expanded := make([]byte, offset+rleSize)
+				copy(expanded, result)
+				result = expanded
+			}
+			for i := 0; i < rleSize; i++ {
+				result[offset+i] = rleValue
+			}
+		} else {
+			// Normal record
+			if pos+size > len(patchData) {
+				return nil, fmt.Errorf("IPS patch truncated reading data at offset %d", pos)
+			}
+
+			// Expand result if needed
+			if offset+size > MaxOutputSize {
+				return nil, fmt.Errorf("IPS patch output would exceed maximum size (%d bytes)", MaxOutputSize)
+			}
+			if offset+size > len(result) {
+				expanded := make([]byte, offset+size)
+				copy(expanded, result)
+				result = expanded
+			}
+			copy(result[offset:], patchData[pos:pos+size])
+			pos += size
+		}
+	}
+
+	// Check for optional truncation marker after EOF
+	pos += 3 // skip "EOF"
+	if pos+3 <= len(patchData) {
+		truncSize := int(patchData[pos])<<16 | int(patchData[pos+1])<<8 | int(patchData[pos+2])
+		if truncSize < len(result) {
+			result = result[:truncSize]
+		}
+	}
+
+	return result, nil
+}
+
+func applyIPS32(romData, patchData []byte) ([]byte, error) {
+	result := make([]byte, len(romData))
+	copy(result, romData)
+
+	pos := 5 // skip "IPS32"
+	for {
+		if pos+4 > len(patchData) {
+			return nil, fmt.Errorf("IPS32 patch truncated at offset %d", pos)
+		}
+
+		// Check for EEOF marker
+		if string(patchData[pos:pos+4]) == ips32EOF {
+			break
+		}
+
+		// Read 4-byte offset
+		offset := int(binary.BigEndian.Uint32(patchData[pos : pos+4]))
+		pos += 4
+
+		if pos+2 > len(patchData) {
+			return nil, fmt.Errorf("IPS32 patch truncated reading size at offset %d", pos)
+		}
+
+		// Read 2-byte size
+		size := int(binary.BigEndian.Uint16(patchData[pos : pos+2]))
+		pos += 2
+
+		if size == 0 {
+			// RLE record
+			if pos+3 > len(patchData) {
+				return nil, fmt.Errorf("IPS32 patch truncated reading RLE at offset %d", pos)
+			}
+			rleSize := int(binary.BigEndian.Uint16(patchData[pos : pos+2]))
+			pos += 2
+			rleValue := patchData[pos]
+			pos++
+
+			if offset+rleSize > MaxOutputSize {
+				return nil, fmt.Errorf("IPS32 patch output would exceed maximum size (%d bytes)", MaxOutputSize)
+			}
+			if offset+rleSize > len(result) {
+				expanded := make([]byte, offset+rleSize)
+				copy(expanded, result)
+				result = expanded
+			}
+			for i := 0; i < rleSize; i++ {
+				result[offset+i] = rleValue
+			}
+		} else {
+			if pos+size > len(patchData) {
+				return nil, fmt.Errorf("IPS32 patch truncated reading data at offset %d", pos)
+			}
+
+			if offset+size > MaxOutputSize {
+				return nil, fmt.Errorf("IPS32 patch output would exceed maximum size (%d bytes)", MaxOutputSize)
+			}
+			if offset+size > len(result) {
+				expanded := make([]byte, offset+size)
+				copy(expanded, result)
+				result = expanded
+			}
+			copy(result[offset:], patchData[pos:pos+size])
+			pos += size
+		}
+	}
+
+	return result, nil
+}

--- a/server/internal/patcher/ips_test.go
+++ b/server/internal/patcher/ips_test.go
@@ -1,0 +1,152 @@
+package patcher
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildIPSPatch creates a valid IPS patch with the given records.
+func buildIPSPatch(records []ipsRecord) []byte {
+	var patch []byte
+	patch = append(patch, []byte("PATCH")...)
+	for _, r := range records {
+		// 3-byte offset
+		patch = append(patch, byte(r.offset>>16), byte(r.offset>>8), byte(r.offset))
+		if r.rle {
+			// size = 0 for RLE
+			patch = append(patch, 0, 0)
+			// RLE size (2 bytes) + value (1 byte)
+			size := make([]byte, 2)
+			binary.BigEndian.PutUint16(size, uint16(r.rleSize))
+			patch = append(patch, size...)
+			patch = append(patch, r.rleValue)
+		} else {
+			// size (2 bytes) + data
+			size := make([]byte, 2)
+			binary.BigEndian.PutUint16(size, uint16(len(r.data)))
+			patch = append(patch, size...)
+			patch = append(patch, r.data...)
+		}
+	}
+	patch = append(patch, []byte("EOF")...)
+	return patch
+}
+
+type ipsRecord struct {
+	offset   int
+	data     []byte
+	rle      bool
+	rleSize  int
+	rleValue byte
+}
+
+func TestApplyIPS_SimpleReplace(t *testing.T) {
+	rom := []byte("Hello, World!")
+	patch := buildIPSPatch([]ipsRecord{
+		{offset: 7, data: []byte("Go!!!")},
+	})
+
+	result, err := ApplyIPS(rom, patch)
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, Go!!!!", string(result))
+}
+
+func TestApplyIPS_MultipleRecords(t *testing.T) {
+	rom := make([]byte, 20)
+	for i := range rom {
+		rom[i] = 'A'
+	}
+
+	patch := buildIPSPatch([]ipsRecord{
+		{offset: 0, data: []byte("BB")},
+		{offset: 10, data: []byte("CC")},
+		{offset: 18, data: []byte("DD")},
+	})
+
+	result, err := ApplyIPS(rom, patch)
+	require.NoError(t, err)
+	assert.Equal(t, byte('B'), result[0])
+	assert.Equal(t, byte('B'), result[1])
+	assert.Equal(t, byte('A'), result[2])
+	assert.Equal(t, byte('C'), result[10])
+	assert.Equal(t, byte('C'), result[11])
+	assert.Equal(t, byte('D'), result[18])
+	assert.Equal(t, byte('D'), result[19])
+}
+
+func TestApplyIPS_RLERecord(t *testing.T) {
+	rom := make([]byte, 10)
+
+	patch := buildIPSPatch([]ipsRecord{
+		{offset: 2, rle: true, rleSize: 5, rleValue: 0xFF},
+	})
+
+	result, err := ApplyIPS(rom, patch)
+	require.NoError(t, err)
+	assert.Equal(t, byte(0), result[0])
+	assert.Equal(t, byte(0), result[1])
+	for i := 2; i < 7; i++ {
+		assert.Equal(t, byte(0xFF), result[i], "byte at offset %d", i)
+	}
+	assert.Equal(t, byte(0), result[7])
+}
+
+func TestApplyIPS_ExpandsROM(t *testing.T) {
+	rom := make([]byte, 5)
+
+	patch := buildIPSPatch([]ipsRecord{
+		{offset: 8, data: []byte("XYZ")},
+	})
+
+	result, err := ApplyIPS(rom, patch)
+	require.NoError(t, err)
+	assert.Equal(t, 11, len(result))
+	assert.Equal(t, byte('X'), result[8])
+	assert.Equal(t, byte('Y'), result[9])
+	assert.Equal(t, byte('Z'), result[10])
+}
+
+func TestApplyIPS_InvalidHeader(t *testing.T) {
+	rom := []byte("test")
+	patch := []byte("WRONG")
+
+	_, err := ApplyIPS(rom, patch)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid IPS header")
+}
+
+func TestApplyIPS_TooShort(t *testing.T) {
+	rom := []byte("test")
+	patch := []byte("PAT")
+
+	_, err := ApplyIPS(rom, patch)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestApplyIPS_EmptyPatch(t *testing.T) {
+	rom := []byte("Hello, World!")
+	patch := buildIPSPatch(nil)
+
+	result, err := ApplyIPS(rom, patch)
+	require.NoError(t, err)
+	assert.Equal(t, rom, result)
+}
+
+func TestApplyIPS_RLEExpandsROM(t *testing.T) {
+	rom := make([]byte, 3)
+
+	patch := buildIPSPatch([]ipsRecord{
+		{offset: 5, rle: true, rleSize: 4, rleValue: 0xAB},
+	})
+
+	result, err := ApplyIPS(rom, patch)
+	require.NoError(t, err)
+	assert.Equal(t, 9, len(result))
+	for i := 5; i < 9; i++ {
+		assert.Equal(t, byte(0xAB), result[i])
+	}
+}

--- a/server/internal/patcher/patcher.go
+++ b/server/internal/patcher/patcher.go
@@ -1,0 +1,31 @@
+// Package patcher applies ROM patches in IPS, BPS, UPS, and xdelta formats.
+package patcher
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// MaxOutputSize is the maximum allowed patched ROM size (256 MB).
+// This prevents denial-of-service via malicious patches that specify
+// arbitrarily large output sizes.
+const MaxOutputSize = 256 * 1024 * 1024
+
+// Apply applies a patch to ROM data and returns the patched result.
+// The format is auto-detected from the patch file extension.
+func Apply(romData, patchData []byte, patchFilename string) ([]byte, error) {
+	ext := strings.ToLower(filepath.Ext(patchFilename))
+	switch ext {
+	case ".ips":
+		return ApplyIPS(romData, patchData)
+	case ".bps":
+		return ApplyBPS(romData, patchData)
+	case ".ups":
+		return ApplyUPS(romData, patchData)
+	case ".xdelta", ".vcdiff":
+		return ApplyXDelta(romData, patchData)
+	default:
+		return nil, fmt.Errorf("unsupported patch format: %s", ext)
+	}
+}

--- a/server/internal/patcher/patcher_test.go
+++ b/server/internal/patcher/patcher_test.go
@@ -1,0 +1,61 @@
+package patcher
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestApply_IPS(t *testing.T) {
+	rom := []byte("Hello, World!")
+	patch := buildIPSPatch([]ipsRecord{
+		{offset: 7, data: []byte("Go!!!")},
+	})
+
+	result, err := Apply(rom, patch, "patch.ips")
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, Go!!!!", string(result))
+}
+
+func TestApply_BPS(t *testing.T) {
+	source := []byte("Hello, World!")
+	target := []byte("Hello, Go!!!")
+
+	patch := buildBPSPatch(source, target)
+
+	result, err := Apply(source, patch, "patch.bps")
+	require.NoError(t, err)
+	assert.Equal(t, target, result)
+}
+
+func TestApply_UPS(t *testing.T) {
+	source := []byte("Hello, World!")
+	target := []byte("Hello, Go!!!")
+
+	patch := buildUPSPatch(source, target)
+
+	result, err := Apply(source, patch, "patch.ups")
+	require.NoError(t, err)
+	assert.Equal(t, string(target), string(result))
+}
+
+func TestApply_UnsupportedFormat(t *testing.T) {
+	rom := []byte("test")
+	patch := []byte("data")
+
+	_, err := Apply(rom, patch, "patch.xyz")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported patch format")
+}
+
+func TestApply_CaseInsensitiveExtension(t *testing.T) {
+	rom := []byte("Hello, World!")
+	patch := buildIPSPatch([]ipsRecord{
+		{offset: 7, data: []byte("Go!!!")},
+	})
+
+	result, err := Apply(rom, patch, "patch.IPS")
+	require.NoError(t, err)
+	assert.Equal(t, "Hello, Go!!!!", string(result))
+}

--- a/server/internal/patcher/ups.go
+++ b/server/internal/patcher/ups.go
@@ -1,0 +1,108 @@
+package patcher
+
+import (
+	"fmt"
+	"hash/crc32"
+)
+
+// UPS format specification:
+// Header: "UPS1" (4 bytes)
+// Source size: variable-length encoded
+// Target size: variable-length encoded
+// XOR diffs until 12 bytes before end:
+//   Relative offset to next change (variable-length encoded)
+//   XOR data bytes (terminated by 0x00)
+// Footer (last 12 bytes):
+//   Source CRC32 (4 bytes, little-endian)
+//   Target CRC32 (4 bytes, little-endian)
+//   Patch CRC32  (4 bytes, little-endian)
+
+const upsHeader = "UPS1"
+
+// ApplyUPS applies a UPS patch to ROM data with CRC32 verification.
+func ApplyUPS(romData, patchData []byte) ([]byte, error) {
+	if len(patchData) < 16 {
+		return nil, fmt.Errorf("UPS patch too short")
+	}
+
+	// Verify patch CRC32
+	patchCRC := readLE32(patchData[len(patchData)-4:])
+	actualPatchCRC := crc32.ChecksumIEEE(patchData[:len(patchData)-4])
+	if patchCRC != actualPatchCRC {
+		return nil, fmt.Errorf("UPS patch CRC32 mismatch: expected %08x, got %08x", patchCRC, actualPatchCRC)
+	}
+
+	// Verify header
+	if string(patchData[:4]) != upsHeader {
+		return nil, fmt.Errorf("invalid UPS header: expected %q, got %q", upsHeader, string(patchData[:4]))
+	}
+
+	pos := 4
+
+	// Read source size
+	sourceSize, n := decodeVLQ(patchData[pos:])
+	pos += n
+
+	if int(sourceSize) != len(romData) {
+		return nil, fmt.Errorf("UPS source size mismatch: patch expects %d bytes, ROM is %d bytes", sourceSize, len(romData))
+	}
+
+	// Read target size
+	targetSize, n := decodeVLQ(patchData[pos:])
+	pos += n
+
+	// Verify source CRC32
+	sourceCRC := readLE32(patchData[len(patchData)-12:])
+	actualSourceCRC := crc32.ChecksumIEEE(romData)
+	if sourceCRC != actualSourceCRC {
+		return nil, fmt.Errorf("UPS source CRC32 mismatch: expected %08x, got %08x (wrong base ROM?)", sourceCRC, actualSourceCRC)
+	}
+
+	// Validate target size
+	if targetSize > MaxOutputSize {
+		return nil, fmt.Errorf("UPS target size %d exceeds maximum allowed size (%d bytes)", targetSize, MaxOutputSize)
+	}
+
+	// Create target as copy of source (padded/truncated to target size)
+	target := make([]byte, targetSize)
+	copy(target, romData)
+
+	// Apply XOR diffs
+	targetPos := 0
+	endPos := len(patchData) - 12
+
+	for pos < endPos {
+		// Read relative offset to next change
+		relOffset, n := decodeVLQ(patchData[pos:])
+		pos += n
+		targetPos += int(relOffset)
+
+		// Read XOR data until 0x00 terminator
+		for pos < endPos {
+			xorByte := patchData[pos]
+			pos++
+			if xorByte == 0x00 {
+				targetPos++
+				break
+			}
+			if targetPos < len(target) {
+				// XOR with source byte (0 if beyond source)
+				sourceByte := byte(0)
+				if targetPos < len(romData) {
+					sourceByte = romData[targetPos]
+				}
+				target[targetPos] = sourceByte ^ xorByte
+			}
+			targetPos++
+		}
+	}
+
+	// Verify target CRC32
+	targetCRC := readLE32(patchData[len(patchData)-8:])
+	actualTargetCRC := crc32.ChecksumIEEE(target)
+	if targetCRC != actualTargetCRC {
+		return nil, fmt.Errorf("UPS target CRC32 mismatch: expected %08x, got %08x", targetCRC, actualTargetCRC)
+	}
+
+	return target, nil
+}

--- a/server/internal/patcher/ups_test.go
+++ b/server/internal/patcher/ups_test.go
@@ -1,0 +1,160 @@
+package patcher
+
+import (
+	"hash/crc32"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildUPSPatch creates a valid UPS patch that transforms source into target.
+func buildUPSPatch(source, target []byte) []byte {
+	var patch []byte
+	patch = append(patch, []byte("UPS1")...)
+	patch = append(patch, encodeVLQ(uint64(len(source)))...)
+	patch = append(patch, encodeVLQ(uint64(len(target)))...)
+
+	// Generate XOR diffs
+	maxLen := len(source)
+	if len(target) > maxLen {
+		maxLen = len(target)
+	}
+
+	lastDiffEnd := 0
+	i := 0
+	for i < maxLen {
+		// Get source and target bytes (0 if beyond length)
+		var sb, tb byte
+		if i < len(source) {
+			sb = source[i]
+		}
+		if i < len(target) {
+			tb = target[i]
+		}
+
+		if sb != tb {
+			// Found a difference: write relative offset
+			relOffset := i - lastDiffEnd
+			patch = append(patch, encodeVLQ(uint64(relOffset))...)
+
+			// Write XOR bytes until we hit a match (or end)
+			for i < maxLen {
+				sb = 0
+				tb = 0
+				if i < len(source) {
+					sb = source[i]
+				}
+				if i < len(target) {
+					tb = target[i]
+				}
+				xorByte := sb ^ tb
+				if xorByte == 0 {
+					// Terminate the diff block
+					patch = append(patch, 0x00)
+					i++
+					lastDiffEnd = i
+					break
+				}
+				patch = append(patch, xorByte)
+				i++
+				if i >= maxLen {
+					// End of data, add terminator
+					patch = append(patch, 0x00)
+					lastDiffEnd = i + 1
+				}
+			}
+		} else {
+			i++
+		}
+	}
+
+	// Footer: source CRC32, target CRC32, patch CRC32
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(source))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(target))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(patch))...)
+
+	return patch
+}
+
+func TestApplyUPS_Simple(t *testing.T) {
+	source := []byte("Hello, World!")
+	target := []byte("Hello, Go!!!")
+
+	patch := buildUPSPatch(source, target)
+
+	result, err := ApplyUPS(source, patch)
+	require.NoError(t, err)
+	assert.Equal(t, string(target), string(result))
+}
+
+func TestApplyUPS_NoChanges(t *testing.T) {
+	source := []byte("Identical")
+	target := []byte("Identical")
+
+	patch := buildUPSPatch(source, target)
+
+	result, err := ApplyUPS(source, patch)
+	require.NoError(t, err)
+	assert.Equal(t, target, result)
+}
+
+func TestApplyUPS_InvalidHeader(t *testing.T) {
+	source := []byte("test")
+	// Build a patch with wrong header but valid CRC so header check is reached
+	patch := []byte("XXXX")
+	patch = append(patch, encodeVLQ(4)...)  // source size
+	patch = append(patch, encodeVLQ(4)...)  // target size
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(source))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(source))...)
+	patch = append(patch, writeLE32(crc32.ChecksumIEEE(patch))...)
+
+	_, err := ApplyUPS(source, patch)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid UPS header")
+}
+
+func TestApplyUPS_WrongSource(t *testing.T) {
+	source := []byte("Hello, World!")
+	target := []byte("Hello, Go!!!")
+
+	patch := buildUPSPatch(source, target)
+
+	wrongSource := []byte("Wrong source!!")
+	_, err := ApplyUPS(wrongSource, patch)
+	assert.Error(t, err)
+	// Could be size mismatch or CRC mismatch depending on length
+}
+
+func TestApplyUPS_CorruptPatchCRC(t *testing.T) {
+	source := []byte("Hello, World!")
+	target := []byte("Hello, Go!!!")
+
+	patch := buildUPSPatch(source, target)
+	// Corrupt the last byte
+	patch[len(patch)-1] ^= 0xFF
+
+	_, err := ApplyUPS(source, patch)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "patch CRC32 mismatch")
+}
+
+func TestApplyUPS_TooShort(t *testing.T) {
+	source := []byte("test")
+	patch := []byte("UPS1")
+
+	_, err := ApplyUPS(source, patch)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestApplyUPS_SingleByteDiff(t *testing.T) {
+	source := []byte("AAAA")
+	target := []byte("ABAA")
+
+	patch := buildUPSPatch(source, target)
+
+	result, err := ApplyUPS(source, patch)
+	require.NoError(t, err)
+	assert.Equal(t, target, result)
+}

--- a/server/internal/patcher/xdelta.go
+++ b/server/internal/patcher/xdelta.go
@@ -1,0 +1,65 @@
+package patcher
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+)
+
+// ApplyXDelta applies an xdelta/VCDIFF patch by shelling out to xdelta3.
+// This requires xdelta3 to be installed on the system.
+func ApplyXDelta(romData, patchData []byte) ([]byte, error) {
+	// Check if xdelta3 is available
+	xdeltaPath, err := exec.LookPath("xdelta3")
+	if err != nil {
+		return nil, fmt.Errorf("xdelta3 not found in PATH: install xdelta3 to apply .xdelta patches")
+	}
+
+	// Write source and patch to temp files
+	srcFile, err := os.CreateTemp("", "xdelta-src-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp source file: %w", err)
+	}
+	defer os.Remove(srcFile.Name())
+
+	if _, err := srcFile.Write(romData); err != nil {
+		srcFile.Close()
+		return nil, fmt.Errorf("writing temp source file: %w", err)
+	}
+	srcFile.Close()
+
+	patchFile, err := os.CreateTemp("", "xdelta-patch-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp patch file: %w", err)
+	}
+	defer os.Remove(patchFile.Name())
+
+	if _, err := patchFile.Write(patchData); err != nil {
+		patchFile.Close()
+		return nil, fmt.Errorf("writing temp patch file: %w", err)
+	}
+	patchFile.Close()
+
+	// Create output temp file
+	outFile, err := os.CreateTemp("", "xdelta-out-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp output file: %w", err)
+	}
+	defer os.Remove(outFile.Name())
+	outFile.Close()
+
+	// Run xdelta3
+	cmd := exec.Command(xdeltaPath, "-d", "-s", srcFile.Name(), patchFile.Name(), outFile.Name())
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("xdelta3 failed: %s: %w", string(output), err)
+	}
+
+	// Read result
+	result, err := os.ReadFile(outFile.Name())
+	if err != nil {
+		return nil, fmt.Errorf("reading xdelta3 output: %w", err)
+	}
+
+	return result, nil
+}

--- a/server/internal/scanner/filename_parser.go
+++ b/server/internal/scanner/filename_parser.go
@@ -154,6 +154,12 @@ func ParseFilenameMetadata(filename string) FilenameMetadata {
 	return meta
 }
 
+// NormalizeGroupKey produces a normalized title for grouping variants.
+// Exported for use by other packages (e.g. ROM hack creation).
+func NormalizeGroupKey(title string) string {
+	return normalizeGroupKey(title)
+}
+
 // normalizeGroupKey produces a normalized title from a filename for grouping variants.
 // Mirrors the normalization approach from scraper/namematch.go's normalizeName().
 func normalizeGroupKey(filename string) string {

--- a/server/internal/scanner/grouping.go
+++ b/server/internal/scanner/grouping.go
@@ -148,18 +148,26 @@ func electPrimaryForGroup(database *gorm.DB, consoleID uint, groupKey string) er
 // betterVariant returns true if game a is a better variant than game b.
 // Election priority (highest priority first):
 // 1. Not pre-release (IsPreRelease = false beats true)
-// 2. Region preference: USA > World > Europe > other
-// 3. Latest revision (Rev B > Rev A > no revision; v1.1 > v1.0)
-// 4. Has metadata (non-empty Description or CoverURL)
-// 5. CRC verified (VerificationStatus = "verified")
-// 6. Shortest FileName
+// 2. Not a hack (non-hack beats hack-tagged games)
+// 3. Region preference: USA > World > Europe > other
+// 4. Latest revision (Rev B > Rev A > no revision; v1.1 > v1.0)
+// 5. Has metadata (non-empty Description or CoverURL)
+// 6. CRC verified (VerificationStatus = "verified")
+// 7. Shortest FileName
 func betterVariant(a, b db.Game) bool {
 	// 1. Not pre-release beats pre-release
 	if a.IsPreRelease != b.IsPreRelease {
 		return !a.IsPreRelease
 	}
 
-	// 2. Region preference
+	// 2. Non-hack beats hack (deprioritize ROM hacks in primary election)
+	aIsHack := isHackTagged(a.Tags)
+	bIsHack := isHackTagged(b.Tags)
+	if aIsHack != bIsHack {
+		return !aIsHack
+	}
+
+	// 3. Region preference
 	aRegion := regionPriority(a.Region)
 	bRegion := regionPriority(b.Region)
 	if aRegion != bRegion {
@@ -194,6 +202,16 @@ func betterVariant(a, b db.Game) bool {
 
 	// 7. Lower ID wins (deterministic tiebreaker)
 	return a.ID < b.ID
+}
+
+// isHackTagged returns true if the comma-separated tags string contains "hack".
+func isHackTagged(tags string) bool {
+	for _, t := range strings.Split(tags, ",") {
+		if strings.TrimSpace(t) == "hack" {
+			return true
+		}
+	}
+	return false
 }
 
 // defaultRegionOrder is the default region preference for primary election.
@@ -234,6 +252,11 @@ func GroupAndElectPrimariesWithRegions(database *gorm.DB, regionOrder []string) 
 func betterVariantWithRegions(a, b db.Game, regionOrder []string) bool {
 	if a.IsPreRelease != b.IsPreRelease {
 		return !a.IsPreRelease
+	}
+	aIsHack := isHackTagged(a.Tags)
+	bIsHack := isHackTagged(b.Tags)
+	if aIsHack != bIsHack {
+		return !aIsHack
 	}
 	aRegion := regionPriorityWithOrder(a.Region, regionOrder)
 	bRegion := regionPriorityWithOrder(b.Region, regionOrder)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import { AdminCheatsPage } from "@/pages/admin/cheats-page";
 import { AdminBiosPage } from "@/pages/admin/bios-page";
 import { CoreCompatibilityPage } from "@/pages/admin/core-compatibility-page";
 import { UploadRomsPage } from "@/pages/admin/upload-roms-page";
+import { RomHacksPage } from "@/pages/admin/rom-hacks-page";
 import { PreferencesPage } from "@/pages/preferences-page";
 import { PlayPage } from "@/pages/play-page";
 import { StatsPage } from "@/pages/stats-page";
@@ -213,6 +214,14 @@ export function App() {
                       element={
                         <ProtectedRoute requireAdmin>
                           <UploadRomsPage />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="admin/rom-hacks"
+                      element={
+                        <ProtectedRoute requireAdmin>
+                          <RomHacksPage />
                         </ProtectedRoute>
                       }
                     />

--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -20,6 +20,7 @@ import {
   Trophy,
   Gamepad2,
   GitCompareArrows,
+  Puzzle,
 } from "lucide-react";
 import { Sidebar } from "@/components/ui";
 import { useAuth } from "@/hooks/use-auth";
@@ -121,6 +122,7 @@ export function AppLayout() {
                 warning: hasMissingBios,
               },
               { to: "/admin/upload", icon: Upload, label: "Upload ROMs" },
+              { to: "/admin/rom-hacks", icon: Puzzle, label: "ROM Hacks" },
               { to: "/admin/scan", icon: ScanSearch, label: "Library Scan" },
               {
                 to: "/admin/metadata",

--- a/web/src/features/game-detail/components/based-on-link.tsx
+++ b/web/src/features/game-detail/components/based-on-link.tsx
@@ -1,0 +1,38 @@
+import { Link } from "react-router-dom";
+import { Gamepad2 } from "lucide-react";
+
+interface BasedOnLinkProps {
+  parentGame: {
+    id: string;
+    title: string;
+    coverUrl: string;
+  };
+}
+
+export function BasedOnLink({ parentGame }: BasedOnLinkProps) {
+  return (
+    <Link
+      to={`/games/${parentGame.id}`}
+      className="inline-flex items-center gap-3 text-sm text-surface-300 hover:text-brand-400 transition-colors bg-surface-900/60 border border-surface-800/50 rounded-lg px-3 py-2 hover:border-surface-700/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+      data-testid="based-on-link"
+    >
+      {parentGame.coverUrl ? (
+        <img
+          src={parentGame.coverUrl}
+          alt={parentGame.title}
+          className="h-8 w-6 rounded object-cover flex-shrink-0"
+        />
+      ) : (
+        <div className="h-8 w-6 rounded bg-surface-800 flex items-center justify-center flex-shrink-0">
+          <Gamepad2 className="h-3 w-3 text-surface-600" />
+        </div>
+      )}
+      <span>
+        Based on{" "}
+        <span className="font-semibold text-surface-100">
+          {parentGame.title}
+        </span>
+      </span>
+    </Link>
+  );
+}

--- a/web/src/features/game-detail/components/game-variants-section.tsx
+++ b/web/src/features/game-detail/components/game-variants-section.tsx
@@ -1,0 +1,108 @@
+import { Link } from "react-router-dom";
+import { Layers, Puzzle, HardDrive } from "lucide-react";
+import { Badge } from "@/components/ui";
+import { formatFileSize } from "@/lib/format";
+import type { GameVariant } from "@/types/api";
+
+interface GameVariantsSectionProps {
+  variants: GameVariant[];
+}
+
+function hasHackTag(variant: GameVariant): boolean {
+  if (!variant.tags) return false;
+  return variant.tags
+    .split(",")
+    .map((t) => t.trim().toLowerCase())
+    .includes("hack");
+}
+
+function VariantRow({ variant }: { variant: GameVariant }) {
+  return (
+    <Link
+      to={`/games/${variant.id}`}
+      className="flex items-center gap-3 px-4 py-3 rounded-xl bg-surface-800/30 hover:bg-surface-800/50 transition-colors group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+      data-testid={`variant-${variant.id}`}
+    >
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-surface-200 truncate group-hover:text-brand-400 transition-colors">
+          {variant.title}
+        </p>
+        <div className="flex flex-wrap items-center gap-2 mt-1">
+          {variant.region && (
+            <Badge variant="default">{variant.region}</Badge>
+          )}
+          {variant.revision && (
+            <Badge variant="default">{variant.revision}</Badge>
+          )}
+          {variant.tags &&
+            variant.tags
+              .split(",")
+              .map((t) => t.trim())
+              .filter((t) => t.toLowerCase() !== "hack" && t !== "")
+              .map((tag) => (
+                <Badge key={tag} variant="default">
+                  {tag}
+                </Badge>
+              ))}
+        </div>
+      </div>
+      <span className="flex items-center gap-1 text-xs text-surface-500 whitespace-nowrap">
+        <HardDrive className="h-3 w-3" />
+        {formatFileSize(variant.fileSize)}
+      </span>
+    </Link>
+  );
+}
+
+export function GameVariantsSection({ variants }: GameVariantsSectionProps) {
+  if (!variants || variants.length === 0) return null;
+
+  const versionVariants = variants.filter((v) => !hasHackTag(v));
+  const hackVariants = variants.filter((v) => hasHackTag(v));
+
+  // If both lists are empty (shouldn't happen, but guard)
+  if (versionVariants.length === 0 && hackVariants.length === 0) return null;
+
+  return (
+    <section data-testid="game-variants-section">
+      {versionVariants.length > 0 && (
+        <div data-testid="versions-subsection">
+          <div className="flex items-center gap-2.5 mb-3">
+            <Layers className="h-5 w-5 text-brand-400" />
+            <h2 className="text-lg font-semibold text-surface-100">Versions</h2>
+            <span className="text-sm text-surface-500">
+              ({versionVariants.length})
+            </span>
+          </div>
+          <div className="space-y-2">
+            {versionVariants.map((variant) => (
+              <VariantRow key={variant.id} variant={variant} />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {hackVariants.length > 0 && (
+        <div
+          className={versionVariants.length > 0 ? "mt-6" : undefined}
+          data-testid="rom-hacks-subsection"
+        >
+          <div className="flex items-center gap-2.5 mb-3">
+            <Puzzle className="h-5 w-5 text-brand-400" />
+            <h2 className="text-lg font-semibold text-surface-100">
+              ROM Hacks
+            </h2>
+            <span className="text-sm text-surface-500">
+              ({hackVariants.length})
+            </span>
+          </div>
+          <div className="space-y-2">
+            {hackVariants.map((variant) => (
+              <VariantRow key={variant.id} variant={variant} />
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/web/src/features/game-detail/components/standalone-rom-hacks-section.tsx
+++ b/web/src/features/game-detail/components/standalone-rom-hacks-section.tsx
@@ -1,0 +1,54 @@
+import { Link } from "react-router-dom";
+import { Puzzle, Gamepad2 } from "lucide-react";
+import { Card } from "@/components/ui";
+
+interface RomHackEntry {
+  id: string;
+  title: string;
+  coverUrl: string;
+}
+
+interface StandaloneRomHacksSectionProps {
+  romHacks: RomHackEntry[];
+}
+
+export function StandaloneRomHacksSection({
+  romHacks,
+}: StandaloneRomHacksSectionProps) {
+  if (!romHacks || romHacks.length === 0) return null;
+
+  return (
+    <Card className="p-6" data-testid="standalone-rom-hacks-section">
+      <div className="flex items-center gap-2.5 mb-4">
+        <Puzzle className="h-5 w-5 text-brand-400" />
+        <h2 className="text-lg font-semibold text-surface-100">ROM Hacks</h2>
+        <span className="text-sm text-surface-500">({romHacks.length})</span>
+      </div>
+      <div className="space-y-2">
+        {romHacks.map((hack) => (
+          <Link
+            key={hack.id}
+            to={`/games/${hack.id}`}
+            className="flex items-center gap-3 px-4 py-3 rounded-xl bg-surface-800/30 hover:bg-surface-800/50 transition-colors group focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500"
+            data-testid={`rom-hack-${hack.id}`}
+          >
+            {hack.coverUrl ? (
+              <img
+                src={hack.coverUrl}
+                alt={hack.title}
+                className="h-12 w-9 rounded object-cover flex-shrink-0"
+              />
+            ) : (
+              <div className="h-12 w-9 rounded bg-surface-800 flex items-center justify-center flex-shrink-0">
+                <Gamepad2 className="h-4 w-4 text-surface-600" />
+              </div>
+            )}
+            <p className="text-sm font-medium text-surface-200 truncate group-hover:text-brand-400 transition-colors">
+              {hack.title}
+            </p>
+          </Link>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/web/src/hooks/use-rom-hacks.ts
+++ b/web/src/hooks/use-rom-hacks.ts
@@ -1,0 +1,39 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+
+interface CreateRomHackParams {
+  baseGameId: string;
+  patchFile: File;
+  mode: "variant" | "standalone";
+  label?: string;
+  title?: string;
+}
+
+interface CreateRomHackResponse {
+  id: string;
+  title: string;
+}
+
+export function useCreateRomHack() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: CreateRomHackParams) => {
+      const formData = new FormData();
+      formData.append("base_game_id", params.baseGameId);
+      formData.append("patch_file", params.patchFile);
+      formData.append("mode", params.mode);
+      if (params.mode === "variant" && params.label) {
+        formData.append("label", params.label);
+      }
+      if (params.mode === "standalone" && params.title) {
+        formData.append("title", params.title);
+      }
+      return api.upload<CreateRomHackResponse>("/admin/rom-hacks", formData);
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["games"] });
+      queryClient.invalidateQueries({ queryKey: ["game"] });
+    },
+  });
+}

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -302,6 +302,7 @@ export type ApiPostPath = WithQuery<
   | `/admin/uploads/${string}/reject`
   | "/admin/uploads/accept-all"
   | "/admin/uploads/reject-all"
+  | "/admin/rom-hacks"
 >;
 
 // ── PUT ──────────────────────────────────────────────────────────────────────

--- a/web/src/pages/admin/rom-hacks-page.tsx
+++ b/web/src/pages/admin/rom-hacks-page.tsx
@@ -1,0 +1,225 @@
+import { useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { Loader2, Puzzle } from "lucide-react";
+import { Button, Input } from "@/components/ui";
+import { useToast } from "@/components/ui";
+import { GamePicker } from "@/components/game-picker";
+import { useCreateRomHack } from "@/hooks/use-rom-hacks";
+import type { Game } from "@/types/api";
+
+const ACCEPTED_EXTENSIONS = ".ips,.bps,.ups,.xdelta";
+
+export function RomHacksPage() {
+  const navigate = useNavigate();
+  const { toast } = useToast();
+  const createRomHack = useCreateRomHack();
+
+  const [selectedGame, setSelectedGame] = useState<Game | null>(null);
+  const [patchFile, setPatchFile] = useState<File | null>(null);
+  const [mode, setMode] = useState<"variant" | "standalone">("variant");
+  const [label, setLabel] = useState("");
+  const [title, setTitle] = useState("");
+
+  const canSubmit =
+    selectedGame &&
+    patchFile &&
+    ((mode === "variant" && label.trim() !== "") ||
+      (mode === "standalone" && title.trim() !== ""));
+
+  const handleFileChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0] ?? null;
+      setPatchFile(file);
+    },
+    [],
+  );
+
+  const handleSubmit = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      if (!selectedGame || !patchFile) return;
+
+      createRomHack.mutate(
+        {
+          baseGameId: selectedGame.id,
+          patchFile,
+          mode,
+          label: mode === "variant" ? label.trim() : undefined,
+          title: mode === "standalone" ? title.trim() : undefined,
+        },
+        {
+          onSuccess: (data) => {
+            toast("success", `ROM hack created: ${data.title}`);
+            navigate(`/games/${data.id}`);
+          },
+          onError: (err) => {
+            toast(
+              "error",
+              err instanceof Error ? err.message : "Failed to create ROM hack",
+            );
+          },
+        },
+      );
+    },
+    [selectedGame, patchFile, mode, label, title, createRomHack, toast, navigate],
+  );
+
+  return (
+    <div className="space-y-6 max-w-2xl">
+      <div>
+        <h1 className="text-3xl font-bold text-surface-100">Add ROM Hack</h1>
+        <p className="mt-1 text-surface-400">
+          Upload a patch file to apply to a base game ROM.
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-6">
+        {/* Game picker */}
+        <GamePicker
+          selectedGame={selectedGame}
+          onSelect={setSelectedGame}
+          onClear={() => setSelectedGame(null)}
+        />
+
+        {/* Patch file upload */}
+        <div className="space-y-1.5">
+          <label className="block text-sm font-medium text-surface-300">
+            Patch File
+          </label>
+          <div className="relative">
+            <input
+              type="file"
+              accept={ACCEPTED_EXTENSIONS}
+              onChange={handleFileChange}
+              className="block w-full text-sm text-surface-400
+                file:mr-4 file:py-2 file:px-4
+                file:rounded-lg file:border-0
+                file:text-sm file:font-medium
+                file:bg-surface-800 file:text-surface-200
+                file:cursor-pointer file:transition-colors
+                hover:file:bg-surface-700
+                focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500
+                cursor-pointer"
+              data-testid="patch-file-input"
+            />
+          </div>
+          <p className="text-xs text-surface-500">
+            Supported formats: .ips, .bps, .ups, .xdelta
+          </p>
+        </div>
+
+        {/* Mode selector */}
+        <div className="space-y-1.5">
+          <label className="block text-sm font-medium text-surface-300">
+            Mode
+          </label>
+          <div className="flex gap-2" role="radiogroup" aria-label="ROM hack mode">
+            <button
+              type="button"
+              role="radio"
+              aria-checked={mode === "variant"}
+              onClick={() => setMode("variant")}
+              className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 ${
+                mode === "variant"
+                  ? "bg-brand-500/15 border-brand-500/40 text-brand-400"
+                  : "bg-surface-800/50 border-surface-700 text-surface-400 hover:text-surface-200 hover:border-surface-600"
+              }`}
+              data-testid="mode-variant"
+            >
+              Add as variant
+            </button>
+            <button
+              type="button"
+              role="radio"
+              aria-checked={mode === "standalone"}
+              onClick={() => setMode("standalone")}
+              className={`flex-1 px-4 py-2.5 rounded-lg text-sm font-medium transition-colors border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 ${
+                mode === "standalone"
+                  ? "bg-brand-500/15 border-brand-500/40 text-brand-400"
+                  : "bg-surface-800/50 border-surface-700 text-surface-400 hover:text-surface-200 hover:border-surface-600"
+              }`}
+              data-testid="mode-standalone"
+            >
+              Create standalone game
+            </button>
+          </div>
+          <p className="text-xs text-surface-500">
+            {mode === "variant"
+              ? "The patched ROM will appear as a variant of the base game."
+              : "The patched ROM will become its own game entry in the library."}
+          </p>
+        </div>
+
+        {/* Label input (variant mode) */}
+        {mode === "variant" && (
+          <div className="space-y-1.5">
+            <label
+              htmlFor="hack-label"
+              className="block text-sm font-medium text-surface-300"
+            >
+              Label
+            </label>
+            <Input
+              id="hack-label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder='e.g. "English Translation", "Bugfix v1.2"'
+              data-testid="label-input"
+            />
+          </div>
+        )}
+
+        {/* Title input (standalone mode) */}
+        {mode === "standalone" && (
+          <div className="space-y-1.5">
+            <label
+              htmlFor="hack-title"
+              className="block text-sm font-medium text-surface-300"
+            >
+              Game Title
+            </label>
+            <Input
+              id="hack-title"
+              value={title}
+              onChange={(e) => setTitle(e.target.value)}
+              placeholder="Title for the new game entry"
+              data-testid="title-input"
+            />
+          </div>
+        )}
+
+        {/* Error display */}
+        {createRomHack.isError && (
+          <div
+            className="rounded-xl border border-red-500/30 bg-red-500/10 p-4"
+            role="alert"
+            data-testid="error-message"
+          >
+            <p className="text-sm text-red-400">
+              {createRomHack.error instanceof Error
+                ? createRomHack.error.message
+                : "An error occurred while creating the ROM hack."}
+            </p>
+          </div>
+        )}
+
+        {/* Submit button */}
+        <Button
+          type="submit"
+          disabled={!canSubmit || createRomHack.isPending}
+          loading={createRomHack.isPending}
+          icon={
+            createRomHack.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Puzzle className="h-4 w-4" />
+            )
+          }
+          data-testid="create-button"
+        >
+          {createRomHack.isPending ? "Applying patch..." : "Create ROM Hack"}
+        </Button>
+      </form>
+    </div>
+  );
+}

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -41,6 +41,9 @@ import { BiosWarningBanner } from "@/features/bios/components/bios-warning-banne
 import { ScrapeMatchModal } from "@/features/game-detail/components/scrape-match-modal";
 import { ReplaceRomModal } from "@/features/game-detail/components/replace-rom-modal";
 import { TimeToBeatCard } from "@/features/game-detail/components/time-to-beat-card";
+import { GameVariantsSection } from "@/features/game-detail/components/game-variants-section";
+import { BasedOnLink } from "@/features/game-detail/components/based-on-link";
+import { StandaloneRomHacksSection } from "@/features/game-detail/components/standalone-rom-hacks-section";
 import { api } from "@/lib/api-client";
 import type { Collection } from "@/types/api";
 
@@ -243,13 +246,15 @@ export function GameDetailPage() {
         onClose={() => setShowCollectionPicker(false)}
       />
 
-      {/* Series & Franchise links */}
-      {((gameSeries && gameSeries.length > 0) ||
+      {/* Based on / Series & Franchise links */}
+      {(game.parentGame ||
+        (gameSeries && gameSeries.length > 0) ||
         (gameFranchises && gameFranchises.length > 0)) && (
         <div
           className="flex flex-wrap items-center gap-3"
           data-testid="series-franchise-links"
         >
+          {game.parentGame && <BasedOnLink parentGame={game.parentGame} />}
           {gameSeries?.map((s) => (
             <Link
               key={`series-${s.id}`}
@@ -277,6 +282,16 @@ export function GameDetailPage() {
             </Link>
           ))}
         </div>
+      )}
+
+      {game.variants && game.variants.length > 0 && (
+        <Card className="p-6">
+          <GameVariantsSection variants={game.variants} />
+        </Card>
+      )}
+
+      {game.romHacks && game.romHacks.length > 0 && (
+        <StandaloneRomHacksSection romHacks={game.romHacks} />
       )}
 
       <TimeToBeatCard game={game} />

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -116,6 +116,8 @@ export interface Game {
   variantCount?: number;
   groupKey?: string;
   variants?: GameVariant[];
+  parentGame?: { id: string; title: string; coverUrl: string };
+  romHacks?: { id: string; title: string; coverUrl: string }[];
   coverAspectRatio: number;
   playable: boolean;
   biosStatus?: "ready" | "missing" | "invalid" | "not_required";


### PR DESCRIPTION
## Summary
- Add server-side ROM patching engine supporting IPS, BPS (with CRC32 verification), UPS, and xdelta formats with 256 MB output cap
- Add admin "Create ROM Hack" page: select base game, upload patch file, choose variant (grouped with base game) or standalone (own game entry with "based on" link) mode
- Split game detail variants into "Versions" and "ROM Hacks" sub-sections across web and player app
- Show "Based on" parent game link and standalone ROM hacks section on game detail pages

## Details

**Backend (Go)**
- New `server/internal/patcher/` package with format-specific implementations and security limits (MaxOutputSize)
- `POST /api/admin/rom-hacks` endpoint: validates input, reads base ROM, applies patch, writes patched ROM, creates game record
- Variant mode: same GroupKey, tagged `hack`, inherits metadata, re-elects primary to avoid hack becoming default
- Standalone mode: own GroupKey, sets ParentGameID for "based on" linking
- `GET /api/games/:id` extended with `parentGame` and `romHacks` fields
- Hack-tagged games deprioritized in primary variant election

**Web (React)**
- Admin page with game picker, file upload, variant/standalone mode selector with ARIA semantics
- `GameVariantsSection` splits variants by hack tag into Versions and ROM Hacks
- `BasedOnLink` and `StandaloneRomHacksSection` components on game detail
- `useCreateRomHack` mutation hook

**Player (Kotlin Multiplatform)**
- Updated DTOs, models, and mappers for parentGame/romHacks
- `BasedOnSection` and `RomHacksSection` composables in GameDetailScreen
- Case-insensitive hack tag detection

## Test plan
- [x] Go patcher unit tests (IPS, BPS, UPS, xdelta dispatcher) — all pass
- [x] Go admin endpoint tests (validation, variant/standalone creation) — all pass
- [x] Go grouping tests (hack deprioritization in primary election) — all pass
- [x] Web unit tests (1376 tests pass)
- [x] Player desktop E2E tests (668 tests pass)
- [ ] Manual: upload IPS/BPS patch via admin UI, verify patched ROM appears correctly
- [ ] Manual: verify variant hack shows in ROM Hacks sub-section on game detail
- [ ] Manual: verify standalone hack shows "Based on" link and parent shows ROM Hacks section