### PR TITLE
fix: address code review and UX review findings

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
@@ -55,10 +55,14 @@ class PrepareGameUseCase(
         }
 
         val coreName = platformCoreSubstitution(core.name)
+        // When the core name was substituted, the server's download URL is for the
+        // original name. Clear it so CoreRepository falls back to the buildbot URL
+        // constructed from the substituted name.
+        val downloadUrl = if (coreName != core.name) null else core.downloadUrl
 
         val corePath = coreRepository.getLocalCorePath(coreName)
             ?: run {
-                coreRepository.downloadCore(coreName, core.downloadUrl).getOrElse {
+                coreRepository.downloadCore(coreName, downloadUrl).getOrElse {
                     return Result.failure(it)
                 }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
@@ -80,7 +80,7 @@ internal fun SessionsSection(
     ) {
         if (sessions.isEmpty() && !isLoading) {
             Text(
-                text = "No sessions yet. Start a new playthrough to track your progress.",
+                text = "No sessions yet. Press Play to start your first playthrough.",
                 style = SpTypography.BodyMedium,
                 color = SpColor.OnBackgroundTertiary,
                 modifier = Modifier.testTag("sessions_empty"),

--- a/server/internal/api/bios_handler.go
+++ b/server/internal/api/bios_handler.go
@@ -426,6 +426,15 @@ func (h *BiosHandler) UploadBiosFile(c *gin.Context) {
 
 	if len(matches) > 0 {
 		match := matches[0]
+		// Move to subdirectory if required by the registry entry
+		if match.SubDir != "" {
+			subDirPath := match.FilePath(h.Storage.BiosDir)
+			if err := os.MkdirAll(filepath.Dir(subDirPath), 0755); err == nil {
+				if err := os.Rename(safePath, subDirPath); err == nil {
+					safePath = subDirPath
+				}
+			}
+		}
 		consoleName := names[match.ConsoleID]
 		consoleID := match.ConsoleID
 		desc := match.Description
@@ -453,8 +462,20 @@ func (h *BiosHandler) DeleteBiosFile(c *gin.Context) {
 	path := h.Storage.BiosFilePath(filename)
 
 	if _, err := os.Stat(path); os.IsNotExist(err) {
-		c.JSON(http.StatusNotFound, gin.H{"error": "bios file not found"})
-		return
+		// Check subdirectory paths for entries with SubDir
+		for _, e := range bios.ByFileName(filename) {
+			if e.SubDir != "" {
+				subPath := e.FilePath(h.Storage.BiosDir)
+				if _, serr := os.Stat(subPath); serr == nil {
+					path = subPath
+					break
+				}
+			}
+		}
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			c.JSON(http.StatusNotFound, gin.H{"error": "bios file not found"})
+			return
+		}
 	}
 
 	// Validate the resolved path stays within BiosDir (same check as GetBiosFile)
@@ -503,7 +524,7 @@ func (h *BiosHandler) TriggerDownload(c *gin.Context) {
 	entries := bios.Downloadable()
 	missing := 0
 	for _, e := range entries {
-		path := filepath.Join(h.Storage.BiosDir, e.FileName)
+		path := e.FilePath(h.Storage.BiosDir)
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			missing++
 		}
@@ -566,7 +587,7 @@ func GetConsoleStatus(biosDir string, consoleAbbr string) string {
 		}
 		hasRequired = true
 
-		filePath := filepath.Join(biosDir, e.FileName)
+		filePath := e.FilePath(biosDir)
 		if _, err := os.Stat(filePath); os.IsNotExist(err) {
 			hasMissingRequired = true
 			continue


### PR DESCRIPTION
## Summary

Fixes issues found by code reviewer and UX reviewer on the recent PRs.

### Code review fixes
- **Core substitution URL (PR #234)**: When a core name is substituted on Android (e.g. `beetle_pce` → `mednafen_pce_fast`), the server's download URL was for the original name. Now cleared to force buildbot URL resolution with the substituted name.
- **GetConsoleStatus ignores SubDir (PR #238)**: CD-i was always reporting "BIOS missing" because the status check used flat paths. Now uses `entry.FilePath()` for SubDir-aware resolution.
- **TriggerDownload missing count (PR #238)**: Same SubDir fix applied.
- **UploadBiosFile (PR #238)**: Uploaded BIOS files for SubDir entries are now moved to the correct subdirectory.
- **DeleteBiosFile (PR #238)**: Now checks SubDir paths as fallback, matching GetBiosFile behavior.

### UX review fix
- **Sessions empty state message**: Changed from "Start a new playthrough to track your progress" to "Press Play to start your first playthrough" to accurately reflect the auto-create behavior.

## Test plan
- [x] Server builds and BIOS tests pass
- [x] Player compiles successfully