### PR TITLE
fix: hide redundant console name on console pages

### DIFF
--- a/web/src/components/game-card.tsx
+++ b/web/src/components/game-card.tsx
@@ -9,6 +9,7 @@ interface GameCardProps {
   game: Game;
   aspectRatio?: number;
   showConsoleBadge?: boolean;
+  hideConsoleName?: boolean;
   onToggleFavorite?: (game: Game) => void;
   onTogglePlayLater?: (game: Game) => void;
 }
@@ -17,6 +18,7 @@ export function GameCard({
   game,
   aspectRatio,
   showConsoleBadge,
+  hideConsoleName,
   onToggleFavorite,
   onTogglePlayLater,
 }: GameCardProps) {
@@ -127,8 +129,16 @@ export function GameCard({
           </span>
         )}
         <div className="flex items-center gap-2">
-          {game.consoleName && (
-            <p className="text-xs text-surface-500">{game.consoleName}</p>
+          {hideConsoleName ? (
+            game.releaseDate && (
+              <p className="text-xs text-surface-500">
+                {new Date(game.releaseDate).getFullYear()}
+              </p>
+            )
+          ) : (
+            game.consoleName && (
+              <p className="text-xs text-surface-500">{game.consoleName}</p>
+            )
           )}
           {game.averageRating > 0 && (
             <span className="flex items-center gap-0.5 text-xs text-surface-400">

--- a/web/src/components/game-card.tsx
+++ b/web/src/components/game-card.tsx
@@ -130,9 +130,11 @@ export function GameCard({
         )}
         <div className="flex items-center gap-2">
           {hideConsoleName ? (
-            game.releaseDate && (
+            (game.releaseDate || game.developer) && (
               <p className="text-xs text-surface-500">
-                {new Date(game.releaseDate).getFullYear()}
+                {game.releaseDate
+                  ? new Date(game.releaseDate).getFullYear()
+                  : game.developer}
               </p>
             )
           ) : (

--- a/web/src/features/explore/components/console-showcase-sections.tsx
+++ b/web/src/features/explore/components/console-showcase-sections.tsx
@@ -22,6 +22,7 @@ export function ConsoleEssentials({ consoleId }: ConsoleShowcaseSectionProps) {
       title="Essentials"
       games={showcase.essentials}
       isLoading={false}
+      hideConsoleName
       onToggleFavorite={handleToggleFavorite}
       onTogglePlayLater={handleTogglePlayLater}
     />
@@ -40,6 +41,7 @@ export function ConsoleHiddenGems({ consoleId }: ConsoleShowcaseSectionProps) {
       title="Hidden Gems"
       games={showcase.hiddenGems}
       isLoading={false}
+      hideConsoleName
       onToggleFavorite={handleToggleFavorite}
       onTogglePlayLater={handleTogglePlayLater}
     />
@@ -153,6 +155,7 @@ export function ConsoleRecentlyAdded({
       title="Recently Added"
       games={showcase.recentlyAdded}
       isLoading={false}
+      hideConsoleName
       onToggleFavorite={handleToggleFavorite}
       onTogglePlayLater={handleTogglePlayLater}
     />
@@ -174,6 +177,7 @@ export function ConsoleRecentlyPlayed({
         title="Recently Played"
         games={showcase.recentlyPlayed}
         isLoading={false}
+        hideConsoleName
         onToggleFavorite={handleToggleFavorite}
         onTogglePlayLater={handleTogglePlayLater}
       />

--- a/web/src/features/explore/components/game-shelf.tsx
+++ b/web/src/features/explore/components/game-shelf.tsx
@@ -8,6 +8,7 @@ interface GameShelfProps {
   title: string;
   games: Game[] | undefined;
   isLoading: boolean;
+  hideConsoleName?: boolean;
   onToggleFavorite?: (game: Game) => void;
   onTogglePlayLater?: (game: Game) => void;
 }
@@ -31,6 +32,7 @@ export function GameShelf({
   title,
   games,
   isLoading,
+  hideConsoleName,
   onToggleFavorite,
   onTogglePlayLater,
 }: GameShelfProps) {
@@ -119,7 +121,8 @@ export function GameShelf({
             >
               <GameCard
                 game={game}
-                showConsoleBadge
+                showConsoleBadge={!hideConsoleName}
+                hideConsoleName={hideConsoleName}
                 onToggleFavorite={onToggleFavorite}
                 onTogglePlayLater={onTogglePlayLater}
               />

--- a/web/src/features/games/components/game-list-row.tsx
+++ b/web/src/features/games/components/game-list-row.tsx
@@ -37,8 +37,10 @@ export function GameListRow({ game, hideConsoleName }: GameListRowProps) {
           {game.title}
         </p>
         {hideConsoleName ? (
-          releaseYear && (
-            <p className="text-xs text-surface-500">{releaseYear}</p>
+          (releaseYear || game.developer) && (
+            <p className="text-xs text-surface-500">
+              {releaseYear ?? game.developer}
+            </p>
           )
         ) : (
           consoleName && (

--- a/web/src/features/games/components/game-list-row.tsx
+++ b/web/src/features/games/components/game-list-row.tsx
@@ -5,10 +5,14 @@ import type { Game } from "@/types/api";
 
 interface GameListRowProps {
   game: Game;
+  hideConsoleName?: boolean;
 }
 
-export function GameListRow({ game }: GameListRowProps) {
+export function GameListRow({ game, hideConsoleName }: GameListRowProps) {
   const consoleName = game.consoleName ?? "";
+  const releaseYear = game.releaseDate
+    ? new Date(game.releaseDate).getFullYear().toString()
+    : undefined;
 
   return (
     <Link
@@ -32,11 +36,17 @@ export function GameListRow({ game }: GameListRowProps) {
         <p className="text-sm font-medium text-surface-100 truncate group-hover:text-brand-400 transition-colors">
           {game.title}
         </p>
-        {consoleName && (
-          <p className="text-xs text-surface-500">{consoleName}</p>
+        {hideConsoleName ? (
+          releaseYear && (
+            <p className="text-xs text-surface-500">{releaseYear}</p>
+          )
+        ) : (
+          consoleName && (
+            <p className="text-xs text-surface-500">{consoleName}</p>
+          )
         )}
       </div>
-      {consoleName && <Badge>{consoleName}</Badge>}
+      {!hideConsoleName && consoleName && <Badge>{consoleName}</Badge>}
       {game.variantCount != null && game.variantCount > 1 && (
         <span className="text-xs text-surface-400 whitespace-nowrap">
           +{game.variantCount - 1} {game.variantCount === 2 ? "version" : "versions"}

--- a/web/src/pages/__tests__/console-detail-page.test.tsx
+++ b/web/src/pages/__tests__/console-detail-page.test.tsx
@@ -209,6 +209,41 @@ describe("ConsoleDetailPage", () => {
       expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
     });
 
+    it("hides console name and shows release year on game cards", () => {
+      mockUseGames.mockReturnValue({
+        data: {
+          data: [
+            makeGame({ id: "1", title: "Super Mario World", consoleName: "Super Nintendo", releaseDate: "1990-11-21" }),
+            makeGame({ id: "2", title: "Chrono Trigger", consoleName: "Super Nintendo", releaseDate: "1995-03-11" }),
+          ],
+          total: 2,
+          page: 1,
+          pageSize: 24,
+        },
+        isLoading: false,
+      });
+      renderPage();
+
+      // Game titles are visible
+      expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+      expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
+
+      // Console name "Super Nintendo" should NOT appear below game cards
+      // (it will appear in the hero banner heading, but not repeated on every card)
+      const gameCardLinks = screen.getAllByRole("link").filter(
+        (el) => el.getAttribute("href")?.startsWith("/games/"),
+      );
+      gameCardLinks.forEach((card) => {
+        // No element within the card should display the console name as subtitle text
+        const texts = Array.from(card.querySelectorAll("p")).map((p) => p.textContent);
+        expect(texts).not.toContain("Super Nintendo");
+      });
+
+      // Instead, release year should be shown
+      expect(screen.getByText("1990")).toBeInTheDocument();
+      expect(screen.getByText("1995")).toBeInTheDocument();
+    });
+
     it("does not render browse all games link", () => {
       renderPage();
       expect(screen.queryByTestId("browse-all-games-link")).not.toBeInTheDocument();

--- a/web/src/pages/__tests__/console-games-page.test.tsx
+++ b/web/src/pages/__tests__/console-games-page.test.tsx
@@ -164,6 +164,39 @@ describe("ConsoleGamesPage", () => {
     expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
   });
 
+  it("hides console name and shows release year on game cards", () => {
+    mockUseGames.mockReturnValue({
+      data: {
+        data: [
+          makeGame({ id: "1", title: "Super Mario World", consoleName: "Super Nintendo", releaseDate: "1990-11-21" }),
+          makeGame({ id: "2", title: "Chrono Trigger", consoleName: "Super Nintendo", releaseDate: "1995-03-11" }),
+        ],
+        total: 2,
+        page: 1,
+        pageSize: 48,
+      },
+      isLoading: false,
+    });
+    renderPage();
+
+    // Game titles are visible
+    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+    expect(screen.getByText("Chrono Trigger")).toBeInTheDocument();
+
+    // Console name should NOT appear below game cards
+    const gameCardLinks = screen.getAllByRole("link").filter(
+      (el) => el.getAttribute("href")?.startsWith("/games/"),
+    );
+    gameCardLinks.forEach((card) => {
+      const texts = Array.from(card.querySelectorAll("p")).map((p) => p.textContent);
+      expect(texts).not.toContain("Super Nintendo");
+    });
+
+    // Instead, release year should be shown
+    expect(screen.getByText("1990")).toBeInTheDocument();
+    expect(screen.getByText("1995")).toBeInTheDocument();
+  });
+
   it("shows empty state when no games", () => {
     mockUseGames.mockReturnValue({
       data: { data: [], total: 0, page: 1, pageSize: 48 },

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -226,6 +226,7 @@ export function ConsoleDetailPage() {
                   key={game.id}
                   game={game}
                   aspectRatio={console?.coverAspectRatio}
+                  hideConsoleName
                   onToggleFavorite={handleToggleFavorite}
                   onTogglePlayLater={handleTogglePlayLater}
                 />

--- a/web/src/pages/console-games-page.tsx
+++ b/web/src/pages/console-games-page.tsx
@@ -274,6 +274,7 @@ export function ConsoleGamesPage() {
               key={game.id}
               game={game}
               aspectRatio={console?.coverAspectRatio}
+              hideConsoleName
               onToggleFavorite={handleToggleFavorite}
               onTogglePlayLater={handleTogglePlayLater}
             />
@@ -282,7 +283,7 @@ export function ConsoleGamesPage() {
       ) : (
         <div className="space-y-1">
           {games.map((game) => (
-            <GameListRow key={game.id} game={game} />
+            <GameListRow key={game.id} game={game} hideConsoleName />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary
- On console-specific pages (`/consoles/nes` and `/consoles/nes/games`), game cards no longer show the platform name below each title — it was redundant since the user already knows which console page they're on
- Instead, shows the release year (or developer name as fallback) for more useful context
- Applies to both grid view (`GameCard`) and list view (`GameListRow`), including all console showcase shelf sections (Essentials, Hidden Gems, Recently Added, Recently Played)

## Test plan
- [x] Added failing tests first, then implemented the fix
- [x] `console-detail-page.test.tsx`: verifies console name is absent from game cards, release year is shown
- [x] `console-games-page.test.tsx`: same verification for the full browse page
- [x] Full web test suite passes (1378 tests, 0 failures)