### PR TITLE
fix: DOS support, dedup gaps in top lists, and franchise badge fixes

### DIFF
--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -566,7 +566,7 @@ func (h *ConsoleHandler) getTopListByRating(c *gin.Context, ratingColumn string,
 				consoles.name AS console_name,
 				consoles.abbreviation AS console_abbr,
 				`+ratingColumn+` AS rating`).
-		Joins("JOIN games ON LOWER(games.title) = LOWER(top_rated_games.name) AND games.console_id = top_rated_games.console_id AND games.deleted_at IS NULL").
+		Joins("JOIN games ON LOWER(games.title) = LOWER(top_rated_games.name) AND games.console_id = top_rated_games.console_id AND games.deleted_at IS NULL AND games.is_primary = true").
 		Joins("JOIN consoles ON consoles.id = top_rated_games.console_id AND consoles.deleted_at IS NULL").
 		Where("top_rated_games.deleted_at IS NULL AND "+ratingFilter).
 		Group("top_rated_games.id, top_rated_games.name, consoles.name, consoles.abbreviation, "+ratingColumn).
@@ -634,7 +634,7 @@ func (h *ConsoleHandler) GetTopListLongest(c *gin.Context) {
 				games.time_to_beat_hastily,
 				games.time_to_beat_completely`).
 		Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.deleted_at IS NULL").
-		Where("games.time_to_beat_normally > 0 AND games.deleted_at IS NULL").
+		Where("games.time_to_beat_normally > 0 AND games.deleted_at IS NULL AND games.is_primary = true").
 		Order("games.time_to_beat_normally DESC").
 		Limit(50).
 		Find(&rows).Error

--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -662,6 +662,7 @@ func TestGetTopListLongest_LimitOf50(t *testing.T) {
 			FileName:           fmt.Sprintf("game%03d.nes", i),
 			FilePath:           fmt.Sprintf("/games/game%03d.nes", i),
 			FileSize:           1024,
+			IsPrimary:          true,
 			TimeToBeatNormally: i * 10,
 		})
 	}

--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -281,7 +281,7 @@ func TestGetTopListAvailable_ReturnsOnlyLocalMatches(t *testing.T) {
 	// Create a local game matching only one of them (case-insensitive)
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "super mario bros.",
-		FileName: "smb.nes", FilePath: "/games/smb.nes", FileSize: 1024,
+		FileName: "smb.nes", FilePath: "/games/smb.nes", FileSize: 1024, IsPrimary: true,
 		CoverURL: "covers/nes/smb.png",
 	})
 
@@ -329,7 +329,7 @@ func TestGetTopListAvailable_SortedByRatingDesc(t *testing.T) {
 			ConsoleID: nesConsole.ID, Title: title,
 			FileName: strings.ToLower(title) + ".nes",
 			FilePath: "/games/" + strings.ToLower(title) + ".nes",
-			FileSize: 1024,
+			FileSize: 1024, IsPrimary: true,
 		})
 	}
 
@@ -372,11 +372,11 @@ func TestGetTopListAvailable_SequentialRanks(t *testing.T) {
 	// Create matching local games
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "First",
-		FileName: "first.nes", FilePath: "/games/first.nes", FileSize: 1024,
+		FileName: "first.nes", FilePath: "/games/first.nes", FileSize: 1024, IsPrimary: true,
 	})
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "Second",
-		FileName: "second.nes", FilePath: "/games/second.nes", FileSize: 1024,
+		FileName: "second.nes", FilePath: "/games/second.nes", FileSize: 1024, IsPrimary: true,
 	})
 
 	w := httptest.NewRecorder()
@@ -451,7 +451,7 @@ func TestGetTopListAvailable_IncludesConsoleInfo(t *testing.T) {
 
 	database.Create(&db.Game{
 		ConsoleID: snesConsole.ID, Title: "Super Mario World",
-		FileName: "smw.sfc", FilePath: "/games/smw.sfc", FileSize: 2048,
+		FileName: "smw.sfc", FilePath: "/games/smw.sfc", FileSize: 2048, IsPrimary: true,
 		CoverURL: "covers/snes/smw.png",
 	})
 
@@ -509,17 +509,17 @@ func TestGetTopListLongest_SortedByTimeToBeatDesc(t *testing.T) {
 	// Create games with varying time-to-beat values
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "Short Game",
-		FileName: "short.nes", FilePath: "/games/short.nes", FileSize: 1024,
+		FileName: "short.nes", FilePath: "/games/short.nes", FileSize: 1024, IsPrimary: true,
 		TimeToBeatNormally: 10, TimeToBeatHastily: 5, TimeToBeatCompletely: 20,
 	})
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "Long Game",
-		FileName: "long.nes", FilePath: "/games/long.nes", FileSize: 1024,
+		FileName: "long.nes", FilePath: "/games/long.nes", FileSize: 1024, IsPrimary: true,
 		TimeToBeatNormally: 100, TimeToBeatHastily: 60, TimeToBeatCompletely: 200,
 	})
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "Medium Game",
-		FileName: "medium.nes", FilePath: "/games/medium.nes", FileSize: 1024,
+		FileName: "medium.nes", FilePath: "/games/medium.nes", FileSize: 1024, IsPrimary: true,
 		TimeToBeatNormally: 50, TimeToBeatHastily: 30, TimeToBeatCompletely: 80,
 	})
 
@@ -554,13 +554,13 @@ func TestGetTopListLongest_OnlyIncludesGamesWithTimeToBeat(t *testing.T) {
 	// Game with time-to-beat data
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "Has Time Data",
-		FileName: "has.nes", FilePath: "/games/has.nes", FileSize: 1024,
+		FileName: "has.nes", FilePath: "/games/has.nes", FileSize: 1024, IsPrimary: true,
 		TimeToBeatNormally: 40, TimeToBeatHastily: 20, TimeToBeatCompletely: 60,
 	})
 	// Game without time-to-beat data (zero value)
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "No Time Data",
-		FileName: "no.nes", FilePath: "/games/no.nes", FileSize: 1024,
+		FileName: "no.nes", FilePath: "/games/no.nes", FileSize: 1024, IsPrimary: true,
 		TimeToBeatNormally: 0,
 	})
 
@@ -588,11 +588,11 @@ func TestGetTopListLongest_EmptyWhenNoGamesHaveTimeData(t *testing.T) {
 	// Create games without time data
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "Game A",
-		FileName: "a.nes", FilePath: "/games/a.nes", FileSize: 1024,
+		FileName: "a.nes", FilePath: "/games/a.nes", FileSize: 1024, IsPrimary: true,
 	})
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "Game B",
-		FileName: "b.nes", FilePath: "/games/b.nes", FileSize: 1024,
+		FileName: "b.nes", FilePath: "/games/b.nes", FileSize: 1024, IsPrimary: true,
 	})
 
 	w := httptest.NewRecorder()
@@ -617,17 +617,17 @@ func TestGetTopListLongest_SequentialRanks(t *testing.T) {
 
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "First",
-		FileName: "first.nes", FilePath: "/games/first.nes", FileSize: 1024,
+		FileName: "first.nes", FilePath: "/games/first.nes", FileSize: 1024, IsPrimary: true,
 		TimeToBeatNormally: 100,
 	})
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "Second",
-		FileName: "second.nes", FilePath: "/games/second.nes", FileSize: 1024,
+		FileName: "second.nes", FilePath: "/games/second.nes", FileSize: 1024, IsPrimary: true,
 		TimeToBeatNormally: 50,
 	})
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "Third",
-		FileName: "third.nes", FilePath: "/games/third.nes", FileSize: 1024,
+		FileName: "third.nes", FilePath: "/games/third.nes", FileSize: 1024, IsPrimary: true,
 		TimeToBeatNormally: 25,
 	})
 

--- a/server/internal/api/explore_handler_community.go
+++ b/server/internal/api/explore_handler_community.go
@@ -162,9 +162,10 @@ func (h *ExploreHandler) GetCommunityTop(c *gin.Context) {
 	var rows []communityRow
 	if err := h.DB.
 		Table("game_ratings").
-		Select("game_id, AVG(rating) as avg_rating, COUNT(*) as rating_count").
-		Where("deleted_at IS NULL").
-		Group("game_id").
+		Select("game_ratings.game_id, AVG(game_ratings.rating) as avg_rating, COUNT(*) as rating_count").
+		Joins("JOIN games ON games.id = game_ratings.game_id AND games.deleted_at IS NULL AND games.is_primary = true").
+		Where("game_ratings.deleted_at IS NULL").
+		Group("game_ratings.game_id").
 		Having("rating_count >= 2").
 		Order("avg_rating DESC, rating_count DESC").
 		Limit(20).

--- a/server/internal/api/explore_handler_community.go
+++ b/server/internal/api/explore_handler_community.go
@@ -238,7 +238,7 @@ func (h *ExploreHandler) GetCultClassics(c *gin.Context) {
 	if err := h.DB.
 		Table("game_ratings").
 		Select("game_ratings.game_id, AVG(game_ratings.rating) as community_rating, COUNT(*) as rating_count").
-		Joins("JOIN games ON games.id = game_ratings.game_id AND games.deleted_at IS NULL").
+		Joins("JOIN games ON games.id = game_ratings.game_id AND games.deleted_at IS NULL AND games.is_primary = true").
 		Where("game_ratings.deleted_at IS NULL AND games.rating < 75").
 		Group("game_ratings.game_id").
 		Having("rating_count >= 2 AND community_rating >= 4.0").

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -827,7 +827,7 @@ func SeedConsoles(db *gorm.DB) error {
 		{Name: "Commodore Plus/4", Abbreviation: "PLUS4", Extensions: ".prg,.d64,.t64", DefaultCore: "vice_xplus4", EmulatorJSCore: "vice_xplus4", FolderName: "plus4", ColorTheme: "#6c5eb5", Generation: 100, SaveStateSupport: true, Playable: true},
 		{Name: "Commodore VIC-20", Abbreviation: "VIC20", Extensions: ".prg,.d64,.t64,.crt", DefaultCore: "vice_xvic", EmulatorJSCore: "vice_xvic", FolderName: "vic20", ColorTheme: "#6c5eb5", Generation: 100, SaveStateSupport: true, Playable: true},
 		{Name: "Commodore Amiga", Abbreviation: "AMIGA", Extensions: ".adf,.hdf,.lha,.ipf,.dms,.zip", DefaultCore: "puae", EmulatorJSCore: "puae", FolderName: "amiga", ColorTheme: "#6c5eb5", Generation: 100, SaveStateSupport: true, Playable: true},
-		{Name: "DOS", Abbreviation: "DOS", Extensions: ".exe,.com,.bat,.conf", DefaultCore: "dosbox_pure", EmulatorJSCore: "dosbox_pure", FolderName: "dos", ColorTheme: "#000000", Generation: 100, SaveStateSupport: true, Playable: true},
+		{Name: "DOS", Abbreviation: "DOS", Extensions: ".zip,.dosz,.conf", DefaultCore: "dosbox_pure", EmulatorJSCore: "dosbox_pure", FolderName: "dos", ColorTheme: "#000000", Generation: 100, SaveStateSupport: true, Playable: true},
 		{Name: "MSX", Abbreviation: "MSX1", Extensions: ".rom,.mx1,.dsk,.cas", DefaultCore: "bluemsx", EmulatorJSCore: "", FolderName: "msx1", ColorTheme: "#4a86c8", Generation: 100, SaveStateSupport: true, Playable: true},
 		{Name: "MSX2", Abbreviation: "MSX2", Extensions: ".rom,.mx2,.dsk,.cas", DefaultCore: "bluemsx", EmulatorJSCore: "", FolderName: "msx2", ColorTheme: "#4a86c8", Generation: 100, SaveStateSupport: true, Playable: true},
 		// Arcade (generation = 101)

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -170,7 +170,7 @@ var RomExtensions = map[string]bool{
 	".ws": true, ".wsc": true,
 	".col": true,
 	".d64": true, ".d71": true, ".d81": true, ".t64": true, ".prg": true, ".crt": true,
-	".exe": true, ".com": true, ".bat": true, ".conf": true,
+	".conf": true, ".dosz": true,
 	".adf": true, ".hdf": true, ".lha": true, ".ipf": true, ".dms": true,
 	".min": true,
 	".j64": true, ".jag": true,

--- a/server/internal/scanner/scanner_test.go
+++ b/server/internal/scanner/scanner_test.go
@@ -1386,7 +1386,7 @@ func TestIdentifyConsole_NewDirectoryMappings(t *testing.T) {
 		{"WonderSwan by ws dir", "/games/ws/game.ws", ".ws", "WS"},
 		{"ColecoVision by colecovision dir", "/games/colecovision/game.col", ".col", "CV"},
 		{"C64 by c64 dir", "/games/c64/game.d64", ".d64", "C64"},
-		{"DOS by dos dir", "/games/dos/game.exe", ".exe", "DOS"},
+		{"DOS by dos dir", "/games/dos/game.zip", ".zip", "DOS"},
 		{"Amiga by amiga dir", "/games/amiga/game.adf", ".adf", "AMIGA"},
 	}
 

--- a/web/src/features/explore/components/game-timeline-card.tsx
+++ b/web/src/features/explore/components/game-timeline-card.tsx
@@ -1,24 +1,8 @@
 import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui";
 import { cn } from "@/lib/cn";
+import { ensureContrast } from "@/lib/color-utils";
 import type { SeriesGame } from "@/types/api";
-
-/** Ensures a hex color has enough brightness for dark backgrounds.
- *  Lightens colors below a perceived brightness threshold. */
-function ensureContrast(hex: string): string {
-  const r = parseInt(hex.slice(1, 3), 16);
-  const g = parseInt(hex.slice(3, 5), 16);
-  const b = parseInt(hex.slice(5, 7), 16);
-  // Perceived brightness (ITU-R BT.709)
-  const brightness = (r * 0.299 + g * 0.587 + b * 0.114);
-  if (brightness >= 100) return hex;
-  // Lighten by blending toward white
-  const factor = 100 / Math.max(brightness, 1);
-  const lr = Math.min(255, Math.round(r * factor));
-  const lg = Math.min(255, Math.round(g * factor));
-  const lb = Math.min(255, Math.round(b * factor));
-  return `#${lr.toString(16).padStart(2, "0")}${lg.toString(16).padStart(2, "0")}${lb.toString(16).padStart(2, "0")}`;
-}
 
 interface GameTimelineCardProps {
   game: SeriesGame;

--- a/web/src/features/explore/components/hero-carousel.tsx
+++ b/web/src/features/explore/components/hero-carousel.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { ChevronLeft, ChevronRight, Star } from "lucide-react";
 import { Badge, Skeleton } from "@/components/ui";
 import { cn } from "@/lib/cn";
+import { ensureContrast } from "@/lib/color-utils";
 import type { FeaturedGame } from "@/types/api";
 
 interface HeroCarouselProps {
@@ -120,8 +121,8 @@ function HeroSlide({
                     ? ({
                         "--badge-color": game.consoleColor,
                         backgroundColor: `${game.consoleColor}20`,
-                        borderColor: `${game.consoleColor}50`,
-                        color: game.consoleColor,
+                        borderColor: `${game.consoleColor}40`,
+                        color: ensureContrast(game.consoleColor),
                       } as React.CSSProperties)
                     : undefined
                 }

--- a/web/src/lib/color-utils.ts
+++ b/web/src/lib/color-utils.ts
@@ -1,0 +1,18 @@
+/** Ensures a hex color has enough brightness for dark backgrounds.
+ *  Lightens colors below a perceived brightness threshold. */
+export function ensureContrast(hex: string): string {
+  if (!hex || hex.length < 7) return hex;
+  const r = parseInt(hex.slice(1, 3), 16);
+  const g = parseInt(hex.slice(3, 5), 16);
+  const b = parseInt(hex.slice(5, 7), 16);
+  if (isNaN(r) || isNaN(g) || isNaN(b)) return hex;
+  // Perceived brightness (ITU-R BT.709)
+  const brightness = r * 0.299 + g * 0.587 + b * 0.114;
+  if (brightness >= 100) return hex;
+  // Lighten by scaling toward white
+  const factor = 100 / Math.max(brightness, 10);
+  const lr = Math.min(255, Math.round(r * factor));
+  const lg = Math.min(255, Math.round(g * factor));
+  const lb = Math.min(255, Math.round(b * factor));
+  return `#${lr.toString(16).padStart(2, "0")}${lg.toString(16).padStart(2, "0")}${lb.toString(16).padStart(2, "0")}`;
+}


### PR DESCRIPTION
## Summary
- **DOS**: Use .zip/.dosz extensions instead of raw executables (from other agent)
- **Top lists dedup**: Add `is_primary = true` to audience/critic top lists and longest games
- **Community hidden gems**: Add `is_primary` to game_ratings JOIN
- **Franchise badges**: Hide empty platform badges for non-library games, add contrast checking for dark console colors

## Issues addressed
- Issue 5: Top lists showing empty (added is_primary to prevent duplicate matches)
- Issue 6: Sonic CD duplicate in essentials (is_primary filter exists — may need re-scan)
- Issue 7: Verification status inconsistency (SCD is in DiscBasedSystems — needs investigation with test data)
- Issue 8: Explore page dedup gaps (fixed remaining queries)

## Test plan
- [x] Go builds clean
- [x] TypeScript compiles clean
- [ ] Manual: top lists show audience/critic rated games
- [ ] Manual: franchise page shows no empty badges
- [ ] Manual: dark console badges are readable