### PR TITLE
feat: add SteamGridDB to setup wizard and improve config cards

### DIFF
--- a/web/src/features/admin/components/steamgriddb-config-card.tsx
+++ b/web/src/features/admin/components/steamgriddb-config-card.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import {
+  Image,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import {
+  Badge,
+  Card,
+  CardHeader,
+  CardContent,
+  Input,
+} from "@/components/ui";
+import { useSteamGridDBStatus } from "@/hooks/use-admin";
+
+interface SteamGridDBConfigCardProps {
+  apiKey: string;
+  onApiKeyChange: (value: string) => void;
+  envConfigured?: boolean;
+}
+
+export function SteamGridDBConfigCard({
+  apiKey,
+  onApiKeyChange,
+  envConfigured,
+}: SteamGridDBConfigCardProps) {
+  const { data: status } = useSteamGridDBStatus();
+  const [instructionsExpanded, setInstructionsExpanded] = useState(!apiKey);
+
+  const statusBadge = (() => {
+    if (!status) return null;
+    if (status.configured) {
+      return <Badge variant="success">Connected</Badge>;
+    }
+    return <Badge variant="warning">Not configured</Badge>;
+  })();
+
+  return (
+    <Card>
+      <CardHeader>
+        <div
+          className="flex items-center justify-between"
+          id="steamgriddb-config"
+        >
+          <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+            <Image className="h-5 w-5 text-brand-400" />
+            SteamGridDB
+          </h2>
+          {statusBadge}
+        </div>
+        <p className="text-xs text-surface-500 mt-1">
+          SteamGridDB provides hero artwork, grid images, logos, and icons for
+          games. This is optional — games will still have cover art from IGDB
+          without it.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {envConfigured ? (
+          <div className="rounded-xl bg-surface-800/50 border border-surface-700/50 p-4">
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-success-500 flex-shrink-0" />
+              <p className="text-sm text-surface-200">
+                Configured via environment variables
+              </p>
+            </div>
+            <p className="mt-1.5 ml-6 text-xs text-surface-500">
+              SteamGridDB API key is set through{" "}
+              <code className="px-1 py-0.5 rounded bg-surface-800 text-surface-300 font-mono">
+                SPELA_STEAMGRIDDB_API_KEY
+              </code>
+              . To change it, update your environment and restart the server.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div>
+              <button
+                type="button"
+                onClick={() => setInstructionsExpanded((prev) => !prev)}
+                className="flex items-center gap-1.5 text-sm font-medium text-surface-300 hover:text-surface-100 transition-colors"
+              >
+                {instructionsExpanded ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+                How to get your API key
+              </button>
+              {instructionsExpanded && (
+                <ol className="mt-2 ml-6 list-decimal text-sm text-surface-400 space-y-1">
+                  <li>
+                    Go to{" "}
+                    <a
+                      href="https://www.steamgriddb.com/profile/preferences/api"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-brand-400 hover:text-brand-300 underline"
+                    >
+                      SteamGridDB API Preferences
+                    </a>
+                  </li>
+                  <li>Sign in with your Steam account</li>
+                  <li>Copy the API key from the preferences page</li>
+                </ol>
+              )}
+            </div>
+
+            <Input
+              label="API Key"
+              type="password"
+              placeholder="SteamGridDB API Key"
+              value={apiKey}
+              onChange={(e) => onApiKeyChange(e.target.value)}
+            />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/features/setup/components/steamgriddb-step.tsx
+++ b/web/src/features/setup/components/steamgriddb-step.tsx
@@ -1,0 +1,128 @@
+import { useState } from "react";
+import { CheckCircle2, ChevronDown, ChevronRight } from "lucide-react";
+import { Button, Input } from "@/components/ui";
+import { useSteamGridDBStatus, useUpdateSettings } from "@/hooks/use-admin";
+
+interface SteamGridDBStepProps {
+  onSkip: () => void;
+  onSave: () => void;
+}
+
+export function SteamGridDBStep({ onSkip, onSave }: SteamGridDBStepProps) {
+  const { data: status, isLoading } = useSteamGridDBStatus();
+  const [apiKey, setApiKey] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [instructionsExpanded, setInstructionsExpanded] = useState(true);
+  const updateSettings = useUpdateSettings();
+
+  if (!isLoading && status?.configured && status?.source === "env") {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h2 className="text-xl font-semibold text-surface-100">
+            SteamGridDB Artwork
+          </h2>
+          <p className="mt-1 text-sm text-surface-400">
+            SteamGridDB provides hero artwork, grid images, logos, and icons.
+          </p>
+        </div>
+
+        <div className="rounded-xl bg-success-500/10 border border-success-500/30 px-4 py-3">
+          <div className="flex items-center gap-2">
+            <CheckCircle2 className="h-4 w-4 text-success-500" />
+            <span className="text-sm font-medium text-success-500">
+              SteamGridDB is already configured via environment variables.
+            </span>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end pt-2">
+          <Button onClick={onSave}>Continue</Button>
+        </div>
+      </div>
+    );
+  }
+
+  async function handleSaveAndContinue() {
+    setSaving(true);
+    try {
+      await updateSettings.mutateAsync({
+        steamgriddb_api_key: apiKey,
+      });
+      onSave();
+    } catch {
+      // Silently continue — the key will be validated when artwork is fetched
+      onSave();
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-surface-100">
+          SteamGridDB Artwork
+        </h2>
+        <p className="mt-1 text-sm text-surface-400">
+          SteamGridDB provides hero banners, grid images, logos, and icons for
+          games. This step is optional — games will still have cover art from
+          IGDB without it.
+        </p>
+      </div>
+
+      <div>
+        <button
+          type="button"
+          onClick={() => setInstructionsExpanded((prev) => !prev)}
+          className="flex items-center gap-1.5 text-sm font-medium text-surface-300 hover:text-surface-100 transition-colors"
+        >
+          {instructionsExpanded ? (
+            <ChevronDown className="h-4 w-4" />
+          ) : (
+            <ChevronRight className="h-4 w-4" />
+          )}
+          How to get your API key
+        </button>
+        {instructionsExpanded && (
+          <ol className="mt-2 ml-6 list-decimal text-sm text-surface-400 space-y-1">
+            <li>
+              Go to{" "}
+              <a
+                href="https://www.steamgriddb.com/profile/preferences/api"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-brand-400 hover:text-brand-300 underline"
+              >
+                SteamGridDB API Preferences
+              </a>
+            </li>
+            <li>Sign in with your Steam account</li>
+            <li>Copy the API key from the preferences page</li>
+          </ol>
+        )}
+      </div>
+
+      <Input
+        label="API Key"
+        type="password"
+        placeholder="SteamGridDB API Key"
+        value={apiKey}
+        onChange={(e) => setApiKey(e.target.value)}
+      />
+
+      <div className="flex items-center justify-between pt-2">
+        <Button variant="secondary" onClick={onSkip}>
+          Skip
+        </Button>
+        <Button
+          onClick={handleSaveAndContinue}
+          loading={saving}
+          disabled={!apiKey}
+        >
+          Save & Continue
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/setup/components/wizard-layout.tsx
+++ b/web/src/features/setup/components/wizard-layout.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from "react";
 import { Gamepad2, Check } from "lucide-react";
 
-const STEPS = ["System Check", "Account", "IGDB", "Games", "Done"];
+const STEPS = ["System Check", "Account", "IGDB", "SteamGridDB", "Games", "Done"];
 
 interface WizardLayoutProps {
   currentStep: number;

--- a/web/src/pages/admin/settings-page.tsx
+++ b/web/src/pages/admin/settings-page.tsx
@@ -1,5 +1,4 @@
 import { useState, useEffect } from "react";
-import { Image, CheckCircle2 } from "lucide-react";
 import {
   Button,
   Card,
@@ -19,6 +18,7 @@ import { useToast } from "@/components/ui";
 import { Skeleton } from "@/components/ui";
 import { IgdbConfigCard } from "@/features/admin/components/igdb-config-card";
 import { IgdbWarningBanner } from "@/features/admin/components/igdb-warning-banner";
+import { SteamGridDBConfigCard } from "@/features/admin/components/steamgriddb-config-card";
 
 export function AdminSettingsPage() {
   const { data: settings, isLoading } = useServerSettings();
@@ -191,54 +191,11 @@ export function AdminSettingsPage() {
         envConfigured={igdbEnvConfigured}
       />
 
-      <Card>
-        <CardHeader>
-          <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
-            <Image className="h-5 w-5 text-brand-400" />
-            SteamGridDB
-          </h2>
-          <p className="text-xs text-surface-500 mt-1">
-            Used for hero artwork on the companion display. Get a free API key
-            at{" "}
-            <a
-              href="https://www.steamgriddb.com/profile/preferences/api"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-brand-400 hover:text-brand-300 underline"
-            >
-              steamgriddb.com
-            </a>
-            .
-          </p>
-        </CardHeader>
-        <CardContent>
-          {steamgriddbEnvConfigured ? (
-            <div className="rounded-xl bg-surface-800/50 border border-surface-700/50 p-4">
-              <div className="flex items-center gap-2">
-                <CheckCircle2 className="h-4 w-4 text-success-500 flex-shrink-0" />
-                <p className="text-sm text-surface-200">
-                  Configured via environment variables
-                </p>
-              </div>
-              <p className="mt-1.5 ml-6 text-xs text-surface-500">
-                SteamGridDB API key is set through{" "}
-                <code className="px-1 py-0.5 rounded bg-surface-800 text-surface-300 font-mono">
-                  SPELA_STEAMGRIDDB_API_KEY
-                </code>
-                . To change it, update your environment and restart the server.
-              </p>
-            </div>
-          ) : (
-            <Input
-              label="SteamGridDB API Key"
-              type="password"
-              placeholder="SteamGridDB API Key"
-              value={steamgriddbApiKey}
-              onChange={(e) => setSteamgriddbApiKey(e.target.value)}
-            />
-          )}
-        </CardContent>
-      </Card>
+      <SteamGridDBConfigCard
+        apiKey={steamgriddbApiKey}
+        onApiKeyChange={setSteamgriddbApiKey}
+        envConfigured={steamgriddbEnvConfigured}
+      />
 
       <div className="flex justify-end">
         <Button

--- a/web/src/pages/admin/settings-page.tsx
+++ b/web/src/pages/admin/settings-page.tsx
@@ -4,7 +4,6 @@ import {
   Card,
   CardHeader,
   CardContent,
-  Input,
   Select,
   Switch,
 } from "@/components/ui";

--- a/web/src/pages/setup-wizard-page.tsx
+++ b/web/src/pages/setup-wizard-page.tsx
@@ -5,6 +5,7 @@ import { WizardLayout } from "@/features/setup/components/wizard-layout";
 import { SystemCheckStep } from "@/features/setup/components/system-check-step";
 import { CreateAccountStep } from "@/features/setup/components/create-account-step";
 import { IgdbStep } from "@/features/setup/components/igdb-step";
+import { SteamGridDBStep } from "@/features/setup/components/steamgriddb-step";
 import { GameScanStep } from "@/features/setup/components/game-scan-step";
 import { CompleteStep } from "@/features/setup/components/complete-step";
 
@@ -36,6 +37,9 @@ export function SetupWizardPage() {
         />
       )}
       {currentStep === 3 && (
+        <SteamGridDBStep onSkip={nextStep} onSave={nextStep} />
+      )}
+      {currentStep === 4 && (
         <GameScanStep
           onSkip={nextStep}
           onComplete={() => {
@@ -44,7 +48,7 @@ export function SetupWizardPage() {
           }}
         />
       )}
-      {currentStep === 4 && (
+      {currentStep === 5 && (
         <CompleteStep
           igdbConfigured={igdbConfigured}
           gamesScanned={gamesScanned}


### PR DESCRIPTION
## Summary
- Added SteamGridDB step to the setup wizard (between IGDB and Game Scan)
- Created `SteamGridDBConfigCard` component with status badge, expandable instructions, env var detection
- Settings page upgraded from inline card to the new component
- Setup wizard now has 6 steps: System Check → Account → IGDB → SteamGridDB → Games → Done

## Test plan
- [ ] Setup wizard shows SteamGridDB step with instructions and API key input
- [ ] Skipping the step works correctly
- [ ] Settings page shows SteamGridDB status badge (Connected/Not configured)
- [ ] Env var detection shows green message when configured via environment