### PR TITLE
fix: show MD5 checksum for missing BIOS files

### DIFF
--- a/web/src/features/bios/components/bios-console-card.tsx
+++ b/web/src/features/bios/components/bios-console-card.tsx
@@ -90,16 +90,23 @@ export function BiosConsoleCard({
             >
               {fileStatusIcon(file.status)}
               <div className="flex-1 min-w-0">
-                <span className="text-surface-200 font-mono text-xs">
-                  {file.fileName}
-                </span>
-                <span className="text-surface-500 ml-2 text-xs">
-                  {file.description}
-                </span>
-                {file.required && (
-                  <Badge variant="danger" className="ml-2 text-[10px] px-1.5 py-0">
-                    Required
-                  </Badge>
+                <div>
+                  <span className="text-surface-200 font-mono text-xs">
+                    {file.fileName}
+                  </span>
+                  <span className="text-surface-500 ml-2 text-xs">
+                    {file.description}
+                  </span>
+                  {file.required && (
+                    <Badge variant="danger" className="ml-2 text-[10px] px-1.5 py-0">
+                      Required
+                    </Badge>
+                  )}
+                </div>
+                {file.md5 && file.status === "missing" && (
+                  <p className="text-[10px] text-surface-600 font-mono mt-0.5">
+                    MD5: {file.md5}
+                  </p>
                 )}
               </div>
               {file.status !== "missing" && onDeleteFile && (


### PR DESCRIPTION
## Summary
Display the expected MD5 hash below the filename on the BIOS status page when a file is missing. This helps users search for and verify the correct BIOS files online.

Only shown for missing files that have a known checksum (Neo Geo and CD-i BIOS zips don't have MD5s since zip repacking changes the hash).

**Before:** Just filename + "Missing" badge
**After:** Filename + "Missing" badge + `MD5: 82a21c1890cae844b3df741f2762d48d`

## Regarding alternative auto-download sources
Neo Geo, Neo Geo CD, Amiga, and CD-i BIOS files are copyrighted firmware not available in the retroarch_system repo. No reliable open-source auto-download source exists. Showing the MD5 is the pragmatic alternative — users can verify they have the right file.

## Test plan
- [x] TypeScript compiles clean
- [ ] Manual: BIOS page shows MD5 for missing Amiga/Lynx/3DO/PC-FX files
- [ ] Manual: No MD5 shown for Neo Geo/CD-i (empty checksum)