### PR TITLE
fix: make SCPH-39001.bin the required PS2 BIOS

### DIFF
--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -22,8 +22,8 @@ var registry = []Entry{
 	// PlayStation 2 (PS2) — pcsx2_libretro.info
 	// PCSX2 auto-detects BIOS files; no strict filename or MD5 enforced by core.
 	// Common BIOS models listed for user guidance.
-	{ConsoleID: "ps2", FileName: "SCPH-70012.bin", Description: "PS2 BIOS v12 (North America)", MD5: "", Required: true},
-	{ConsoleID: "ps2", FileName: "SCPH-39001.bin", Description: "PS2 BIOS v7 (North America)", MD5: "", Required: false},
+	{ConsoleID: "ps2", FileName: "SCPH-39001.bin", Description: "PS2 BIOS v7 (North America)", MD5: "", Required: true},
+	{ConsoleID: "ps2", FileName: "SCPH-70012.bin", Description: "PS2 BIOS v12 (North America)", MD5: "", Required: false},
 	{ConsoleID: "ps2", FileName: "SCPH-70004.bin", Description: "PS2 BIOS v12 (Europe)", MD5: "", Required: false},
 	{ConsoleID: "ps2", FileName: "SCPH-70000.bin", Description: "PS2 BIOS v12 (Japan)", MD5: "", Required: false},
 


### PR DESCRIPTION
## Summary
- SCPH-70012.bin was marked Required but returns 404 from the retrobios repo
- Swapped to SCPH-39001.bin which auto-downloads successfully
- PCSX2 auto-detects any PS2 BIOS

## Test plan
- [x] BIOS registry tests pass
- [ ] BIOS page shows PS2 as available