### PR TITLE
fix: brighten default screen background gradient

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
@@ -90,8 +90,8 @@ object SpColor {
     val DividerLight = Color(0xFF3A3A4A)
 
     // Default screen background gradient (dark, non-black)
-    val ScreenGradientStart = Color(0xFF14142A)
-    val ScreenGradientEnd = Color(0xFF0F1A2A)
+    val ScreenGradientStart = Color(0xFF1E1E3A)
+    val ScreenGradientEnd = Color(0xFF162030)
 }
 
 /**


### PR DESCRIPTION
## Summary
Previous gradient (`#14142A` → `#0F1A2A`) was too close to black — cards with transparent overlays were hard to see. Brightened to `#1E1E3A` → `#162030` (deep indigo/navy), matching the intensity of existing screen gradients like Home and Consoles.