### PR TITLE
fix: clear saved screen state on forward navigation

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -362,6 +362,14 @@ fun SpelaApp(
                 Box(modifier = Modifier.weight(1f)) {
                     val animationsEnabled = com.spela.player.presentation.ui.components.LocalAnimationsEnabled.current
                     val saveableStateHolder = rememberSaveableStateHolder()
+
+                    // When navigating forward, clear saved state for the new screen
+                    // so it starts fresh (e.g., scroll position at top).
+                    // When going back, the saved state is preserved by SaveableStateProvider.
+                    if (!navState.isGoingBack) {
+                        saveableStateHolder.removeState(navState.currentScreen.route)
+                    }
+
                     AnimatedContent(
                         targetState = navState.currentScreen,
                         transitionSpec = {
@@ -1289,9 +1297,9 @@ fun SpelaApp(
                                     )
                                 }
                             }
-                        }
-                        }
-                    }
+                        } // when (screen)
+                        } // SaveableStateProvider
+                    } // AnimatedContent
 
                     // Emulation surface + in-game overlay
                     if (navState.showInGameOverlay) {


### PR DESCRIPTION
## Summary

Review follow-up from PRs #233 and #239.

**Issues found:**
1. **SaveableStateProvider never cleared state on forward navigation** — navigating to `game/123` then back, then to `game/456`, could show stale state from `game/123` if routes collide. Now `removeState()` is called for the target screen when navigating forward, ensuring a fresh start.
2. **Indentation/readability** — added closing brace comments to the deeply nested AnimatedContent/SaveableStateProvider/when block.

**Not an issue (confirmed):**
- `ensureSession` picks `existing.first()` — the server sorts by `updated_at DESC`, so this correctly picks the most recently updated session.

## Test plan
- [x] ScrollPositionTest passes (forward nav resets, back nav preserves)
- [x] EmulationViewModelGameLifecycleTest passes (20 tests)