### PR TITLE
fix: auto-reset database on schema incompatibility instead of blocking

### DIFF
--- a/player/shared/src/androidMain/kotlin/com/spela/player/di/PlatformModule.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/di/PlatformModule.kt
@@ -35,16 +35,24 @@ actual fun platformModule(): Module = module {
         DatabaseResetHelper.init(context)
         // Create driver first — AndroidSqliteDriver runs migrations automatically
         val driver = AndroidSqliteDriver(SpelaDatabase.Schema, context, "spela.db")
-        // Validate schema after migration using the same driver connection
+        // Validate schema after migration — auto-reset if incompatible.
+        // The local DB is a cache (game metadata, auth tokens, download records).
+        // Saves are on the server, so resetting is safe and avoids blocking the user.
         try {
             val errorMessage = validateSchemaWithDriver(driver)
             if (errorMessage != null) {
-                println("Spela: $errorMessage")
-                DatabaseHealthCheck.reportError("$errorMessage Please reset the app.")
+                println("Spela: $errorMessage — auto-resetting database")
+                driver.close()
+                context.deleteDatabase("spela.db")
+                val freshDriver = AndroidSqliteDriver(SpelaDatabase.Schema, context, "spela.db")
+                return@single freshDriver
             }
         } catch (e: Exception) {
-            println("Spela: Failed to validate database: ${e.message}")
-            DatabaseHealthCheck.reportError("Database validation failed: ${e.message}. Please reset the app.")
+            println("Spela: Schema validation failed: ${e.message} — auto-resetting database")
+            driver.close()
+            context.deleteDatabase("spela.db")
+            val freshDriver = AndroidSqliteDriver(SpelaDatabase.Schema, context, "spela.db")
+            return@single freshDriver
         }
         driver
     }

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/di/PlatformModule.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/di/PlatformModule.kt
@@ -70,16 +70,32 @@ actual fun platformModule(): Module = module {
             driver.execute(null, "PRAGMA user_version = $schemaVersion", 0)
         }
 
-        // Validate schema after create/migrate to catch corruption
+        // Validate schema after create/migrate — auto-reset if incompatible.
+        // The local DB is a cache (game metadata, auth tokens, download records).
+        // Saves are on the server, so resetting is safe and avoids blocking the user.
         try {
             val errorMessage = validateSchemaWithDriver(driver)
             if (errorMessage != null) {
-                println("Spela: $errorMessage")
-                DatabaseHealthCheck.reportError("$errorMessage Please reset the app.")
+                println("Spela: $errorMessage — auto-resetting database")
+                driver.close()
+                java.io.File(dbPath).delete()
+                java.io.File("$dbPath-wal").delete()
+                java.io.File("$dbPath-shm").delete()
+                val freshDriver = JdbcSqliteDriver("jdbc:sqlite:$dbPath")
+                SpelaDatabase.Schema.create(freshDriver)
+                freshDriver.execute(null, "PRAGMA user_version = $schemaVersion", 0)
+                return@single freshDriver
             }
         } catch (e: Exception) {
-            println("Spela: Failed to validate database: ${e.message}")
-            DatabaseHealthCheck.reportError("Database validation failed: ${e.message}. Please reset the app.")
+            println("Spela: Schema validation failed: ${e.message} — auto-resetting database")
+            driver.close()
+            java.io.File(dbPath).delete()
+            java.io.File("$dbPath-wal").delete()
+            java.io.File("$dbPath-shm").delete()
+            val freshDriver = JdbcSqliteDriver("jdbc:sqlite:$dbPath")
+            SpelaDatabase.Schema.create(freshDriver)
+            freshDriver.execute(null, "PRAGMA user_version = $schemaVersion", 0)
+            return@single freshDriver
         }
 
         driver


### PR DESCRIPTION
## Summary
- Previously, an incompatible database schema (after an app update) showed a full-screen error requiring the user to manually tap "Reset App"
- Now the database is automatically deleted and recreated — the user just sees the login screen
- The local DB is a cache (game metadata, auth tokens, downloads). Saves are on the server, so resetting is safe.
- Applied to both desktop and Android

## Test plan
- [x] Desktop builds successfully
- [x] Schema validation logic preserved — only auto-resets when validation actually fails