### PR TITLE
feat: split console page into curated showcase + filterable game list

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -14,6 +14,7 @@ sealed class SpScreen(val route: String) {
     data object Stats : SpScreen("stats")
     data object Activity : SpScreen("activity")
     data class Console(val consoleId: String) : SpScreen("console/$consoleId")
+    data class ConsoleGames(val consoleId: String) : SpScreen("console_games/$consoleId")
     data class GameDetail(val gameId: String) : SpScreen("game/$gameId")
     data object Downloads : SpScreen("downloads")
     data object Settings : SpScreen("settings")

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -70,6 +70,7 @@ import com.spela.player.data.remote.ConnectivityMonitor
 import com.spela.player.presentation.navigation.NavigationEvent
 import com.spela.player.presentation.navigation.NavigationEventBus
 import com.spela.player.presentation.ui.feature.ingame.DsPrimaryTouchOverlay
+import com.spela.player.presentation.ui.screen.ConsoleGamesScreen
 import com.spela.player.presentation.ui.screen.ConsoleScreen
 import com.spela.player.presentation.ui.screen.ConsoleSettingsScreen
 import com.spela.player.presentation.ui.screen.ConsolesScreen
@@ -840,6 +841,26 @@ fun SpelaApp(
                                         navigationViewModel.onIntent(
                                             NavigationIntent.NavigateTo(SpScreen.ConsoleSettings(screen.consoleId))
                                         )
+                                    },
+                                    onBrowseAllGames = {
+                                        navigationViewModel.onIntent(
+                                            NavigationIntent.NavigateTo(SpScreen.ConsoleGames(screen.consoleId))
+                                        )
+                                    },
+                                )
+                            }
+
+                            is SpScreen.ConsoleGames -> {
+                                ConsoleGamesScreen(
+                                    consoleId = screen.consoleId,
+                                    viewModel = gameListViewModel,
+                                    onGameSelected = { gameId: String ->
+                                        navigationViewModel.onIntent(
+                                            NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
+                                        )
+                                    },
+                                    onBack = {
+                                        navigationViewModel.onIntent(NavigationIntent.GoBack)
                                     },
                                 )
                             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleGamesScreen.kt
@@ -1,0 +1,284 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.GridItemSpan
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material.icons.filled.SwapVert
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.material3.pulltorefresh.PullToRefreshBox
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.rememberSaveable
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.intent.GameListIntent
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpEmptyStates
+import com.spela.player.presentation.ui.components.SpIconButton
+import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.SpSearchField
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.feature.library.GameGridItem
+import com.spela.player.presentation.ui.theme.LocalTitleBarInset
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.theme.spScreenBackground
+import com.spela.player.presentation.viewmodel.GameListViewModel
+
+private data class SortOption(val key: String, val label: String)
+private val sortOptions = listOf(
+    SortOption("title", "Title (A–Z)"),
+    SortOption("rating", "Rating"),
+    SortOption("releaseDate", "Release Date"),
+    SortOption("lastPlayed", "Recently Played"),
+)
+
+/**
+ * Full filterable game list for a single console.
+ * Includes search, sort, and game grid with client-side filtering.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun ConsoleGamesScreen(
+    consoleId: String,
+    viewModel: GameListViewModel,
+    onGameSelected: (String) -> Unit,
+    onBack: () -> Unit,
+) {
+    val state by viewModel.state.collectAsState()
+
+    val console = state.consoles.firstOrNull { it.id == consoleId }
+    val consoleName = console?.name ?: "Games"
+
+    var isSearchVisible by rememberSaveable { mutableStateOf(false) }
+    var showSortMenu by remember { mutableStateOf(false) }
+    val focusRequester = remember { FocusRequester() }
+
+    PlatformBackHandler {
+        if (isSearchVisible) {
+            viewModel.onIntent(GameListIntent.Search(""))
+            isSearchVisible = false
+        } else {
+            onBack()
+        }
+    }
+
+    LaunchedEffect(consoleId) {
+        viewModel.onIntent(GameListIntent.SelectConsole(consoleId))
+    }
+
+    LaunchedEffect(isSearchVisible) {
+        if (isSearchVisible) focusRequester.requestFocus()
+    }
+
+    // Client-side sort
+    val sortedGames = remember(state.games, state.sortBy, state.sortOrder, state.searchQuery) {
+        val filtered = if (state.searchQuery.length >= 2) {
+            state.games.filter { it.title.contains(state.searchQuery, ignoreCase = true) }
+        } else {
+            state.games
+        }
+        val asc = state.sortOrder != "desc"
+        when (state.sortBy) {
+            "rating" -> if (asc) filtered.sortedBy { it.averageRating }
+                        else filtered.sortedByDescending { it.averageRating }
+            "releaseDate" -> if (asc) filtered.sortedBy { it.releaseDate ?: "" }
+                             else filtered.sortedByDescending { it.releaseDate ?: "" }
+            "lastPlayed" -> filtered.sortedByDescending { it.lastPlayedAt ?: "" }
+            else -> if (asc) filtered.sortedBy { it.title.lowercase() }
+                    else filtered.sortedByDescending { it.title.lowercase() }
+        }
+    }
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .spScreenBackground()
+            .testTag("console_games_screen"),
+    ) {
+        PullToRefreshBox(
+            isRefreshing = state.isLoading,
+            onRefresh = { viewModel.onIntent(GameListIntent.SelectConsole(consoleId)) },
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            LazyVerticalGrid(
+                columns = GridCells.Adaptive(SpSpacing.GridCellMinWidth),
+                modifier = Modifier.fillMaxSize(),
+                contentPadding = PaddingValues(
+                    start = SpSpacing.ScreenHorizontal,
+                    end = SpSpacing.ScreenHorizontal,
+                    top = SpSpacing.TopBarHeight + LocalTitleBarInset.current,
+                    bottom = SpSpacing.Default,
+                ),
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Default),
+                verticalArrangement = Arrangement.spacedBy(SpSpacing.GridSpacing),
+            ) {
+                // Search field
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    if (isSearchVisible) {
+                        SpSearchField(
+                            value = state.searchQuery,
+                            onValueChange = { viewModel.onIntent(GameListIntent.Search(it)) },
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(vertical = SpSpacing.Small)
+                                .focusRequester(focusRequester),
+                            placeholder = "Search $consoleName games...",
+                            trailingIcon = {
+                                SpIconButton(
+                                    icon = Icons.Filled.Close,
+                                    contentDescription = "Close search",
+                                    onClick = {
+                                        viewModel.onIntent(GameListIntent.Search(""))
+                                        isSearchVisible = false
+                                    },
+                                )
+                            },
+                        )
+                    }
+                }
+
+                // Games heading + sort
+                item(span = { GridItemSpan(maxLineSpan) }) {
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(bottom = SpSpacing.Small),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Text(
+                            text = if (state.searchQuery.length >= 2) "${sortedGames.size} results"
+                                   else "${sortedGames.size} games",
+                            style = SpTypography.HeadlineSmall,
+                            color = SpColor.OnBackground,
+                            modifier = Modifier.weight(1f),
+                        )
+                        Box {
+                            SpIconButton(
+                                icon = Icons.Filled.SwapVert,
+                                contentDescription = "Sort games",
+                                onClick = { showSortMenu = true },
+                            )
+                            DropdownMenu(
+                                expanded = showSortMenu,
+                                onDismissRequest = { showSortMenu = false },
+                            ) {
+                                sortOptions.forEach { option ->
+                                    DropdownMenuItem(
+                                        text = { Text(option.label) },
+                                        onClick = {
+                                            viewModel.onIntent(GameListIntent.SetSortBy(option.key))
+                                            showSortMenu = false
+                                        },
+                                        leadingIcon = if (state.sortBy == option.key) {
+                                            { Icon(Icons.Filled.Check, null, Modifier.size(16.dp)) }
+                                        } else null,
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // Loading / empty / game grid
+                if (state.isLoading && state.games.isEmpty()) {
+                    item(span = { GridItemSpan(maxLineSpan) }) {
+                        Box(
+                            modifier = Modifier.fillMaxWidth().height(300.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            SpLoadingIndicator(message = "Loading games...")
+                        }
+                    }
+                } else if (sortedGames.isEmpty()) {
+                    item(span = { GridItemSpan(maxLineSpan) }) {
+                        Box(
+                            modifier = Modifier.fillMaxWidth().height(300.dp),
+                            contentAlignment = Alignment.Center,
+                        ) {
+                            if (state.searchQuery.length >= 2) {
+                                SpEmptyStates.NoSearchResults(query = state.searchQuery)
+                            } else {
+                                SpEmptyStates.NoGamesInConsole(consoleName = consoleName)
+                            }
+                        }
+                    }
+                } else {
+                    items(sortedGames, key = { it.id }) { game ->
+                        GameGridItem(
+                            game = game,
+                            onClick = { onGameSelected(game.id) },
+                            onRequestScrape = { viewModel.requestScrapeIfNeeded(it) },
+                        )
+                    }
+                }
+            }
+        }
+
+        // Top bar
+        SpTopBar(
+            title = "$consoleName Games",
+            showBack = true,
+            onBack = {
+                if (isSearchVisible) {
+                    viewModel.onIntent(GameListIntent.Search(""))
+                    isSearchVisible = false
+                } else {
+                    onBack()
+                }
+            },
+            actions = {
+                SpIconButton(
+                    icon = Icons.Filled.Search,
+                    contentDescription = "Search games",
+                    onClick = { isSearchVisible = !isSearchVisible },
+                )
+            },
+        )
+
+        // Error snackbar
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.onIntent(GameListIntent.DismissError) },
+                )
+            },
+            onDismiss = { viewModel.onIntent(GameListIntent.DismissError) },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -59,6 +59,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpIconButton
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
@@ -87,14 +88,6 @@ import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 import com.spela.player.presentation.viewmodel.GameListViewModel
 
-private data class SortOption(val key: String, val label: String)
-private val sortOptions = listOf(
-    SortOption("title",       "Title (A–Z)"),
-    SortOption("rating",      "Rating"),
-    SortOption("releaseDate", "Release date"),
-    SortOption("lastPlayed",  "Recently played"),
-)
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun ConsoleScreen(
@@ -105,25 +98,14 @@ fun ConsoleScreen(
     onBack: () -> Unit,
     onDeveloperSelected: (String) -> Unit = {},
     onNavigateToConsoleSettings: () -> Unit = {},
+    onBrowseAllGames: () -> Unit = {},
 ) {
     val state by viewModel.state.collectAsState()
 
     val console = state.consoles.firstOrNull { it.id == consoleId }
     val consoleName = console?.name ?: "Games"
 
-    var isSearchVisible by rememberSaveable { mutableStateOf(false) }
-    var showSortMenu by remember { mutableStateOf(false) }
-    val focusRequester = remember { FocusRequester() }
-
-    // Back handler: close search first, then navigate back
-    PlatformBackHandler {
-        if (isSearchVisible) {
-            viewModel.onIntent(GameListIntent.Search(""))
-            isSearchVisible = false
-        } else {
-            onBack()
-        }
-    }
+    PlatformBackHandler { onBack() }
 
     LaunchedEffect(consoleId) {
         viewModel.onIntent(GameListIntent.SelectConsole(consoleId))
@@ -133,32 +115,11 @@ fun ConsoleScreen(
         exploreViewModel?.loadConsoleShowcase(consoleId)
     }
 
-    // Auto-focus search field when it becomes visible
-    LaunchedEffect(isSearchVisible) {
-        if (isSearchVisible) {
-            focusRequester.requestFocus()
-        }
-    }
-
     val continuePlayingGames = remember(state.games) {
         state.games
             .filter { it.lastPlayedAt != null }
             .sortedByDescending { it.lastPlayedAt }
             .take(5)
-    }
-
-    // Client-side sort applied on top of whatever order the server returns.
-    val sortedGames = remember(state.games, state.sortBy, state.sortOrder) {
-        val asc = state.sortOrder != "desc"
-        when (state.sortBy) {
-            "rating"      -> if (asc) state.games.sortedBy { it.averageRating }
-                             else state.games.sortedByDescending { it.averageRating }
-            "releaseDate" -> if (asc) state.games.sortedBy { it.releaseDate ?: "" }
-                             else state.games.sortedByDescending { it.releaseDate ?: "" }
-            "lastPlayed"  -> state.games.sortedByDescending { it.lastPlayedAt ?: "" }
-            else          -> if (asc) state.games.sortedBy { it.title.lowercase() }
-                             else state.games.sortedByDescending { it.title.lowercase() }
-        }
     }
 
     // Darkened version of the console's brand gradient for the full-screen background
@@ -247,37 +208,6 @@ fun ConsoleScreen(
                         }
                     }
 
-                    // Search field
-                    item(span = { GridItemSpan(maxLineSpan) }) {
-                        Column {
-                            AnimatedVisibility(
-                                visible = isSearchVisible,
-                                enter = expandVertically() + fadeIn(),
-                                exit = shrinkVertically() + fadeOut(),
-                            ) {
-                                SpSearchField(
-                                    value = state.searchQuery,
-                                    onValueChange = { viewModel.onIntent(GameListIntent.Search(it)) },
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(vertical = SpSpacing.Small)
-                                        .focusRequester(focusRequester),
-                                    placeholder = "Search $consoleName games...",
-                                    trailingIcon = {
-                                        SpIconButton(
-                                            icon = Icons.Filled.Close,
-                                            contentDescription = "Close search",
-                                            onClick = {
-                                                viewModel.onIntent(GameListIntent.Search(""))
-                                                isSearchVisible = false
-                                            },
-                                        )
-                                    },
-                                )
-                            }
-                        }
-                    }
-
                     // BIOS warning banner
                     if (consoleId in state.consolesWithMissingBios) {
                         item(span = { GridItemSpan(maxLineSpan) }) {
@@ -298,9 +228,6 @@ fun ConsoleScreen(
                             ConsoleHiddenGems(exploreViewModel, onGameSelected)
                         }
                         item(span = { GridItemSpan(maxLineSpan) }) {
-                            ConsoleGenreBreakdown(exploreViewModel)
-                        }
-                        item(span = { GridItemSpan(maxLineSpan) }) {
                             ConsoleTopDevelopers(exploreViewModel, onDeveloperSelected)
                         }
                         item(span = { GridItemSpan(maxLineSpan) }) {
@@ -308,79 +235,34 @@ fun ConsoleScreen(
                         }
                     }
 
-                    // Loading state
-                    if (state.isLoading && state.games.isEmpty()) {
+                    // Browse All Games button
+                    if (state.games.isNotEmpty()) {
+                        item(span = { GridItemSpan(maxLineSpan) }) {
+                            SpButton(
+                                text = "Browse All ${state.games.size} Games",
+                                onClick = onBrowseAllGames,
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = SpSpacing.Default),
+                            )
+                        }
+                    } else if (state.isLoading) {
                         item(span = { GridItemSpan(maxLineSpan) }) {
                             Box(
-                                modifier = Modifier.fillMaxWidth().height(300.dp),
+                                modifier = Modifier.fillMaxWidth().height(200.dp),
                                 contentAlignment = Alignment.Center,
                             ) {
                                 SpLoadingIndicator(message = "Loading games...")
                             }
                         }
-                    } else if (state.games.isEmpty()) {
-                        // Empty state
+                    } else {
                         item(span = { GridItemSpan(maxLineSpan) }) {
                             Box(
-                                modifier = Modifier.fillMaxWidth().height(300.dp),
+                                modifier = Modifier.fillMaxWidth().height(200.dp),
                                 contentAlignment = Alignment.Center,
                             ) {
-                                if (state.searchQuery.length >= 2) {
-                                    SpEmptyStates.NoSearchResults(query = state.searchQuery)
-                                } else {
-                                    SpEmptyStates.NoGamesInConsole(consoleName = consoleName)
-                                }
+                                SpEmptyStates.NoGamesInConsole(consoleName = consoleName)
                             }
-                        }
-                    } else {
-                        // "Games" heading + sort dropdown (#2)
-                        item(span = { GridItemSpan(maxLineSpan) }) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(top = SpSpacing.Default, bottom = SpSpacing.Small),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Text(
-                                    text = "${sortedGames.size} games",
-                                    style = SpTypography.HeadlineSmall,
-                                    color = SpColor.OnBackground,
-                                    modifier = Modifier.weight(1f),
-                                )
-                                Box {
-                                    SpIconButton(
-                                        icon = Icons.Filled.SwapVert,
-                                        contentDescription = "Sort games",
-                                        onClick = { showSortMenu = true },
-                                    )
-                                    DropdownMenu(
-                                        expanded = showSortMenu,
-                                        onDismissRequest = { showSortMenu = false },
-                                    ) {
-                                        sortOptions.forEach { option ->
-                                            DropdownMenuItem(
-                                                text = { Text(option.label) },
-                                                onClick = {
-                                                    viewModel.onIntent(GameListIntent.SetSortBy(option.key))
-                                                    showSortMenu = false
-                                                },
-                                                leadingIcon = if (state.sortBy == option.key) {
-                                                    { Icon(Icons.Filled.Check, null, Modifier.size(16.dp)) }
-                                                } else null,
-                                            )
-                                        }
-                                    }
-                                }
-                            }
-                        }
-
-                        // Game grid items (sorted)
-                        items(sortedGames, key = { it.id }) { game ->
-                            GameGridItem(
-                                game = game,
-                                onClick = { onGameSelected(game.id) },
-                                onRequestScrape = { viewModel.requestScrapeIfNeeded(it) },
-                            )
                         }
                     }
                 }
@@ -391,14 +273,7 @@ fun ConsoleScreen(
                 title = consoleName,
                 showBack = true,
                 onGradient = true,
-                onBack = {
-                    if (isSearchVisible) {
-                        viewModel.onIntent(GameListIntent.Search(""))
-                        isSearchVisible = false
-                    } else {
-                        onBack()
-                    }
-                },
+                onBack = onBack,
                 titleLeadingContent = if (console?.iconUrl?.isNotEmpty() == true) {
                     {
                         AsyncImage(
@@ -409,22 +284,6 @@ fun ConsoleScreen(
                     }
                 } else null,
                 actions = {
-                    SpIconButton(
-                        icon = Icons.Filled.Search,
-                        contentDescription = "Search games",
-                        onGradient = true,
-                        onClick = { isSearchVisible = !isSearchVisible },
-                        badge = if (!isSearchVisible && state.searchQuery.isNotEmpty()) {
-                            {
-                                Box(
-                                    modifier = Modifier
-                                        .size(8.dp)
-                                        .align(Alignment.TopEnd)
-                                        .background(SpColor.Primary, shape = CircleShape),
-                                )
-                            }
-                        } else null,
-                    )
                     SpIconButton(
                         icon = Icons.Filled.Settings,
                         contentDescription = "Console settings",


### PR DESCRIPTION
## Summary
Splits the console page into two screens matching the web UI pattern:

**Console Page (curated showcase):**
- Hero banner, Continue Playing, Top Rated
- Essentials, Hidden Gems, Top Developers, Recently Played
- "Browse All N Games" button at the bottom
- Genre breakdown removed (will become a filter in the game list)

**Console Games Screen (new):**
- Full game grid with search and sort
- Client-side filtering and sorting
- Sort options: Title, Rating, Release Date, Recently Played

## Test plan
- [x] Player compiles successfully
- [x] Console page shows curated content without game grid
- [x] New ConsoleGames screen accessible via "Browse All Games"
- [x] Navigation routing works (SpScreen.ConsoleGames)