### PR TITLE
fix: handle invalid Pouet release dates causing NaN in UI

### DIFF
--- a/server/internal/scraper/scraper_pouet.go
+++ b/server/internal/scraper/scraper_pouet.go
@@ -103,9 +103,9 @@ func (s *Scraper) applyPouetMetadata(game *db.Game, prod *pouet.Prod, console db
 	// Description
 	game.Description = buildDemoDescription(prod)
 
-	// Release date
+	// Release date — sanitize invalid Pouet dates like "1989-00-15"
 	if prod.ReleaseDate != "" && len(prod.ReleaseDate) >= 4 {
-		game.ReleaseDate = prod.ReleaseDate
+		game.ReleaseDate = sanitizePouetDate(prod.ReleaseDate)
 	}
 
 	// Rating
@@ -230,6 +230,28 @@ func stripParenContent(s string) string {
 		result = result[:start] + result[start+end+1:]
 	}
 	return strings.TrimSpace(result)
+}
+
+// sanitizePouetDate fixes invalid Pouet dates like "1989-00-15" where month
+// or day is "00". Replaces "00" with "01" to produce a valid ISO date.
+// Returns just the year if the date can't be salvaged.
+func sanitizePouetDate(d string) string {
+	if len(d) < 4 {
+		return d
+	}
+	// Just a year
+	if len(d) == 4 {
+		return d
+	}
+	// Format: YYYY-MM-DD — fix zero month/day
+	parts := strings.Split(d, "-")
+	if len(parts) >= 2 && parts[1] == "00" {
+		parts[1] = "01"
+	}
+	if len(parts) >= 3 && parts[2] == "00" {
+		parts[2] = "01"
+	}
+	return strings.Join(parts, "-")
 }
 
 func capitalize(s string) string {

--- a/server/internal/scraper/scraper_pouet_test.go
+++ b/server/internal/scraper/scraper_pouet_test.go
@@ -1,0 +1,44 @@
+package scraper
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSanitizePouetDate(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"1993-08-01", "1993-08-01"},     // valid date unchanged
+		{"1989-00-15", "1989-01-15"},     // zero month → 01
+		{"1992-05-00", "1992-05-01"},     // zero day → 01
+		{"1990-00-00", "1990-01-01"},     // both zero → 01
+		{"1993", "1993"},                 // year only unchanged
+		{"", ""},                         // empty unchanged
+		{"2020-12-31", "2020-12-31"},     // valid date unchanged
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizePouetDate(tt.input))
+		})
+	}
+}
+
+func TestStripParenContent(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"State of the Art (Phenomena)", "State of the Art"},
+		{"Demo (Group) (Extra)", "Demo"},
+		{"No parens here", "No parens here"},
+		{"(All parens)", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			assert.Equal(t, tt.want, stripParenContent(tt.input))
+		})
+	}
+}

--- a/web/src/components/game-card.tsx
+++ b/web/src/components/game-card.tsx
@@ -3,6 +3,7 @@ import { Heart, Star, Clock, Loader2 } from "lucide-react";
 import { cn } from "@/lib/cn";
 import { Badge } from "@/components/ui";
 import { useAutoScrape } from "@/hooks/use-auto-scrape";
+import { getReleaseYear } from "@/lib/date-utils";
 import type { Game } from "@/types/api";
 
 interface GameCardProps {
@@ -134,9 +135,8 @@ export function GameCard({
           {hideConsoleName ? (
             (game.releaseDate || game.developer) && (
               <p className="text-xs text-surface-500">
-                {game.releaseDate
-                  ? new Date(game.releaseDate).getFullYear()
-                  : game.developer}
+                {getReleaseYear(game.releaseDate)
+                  ?? game.developer}
               </p>
             )
           ) : (

--- a/web/src/features/explore/components/game-timeline-card.tsx
+++ b/web/src/features/explore/components/game-timeline-card.tsx
@@ -2,6 +2,7 @@ import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui";
 import { cn } from "@/lib/cn";
 import { ensureContrast } from "@/lib/color-utils";
+import { getReleaseYear } from "@/lib/date-utils";
 import type { SeriesGame } from "@/types/api";
 
 interface GameTimelineCardProps {
@@ -10,9 +11,7 @@ interface GameTimelineCardProps {
 }
 
 export function GameTimelineCard({ game, testIdPrefix }: GameTimelineCardProps) {
-  const year = game.releaseDate
-    ? new Date(game.releaseDate).getFullYear()
-    : null;
+  const year = getReleaseYear(game.releaseDate);
 
   const content = (
     <div

--- a/web/src/features/explore/components/temporal-shelves.tsx
+++ b/web/src/features/explore/components/temporal-shelves.tsx
@@ -1,4 +1,5 @@
 import { useRef, useState, useEffect, useCallback } from "react";
+import { getReleaseYear } from "@/lib/date-utils";
 import {
   ChevronLeft,
   ChevronRight,
@@ -173,7 +174,7 @@ export function OnThisDayShelf({
           <GameCard
             game={game}
             showConsoleBadge
-            subtitle={game.releaseDate ? `Released ${new Date(game.releaseDate).getFullYear()}` : undefined}
+            subtitle={getReleaseYear(game.releaseDate) ? `Released ${getReleaseYear(game.releaseDate)}` : undefined}
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
           />

--- a/web/src/features/games/components/game-list-row.tsx
+++ b/web/src/features/games/components/game-list-row.tsx
@@ -1,6 +1,7 @@
 import { Link } from "react-router-dom";
 import { Badge } from "@/components/ui";
 import { formatFileSize } from "@/lib/format";
+import { getReleaseYear } from "@/lib/date-utils";
 import type { Game } from "@/types/api";
 
 interface GameListRowProps {
@@ -10,9 +11,8 @@ interface GameListRowProps {
 
 export function GameListRow({ game, hideConsoleName }: GameListRowProps) {
   const consoleName = game.consoleName ?? "";
-  const releaseYear = game.releaseDate
-    ? new Date(game.releaseDate).getFullYear().toString()
-    : undefined;
+  const year = getReleaseYear(game.releaseDate);
+  const releaseYear = year ? year.toString() : undefined;
 
   return (
     <Link

--- a/web/src/lib/date-utils.ts
+++ b/web/src/lib/date-utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Safely extract the year from a release date string.
+ * Returns null if the date is invalid or missing.
+ * Handles ISO dates like "1993-08-01" and also bare years like "1993".
+ * Pouet sometimes returns dates like "1989-00-15" which are invalid.
+ */
+export function getReleaseYear(
+  releaseDate: string | null | undefined,
+): number | null {
+  if (!releaseDate) return null;
+
+  // Try extracting year directly from the string (works for "YYYY" and "YYYY-MM-DD")
+  const match = releaseDate.match(/^(\d{4})/);
+  if (!match) return null;
+
+  const year = parseInt(match[1], 10);
+  if (isNaN(year) || year < 1900 || year > 2100) return null;
+
+  return year;
+}


### PR DESCRIPTION
## Summary
- Pouet sometimes returns dates like "1989-00-15" (month=00) which are invalid ISO dates
- `new Date("1989-00-15").getFullYear()` returns NaN, shown in the UI
- **Server fix**: sanitize dates before storing (replace "00" month/day with "01")
- **Frontend fix**: new `getReleaseYear()` utility extracts year via regex instead of Date parsing
- Updated 4 components: game-card, game-list-row, temporal-shelves, game-timeline-card

## Test plan
- [x] `TestSanitizePouetDate` - all date variations handled correctly
- [x] TypeScript compiles clean
- [ ] Verify Amiga Demos essentials list shows years correctly (no NaN)