### PR TITLE
fix: show error message when emulator crashes instead of black screen

### DIFF
--- a/web/public/emulator.js
+++ b/web/public/emulator.js
@@ -26,6 +26,25 @@
 
   var parentOrigin = window.location.origin;
 
+  // Catch uncaught errors/exceptions and forward to parent as emulator-error.
+  // This catches WASM core crashes, OOM, and other fatal errors.
+  window.addEventListener("error", function (event) {
+    sendToParent({
+      type: "emulator-error",
+      error: event.message || "An unexpected error occurred in the emulator",
+    });
+  });
+  window.addEventListener("unhandledrejection", function (event) {
+    var reason =
+      event.reason instanceof Error
+        ? event.reason.message
+        : String(event.reason || "Emulator promise rejected");
+    sendToParent({
+      type: "emulator-error",
+      error: reason,
+    });
+  });
+
   /** Send a typed message to the parent window. */
   function sendToParent(msg) {
     if (window.parent && window.parent !== window) {

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -392,6 +392,33 @@ export function PlayPage() {
     );
   }
 
+  // ── Error state ──────────────────────────────────────────────────
+
+  if (emulator.status === "error") {
+    return (
+      <div className="text-center py-20 space-y-4">
+        <AlertTriangle className="h-12 w-12 text-danger-500 mx-auto" />
+        <h2 className="text-xl font-bold text-surface-100">
+          Emulation Error
+        </h2>
+        <p className="text-surface-400 max-w-md mx-auto">
+          {emulator.error || "The emulator encountered an unexpected error."}
+        </p>
+        <div className="flex items-center justify-center gap-3 pt-2">
+          <Button
+            variant="secondary"
+            onClick={() => navigate(`/games/${id}`)}
+          >
+            Back to Game Details
+          </Button>
+          <Button onClick={() => window.location.reload()}>
+            Try Again
+          </Button>
+        </div>
+      </div>
+    );
+  }
+
   // ── Main emulator layout ──────────────────────────────────────────
 
   return (


### PR DESCRIPTION
## Summary
- **Issue 5**: PSP (and other cores) throwing exceptions showed a black screen with no information
- Now catches uncaught errors in the emulator iframe and displays a user-friendly error page
- Error page shows the error message with "Back to Game Details" and "Try Again" buttons
- **Issue 4 (restart button)**: This is an EmulatorJS built-in button we can't control, but crashes from restart attempts are now caught and displayed

## Test plan
- [x] TypeScript compiles clean
- [ ] Trigger PSP crash → verify error message appears instead of black screen
- [ ] Normal gameplay → verify no false error triggers