### PR TITLE
feat: auto-create game session when playing without one

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -250,7 +250,7 @@ class EmulationViewModel(
                 sharedSessionId = sharedSessionId,
                 turnToken = turnToken,
                 netplaySessionId = netplaySessionId,
-                sessionId = sessionId,
+                sessionId = sessionId, // may be updated by ensureSession below
                 challengeId = challengeId,
                 challengeAttemptId = null,
                 challengeElapsedMs = 0,
@@ -310,6 +310,17 @@ class EmulationViewModel(
                             gameRating = detail.game.rating,
                             gamePlayers = detail.game.players,
                         )
+                    }
+                }
+            }
+
+            // Auto-create or reuse session for normal play (not shared/netplay/challenge)
+            if (sharedSessionId == null && netplaySessionId == null && challengeId == null) {
+                val resolvedSessionId = saveManager.ensureSession(gameId, sessionId)
+                saveManager.currentSessionId = resolvedSessionId
+                if (resolvedSessionId != null && resolvedSessionId != sessionId) {
+                    withContext(dispatchers.main) {
+                        _state.update { it.copy(sessionId = resolvedSessionId) }
                     }
                 }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -57,6 +57,27 @@ class SaveManager(
     var currentSessionId: String? = null
 
     /**
+     * Ensures a session exists for the given game. If sessionId is already set,
+     * returns it. Otherwise tries to reuse the most recent session, or creates
+     * a new one named "Default" (matching the web UI behavior).
+     * Returns the resolved session ID, or null if offline/failed.
+     */
+    suspend fun ensureSession(gameId: String, sessionId: String?): String? {
+        if (sessionId != null) return sessionId
+        return try {
+            val existing = sessionRepository.getSessionsForGame(gameId).getOrNull()
+            if (!existing.isNullOrEmpty()) {
+                existing.first().id
+            } else {
+                sessionRepository.createSession(gameId, "Default").getOrNull()?.id
+            }
+        } catch (e: Exception) {
+            println("[SaveManager] Failed to ensure session: ${e.message}")
+            null
+        }
+    }
+
+    /**
      * Load SRAM (save data) before starting emulation.
      * Downloads from session SRAM endpoint.
      * If the data starts with ZIP magic bytes, it's a directory-based save (e.g. Dolphin)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
@@ -219,4 +219,40 @@ class EmulationViewModelGameLifecycleTest {
         // Immediately after startGame, supportsSaveStates should be reset to true
         assertTrue(vm.state.value.supportsSaveStates, "supportsSaveStates should reset to true on new game start")
     }
+
+    @Test
+    fun startGameAutoCreatesSessionWhenNoneProvided() = runTest {
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+
+        // Session should have been auto-created
+        assertNotNull(vm.state.value.sessionId, "Session should be auto-created when none provided")
+        assertEquals(1, builder.sessionRepository.createSessionCallCount)
+        assertEquals("Default", builder.sessionRepository.lastCreatedSessionName)
+    }
+
+    @Test
+    fun startGameReusesExistingSession() = runTest {
+        builder.sessionRepository.existingSessions = listOf(
+            com.spela.player.domain.model.GameSession(id = "existing-42", gameId = "game1", name = "My Save")
+        )
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1"))
+        builder.advanceTimeBy(100)
+
+        // Should reuse existing session, not create a new one
+        assertEquals("existing-42", vm.state.value.sessionId)
+        assertEquals(0, builder.sessionRepository.createSessionCallCount)
+    }
+
+    @Test
+    fun startGameWithExplicitSessionIdDoesNotAutoCreate() = runTest {
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame("game1", sessionId = "explicit-session"))
+        builder.advanceTimeBy(100)
+
+        assertEquals("explicit-session", vm.state.value.sessionId)
+        assertEquals(0, builder.sessionRepository.createSessionCallCount)
+    }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -346,13 +346,20 @@ class StubSessionRepository : SessionRepository {
     var uploadSessionSramCallCount = 0; private set
     var downloadSessionSramCallCount = 0; private set
     var uploadSessionSaveCallCount = 0; private set
+    var createSessionCallCount = 0; private set
+    var lastCreatedSessionName: String? = null; private set
 
     var downloadSessionAutoSaveResult: Result<ByteArray> = Result.failure(Exception("no auto-save"))
     var downloadSessionSramResult: Result<ByteArray> = Result.failure(Exception("no sram"))
+    var existingSessions: List<GameSession> = emptyList()
 
-    override suspend fun getSessionsForGame(gameId: String) = Result.success(emptyList<GameSession>())
+    override suspend fun getSessionsForGame(gameId: String) = Result.success(existingSessions)
     override suspend fun getSession(sessionId: String) = Result.failure<GameSession>(Exception("stub"))
-    override suspend fun createSession(gameId: String, name: String) = Result.failure<GameSession>(Exception("stub"))
+    override suspend fun createSession(gameId: String, name: String): Result<GameSession> {
+        createSessionCallCount++
+        lastCreatedSessionName = name
+        return Result.success(GameSession(id = "auto-${createSessionCallCount}", gameId = gameId, name = name))
+    }
     override suspend fun updateSession(sessionId: String, name: String?, coreName: String?) = Result.failure<GameSession>(Exception("stub"))
     override suspend fun deleteSession(sessionId: String) = Result.success(Unit)
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())


### PR DESCRIPTION
## Summary
- When a user plays a game without an existing session, automatically create one named "Default" (matching the web UI behavior)
- If sessions already exist for the game, reuse the most recent one
- Auto-save now works out of the box — saves are uploaded to the session, and sessions appear on the game detail screen
- Shared sessions, netplay, and challenges are excluded from auto-creation

## Changes
- `SaveManager.ensureSession()` — resolves or creates a session for normal play
- `EmulationViewModel.startGame()` — calls `ensureSession` before game load
- `StubSessionRepository` — updated to support configurable session creation in tests

## Test plan
- [x] `startGameAutoCreatesSessionWhenNoneProvided` — verifies "Default" session is created
- [x] `startGameReusesExistingSession` — verifies most recent session is reused
- [x] `startGameWithExplicitSessionIdDoesNotAutoCreate` — verifies explicit session ID is preserved
- [x] All 20 EmulationViewModelGameLifecycleTest tests pass