### PR TITLE
fix: suppress expected 404 errors in browser console

### DIFF
--- a/web/src/hooks/use-ratings.ts
+++ b/web/src/hooks/use-ratings.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
+import { api, ApiError } from "@/lib/api-client";
 import type {
   GameRating,
   GameRatingsResponse,
@@ -32,7 +32,17 @@ export function useGameRatingSummary(gameId: string) {
 export function useMyRating(gameId: string) {
   return useQuery({
     queryKey: ["ratings", gameId, "mine"],
-    queryFn: () => api.get<GameRating>(`/games/${gameId}/ratings/mine`),
+    queryFn: async () => {
+      try {
+        return await api.get<GameRating>(`/games/${gameId}/ratings/mine`);
+      } catch (e) {
+        // 404 = no rating submitted yet, not an error
+        if (e instanceof ApiError && e.status === 404) {
+          return null;
+        }
+        throw e;
+      }
+    },
     enabled: !!gameId,
     retry: false,
   });

--- a/web/src/hooks/use-retroachievements.ts
+++ b/web/src/hooks/use-retroachievements.ts
@@ -69,7 +69,7 @@ export function useGameAchievementProgress(gameId: string | undefined) {
         .get<GameAchievementProgressResponse>(
           `/games/${gameId}/achievements/progress`,
         )
-        .then((res) => res.progress),
+        .then((res) => res.progress ?? null),
     enabled: !!gameId,
   });
 }

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -1,6 +1,6 @@
 const API_BASE = "/api";
 
-class ApiError extends Error {
+export class ApiError extends Error {
   status: number;
 
   constructor(status: number, message: string) {


### PR DESCRIPTION
## Summary
- `GET /games/:id/ratings/mine` returning 404 (no rating yet) was logged as an error on every game detail page visit. Now catches 404 and returns null silently.
- `game-achievement-progress` query could return undefined, triggering TanStack Query warning. Now falls back to null.
- Exported `ApiError` class for typed catch blocks.

## Test plan
- [x] TypeScript compiles clean
- [ ] Visit game detail page → no 404 errors in console
- [ ] No "Query data cannot be undefined" warnings