### PR TITLE
feat: add Pouet.net integration for demoscene metadata

### DIFF
--- a/server/internal/pouet/client.go
+++ b/server/internal/pouet/client.go
@@ -1,0 +1,297 @@
+package pouet
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// API base URL (variable for testability).
+var apiBase = "https://api.pouet.net/v1"
+
+// AbbreviationToPouetPlatforms maps Spela console abbreviations to Pouet platform IDs.
+// Pouet has no platform filter on search, so we filter client-side.
+var AbbreviationToPouetPlatforms = map[string][]int{
+	"ADEMO": {73, 71, 79}, // Amiga OCS/ECS, Amiga AGA, Amiga PPC/RTG
+	"DDEMO": {67, 69},     // MS-Dos, MS-Dos/gus
+}
+
+// Client is a Pouet.net API client. No authentication required.
+type Client struct {
+	HTTPClient *http.Client
+	BaseURL    string
+	rateTick   <-chan time.Time
+}
+
+// NewClient creates a new Pouet API client with a conservative rate limiter.
+func NewClient() *Client {
+	ticker := time.NewTicker(500 * time.Millisecond)
+	return &Client{
+		HTTPClient: &http.Client{Timeout: 15 * time.Second},
+		BaseURL:    apiBase,
+		rateTick:   ticker.C,
+	}
+}
+
+// Group represents a demoscene group/crew.
+type Group struct {
+	ID      string `json:"id"`
+	Name    string `json:"name"`
+	Acronym string `json:"acronym"`
+	Web     string `json:"web"`
+}
+
+// Platform represents a Pouet platform entry.
+type Platform struct {
+	Name string `json:"name"`
+	Slug string `json:"slug"`
+}
+
+// Placement represents a competition placement at a demoparty.
+type Placement struct {
+	Party     Party  `json:"party"`
+	Compo     string `json:"compo"`
+	Ranking   string `json:"ranking"`
+	Year      string `json:"year"`
+	CompoName string `json:"compo_name"`
+}
+
+// Party represents a demoparty/event.
+type Party struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+// Prod represents a Pouet production (demo, intro, etc.).
+type Prod struct {
+	ID         string              `json:"id"`
+	Name       string              `json:"name"`
+	Types      []string            `json:"types"`
+	Groups     []Group             `json:"groups"`
+	Platforms  map[string]Platform `json:"platforms"`
+	Screenshot string              `json:"screenshot"`
+	Download   string              `json:"download"`
+	Placings   []Placement         `json:"placings"`
+	VoteUp   json.Number `json:"voteup"`
+	VotePig  json.Number `json:"votepig"`
+	VoteDown json.Number `json:"votedown"`
+
+	ReleaseDate string `json:"releaseDate"`
+
+	// Full prod fields (only from GetProd, not search)
+	Party     *Party `json:"party"`
+	PartyYear string `json:"party_year"`
+	PartyComp string `json:"party_compo_name"`
+	Rank      string `json:"party_place"`
+}
+
+// searchResponse is the API response for search queries.
+type searchResponse struct {
+	Results []Prod `json:"results"`
+}
+
+// prodResponse is the API response for single prod queries.
+type prodResponse struct {
+	Prod Prod `json:"prod"`
+}
+
+// SearchProd searches Pouet for productions matching the query.
+func (c *Client) SearchProd(query string) ([]Prod, error) {
+	<-c.rateTick
+
+	u := fmt.Sprintf("%s/search/prod/?q=%s", c.BaseURL, url.QueryEscape(query))
+	slog.Debug("pouet search", "query", query, "url", u)
+
+	resp, err := c.HTTPClient.Get(u)
+	if err != nil {
+		return nil, fmt.Errorf("pouet search request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("pouet search: HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("pouet search: reading body: %w", err)
+	}
+
+	var result searchResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("pouet search: parsing JSON: %w", err)
+	}
+
+	slog.Debug("pouet search results", "query", query, "count", len(result.Results))
+	return result.Results, nil
+}
+
+// GetProd fetches a single production by ID with full details.
+func (c *Client) GetProd(id string) (*Prod, error) {
+	<-c.rateTick
+
+	u := fmt.Sprintf("%s/prod/?id=%s", c.BaseURL, url.QueryEscape(id))
+
+	resp, err := c.HTTPClient.Get(u)
+	if err != nil {
+		return nil, fmt.Errorf("pouet get prod: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("pouet get prod: HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("pouet get prod: reading body: %w", err)
+	}
+
+	var result prodResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, fmt.Errorf("pouet get prod: parsing JSON: %w", err)
+	}
+
+	return &result.Prod, nil
+}
+
+// FilterByPlatform filters productions to only those matching any of the given platform IDs.
+func FilterByPlatform(prods []Prod, platformIDs []int) []Prod {
+	idSet := make(map[string]bool)
+	for _, id := range platformIDs {
+		idSet[fmt.Sprintf("%d", id)] = true
+	}
+
+	var filtered []Prod
+	for _, p := range prods {
+		for platID := range p.Platforms {
+			if idSet[platID] {
+				filtered = append(filtered, p)
+				break
+			}
+		}
+	}
+	return filtered
+}
+
+// CleanDemoName extracts a clean production name from a demo filename.
+// Demo filenames typically look like:
+//   - "State of the Art (Phenomena) [1992].adf"
+//   - "Second_Reality.zip"
+//   - "Batman Rises (Batman Group) A.adf"
+func CleanDemoName(fileName string) string {
+	// Remove extension
+	name := fileName
+	if idx := strings.LastIndex(name, "."); idx > 0 {
+		name = name[:idx]
+	}
+
+	// Remove trailing disc indicators (A, B, _1, _2)
+	for _, suffix := range []string{" A", " B", " C", " D", "_1", "_2", "_3", "_4"} {
+		name = strings.TrimSuffix(name, suffix)
+	}
+
+	// Remove bracketed content [year], [tags]
+	for {
+		start := strings.Index(name, "[")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(name[start:], "]")
+		if end < 0 {
+			break
+		}
+		name = name[:start] + name[start+end+1:]
+	}
+
+	// Replace underscores with spaces
+	name = strings.ReplaceAll(name, "_", " ")
+
+	// Trim whitespace
+	name = strings.TrimSpace(name)
+
+	return name
+}
+
+// GroupNames returns a formatted string of group names from a production.
+func GroupNames(prod *Prod) string {
+	if len(prod.Groups) == 0 {
+		return ""
+	}
+	names := make([]string, len(prod.Groups))
+	for i, g := range prod.Groups {
+		names[i] = g.Name
+	}
+	return strings.Join(names, " & ")
+}
+
+// PartyInfo returns a formatted party placement string.
+func PartyInfo(prod *Prod) string {
+	if len(prod.Placings) == 0 {
+		if prod.Party != nil && prod.Party.Name != "" {
+			info := prod.Party.Name
+			if prod.PartyYear != "" {
+				info += " " + prod.PartyYear
+			}
+			if prod.Rank != "" {
+				info += ", " + ordinal(prod.Rank) + " place"
+			}
+			return info
+		}
+		return ""
+	}
+
+	// Use the first/most notable placement
+	p := prod.Placings[0]
+	info := p.Party.Name
+	if p.Year != "" {
+		info += " " + p.Year
+	}
+	if p.Ranking != "" && p.Ranking != "0" {
+		info += ", " + ordinal(p.Ranking) + " place"
+	}
+	if p.CompoName != "" {
+		info += " (" + p.CompoName + ")"
+	}
+	return info
+}
+
+// TypesString returns production types as a comma-separated string.
+func TypesString(prod *Prod) string {
+	if len(prod.Types) == 0 {
+		return "demo"
+	}
+	return strings.Join(prod.Types, ", ")
+}
+
+// Rating converts Pouet voting to a 0-100 score.
+func Rating(prod *Prod) float64 {
+	up, _ := prod.VoteUp.Int64()
+	pig, _ := prod.VotePig.Int64()
+	down, _ := prod.VoteDown.Int64()
+	total := up + pig + down
+	if total == 0 {
+		return 0
+	}
+	// Weighted: up=1, pig=0.5, down=0
+	score := (float64(up) + float64(pig)*0.5) / float64(total) * 100
+	return score
+}
+
+func ordinal(s string) string {
+	switch s {
+	case "1":
+		return "1st"
+	case "2":
+		return "2nd"
+	case "3":
+		return "3rd"
+	default:
+		return s + "th"
+	}
+}

--- a/server/internal/pouet/client_test.go
+++ b/server/internal/pouet/client_test.go
@@ -1,0 +1,138 @@
+package pouet
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testClient(handler http.HandlerFunc) *Client {
+	server := httptest.NewServer(handler)
+	ticker := time.NewTicker(1 * time.Millisecond)
+	return &Client{
+		HTTPClient: server.Client(),
+		BaseURL:    server.URL,
+		rateTick:   ticker.C,
+	}
+}
+
+func TestSearchProd(t *testing.T) {
+	c := testClient(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/search/prod/")
+		assert.Equal(t, "second reality", r.URL.Query().Get("q"))
+		w.Write([]byte(`{"results":[
+			{"id":"3064","name":"Second Reality","types":["demo"],
+			 "groups":[{"id":"44","name":"Future Crew","acronym":"FC"}],
+			 "platforms":{"67":{"name":"MS-Dos","slug":"msdos"}},
+			 "voteup":1200,"votepig":100,"votedown":20,
+			 "releaseDate":"1993-08-01"}
+		]}`))
+	})
+
+	prods, err := c.SearchProd("second reality")
+	require.NoError(t, err)
+	require.Len(t, prods, 1)
+	assert.Equal(t, "3064", prods[0].ID)
+	assert.Equal(t, "Second Reality", prods[0].Name)
+	assert.Equal(t, "Future Crew", prods[0].Groups[0].Name)
+	assert.Contains(t, prods[0].Platforms, "67")
+}
+
+func TestGetProd(t *testing.T) {
+	c := testClient(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "/prod/")
+		assert.Equal(t, "3064", r.URL.Query().Get("id"))
+		w.Write([]byte(`{"prod":{
+			"id":"3064","name":"Second Reality","types":["demo"],
+			"groups":[{"id":"44","name":"Future Crew"}],
+			"platforms":{"67":{"name":"MS-Dos"}},
+			"screenshot":"https://content.pouet.net/files/screenshots/00003/00003064.jpg",
+			"voteup":1200,"votepig":100,"votedown":"20",
+			"releaseDate":"1993-08-01",
+			"party":{"id":"3","name":"Assembly"},
+			"party_year":"1993",
+			"party_compo_name":"pc demo",
+			"party_place":"1",
+			"placings":[{"party":{"id":"3","name":"Assembly"},"year":"1993","ranking":"1","compo_name":"pc demo"}]
+		}}`))
+	})
+
+	prod, err := c.GetProd("3064")
+	require.NoError(t, err)
+	assert.Equal(t, "Second Reality", prod.Name)
+	assert.Equal(t, "https://content.pouet.net/files/screenshots/00003/00003064.jpg", prod.Screenshot)
+	assert.Len(t, prod.Placings, 1)
+}
+
+func TestFilterByPlatform(t *testing.T) {
+	prods := []Prod{
+		{ID: "1", Name: "DOS Demo", Platforms: map[string]Platform{"67": {Name: "MS-Dos"}}},
+		{ID: "2", Name: "Windows Demo", Platforms: map[string]Platform{"68": {Name: "Windows"}}},
+		{ID: "3", Name: "Amiga Demo", Platforms: map[string]Platform{"73": {Name: "Amiga OCS/ECS"}}},
+		{ID: "4", Name: "Multi", Platforms: map[string]Platform{"67": {Name: "MS-Dos"}, "68": {Name: "Windows"}}},
+	}
+
+	dos := FilterByPlatform(prods, []int{67, 69})
+	assert.Len(t, dos, 2)
+	assert.Equal(t, "DOS Demo", dos[0].Name)
+	assert.Equal(t, "Multi", dos[1].Name)
+
+	amiga := FilterByPlatform(prods, []int{73, 71})
+	assert.Len(t, amiga, 1)
+	assert.Equal(t, "Amiga Demo", amiga[0].Name)
+}
+
+func TestCleanDemoName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"State of the Art (Phenomena) [1992].adf", "State of the Art (Phenomena)"},
+		{"Second_Reality.zip", "Second Reality"},
+		{"Batman Rises (Batman Group) A.adf", "Batman Rises (Batman Group)"},
+		{"BatmanVuelve_1.adf", "BatmanVuelve"},
+		{"Enigma (Phenomena).adf", "Enigma (Phenomena)"},
+		{"2nd Demo (Hypnotic) [1991].adf", "2nd Demo (Hypnotic)"},
+		{"+6 dB (Teklords) [1998].zip", "+6 dB (Teklords)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, CleanDemoName(tt.input))
+		})
+	}
+}
+
+func TestGroupNames(t *testing.T) {
+	prod := &Prod{Groups: []Group{{Name: "Future Crew"}, {Name: "Remedy"}}}
+	assert.Equal(t, "Future Crew & Remedy", GroupNames(prod))
+
+	empty := &Prod{}
+	assert.Equal(t, "", GroupNames(empty))
+}
+
+func TestPartyInfo(t *testing.T) {
+	prod := &Prod{Placings: []Placement{
+		{Party: Party{Name: "Assembly"}, Year: "1993", Ranking: "1", CompoName: "pc demo"},
+	}}
+	assert.Equal(t, "Assembly 1993, 1st place (pc demo)", PartyInfo(prod))
+
+	noPlace := &Prod{Placings: []Placement{
+		{Party: Party{Name: "Revision"}, Year: "2020", Ranking: "0", CompoName: "amiga demo"},
+	}}
+	assert.Equal(t, "Revision 2020 (amiga demo)", PartyInfo(noPlace))
+}
+
+func TestRating(t *testing.T) {
+	prod := &Prod{VoteUp: "100", VotePig: "0", VoteDown: "0"}
+	assert.InDelta(t, 100.0, Rating(prod), 0.1)
+
+	mixed := &Prod{VoteUp: "50", VotePig: "30", VoteDown: "20"}
+	assert.InDelta(t, 65.0, Rating(mixed), 0.1)
+
+	none := &Prod{}
+	assert.Equal(t, 0.0, Rating(none))
+}

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/spela/server/internal/igdb"
+	"github.com/spela/server/internal/pouet"
 	"github.com/spela/server/internal/storage"
 	"gorm.io/gorm"
 )
@@ -18,6 +19,7 @@ type Scraper struct {
 	HTTPClient       *http.Client
 	IGDBClient       *igdb.Client
 	SteamGridDBClient *SteamGridDBClient
+	PouetClient       *pouet.Client
 	DATCache         *DATCache
 	GameDirs         []string
 	cache            *nameCache
@@ -40,12 +42,13 @@ func NewScraper(database *gorm.DB, store *storage.Storage, datDir string, gameDi
 		Timeout: 30 * time.Second,
 	}
 	return &Scraper{
-		DB:         database,
-		Storage:    store,
-		HTTPClient: httpClient,
-		DATCache:   NewDATCache(datDir, httpClient),
-		GameDirs:   gameDirs,
-		cache:      &nameCache{entries: make(map[string][]nameEntry)},
+		DB:          database,
+		Storage:     store,
+		HTTPClient:  httpClient,
+		PouetClient: pouet.NewClient(),
+		DATCache:    NewDATCache(datDir, httpClient),
+		GameDirs:    gameDirs,
+		cache:       &nameCache{entries: make(map[string][]nameEntry)},
 	}
 }
 

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -67,6 +67,20 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 	gameName := gameNameFromFileName(game.FileName)
 	gameIDStr := strconv.FormatUint(uint64(game.ID), 10)
 
+	// --- Pouet (for demoscene consoles) ---
+	if DemoConsoles[console.Abbreviation] {
+		if err := s.scrapePouet(game, console, gameIDStr); err != nil {
+			slog.Warn("Pouet scrape failed", "game", game.Title, "error", err)
+		}
+		// Skip IGDB for demo consoles — demoscene productions don't exist in IGDB.
+		// Also skip LibRetro (no demo thumbnails there either).
+		game.ScrapeAttempts++
+		if err := s.DB.Save(game).Error; err != nil {
+			return fmt.Errorf("saving game after Pouet scrape: %w", err)
+		}
+		return nil
+	}
+
 	// --- IGDB (primary metadata + images, when configured) ---
 	igdbAttempted := false
 	if s.IGDBClient != nil && s.IGDBClient.IsConfigured() {

--- a/server/internal/scraper/scraper_pouet.go
+++ b/server/internal/scraper/scraper_pouet.go
@@ -1,0 +1,240 @@
+package scraper
+
+import (
+	"fmt"
+	"log/slog"
+	"strings"
+
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/pouet"
+)
+
+// DemoConsoles maps console abbreviations that should use Pouet for scraping.
+var DemoConsoles = map[string]bool{
+	"ADEMO": true,
+	"DDEMO": true,
+}
+
+// scrapePouet searches Pouet.net for a matching demoscene production and applies metadata.
+func (s *Scraper) scrapePouet(game *db.Game, console db.Console, gameIDStr string) error {
+	if s.PouetClient == nil {
+		return fmt.Errorf("pouet client not initialized")
+	}
+
+	platformIDs, ok := pouet.AbbreviationToPouetPlatforms[console.Abbreviation]
+	if !ok {
+		return fmt.Errorf("no Pouet platform mapping for console %s", console.Abbreviation)
+	}
+
+	// Clean the demo filename for searching
+	cleanName := pouet.CleanDemoName(game.FileName)
+	slog.Info("searching Pouet", "game", game.Title, "query", cleanName)
+
+	// Try searching with the full name first (includes group name in parens)
+	prods, err := s.PouetClient.SearchProd(cleanName)
+	if err != nil {
+		return fmt.Errorf("pouet search: %w", err)
+	}
+
+	// Filter by platform
+	filtered := pouet.FilterByPlatform(prods, platformIDs)
+
+	// If no results with full name, try without the group name in parentheses
+	if len(filtered) == 0 {
+		nameWithoutGroup := stripParenContent(cleanName)
+		if nameWithoutGroup != cleanName && nameWithoutGroup != "" {
+			slog.Debug("retrying Pouet search without group name", "query", nameWithoutGroup)
+			prods, err = s.PouetClient.SearchProd(nameWithoutGroup)
+			if err != nil {
+				return fmt.Errorf("pouet search retry: %w", err)
+			}
+			filtered = pouet.FilterByPlatform(prods, platformIDs)
+		}
+	}
+
+	if len(filtered) == 0 {
+		slog.Debug("no Pouet results", "game", game.Title)
+		return nil
+	}
+
+	// Pick the best match using name similarity
+	best := bestPouetMatch(cleanName, filtered)
+	if best == nil {
+		return nil
+	}
+
+	slog.Info("pouet match found", "game", game.Title, "match", best.Name, "id", best.ID)
+
+	// Fetch full production details (search results don't include screenshots)
+	fullProd, err := s.PouetClient.GetProd(best.ID)
+	if err != nil {
+		slog.Warn("failed to fetch full Pouet prod", "id", best.ID, "error", err)
+		fullProd = best // Fall back to search result data
+	}
+
+	// Apply metadata
+	s.applyPouetMetadata(game, fullProd, console, gameIDStr)
+
+	return nil
+}
+
+// applyPouetMetadata maps Pouet production data to Game model fields.
+func (s *Scraper) applyPouetMetadata(game *db.Game, prod *pouet.Prod, console db.Console, gameIDStr string) {
+	game.ScraperID = "pouet:" + prod.ID
+
+	// Title: use the Pouet name if available
+	if prod.Name != "" {
+		game.Title = prod.Name
+	}
+
+	// Developer = group names
+	if groups := pouet.GroupNames(prod); groups != "" {
+		game.Developer = groups
+	}
+
+	// Genre = production type
+	game.Genre = pouet.TypesString(prod)
+
+	// Party info
+	if info := pouet.PartyInfo(prod); info != "" {
+		game.PartyInfo = info
+	}
+
+	// Description
+	game.Description = buildDemoDescription(prod)
+
+	// Release date
+	if prod.ReleaseDate != "" && len(prod.ReleaseDate) >= 4 {
+		game.ReleaseDate = prod.ReleaseDate
+	}
+
+	// Rating
+	if rating := pouet.Rating(prod); rating > 0 {
+		game.Rating = rating
+	}
+
+	// Download screenshot
+	if prod.Screenshot != "" {
+		subpath := fmt.Sprintf("%s/%s/cover.jpg", console.Abbreviation, gameIDStr)
+		if path := s.DownloadExternalImage(prod.Screenshot, subpath); path != "" {
+			game.CoverURL = path
+			game.IGDBCoverURL = path
+		}
+	}
+
+	game.ScrapeAttempts++
+
+	if err := s.DB.Save(game).Error; err != nil {
+		slog.Warn("failed to save Pouet metadata", "game", game.Title, "error", err)
+	}
+}
+
+// ScrapeGameWithPouetMatch applies metadata from a specific Pouet production ID.
+func (s *Scraper) ScrapeGameWithPouetMatch(game *db.Game, pouetID string) error {
+	prod, err := s.PouetClient.GetProd(pouetID)
+	if err != nil {
+		return fmt.Errorf("fetching Pouet prod %s: %w", pouetID, err)
+	}
+
+	var console db.Console
+	if game.Console.ID != 0 {
+		console = game.Console
+	} else {
+		if err := s.DB.First(&console, game.ConsoleID).Error; err != nil {
+			return fmt.Errorf("loading console: %w", err)
+		}
+	}
+
+	gameIDStr := fmt.Sprintf("%d", game.ID)
+	s.applyPouetMetadata(game, prod, console, gameIDStr)
+	return nil
+}
+
+// bestPouetMatch picks the best matching production from search results.
+func bestPouetMatch(query string, prods []pouet.Prod) *pouet.Prod {
+	if len(prods) == 0 {
+		return nil
+	}
+
+	normalizedQuery := normalizeDemoName(query)
+	var bestProd *pouet.Prod
+	var bestScore float64
+
+	for i := range prods {
+		normalizedName := normalizeDemoName(prods[i].Name)
+		score := jaroWinkler(normalizedQuery, normalizedName)
+
+		// Bonus for exact match
+		if strings.EqualFold(normalizedQuery, normalizedName) {
+			score = 1.0
+		}
+
+		if score > bestScore {
+			bestScore = score
+			bestProd = &prods[i]
+		}
+	}
+
+	// Require a minimum similarity threshold
+	if bestScore < 0.75 {
+		slog.Debug("no Pouet match above threshold", "query", query, "bestScore", bestScore)
+		return nil
+	}
+
+	return bestProd
+}
+
+// buildDemoDescription creates a human-readable description from Pouet data.
+func buildDemoDescription(prod *pouet.Prod) string {
+	var parts []string
+
+	typeStr := pouet.TypesString(prod)
+	groups := pouet.GroupNames(prod)
+
+	if groups != "" {
+		parts = append(parts, fmt.Sprintf("%s by %s", capitalize(typeStr), groups))
+	} else {
+		parts = append(parts, capitalize(typeStr))
+	}
+
+	if info := pouet.PartyInfo(prod); info != "" {
+		parts = append(parts, "Released at "+info)
+	} else if prod.ReleaseDate != "" && len(prod.ReleaseDate) >= 4 {
+		parts = append(parts, "Released "+prod.ReleaseDate[:4])
+	}
+
+	return strings.Join(parts, ". ") + "."
+}
+
+// normalizeDemoName normalizes a demo name for comparison.
+func normalizeDemoName(name string) string {
+	name = strings.ToLower(name)
+	// Strip content in parentheses (group names)
+	name = stripParenContent(name)
+	name = strings.TrimSpace(name)
+	return name
+}
+
+// stripParenContent removes all parenthesized content from a string.
+func stripParenContent(s string) string {
+	result := s
+	for {
+		start := strings.Index(result, "(")
+		if start < 0 {
+			break
+		}
+		end := strings.Index(result[start:], ")")
+		if end < 0 {
+			break
+		}
+		result = result[:start] + result[start+end+1:]
+	}
+	return strings.TrimSpace(result)
+}
+
+func capitalize(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}


### PR DESCRIPTION
## Summary
- Demoscene productions (Amiga Demos, DOS Demos) now get metadata from Pouet.net instead of IGDB
- IGDB only has commercial games, so demos were either unmatched or wrongly matched (e.g., "Batman Rises" by Batman Group → Batman video game)
- New `pouet` package with API client: search productions, get full details, filter by platform
- Metadata mapping: group names → Developer, prod type → Genre, party placement → PartyInfo, Pouet screenshot → cover, vote score → Rating
- Demo consoles skip IGDB and LibRetro entirely
- Rate-limited (500ms between requests) to be a good API citizen

## New files
- `server/internal/pouet/client.go` - Pouet API client
- `server/internal/pouet/client_test.go` - Unit tests
- `server/internal/scraper/scraper_pouet.go` - Scraper integration

## Test plan
- [x] Pouet client unit tests pass (search, platform filtering, name cleaning, rating calculation)
- [x] Scraper tests pass (no regressions)
- [ ] Deploy and run "Scrape new" on Amiga Demos — verify demos get Pouet metadata
- [ ] Verify commercial game consoles still use IGDB normally