### PR TITLE
fix: remove Float.MAX_VALUE from Developer Spotlight gradient (Skia crash)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperSpotlightSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperSpotlightSection.kt
@@ -79,8 +79,6 @@ fun DeveloperSpotlightSection(
                                 Color(0xFF1A1A4E),
                                 SpColor.AccentDark.copy(alpha = 0.6f),
                             ),
-                            start = Offset(0f, 0f),
-                            end = Offset(Float.MAX_VALUE, Float.MAX_VALUE),
                         ),
                     ),
             ) {


### PR DESCRIPTION
Skia crashes when Brush.linearGradient receives Float.MAX_VALUE as endpoint. Remove explicit start/end to use Compose defaults.