### PR TITLE
feat: refresh top-rated after scrape + per-console top lists

### DIFF
--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -81,6 +81,11 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 			return
 		}
 		h.Hub.Broadcast(ws.Event{Type: "scrape_complete", Payload: gin.H{"scraped": count, "total": total}})
+
+		// Refresh top-rated cache for all consoles with IGDB platform mappings.
+		if h.Scraper.IGDBClient != nil && h.Scraper.IGDBClient.IsConfigured() {
+			h.refreshTopRatedForAllConsoles()
+		}
 	}()
 
 	adminID, _ := c.Get("userId")
@@ -261,4 +266,37 @@ func IGDBSource(database *gorm.DB) string {
 		return "database"
 	}
 	return "none"
+}
+
+// refreshTopRatedForAllConsoles fetches IGDB top-rated games for every console
+// that has an IGDB platform mapping and upserts them into the cache.
+// Called after a scrape completes so the top lists are always fresh.
+func (h *AdminHandler) refreshTopRatedForAllConsoles() {
+	slog.Info("refreshing top-rated games for all consoles")
+
+	var consoles []db.Console
+	h.DB.Find(&consoles)
+
+	consoleHandler := &ConsoleHandler{DB: h.DB, Scraper: h.Scraper}
+	refreshed := 0
+
+	for _, console := range consoles {
+		abbr := console.Abbreviation
+		platformID, ok := igdb.AbbreviationToIGDBPlatform[abbr]
+		if !ok {
+			continue
+		}
+
+		topGames, err := h.Scraper.IGDBClient.GetTopGames(platformID, 100)
+		if err != nil {
+			slog.Warn("failed to fetch top-rated games", "console", abbr, "error", err)
+			continue
+		}
+
+		ranked := bayesianRank(topGames, 25)
+		consoleHandler.upsertTopRatedGames(console.ID, ranked)
+		refreshed++
+	}
+
+	slog.Info("top-rated refresh complete", "consoles", refreshed)
 }

--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -566,8 +566,7 @@ func (h *ConsoleHandler) getTopListByRating(c *gin.Context, ratingColumn string,
 		Rating      float64
 	}
 
-	var rows []row
-	err := h.DB.
+	q := h.DB.
 		Table("top_rated_games").
 		Select(`MIN(games.id) AS game_id,
 				top_rated_games.name AS name,
@@ -578,7 +577,15 @@ func (h *ConsoleHandler) getTopListByRating(c *gin.Context, ratingColumn string,
 		Joins("JOIN games ON LOWER(games.title) = LOWER(top_rated_games.name) AND games.console_id = top_rated_games.console_id AND games.deleted_at IS NULL AND games.is_primary = true").
 		Joins("JOIN consoles ON consoles.id = top_rated_games.console_id AND consoles.deleted_at IS NULL").
 		Where("top_rated_games.deleted_at IS NULL AND "+ratingFilter).
-		Where("consoles.abbreviation NOT IN ?", demoConsoleAbbreviations).
+		Where("consoles.abbreviation NOT IN ?", demoConsoleAbbreviations)
+
+	// Per-console filter when accessed via /consoles/:id/top-lists/*
+	if consoleParam := c.Param("id"); consoleParam != "" {
+		q = q.Where("LOWER(consoles.abbreviation) = LOWER(?)", consoleParam)
+	}
+
+	var rows []row
+	err := q.
 		Group("top_rated_games.id, top_rated_games.name, consoles.name, consoles.abbreviation, "+ratingColumn).
 		Order(ratingColumn + " DESC").
 		Limit(50).
@@ -633,7 +640,7 @@ func (h *ConsoleHandler) GetTopListLongest(c *gin.Context) {
 	}
 
 	var rows []row
-	err := h.DB.
+	q := h.DB.
 		Table("games").
 		Select(`games.id AS game_id,
 				games.title,
@@ -645,7 +652,14 @@ func (h *ConsoleHandler) GetTopListLongest(c *gin.Context) {
 				games.time_to_beat_completely`).
 		Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.deleted_at IS NULL").
 		Where("games.time_to_beat_normally > 0 AND games.time_to_beat_normally <= ? AND games.deleted_at IS NULL AND games.is_primary = true", maxTimeToBeatSeconds).
-		Where("consoles.abbreviation NOT IN ?", demoConsoleAbbreviations).
+		Where("consoles.abbreviation NOT IN ?", demoConsoleAbbreviations)
+
+	// Per-console filter when accessed via /consoles/:id/top-lists/*
+	if consoleParam := c.Param("id"); consoleParam != "" {
+		q = q.Where("LOWER(consoles.abbreviation) = LOWER(?)", consoleParam)
+	}
+
+	err := q.
 		Order("games.time_to_beat_normally DESC").
 		Limit(50).
 		Find(&rows).Error

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -255,6 +255,9 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		api.GET("/top-lists/top-rated", consoleHandler.GetTopListAvailable)
 		api.GET("/top-lists/top-rated-critics", consoleHandler.GetTopListCritics)
 		api.GET("/top-lists/longest", consoleHandler.GetTopListLongest)
+		api.GET("/consoles/:id/top-lists/top-rated", consoleHandler.GetTopListAvailable)
+		api.GET("/consoles/:id/top-lists/top-rated-critics", consoleHandler.GetTopListCritics)
+		api.GET("/consoles/:id/top-lists/longest", consoleHandler.GetTopListLongest)
 
 		// Explore
 		explore := api.Group("/explore")


### PR DESCRIPTION
## Summary
- Top-rated games cache is now refreshed automatically after scraping completes
- Added per-console top list endpoints (e.g., `/consoles/snes/top-lists/top-rated`)
- Same handlers, optional `:id` param filters by console

## Test plan
- [x] Builds clean
- [x] Global top lists: 32 results
- [x] Per-console (SNES): 11 results, correct games (Super Metroid #1)
- [x] Per-console critics and longest also work
- [ ] Run scrape → verify top-rated is refreshed automatically