### PR TITLE
feat: merge game groups by IGDB ID for cross-regional dedup

### DIFF
--- a/server/internal/scanner/grouping.go
+++ b/server/internal/scanner/grouping.go
@@ -400,16 +400,17 @@ func MergeGroupsByIGDBID(database *gorm.DB) (int, error) {
 
 		for _, g := range games {
 			if g.GroupKey != canonicalGroupKey {
-				affectedGroupKeys[g.GroupKey] = true
+				oldKey := g.GroupKey
+				affectedGroupKeys[oldKey] = true
 				// Update this game's GroupKey to the canonical one
 				if err := database.Model(&g).Update("group_key", canonicalGroupKey).Error; err != nil {
 					slog.Warn("failed to update group key for IGDB merge",
-						"gameID", g.ID, "old", g.GroupKey, "new", canonicalGroupKey, "error", err)
+						"gameID", g.ID, "old", oldKey, "new", canonicalGroupKey, "error", err)
 					continue
 				}
 				mergedCount++
 				slog.Info("merged game into IGDB group",
-					"game", g.Title, "oldGroupKey", g.GroupKey,
+					"game", g.Title, "oldGroupKey", oldKey,
 					"newGroupKey", canonicalGroupKey, "scraperID", c.ScraperID)
 			}
 		}
@@ -418,6 +419,14 @@ func MergeGroupsByIGDBID(database *gorm.DB) (int, error) {
 		if err := electPrimaryForGroup(database, c.ConsoleID, canonicalGroupKey); err != nil {
 			slog.Warn("failed to re-elect primary after IGDB merge",
 				"consoleID", c.ConsoleID, "groupKey", canonicalGroupKey, "error", err)
+		}
+
+		// Re-elect primaries for old groups (may still contain other games)
+		for oldKey := range affectedGroupKeys {
+			if err := electPrimaryForGroup(database, c.ConsoleID, oldKey); err != nil {
+				slog.Warn("failed to re-elect primary for vacated group",
+					"consoleID", c.ConsoleID, "groupKey", oldKey, "error", err)
+			}
 		}
 	}
 

--- a/server/internal/scanner/grouping.go
+++ b/server/internal/scanner/grouping.go
@@ -350,3 +350,79 @@ func ReElectPrimaryForGroup(database *gorm.DB, consoleID uint, groupKey string) 
 	}
 	return electPrimaryForGroup(database, consoleID, groupKey)
 }
+
+// MergeGroupsByIGDBID finds games that share the same IGDB game ID on the
+// same console but have different GroupKeys (e.g., "Sonic CD" USA and
+// "Sonic the Hedgehog CD" Japan). It merges them into a single group by
+// assigning the same GroupKey, then re-elects primaries for affected groups.
+//
+// This should be called after scraping, when ScraperID is populated.
+func MergeGroupsByIGDBID(database *gorm.DB) (int, error) {
+	// Find IGDB IDs that appear on 2+ games with different GroupKeys (same console)
+	type mergeCandidate struct {
+		ConsoleID uint
+		ScraperID string
+		GroupKeys int
+	}
+	var candidates []mergeCandidate
+	if err := database.Model(&db.Game{}).
+		Select("console_id, scraper_id, COUNT(DISTINCT group_key) as group_keys").
+		Where("scraper_id != '' AND group_key != '' AND deleted_at IS NULL").
+		Group("console_id, scraper_id").
+		Having("group_keys > 1").
+		Scan(&candidates).Error; err != nil {
+		return 0, fmt.Errorf("finding IGDB merge candidates: %w", err)
+	}
+
+	if len(candidates) == 0 {
+		return 0, nil
+	}
+
+	mergedCount := 0
+	for _, c := range candidates {
+		// Get all games with this IGDB ID on this console
+		var games []db.Game
+		if err := database.
+			Where("console_id = ? AND scraper_id = ? AND deleted_at IS NULL", c.ConsoleID, c.ScraperID).
+			Order("group_key ASC").
+			Find(&games).Error; err != nil {
+			slog.Warn("failed to load games for IGDB merge", "scraperID", c.ScraperID, "error", err)
+			continue
+		}
+
+		if len(games) < 2 {
+			continue
+		}
+
+		// Use the first GroupKey (alphabetically lowest) as the canonical one
+		canonicalGroupKey := games[0].GroupKey
+		affectedGroupKeys := make(map[string]bool)
+
+		for _, g := range games {
+			if g.GroupKey != canonicalGroupKey {
+				affectedGroupKeys[g.GroupKey] = true
+				// Update this game's GroupKey to the canonical one
+				if err := database.Model(&g).Update("group_key", canonicalGroupKey).Error; err != nil {
+					slog.Warn("failed to update group key for IGDB merge",
+						"gameID", g.ID, "old", g.GroupKey, "new", canonicalGroupKey, "error", err)
+					continue
+				}
+				mergedCount++
+				slog.Info("merged game into IGDB group",
+					"game", g.Title, "oldGroupKey", g.GroupKey,
+					"newGroupKey", canonicalGroupKey, "scraperID", c.ScraperID)
+			}
+		}
+
+		// Re-elect primary for the merged group
+		if err := electPrimaryForGroup(database, c.ConsoleID, canonicalGroupKey); err != nil {
+			slog.Warn("failed to re-elect primary after IGDB merge",
+				"consoleID", c.ConsoleID, "groupKey", canonicalGroupKey, "error", err)
+		}
+	}
+
+	if mergedCount > 0 {
+		slog.Info("IGDB group merge complete", "merged", mergedCount, "candidates", len(candidates))
+	}
+	return mergedCount, nil
+}

--- a/server/internal/scanner/grouping_test.go
+++ b/server/internal/scanner/grouping_test.go
@@ -348,6 +348,72 @@ func TestGroupAndElectPrimaries_SingleGameGroup(t *testing.T) {
 	assert.True(t, result.IsPrimary, "single game in group should be primary")
 }
 
+func TestMergeGroupsByIGDBID(t *testing.T) {
+	database := setupTestDB(t)
+
+	var scd db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SCD").First(&scd).Error)
+
+	// Two games with different titles/GroupKeys but same IGDB ID
+	game1 := db.Game{
+		ConsoleID: scd.ID,
+		Title:     "Sonic CD",
+		FileName:  "Sonic CD (USA).cue",
+		FilePath:  "segacd/Sonic CD (USA).cue",
+		GroupKey:  "sonic cd",
+		Region:    "USA",
+		ScraperID: "igdb:2071",
+	}
+	game2 := db.Game{
+		ConsoleID: scd.ID,
+		Title:     "Sonic the Hedgehog CD",
+		FileName:  "Sonic the Hedgehog CD (Japan).cue",
+		FilePath:  "segacd/Sonic the Hedgehog CD (Japan).cue",
+		GroupKey:  "sonic hedgehog cd",
+		Region:    "Japan",
+		ScraperID: "igdb:2071",
+	}
+	require.NoError(t, database.Create(&game1).Error)
+	require.NoError(t, database.Create(&game2).Error)
+
+	// Before merge: both should be in different groups
+	require.NotEqual(t, game1.GroupKey, game2.GroupKey)
+
+	// Run election first — each gets elected primary in its own group
+	require.NoError(t, GroupAndElectPrimaries(database))
+
+	var pre1, pre2 db.Game
+	database.First(&pre1, game1.ID)
+	database.First(&pre2, game2.ID)
+	assert.True(t, pre1.IsPrimary, "game1 should be primary before merge")
+	assert.True(t, pre2.IsPrimary, "game2 should be primary before merge")
+
+	// Run IGDB merge
+	merged, err := MergeGroupsByIGDBID(database)
+	require.NoError(t, err)
+	assert.Equal(t, 1, merged, "should have merged 1 game into a different group")
+
+	// After merge: both should share the same GroupKey
+	var post1, post2 db.Game
+	database.First(&post1, game1.ID)
+	database.First(&post2, game2.ID)
+	assert.Equal(t, post1.GroupKey, post2.GroupKey, "both games should share the same GroupKey after merge")
+
+	// Only one should be primary (USA preferred)
+	primaryCount := 0
+	if post1.IsPrimary {
+		primaryCount++
+	}
+	if post2.IsPrimary {
+		primaryCount++
+	}
+	assert.Equal(t, 1, primaryCount, "exactly one game should be primary after merge")
+
+	// USA version should be primary (region preference)
+	assert.True(t, post1.IsPrimary, "USA version should be primary")
+	assert.False(t, post2.IsPrimary, "Japan version should not be primary")
+}
+
 func TestReElectPrimaryForGroup(t *testing.T) {
 	database := setupTestDB(t)
 

--- a/server/internal/scraper/scraper_batch.go
+++ b/server/internal/scraper/scraper_batch.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/scanner"
 )
 
 // EnrichProgress holds progress information for a metadata enrichment operation.
@@ -321,6 +322,15 @@ func (s *Scraper) ScrapeAll(ctx context.Context, mode string, consoleID uint, on
 		if onProgress != nil {
 			onProgress(progress(i, game))
 		}
+	}
+
+	// After all games are scraped, merge groups where different regional titles
+	// mapped to the same IGDB game (e.g., "Sonic CD" USA and "Sonic the
+	// Hedgehog CD" Japan have different GroupKeys but the same IGDB ID).
+	if merged, err := scanner.MergeGroupsByIGDBID(s.DB); err != nil {
+		slog.Warn("IGDB group merge failed", "error", err)
+	} else if merged > 0 {
+		slog.Info("merged game groups by IGDB ID", "merged", merged)
 	}
 
 	return successes, total, nil


### PR DESCRIPTION
## Summary
Games with different regional titles (e.g., "Sonic CD" USA vs "Sonic the Hedgehog CD" Japan) get different GroupKeys from filename parsing, making each one its own primary — appearing as duplicates in all game lists.

After scraping, both match the same IGDB game ID (e.g., `igdb:2071`). This PR adds `MergeGroupsByIGDBID()` which:
1. Finds games sharing an IGDB ID on the same console but with different GroupKeys
2. Merges them into one group (picks alphabetically lowest GroupKey)
3. Re-elects the primary (USA/World preferred)

Called automatically at the end of `ScrapeAll`.

## How it works
```
Before: "Sonic CD (USA)" → GroupKey "sonic cd" → PRIMARY
        "Sonic the Hedgehog CD (Japan)" → GroupKey "sonic hedgehog cd" → PRIMARY (duplicate!)

After:  "Sonic CD (USA)" → GroupKey "sonic cd" → PRIMARY ✓
        "Sonic the Hedgehog CD (Japan)" → GroupKey "sonic cd" → variant (hidden from lists)
```

## Test plan
- [x] Go builds clean
- [x] `TestMergeGroupsByIGDBID` passes — creates USA/Japan variants with same IGDB ID, verifies merge and re-election
- [ ] Manual: scrape Sega CD games with regional title variants → verify only one appears in lists