### PR TITLE
fix: improve contrast for links, badges, and bottom nav

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpBottomNavBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpBottomNavBar.kt
@@ -78,9 +78,9 @@ fun SpBottomNavBar(
                 val interactionSource = remember { MutableInteractionSource() }
                 val isFocused by interactionSource.collectIsFocusedAsState()
                 val color = when {
-                    isSelected -> SpColor.Primary
-                    isFocused -> SpColor.Primary.copy(alpha = 0.7f)
-                    else -> SpColor.OnBackgroundTertiary
+                    isSelected -> SpColor.PrimaryLight
+                    isFocused -> SpColor.PrimaryLight.copy(alpha = 0.7f)
+                    else -> SpColor.OnBackgroundSecondary
                 }
 
                 Box(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/AchievementDiscoverySection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/AchievementDiscoverySection.kt
@@ -238,7 +238,7 @@ internal fun ActiveChallengesSection(
                 Text(
                     text = "${ch.type} \u00b7 ${ch.difficulty}",
                     style = SpTypography.LabelSmall,
-                    color = SpColor.Primary,
+                    color = SpColor.Link,
                     maxLines = 1,
                 )
                 Text(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ArtworkShowcaseSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ArtworkShowcaseSection.kt
@@ -59,7 +59,7 @@ fun ArtworkShowcaseSection(
                 Text(
                     text = "Browse Gallery",
                     style = SpTypography.LabelLarge,
-                    color = SpColor.Primary,
+                    color = SpColor.Link,
                     modifier = Modifier
                         .clip(RoundedCornerShape(SpSpacing.Small))
                         .clickable(onClick = onGallerySelected)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
@@ -690,7 +690,7 @@ internal fun DeveloperCompanyDescription(
                 Text(
                     text = if (expanded) "Show less" else "Show more",
                     style = SpTypography.LabelMedium,
-                    color = SpColor.Primary,
+                    color = SpColor.Link,
                     modifier = Modifier
                         .clickable { expanded = !expanded }
                         .testTag("developer_company_description_toggle"),
@@ -723,7 +723,7 @@ internal fun DeveloperCompanyDescription(
                     Text(
                         text = "Website",
                         style = SpTypography.LabelMedium,
-                        color = SpColor.Primary,
+                        color = SpColor.Link,
                         modifier = Modifier
                             .clickable { uriHandler.openUri(websiteUrl) }
                             .testTag("developer_company_website_link"),
@@ -733,7 +733,7 @@ internal fun DeveloperCompanyDescription(
                     Text(
                         text = "Wikipedia",
                         style = SpTypography.LabelMedium,
-                        color = SpColor.Primary,
+                        color = SpColor.Link,
                         modifier = Modifier
                             .clickable { uriHandler.openUri(wikipediaUrl) }
                             .testTag("developer_company_wikipedia_link"),
@@ -917,7 +917,7 @@ private fun TimelineYearColumn(
         Text(
             text = "${entry.year}",
             style = SpTypography.TitleSmall,
-            color = SpColor.Primary,
+            color = SpColor.Link,
         )
         Spacer(Modifier.height(SpSpacing.Small))
         entry.games.forEach { game ->

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/HeroCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/HeroCarousel.kt
@@ -285,6 +285,7 @@ private fun HeroSlide(
                     text = game.consoleAbbreviation,
                     color = consoleColor,
                     isSelected = true,
+                    onGradient = true,
                 )
 
                 // Rating
@@ -309,7 +310,7 @@ private fun HeroSlide(
 
                 // Genre
                 if (game.genre.isNotEmpty()) {
-                    SpChip(text = game.genre)
+                    SpChip(text = game.genre, onGradient = true)
                 }
             }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SocialDiscoverySection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SocialDiscoverySection.kt
@@ -241,7 +241,7 @@ fun ActiveNowSection(
                 Text(
                     text = badges.joinToString(" · "),
                     style = SpTypography.LabelSmall,
-                    color = SpColor.Primary,
+                    color = SpColor.Link,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                     modifier = Modifier.testTag("active_badge_${item.game.id}"),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ActivityScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ActivityScreen.kt
@@ -170,7 +170,7 @@ fun ActivityScreen(
                                 ) {
                                     if (com.spela.player.presentation.ui.components.LocalAnimationsEnabled.current) {
                                         CircularProgressIndicator(
-                                            color = SpColor.Primary,
+                                            color = SpColor.Link,
                                             modifier = Modifier.size(24.dp),
                                         )
                                     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalChallengesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalChallengesScreen.kt
@@ -83,7 +83,7 @@ fun GlobalChallengesScreen(
                 if (selectedTabIndex < tabPositions.size) {
                     TabRowDefaults.SecondaryIndicator(
                         modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
-                        color = SpColor.Primary,
+                        color = SpColor.Link,
                     )
                 }
             },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -573,7 +573,7 @@ private fun SeeAllLink(
     Text(
         text = "See all",
         style = SpTypography.LabelLarge,
-        color = SpColor.Primary,
+        color = SpColor.Link,
         modifier = Modifier
             .clip(RoundedCornerShape(SpSpacing.Small))
             .clickable(onClick = onClick)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
@@ -150,7 +150,7 @@ private fun ProfileContent(
                         Text(
                             text = "Playing ${profile.currentGame.title}",
                             style = SpTypography.BodySmall,
-                            color = SpColor.Primary,
+                            color = SpColor.Link,
                         )
                     } else if (profile.isOnline) {
                         Text(
@@ -237,7 +237,7 @@ private fun StatCard(
             Text(
                 text = value,
                 style = SpTypography.HeadlineLarge,
-                color = SpColor.Primary,
+                color = SpColor.Link,
             )
             Spacer(Modifier.height(SpSpacing.XXSmall))
             Text(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
@@ -13,6 +13,9 @@ object SpColor {
     val PrimaryDark = Color(0xFF4834D4)
     val PrimaryContainer = Color(0xFF1E1640)
 
+    // Link color — brighter than Primary for readable text on dark backgrounds
+    val Link = Color(0xFF9B8FEF)
+
     // Secondary palette - vivid coral/rose
     val Secondary = Color(0xFFFF6B81)
     val SecondaryLight = Color(0xFFFF8E9E)


### PR DESCRIPTION
## Summary
- **Link text**: Added `SpColor.Link` (#9B8FEF, brighter indigo) and replaced `SpColor.Primary` (#6C5CE7) for all clickable text — "See all", "Browse Gallery", "Show more/less", website links, etc.
- **Bottom nav**: Active tab now uses `PrimaryLight`, inactive uses `OnBackgroundSecondary` (was `OnBackgroundTertiary` — too dim)
- **Hero carousel badges**: Console badge and genre chip now use `onGradient = true` for white text on the gradient overlay

## Test plan
- [x] Player compiles successfully
- [x] All link text uses the brighter Link color
- [x] Bottom nav tabs have better contrast