### PR TITLE
fix: franchise/series page — hide empty badges and fix dark contrast

### DIFF
--- a/web/src/features/explore/components/game-timeline-card.tsx
+++ b/web/src/features/explore/components/game-timeline-card.tsx
@@ -3,6 +3,23 @@ import { Badge } from "@/components/ui";
 import { cn } from "@/lib/cn";
 import type { SeriesGame } from "@/types/api";
 
+/** Ensures a hex color has enough brightness for dark backgrounds.
+ *  Lightens colors below a perceived brightness threshold. */
+function ensureContrast(hex: string): string {
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  // Perceived brightness (ITU-R BT.709)
+  const brightness = (r * 0.299 + g * 0.587 + b * 0.114);
+  if (brightness >= 100) return hex;
+  // Lighten by blending toward white
+  const factor = 100 / Math.max(brightness, 1);
+  const lr = Math.min(255, Math.round(r * factor));
+  const lg = Math.min(255, Math.round(g * factor));
+  const lb = Math.min(255, Math.round(b * factor));
+  return `#${lr.toString(16).padStart(2, "0")}${lg.toString(16).padStart(2, "0")}${lb.toString(16).padStart(2, "0")}`;
+}
+
 interface GameTimelineCardProps {
   game: SeriesGame;
   testIdPrefix: string;
@@ -50,20 +67,22 @@ export function GameTimelineCard({ game, testIdPrefix }: GameTimelineCardProps) 
           {game.name}
         </h3>
         <div className="flex items-center gap-2 mt-1">
-          <Badge
-            variant="default"
-            style={
-              game.inLibrary && game.consoleColor
-                ? {
-                    backgroundColor: `${game.consoleColor}20`,
-                    color: game.consoleColor,
-                    borderColor: `${game.consoleColor}40`,
-                  }
-                : undefined
-            }
-          >
-            {game.consoleName}
-          </Badge>
+          {game.consoleName && (
+            <Badge
+              variant="default"
+              style={
+                game.consoleColor
+                  ? {
+                      backgroundColor: `${game.consoleColor}20`,
+                      color: ensureContrast(game.consoleColor),
+                      borderColor: `${game.consoleColor}40`,
+                    }
+                  : undefined
+              }
+            >
+              {game.consoleName}
+            </Badge>
+          )}
           {year && (
             <span className="text-xs text-surface-500">{year}</span>
           )}


### PR DESCRIPTION
## Summary
Fixes two issues on `/explore/franchise/:id` and `/explore/series/:id`:

1. **Empty platform badge** — non-library games showed an empty console badge. Now only renders when consoleName is present.
2. **Dark badge contrast** — some consoles (e.g. GBA) have very dark colors that were unreadable. Added `ensureContrast()` that lightens colors below a brightness threshold.

Also removed the `inLibrary` guard from badge color styling — console colors should show for all games, not just library ones.

Issues 3 (shared game list component) and 4 (franchise logo) are larger scope and deferred.

## Test plan
- [x] TypeScript compiles clean
- [ ] Manual: franchise page shows no empty badges for non-library games
- [ ] Manual: GBA and other dark console badges are now readable