### PR TITLE
fix: capitalize error messages

### DIFF
--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -41,7 +41,7 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 
 	ctx, ok := h.Scraper.TryStartScrape()
 	if !ok {
-		c.JSON(http.StatusConflict, gin.H{"error": "a scrape operation is already in progress"})
+		c.JSON(http.StatusConflict, gin.H{"error": "A scrape operation is already in progress"})
 		return
 	}
 

--- a/server/internal/api/bios_handler.go
+++ b/server/internal/api/bios_handler.go
@@ -461,7 +461,7 @@ func (h *BiosHandler) TriggerDownload(c *gin.Context) {
 	h.downloadMu.Lock()
 	if h.downloading {
 		h.downloadMu.Unlock()
-		c.JSON(http.StatusConflict, gin.H{"error": "a BIOS download is already in progress"})
+		c.JSON(http.StatusConflict, gin.H{"error": "A BIOS download is already in progress"})
 		return
 	}
 	h.downloading = true

--- a/server/internal/api/enrichment_handler.go
+++ b/server/internal/api/enrichment_handler.go
@@ -853,7 +853,7 @@ func (h *EnrichmentHandler) TriggerEnrichMetadata(c *gin.Context) {
 	mode := c.DefaultQuery("mode", "missing")
 
 	if !h.Scraper.TryStartEnrich() {
-		c.JSON(http.StatusConflict, gin.H{"error": "an enrichment or scrape operation is already in progress"})
+		c.JSON(http.StatusConflict, gin.H{"error": "An enrichment or scrape operation is already in progress"})
 		return
 	}
 

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -561,7 +561,7 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 	}
 
 	if !h.Scanner.TryStartScan() {
-		c.JSON(http.StatusConflict, gin.H{"error": "a scan is already in progress"})
+		c.JSON(http.StatusConflict, gin.H{"error": "A scan is already in progress"})
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Capitalize the first letter of "already in progress" error messages across scan, scrape, enrichment, and BIOS download endpoints

## Test plan
- [ ] Trigger a scan while one is running, verify error message starts with uppercase