### PR TITLE
fix: use console abbreviation and FlowRow for game cards

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
@@ -517,7 +517,7 @@ internal fun DeveloperGameItem(
             )
             .testTag("developer_game_${game.id}")
             .semantics {
-                contentDescription = "${game.title}, ${game.consoleName}"
+                contentDescription = "${game.title}, ${game.consoleId.uppercase()}"
                 role = Role.Button
             },
         onClick = onClick,
@@ -557,7 +557,7 @@ internal fun DeveloperGameItem(
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
                 ) {
                     Text(
-                        text = game.consoleName,
+                        text = game.consoleId.uppercase(),
                         style = SpTypography.LabelSmall,
                         color = SpColor.OnBackgroundTertiary,
                     )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperSpotlightSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperSpotlightSection.kt
@@ -159,7 +159,7 @@ private fun SpotlightGameCard(
             .width(SpSpacing.CoverMediumWidth)
             .testTag("developer_spotlight_game_${game.id}")
             .semantics {
-                contentDescription = "${game.title}, ${game.consoleName}"
+                contentDescription = "${game.title}, ${game.consoleId.uppercase()}"
                 role = Role.Button
             },
         onClick = onClick,
@@ -187,7 +187,7 @@ private fun SpotlightGameCard(
                 )
                 Spacer(Modifier.height(SpSpacing.XXSmall))
                 Text(
-                    text = game.consoleName,
+                    text = game.consoleId.uppercase(),
                     style = SpTypography.LabelSmall,
                     color = SpColor.OnBackgroundTertiary,
                     maxLines = 1,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ForYouSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ForYouSection.kt
@@ -125,7 +125,7 @@ private fun ForYouGameCard(
             .width(SpSpacing.CoverMediumWidth)
             .testTag("for_you_game_${game.id}")
             .semantics {
-                contentDescription = "${game.title}, ${game.consoleName}"
+                contentDescription = "${game.title}, ${game.consoleId.uppercase()}"
                 role = Role.Button
             },
         onClick = onClick,
@@ -159,7 +159,7 @@ private fun ForYouGameCard(
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
                 ) {
                     Text(
-                        text = game.consoleName,
+                        text = game.consoleId.uppercase(),
                         style = SpTypography.LabelSmall,
                         color = SpColor.OnBackgroundTertiary,
                         maxLines = 1,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
@@ -3,6 +3,8 @@ package com.spela.player.presentation.ui.feature.explore
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -59,6 +61,7 @@ fun GameShelf(
     }
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun ExploreGameCard(
     game: Game,
@@ -69,7 +72,7 @@ internal fun ExploreGameCard(
         modifier = modifier
             .testTag("explore_game_card_${game.id}")
             .semantics {
-                contentDescription = "${game.title}, ${game.consoleName}"
+                contentDescription = "${game.title}, ${game.consoleId.uppercase()}"
                 role = Role.Button
             },
         onClick = onClick,
@@ -98,31 +101,36 @@ internal fun ExploreGameCard(
 
                 Spacer(Modifier.height(SpSpacing.XXSmall))
 
-                // Console badge
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
+                // Console abbreviation + rating (wraps to new line if needed)
+                FlowRow(
+                    verticalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
                 ) {
                     Text(
-                        text = game.consoleName,
+                        text = game.consoleId.uppercase(),
                         style = SpTypography.LabelSmall,
                         color = SpColor.OnBackgroundTertiary,
                         maxLines = 1,
                     )
 
-                    // Rating
+                    // Rating (star + number treated as a unit)
                     if (game.rating > 0) {
-                        Icon(
-                            imageVector = Icons.Filled.Star,
-                            contentDescription = null,
-                            tint = SpColor.Rating,
-                            modifier = Modifier.size(10.dp),
-                        )
-                        Text(
-                            text = formatRating(game.rating),
-                            style = SpTypography.LabelSmall,
-                            color = SpColor.OnBackgroundTertiary,
-                        )
+                        Row(
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+                        ) {
+                            Icon(
+                                imageVector = Icons.Filled.Star,
+                                contentDescription = null,
+                                tint = SpColor.Rating,
+                                modifier = Modifier.size(10.dp),
+                            )
+                            Text(
+                                text = formatRating(game.rating),
+                                style = SpTypography.LabelSmall,
+                                color = SpColor.OnBackgroundTertiary,
+                            )
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Summary
- Game cards now show console abbreviation (e.g. "NES") instead of full name ("Nintendo Entertainment System") — was too long for small cards
- Star rating uses FlowRow to wrap to a new line when space is tight, with star+number as one atomic unit
- Applied consistently across all explore card components: ExploreGameCard, ForYouGameCard, DeveloperSpotlightGameCard, DeveloperDetailGameCard
- contentDescription updated to match displayed text
- Raw `2.dp` replaced with `SpSpacing.XXSmall` token

## Review
- UX agent: found inconsistency with other card components → fixed
- Code reviewer: found contentDescription mismatch and raw dp literal → fixed

## Test plan
- [x] Player compiles successfully
- [x] All card components use consistent console abbreviation format