### PR TITLE
fix: add missing extensions and directory mappings to scanner

### DIFF
--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -169,9 +169,9 @@ var RomExtensions = map[string]bool{
 	".ngp": true, ".ngc": true,
 	".ws": true, ".wsc": true,
 	".col": true,
-	".d64": true, ".t64": true, ".prg": true, ".crt": true,
+	".d64": true, ".d71": true, ".d81": true, ".t64": true, ".prg": true, ".crt": true,
 	".exe": true, ".com": true, ".bat": true, ".conf": true,
-	".adf": true, ".hdf": true, ".lha": true,
+	".adf": true, ".hdf": true, ".lha": true, ".ipf": true, ".dms": true,
 	".min": true,
 	".j64": true, ".jag": true,
 	".32x": true,
@@ -249,6 +249,12 @@ var directoryConsoleMap = map[string]string{
 	"c64":          "C64",
 	"dos":          "DOS",
 	"amiga":        "AMIGA",
+	"3do":          "3DO",
+	"c128":         "C128",
+	"pet":          "PET",
+	"plus4":        "PLUS4",
+	"vic20":        "VIC20",
+	"cdi":          "CDI",
 }
 
 // discPattern matches disc/disk/cd markers in filenames, e.g. "(Disc 1)", "[Disk 2]", "(CD 3)".


### PR DESCRIPTION
## Summary
The Amiga console had `.ipf,.dms,.zip` added to its DB extensions but the scanner's `RomExtensions` map didn't include `.ipf` or `.dms`, so it silently skipped those files. Same issue for Commodore 128's `.d71,.d81` formats.

Also adds directory-to-console mappings for all 6 new consoles (3DO, C128, PET, Plus/4, VIC-20, CDi) so the scanner can identify games in those folders.

## Root cause
Two separate maps need to be in sync:
1. `Console.Extensions` in the DB (what the console supports)
2. `RomExtensions` in the scanner (what files to scan at all)

When we added `.ipf,.dms,.zip` to the Amiga console, we only updated #1.

## Test plan
- [x] Go builds clean
- [ ] Manual: start server with testdata/roms/amiga containing .ipf files → trigger scan → Amiga games appear