### PR TITLE
fix: correct Pouet API response parsing

### DIFF
--- a/server/internal/pouet/client.go
+++ b/server/internal/pouet/client.go
@@ -91,8 +91,9 @@ type Prod struct {
 }
 
 // searchResponse is the API response for search queries.
+// Results is an object keyed by prod ID, not an array.
 type searchResponse struct {
-	Results []Prod `json:"results"`
+	Results map[string]Prod `json:"results"`
 }
 
 // prodResponse is the API response for single prod queries.
@@ -127,8 +128,14 @@ func (c *Client) SearchProd(query string) ([]Prod, error) {
 		return nil, fmt.Errorf("pouet search: parsing JSON: %w", err)
 	}
 
-	slog.Debug("pouet search results", "query", query, "count", len(result.Results))
-	return result.Results, nil
+	// Convert map to slice
+	prods := make([]Prod, 0, len(result.Results))
+	for _, p := range result.Results {
+		prods = append(prods, p)
+	}
+
+	slog.Debug("pouet search results", "query", query, "count", len(prods))
+	return prods, nil
 }
 
 // GetProd fetches a single production by ID with full details.

--- a/server/internal/pouet/client_test.go
+++ b/server/internal/pouet/client_test.go
@@ -24,13 +24,13 @@ func TestSearchProd(t *testing.T) {
 	c := testClient(func(w http.ResponseWriter, r *http.Request) {
 		assert.Contains(t, r.URL.Path, "/search/prod/")
 		assert.Equal(t, "second reality", r.URL.Query().Get("q"))
-		w.Write([]byte(`{"results":[
-			{"id":"3064","name":"Second Reality","types":["demo"],
+		w.Write([]byte(`{"success":true,"results":{
+			"3064":{"id":"3064","name":"Second Reality","types":["demo"],
 			 "groups":[{"id":"44","name":"Future Crew","acronym":"FC"}],
 			 "platforms":{"67":{"name":"MS-Dos","slug":"msdos"}},
-			 "voteup":1200,"votepig":100,"votedown":20,
+			 "voteup":"1200","votepig":"100","votedown":"20",
 			 "releaseDate":"1993-08-01"}
-		]}`))
+		}}`))
 	})
 
 	prods, err := c.SearchProd("second reality")
@@ -51,7 +51,7 @@ func TestGetProd(t *testing.T) {
 			"groups":[{"id":"44","name":"Future Crew"}],
 			"platforms":{"67":{"name":"MS-Dos"}},
 			"screenshot":"https://content.pouet.net/files/screenshots/00003/00003064.jpg",
-			"voteup":1200,"votepig":100,"votedown":"20",
+			"voteup":"1200","votepig":"100","votedown":"20",
 			"releaseDate":"1993-08-01",
 			"party":{"id":"3","name":"Assembly"},
 			"party_year":"1993",


### PR DESCRIPTION
## Summary
- Fixed Pouet API response parsing: `results` is an object keyed by prod ID, not an array
- Fixed vote fields: Pouet returns them as strings, not numbers
- Tested against live Pouet API — both Amiga and DOS demos match correctly

## Test plan
- [x] Unit tests pass
- [x] Live API test: "2nd Demo" → Scoopex (rating 92.9), "+6 dB" → Teklords