### PR TITLE
feat: add Neo Geo BIOS auto-download from archive.org

### DIFF
--- a/server/internal/bios/downloader.go
+++ b/server/internal/bios/downloader.go
@@ -66,9 +66,14 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 			continue
 		}
 
-		// Build URL: {baseURL}/{RepoFolder(consoleID)}/{fileName}
-		folder := RepoFolder(entry.ConsoleID)
-		url := fmt.Sprintf("%s/%s/%s", baseURL, folder, entry.FileName)
+		// Use OverrideURL if set, otherwise build from repo base URL
+		var url string
+		if entry.OverrideURL != "" {
+			url = entry.OverrideURL
+		} else {
+			folder := RepoFolder(entry.ConsoleID)
+			url = fmt.Sprintf("%s/%s/%s", baseURL, folder, entry.FileName)
+		}
 
 		resp, err := client.Get(url)
 		if err != nil {

--- a/server/internal/bios/downloader_test.go
+++ b/server/internal/bios/downloader_test.go
@@ -162,6 +162,40 @@ func TestDownloadMissing_EmptyMD5Accepted(t *testing.T) {
 	assert.Equal(t, fileContent, data)
 }
 
+func TestDownloadMissing_OverrideURL(t *testing.T) {
+	biosDir := t.TempDir()
+	fileContent := []byte("neo geo bios content")
+
+	// This server simulates the OverrideURL (archive.org)
+	overrideServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(fileContent)
+	}))
+	defer overrideServer.Close()
+
+	// This server simulates the default repo — should NOT be called
+	defaultServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("default server should not be called for entries with OverrideURL")
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer defaultServer.Close()
+
+	origRegistry := make([]Entry, len(registry))
+	copy(origRegistry, registry)
+	registry = []Entry{
+		{ConsoleID: "neogeo", FileName: "neogeo.zip", Description: "Neo Geo BIOS", MD5: "", Required: true, OverrideURL: overrideServer.URL + "/neogeo.zip"},
+	}
+	defer func() { registry = origRegistry }()
+
+	result := DownloadMissing(biosDir, defaultServer.URL, nil)
+
+	assert.Equal(t, 1, result.Downloaded)
+	assert.Equal(t, 0, result.Failed)
+
+	data, err := os.ReadFile(filepath.Join(biosDir, "neogeo.zip"))
+	require.NoError(t, err)
+	assert.Equal(t, fileContent, data)
+}
+
 func TestDownloadMissing_NilProgressCallback(t *testing.T) {
 	biosDir := t.TempDir()
 

--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -7,6 +7,7 @@ type Entry struct {
 	Description string // human-readable label
 	MD5         string // expected MD5 checksum (lowercase hex)
 	Required    bool   // true if the console cannot function without it
+	OverrideURL string // if set, download from this URL instead of the default repo
 }
 
 // registry is the built-in list of known BIOS files.
@@ -55,11 +56,11 @@ var registry = []Entry{
 
 	// Neo Geo (NEOGEO) — fbneo_libretro.info
 	// neogeo.zip must contain the individual BIOS ROMs (sp-s2.sp1, etc.)
-	{ConsoleID: "neogeo", FileName: "neogeo.zip", Description: "Neo Geo BIOS (arcade/AES/MVS)", MD5: "", Required: true},
+	{ConsoleID: "neogeo", FileName: "neogeo.zip", Description: "Neo Geo BIOS (arcade/AES/MVS)", MD5: "", Required: true, OverrideURL: "https://archive.org/download/real-bout-fatal-fury-world-cdz-patched/neogeo.zip"},
 
 	// Neo Geo CD (NEOCD) — neocd_libretro.info
-	{ConsoleID: "neocd", FileName: "neocdz.zip", Description: "Neo Geo CDZ BIOS", MD5: "", Required: true},
-	{ConsoleID: "neocd", FileName: "neocd.zip", Description: "Neo Geo CD Front Loader BIOS", MD5: "", Required: false},
+	{ConsoleID: "neocd", FileName: "neocdz.zip", Description: "Neo Geo CDZ BIOS", MD5: "", Required: true, OverrideURL: "https://archive.org/download/real-bout-fatal-fury-world-cdz-patched/neocdz.zip"},
+	{ConsoleID: "neocd", FileName: "neocd.zip", Description: "Neo Geo CD Front Loader BIOS", MD5: "", Required: false, OverrideURL: "https://archive.org/download/real-bout-fatal-fury-world-cdz-patched/neocd.zip"},
 
 	// Atari Lynx (LYNX) — handy_libretro.info
 	{ConsoleID: "lynx", FileName: "lynxboot.img", Description: "Atari Lynx Boot ROM", MD5: "fcd403db69f54290b51035d82f835e7b", Required: false},
@@ -110,12 +111,13 @@ func RepoFolder(consoleID string) string {
 	return repoFolders[consoleID]
 }
 
-// Downloadable returns all registry entries whose console has a known
-// repository folder, i.e. entries that can be auto-downloaded.
+// Downloadable returns all registry entries that can be auto-downloaded,
+// i.e. entries whose console has a known repository folder OR that have
+// an explicit OverrideURL.
 func Downloadable() []Entry {
 	var out []Entry
 	for _, e := range registry {
-		if repoFolders[e.ConsoleID] != "" {
+		if repoFolders[e.ConsoleID] != "" || e.OverrideURL != "" {
 			out = append(out, e)
 		}
 	}

--- a/server/internal/bios/registry_test.go
+++ b/server/internal/bios/registry_test.go
@@ -113,9 +113,11 @@ func TestDownloadable(t *testing.T) {
 	entries := Downloadable()
 	assert.NotEmpty(t, entries)
 
-	// Every downloadable entry must have a repo folder mapping
+	// Every downloadable entry must have a repo folder mapping OR an OverrideURL
 	for _, e := range entries {
-		assert.NotEmpty(t, RepoFolder(e.ConsoleID), "entry %s should have a repo folder", e.FileName)
+		hasFolder := RepoFolder(e.ConsoleID) != ""
+		hasOverride := e.OverrideURL != ""
+		assert.True(t, hasFolder || hasOverride, "entry %s should have a repo folder or OverrideURL", e.FileName)
 	}
 
 	// PS2 entries should NOT be in the downloadable list
@@ -123,8 +125,27 @@ func TestDownloadable(t *testing.T) {
 		assert.NotEqual(t, "ps2", e.ConsoleID, "ps2 entries should not be downloadable")
 	}
 
-	// Should be fewer than All() since PS2 is excluded
+	// Should be fewer than All() since PS2, amiga, cdi are excluded
 	assert.Less(t, len(entries), len(All()))
+}
+
+func TestDownloadable_IncludesOverrideURLEntries(t *testing.T) {
+	entries := Downloadable()
+
+	// Neo Geo entries have OverrideURL and should be downloadable
+	var neoGeoFound, neoCDZFound bool
+	for _, e := range entries {
+		if e.ConsoleID == "neogeo" && e.FileName == "neogeo.zip" {
+			neoGeoFound = true
+			assert.NotEmpty(t, e.OverrideURL)
+		}
+		if e.ConsoleID == "neocd" && e.FileName == "neocdz.zip" {
+			neoCDZFound = true
+			assert.NotEmpty(t, e.OverrideURL)
+		}
+	}
+	assert.True(t, neoGeoFound, "neogeo.zip should be in downloadable list")
+	assert.True(t, neoCDZFound, "neocdz.zip should be in downloadable list")
 }
 
 func TestRegistryEntries_HaveRequiredFields(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `OverrideURL` field to BIOS registry entries, allowing alternative download sources beyond the default GitHub repo
- Neo Geo BIOS files (`neogeo.zip`, `neocdz.zip`, `neocd.zip`) now auto-download from `archive.org` when missing
- `Downloadable()` now includes entries with `OverrideURL` even if they lack a `repoFolders` mapping

## Test plan
- [x] All existing BIOS tests pass (no regressions)
- [x] New `TestDownloadMissing_OverrideURL` verifies override server is used instead of default repo
- [x] New `TestDownloadable_IncludesOverrideURLEntries` verifies Neo Geo entries appear in downloadable list
- [ ] Manual: enable BIOS auto-download, verify Neo Geo BIOS files download on startup