### PR TITLE
feat: add SteamGridDB to system check diagnostics

### DIFF
--- a/server/internal/api/setup_handler.go
+++ b/server/internal/api/setup_handler.go
@@ -99,6 +99,7 @@ func (h *SetupHandler) runDiagnostics() []DiagnosticCheck {
 	checks = append(checks, h.checkGameDirs())
 	checks = append(checks, h.checkStorageWritable())
 	checks = append(checks, h.checkIGDB())
+	checks = append(checks, h.checkSteamGridDB())
 
 	return checks
 }
@@ -265,6 +266,24 @@ func (h *SetupHandler) checkIGDB() DiagnosticCheck {
 		check.Status = "warning"
 		check.Detail = "Not configured"
 		check.Fix = "Configure IGDB in the next step for game metadata and cover art"
+	}
+	return check
+}
+
+func (h *SetupHandler) checkSteamGridDB() DiagnosticCheck {
+	check := DiagnosticCheck{ID: "steamgriddb", Label: "SteamGridDB Artwork"}
+	source := SteamGridDBSource(h.DB)
+	switch source {
+	case "env":
+		check.Status = "ok"
+		check.Detail = "Configured via environment variables"
+	case "database":
+		check.Status = "ok"
+		check.Detail = "Configured via settings"
+	default:
+		check.Status = "warning"
+		check.Detail = "Not configured (optional)"
+		check.Fix = "Configure SteamGridDB for hero artwork, logos, and grid images"
 	}
 	return check
 }

--- a/server/internal/api/setup_handler_test.go
+++ b/server/internal/api/setup_handler_test.go
@@ -299,9 +299,9 @@ func TestDiagnostics_RunDiagnostics_ReturnsAllChecks(t *testing.T) {
 	}
 
 	checks := handler.runDiagnostics()
-	assert.Len(t, checks, 6)
+	assert.Len(t, checks, 7)
 
-	expectedIDs := []string{"database", "jwt_secret", "encryption_key", "game_dirs", "storage_writable", "igdb"}
+	expectedIDs := []string{"database", "jwt_secret", "encryption_key", "game_dirs", "storage_writable", "igdb", "steamgriddb"}
 	for i, id := range expectedIDs {
 		assert.Equal(t, id, checks[i].ID)
 	}


### PR DESCRIPTION
## Summary
- System check page now shows SteamGridDB configuration status alongside IGDB
- Shows "Configured via environment variables", "Configured via settings", or "Not configured (optional)"

## Test plan
- [x] `TestDiagnostics_RunDiagnostics_ReturnsAllChecks` updated for 7 checks
- [ ] Setup wizard system check page shows SteamGridDB row