### PR TITLE
fix: bundle legacy EmulatorJS core variants

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -162,9 +162,6 @@ function serveEmulatorjs(): Plugin {
           const pkgDir = path.join(coresBaseDir, entry);
           for (const file of fs.readdirSync(pkgDir)) {
             if (!file.endsWith(".data")) continue;
-            // Skip legacy variants — modern browsers don't need them,
-            // and they'll fall back to CDN if somehow requested.
-            if (file.includes("-legacy-")) continue;
             fs.cpSync(
               path.join(pkgDir, file),
               path.join(coresTargetDir, file),


### PR DESCRIPTION
## Summary
- Remove the build filter that skipped `-legacy-` EmulatorJS core variants
- "Legacy" cores are compiled without WebGL2 rendering — most cores don't set `defaultWebGL2: true` in their report JSON, making the legacy variant the one EmulatorJS actually requests
- Without these files, games 404 locally and fall back to the (unreliable) EmulatorJS CDN

## Test plan
- [ ] Build the Docker image and verify legacy core files exist in `/app/frontend/emulatorjs/data/cores/`
- [ ] Launch a Sega CD or TurboGrafx-16 game in the web UI — no 404 errors in dev tools