### PR TITLE
feat: add DOS Demos console

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -149,7 +149,7 @@ fun GameDetailScreen(
 
     val detail = state.gameDetail ?: return
     val game = detail.game
-    val isDemoConsole = state.console?.abbreviation == "ADEMO"
+    val isDemoConsole = state.console?.abbreviation == "ADEMO" || state.console?.abbreviation == "DDEMO"
 
     // Per-console gradient background (same as console screen, darkened)
     val backgroundColors = remember(game.consoleId) {

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -829,6 +829,7 @@ func SeedConsoles(db *gorm.DB) error {
 		{Name: "Commodore Amiga", Abbreviation: "AMIGA", Extensions: ".adf,.hdf,.lha,.ipf,.dms,.zip", DefaultCore: "puae", EmulatorJSCore: "puae", FolderName: "amiga", ColorTheme: "#6c5eb5", Generation: 100, SaveStateSupport: true, Playable: true},
 		{Name: "Amiga Demos", Abbreviation: "ADEMO", Extensions: ".adf,.hdf,.lha,.dms,.zip", DefaultCore: "puae", EmulatorJSCore: "puae", FolderName: "amiga-demos", ColorTheme: "#8b7fc7", Generation: 100, SaveStateSupport: false, Playable: true},
 		{Name: "DOS", Abbreviation: "DOS", Extensions: ".zip,.dosz,.conf", DefaultCore: "dosbox_pure", EmulatorJSCore: "dosbox_pure", FolderName: "dos", ColorTheme: "#000000", Generation: 100, SaveStateSupport: true, Playable: true},
+		{Name: "DOS Demos", Abbreviation: "DDEMO", Extensions: ".zip,.dosz,.conf", DefaultCore: "dosbox_pure", EmulatorJSCore: "dosbox_pure", FolderName: "dos-demos", ColorTheme: "#333333", Generation: 100, SaveStateSupport: false, Playable: true},
 		{Name: "MSX", Abbreviation: "MSX1", Extensions: ".rom,.mx1,.dsk,.cas", DefaultCore: "bluemsx", EmulatorJSCore: "", FolderName: "msx1", ColorTheme: "#4a86c8", Generation: 100, SaveStateSupport: true, Playable: true},
 		{Name: "MSX2", Abbreviation: "MSX2", Extensions: ".rom,.mx2,.dsk,.cas", DefaultCore: "bluemsx", EmulatorJSCore: "", FolderName: "msx2", ColorTheme: "#4a86c8", Generation: 100, SaveStateSupport: true, Playable: true},
 		// Arcade (generation = 101)

--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -48,6 +48,7 @@ var AbbreviationToIGDBPlatform = map[string]int{
 	"AMIGA":  16,
 	"ADEMO":  16,
 	"DOS":    13,
+	"DDEMO":  13,
 	"A52":    66,
 	"A78":    60,
 	"LYNX":   61,

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -251,6 +251,8 @@ var directoryConsoleMap = map[string]string{
 	"amiga":        "AMIGA",
 	"amiga-demos":  "ADEMO",
 	"amigademos":   "ADEMO",
+	"dos-demos":    "DDEMO",
+	"dosdemos":     "DDEMO",
 	"3do":          "3DO",
 	"c128":         "C128",
 	"pet":          "PET",

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -193,6 +193,7 @@ var AbbreviationToLibRetro = map[string]string{
 	"PS2":   "Sony - PlayStation 2",
 	"C64":   "Commodore - 64",
 	"DOS":   "DOS",
+	"DDEMO": "DOS",
 	"AMIGA": "Commodore - Amiga",
 	"ADEMO": "Commodore - Amiga",
 	"MSX1":  "Microsoft - MSX",

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -126,7 +126,7 @@ export function GameDetailPage() {
   const consoleInfo = consoles?.find((c) => c.id === game?.consoleId);
   const canPlayInBrowser = !!consoleInfo?.emulatorJsCore;
   const hasAchievements = (gameAchievements?.achievements?.length ?? 0) > 0;
-  const isDemo = consoleInfo?.abbreviation === "ADEMO";
+  const isDemo = consoleInfo?.abbreviation === "ADEMO" || consoleInfo?.abbreviation === "DDEMO";
   const [showCollectionPicker, setShowCollectionPicker] = useState(false);
   const [showScrapeMatch, setShowScrapeMatch] = useState(false);
   const [showReplaceRom, setShowReplaceRom] = useState(false);


### PR DESCRIPTION
## Summary
- Add "DOS Demos" console (abbreviation DDEMO, folder `dos-demos/`, core `dosbox_pure`)
- Same pattern as Amiga Demos: `saveStateSupport: false`, demo-specific labels (Group/Type/Year/Party)
- Update demo detection in web and player to include both ADEMO and DDEMO

## Test plan
- [x] Go and TypeScript compile cleanly
- [ ] Existing test suites pass (CI)
- [ ] Place `.zip` files in `dos-demos/` folder, scan, verify they appear under "DOS Demos"