### PR TITLE
fix: add missing Android core substitutions for beetle-family cores

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
@@ -20,6 +20,12 @@ private val ANDROID_CORE_SUBSTITUTIONS = mapOf(
     "mupen64plus_next" to "mupen64plus_next_gles3",
     "beetle_psx_hw" to "mednafen_psx_hw",
     "beetle_psx" to "mednafen_psx",
+    "beetle_pce" to "mednafen_pce_fast",
+    "beetle_saturn" to "mednafen_saturn",
+    "beetle_vb" to "mednafen_vb",
+    "beetle_ngp" to "mednafen_ngp",
+    "beetle_wswan" to "mednafen_wswan",
+    "beetle_pcfx" to "mednafen_pcfx",
 )
 
 class PrepareGameUseCase(


### PR DESCRIPTION
## Summary
- The libretro buildbot for Android hosts Mednafen-based cores under `mednafen_*` names, not `beetle_*`
- Added substitutions for: `beetle_pce` → `mednafen_pce_fast`, `beetle_saturn` → `mednafen_saturn`, `beetle_vb` → `mednafen_vb`, `beetle_ngp` → `mednafen_ngp`, `beetle_wswan` → `mednafen_wswan`, `beetle_pcfx` → `mednafen_pcfx`
- Fixes TG16 game crash (issue 8) and Saturn core download failure (issue 9)

## Test plan
- [x] Verified buildbot URL patterns match expected core names
- [x] Existing substitutions for PSX and N64 remain unchanged