### PR TITLE
fix: top lists empty, unreasonable time-to-beat, demo exclusion

### DIFF
--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -412,6 +412,13 @@ type TopRatedGameResponse struct {
 // topRatedStaleness is how long cached top-rated data is considered fresh.
 const topRatedStaleness = 7 * 24 * time.Hour
 
+// maxTimeToBeatSeconds caps time-to-beat values at ~10000 hours to filter out
+// bogus IGDB data (e.g. World Cup 98 listed at 567890 hours).
+const maxTimeToBeatSeconds = 10000 * 3600
+
+// demoConsoleAbbreviations lists consoles that should be excluded from top lists.
+var demoConsoleAbbreviations = []string{"ADEMO", "DDEMO"}
+
 // GetTopRated returns the top-rated IGDB games for a console.
 // Results are cached in the local DB and refreshed when stale (>7 days).
 func (h *ConsoleHandler) GetTopRated(c *gin.Context) {
@@ -536,9 +543,11 @@ type TopListGameResponse struct {
 }
 
 // GetTopListAvailable returns IGDB audience top-rated games that have a matching
-// local game on the server, sorted by user rating descending, limited to 50 results.
+// local game on the server, sorted by total rating descending, limited to 50 results.
+// Uses total_rating (combined user+critic) rather than user_rating alone, since
+// IGDB's user-only rating field is often null for games that do have ratings.
 func (h *ConsoleHandler) GetTopListAvailable(c *gin.Context) {
-	h.getTopListByRating(c, "top_rated_games.user_rating", "top_rated_games.user_rating > 0")
+	h.getTopListByRating(c, "top_rated_games.total_rating", "top_rated_games.total_rating > 0")
 }
 
 // GetTopListCritics returns IGDB critic top-rated games that have a matching
@@ -569,6 +578,7 @@ func (h *ConsoleHandler) getTopListByRating(c *gin.Context, ratingColumn string,
 		Joins("JOIN games ON LOWER(games.title) = LOWER(top_rated_games.name) AND games.console_id = top_rated_games.console_id AND games.deleted_at IS NULL AND games.is_primary = true").
 		Joins("JOIN consoles ON consoles.id = top_rated_games.console_id AND consoles.deleted_at IS NULL").
 		Where("top_rated_games.deleted_at IS NULL AND "+ratingFilter).
+		Where("consoles.abbreviation NOT IN ?", demoConsoleAbbreviations).
 		Group("top_rated_games.id, top_rated_games.name, consoles.name, consoles.abbreviation, "+ratingColumn).
 		Order(ratingColumn + " DESC").
 		Limit(50).
@@ -634,7 +644,8 @@ func (h *ConsoleHandler) GetTopListLongest(c *gin.Context) {
 				games.time_to_beat_hastily,
 				games.time_to_beat_completely`).
 		Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.deleted_at IS NULL").
-		Where("games.time_to_beat_normally > 0 AND games.deleted_at IS NULL AND games.is_primary = true").
+		Where("games.time_to_beat_normally > 0 AND games.time_to_beat_normally <= ? AND games.deleted_at IS NULL AND games.is_primary = true", maxTimeToBeatSeconds).
+		Where("consoles.abbreviation NOT IN ?", demoConsoleAbbreviations).
 		Order("games.time_to_beat_normally DESC").
 		Limit(50).
 		Find(&rows).Error

--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -257,6 +257,8 @@ func setupTopListTestEnv(t *testing.T) (*gorm.DB, *gin.Engine) {
 
 	handler := &ConsoleHandler{DB: database}
 	router.GET("/api/top-lists/top-rated", handler.GetTopListAvailable)
+	router.GET("/api/top-lists/top-rated-critics", handler.GetTopListCritics)
+	router.GET("/api/top-lists/longest", handler.GetTopListLongest)
 
 	return database, router
 }
@@ -684,4 +686,165 @@ func TestGetTopListLongest_LimitOf50(t *testing.T) {
 	// The last result should be the 50th longest (game 6 → 60 hours)
 	assert.Equal(t, 60, result[49].TimeToBeatNormally)
 	assert.Equal(t, 50, result[49].Rank)
+}
+
+// --- Bug fix tests ---
+
+func TestGetTopListAvailable_UsesTotalRatingNotUserRating(t *testing.T) {
+	// Bug: Audience list was empty because it used user_rating which IGDB
+	// often returns as null (stored as 0). Fix uses total_rating instead.
+	database, router := setupTopListTestEnv(t)
+
+	var nesConsole db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
+
+	// Game with total_rating but user_rating=0 (typical IGDB response)
+	database.Create(&db.TopRatedGame{
+		ConsoleID: nesConsole.ID, IGDBGameID: 100, Name: "Mega Man 2",
+		TotalRating: 88.0, TotalRatingCount: 200,
+		UserRating: 0, UserRatingCount: 0,
+		CriticRating: 85.0, CriticRatingCount: 5, Rank: 1,
+	})
+	database.Create(&db.Game{
+		ConsoleID: nesConsole.ID, Title: "Mega Man 2",
+		FileName: "mm2.nes", FilePath: "/games/mm2.nes", IsPrimary: true,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var result []TopListGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+	assert.Len(t, result, 1, "should include game with total_rating even if user_rating is 0")
+	assert.Equal(t, "Mega Man 2", result[0].Name)
+	assert.Equal(t, 88.0, result[0].Rating)
+}
+
+func TestGetTopListCritics_ReturnsGamesWithCriticRating(t *testing.T) {
+	database, router := setupTopListTestEnv(t)
+
+	var nesConsole db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
+
+	database.Create(&db.TopRatedGame{
+		ConsoleID: nesConsole.ID, IGDBGameID: 100, Name: "Zelda",
+		TotalRating: 92.0, TotalRatingCount: 500,
+		CriticRating: 95.0, CriticRatingCount: 10, Rank: 1,
+	})
+	database.Create(&db.Game{
+		ConsoleID: nesConsole.ID, Title: "Zelda",
+		FileName: "zelda.nes", FilePath: "/games/zelda.nes", IsPrimary: true,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-lists/top-rated-critics", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+	var result []TopListGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+	assert.Len(t, result, 1)
+	assert.Equal(t, 95.0, result[0].Rating)
+}
+
+func TestGetTopListAvailable_ExcludesDemoConsoles(t *testing.T) {
+	database, router := setupTopListTestEnv(t)
+
+	var nesConsole, ademoConsole db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
+	require.NoError(t, database.Where("abbreviation = ?", "ADEMO").First(&ademoConsole).Error)
+
+	// NES game (should appear)
+	database.Create(&db.TopRatedGame{
+		ConsoleID: nesConsole.ID, IGDBGameID: 100, Name: "Super Mario",
+		TotalRating: 90.0, TotalRatingCount: 400, Rank: 1,
+	})
+	database.Create(&db.Game{
+		ConsoleID: nesConsole.ID, Title: "Super Mario",
+		FileName: "sm.nes", FilePath: "/games/sm.nes", IsPrimary: true,
+	})
+
+	// Demo "game" (should be excluded)
+	database.Create(&db.TopRatedGame{
+		ConsoleID: ademoConsole.ID, IGDBGameID: 200, Name: "Some Demo",
+		TotalRating: 95.0, TotalRatingCount: 50, Rank: 1,
+	})
+	database.Create(&db.Game{
+		ConsoleID: ademoConsole.ID, Title: "Some Demo",
+		FileName: "demo.adf", FilePath: "/games/demo.adf", IsPrimary: true,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	router.ServeHTTP(w, req)
+
+	var result []TopListGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+	assert.Len(t, result, 1, "should exclude demo console entries")
+	assert.Equal(t, "Super Mario", result[0].Name)
+}
+
+func TestGetTopListLongest_CapsUnreasonableTimeToBeat(t *testing.T) {
+	database, router := setupTopListTestEnv(t)
+
+	var nesConsole db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
+
+	// Reasonable game
+	database.Create(&db.Game{
+		ConsoleID: nesConsole.ID, Title: "Long RPG",
+		FileName: "rpg.nes", FilePath: "/games/rpg.nes", IsPrimary: true,
+		TimeToBeatNormally: 100 * 3600, // 100 hours
+	})
+
+	// Unreasonable game (567890 hours like World Cup 98)
+	database.Create(&db.Game{
+		ConsoleID: nesConsole.ID, Title: "Broken Data",
+		FileName: "broken.nes", FilePath: "/games/broken.nes", IsPrimary: true,
+		TimeToBeatNormally: 567890 * 3600,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-lists/longest", nil)
+	router.ServeHTTP(w, req)
+
+	var result []LongestGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+	assert.Len(t, result, 1, "should exclude games with unreasonable time-to-beat")
+	assert.Equal(t, "Long RPG", result[0].Name)
+}
+
+func TestGetTopListLongest_ExcludesDemoConsoles(t *testing.T) {
+	database, router := setupTopListTestEnv(t)
+
+	var nesConsole, ddemoConsole db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
+	require.NoError(t, database.Where("abbreviation = ?", "DDEMO").First(&ddemoConsole).Error)
+
+	database.Create(&db.Game{
+		ConsoleID: nesConsole.ID, Title: "Real Game",
+		FileName: "game.nes", FilePath: "/games/game.nes", IsPrimary: true,
+		TimeToBeatNormally: 50 * 3600,
+	})
+	database.Create(&db.Game{
+		ConsoleID: ddemoConsole.ID, Title: "DOS Demo",
+		FileName: "demo.zip", FilePath: "/games/demo.zip", IsPrimary: true,
+		TimeToBeatNormally: 1 * 3600,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-lists/longest", nil)
+	router.ServeHTTP(w, req)
+
+	var result []LongestGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+	assert.Len(t, result, 1, "should exclude demo console entries")
+	assert.Equal(t, "Real Game", result[0].Name)
 }


### PR DESCRIPTION
## Summary
- **Audience Top Rated empty**: used `user_rating` which IGDB often returns as null → changed to `total_rating` 
- **World Cup 98 at 567890 hours**: added 10000-hour cap on time-to-beat values
- **Demos in top lists**: excluded ADEMO/DDEMO consoles from all top list queries

## Test plan
- [x] `TestGetTopListAvailable_UsesTotalRatingNotUserRating` - game with total_rating but user_rating=0 now appears
- [x] `TestGetTopListCritics_ReturnsGamesWithCriticRating` - critic list works
- [x] `TestGetTopListAvailable_ExcludesDemoConsoles` - demo entries filtered out
- [x] `TestGetTopListLongest_CapsUnreasonableTimeToBeat` - 567890 hours filtered out
- [x] `TestGetTopListLongest_ExcludesDemoConsoles` - demo entries filtered out
- [x] All 11 existing tests still pass