### PR TITLE
fix: add dark gradient background to all content screens

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
@@ -52,6 +52,7 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.util.formatRating
 
 /**
@@ -83,11 +84,10 @@ fun ExploreGroupDetailContent(
     onConsoleFilterSelected: (String?) -> Unit,
     onDismissError: () -> Unit,
 ) {
-    Box(modifier = Modifier.fillMaxSize().testTag("explore_${groupLabel}_screen")) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground().testTag("explore_${groupLabel}_screen")) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = title,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
@@ -41,6 +41,7 @@ import com.spela.player.presentation.ui.feature.library.GameLibraryControls
 import com.spela.player.presentation.ui.feature.library.GameListRowItem
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -59,7 +60,7 @@ fun AllGamesScreen(
         viewModel.onIntent(GameListIntent.Search(""))
     }
 
-    Column(modifier = Modifier.fillMaxSize()) {
+    Column(modifier = Modifier.fillMaxSize().spScreenBackground()) {
         SpSearchField(
             value = searchQuery,
             onValueChange = { query ->

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeDetailScreen.kt
@@ -55,6 +55,7 @@ import com.spela.player.presentation.ui.components.challenge.formatDuration
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.ChallengeDetailViewModel
 
 @Composable
@@ -80,11 +81,10 @@ fun ChallengeDetailScreen(
 
     PlatformBackHandler(onBack = onBack)
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground()) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = state.challenge?.name ?: "Challenge",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeListScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeListScreen.kt
@@ -25,6 +25,7 @@ import com.spela.player.presentation.ui.components.challenge.SpChallengeCard
 import com.spela.player.presentation.ui.components.challenge.SpChallengeCardSkeleton
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.ChallengeListViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -47,7 +48,7 @@ fun ChallengeListScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(SpColor.Background),
+            .spScreenBackground(),
     ) {
         SpTopBar(
             title = gameTitle,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DownloadsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DownloadsScreen.kt
@@ -45,6 +45,7 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.util.formatBytes
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.viewmodel.DownloadsIntent
@@ -67,7 +68,7 @@ fun DownloadsScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(SpColor.Background),
+            .spScreenBackground(),
     ) {
         SpTopBar(title = "Downloads", showBack = true, onBack = onBack)
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
@@ -50,6 +50,7 @@ import com.spela.player.presentation.ui.feature.explore.DeveloperUserStatsCard
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 import androidx.compose.material3.Text
 
@@ -75,11 +76,10 @@ fun ExploreDeveloperScreen(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize().testTag("developer_detail_screen")) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground().testTag("developer_detail_screen")) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = name,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreGalleryScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreGalleryScreen.kt
@@ -48,6 +48,7 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 
 private const val SCREENSHOT_ASPECT_RATIO = 16f / 9f
@@ -66,11 +67,10 @@ fun ExploreGalleryScreen(
         viewModel.loadScreenshotGallery()
     }
 
-    Box(modifier = Modifier.fillMaxSize().testTag("gallery_screen")) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground().testTag("gallery_screen")) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = "Screenshot Gallery",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreKeywordScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreKeywordScreen.kt
@@ -46,6 +46,7 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 import com.spela.player.util.formatRating
 
@@ -65,11 +66,10 @@ fun ExploreKeywordScreen(
         viewModel.loadKeywordGames(keywordId, keywordName)
     }
 
-    Box(modifier = Modifier.fillMaxSize().testTag("explore_keyword_screen")) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground().testTag("explore_keyword_screen")) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = keywordName,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -111,6 +112,7 @@ fun ExploreScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .spScreenBackground()
             .testTag("explore_screen"),
     ) {
         when {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreSearchScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreSearchScreen.kt
@@ -49,6 +49,7 @@ import com.spela.player.presentation.ui.feature.explore.GameFilterPanel
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 import com.spela.player.util.formatRating
 
@@ -69,12 +70,12 @@ fun ExploreSearchScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .spScreenBackground()
             .testTag("explore_search_screen"),
     ) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = "Advanced Search",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreThemeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreThemeScreen.kt
@@ -47,6 +47,7 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 import com.spela.player.util.formatRating
 
@@ -66,11 +67,10 @@ fun ExploreThemeScreen(
         viewModel.loadThemeGames(themeId, themeName)
     }
 
-    Box(modifier = Modifier.fillMaxSize().testTag("explore_theme_screen")) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground().testTag("explore_theme_screen")) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = themeName,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreWizardScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreWizardScreen.kt
@@ -40,6 +40,7 @@ import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 
 @Composable
@@ -58,6 +59,7 @@ fun ExploreWizardScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
+            .spScreenBackground()
             .testTag("wizard_screen"),
     ) {
         // Top bar with back button

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/FavoritesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/FavoritesScreen.kt
@@ -20,6 +20,7 @@ import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -34,43 +35,45 @@ fun FavoritesScreen(
         viewModel.onIntent(GameListIntent.LoadDashboard)
     }
 
-    if (state.isLoading && state.favoriteGames.isEmpty()) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
-        ) {
-            SpLoadingIndicator(message = "Loading favorites...")
-        }
-    } else {
-        PullToRefreshBox(
-            isRefreshing = state.isLoading,
-            onRefresh = { viewModel.onIntent(GameListIntent.LoadDashboard) },
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            if (state.favoriteGames.isEmpty()) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    SpEmptyStates.NoFavorites()
-                }
-            } else {
-                LazyVerticalGrid(
-                    columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(
-                        horizontal = SpSpacing.ScreenHorizontal,
-                        vertical = SpSpacing.Default,
-                    ),
-                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
-                    verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
-                ) {
-                    items(state.favoriteGames, key = { it.id }) { game ->
-                        GameGridItem(
-                            game = game,
-                            onClick = { onGameSelected(game.id) },
-                            onRequestScrape = { viewModel.requestScrapeIfNeeded(it) },
-                        )
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground()) {
+        if (state.isLoading && state.favoriteGames.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                SpLoadingIndicator(message = "Loading favorites...")
+            }
+        } else {
+            PullToRefreshBox(
+                isRefreshing = state.isLoading,
+                onRefresh = { viewModel.onIntent(GameListIntent.LoadDashboard) },
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                if (state.favoriteGames.isEmpty()) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyStates.NoFavorites()
+                    }
+                } else {
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(
+                            horizontal = SpSpacing.ScreenHorizontal,
+                            vertical = SpSpacing.Default,
+                        ),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                    ) {
+                        items(state.favoriteGames, key = { it.id }) { game ->
+                            GameGridItem(
+                                game = game,
+                                onClick = { onGameSelected(game.id) },
+                                onRequestScrape = { viewModel.requestScrapeIfNeeded(it) },
+                            )
+                        }
                     }
                 }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalChallengesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalChallengesScreen.kt
@@ -36,6 +36,7 @@ import com.spela.player.presentation.ui.feature.challenges.ChallengeFilterBar
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.ChallengeListViewModel
 
 private val tabs = listOf(
@@ -63,7 +64,7 @@ fun GlobalChallengesScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(SpColor.Background),
+            .spScreenBackground(),
     ) {
         SpTopBar(
             title = "Challenges",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalSearchScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalSearchScreen.kt
@@ -40,6 +40,7 @@ import com.spela.player.presentation.ui.feature.search.SearchResultSkeleton
 import com.spela.player.presentation.ui.feature.search.SearchResultsList
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.GlobalSearchViewModel
 
 @Composable
@@ -67,12 +68,12 @@ fun GlobalSearchScreen(
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .spScreenBackground()
             .testTag("global_search_screen"),
     ) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = "Search",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayListScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayListScreen.kt
@@ -53,6 +53,7 @@ import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.NetplayViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -79,11 +80,10 @@ fun NetplayListScreen(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground()) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = "Netplay",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
@@ -54,6 +54,7 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.NetplayLobbyViewModel
 import kotlinx.coroutines.delay
 
@@ -116,11 +117,10 @@ fun NetplayLobbyScreen(
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground()) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = "Netplay Lobby",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/PlayLaterScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/PlayLaterScreen.kt
@@ -20,6 +20,7 @@ import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
 import com.spela.player.presentation.ui.feature.library.GameGridItem
 import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -34,43 +35,45 @@ fun PlayLaterScreen(
         viewModel.onIntent(GameListIntent.LoadDashboard)
     }
 
-    if (state.isLoading && state.playLaterGames.isEmpty()) {
-        Box(
-            modifier = Modifier.fillMaxSize(),
-            contentAlignment = Alignment.Center,
-        ) {
-            SpLoadingIndicator(message = "Loading play later...")
-        }
-    } else {
-        PullToRefreshBox(
-            isRefreshing = state.isLoading,
-            onRefresh = { viewModel.onIntent(GameListIntent.LoadDashboard) },
-            modifier = Modifier.fillMaxSize(),
-        ) {
-            if (state.playLaterGames.isEmpty()) {
-                Box(
-                    modifier = Modifier.fillMaxSize(),
-                    contentAlignment = Alignment.Center,
-                ) {
-                    SpEmptyStates.NoPlayLater()
-                }
-            } else {
-                LazyVerticalGrid(
-                    columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
-                    modifier = Modifier.fillMaxSize(),
-                    contentPadding = PaddingValues(
-                        horizontal = SpSpacing.ScreenHorizontal,
-                        vertical = SpSpacing.Default,
-                    ),
-                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
-                    verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
-                ) {
-                    items(state.playLaterGames, key = { it.id }) { game ->
-                        GameGridItem(
-                            game = game,
-                            onClick = { onGameSelected(game.id) },
-                            onRequestScrape = { viewModel.requestScrapeIfNeeded(it) },
-                        )
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground()) {
+        if (state.isLoading && state.playLaterGames.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center,
+            ) {
+                SpLoadingIndicator(message = "Loading play later...")
+            }
+        } else {
+            PullToRefreshBox(
+                isRefreshing = state.isLoading,
+                onRefresh = { viewModel.onIntent(GameListIntent.LoadDashboard) },
+                modifier = Modifier.fillMaxSize(),
+            ) {
+                if (state.playLaterGames.isEmpty()) {
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyStates.NoPlayLater()
+                    }
+                } else {
+                    LazyVerticalGrid(
+                        columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
+                        modifier = Modifier.fillMaxSize(),
+                        contentPadding = PaddingValues(
+                            horizontal = SpSpacing.ScreenHorizontal,
+                            vertical = SpSpacing.Default,
+                        ),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+                    ) {
+                        items(state.playLaterGames, key = { it.id }) { game ->
+                            GameGridItem(
+                                game = game,
+                                onClick = { onGameSelected(game.id) },
+                                onRequestScrape = { viewModel.requestScrapeIfNeeded(it) },
+                            )
+                        }
                     }
                 }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
@@ -36,6 +36,7 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.SharedSessionDetailViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -55,11 +56,10 @@ fun SharedSessionDetailScreen(
         viewModel.onIntent(SharedSessionDetailIntent.LoadSaves(sharedSessionId))
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground()) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = state.sharedSession?.name ?: "Shared Session",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionsScreen.kt
@@ -57,6 +57,7 @@ import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.SharedSessionsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -74,11 +75,10 @@ fun SharedSessionsScreen(
         viewModel.onIntent(SharedSessionIntent.RefreshAll)
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground()) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = "Shared Sessions",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/StatsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/StatsScreen.kt
@@ -34,6 +34,7 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.StatsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -52,11 +53,10 @@ fun StatsScreen(
         viewModel.onIntent(StatsIntent.LoadStats)
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground()) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = "Stats",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/TopListsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/TopListsScreen.kt
@@ -59,6 +59,7 @@ import com.spela.player.presentation.ui.feature.stats.RankBadge
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.TopListsViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -76,11 +77,10 @@ fun TopListsScreen(
         viewModel.onIntent(TopListsIntent.LoadTopLists)
     }
 
-    Box(modifier = Modifier.fillMaxSize().testTag("top_lists_screen")) {
+    Box(modifier = Modifier.fillMaxSize().spScreenBackground().testTag("top_lists_screen")) {
         Column(
             modifier = Modifier
-                .fillMaxSize()
-                .background(SpColor.Background),
+                .fillMaxSize(),
         ) {
             SpTopBar(
                 title = "Top Lists",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
@@ -39,6 +39,7 @@ import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.SocialViewModel
 import com.spela.player.util.formatPlayTime
 
@@ -60,7 +61,7 @@ fun UserProfileScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .background(SpColor.Background),
+            .spScreenBackground(),
     ) {
         SpTopBar(
             title = state.publicProfile?.username ?: "Profile",

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
@@ -1,5 +1,9 @@
 package com.spela.player.presentation.ui.theme
 
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 
 object SpColor {
@@ -84,4 +88,29 @@ object SpColor {
     // Divider
     val Divider = Color(0xFF2A2A3A)
     val DividerLight = Color(0xFF3A3A4A)
+
+    // Default screen background gradient (dark, non-black)
+    val ScreenGradientStart = Color(0xFF14142A)
+    val ScreenGradientEnd = Color(0xFF0F1A2A)
+}
+
+/**
+ * Applies the standard dark gradient background used on content screens.
+ * Ensures cards with transparent backgrounds blend properly instead of
+ * showing pure black.
+ */
+fun Modifier.spScreenBackground(
+    from: Color = SpColor.ScreenGradientStart,
+    to: Color = SpColor.ScreenGradientEnd,
+): Modifier = drawBehind {
+    val cx = size.width / 2f
+    val cy = size.height / 2f
+    val d = (size.width + size.height) * 0.25f
+    drawRect(
+        brush = Brush.linearGradient(
+            colors = listOf(from, to),
+            start = Offset(cx - d, cy - d),
+            end = Offset(cx + d, cy + d),
+        ),
+    )
 }


### PR DESCRIPTION
## Summary
- Cards use transparent white/black overlays that blend with the page background. Screens without a background showed pure black, making cards invisible or poorly contrasted.
- Added `spScreenBackground()` modifier extension in `SpColor.kt` — a subtle dark gradient (deep indigo/navy, non-black)
- Applied to all 23 content screens that were missing backgrounds
- Screens that already had custom gradients (Home, Console, GameDetail, etc.) are unchanged

## Test plan
- [x] Player compiles successfully
- [x] Gradient colors are dark enough to maintain text contrast
- [x] Existing screens with custom backgrounds are unaffected