### PR TITLE
fix: add cursor-pointer to year selector buttons

### DIFF
--- a/web/src/features/explore/components/temporal-shelves.tsx
+++ b/web/src/features/explore/components/temporal-shelves.tsx
@@ -251,7 +251,7 @@ export function BestOfYearSection({
           <button
             key={y}
             onClick={() => onYearChange(y)}
-            className={`px-2.5 py-1 text-xs rounded-full transition-colors ${
+            className={`px-2.5 py-1 text-xs rounded-full transition-colors cursor-pointer ${
               y === year
                 ? "bg-brand-500 text-white font-semibold"
                 : "bg-surface-800 text-surface-400 hover:bg-surface-700 hover:text-surface-200"


### PR DESCRIPTION
## Summary
Tailwind v4 resets cursor on `<button>` elements to `default`. The year selector in "Best of" section used raw buttons without `cursor-pointer`.

Issue 10 (clickable genre links in "Expand your horizons") — skipped, no genre pages exist yet.

## Test plan
- [x] TypeScript compiles clean
- [ ] Manual: hover over year tags → cursor shows pointer