### PR TITLE
fix: deduplicate global top-rated games by IGDB game ID

### DIFF
--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -471,12 +471,51 @@ func (h *ConsoleHandler) GetTopRated(c *gin.Context) {
 }
 
 // GetTopRatedGlobal returns the top 20 top-rated IGDB games across all consoles.
-// Results are pulled from the existing cached top-rated data and sorted by rating.
+// The same IGDB game can appear under multiple consoles (e.g. Super Metroid on
+// SNES, Wii, 3DS). We deduplicate by igdb_game_id, preferring the console entry
+// that has a matching local library game so the card shows as "available".
 func (h *ConsoleHandler) GetTopRatedGlobal(c *gin.Context) {
-	var cached []db.TopRatedGame
-	h.DB.Order("total_rating desc").Limit(20).Find(&cached)
+	var all []db.TopRatedGame
+	h.DB.Order("total_rating desc").Find(&all)
 
-	c.JSON(http.StatusOK, h.buildTopRatedResponses(cached, true))
+	// Build a set of (igdb_game_id → console_id) pairs that have a local game match,
+	// so we can prefer those entries during dedup.
+	localConsoles := make(map[int]uint) // igdb_game_id → preferred console_id
+	for _, tr := range all {
+		if _, seen := localConsoles[tr.IGDBGameID]; seen {
+			continue
+		}
+		var count int64
+		h.DB.Model(&db.Game{}).Where("LOWER(title) = LOWER(?) AND console_id = ?", tr.Name, tr.ConsoleID).Count(&count)
+		if count > 0 {
+			localConsoles[tr.IGDBGameID] = tr.ConsoleID
+		}
+	}
+
+	// Deduplicate: for each igdb_game_id, prefer the entry whose console has a
+	// local library match; otherwise keep the highest-rated (first encountered).
+	best := make(map[int]db.TopRatedGame) // igdb_game_id → best entry
+	order := make([]int, 0)               // insertion order for stable iteration
+	for _, tr := range all {
+		existing, seen := best[tr.IGDBGameID]
+		if !seen {
+			best[tr.IGDBGameID] = tr
+			order = append(order, tr.IGDBGameID)
+		} else if prefConsole, ok := localConsoles[tr.IGDBGameID]; ok && tr.ConsoleID == prefConsole && existing.ConsoleID != prefConsole {
+			// Swap in the entry that matches the local library
+			best[tr.IGDBGameID] = tr
+		}
+	}
+
+	deduped := make([]db.TopRatedGame, 0, 20)
+	for _, igdbID := range order {
+		deduped = append(deduped, best[igdbID])
+		if len(deduped) >= 20 {
+			break
+		}
+	}
+
+	c.JSON(http.StatusOK, h.buildTopRatedResponses(deduped, true))
 }
 
 // TopListGameResponse is the API response for a top-rated IGDB game that is

--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -848,3 +848,93 @@ func TestGetTopListLongest_ExcludesDemoConsoles(t *testing.T) {
 	assert.Len(t, result, 1, "should exclude demo console entries")
 	assert.Equal(t, "Real Game", result[0].Name)
 }
+
+func TestGetTopRatedGlobal_DeduplicatesSameGameAcrossConsoles(t *testing.T) {
+	database, store, router := setupConsoleTestEnv(t)
+
+	handler := &ConsoleHandler{DB: database, Storage: store}
+	router.GET("/api/top-rated", handler.GetTopRatedGlobal)
+
+	// Look up two different consoles
+	var snes, gba db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
+	require.NoError(t, database.Where("abbreviation = ?", "GBA").First(&gba).Error)
+
+	// Insert the same game (same IGDB game ID) as top-rated on two consoles.
+	// This happens because IGDB lists "Super Metroid" on both SNES and GBA
+	// (or virtual console re-releases), and upsertTopRatedGames runs per-console.
+	database.Create(&db.TopRatedGame{
+		ConsoleID: snes.ID, IGDBGameID: 1103, Name: "Super Metroid",
+		TotalRating: 96.0, TotalRatingCount: 500, Rank: 1,
+	})
+	database.Create(&db.TopRatedGame{
+		ConsoleID: gba.ID, IGDBGameID: 1103, Name: "Super Metroid",
+		TotalRating: 95.0, TotalRatingCount: 200, Rank: 1,
+	})
+	// A different game for variety
+	database.Create(&db.TopRatedGame{
+		ConsoleID: snes.ID, IGDBGameID: 2000, Name: "Chrono Trigger",
+		TotalRating: 92.0, TotalRatingCount: 400, Rank: 2,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-rated", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []TopRatedGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+	// Super Metroid should appear exactly once, not twice
+	names := make([]string, len(result))
+	for i, g := range result {
+		names[i] = g.Name
+	}
+	assert.Len(t, result, 2, "should deduplicate: got %v", names)
+	assert.Equal(t, "Super Metroid", result[0].Name)
+	assert.Equal(t, "Chrono Trigger", result[1].Name)
+}
+
+func TestGetTopRatedGlobal_DeduplicatePrefersLocalLibraryMatch(t *testing.T) {
+	database, store, router := setupConsoleTestEnv(t)
+
+	handler := &ConsoleHandler{DB: database, Storage: store}
+	router.GET("/api/top-rated", handler.GetTopRatedGlobal)
+
+	var snes, gba db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
+	require.NoError(t, database.Where("abbreviation = ?", "GBA").First(&gba).Error)
+
+	// Add a local SNES game matching "Super Metroid"
+	database.Create(&db.Game{
+		ConsoleID: snes.ID, Title: "Super Metroid",
+		FileName: "super_metroid.sfc", FilePath: "SNES/super_metroid.sfc",
+		CoverURL: "SNES/1/boxart.png",
+	})
+
+	// Insert same game on two consoles — GBA version has higher rating
+	// but SNES has the local library match
+	database.Create(&db.TopRatedGame{
+		ConsoleID: gba.ID, IGDBGameID: 1103, Name: "Super Metroid",
+		TotalRating: 97.0, TotalRatingCount: 200, Rank: 1,
+	})
+	database.Create(&db.TopRatedGame{
+		ConsoleID: snes.ID, IGDBGameID: 1103, Name: "Super Metroid",
+		TotalRating: 96.0, TotalRatingCount: 500, Rank: 1,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/top-rated", nil)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusOK, w.Code)
+
+	var result []TopRatedGameResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
+
+	require.Len(t, result, 1)
+	assert.Equal(t, "Super Metroid", result[0].Name)
+	// Should have a localGameId because the SNES version matches a library game
+	assert.NotNil(t, result[0].LocalGameId, "should prefer the console entry that has a local library match")
+}


### PR DESCRIPTION
## Summary
- The same IGDB game (e.g. Super Metroid) appears in `top_rated_games` for every console it was released on (SNES, 3DS, Wii, etc.)
- `GetTopRatedGlobal` was returning all entries, causing each game to appear multiple times in the UI
- Fix: deduplicate by `igdb_game_id`, preferring the console entry that has a matching local library game so the card shows as "available"

## Test plan
- [x] `TestGetTopRatedGlobal_DeduplicatesSameGameAcrossConsoles` — same game on two consoles appears once
- [x] `TestGetTopRatedGlobal_DeduplicatePrefersLocalLibraryMatch` — when deduplicating, prefers the entry with a local library match
- [x] Full test suite passes