### PR TITLE
fix: "New Game" creates a fresh session instead of reusing existing

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -314,9 +314,11 @@ class EmulationViewModel(
                 }
             }
 
-            // Auto-create or reuse session for normal play (not shared/netplay/challenge)
+            // Auto-create or reuse session for normal play (not shared/netplay/challenge).
+            // When skipAutoLoad is true ("New Game"), force a fresh session to avoid
+            // overwriting auto-saves from a previous playthrough.
             if (sharedSessionId == null && netplaySessionId == null && challengeId == null) {
-                val resolvedSessionId = saveManager.ensureSession(gameId, sessionId)
+                val resolvedSessionId = saveManager.ensureSession(gameId, sessionId, forceNew = skipAutoLoad)
                 saveManager.currentSessionId = resolvedSessionId
                 if (resolvedSessionId != null && resolvedSessionId != sessionId) {
                     withContext(dispatchers.main) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -60,17 +60,26 @@ class SaveManager(
      * Ensures a session exists for the given game. If sessionId is already set,
      * returns it. Otherwise tries to reuse the most recent session, or creates
      * a new one named "Default" (matching the web UI behavior).
+     *
+     * When [forceNew] is true (user chose "New Game"), always creates a fresh
+     * session instead of reusing an existing one. This prevents overwriting
+     * auto-saves from a previous playthrough.
+     *
      * Returns the resolved session ID, or null if offline/failed.
      */
-    suspend fun ensureSession(gameId: String, sessionId: String?): String? {
+    suspend fun ensureSession(gameId: String, sessionId: String?, forceNew: Boolean = false): String? {
         if (sessionId != null) return sessionId
         return try {
-            val existing = sessionRepository.getSessionsForGame(gameId).getOrNull()
-            if (!existing.isNullOrEmpty()) {
-                existing.first().id
-            } else {
-                sessionRepository.createSession(gameId, "Default").getOrNull()?.id
+            if (!forceNew) {
+                val existing = sessionRepository.getSessionsForGame(gameId).getOrNull()
+                if (!existing.isNullOrEmpty()) {
+                    return existing.first().id
+                }
             }
+            val existing = sessionRepository.getSessionsForGame(gameId).getOrNull()
+            val number = (existing?.size ?: 0) + 1
+            val name = if (number == 1) "Default" else "Playthrough $number"
+            sessionRepository.createSession(gameId, name).getOrNull()?.id
         } catch (e: Exception) {
             println("[SaveManager] Failed to ensure session: ${e.message}")
             null

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
@@ -255,4 +255,24 @@ class EmulationViewModelGameLifecycleTest {
         assertEquals("explicit-session", vm.state.value.sessionId)
         assertEquals(0, builder.sessionRepository.createSessionCallCount)
     }
+
+    @Test
+    fun newGameCreatesNewSessionInsteadOfReusing() = runTest {
+        // Set up an existing session
+        builder.sessionRepository.existingSessions = listOf(
+            com.spela.player.domain.model.GameSession(id = "existing-42", gameId = "game1", name = "Default")
+        )
+        val vm = builder.build()
+
+        // Start game with skipAutoLoad=true ("New Game")
+        vm.onIntent(EmulationIntent.StartGame("game1", skipAutoLoad = true))
+        builder.advanceTimeBy(100)
+
+        // Should create a NEW session, not reuse the existing one
+        assertEquals(1, builder.sessionRepository.createSessionCallCount)
+        assertNotNull(vm.state.value.sessionId)
+        // The new session ID should NOT be the existing one
+        assertTrue(vm.state.value.sessionId != "existing-42",
+            "New Game should create a fresh session, not reuse existing")
+    }
 }


### PR DESCRIPTION
## Summary
- **Bug**: When the user chose "New Game" from the split button menu, `ensureSession()` reused the most recent session. The new playthrough's auto-save would overwrite the previous session's save data on exit.
- **Fix**: `ensureSession()` now accepts a `forceNew` parameter. When `skipAutoLoad=true` (user chose "New Game"), it always creates a fresh session named "Playthrough N" instead of reusing an existing one. Normal "Play" still reuses the most recent session.
- New sessions are named "Default" for the first, "Playthrough 2", "Playthrough 3", etc. for subsequent ones.

## Test plan
- [x] `newGameCreatesNewSessionInsteadOfReusing` — verifies a fresh session is created, not the existing one
- [x] `startGameReusesExistingSession` — normal Play still reuses (unchanged)
- [x] `startGameAutoCreatesSessionWhenNoneProvided` — first play creates "Default" (unchanged)
- [x] All 21 EmulationViewModelGameLifecycleTest tests pass