### PR TITLE
fix: handle tilde-separated alternate titles in IGDB search

### DIFF
--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -1406,6 +1406,8 @@ func escapeQuery(s string) string {
 
 // CleanGameName strips file extensions, region tags, revision tags,
 // disc indicators, and bracket/parentheses content from a ROM filename.
+// For titles with alternate names separated by " ~ " (e.g.,
+// "Puzzle Bobble ~ Bust-A-Move"), uses the first (primary) title.
 func CleanGameName(fileName string) string {
 	// Remove file extension
 	if idx := strings.LastIndex(fileName, "."); idx > 0 {
@@ -1421,6 +1423,14 @@ func CleanGameName(fileName string) string {
 			break
 		}
 		result = cleaned
+	}
+
+	result = strings.TrimSpace(result)
+
+	// Handle tilde-separated alternate titles (No-Intro naming convention).
+	// Use the first (primary) title for search.
+	if idx := strings.Index(result, " ~ "); idx > 0 {
+		result = result[:idx]
 	}
 
 	return strings.TrimSpace(result)

--- a/server/internal/igdb/client_test.go
+++ b/server/internal/igdb/client_test.go
@@ -407,6 +407,8 @@ func TestCleanGameName(t *testing.T) {
 		{"Simple", "Simple"},
 		{"Brackets [a] (b) [c].rom", "Brackets"},
 		{"Final Fantasy III (Japan) (Rev 1).smc", "Final Fantasy III"},
+		{"Puzzle Bobble ~ Bust-A-Move (Japan) (En,Ja).cue", "Puzzle Bobble"},
+		{"Bakumatsu Roman - Gekka no Kenshi ~ The Last Blade (Japan).cue", "Bakumatsu Roman - Gekka no Kenshi"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- "Puzzle Bobble ~ Bust-A-Move" on Neo Geo CD had no metadata because the tilde-separated name wasn't recognized by IGDB
- `CleanGameName` now strips alternate titles after " ~ ", sending just "Puzzle Bobble" to IGDB
- Also fixes other tilde-separated games (e.g., "Bakumatsu Roman ~ The Last Blade")

## Test plan
- [x] `TestCleanGameName` - 2 new tilde cases pass
- [ ] Re-scrape Puzzle Bobble on Neo Geo CD → should now get IGDB metadata