### PR TITLE
fix: only show Back online snackbar after genuine offline→online transition

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/OfflineIndicatorTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/OfflineIndicatorTest.kt
@@ -83,4 +83,49 @@ class OfflineIndicatorTest {
 
         onNodeWithContentDescription("Database error screen").assertDoesNotExist()
     }
+
+    @Test
+    fun backOnlineSnackbarNotShownWithoutPriorOffline() = runComposeUiTest {
+        // App starts with no server configured — should NOT show "Back online"
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // The server connection screen should be shown
+        onNodeWithText("Connect to your game server").assertIsDisplayed()
+
+        // "Back online" snackbar must NOT appear — the app was never offline
+        onNodeWithText("Back online").assertDoesNotExist()
+    }
+
+    @Test
+    fun backOnlineSnackbarNotShownOnInitialLogin() = runComposeUiTest {
+        // App starts logged in — should NOT show "Back online" on first load
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // "Back online" snackbar must NOT appear on initial app load
+        onNodeWithText("Back online").assertDoesNotExist()
+    }
+
+    @Test
+    fun backOnlineSnackbarShownAfterOfflineToOnlineTransition() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+
+        setContent { harness.App() }
+        advance(harness)
+
+        // Simulate going offline (DatabaseError has isConnected=false) then back online
+        harness.connectivityMonitor.reportDatabaseError("test-offline")
+        advanceQuick(harness)
+
+        harness.connectivityMonitor.clearDatabaseError()
+        advanceQuick(harness)
+
+        // NOW "Back online" should appear
+        onNodeWithText("Back online").assertIsDisplayed()
+    }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -301,17 +301,19 @@ fun SpelaApp(
                 var serverWarningDismissed by remember { mutableStateOf(false) }
                 var snackbarData by remember { mutableStateOf<SpSnackbarData?>(null) }
 
-                // "Back online" snackbar: fires when transitioning to Online
+                // "Back online" snackbar: fires only after a genuine offline→online transition
+                var hasBeenOffline by remember { mutableStateOf(false) }
                 LaunchedEffect(currentConnectionState) {
                     if (currentConnectionState is ConnectionState.Online) {
-                        // Only show if we're past initial load
-                        if (!navState.isRestoringSession) {
+                        if (hasBeenOffline) {
                             snackbarData = SpSnackbarData(
                                 message = "Back online",
                                 type = SpSnackbarType.Success,
                                 durationMs = 3000L,
                             )
                         }
+                    } else if (!currentConnectionState.isConnected) {
+                        hasBeenOffline = true
                     }
                     // Reset dismiss when state changes away from ServerUnreachable
                     if (currentConnectionState !is ConnectionState.ServerUnreachable) {


### PR DESCRIPTION
## Summary
- **Bug**: The Android app showed "Back online" snackbar on startup even when no server had been configured
- **Root cause**: `ConnectivityMonitor` initializes with `Online` state. The `LaunchedEffect` in `SpelaApp` fired when `isRestoringSession` became false, showing the snackbar despite never having been offline
- **Fix**: Track whether the app has actually been in a disconnected state (`hasBeenOffline`) before showing the recovery message. The snackbar now only appears after a genuine offline→online transition

## Test plan
- [x] Added `backOnlineSnackbarNotShownWithoutPriorOffline` — no server configured, no snackbar
- [x] Added `backOnlineSnackbarNotShownOnInitialLogin` — logged in, first load, no snackbar
- [x] Added `backOnlineSnackbarShownAfterOfflineToOnlineTransition` — offline then online, snackbar appears
- [x] Full desktop test suite passes (682 tests, 0 failures)