### PR TITLE
fix: guard gradient background against zero-size Skia crash

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
@@ -106,6 +106,7 @@ fun Modifier.spScreenBackground(
     from: Color = SpColor.ScreenGradientStart,
     to: Color = SpColor.ScreenGradientEnd,
 ): Modifier = drawBehind {
+    if (size.width <= 0f || size.height <= 0f) return@drawBehind
     val cx = size.width / 2f
     val cy = size.height / 2f
     val d = (size.width + size.height) * 0.25f


### PR DESCRIPTION
## Summary
Desktop app crashed on startup with `RuntimeException: Can't wrap nullptr` from Skia's `Shader.makeLinearGradient`. The `spScreenBackground()` modifier created a gradient with `start == end == (0,0)` when the composable had zero size before layout. Skia can't create a gradient shader with identical endpoints.

Fix: skip drawing when `size.width` or `size.height` is zero.