### PR TITLE
fix: support BIOS subdirectories for MAME-based cores (CD-i)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -549,6 +549,7 @@ data class BiosFileDto(
     val name: String,
     val size: Long,
     val md5: String? = null,
+    val subDir: String? = null,
     val consoleId: String? = null,
     val consoleName: String? = null,
     val description: String? = null,
@@ -576,6 +577,7 @@ data class BiosConsoleFileDto(
     val required: Boolean = false,
     val md5: String? = null,
     val status: String = "missing",
+    val subDir: String? = null,
 )
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/BiosRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/BiosRepository.kt
@@ -20,9 +20,11 @@ open class BiosRepository(
         }
         val biosDir = fileStorage.getBiosDir()
         for (file in serverFiles) {
-            val localPath = "$biosDir/${file.name}"
+            val localDir = if (!file.subDir.isNullOrEmpty()) "$biosDir/${file.subDir}" else biosDir
+            val localPath = "$localDir/${file.name}"
             if (!fileStorage.fileExists(localPath)) {
                 try {
+                    if (!file.subDir.isNullOrEmpty()) fileStorage.createDirectory(localDir)
                     val data = apiClient.downloadBiosFile(file.name)
                     fileStorage.writeFile(localPath, data)
                 } catch (e: Exception) {
@@ -60,15 +62,21 @@ open class BiosRepository(
     open suspend fun getConsoleStatus(consoleId: String): BiosConsoleStatus? {
         val status = cachedBiosStatus ?: fetchBiosStatus() ?: return null
         val console = status.consoles.find { it.consoleId == consoleId } ?: return null
+        val biosDir = fileStorage.getBiosDir()
 
         val missingFiles = console.files
             .filter { it.required && it.status == "missing" }
-            .map { BiosMissingFile(it.fileName, it.description, it.required) }
+            .map { BiosMissingFile(it.fileName, it.description, it.required, it.subDir) }
 
         // Also check local files - some may have been synced already
         val localFiles = getLocalBiosFiles()
         val actuallyMissing = missingFiles.filter { missing ->
-            missing.fileName !in localFiles
+            val localPath = if (!missing.subDir.isNullOrEmpty()) {
+                "$biosDir/${missing.subDir}/${missing.fileName}"
+            } else {
+                "$biosDir/${missing.fileName}"
+            }
+            missing.fileName !in localFiles && !fileStorage.fileExists(localPath)
         }
 
         return BiosConsoleStatus(
@@ -96,9 +104,11 @@ open class BiosRepository(
         val stillMissing = mutableListOf<BiosMissingFile>()
 
         for (missing in consoleStatus.missingFiles) {
-            val localPath = "$biosDir/${missing.fileName}"
+            val localDir = if (!missing.subDir.isNullOrEmpty()) "$biosDir/${missing.subDir}" else biosDir
+            val localPath = "$localDir/${missing.fileName}"
             if (!fileStorage.fileExists(localPath)) {
                 try {
+                    if (!missing.subDir.isNullOrEmpty()) fileStorage.createDirectory(localDir)
                     val data = apiClient.downloadBiosFile(missing.fileName)
                     fileStorage.writeFile(localPath, data)
                 } catch (e: Exception) {
@@ -117,14 +127,22 @@ open class BiosRepository(
     open suspend fun getConsolesWithMissingBios(): Map<String, BiosConsoleStatus> {
         val status = cachedBiosStatus ?: fetchBiosStatus() ?: return emptyMap()
         val localFiles = getLocalBiosFiles()
+        val biosDir = fileStorage.getBiosDir()
 
         return status.consoles
             .filter { it.biosRequired && it.status == "missing" }
             .mapNotNull { console ->
                 val missingFiles = console.files
                     .filter { it.required && it.status == "missing" }
-                    .filter { it.fileName !in localFiles }
-                    .map { BiosMissingFile(it.fileName, it.description, it.required) }
+                    .filter { file ->
+                        val localPath = if (!file.subDir.isNullOrEmpty()) {
+                            "$biosDir/${file.subDir}/${file.fileName}"
+                        } else {
+                            "$biosDir/${file.fileName}"
+                        }
+                        file.fileName !in localFiles && !fileStorage.fileExists(localPath)
+                    }
+                    .map { BiosMissingFile(it.fileName, it.description, it.required, it.subDir) }
 
                 if (missingFiles.isNotEmpty()) {
                     console.consoleId to BiosConsoleStatus(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -733,4 +733,5 @@ data class BiosMissingFile(
     val fileName: String,
     val description: String,
     val required: Boolean,
+    val subDir: String? = null,
 )

--- a/server/internal/api/bios_handler.go
+++ b/server/internal/api/bios_handler.go
@@ -37,6 +37,7 @@ type BiosFileResponse struct {
 	Size        int64   `json:"size"`
 	MD5         string  `json:"md5"`
 	ExpectedMD5 string  `json:"expectedMd5,omitempty"`
+	SubDir      string  `json:"subDir,omitempty"`
 	ConsoleID   *string `json:"consoleId"`
 	ConsoleName *string `json:"consoleName,omitempty"`
 	Description *string `json:"description,omitempty"`
@@ -50,7 +51,8 @@ type ConsoleFileStatus struct {
 	Description string `json:"description"`
 	Required    bool   `json:"required"`
 	MD5         string `json:"md5"`
-	Status      string `json:"status"` // "valid", "present", "invalid", "missing"
+	Status      string `json:"status"`            // "valid", "present", "invalid", "missing"
+	SubDir      string `json:"subDir,omitempty"`   // subdirectory within system_dir
 }
 
 // ConsoleBiosStatus represents the BIOS status summary for one console.
@@ -134,12 +136,22 @@ func (h *BiosHandler) ListBiosFiles(c *gin.Context) {
 		consoleID := e.ConsoleID
 		desc := e.Description
 
+		// Check if file exists: flat first, then subdirectory path
+		fullPath := e.FilePath(h.Storage.BiosDir)
 		info, onDisk := diskFiles[e.FileName]
+		if !onDisk && e.SubDir != "" {
+			// Check subdirectory path
+			if fi, err := os.Stat(fullPath); err == nil {
+				info = fi
+				onDisk = true
+			}
+		}
 		if !onDisk {
 			fileResponses = append(fileResponses, BiosFileResponse{
 				Name:        e.FileName,
 				Size:        0,
 				MD5:         e.MD5,
+				SubDir:      e.SubDir,
 				ConsoleID:   &consoleID,
 				ConsoleName: &consoleName,
 				Description: &desc,
@@ -152,7 +164,7 @@ func (h *BiosHandler) ListBiosFiles(c *gin.Context) {
 		matchedFiles[e.FileName] = true
 
 		// Compute MD5 of the file on disk
-		fileMD5, err := computeFileMD5(filepath.Join(h.Storage.BiosDir, e.FileName))
+		fileMD5, err := computeFileMD5(fullPath)
 		status := "present"
 		if err == nil {
 			if e.MD5 == "" {
@@ -169,6 +181,7 @@ func (h *BiosHandler) ListBiosFiles(c *gin.Context) {
 			Name:        e.FileName,
 			Size:        info.Size(),
 			MD5:         fileMD5,
+			SubDir:      e.SubDir,
 			ConsoleID:   &consoleID,
 			ConsoleName: &consoleName,
 			Description: &desc,
@@ -216,10 +229,16 @@ func (h *BiosHandler) ListBiosFiles(c *gin.Context) {
 				optionalTotal++
 			}
 
+			fullPath := e.FilePath(h.Storage.BiosDir)
 			_, onDisk := diskFiles[e.FileName]
+			if !onDisk && e.SubDir != "" {
+				if _, err := os.Stat(fullPath); err == nil {
+					onDisk = true
+				}
+			}
 			status := "missing"
 			if onDisk {
-				fileMD5, err := computeFileMD5(filepath.Join(h.Storage.BiosDir, e.FileName))
+				fileMD5, err := computeFileMD5(fullPath)
 				if err == nil && e.MD5 == "" {
 					status = "present"
 				} else if err == nil && fileMD5 == e.MD5 {
@@ -253,6 +272,7 @@ func (h *BiosHandler) ListBiosFiles(c *gin.Context) {
 				Required:    e.Required,
 				MD5:         e.MD5,
 				Status:      status,
+				SubDir:      e.SubDir,
 			})
 		}
 
@@ -292,8 +312,20 @@ func (h *BiosHandler) GetBiosFile(c *gin.Context) {
 	path := h.Storage.BiosFilePath(filename)
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "bios file not found"})
-		return
+		// Check if the file exists in a registry-defined subdirectory
+		for _, e := range bios.ByFileName(filename) {
+			if e.SubDir != "" {
+				subPath := e.FilePath(h.Storage.BiosDir)
+				if _, serr := os.Stat(subPath); serr == nil {
+					path = subPath
+					break
+				}
+			}
+		}
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "bios file not found"})
+			return
+		}
 	}
 
 	// Validate the resolved path stays within BiosDir

--- a/server/internal/bios/downloader.go
+++ b/server/internal/bios/downloader.go
@@ -58,7 +58,7 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 		}
 
 		// Skip if already present
-		destPath := filepath.Join(biosDir, entry.FileName)
+		destPath := entry.FilePath(biosDir)
 		if _, err := os.Stat(destPath); err == nil {
 			progress.Status = "skipped"
 			result.Skipped++
@@ -99,6 +99,21 @@ func DownloadMissing(biosDir, baseURL string, onProgress func(DownloadProgress))
 				onProgress(progress)
 			}
 			continue
+		}
+
+		// Ensure subdirectory exists for entries that need it
+		if entry.SubDir != "" {
+			if err := os.MkdirAll(filepath.Dir(destPath), 0755); err != nil {
+				resp.Body.Close()
+				progress.Status = "failed"
+				progress.Error = fmt.Sprintf("creating subdirectory: %v", err)
+				result.Failed++
+				result.Errors = append(result.Errors, fmt.Sprintf("%s: %s", entry.FileName, progress.Error))
+				if onProgress != nil {
+					onProgress(progress)
+				}
+				continue
+			}
 		}
 
 		// Write to .tmp file first

--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -1,5 +1,7 @@
 package bios
 
+import "path/filepath"
+
 // Entry represents a known BIOS file in the registry.
 type Entry struct {
 	ConsoleID   string // lowercase abbreviation, e.g. "psx"
@@ -8,6 +10,16 @@ type Entry struct {
 	MD5         string // expected MD5 checksum (lowercase hex)
 	Required    bool   // true if the console cannot function without it
 	OverrideURL string // if set, download from this URL instead of the default repo
+	SubDir      string // subdirectory within system_dir, e.g. "same_cdi/bios" (empty = flat)
+}
+
+// FilePath returns the path of this entry relative to the BIOS directory,
+// taking SubDir into account.
+func (e Entry) FilePath(biosDir string) string {
+	if e.SubDir != "" {
+		return filepath.Join(biosDir, e.SubDir, e.FileName)
+	}
+	return filepath.Join(biosDir, e.FileName)
 }
 
 // registry is the built-in list of known BIOS files.
@@ -86,10 +98,10 @@ var registry = []Entry{
 	// Repo has BIOS.col; we download and save as colecovision.rom (expected by cores).
 	{ConsoleID: "cv", FileName: "colecovision.rom", Description: "ColecoVision BIOS", MD5: "2c66f5911e5b42b8ebe113403548eee7", Required: true, OverrideURL: "https://raw.githubusercontent.com/Abdess/retrobios/main/bios/Coleco/ColecoVision/BIOS.col"},
 
-	// Philips CD-i (CDI) — same_cdi_libretro.info
-	{ConsoleID: "cdi", FileName: "cdimono1.zip", Description: "CD-i Mono-I BIOS", MD5: "", Required: true, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdimono1.zip"},
-	{ConsoleID: "cdi", FileName: "cdimono2.zip", Description: "CD-i Mono-II BIOS", MD5: "", Required: false, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdimono2.zip"},
-	{ConsoleID: "cdi", FileName: "cdibios.zip", Description: "CD-i BIOS (generic)", MD5: "", Required: false, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdibios.zip"},
+	// Philips CD-i (CDI) — same_cdi_libretro.info (MAME-based, needs subdirectory)
+	{ConsoleID: "cdi", FileName: "cdimono1.zip", Description: "CD-i Mono-I BIOS", MD5: "", Required: true, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdimono1.zip", SubDir: "same_cdi/bios"},
+	{ConsoleID: "cdi", FileName: "cdimono2.zip", Description: "CD-i Mono-II BIOS", MD5: "", Required: false, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdimono2.zip", SubDir: "same_cdi/bios"},
+	{ConsoleID: "cdi", FileName: "cdibios.zip", Description: "CD-i BIOS (generic)", MD5: "", Required: false, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdibios.zip", SubDir: "same_cdi/bios"},
 }
 
 // repoFolders maps console IDs to their folder path in the


### PR DESCRIPTION
## Summary
- The `same_cdi` core (MAME-based) expects BIOS files at `<system_dir>/same_cdi/bios/cdimono1.zip` but Spela stored them flat
- Added `SubDir` field to BIOS registry `Entry` struct — CD-i entries set `SubDir: "same_cdi/bios"`
- Server downloader creates subdirectories; API exposes `subDir` in responses
- Player `BiosRepository` places files in subdirectories during sync and pre-launch check
- `GetBiosFile` endpoint checks subdirectory paths as fallback for backward compat
- Future MAME-based cores can simply set `SubDir` on their registry entries

## Test plan
- [x] Server builds and existing BIOS tests pass
- [x] Player compiles successfully
- [x] Backward compatible — entries without `SubDir` behave exactly as before