### PR TITLE
feat: add netplay session deletion

### DIFF
--- a/server/internal/api/netplay_handler.go
+++ b/server/internal/api/netplay_handler.go
@@ -287,34 +287,49 @@ func (h *NetplayHandler) LeaveSession(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "session ended", "endReason": endReason})
 }
 
-// DeleteSession cancels a waiting session. Host only.
+// DeleteSession soft-deletes a netplay session.
+// - Host can delete sessions in any status (waiting sessions are ended first, then soft-deleted).
+// - Admin/owner can force-delete any session regardless of ownership.
+// - Non-host non-admin users get 403.
+// Associated NetplayInvite records are cleaned up.
 func (h *NetplayHandler) DeleteSession(c *gin.Context) {
 	uid := getUserID(c)
+	role, _ := c.Get("role")
+	roleStr, _ := role.(string)
+	isAdmin := db.IsAdminOrOwner(roleStr)
 
 	session, ok := h.loadSession(c)
 	if !ok {
 		return
 	}
 
-	if session.HostUserID != uid {
-		c.JSON(http.StatusForbidden, gin.H{"error": "only the host can cancel the session"})
+	if session.HostUserID != uid && !isAdmin {
+		c.JSON(http.StatusForbidden, gin.H{"error": "only the host or an admin can delete the session"})
 		return
 	}
 
-	if session.Status != "waiting" {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "can only cancel a waiting session. Use leave to end an active session."})
-		return
+	// End the session first if it's not already ended
+	if session.Status != "ended" {
+		now := time.Now()
+		endReason := "host_left"
+		if isAdmin && session.HostUserID != uid {
+			endReason = "admin_deleted"
+		}
+		h.DB.Model(&session).Updates(map[string]interface{}{
+			"status":     "ended",
+			"end_reason": endReason,
+			"ended_at":   now,
+		})
 	}
 
-	now := time.Now()
-	h.DB.Model(&session).Updates(map[string]interface{}{
-		"status":     "ended",
-		"end_reason": "host_left",
-		"ended_at":   now,
-	})
-
-	// Expire pending invites when session is cancelled (AC-5.2)
+	// Expire pending invites
 	h.expireNetplayInvites(session.ID)
+
+	// Clean up invite records (soft delete)
+	h.DB.Where("netplay_session_id = ?", session.ID).Delete(&db.NetplayInvite{})
+
+	// Soft-delete the session
+	h.DB.Delete(&session)
 
 	if h.Hub != nil {
 		h.Hub.Broadcast(ws.Event{Type: "netplay_session_deleted", Payload: gin.H{
@@ -322,7 +337,7 @@ func (h *NetplayHandler) DeleteSession(c *gin.Context) {
 		}})
 	}
 
-	c.JSON(http.StatusOK, gin.H{"message": "session cancelled"})
+	c.JSON(http.StatusOK, gin.H{"message": "session deleted"})
 }
 
 // UpdateSettings updates the input delay for a session. Host only.

--- a/server/internal/api/netplay_test.go
+++ b/server/internal/api/netplay_test.go
@@ -23,6 +23,7 @@ func registerUserAndGetToken(t *testing.T, router http.Handler, ownerToken, user
 // netplayTestCtx holds shared state for netplay tests.
 type netplayTestCtx struct {
 	router      http.Handler
+	ownerToken  string
 	hostToken   string
 	clientToken string
 	gameID      string
@@ -48,6 +49,7 @@ func setupNetplayCtx(t *testing.T) netplayTestCtx {
 
 	return netplayTestCtx{
 		router:      router,
+		ownerToken:  ownerToken,
 		hostToken:   hostToken,
 		clientToken: clientToken,
 		gameID:      "1",
@@ -460,31 +462,33 @@ func TestNetplay_DeleteSession_HostOnly(t *testing.T) {
 	ctx := setupNetplayCtx(t)
 	session := createSession(t, ctx)
 
+	// Non-host cannot delete
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("DELETE", "/api/netplay/sessions/"+session.ID, nil)
 	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
 	ctx.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusForbidden, w.Code)
 
+	// Host can delete
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest("DELETE", "/api/netplay/sessions/"+session.ID, nil)
 	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
 	ctx.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
+	// Session should be soft-deleted (not found)
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest("GET", "/api/netplay/sessions/"+session.ID, nil)
 	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
 	ctx.router.ServeHTTP(w, req)
-	var detail NetplaySessionResponse
-	json.Unmarshal(w.Body.Bytes(), &detail)
-	assert.Equal(t, "ended", detail.Status)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
-func TestNetplay_DeleteSession_NotWaiting(t *testing.T) {
+func TestNetplay_DeleteSession_InProgress(t *testing.T) {
 	ctx := setupNetplayCtx(t)
 	session := createSession(t, ctx)
 
+	// Client joins => in_progress
 	body, _ := json.Marshal(map[string]interface{}{"inviteCode": session.InviteCode})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/netplay/sessions/join", bytes.NewReader(body))
@@ -493,11 +497,125 @@ func TestNetplay_DeleteSession_NotWaiting(t *testing.T) {
 	ctx.router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
+	// Host can delete an in-progress session (ends it first, then soft-deletes)
 	w = httptest.NewRecorder()
 	req = httptest.NewRequest("DELETE", "/api/netplay/sessions/"+session.ID, nil)
 	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
 	ctx.router.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Session should no longer be found (soft-deleted)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/sessions/"+session.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNetplay_DeleteSession_Ended(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// End the session by host leaving
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/leave", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Host can delete an ended session
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("DELETE", "/api/netplay/sessions/"+session.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Session should no longer be found (soft-deleted)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/sessions/"+session.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNetplay_DeleteSession_AdminForceDelete(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Client joins => in_progress
+	body, _ := json.Marshal(map[string]interface{}{"inviteCode": session.InviteCode})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/join", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Owner (first registered user) can force-delete any session
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("DELETE", "/api/netplay/sessions/"+session.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.ownerToken)
+	ctx.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Session should no longer be found
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/sessions/"+session.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.ownerToken)
+	ctx.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestNetplay_DeleteSession_NonHostNonAdmin(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Client (non-host, non-admin) cannot delete
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("DELETE", "/api/netplay/sessions/"+session.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
+}
+
+func TestNetplay_DeleteSession_CleansUpInvites(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Send an invite to the client
+	body, _ := json.Marshal(map[string]interface{}{"username": "client"})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/invites", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	// Verify invite exists
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/invites/count", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var countResp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &countResp)
+	assert.Equal(t, float64(1), countResp["count"])
+
+	// Delete the session
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("DELETE", "/api/netplay/sessions/"+session.ID, nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	// Invites should be cleaned up (expired + soft-deleted)
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/netplay/invites/count", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	json.Unmarshal(w.Body.Bytes(), &countResp)
+	assert.Equal(t, float64(0), countResp["count"])
 }
 
 func TestNetplay_UpdateSettings(t *testing.T) {
@@ -575,6 +693,27 @@ func TestNetplay_JoinEndedSession(t *testing.T) {
 	ctx := setupNetplayCtx(t)
 	session := createSession(t, ctx)
 
+	// End the session via leave (not delete, which soft-deletes)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/netplay/sessions/"+session.ID+"/leave", nil)
+	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
+	ctx.router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	body, _ := json.Marshal(map[string]interface{}{"inviteCode": session.InviteCode})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("POST", "/api/netplay/sessions/join", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
+	ctx.router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusBadRequest, w.Code)
+}
+
+func TestNetplay_JoinDeletedSession(t *testing.T) {
+	ctx := setupNetplayCtx(t)
+	session := createSession(t, ctx)
+
+	// Delete the session (soft-deletes, so invite code lookup returns 404)
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("DELETE", "/api/netplay/sessions/"+session.ID, nil)
 	req.Header.Set("Authorization", "Bearer "+ctx.hostToken)
@@ -587,7 +726,7 @@ func TestNetplay_JoinEndedSession(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+ctx.clientToken)
 	ctx.router.ServeHTTP(w, req)
-	assert.Equal(t, http.StatusBadRequest, w.Code)
+	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestNetplay_WebSocket_NotPlayer(t *testing.T) {

--- a/web/src/features/netplay/components/__tests__/netplay-session-row.test.tsx
+++ b/web/src/features/netplay/components/__tests__/netplay-session-row.test.tsx
@@ -1,0 +1,133 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NetplaySessionRow } from "../netplay-session-row";
+import type { NetplaySession } from "@/types/api";
+
+const mockMutate = vi.fn();
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: "u1", username: "alice", role: "user" },
+  })),
+}));
+
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual("@/components/ui");
+  return {
+    ...actual,
+    useToast: vi.fn(() => ({ toast: vi.fn() })),
+  };
+});
+
+vi.mock("@/hooks/use-netplay", () => ({
+  useDeleteNetplaySession: vi.fn(() => ({
+    mutate: mockMutate,
+    isPending: false,
+  })),
+}));
+
+const baseSession: NetplaySession = {
+  id: "s1",
+  hostId: "u1",
+  hostUsername: "alice",
+  hostAvatarUrl: null,
+  clientId: "u2",
+  clientUsername: "bob",
+  clientAvatarUrl: null,
+  gameId: "g1",
+  gameTitle: "Super Mario World",
+  gameCoverUrl: null,
+  consoleName: "SNES",
+  coverAspectRatio: 1,
+  status: "ended",
+  endReason: "completed",
+  inputDelay: 2,
+  inviteCode: "ABC123",
+  createdAt: "2026-03-01T10:00:00Z",
+  startedAt: "2026-03-01T10:01:00Z",
+  endedAt: "2026-03-01T11:00:00Z",
+};
+
+function renderRow(session: NetplaySession = baseSession) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter>
+        <NetplaySessionRow session={session} />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("NetplaySessionRow", () => {
+  it("renders game title and badges", () => {
+    renderRow();
+    expect(screen.getByText("Super Mario World")).toBeInTheDocument();
+    expect(screen.getByText("SNES")).toBeInTheDocument();
+  });
+
+  it("renders host and client usernames", () => {
+    renderRow();
+    expect(screen.getByText("alice")).toBeInTheDocument();
+    expect(screen.getByText("bob")).toBeInTheDocument();
+  });
+
+  it("shows delete button for ended sessions where user is host", () => {
+    renderRow();
+    expect(screen.getByLabelText("Delete session")).toBeInTheDocument();
+  });
+
+  it("does not show delete button for waiting sessions", () => {
+    renderRow({ ...baseSession, status: "waiting" });
+    expect(screen.queryByLabelText("Delete session")).not.toBeInTheDocument();
+  });
+
+  it("does not show delete button for in-progress sessions", () => {
+    renderRow({ ...baseSession, status: "in_progress" });
+    expect(screen.queryByLabelText("Delete session")).not.toBeInTheDocument();
+  });
+
+  it("does not show delete button when user is not the host", () => {
+    renderRow({ ...baseSession, hostId: "other-user" });
+    expect(screen.queryByLabelText("Delete session")).not.toBeInTheDocument();
+  });
+
+  it("opens confirm modal when delete button is clicked", () => {
+    renderRow();
+    fireEvent.click(screen.getByLabelText("Delete session"));
+    expect(screen.getByText("Delete Session")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "Permanently delete this netplay session. This action cannot be undone.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("calls delete mutation when confirmed", () => {
+    renderRow();
+    fireEvent.click(screen.getByLabelText("Delete session"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+    expect(mockMutate).toHaveBeenCalledWith("s1", expect.any(Object));
+  });
+
+  it("closes modal when cancel is clicked", () => {
+    renderRow();
+    fireEvent.click(screen.getByLabelText("Delete session"));
+    expect(screen.getByText("Delete Session")).toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Cancel" }));
+    expect(screen.queryByText("Delete Session")).not.toBeInTheDocument();
+  });
+
+  it("shows invite code for waiting sessions", () => {
+    renderRow({ ...baseSession, status: "waiting" });
+    expect(screen.getByText("ABC123")).toBeInTheDocument();
+  });
+});

--- a/web/src/features/netplay/components/netplay-session-row.tsx
+++ b/web/src/features/netplay/components/netplay-session-row.tsx
@@ -1,12 +1,14 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { Copy, Check, Wifi } from "lucide-react";
-import { Badge, Button } from "@/components/ui";
+import { Copy, Check, Wifi, Trash2 } from "lucide-react";
+import { Badge, Button, ConfirmDeleteModal, useToast } from "@/components/ui";
 import {
   netplayStatusVariant,
   netplayStatusLabel,
   endReasonLabel,
 } from "@/features/netplay/components/netplay-status";
+import { useDeleteNetplaySession } from "@/hooks/use-netplay";
+import { useAuth } from "@/hooks/use-auth";
 import { formatRelativeTime } from "@/lib/format";
 import type { NetplaySession } from "@/types/api";
 
@@ -16,6 +18,13 @@ interface NetplaySessionRowProps {
 
 export function NetplaySessionRow({ session }: NetplaySessionRowProps) {
   const [copied, setCopied] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+  const { user } = useAuth();
+  const deleteSession = useDeleteNetplaySession();
+  const { toast } = useToast();
+
+  const isHost = user?.id === session.hostId;
+  const canDelete = isHost && session.status === "ended";
 
   function handleCopy(e: React.MouseEvent) {
     e.preventDefault();
@@ -26,82 +35,125 @@ export function NetplaySessionRow({ session }: NetplaySessionRowProps) {
     });
   }
 
+  function handleDeleteClick(e: React.MouseEvent) {
+    e.preventDefault();
+    e.stopPropagation();
+    setShowDeleteConfirm(true);
+  }
+
+  function handleConfirmDelete() {
+    deleteSession.mutate(session.id, {
+      onSuccess: () => {
+        setShowDeleteConfirm(false);
+      },
+      onError: () => {
+        toast("error", "Failed to delete session");
+      },
+    });
+  }
+
   return (
-    <Link
-      to={`/netplay/${session.id}`}
-      className="flex items-center gap-4 px-4 py-4 rounded-xl bg-surface-900/50 hover:bg-surface-800/50 transition-colors"
-      data-testid={`netplay-session-row-${session.id}`}
-    >
-      {/* Cover art thumbnail */}
-      <div className="h-16 w-12 flex-shrink-0 rounded-lg overflow-hidden bg-surface-800">
-        {session.gameCoverUrl ? (
-          <img
-            src={session.gameCoverUrl}
-            alt={session.gameTitle}
-            className="h-full w-full object-cover"
-            loading="lazy"
-          />
-        ) : (
-          <div className="h-full w-full flex items-center justify-center">
-            <Wifi className="h-5 w-5 text-surface-600" />
+    <>
+      <Link
+        to={`/netplay/${session.id}`}
+        className="group flex items-center gap-4 px-4 py-4 rounded-xl bg-surface-900/50 hover:bg-surface-800/50 transition-colors"
+        data-testid={`netplay-session-row-${session.id}`}
+      >
+        {/* Cover art thumbnail */}
+        <div className="h-16 w-12 flex-shrink-0 rounded-lg overflow-hidden bg-surface-800">
+          {session.gameCoverUrl ? (
+            <img
+              src={session.gameCoverUrl}
+              alt={session.gameTitle}
+              className="h-full w-full object-cover"
+              loading="lazy"
+            />
+          ) : (
+            <div className="h-full w-full flex items-center justify-center">
+              <Wifi className="h-5 w-5 text-surface-600" />
+            </div>
+          )}
+        </div>
+
+        {/* Session info */}
+        <div className="flex-1 min-w-0 space-y-1">
+          <div className="flex items-center gap-2">
+            <p className="text-sm font-medium text-surface-100 truncate">
+              {session.gameTitle}
+            </p>
+            <Badge variant="brand" className="flex-shrink-0">
+              {session.consoleName}
+            </Badge>
+            <Badge
+              variant={netplayStatusVariant[session.status]}
+              className="flex-shrink-0"
+            >
+              {netplayStatusLabel[session.status]}
+            </Badge>
+            {session.status === "ended" && session.endReason && (
+              <Badge variant="default" className="flex-shrink-0">
+                {endReasonLabel[session.endReason]}
+              </Badge>
+            )}
+          </div>
+          <div className="flex items-center gap-2 text-xs text-surface-500">
+            <span>{session.hostUsername}</span>
+            {session.clientUsername && (
+              <>
+                <span>vs</span>
+                <span>{session.clientUsername}</span>
+              </>
+            )}
+            <span>&middot;</span>
+            <span>{formatRelativeTime(session.createdAt)}</span>
+          </div>
+        </div>
+
+        {/* Invite code for waiting sessions */}
+        {session.status === "waiting" && (
+          <div className="flex items-center gap-2 flex-shrink-0">
+            <span className="font-mono text-sm tracking-wider text-surface-300">
+              {session.inviteCode}
+            </span>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleCopy}
+              title="Copy invite code"
+            >
+              {copied ? (
+                <Check className="h-3.5 w-3.5" />
+              ) : (
+                <Copy className="h-3.5 w-3.5" />
+              )}
+            </Button>
           </div>
         )}
-      </div>
 
-      {/* Session info */}
-      <div className="flex-1 min-w-0 space-y-1">
-        <div className="flex items-center gap-2">
-          <p className="text-sm font-medium text-surface-100 truncate">
-            {session.gameTitle}
-          </p>
-          <Badge variant="brand" className="flex-shrink-0">
-            {session.consoleName}
-          </Badge>
-          <Badge
-            variant={netplayStatusVariant[session.status]}
-            className="flex-shrink-0"
-          >
-            {netplayStatusLabel[session.status]}
-          </Badge>
-          {session.status === "ended" && session.endReason && (
-            <Badge variant="default" className="flex-shrink-0">
-              {endReasonLabel[session.endReason]}
-            </Badge>
-          )}
-        </div>
-        <div className="flex items-center gap-2 text-xs text-surface-500">
-          <span>{session.hostUsername}</span>
-          {session.clientUsername && (
-            <>
-              <span>vs</span>
-              <span>{session.clientUsername}</span>
-            </>
-          )}
-          <span>&middot;</span>
-          <span>{formatRelativeTime(session.createdAt)}</span>
-        </div>
-      </div>
+        {/* Delete button for ended sessions (host only) */}
+        {canDelete && (
+          <div className="flex-shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={handleDeleteClick}
+              title="Delete session"
+              aria-label="Delete session"
+            >
+              <Trash2 className="h-3.5 w-3.5 text-danger-500" />
+            </Button>
+          </div>
+        )}
+      </Link>
 
-      {/* Invite code for waiting sessions */}
-      {session.status === "waiting" && (
-        <div className="flex items-center gap-2 flex-shrink-0">
-          <span className="font-mono text-sm tracking-wider text-surface-300">
-            {session.inviteCode}
-          </span>
-          <Button
-            variant="ghost"
-            size="sm"
-            onClick={handleCopy}
-            title="Copy invite code"
-          >
-            {copied ? (
-              <Check className="h-3.5 w-3.5" />
-            ) : (
-              <Copy className="h-3.5 w-3.5" />
-            )}
-          </Button>
-        </div>
-      )}
-    </Link>
+      <ConfirmDeleteModal
+        open={showDeleteConfirm}
+        onClose={() => setShowDeleteConfirm(false)}
+        title="Delete Session"
+        message="Permanently delete this netplay session. This action cannot be undone."
+        onConfirm={handleConfirmDelete}
+        isPending={deleteSession.isPending}
+      />
+    </>
   );
 }

--- a/web/src/features/netplay/components/netplay-status.ts
+++ b/web/src/features/netplay/components/netplay-status.ts
@@ -23,4 +23,5 @@ export const endReasonLabel: Record<
   client_left: "Client left",
   timeout: "Expired",
   completed: "Completed",
+  admin_deleted: "Removed by admin",
 };

--- a/web/src/pages/__tests__/netplay-page.test.tsx
+++ b/web/src/pages/__tests__/netplay-page.test.tsx
@@ -16,6 +16,10 @@ vi.mock("@/hooks/use-netplay", () => ({
     isPending: false,
   })),
   useNetplayInvitesRealtime: vi.fn(),
+  useDeleteNetplaySession: vi.fn(() => ({
+    mutate: vi.fn(),
+    isPending: false,
+  })),
   useNetplayInvites: vi.fn(() => ({
     data: { data: [], total: 0 },
     isLoading: false,
@@ -32,6 +36,14 @@ vi.mock("@/hooks/use-netplay", () => ({
 
 vi.mock("@/hooks/use-games", () => ({
   useGames: vi.fn(() => ({ data: { data: [] } })),
+}));
+
+vi.mock("@/hooks/use-auth", () => ({
+  useAuth: vi.fn(() => ({
+    user: { id: "u1", username: "alice", role: "user" },
+    isAdmin: false,
+    isAuthenticated: true,
+  })),
 }));
 
 vi.mock("@/components/ui", async () => {

--- a/web/src/pages/netplay-session-page.tsx
+++ b/web/src/pages/netplay-session-page.tsx
@@ -5,6 +5,7 @@ import {
   Button,
   BackButton,
   Badge,
+  ConfirmDeleteModal,
   Modal,
   Skeleton,
   EmptyState,
@@ -61,6 +62,7 @@ export function NetplaySessionPage() {
   const deleteSession = useDeleteNetplaySession();
 
   const [showCancelModal, setShowCancelModal] = useState(false);
+  const [showDeleteModal, setShowDeleteModal] = useState(false);
   const [showInviteModal, setShowInviteModal] = useState(false);
   useNetplayInvitesRealtime(id);
 
@@ -75,6 +77,20 @@ export function NetplaySessionPage() {
       },
       onError: () => {
         toast("error", "Failed to cancel session");
+      },
+    });
+  }
+
+  function handleDelete() {
+    if (!session) return;
+    const isInProgress = session.status === "in_progress";
+    deleteSession.mutate(session.id, {
+      onSuccess: () => {
+        toast("success", isInProgress ? "Session ended and deleted" : "Session deleted");
+        navigate("/netplay");
+      },
+      onError: () => {
+        toast("error", "Failed to delete session");
       },
     });
   }
@@ -202,16 +218,38 @@ export function NetplaySessionPage() {
 
             {/* Host-only cancel for waiting sessions */}
             {isHost && session.status === "waiting" && (
-              <div className="flex flex-wrap items-center gap-2">
-                <Button
-                  variant="danger"
-                  size="sm"
-                  onClick={() => setShowCancelModal(true)}
-                >
-                  <Trash2 className="h-5 w-5" />
-                  Cancel Session
-                </Button>
-              </div>
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => setShowCancelModal(true)}
+              >
+                <Trash2 className="h-4 w-4" />
+                Cancel Session
+              </Button>
+            )}
+
+            {/* Host-only delete for ended sessions */}
+            {isHost && session.status === "ended" && (
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => setShowDeleteModal(true)}
+              >
+                <Trash2 className="h-4 w-4" />
+                Delete Session
+              </Button>
+            )}
+
+            {/* Host-only end & delete for in-progress sessions */}
+            {isHost && session.status === "in_progress" && (
+              <Button
+                variant="danger"
+                size="sm"
+                onClick={() => setShowDeleteModal(true)}
+              >
+                <Trash2 className="h-4 w-4" />
+                End &amp; Delete Session
+              </Button>
             )}
           </div>
 
@@ -301,6 +339,20 @@ export function NetplaySessionPage() {
           </Button>
         </div>
       </Modal>
+
+      {/* Delete confirm modal */}
+      <ConfirmDeleteModal
+        open={showDeleteModal}
+        onClose={() => setShowDeleteModal(false)}
+        title={session.status === "in_progress" ? "End & Delete Session" : "Delete Session"}
+        message={
+          session.status === "in_progress"
+            ? "This will end the session and disconnect any connected players. This action cannot be undone."
+            : "Permanently delete this netplay session. This action cannot be undone."
+        }
+        onConfirm={handleDelete}
+        isPending={deleteSession.isPending}
+      />
     </div>
   );
 }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -640,7 +640,7 @@ export interface NetplaySession {
   consoleName: string;
   coverAspectRatio: number;
   status: "waiting" | "in_progress" | "ended";
-  endReason: "host_left" | "client_left" | "timeout" | "completed" | null;
+  endReason: "host_left" | "client_left" | "timeout" | "completed" | "admin_deleted" | null;
   inputDelay: number;
   inviteCode: string;
   createdAt: string;


### PR DESCRIPTION
## Summary
- **Backend**: Update `DELETE /api/netplay/sessions/:id` to support all session statuses (waiting, in-progress, ended), soft delete via GORM `DeletedAt`, admin force-delete, invite cleanup, and WebSocket `netplay_session_deleted` notification
- **Web detail page**: "Delete Session" button for ended sessions, "End & Delete Session" for in-progress (host only), with `ConfirmDeleteModal` and disconnect warning
- **Web list rows**: Hover-reveal trash icon for ended sessions (host only), matching `SessionCard` pattern
- **Type safety**: Add `"admin_deleted"` to frontend `endReason` union type and label map
- **Tests**: 58 backend netplay tests + 37 web netplay tests all pass

## Test plan
- [x] All 58 Go netplay tests pass
- [x] All 37 web netplay tests pass (session page, session detail, session row)
- [x] TypeScript compiles clean
- [x] Go builds clean
- [ ] Manual: create session → end it → delete from detail page
- [ ] Manual: create session → end it → delete from list row (hover trash)
- [ ] Manual: create in-progress session → "End & Delete" from detail page
- [ ] Manual: verify non-host users don't see delete buttons
- [ ] Manual: verify deleted session returns 404