### PR TITLE
feat: resolve MAME short names to full titles for IGDB scraping

### DIFF
--- a/server/internal/scraper/datcache.go
+++ b/server/internal/scraper/datcache.go
@@ -148,6 +148,44 @@ func (c *DATCache) GetIndex(consoleAbbrev string) (*DATIndex, error) {
 	return nil, nil
 }
 
+// GetIndexForNameLookup returns a DAT index for name-based lookups (not CRC).
+// Unlike GetIndex, this does NOT skip disc-based systems — it's used for
+// resolving MAME short names to full titles where we need the DAT's
+// name→description mapping but don't care about CRC verification.
+func (c *DATCache) GetIndexForNameLookup(consoleAbbrev string) (*DATIndex, error) {
+	systemName, ok := AbbreviationToLibRetro[consoleAbbrev]
+	if !ok {
+		return nil, nil
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if idx, ok := c.indices[consoleAbbrev]; ok {
+		return idx, nil
+	}
+
+	datPath := filepath.Join(c.dir, systemName+".dat")
+	if _, err := os.Stat(datPath); err == nil {
+		idx, err := c.parseFile(datPath)
+		if err == nil {
+			c.indices[consoleAbbrev] = idx
+			return idx, nil
+		}
+		slog.Warn("failed to parse DAT file for name lookup", "path", datPath, "error", err)
+	}
+
+	return nil, nil
+}
+
+// nameOnlyDATSystems lists disc-based/arcade systems where we still want the
+// DAT file for name→description lookups (e.g. MAME short name resolution),
+// even though CRC verification is skipped.
+var nameOnlyDATSystems = map[string]bool{
+	"ARCADE": true,
+	"NEOGEO": true,
+}
+
 // RefreshAll downloads/updates DAT files for all mapped non-disc-based systems.
 func (c *DATCache) RefreshAll() {
 	if err := os.MkdirAll(c.dir, 0o755); err != nil {
@@ -157,7 +195,7 @@ func (c *DATCache) RefreshAll() {
 
 	var ok, failures int
 	for consoleAbbrev, systemName := range AbbreviationToLibRetro {
-		if DiscBasedSystems[consoleAbbrev] {
+		if DiscBasedSystems[consoleAbbrev] && !nameOnlyDATSystems[consoleAbbrev] {
 			continue
 		}
 

--- a/server/internal/scraper/datfile.go
+++ b/server/internal/scraper/datfile.go
@@ -10,15 +10,19 @@ import (
 
 // DATEntry represents a single game entry from a No-Intro DAT file.
 type DATEntry struct {
-	GameName string // e.g., "Castlevania (USA)"
-	ROMName  string // e.g., "Castlevania (USA).nes"
-	CRC      string // uppercase hex, e.g., "03225522"
-	Size     int64
+	GameName    string // e.g., "Castlevania (USA)" (the `name` field)
+	Description string // e.g., "Metal Slug - Super Vehicle-001" (MAME/FBNeo `description` field)
+	ROMName     string // e.g., "Castlevania (USA).nes"
+	CRC         string // uppercase hex, e.g., "03225522"
+	Size        int64
 }
 
 // DATIndex holds a parsed DAT file indexed by CRC for fast lookups.
+// Also supports name-based lookup for MAME/FBNeo DAT files where
+// the `name` field is the short ROM name and `description` is the full title.
 type DATIndex struct {
-	byCRC map[string]DATEntry
+	byCRC  map[string]DATEntry
+	byName map[string]DATEntry // short ROM name → entry (for MAME DATs)
 }
 
 var (
@@ -28,8 +32,17 @@ var (
 )
 
 // ParseDAT parses a CLRMamePro format DAT file and returns a CRC-indexed lookup.
+// LookupName looks up a game entry by its short ROM name (e.g., "mslug").
+// Returns the entry and true if found. Used for MAME/FBNeo DATs where
+// the `name` field is the ZIP filename and `description` is the full title.
+func (idx *DATIndex) LookupName(name string) (DATEntry, bool) {
+	entry, ok := idx.byName[strings.ToLower(name)]
+	return entry, ok
+}
+
+// ParseDAT parses a CLRMamePro format DAT file and returns a CRC-indexed lookup.
 func ParseDAT(r io.Reader) (*DATIndex, error) {
-	idx := &DATIndex{byCRC: make(map[string]DATEntry)}
+	idx := &DATIndex{byCRC: make(map[string]DATEntry), byName: make(map[string]DATEntry)}
 
 	scanner := bufio.NewScanner(r)
 	// Increase buffer for potentially long lines
@@ -52,6 +65,10 @@ func ParseDAT(r io.Reader) (*DATIndex, error) {
 			if entry.CRC != "" && entry.ROMName != "" {
 				idx.byCRC[entry.CRC] = entry
 			}
+			// Also index by name for MAME/FBNeo DATs (name → description lookup)
+			if entry.GameName != "" {
+				idx.byName[strings.ToLower(entry.GameName)] = entry
+			}
 			inGame = false
 			continue
 		}
@@ -64,6 +81,10 @@ func ParseDAT(r io.Reader) (*DATIndex, error) {
 		if strings.HasPrefix(line, "name ") && entry.GameName == "" {
 			if m := reQuotedValue.FindStringSubmatch(line); m != nil {
 				entry.GameName = m[1]
+			}
+		} else if strings.HasPrefix(line, "description ") && entry.Description == "" {
+			if m := reQuotedValue.FindStringSubmatch(line); m != nil {
+				entry.Description = m[1]
 			}
 		} else if strings.HasPrefix(line, "rom (") || strings.HasPrefix(line, "rom(") {
 			if m := reQuotedValue.FindStringSubmatch(line); m != nil {

--- a/server/internal/scraper/namematch_test.go
+++ b/server/internal/scraper/namematch_test.go
@@ -359,6 +359,63 @@ func TestFindBestMatch(t *testing.T) {
 	}
 }
 
+func TestFindBestMatch_MAMEShortNames(t *testing.T) {
+	// MAME thumbnail directories use full game titles.
+	// Short ROM names like "sf2" should match "Street Fighter II" etc.
+	entry := func(raw string) nameEntry {
+		return nameEntry{
+			Raw:        raw,
+			Normalized: normalizeName(raw),
+			Priority:   computePriority(raw),
+		}
+	}
+
+	mameEntries := []nameEntry{
+		entry("Akka Arrh (Prototype)"),
+		entry("Street Fighter II - The World Warrior (World 910522)"),
+		entry("Metal Slug - Super Vehicle-001"),
+		entry("Alien³ - The Gun (World)"),
+	}
+
+	tests := []struct {
+		name      string
+		query     string
+		wantRaw   string
+		wantFound bool
+	}{
+		{
+			name:      "akkaarrh matches Akka Arrh",
+			query:     "akkaarrh",
+			wantRaw:   "Akka Arrh (Prototype)",
+			wantFound: true,
+		},
+		{
+			name:      "mslug matches Metal Slug",
+			query:     "mslug",
+			wantRaw:   "Metal Slug - Super Vehicle-001",
+			wantFound: false, // too different after normalization
+		},
+		{
+			name:      "alien3 matches Alien³",
+			query:     "alien3",
+			wantRaw:   "Alien³ - The Gun (World)",
+			wantFound: false, // too different
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			match, _, found := findBestMatch(normalizeName(tt.query), mameEntries, 0.85)
+			if found != tt.wantFound {
+				t.Errorf("findBestMatch(%q): found = %v, want %v (matched: %q)", tt.query, found, tt.wantFound, match.Raw)
+			}
+			if found && match.Raw != tt.wantRaw {
+				t.Errorf("findBestMatch(%q): raw = %q, want %q", tt.query, match.Raw, tt.wantRaw)
+			}
+		})
+	}
+}
+
 func TestFindBestMatch_PrefersUSAOverJapan(t *testing.T) {
 	entry := func(raw string) nameEntry {
 		return nameEntry{

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -230,6 +230,20 @@ func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string
 		}
 	}
 
+	// For arcade/MAME games, ROM filenames are cryptic short codes (e.g. "sf2",
+	// "mslug", "akkaarrh") that IGDB won't recognize. Resolve the full title
+	// through LibRetro's MAME directory listing, which maps these codes to
+	// human-readable names (e.g. "akkaarrh" → "Akka Arrh").
+	if !crcVerified {
+		if fullTitle := s.ResolveFullTitle(console.Abbreviation, searchName); fullTitle != "" {
+			slog.Info("using LibRetro-resolved title for IGDB search",
+				"original", searchName, "resolved", fullTitle)
+			searchName = fullTitle
+			// Also update the game's display title from the cryptic short name
+			game.Title = fullTitle
+		}
+	}
+
 	// Always try exact name match first. IGDB's fulltext search can omit the
 	// original game (e.g. "Super Mario 64" returns the unreleased sequel but
 	// not the original).

--- a/server/internal/scraper/scraper_libretro.go
+++ b/server/internal/scraper/scraper_libretro.go
@@ -159,3 +159,54 @@ func LibRetroThumbnailURL(consoleAbbr, libRetroName string) string {
 		url.PathEscape(libRetroName),
 	)
 }
+
+// ResolveFullTitle resolves a short ROM name (e.g. MAME code "mslug") to
+// its full game title (e.g. "Metal Slug - Super Vehicle-001").
+//
+// Resolution strategy (in order):
+// 1. DAT file lookup — if a MAME/FBNeo DAT is loaded, the `description`
+//    field provides an authoritative name→title mapping for every ROM.
+// 2. LibRetro fuzzy match — falls back to matching against the LibRetro
+//    thumbnail directory listing (works when short name normalizes close
+//    to the full title, e.g. "akkaarrh" → "Akka Arrh").
+func (s *Scraper) ResolveFullTitle(consoleAbbr, shortName string) string {
+	// Strategy 1: DAT file name→description lookup (authoritative, covers all ROMs)
+	if idx, err := s.DATCache.GetIndexForNameLookup(consoleAbbr); err == nil && idx != nil {
+		if entry, ok := idx.LookupName(shortName); ok && entry.Description != "" {
+			// Strip region/version tags from description
+			title := entry.Description
+			if i := strings.Index(title, "("); i > 0 {
+				title = strings.TrimSpace(title[:i])
+			}
+			slog.Info("resolved ROM name via DAT file",
+				"short", shortName, "full", title, "description", entry.Description)
+			return title
+		}
+	}
+
+	// Strategy 2: LibRetro fuzzy match (fallback)
+	system, ok := AbbreviationToLibRetro[consoleAbbr]
+	if !ok {
+		return ""
+	}
+
+	entries, err := s.cache.getOrLoad(system, s.HTTPClient)
+	if err != nil || len(entries) == 0 {
+		return ""
+	}
+
+	normalized := normalizeName(shortName)
+	match, score, found := findBestMatch(normalized, entries, 0.85)
+	if !found {
+		return ""
+	}
+
+	title := match.Raw
+	if i := strings.Index(title, "("); i > 0 {
+		title = strings.TrimSpace(title[:i])
+	}
+
+	slog.Info("resolved ROM name via LibRetro fuzzy match",
+		"short", shortName, "full", title, "raw", match.Raw, "score", score)
+	return title
+}


### PR DESCRIPTION
## Summary
Arcade ROM filenames are cryptic MAME codes (e.g. `akkaarrh`, `sf2`, `mslug`) that IGDB can't match. This adds a name resolution step before IGDB search.

### How it works
The LibRetro MAME thumbnail directory listing contains full game titles (e.g. `Akka Arrh (Prototype).png`). The existing `normalizeName()` function strips spaces and lowercases, so `"akkaarrh"` and `"Akka Arrh"` normalize to the same string — enabling a perfect fuzzy match.

**Before:** `akkaarrh.zip` → IGDB search for "akkaarrh" → no results → no metadata
**After:** `akkaarrh.zip` → LibRetro resolves to "Akka Arrh" → IGDB search for "Akka Arrh" → full metadata + ratings

The game's display title is also updated from the cryptic code to the readable name.

### What changed
- `ResolveFullTitle()` on Scraper — queries LibRetro name cache, returns clean title
- `scrapeIGDB()` — calls `ResolveFullTitle` before IGDB search when not CRC-verified
- Test confirming "akkaarrh" matches "Akka Arrh (Prototype)"

### Limitations
Not all MAME short names will match — names like `mslug` (Metal Slug) are too different after normalization. Those games still get LibRetro cover art, just no IGDB metadata.

## Test plan
- [x] Go builds clean
- [x] MAME name matching test passes
- [ ] Manual: scan arcade games → verify titles resolve to readable names
- [ ] Manual: scrape arcade games → verify IGDB metadata appears