### PR TITLE
fix: add SPELA_TEST_MODE to E2E docker-compose

### DIFF
--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -23,6 +23,7 @@ services:
       - SPELA_IGDB_CLIENT_ID=${SPELA_IGDB_CLIENT_ID:-}
       - SPELA_IGDB_CLIENT_SECRET=${SPELA_IGDB_CLIENT_SECRET:-}
       - GIN_MODE=debug
+      - SPELA_TEST_MODE=true
 
   web:
     build:


### PR DESCRIPTION
## Summary
The E2E docker-compose was missing `SPELA_TEST_MODE=true`, causing the `/api/test/reset` endpoint to not be registered. This made 17 E2E tests fail with 404.

## Test results after fix
- Desktop E2E: **668 tests, 0 failures**
- Web unit tests: **1386 pass** (3 flaky animation timer tests)
- Web E2E: **134 pass**, 13 remaining failures (mostly key-mapping and registration-approval — investigating)
- Go tests: all pass (verified via CI)