### PR TITLE
fix: card consistency follow-up from UX/code review

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ArtworkShowcaseSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ArtworkShowcaseSection.kt
@@ -176,7 +176,7 @@ private fun ArtworkCard(
                         modifier = Modifier.testTag("artwork_title_${artwork.gameId}"),
                     )
                     Text(
-                        text = artwork.consoleName,
+                        text = artwork.consoleAbbreviation.uppercase(),
                         style = SpTypography.LabelSmall,
                         color = Color.White.copy(alpha = 0.8f),
                         maxLines = 1,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
@@ -295,7 +295,7 @@ internal fun TopRatedGameCard(
                             imageVector = Icons.Filled.Star,
                             contentDescription = null,
                             tint = SpColor.Rating,
-                            modifier = Modifier.size(10.dp),
+                            modifier = Modifier.size(SpSpacing.IconXSmall),
                         )
                         Text(
                             text = formatRating(game.rating),
@@ -567,7 +567,7 @@ internal fun DeveloperGameItem(
                             imageVector = Icons.Filled.Star,
                             contentDescription = null,
                             tint = SpColor.Rating,
-                            modifier = Modifier.size(10.dp),
+                            modifier = Modifier.size(SpSpacing.IconXSmall),
                         )
                         Text(
                             text = formatRating(game.rating),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperSpotlightSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperSpotlightSection.kt
@@ -106,7 +106,7 @@ fun DeveloperSpotlightSection(
                                 imageVector = Icons.Filled.Star,
                                 contentDescription = null,
                                 tint = SpColor.Rating,
-                                modifier = Modifier.size(10.dp),
+                                modifier = Modifier.size(SpSpacing.IconXSmall),
                             )
                             Text(
                                 text = formatRating(spotlight.avgRating),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
@@ -364,9 +364,9 @@ internal fun TimelineItem(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
                 ) {
-                    game.consoleName?.let { consoleName ->
+                    game.consoleAbbreviation?.let { abbr ->
                         Text(
-                            text = consoleName,
+                            text = abbr.uppercase(),
                             style = SpTypography.LabelSmall,
                             color = SpColor.OnBackgroundTertiary,
                         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ForYouSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ForYouSection.kt
@@ -170,7 +170,7 @@ private fun ForYouGameCard(
                             imageVector = Icons.Filled.Star,
                             contentDescription = null,
                             tint = SpColor.Rating,
-                            modifier = Modifier.size(10.dp),
+                            modifier = Modifier.size(SpSpacing.IconXSmall),
                         )
                         Text(
                             text = formatRating(game.rating),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
@@ -123,7 +123,7 @@ internal fun ExploreGameCard(
                                 imageVector = Icons.Filled.Star,
                                 contentDescription = null,
                                 tint = SpColor.Rating,
-                                modifier = Modifier.size(10.dp),
+                                modifier = Modifier.size(SpSpacing.IconXSmall),
                             )
                             Text(
                                 text = formatRating(game.rating),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameListRowItem.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameListRowItem.kt
@@ -99,7 +99,7 @@ internal fun GameListRowItem(
                             Icon(
                                 imageVector = Icons.Filled.Star,
                                 contentDescription = null,
-                                tint = SpColor.Warning,
+                                tint = SpColor.Rating,
                                 modifier = Modifier.height(SpSpacing.IconSmall).width(SpSpacing.IconSmall),
                             )
                             Spacer(Modifier.width(SpSpacing.XXSmall))


### PR DESCRIPTION
## Summary
Addresses remaining findings from UX agent and code reviewer on PR #251:

- `ExploreGroupDetailContent`: use `consoleAbbreviation` instead of `consoleName`
- `ArtworkShowcaseSection`: use `consoleAbbreviation` instead of `consoleName`  
- Replace raw `10.dp` star icon sizes with `SpSpacing.IconXSmall` token (5 occurrences across 4 files)
- Fix star icon color in `GameListRowItem` from `SpColor.Warning` to `SpColor.Rating`

## Test plan
- [x] Player compiles successfully
- [x] All explore card components now use consistent abbreviation and icon sizing