### PR TITLE
feat: game detail hero banner, franchise logos, search cards, SpGameGrid

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -561,6 +561,7 @@ fun LongestGameDto.toDomain(): LongestGame = LongestGame(
 )
 
 fun SimilarGameDto.toDomain(): SimilarGame = SimilarGame(
+    igdbGameId = igdbGameId,
     name = name,
     coverUrl = coverUrl,
     rating = rating,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -643,6 +643,7 @@ fun SeriesDetailDto.toDomain(): SeriesDetail = SeriesDetail(
     id = id,
     name = name,
     heroUrl = heroUrl,
+    logoUrl = logoUrl,
     consoles = consoles.map { it.toDomain() },
     libraryGames = libraryGames,
     totalGames = totalGames,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1127,6 +1127,7 @@ data class SeriesDetailDto(
     val id: String,
     val name: String,
     val heroUrl: String? = null,
+    val logoUrl: String? = null,
     val consoles: List<SeriesConsoleDto> = emptyList(),
     val libraryGames: Int = 0,
     val totalGames: Int = 0,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -992,6 +992,7 @@ data class LongestGameDto(
 
 @Serializable
 data class SimilarGameDto(
+    val igdbGameId: Int = 0,
     val name: String,
     val coverUrl: String? = null,
     val rating: Double = 0.0,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -109,6 +109,7 @@ class ExploreRepositoryImpl(
         val dto = apiClient.getSeriesDetail(id)
         dto.toDomain().copy(
             heroUrl = apiClient.resolveUrl(dto.heroUrl),
+            logoUrl = apiClient.resolveUrl(dto.logoUrl),
             games = dto.games.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
@@ -121,6 +122,7 @@ class ExploreRepositoryImpl(
         val dto = apiClient.getFranchiseDetail(id)
         dto.toDomain().copy(
             heroUrl = apiClient.resolveUrl(dto.heroUrl),
+            logoUrl = apiClient.resolveUrl(dto.logoUrl),
             games = dto.games.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
@@ -393,6 +393,8 @@ class GameRepositoryImpl(
     /** Resolve relative image URLs to absolute URLs using the server base URL. */
     private fun Game.resolveImageUrls(): Game = copy(
         coverUrl = apiClient.resolveUrl(coverUrl),
+        heroUrl = apiClient.resolveUrl(heroUrl),
+        logoUrl = apiClient.resolveUrl(logoUrl),
     )
 
     private fun Console.resolveImageUrls(): Console = copy(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -45,6 +45,7 @@ data class SeriesDetail(
     val id: String,
     val name: String,
     val heroUrl: String?,
+    val logoUrl: String?,
     val consoles: List<SeriesConsole>,
     val libraryGames: Int,
     val totalGames: Int,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -672,6 +672,7 @@ data class LongestGame(
 // Similar Games
 
 data class SimilarGame(
+    val igdbGameId: Int = 0,
     val name: String,
     val coverUrl: String? = null,
     val rating: Double = 0.0,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.ui.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,9 +26,11 @@ import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -39,13 +42,16 @@ import com.spela.player.presentation.ui.theme.SpSpacing
  * - **Landscape**: Cover art on the LEFT, info/sections on the RIGHT in a Row.
  *   [fullWidthSections] render below the Row at full width.
  *   Both scroll together in one unified scroll container.
- * - **Portrait**: Cover art centered above, all sections below in a single column.
+ * - **Portrait**: Hero banner at the top with cover art + title overlay,
+ *   all sections below in a single column.
  *
  * The top bar floats over content with a transparent background.
  *
  * @param topBar Composable rendered floating over content.
  * @param coverArt Composable for the cover art image.
  * @param coverExtra Optional composable rendered below the cover art.
+ * @param heroUrl URL for the hero banner background image (portrait only).
+ * @param heroContent Composable rendered next to the cover art in the hero banner (portrait only).
  * @param backgroundColors Gradient colors for the screen background.
  * @param sections Content rendered beside the cover art in landscape (right column).
  * @param fullWidthSections Content rendered below the hero row at full width in landscape.
@@ -56,6 +62,8 @@ fun GameDetailLayout(
     topBar: @Composable () -> Unit,
     coverArt: @Composable (modifier: Modifier, isPortrait: Boolean) -> Unit,
     coverExtra: @Composable (isPortrait: Boolean) -> Unit = {},
+    heroUrl: String? = null,
+    heroContent: @Composable () -> Unit = {},
     backgroundColors: List<Color> = listOf(SpColor.Background, SpColor.Background),
     sections: @Composable () -> Unit,
     fullWidthSections: @Composable () -> Unit = {},
@@ -96,6 +104,9 @@ fun GameDetailLayout(
                 topBar = topBar,
                 coverArt = coverArt,
                 coverExtra = coverExtra,
+                heroUrl = heroUrl,
+                heroContent = heroContent,
+                backgroundColors = backgroundColors,
                 sections = sections,
                 fullWidthSections = fullWidthSections,
             )
@@ -189,46 +200,137 @@ private fun PortraitLayout(
     topBar: @Composable () -> Unit,
     coverArt: @Composable (modifier: Modifier, isPortrait: Boolean) -> Unit,
     coverExtra: @Composable (isPortrait: Boolean) -> Unit,
+    heroUrl: String?,
+    heroContent: @Composable () -> Unit,
+    backgroundColors: List<Color>,
     sections: @Composable () -> Unit,
     fullWidthSections: @Composable () -> Unit,
 ) {
+    val bannerHeight = 250.dp + SpSpacing.TopBarHeight
+
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
             modifier = Modifier.fillMaxSize().testTag("game_detail_content"),
-            contentPadding = PaddingValues(top = SpSpacing.TopBarHeight + LocalTitleBarInset.current),
         ) {
+            // Hero banner item
             item {
-                val coverShape = RoundedCornerShape(SpSpacing.CardCornerRadius)
-                Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(bannerHeight),
                 ) {
-                    Spacer(Modifier.height(SpSpacing.Small))
+                    // Background: hero image or gradient fallback
+                    if (heroUrl != null) {
+                        SubcomposeAsyncImage(
+                            model = heroUrl,
+                            contentDescription = "Hero banner",
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop,
+                            loading = {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .background(SpColor.Background),
+                                )
+                            },
+                            error = {
+                                // Fallback to console gradient on error
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxSize()
+                                        .background(
+                                            Brush.verticalGradient(
+                                                listOf(
+                                                    backgroundColors.first().copy(alpha = 0.5f),
+                                                    backgroundColors.last(),
+                                                ),
+                                            ),
+                                        ),
+                                )
+                            },
+                        )
+                    } else {
+                        // Gradient fallback when no hero image
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(
+                                    Brush.verticalGradient(
+                                        listOf(
+                                            backgroundColors.first().copy(alpha = 0.5f),
+                                            backgroundColors.last(),
+                                        ),
+                                    ),
+                                ),
+                        )
+                    }
+
+                    // Gradient overlay: transparent at top, background at bottom
                     Box(
                         modifier = Modifier
+                            .fillMaxSize()
+                            .background(
+                                Brush.verticalGradient(
+                                    colorStops = arrayOf(
+                                        0.0f to Color.Transparent,
+                                        0.4f to backgroundColors.last().copy(alpha = 0.3f),
+                                        1.0f to backgroundColors.last(),
+                                    ),
+                                ),
+                            ),
+                    )
+
+                    // Content overlay: cover art (left) + title/badges (right)
+                    Row(
+                        modifier = Modifier
                             .fillMaxWidth()
-                            .heightIn(max = screenHeight * 0.5f)
-                            .padding(horizontal = SpSpacing.XXLarge)
-                            .shadow(8.dp, coverShape)
-                            .clip(coverShape)
-                            .border(1.dp, SpColor.Divider, coverShape),
+                            .align(Alignment.BottomStart)
+                            .padding(
+                                start = SpSpacing.XLarge,
+                                end = SpSpacing.XLarge,
+                                bottom = SpSpacing.Large,
+                            ),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Large),
+                        verticalAlignment = Alignment.Bottom,
                     ) {
-                        coverArt(Modifier.fillMaxWidth(), true)
+                        // Small cover art on the left
+                        val coverShape = RoundedCornerShape(SpSpacing.CardCornerRadius)
+                        Box(
+                            modifier = Modifier
+                                .width(100.dp)
+                                .shadow(12.dp, coverShape)
+                                .clip(coverShape)
+                                .border(2.dp, Color.White.copy(alpha = 0.15f), coverShape),
+                        ) {
+                            coverArt(Modifier.fillMaxWidth(), true)
+                        }
+
+                        // Title and badges to the right of cover
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .background(
+                                    Color.Black.copy(alpha = 0.4f),
+                                    RoundedCornerShape(SpSpacing.CardCornerRadius),
+                                )
+                                .padding(SpSpacing.Medium),
+                        ) {
+                            heroContent()
+                        }
                     }
-                    Spacer(Modifier.height(SpSpacing.Medium))
-                    coverExtra(true)
-                    Spacer(Modifier.height(SpSpacing.Large))
                 }
             }
 
+            // Sections below the banner
             item {
-                Spacer(Modifier.height(SpSpacing.Large))
                 Column(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(horizontal = SpSpacing.ScreenHorizontal),
+                        .padding(horizontal = SpSpacing.ScreenHorizontal)
+                        .padding(top = SpSpacing.Large),
                     verticalArrangement = Arrangement.spacedBy(SpSpacing.Large),
                 ) {
+                    coverExtra(true)
                     sections()
                     fullWidthSections()
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
@@ -208,14 +208,13 @@ private fun LandscapeLayout(
                         verticalAlignment = Alignment.Bottom,
                         horizontalArrangement = Arrangement.spacedBy(SpSpacing.Large),
                     ) {
-                        // Small cover art
+                        // Cover art — max width and height, dynamic sizing, no crop
                         val coverShape = RoundedCornerShape(SpSpacing.CardCornerRadius)
                         Box(
                             modifier = Modifier
-                                .width(coverWidth)
-                                .shadow(8.dp, coverShape)
-                                .clip(coverShape)
-                                .border(1.dp, SpColor.Divider, coverShape),
+                                .widthIn(max = coverWidth)
+                                .heightIn(max = 200.dp)
+                                .clip(coverShape),
                         ) {
                             coverArt(Modifier.fillMaxWidth(), false)
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/GameDetailLayout.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
@@ -95,6 +97,9 @@ fun GameDetailLayout(
                 topBar = topBar,
                 coverArt = coverArt,
                 coverExtra = coverExtra,
+                heroUrl = heroUrl,
+                heroContent = heroContent,
+                backgroundColors = backgroundColors,
                 sections = sections,
                 fullWidthSections = fullWidthSections,
             )
@@ -121,53 +126,136 @@ private fun LandscapeLayout(
     topBar: @Composable () -> Unit,
     coverArt: @Composable (modifier: Modifier, isPortrait: Boolean) -> Unit,
     coverExtra: @Composable (isPortrait: Boolean) -> Unit,
+    heroUrl: String? = null,
+    heroContent: @Composable () -> Unit = {},
+    backgroundColors: List<Color> = listOf(SpColor.Background, SpColor.Background),
     sections: @Composable () -> Unit,
     fullWidthSections: @Composable () -> Unit,
 ) {
     val verticalPad = if (isCompact) SpSpacing.Medium else SpSpacing.XLarge
+    val bannerHeight = 200.dp + SpSpacing.TopBarHeight + SpSpacing.Large
 
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
             modifier = Modifier
                 .fillMaxSize()
                 .testTag("game_detail_content"),
-            contentPadding = PaddingValues(
-                top = SpSpacing.TopBarHeight + LocalTitleBarInset.current + verticalPad,
-                bottom = verticalPad,
-            ),
+            contentPadding = PaddingValues(bottom = verticalPad),
         ) {
-            // Hero row: cover art (left) + sections (right)
+            // Hero banner — full-width with hero art
             item {
-                val coverShape = RoundedCornerShape(SpSpacing.CardCornerRadius)
-                Row(
+                Box(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(start = SpSpacing.ScreenHorizontal),
-                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXLarge),
+                        .height(bannerHeight),
                 ) {
-                    // Left: Cover art column
-                    Column(
-                        modifier = Modifier.width(coverWidth),
-                        horizontalAlignment = Alignment.CenterHorizontally,
+                    // Background: hero image or gradient fallback
+                    if (heroUrl != null) {
+                        SubcomposeAsyncImage(
+                            model = heroUrl,
+                            contentDescription = null,
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop,
+                            loading = {
+                                Box(modifier = Modifier.fillMaxSize().drawBehind {
+                                    val cx = size.width / 2f
+                                    val cy = size.height / 2f
+                                    val d = (size.width + size.height) * 0.25f
+                                    drawRect(brush = Brush.linearGradient(backgroundColors, Offset(cx - d, cy - d), Offset(cx + d, cy + d)))
+                                })
+                            },
+                            error = {
+                                Box(modifier = Modifier.fillMaxSize().drawBehind {
+                                    val cx = size.width / 2f
+                                    val cy = size.height / 2f
+                                    val d = (size.width + size.height) * 0.25f
+                                    drawRect(brush = Brush.linearGradient(backgroundColors, Offset(cx - d, cy - d), Offset(cx + d, cy + d)))
+                                })
+                            },
+                        )
+                    } else {
+                        Box(modifier = Modifier.fillMaxSize().drawBehind {
+                            val cx = size.width / 2f
+                            val cy = size.height / 2f
+                            val d = (size.width + size.height) * 0.25f
+                            drawRect(brush = Brush.linearGradient(backgroundColors, Offset(cx - d, cy - d), Offset(cx + d, cy + d)))
+                        })
+                    }
+
+                    // Gradient overlay
+                    Box(
+                        modifier = Modifier.fillMaxSize().background(
+                            Brush.verticalGradient(
+                                colorStops = arrayOf(
+                                    0.0f to Color.Transparent,
+                                    0.4f to SpColor.Background.copy(alpha = 0.3f),
+                                    1.0f to SpColor.Background,
+                                ),
+                            ),
+                        ),
+                    )
+
+                    // Content: cover art (left) + title/badges (right) in contrast backdrop
+                    Row(
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .padding(
+                                top = SpSpacing.TopBarHeight + SpSpacing.Large,
+                                start = SpSpacing.XLarge,
+                                end = SpSpacing.XLarge,
+                                bottom = SpSpacing.Large,
+                            ),
+                        verticalAlignment = Alignment.Bottom,
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Large),
                     ) {
+                        // Small cover art
+                        val coverShape = RoundedCornerShape(SpSpacing.CardCornerRadius)
                         Box(
                             modifier = Modifier
-                                .fillMaxWidth()
+                                .width(coverWidth)
                                 .shadow(8.dp, coverShape)
                                 .clip(coverShape)
                                 .border(1.dp, SpColor.Divider, coverShape),
                         ) {
                             coverArt(Modifier.fillMaxWidth(), false)
                         }
-                        Spacer(Modifier.height(SpSpacing.XLarge))
+
+                        // Title + badges in contrast backdrop
+                        Box(
+                            modifier = Modifier
+                                .weight(1f)
+                                .background(
+                                    Color.Black.copy(alpha = 0.4f),
+                                    RoundedCornerShape(SpSpacing.CardCornerRadius),
+                                )
+                                .padding(SpSpacing.Large),
+                        ) {
+                            heroContent()
+                        }
+                    }
+                }
+            }
+
+            // Content sections below the banner
+            item {
+                Spacer(Modifier.height(SpSpacing.Large))
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(horizontal = SpSpacing.ScreenHorizontal),
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXLarge),
+                ) {
+                    // Left: cover extra (rating, etc.)
+                    Column(
+                        modifier = Modifier.width(coverWidth),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                    ) {
                         coverExtra(false)
                     }
 
                     // Right: Content column
                     Column(
-                        modifier = Modifier
-                            .weight(1f)
-                            .padding(end = SpSpacing.ScreenHorizontal),
+                        modifier = Modifier.weight(1f),
                         verticalArrangement = Arrangement.spacedBy(SpSpacing.Large),
                     ) {
                         sections()
@@ -175,7 +263,7 @@ private fun LandscapeLayout(
                 }
             }
 
-            // Full-width sections below the hero row
+            // Full-width sections below
             item {
                 Spacer(Modifier.height(SpSpacing.Large))
                 Column(
@@ -206,7 +294,7 @@ private fun PortraitLayout(
     sections: @Composable () -> Unit,
     fullWidthSections: @Composable () -> Unit,
 ) {
-    val bannerHeight = 250.dp + SpSpacing.TopBarHeight
+    // Banner height is dynamic — wraps content (cover art + info box)
 
     Box(modifier = Modifier.fillMaxSize()) {
         LazyColumn(
@@ -215,89 +303,64 @@ private fun PortraitLayout(
             // Hero banner item
             item {
                 Box(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(bannerHeight),
+                    modifier = Modifier.fillMaxWidth(),
                 ) {
-                    // Background: hero image or gradient fallback
+                    // Background: hero image — sized by the content Column below via matchParentSize
                     if (heroUrl != null) {
                         SubcomposeAsyncImage(
                             model = heroUrl,
                             contentDescription = "Hero banner",
-                            modifier = Modifier.fillMaxSize(),
+                            modifier = Modifier.matchParentSize(),
                             contentScale = ContentScale.Crop,
                             loading = {
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxSize()
-                                        .background(SpColor.Background),
-                                )
+                                Box(modifier = Modifier.matchParentSize().background(SpColor.Background))
                             },
                             error = {
-                                // Fallback to console gradient on error
-                                Box(
-                                    modifier = Modifier
-                                        .fillMaxSize()
-                                        .background(
-                                            Brush.verticalGradient(
-                                                listOf(
-                                                    backgroundColors.first().copy(alpha = 0.5f),
-                                                    backgroundColors.last(),
-                                                ),
-                                            ),
-                                        ),
-                                )
+                                Box(modifier = Modifier.matchParentSize().background(
+                                    Brush.verticalGradient(listOf(
+                                        backgroundColors.first().copy(alpha = 0.5f),
+                                        backgroundColors.last(),
+                                    ))
+                                ))
                             },
                         )
                     } else {
-                        // Gradient fallback when no hero image
-                        Box(
-                            modifier = Modifier
-                                .fillMaxSize()
-                                .background(
-                                    Brush.verticalGradient(
-                                        listOf(
-                                            backgroundColors.first().copy(alpha = 0.5f),
-                                            backgroundColors.last(),
-                                        ),
-                                    ),
-                                ),
-                        )
+                        Box(modifier = Modifier.matchParentSize().background(
+                            Brush.verticalGradient(listOf(
+                                backgroundColors.first().copy(alpha = 0.5f),
+                                backgroundColors.last(),
+                            ))
+                        ))
                     }
 
-                    // Gradient overlay: transparent at top, background at bottom
-                    Box(
-                        modifier = Modifier
-                            .fillMaxSize()
-                            .background(
-                                Brush.verticalGradient(
-                                    colorStops = arrayOf(
-                                        0.0f to Color.Transparent,
-                                        0.4f to backgroundColors.last().copy(alpha = 0.3f),
-                                        1.0f to backgroundColors.last(),
-                                    ),
-                                ),
-                            ),
-                    )
+                    // Gradient overlay
+                    Box(modifier = Modifier.matchParentSize().background(
+                        Brush.verticalGradient(colorStops = arrayOf(
+                            0.0f to Color.Transparent,
+                            0.4f to backgroundColors.last().copy(alpha = 0.3f),
+                            1.0f to backgroundColors.last(),
+                        ))
+                    ))
 
-                    // Content overlay: cover art (left) + title/badges (right)
-                    Row(
+                    // Content: cover art centered above, info below
+                    // This Column defines the banner's height (wraps content)
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .align(Alignment.BottomStart)
                             .padding(
+                                top = SpSpacing.TopBarHeight + SpSpacing.Large,
                                 start = SpSpacing.XLarge,
                                 end = SpSpacing.XLarge,
                                 bottom = SpSpacing.Large,
                             ),
-                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Large),
-                        verticalAlignment = Alignment.Bottom,
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
                     ) {
-                        // Small cover art on the left
+                        // Cover art centered — 50% of screen width, dynamic height
                         val coverShape = RoundedCornerShape(SpSpacing.CardCornerRadius)
                         Box(
                             modifier = Modifier
-                                .width(100.dp)
+                                .fillMaxWidth(0.5f)
                                 .shadow(12.dp, coverShape)
                                 .clip(coverShape)
                                 .border(2.dp, Color.White.copy(alpha = 0.15f), coverShape),
@@ -305,10 +368,10 @@ private fun PortraitLayout(
                             coverArt(Modifier.fillMaxWidth(), true)
                         }
 
-                        // Title and badges to the right of cover
+                        // Title and badges below cover
                         Box(
                             modifier = Modifier
-                                .weight(1f)
+                                .fillMaxWidth()
                                 .background(
                                     Color.Black.copy(alpha = 0.4f),
                                     RoundedCornerShape(SpSpacing.CardCornerRadius),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCoverArt.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCoverArt.kt
@@ -49,7 +49,7 @@ fun SpCoverArt(
     } else {
         modifier.clip(shape)
     }
-    val scale = if (aspectRatio != null) ContentScale.Crop else ContentScale.FillWidth
+    val scale = if (aspectRatio != null) ContentScale.Crop else ContentScale.Fit
 
     Box(
         modifier = boxModifier,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpGameGrid.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpGameGrid.kt
@@ -1,0 +1,59 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.spela.player.presentation.ui.theme.SpSpacing
+import kotlin.math.max
+
+/**
+ * CONTENT component — a responsive non-lazy game card grid.
+ *
+ * Layer 2 in the component hierarchy (Design → Content → Role).
+ * Uses the same adaptive column sizing as the LazyVerticalGrid in ConsoleGamesScreen
+ * (GridCells.Adaptive with SpSpacing.GridCellMinWidth), but can be embedded
+ * inside a LazyColumn item since it's not lazy itself.
+ *
+ * @param items List of composable content blocks, one per grid cell.
+ * @param modifier Modifier for the grid container.
+ */
+@Composable
+fun SpGameGrid(
+    items: List<@Composable () -> Unit>,
+    modifier: Modifier = Modifier,
+) {
+    if (items.isEmpty()) return
+
+    BoxWithConstraints(modifier = modifier) {
+        val minCellWidth = SpSpacing.GridCellMinWidth
+        val gap = SpSpacing.Medium
+        val columns = max(1, ((maxWidth + gap) / (minCellWidth + gap)).toInt())
+        val chunked = items.chunked(columns)
+
+        Column(
+            verticalArrangement = Arrangement.spacedBy(gap),
+        ) {
+            chunked.forEach { rowItems ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(gap),
+                ) {
+                    rowItems.forEach { item ->
+                        Box(modifier = Modifier.weight(1f)) {
+                            item()
+                        }
+                    }
+                    repeat(columns - rowItems.size) {
+                        Spacer(Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpHeroBanner.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpHeroBanner.kt
@@ -1,0 +1,127 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+
+/**
+ * CONTENT component — a full-width hero banner with background art and overlaid content.
+ *
+ * Layer 2 in the component hierarchy (Design → Content → Role).
+ * Renders a hero image (or gradient fallback) with a gradient overlay for readability,
+ * and content overlaid in a semi-transparent contrast box.
+ *
+ * Used by developer/publisher screens, franchise/series screens, etc.
+ *
+ * @param heroUrl URL of the hero image. Falls back to gradient when null.
+ * @param modifier Modifier for the banner root.
+ * @param height Fixed height for the banner. Use null for dynamic height (wraps content).
+ * @param topPadding Padding above the content (e.g. to clear a floating top bar).
+ * @param content Content rendered inside the contrast backdrop box.
+ */
+@Composable
+fun SpHeroBanner(
+    heroUrl: String?,
+    modifier: Modifier = Modifier,
+    height: Dp? = null,
+    topPadding: Dp = SpSpacing.TopBarHeight + SpSpacing.Large,
+    content: @Composable () -> Unit,
+) {
+    val heightModifier = if (height != null) Modifier.height(height) else Modifier
+
+    Box(
+        modifier = modifier
+            .fillMaxWidth()
+            .then(heightModifier),
+    ) {
+        // Background: hero image or gradient fallback
+        if (heroUrl != null) {
+            SubcomposeAsyncImage(
+                model = heroUrl,
+                contentDescription = null,
+                modifier = if (height != null) Modifier.fillMaxSize() else Modifier.matchParentSize(),
+                contentScale = ContentScale.Crop,
+                loading = {
+                    Box(
+                        modifier = (if (height != null) Modifier.fillMaxSize() else Modifier.matchParentSize())
+                            .background(SpColor.Background),
+                    )
+                },
+                error = {
+                    GradientFallback(if (height != null) Modifier.fillMaxSize() else Modifier.matchParentSize())
+                },
+            )
+        } else {
+            GradientFallback(if (height != null) Modifier.fillMaxSize() else Modifier.matchParentSize())
+        }
+
+        // Gradient overlay: transparent at top, background at bottom
+        Box(
+            modifier = (if (height != null) Modifier.fillMaxSize() else Modifier.matchParentSize())
+                .background(
+                    Brush.verticalGradient(
+                        colorStops = arrayOf(
+                            0.0f to Color.Transparent,
+                            0.4f to SpColor.Background.copy(alpha = 0.3f),
+                            1.0f to SpColor.Background,
+                        ),
+                    ),
+                ),
+        )
+
+        // Content in contrast backdrop — centered, wraps content width
+        Box(
+            modifier = Modifier
+                .then(if (height != null) Modifier.fillMaxSize() else Modifier.fillMaxWidth())
+                .padding(
+                    top = topPadding,
+                    start = SpSpacing.XLarge,
+                    end = SpSpacing.XLarge,
+                    bottom = SpSpacing.Large,
+                ),
+            contentAlignment = Alignment.Center,
+        ) {
+            Box(
+                modifier = Modifier
+                    .background(
+                        Color.Black.copy(alpha = 0.4f),
+                        RoundedCornerShape(SpSpacing.CardCornerRadius),
+                    )
+                    .padding(SpSpacing.Large),
+                contentAlignment = Alignment.Center,
+            ) {
+                content()
+            }
+        }
+    }
+}
+
+@Composable
+private fun GradientFallback(modifier: Modifier) {
+    Box(
+        modifier = modifier.background(
+            Brush.verticalGradient(
+                listOf(
+                    SpColor.Primary.copy(alpha = 0.3f),
+                    SpColor.Background,
+                ),
+            ),
+        ),
+    )
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpLinkText.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpLinkText.kt
@@ -1,0 +1,40 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * DESIGN component — text styled as a clickable link.
+ *
+ * Layer 1 in the component hierarchy (Design → Content → Role).
+ * Uses underline decoration for universal affordance on any background.
+ * Does NOT use accent colors — works on all gradient backgrounds.
+ *
+ * Use for inline clickable text (developer name, publisher name, "Show more",
+ * "Browse Gallery", "See all", etc.). Do NOT use for buttons — use [SpButton] instead.
+ */
+@Composable
+fun SpLinkText(
+    text: String,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    onGradient: Boolean = false,
+    maxLines: Int = Int.MAX_VALUE,
+) {
+    Text(
+        text = text,
+        style = SpTypography.BodyMedium,
+        color = if (onGradient) Color.White else SpColor.OnBackground,
+        textDecoration = TextDecoration.Underline,
+        maxLines = maxLines,
+        overflow = TextOverflow.Ellipsis,
+        modifier = modifier.clickable(onClick = onClick),
+    )
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTitledSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTitledSection.kt
@@ -61,8 +61,8 @@ fun SpTitledSection(
             .background(Color.Black.copy(alpha = 0.18f), shape)
             .border(1.dp, SpColor.Divider.copy(alpha = 0.4f), shape)
             .let {
-                if (edgeToEdgeContent) it.padding(vertical = SpSpacing.Default)
-                else it.padding(SpSpacing.Default)
+                if (edgeToEdgeContent) it.padding(top = SpSpacing.Default, bottom = SpSpacing.XLarge)
+                else it.padding(start = SpSpacing.Default, end = SpSpacing.Default, top = SpSpacing.Default, bottom = SpSpacing.XLarge)
             },
     ) {
         Column(modifier = Modifier.fillMaxWidth()) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpWideIconCard.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpWideIconCard.kt
@@ -1,16 +1,21 @@
 package com.spela.player.presentation.ui.components
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.contentDescription
@@ -24,38 +29,34 @@ import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 
 /**
- * CONTENT component — horizontal game card with cover on the left and text on the right.
+ * CONTENT component — horizontal card with icon/avatar on the left and text on the right.
  *
  * Layer 2 in the component hierarchy (Design → Content → Role).
- * Composes [SpCard] + [SpCoverArt] into a horizontal layout.
- * Used for cards that need more horizontal space (e.g. Continue Playing).
+ * Matches the layout of [SpWideGameCard] but with an icon slot instead of cover art.
+ * Used for non-game search results (consoles, developers, collections, etc).
  *
- * Parallel to [SpGameCard] (vertical layout). Both use [SpCard] as their
- * design component. Choose based on layout needs:
- * - [SpGameCard] — vertical, compact, for shelves and grids
- * - [SpWideGameCard] — horizontal, spacious, for featured/prominent cards
- *
- * Does NOT accept a modifier parameter — the layout is strict.
- * Parent controls sizing via the [width] parameter only.
- *
- * @param extraContent Optional composable rendered below the subtitle
- *   (e.g. play time, console chip). Rendered inside the text column.
+ * @param title Primary text (TitleLarge).
+ * @param subtitle Secondary text below title.
+ * @param onClick Click handler.
+ * @param icon Composable rendered inside the icon box (e.g. Icon, Text with initials).
+ * @param iconSize Size of the icon box.
+ * @param testTag Optional test tag.
+ * @param extraContent Optional composable below the subtitle.
  */
 @Composable
-fun SpWideGameCard(
+fun SpWideIconCard(
     title: String,
     subtitle: String,
-    coverUrl: String?,
     onClick: () -> Unit,
-    coverAspectRatio: Float = 0.75f,
-    width: Dp = 280.dp,
-    fillWidth: Boolean = false,
-    coverHeight: Dp = 84.dp,
+    icon: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    iconSize: Dp = 56.dp,
     testTag: String? = null,
     extraContent: (@Composable () -> Unit)? = null,
 ) {
     SpCard(
-        modifier = (if (fillWidth) Modifier.fillMaxWidth() else Modifier.width(width))
+        modifier = modifier
+            .fillMaxWidth()
             .let { if (testTag != null) it.testTag(testTag) else it }
             .semantics {
                 contentDescription = "$title, $subtitle"
@@ -70,13 +71,15 @@ fun SpWideGameCard(
                 .padding(SpSpacing.Medium),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            SpCoverArt(
-                imageUrl = coverUrl,
-                contentDescription = "$title cover art",
-                modifier = Modifier.height(coverHeight),
-                cornerRadius = SpSpacing.RadiusMedium,
-                aspectRatio = coverAspectRatio,
-            )
+            Box(
+                modifier = Modifier
+                    .size(iconSize)
+                    .clip(RoundedCornerShape(SpSpacing.RadiusMedium))
+                    .background(SpColor.SurfaceVariant),
+                contentAlignment = Alignment.Center,
+            ) {
+                icon()
+            }
             Spacer(Modifier.width(SpSpacing.Medium))
             Column(modifier = Modifier.weight(1f)) {
                 Text(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
@@ -57,6 +57,7 @@ import com.spela.player.domain.model.DeveloperDetailUserStats
 import com.spela.player.domain.model.Game
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpLinkText
 import com.spela.player.presentation.ui.components.SpCarouselGameCard
 import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.theme.SpColor
@@ -565,12 +566,10 @@ internal fun DeveloperCompanyDescription(
         )
 
         if (hasOverflow || expanded) {
-            Text(
+            SpLinkText(
                 text = if (expanded) "Show less" else "Show more",
-                style = SpTypography.LabelMedium,
-                color = SpColor.Primary,
+                onClick = { expanded = !expanded },
                 modifier = Modifier
-                    .clickable { expanded = !expanded }
                     .padding(top = SpSpacing.XSmall)
                     .testTag("developer_company_description_toggle"),
             )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
@@ -39,7 +39,15 @@ import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.SeriesConsole
 import com.spela.player.domain.model.SeriesDetail
 import com.spela.player.domain.model.SeriesGame
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpGameGrid
+import com.spela.player.presentation.ui.components.SpGridGameCard
+import com.spela.player.presentation.ui.components.SpHeroBanner
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpEmptyState
@@ -89,14 +97,13 @@ fun ExploreGroupDetailContent(
             modifier = Modifier
                 .fillMaxSize(),
         ) {
-            SpTopBar(
-                title = title,
-                showBack = true,
-                onBack = onBack,
-            )
-
             when {
                 isLoading && detail == null -> {
+                    SpTopBar(
+                        title = title,
+                        showBack = true,
+                        onBack = onBack,
+                    )
                     // Loading skeleton
                     Column(
                         modifier = Modifier
@@ -116,59 +123,58 @@ fun ExploreGroupDetailContent(
                 }
 
                 detail != null -> {
+                    // Use the series/franchise hero URL (best-rated game's hero art)
+                    val heroUrl = detail.heroUrl
+
+                    Box(modifier = Modifier.fillMaxSize()) {
                     LazyColumn(
                         modifier = Modifier.fillMaxSize(),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.Large),
                         contentPadding = PaddingValues(bottom = SpSpacing.XXLarge),
                     ) {
-                        // Hero banner with gradient
+                        // Hero banner
                         item {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .height(160.dp)
-                                    .background(
-                                        Brush.verticalGradient(
-                                            listOf(
-                                                SpColor.Primary.copy(alpha = 0.3f),
-                                                SpColor.Background,
-                                            ),
-                                        ),
+                            SpHeroBanner(
+                                heroUrl = heroUrl,
+                                height = (260 + 64 + 24).dp,
+                                modifier = Modifier.testTag("${groupLabel}_hero_banner"),
+                            ) {
+                                Column(
+                                    horizontalAlignment = Alignment.CenterHorizontally,
+                                    verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                                ) {
+                                    // Franchise/series logo image or name text fallback
+                                    val logoUrl = detail.logoUrl
+                                    if (logoUrl != null) {
+                                        SubcomposeAsyncImage(
+                                            model = logoUrl,
+                                            contentDescription = detail.name,
+                                            modifier = Modifier
+                                                .heightIn(max = 120.dp),
+                                            contentScale = ContentScale.Fit,
+                                            error = {
+                                                Text(
+                                                    text = detail.name,
+                                                    style = SpTypography.DisplaySmall,
+                                                    fontWeight = FontWeight.Bold,
+                                                    color = Color.White,
+                                                )
+                                            },
+                                        )
+                                    } else {
+                                        Text(
+                                            text = detail.name,
+                                            style = SpTypography.DisplaySmall,
+                                            fontWeight = FontWeight.Bold,
+                                            color = Color.White,
+                                        )
+                                    }
+                                    Text(
+                                        text = "${detail.totalGames} games",
+                                        style = SpTypography.BodyMedium,
+                                        color = Color.White.copy(alpha = 0.7f),
                                     )
-                                    .testTag("${groupLabel}_hero_banner"),
-                                contentAlignment = Alignment.Center,
-                            ) {
-                                Text(
-                                    text = detail.name,
-                                    style = SpTypography.DisplaySmall,
-                                    color = SpColor.OnBackground,
-                                )
-                            }
-                        }
-
-                        // Ownership progress
-                        item {
-                            Column(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(horizontal = SpSpacing.ScreenHorizontal)
-                                    .testTag("${groupLabel}_ownership_progress"),
-                            ) {
-                                val progress = if (detail.totalGames > 0) {
-                                    detail.libraryGames.toFloat() / detail.totalGames.toFloat()
-                                } else 0f
-
-                                Text(
-                                    text = "You own ${detail.libraryGames} of ${detail.totalGames} games",
-                                    style = SpTypography.BodyMedium,
-                                    color = SpColor.OnBackgroundSecondary,
-                                    modifier = Modifier.testTag("${groupLabel}_ownership_text"),
-                                )
-                                Spacer(Modifier.height(SpSpacing.Small))
-                                SpProgressBar(
-                                    progress = progress,
-                                    modifier = Modifier.fillMaxWidth(),
-                                )
-                                Spacer(Modifier.height(SpSpacing.Large))
+                                }
                             }
                         }
 
@@ -207,23 +213,46 @@ fun ExploreGroupDetailContent(
                                 }
                             }
                         } else {
-                            items(
-                                items = filteredGames,
-                                key = { it.igdbGameId },
-                            ) { game ->
-                                TimelineItem(
-                                    game = game,
-                                    testTagPrefix = groupLabel,
-                                    onClick = if (game.inLibrary && game.localGameId != null) {
-                                        { onGameSelected(game.localGameId) }
-                                    } else null,
+                            item {
+                                SpGameGrid(
+                                    items = filteredGames.map { game ->
+                                        @Composable {
+                                            Box(modifier = Modifier.alpha(if (game.inLibrary) 1f else 0.5f)) {
+                                                SpGridGameCard(
+                                                    title = game.name,
+                                                    subtitle = game.consoleName ?: "",
+                                                    coverUrl = game.coverUrl,
+                                                    onClick = if (game.inLibrary && game.localGameId != null) {
+                                                        { onGameSelected(game.localGameId) }
+                                                    } else ({}),
+                                                    rating = game.rating,
+                                                    testTag = "${groupLabel}_game_${game.igdbGameId}",
+                                                )
+                                            }
+                                        }
+                                    },
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(horizontal = SpSpacing.ScreenHorizontal),
                                 )
                             }
                         }
                     }
+                    // Floating top bar over the banner
+                    SpTopBar(
+                        title = "",
+                        showBack = true,
+                        onBack = onBack,
+                    )
+                    } // Box
                 }
 
                 else -> {
+                    SpTopBar(
+                        title = title,
+                        showBack = true,
+                        onBack = onBack,
+                    )
                     Box(
                         modifier = Modifier.fillMaxSize(),
                         contentAlignment = Alignment.Center,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
@@ -243,6 +243,7 @@ fun ExploreGroupDetailContent(
                         title = "",
                         showBack = true,
                         onBack = onBack,
+                        onGradient = true,
                     )
                     } // Box
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.Game
 import com.spela.player.presentation.ui.theme.SpColor
@@ -142,7 +143,8 @@ private fun MetadataItem(
             Text(
                 text = value,
                 style = SpTypography.BodyMedium,
-                color = if (isClickable) SpColor.Primary else SpColor.OnBackground,
+                color = if (onGradient) androidx.compose.ui.graphics.Color.White else SpColor.OnBackground,
+                textDecoration = if (isClickable) TextDecoration.Underline else TextDecoration.None,
             )
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SimilarGamesRow.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SimilarGamesRow.kt
@@ -52,7 +52,7 @@ internal fun SimilarGamesSection(
             contentPadding = PaddingValues(horizontal = SpSpacing.XLarge),
             horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
         ) {
-            items(games, key = { it.name }) { game ->
+            items(games, key = { it.igdbGameId }) { game ->
                 SimilarGameCard(
                     game = game,
                     onClick = if (game.localGameId != null) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/QuickResultsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/QuickResultsSection.kt
@@ -1,17 +1,16 @@
 package com.spela.player.presentation.ui.feature.search
 
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Folder
@@ -23,17 +22,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.semantics.Role
-import androidx.compose.ui.semantics.contentDescription
-import androidx.compose.ui.semantics.role
-import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.spela.player.domain.model.SearchSuggestion
 import com.spela.player.domain.model.SuggestionNavigationType
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpCoverArt
-import com.spela.player.presentation.ui.gamepad.spFocusRing
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -55,7 +51,6 @@ fun QuickResultsSection(
             .fillMaxWidth()
             .testTag("quick_results_section"),
     ) {
-        // Section header
         Text(
             text = "Quick results",
             style = SpTypography.TitleMedium,
@@ -93,50 +88,50 @@ private fun QuickResultItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
+    SpCard(
         modifier = modifier
             .fillMaxWidth()
-            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clickable(onClick = onClick)
-            .focusable()
-            .padding(
-                horizontal = SpSpacing.ScreenHorizontal,
-                vertical = SpSpacing.Small,
-            )
-            .testTag("quick_result_${suggestion.type.lowercase()}_${suggestion.id}")
-            .semantics {
-                contentDescription = "${suggestion.name}, ${suggestion.type}"
-                role = Role.Button
-            },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+            .padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XXSmall)
+            .testTag("quick_result_${suggestion.type.lowercase()}_${suggestion.id}"),
+        onClick = onClick,
     ) {
-        // Thumbnail / icon
-        QuickResultThumbnail(suggestion = suggestion)
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SpSpacing.Medium),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+        ) {
+            // Thumbnail / icon
+            QuickResultThumbnail(suggestion = suggestion)
 
-        // Name and subtitle
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = suggestion.name,
-                style = SpTypography.TitleSmall,
-                color = SpColor.OnBackground,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            if (suggestion.subtitle.isNotBlank()) {
+            // Name and subtitle
+            Column(modifier = Modifier.weight(1f)) {
                 Text(
-                    text = suggestion.subtitle,
-                    style = SpTypography.LabelSmall,
-                    color = SpColor.OnBackgroundTertiary,
+                    text = suggestion.name,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis,
                 )
+                if (suggestion.subtitle.isNotBlank()) {
+                    Spacer(Modifier.height(SpSpacing.XXSmall))
+                    Text(
+                        text = suggestion.subtitle,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                        maxLines = 1,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                }
             }
-        }
 
-        // Type badge
-        TypeBadge(type = suggestion.type)
+            // Type badge using SpChip
+            SpChip(
+                text = suggestion.type,
+                isSelected = true,
+            )
+        }
     }
 }
 
@@ -152,16 +147,16 @@ private fun QuickResultThumbnail(
             imageUrl = suggestion.imageUrl,
             contentDescription = "${suggestion.name} cover",
             modifier = modifier
-                .width(SpSpacing.IconXLarge)
-                .height(43.dp), // 32dp * 4/3 aspect ratio
+                .width(40.dp)
+                .height(54.dp),
             aspectRatio = 0.75f,
             cornerRadius = SpSpacing.RadiusSmall,
         )
     } else {
         Box(
             modifier = modifier
-                .size(SpSpacing.IconXLarge)
-                .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
+                .size(40.dp)
+                .clip(RoundedCornerShape(SpSpacing.RadiusMedium))
                 .background(SpColor.SurfaceVariant),
             contentAlignment = Alignment.Center,
         ) {
@@ -173,7 +168,7 @@ private fun QuickResultThumbnail(
                     AsyncImage(
                         model = suggestion.imageUrl,
                         contentDescription = null,
-                        modifier = Modifier.size(SpSpacing.IconDefault),
+                        modifier = Modifier.size(24.dp),
                     )
                 }
                 isCollection -> {
@@ -181,7 +176,7 @@ private fun QuickResultThumbnail(
                         imageVector = Icons.Filled.Folder,
                         contentDescription = null,
                         tint = SpColor.OnBackgroundSecondary,
-                        modifier = Modifier.size(18.dp),
+                        modifier = Modifier.size(20.dp),
                     )
                 }
                 isConsole -> {
@@ -189,38 +184,19 @@ private fun QuickResultThumbnail(
                         imageVector = Icons.Filled.Gamepad,
                         contentDescription = null,
                         tint = SpColor.OnBackgroundSecondary,
-                        modifier = Modifier.size(18.dp),
+                        modifier = Modifier.size(20.dp),
                     )
                 }
                 else -> {
                     Text(
                         text = suggestion.name.take(2).uppercase(),
-                        style = SpTypography.LabelSmall,
+                        style = SpTypography.LabelMedium,
                         color = SpColor.OnBackgroundSecondary,
                     )
                 }
             }
         }
     }
-}
-
-@Composable
-private fun TypeBadge(
-    type: String,
-    modifier: Modifier = Modifier,
-) {
-    Text(
-        text = type,
-        style = SpTypography.LabelSmall,
-        color = SpColor.Primary,
-        modifier = modifier
-            .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
-            .background(SpColor.PrimaryContainer)
-            .padding(
-                horizontal = SpSpacing.Small,
-                vertical = SpSpacing.XXSmall,
-            ),
-    )
 }
 
 private fun dispatchNavigation(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultSections.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/search/SearchResultSections.kt
@@ -1,8 +1,5 @@
 package com.spela.player.presentation.ui.feature.search
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -12,8 +9,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Folder
 import androidx.compose.material.icons.filled.Gamepad
@@ -37,9 +32,11 @@ import com.spela.player.domain.model.SearchConsoleResult
 import com.spela.player.domain.model.SearchFranchiseResult
 import com.spela.player.domain.model.SearchGameResult
 import com.spela.player.domain.model.SearchSeriesResult
-import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpCard
+import com.spela.player.presentation.ui.components.SpLinkText
+import com.spela.player.presentation.ui.components.SpWideGameCard
+import com.spela.player.presentation.ui.components.SpWideIconCard
 import com.spela.player.presentation.ui.components.SpShimmer
-import com.spela.player.presentation.ui.gamepad.spFocusRing
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -72,15 +69,10 @@ fun SearchSectionHeader(
         )
         when {
             isExpanded && onShowLess != null -> {
-                Text(
+                SpLinkText(
                     text = "Show less",
-                    style = SpTypography.LabelSmall,
-                    color = SpColor.Primary,
+                    onClick = onShowLess,
                     modifier = Modifier
-                        .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusSmall))
-                        .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
-                        .clickable(onClick = onShowLess)
-                        .focusable()
                         .padding(
                             horizontal = SpSpacing.Small,
                             vertical = SpSpacing.XSmall,
@@ -89,15 +81,10 @@ fun SearchSectionHeader(
                 )
             }
             total > displayedCount && onSeeAll != null -> {
-                Text(
+                SpLinkText(
                     text = "See all $total",
-                    style = SpTypography.LabelSmall,
-                    color = SpColor.Primary,
+                    onClick = onSeeAll,
                     modifier = Modifier
-                        .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusSmall))
-                        .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
-                        .clickable(onClick = onSeeAll)
-                        .focusable()
                         .padding(
                             horizontal = SpSpacing.Small,
                             vertical = SpSpacing.XSmall,
@@ -122,58 +109,17 @@ fun GameSearchResultItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clickable(onClick = onClick)
-            .focusable()
-            .padding(
-                horizontal = SpSpacing.ScreenHorizontal,
-                vertical = SpSpacing.Small,
-            )
-            .testTag("search_result_game_${game.id}")
-            .semantics {
-                contentDescription = "${game.title}, ${game.consoleName}"
-                role = Role.Button
-            },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-    ) {
-        SpCoverArt(
-            imageUrl = game.coverUrl,
-            contentDescription = "${game.title} cover",
-            modifier = Modifier
-                .width(40.dp)
-                .height(54.dp),
-            aspectRatio = game.coverAspectRatio,
-            cornerRadius = SpSpacing.RadiusSmall,
-        )
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = game.title,
-                style = SpTypography.TitleSmall,
-                color = SpColor.OnBackground,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
-            ) {
-                Text(
-                    text = game.consoleName,
-                    style = SpTypography.LabelSmall,
-                    color = SpColor.Primary,
-                    maxLines = 1,
-                )
-                if (!game.developer.isNullOrBlank()) {
-                    Text(
-                        text = "\u00B7",
-                        style = SpTypography.LabelSmall,
-                        color = SpColor.OnBackgroundTertiary,
-                    )
+    Box(modifier = modifier.padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XXSmall)) {
+        SpWideGameCard(
+            title = game.title,
+            subtitle = game.consoleName,
+            coverUrl = game.coverUrl,
+            onClick = onClick,
+            coverAspectRatio = game.coverAspectRatio,
+            fillWidth = true,
+            testTag = "search_result_game_${game.id}",
+            extraContent = if (!game.developer.isNullOrBlank()) {
+                {
                     Text(
                         text = game.developer,
                         style = SpTypography.LabelSmall,
@@ -182,8 +128,8 @@ fun GameSearchResultItem(
                         overflow = TextOverflow.Ellipsis,
                     )
                 }
-            }
-        }
+            } else null,
+        )
     }
 }
 
@@ -193,61 +139,29 @@ fun ConsoleSearchResultItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clickable(onClick = onClick)
-            .focusable()
-            .padding(
-                horizontal = SpSpacing.ScreenHorizontal,
-                vertical = SpSpacing.Small,
-            )
-            .testTag("search_result_console_${console.id}")
-            .semantics {
-                contentDescription = "${console.name}, ${console.gameCount} games"
-                role = Role.Button
+    Box(modifier = modifier.padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XXSmall)) {
+        SpWideIconCard(
+            title = console.name,
+            subtitle = "${console.gameCount} games",
+            onClick = onClick,
+            testTag = "search_result_console_${console.id}",
+            icon = {
+                if (console.iconUrl.isNotBlank()) {
+                    AsyncImage(
+                        model = console.iconUrl,
+                        contentDescription = null,
+                        modifier = Modifier.size(28.dp),
+                    )
+                } else {
+                    Icon(
+                        imageVector = Icons.Filled.Gamepad,
+                        contentDescription = null,
+                        tint = SpColor.OnBackgroundSecondary,
+                        modifier = Modifier.size(28.dp),
+                    )
+                }
             },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-    ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
-                .background(SpColor.SurfaceVariant),
-            contentAlignment = Alignment.Center,
-        ) {
-            if (console.iconUrl.isNotBlank()) {
-                AsyncImage(
-                    model = console.iconUrl,
-                    contentDescription = null,
-                    modifier = Modifier.size(24.dp),
-                )
-            } else {
-                Icon(
-                    imageVector = Icons.Filled.Gamepad,
-                    contentDescription = null,
-                    tint = SpColor.OnBackgroundSecondary,
-                    modifier = Modifier.size(24.dp),
-                )
-            }
-        }
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = console.name,
-                style = SpTypography.TitleSmall,
-                color = SpColor.OnBackground,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            Text(
-                text = "${console.gameCount} games",
-                style = SpTypography.LabelSmall,
-                color = SpColor.OnBackgroundTertiary,
-            )
-        }
+        )
     }
 }
 
@@ -260,70 +174,40 @@ fun CompanySearchResultItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clickable(onClick = onClick)
-            .focusable()
-            .padding(
-                horizontal = SpSpacing.ScreenHorizontal,
-                vertical = SpSpacing.Small,
-            )
-            .testTag("search_result_${label.lowercase()}_$name")
-            .semantics {
-                contentDescription = "$name, $gameCount games"
-                role = Role.Button
-            },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-    ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
-                .background(SpColor.SurfaceVariant),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = name.take(2).uppercase(),
-                style = SpTypography.LabelMedium,
-                color = SpColor.OnBackgroundSecondary,
-            )
-        }
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = name,
-                style = SpTypography.TitleSmall,
-                color = SpColor.OnBackground,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
-            ) {
+    Box(modifier = modifier.padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XXSmall)) {
+        SpWideIconCard(
+            title = name,
+            subtitle = "$gameCount games",
+            onClick = onClick,
+            testTag = "search_result_${label.lowercase()}_$name",
+            icon = {
                 Text(
-                    text = "$gameCount games",
-                    style = SpTypography.LabelSmall,
-                    color = SpColor.OnBackgroundTertiary,
+                    text = name.take(2).uppercase(),
+                    style = SpTypography.TitleMedium,
+                    color = SpColor.OnBackgroundSecondary,
                 )
-                if (avgRating > 0) {
-                    Icon(
-                        imageVector = Icons.Filled.Star,
-                        contentDescription = null,
-                        tint = SpColor.Rating,
-                        modifier = Modifier.size(SpSpacing.IconXSmall),
-                    )
-                    Text(
-                        text = formatRating(avgRating),
-                        style = SpTypography.LabelSmall,
-                        color = SpColor.OnBackgroundTertiary,
-                    )
+            },
+            extraContent = if (avgRating > 0) {
+                {
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                    ) {
+                        Icon(
+                            imageVector = Icons.Filled.Star,
+                            contentDescription = null,
+                            tint = SpColor.Rating,
+                            modifier = Modifier.size(SpSpacing.IconXSmall),
+                        )
+                        Text(
+                            text = formatRating(avgRating),
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
                 }
-            }
-        }
+            } else null,
+        )
     }
 }
 
@@ -333,62 +217,21 @@ fun CollectionSearchResultItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clickable(onClick = onClick)
-            .focusable()
-            .padding(
-                horizontal = SpSpacing.ScreenHorizontal,
-                vertical = SpSpacing.Small,
-            )
-            .testTag("search_result_collection_${collection.id}")
-            .semantics {
-                contentDescription = "${collection.name}, ${collection.gameCount} games"
-                role = Role.Button
+    Box(modifier = modifier.padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XXSmall)) {
+        SpWideIconCard(
+            title = collection.name,
+            subtitle = "${collection.username} \u00B7 ${collection.gameCount} games",
+            onClick = onClick,
+            testTag = "search_result_collection_${collection.id}",
+            icon = {
+                Icon(
+                    imageVector = Icons.Filled.Folder,
+                    contentDescription = null,
+                    tint = SpColor.OnBackgroundSecondary,
+                    modifier = Modifier.size(28.dp),
+                )
             },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-    ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
-                .background(SpColor.SurfaceVariant),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                imageVector = Icons.Filled.Folder,
-                contentDescription = null,
-                tint = SpColor.OnBackgroundSecondary,
-                modifier = Modifier.size(24.dp),
-            )
-        }
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = collection.name,
-                style = SpTypography.TitleSmall,
-                color = SpColor.OnBackground,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            Row(
-                horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
-            ) {
-                Text(
-                    text = collection.username,
-                    style = SpTypography.LabelSmall,
-                    color = SpColor.Primary,
-                )
-                Text(
-                    text = "\u00B7 ${collection.gameCount} games",
-                    style = SpTypography.LabelSmall,
-                    color = SpColor.OnBackgroundTertiary,
-                )
-            }
-        }
+        )
     }
 }
 
@@ -401,52 +244,20 @@ fun GroupSearchResultItem(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .spFocusRing(shape = RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
-            .clickable(onClick = onClick)
-            .focusable()
-            .padding(
-                horizontal = SpSpacing.ScreenHorizontal,
-                vertical = SpSpacing.Small,
-            )
-            .testTag("search_result_${testTagPrefix}")
-            .semantics {
-                contentDescription = "$name, $subtitle"
-                role = Role.Button
+    Box(modifier = modifier.padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XXSmall)) {
+        SpWideIconCard(
+            title = name,
+            subtitle = subtitle,
+            onClick = onClick,
+            testTag = "search_result_${testTagPrefix}",
+            icon = {
+                Text(
+                    text = avatarText,
+                    style = SpTypography.TitleMedium,
+                    color = SpColor.OnBackgroundSecondary,
+                )
             },
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-    ) {
-        Box(
-            modifier = Modifier
-                .size(40.dp)
-                .clip(RoundedCornerShape(SpSpacing.RadiusSmall))
-                .background(SpColor.SurfaceVariant),
-            contentAlignment = Alignment.Center,
-        ) {
-            Text(
-                text = avatarText,
-                style = SpTypography.LabelMedium,
-                color = SpColor.OnBackgroundSecondary,
-            )
-        }
-        Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = name,
-                style = SpTypography.TitleSmall,
-                color = SpColor.OnBackground,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
-            Text(
-                text = subtitle,
-                style = SpTypography.LabelSmall,
-                color = SpColor.OnBackgroundTertiary,
-            )
-        }
+        )
     }
 }
 
@@ -491,47 +302,25 @@ fun SearchResultSkeleton(
             .fillMaxWidth()
             .padding(horizontal = SpSpacing.ScreenHorizontal),
     ) {
-        // Mimic a section header
         SpShimmer(width = 80.dp, height = 16.dp)
         Spacer(Modifier.height(SpSpacing.Medium))
-
-        // Mimic several result rows
         repeat(4) {
-            Row(
+            SpCard(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(vertical = SpSpacing.Small),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                    .padding(vertical = SpSpacing.XXSmall),
             ) {
-                SpShimmer(width = 40.dp, height = 54.dp)
-                Column(modifier = Modifier.weight(1f)) {
-                    SpShimmer(width = 160.dp, height = 14.dp)
-                    Spacer(Modifier.height(SpSpacing.XSmall))
-                    SpShimmer(width = 100.dp, height = 12.dp)
-                }
-            }
-        }
-
-        Spacer(Modifier.height(SpSpacing.Large))
-
-        // Second section
-        SpShimmer(width = 100.dp, height = 16.dp)
-        Spacer(Modifier.height(SpSpacing.Medium))
-
-        repeat(3) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(vertical = SpSpacing.Small),
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-            ) {
-                SpShimmer(width = 40.dp, height = 40.dp)
-                Column(modifier = Modifier.weight(1f)) {
-                    SpShimmer(width = 140.dp, height = 14.dp)
-                    Spacer(Modifier.height(SpSpacing.XSmall))
-                    SpShimmer(width = 80.dp, height = 12.dp)
+                Row(
+                    modifier = Modifier.padding(SpSpacing.Medium),
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    SpShimmer(width = 40.dp, height = 54.dp)
+                    Column {
+                        SpShimmer(width = 160.dp, height = 14.dp)
+                        Spacer(Modifier.height(SpSpacing.XSmall))
+                        SpShimmer(width = 100.dp, height = 12.dp)
+                    }
                 }
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
@@ -245,6 +245,7 @@ fun ExploreDeveloperScreen(
                         title = "",
                         showBack = true,
                         onBack = onBack,
+                        onGradient = true,
                     )
                     } // Box
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
@@ -27,6 +27,8 @@ import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpGameGrid
+import com.spela.player.presentation.ui.components.SpGridGameCard
 import com.spela.player.presentation.ui.components.SpEmptyState
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpSnackbar
@@ -190,7 +192,41 @@ fun ExploreDeveloperScreen(
                             }
                         }
 
-                        // 4. Your Stats
+                        // 4. Games grid
+                        if (detail.games.isNotEmpty()) {
+                            item {
+                                SpTitledSection(
+                                    title = "Games",
+                                    titleTrailing = if (detail.games.size > 12 && onNavigateToGames != null) {
+                                        {
+                                            SpButton(
+                                                text = "See all",
+                                                style = SpButtonStyle.Ghost,
+                                                onClick = { onNavigateToGames(name, isDeveloper) },
+                                            )
+                                        }
+                                    } else null,
+                                ) {
+                                    SpGameGrid(
+                                        items = detail.games.take(12).map { game ->
+                                            @Composable {
+                                                SpGridGameCard(
+                                                    title = game.title,
+                                                    subtitle = game.consoleName,
+                                                    coverUrl = game.coverUrl,
+                                                    onClick = { onGameSelected(game.id) },
+                                                    rating = game.averageRating,
+                                                    isFavorite = game.isFavorite,
+                                                    isInPlayLater = game.isInPlayLater,
+                                                )
+                                            }
+                                        },
+                                    )
+                                }
+                            }
+                        }
+
+                        // 5. Your Stats
                         if (detail.userStats != null) {
                             item {
                                 SpTitledSection(title = "Your Stats") {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -175,38 +175,22 @@ fun GameDetailScreen(
             backgroundColors = backgroundColors,
             heroUrl = game.heroUrl ?: detail.screenshots.firstOrNull(),
             heroContent = {
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-                ) {
-                    // Title
-                    Text(
-                        text = game.title,
-                        style = SpTypography.HeadlineMedium,
-                        fontWeight = FontWeight.Bold,
-                        color = Color.White,
-                        maxLines = 2,
-                        overflow = TextOverflow.Ellipsis,
-                    )
-                    // Badges: console, region, verification
-                    @OptIn(ExperimentalLayoutApi::class)
-                    FlowRow(
-                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-                        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-                    ) {
-                        SpConsoleChip(
-                            consoleName = game.consoleName,
-                            consoleColor = getConsoleColor(game.consoleName),
-                            onGradient = true,
-                        )
-                        game.region?.takeIf { it.isNotBlank() }?.let { region ->
-                            SpRegionChip(region = region, onGradient = true)
-                        }
-                        VerificationChip(
-                            verificationStatus = game.verificationStatus,
-                            verificationTag = game.verificationTag,
-                        )
-                    }
-                }
+                GameHeroContent(
+                    gameId = gameId,
+                    game = game,
+                    state = state,
+                    hasSaves = state.sessions.isNotEmpty(),
+                    missingBiosFiles = state.missingBiosFiles,
+                    onPlay = onPlay,
+                    onPlayFresh = onPlayFresh,
+                    onDownloadGame = { viewModel.onIntent(GameDetailIntent.DownloadGame) },
+                    onToggleFavorite = { viewModel.onIntent(GameDetailIntent.ToggleFavorite) },
+                    onTogglePlayLater = { viewModel.onIntent(GameDetailIntent.TogglePlayLater) },
+                    onAddToCollection = { viewModel.onIntent(GameDetailIntent.ShowAddToCollectionDialog) },
+                    onCreateNetplay = onCreateNetplay,
+                    onDeleteLocalGame = { viewModel.onIntent(GameDetailIntent.ShowDeleteDownloadDialog) },
+                    syncState = syncState,
+                )
             },
             coverArt = { modifier, isPortrait ->
                 // Read coverUrl from state delegate (not snapshot) so
@@ -575,64 +559,7 @@ private fun GameInfoContent(
     onNavigateToDeveloper: ((name: String) -> Unit)? = null,
     onNavigateToPublisher: ((name: String) -> Unit)? = null,
 ) {
-    // Game info header — title, badges, and actions
-    Column(verticalArrangement = Arrangement.spacedBy(SpSpacing.Default)) {
-
-    // Title and badges are in the hero banner in portrait mode;
-    // only show them here in landscape mode.
-    if (!isPortrait) {
-        // Title row with trophy icon if achievements exist
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-        ) {
-            Text(
-                text = game.title,
-                style = SpTypography.DisplaySmall,
-                color = SpColor.OnBackground,
-                modifier = Modifier.weight(1f, fill = false).semantics { heading() },
-            )
-            if (state.achievements.isNotEmpty()) {
-                Icon(
-                    imageVector = Icons.Filled.EmojiEvents,
-                    contentDescription = "Has achievements",
-                    tint = SpColor.Warning,
-                    modifier = Modifier.size(24.dp),
-                )
-            }
-        }
-
-
-        // Badges row: console, verification, region, IGDB rating, community rating
-        @OptIn(ExperimentalLayoutApi::class)
-        FlowRow(
-            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-            itemVerticalAlignment = Alignment.CenterVertically,
-        ) {
-            SpConsoleChip(
-                consoleName = game.consoleName,
-                consoleColor = getConsoleColor(game.consoleName),
-                onGradient = true,
-            )
-            VerificationChip(
-                verificationStatus = game.verificationStatus,
-                verificationTag = game.verificationTag,
-            )
-            game.region?.takeIf { it.isNotBlank() }?.let { region ->
-                SpRegionChip(region = region, onGradient = true)
-            }
-            if (game.rating > 0) {
-                IgdbRatingStars(rating = game.rating)
-            }
-            if (game.averageRating > 0) {
-                CommunityRatingBadge(
-                    averageRating = game.averageRating,
-                    ratingCount = game.ratingCount,
-                )
-            }
-        }
-    }
+    // Game info content — title, badges, and action buttons are in the hero banner
 
     if (state.isScraping) {
         Row(
@@ -653,137 +580,7 @@ private fun GameInfoContent(
     }
 
 
-    // Action buttons row: Play/Download + Actions menu + playtime chips
-    val supportsNetplay = game.playable && game.consoleId.lowercase() in NETPLAY_SUPPORTED_CONSOLES
-
-    @OptIn(ExperimentalLayoutApi::class)
-    FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-        itemVerticalAlignment = Alignment.CenterVertically,
-    ) {
-        if (state.isGameCached) {
-            if (game.playable) {
-                // Playable game: show Play/Resume with split menu
-                val menuItems = buildList {
-                    if (hasSaves && onPlayFresh != null) {
-                        add(SpSplitButtonMenuItem("New Game") { onPlayFresh(gameId) })
-                    }
-                    if (onCreateNetplay != null && supportsNetplay) {
-                        add(SpSplitButtonMenuItem("Netplay") { onCreateNetplay(gameId) })
-                    }
-                    add(SpSplitButtonMenuItem("Delete Download") { onDeleteLocalGame() })
-                }
-
-                val hasRequiredBiosMissing = missingBiosFiles.any { it.required }
-                val isSyncing = syncState != null
-                val shadowShape = RoundedCornerShape(SpSpacing.RadiusLarge)
-                val shadowColor = SpColor.Primary.copy(alpha = 0.20f)
-                SpSplitButton(
-                    text = if (hasSaves) "Resume" else "Play",
-                    onClick = { onPlay(gameId) },
-                    enabled = !hasRequiredBiosMissing && !isSyncing,
-                    isLoading = false,
-                    modifier = Modifier
-                        .shadow(10.dp, shadowShape, ambientColor = shadowColor, spotColor = shadowColor)
-                        .semantics {
-                            contentDescription = when {
-                                hasRequiredBiosMissing -> "Play disabled, BIOS required"
-                                isSyncing -> "Play disabled, syncing"
-                                hasSaves -> "Resume ${game.title}"
-                                else -> "Play ${game.title}"
-                            }
-                        },
-                    menuItems = menuItems,
-                    onGradient = true,
-                )
-            } else {
-                // Non-playable game (downloaded): show Delete Download button only
-                SpButton(
-                    text = "Delete Download",
-                    onClick = onDeleteLocalGame,
-                    style = SpButtonStyle.Ghost,
-                    onGradient = true,
-                )
-            }
-        } else {
-            val isActivelyDownloading = state.downloadProgress?.state == DownloadState.DOWNLOADING
-            val isBusy = state.isDownloading || isActivelyDownloading
-
-            val menuItems = buildList {
-                if (onCreateNetplay != null && supportsNetplay) {
-                    add(SpSplitButtonMenuItem("Netplay") { onCreateNetplay(gameId) })
-                }
-            }
-
-            val shadowShape = RoundedCornerShape(SpSpacing.RadiusLarge)
-            val shadowColor = SpColor.Primary.copy(alpha = 0.20f)
-            SpSplitButton(
-                text = if (isBusy) "Downloading..." else "Download",
-                onClick = onDownloadGame,
-                modifier = Modifier
-                    .shadow(10.dp, shadowShape, ambientColor = shadowColor, spotColor = shadowColor)
-                    .semantics {
-                        contentDescription = if (isBusy) "Downloading ${game.title}"
-                        else "Download ${game.title}"
-                    },
-                isLoading = isBusy,
-                enabled = !isBusy,
-                menuItems = menuItems,
-                onGradient = true,
-            )
-        }
-
-        GameActionsMenu(
-            isFavorite = game.isFavorite,
-            isInPlayLater = game.isInPlayLater,
-            onToggleFavorite = onToggleFavorite,
-            onTogglePlayLater = onTogglePlayLater,
-            onAddToCollection = onAddToCollection,
-            onGradient = true,
-        )
-
-        // "External Emulator" indicator for non-playable games
-        if (!game.playable) {
-            SpChip(
-                text = "External Emulator",
-                onGradient = true,
-            )
-        }
-
-        // Playtime + last played as highlighted chips (inline with buttons)
-        if (game.totalPlayTime > 0) {
-            SpChip(
-                text = formatPlayTime(game.totalPlayTime),
-                onGradient = true,
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Filled.AccessTime,
-                        contentDescription = null,
-                        tint = Color.White.copy(alpha = 0.65f),
-                        modifier = Modifier.size(14.dp),
-                    )
-                },
-            )
-        }
-        game.lastPlayedAt?.let { timestamp ->
-            val relative = formatRelativeTime(timestamp)
-            if (relative.isNotEmpty()) {
-                SpChip(
-                    text = "Last played $relative",
-                    onGradient = true,
-                    leadingIcon = {
-                        Icon(
-                            imageVector = Icons.Filled.History,
-                            contentDescription = null,
-                            tint = Color.White.copy(alpha = 0.65f),
-                            modifier = Modifier.size(14.dp),
-                        )
-                    },
-                )
-            }
-        }
-    }
+    // Title, badges, and action buttons are now in the hero banner (GameHeroContent)
 
     // Sync status row (shown while pre-launch or post-exit sync is in progress)
     syncState?.takeIf { !it.isTimedOut }?.let { sync ->
@@ -868,8 +665,6 @@ private fun GameInfoContent(
         }
     }
 
-
-    } // end of tightly-spaced header Column
 
     // Description (plain text, matching web UI)
     game.description?.let { description ->
@@ -1161,6 +956,174 @@ private fun RomHacksSection(
                             overflow = TextOverflow.Ellipsis,
                             modifier = Modifier.weight(1f),
                         )
+                    }
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Content rendered inside the hero banner's contrast backdrop in portrait mode.
+ * Shows game title, badges, ratings, and action buttons.
+ */
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun GameHeroContent(
+    gameId: String,
+    game: Game,
+    state: GameDetailState,
+    hasSaves: Boolean,
+    missingBiosFiles: List<BiosMissingFile>,
+    onPlay: (String) -> Unit,
+    onPlayFresh: ((String) -> Unit)?,
+    onDownloadGame: () -> Unit,
+    onToggleFavorite: () -> Unit,
+    onTogglePlayLater: () -> Unit,
+    onAddToCollection: () -> Unit,
+    onCreateNetplay: ((String) -> Unit)?,
+    onDeleteLocalGame: () -> Unit,
+    syncState: GameSyncState?,
+) {
+    val supportsNetplay = game.playable && game.consoleId.lowercase() in NETPLAY_SUPPORTED_CONSOLES
+
+    Column(
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        // Title
+        Text(
+            text = game.title,
+            style = SpTypography.DisplaySmall,
+            fontWeight = FontWeight.Bold,
+            color = Color.White,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+
+        // Badges: console, region, verification, ratings
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            itemVerticalAlignment = Alignment.CenterVertically,
+        ) {
+            SpConsoleChip(
+                consoleName = game.consoleName,
+                consoleColor = getConsoleColor(game.consoleName),
+                onGradient = true,
+            )
+            game.region?.takeIf { it.isNotBlank() }?.let { region ->
+                SpRegionChip(region = region, onGradient = true)
+            }
+            VerificationChip(
+                verificationStatus = game.verificationStatus,
+                verificationTag = game.verificationTag,
+            )
+            if (game.rating > 0) {
+                IgdbRatingStars(rating = game.rating)
+            }
+            if (game.averageRating > 0) {
+                CommunityRatingBadge(
+                    averageRating = game.averageRating,
+                    ratingCount = game.ratingCount,
+                )
+            }
+        }
+
+        // Action buttons: Play/Download + Actions menu + playtime
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            itemVerticalAlignment = Alignment.CenterVertically,
+        ) {
+            if (state.isGameCached) {
+                if (game.playable) {
+                    val menuItems = buildList {
+                        if (hasSaves && onPlayFresh != null) {
+                            add(SpSplitButtonMenuItem("New Game") { onPlayFresh(gameId) })
+                        }
+                        if (onCreateNetplay != null && supportsNetplay) {
+                            add(SpSplitButtonMenuItem("Netplay") { onCreateNetplay(gameId) })
+                        }
+                        add(SpSplitButtonMenuItem("Delete Download") { onDeleteLocalGame() })
+                    }
+                    val hasRequiredBiosMissing = missingBiosFiles.any { it.required }
+                    val isSyncing = syncState != null
+                    SpSplitButton(
+                        text = if (hasSaves) "Resume" else "Play",
+                        onClick = { onPlay(gameId) },
+                        enabled = !hasRequiredBiosMissing && !isSyncing,
+                        isLoading = false,
+                        menuItems = menuItems,
+                        onGradient = true,
+                    )
+                } else {
+                    SpButton(
+                        text = "Delete Download",
+                        onClick = onDeleteLocalGame,
+                        style = SpButtonStyle.Ghost,
+                        onGradient = true,
+                    )
+                }
+            } else {
+                val isActivelyDownloading = state.downloadProgress?.state == DownloadState.DOWNLOADING
+                val isBusy = state.isDownloading || isActivelyDownloading
+                val menuItems = buildList {
+                    if (onCreateNetplay != null && supportsNetplay) {
+                        add(SpSplitButtonMenuItem("Netplay") { onCreateNetplay(gameId) })
+                    }
+                }
+                SpSplitButton(
+                    text = if (isBusy) "Downloading..." else "Download",
+                    onClick = onDownloadGame,
+                    isLoading = isBusy,
+                    enabled = !isBusy,
+                    menuItems = menuItems,
+                    onGradient = true,
+                )
+            }
+
+            GameActionsMenu(
+                isFavorite = game.isFavorite,
+                isInPlayLater = game.isInPlayLater,
+                onToggleFavorite = onToggleFavorite,
+                onTogglePlayLater = onTogglePlayLater,
+                onAddToCollection = onAddToCollection,
+                onGradient = true,
+            )
+
+            // Playtime + last played grouped so they wrap together
+            if (game.totalPlayTime > 0 || game.lastPlayedAt != null) {
+                Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small)) {
+                    if (game.totalPlayTime > 0) {
+                        SpChip(
+                            text = formatPlayTime(game.totalPlayTime),
+                            onGradient = true,
+                            leadingIcon = {
+                                Icon(
+                                    imageVector = Icons.Filled.AccessTime,
+                                    contentDescription = null,
+                                    tint = Color.White.copy(alpha = 0.65f),
+                                    modifier = Modifier.size(14.dp),
+                                )
+                            },
+                        )
+                    }
+                    game.lastPlayedAt?.let { timestamp ->
+                        val relative = formatRelativeTime(timestamp)
+                        if (relative.isNotEmpty()) {
+                            SpChip(
+                                text = "Last played $relative",
+                                onGradient = true,
+                                leadingIcon = {
+                                    Icon(
+                                        imageVector = Icons.Filled.History,
+                                        contentDescription = null,
+                                        tint = Color.White.copy(alpha = 0.65f),
+                                        modifier = Modifier.size(14.dp),
+                                    )
+                                },
+                            )
+                        }
                     }
                 }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.BiosMissingFile
@@ -172,6 +173,41 @@ fun GameDetailScreen(
                 )
             },
             backgroundColors = backgroundColors,
+            heroUrl = game.heroUrl ?: detail.screenshots.firstOrNull(),
+            heroContent = {
+                Column(
+                    verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    // Title
+                    Text(
+                        text = game.title,
+                        style = SpTypography.HeadlineMedium,
+                        fontWeight = FontWeight.Bold,
+                        color = Color.White,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis,
+                    )
+                    // Badges: console, region, verification
+                    @OptIn(ExperimentalLayoutApi::class)
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                    ) {
+                        SpConsoleChip(
+                            consoleName = game.consoleName,
+                            consoleColor = getConsoleColor(game.consoleName),
+                            onGradient = true,
+                        )
+                        game.region?.takeIf { it.isNotBlank() }?.let { region ->
+                            SpRegionChip(region = region, onGradient = true)
+                        }
+                        VerificationChip(
+                            verificationStatus = game.verificationStatus,
+                            verificationTag = game.verificationTag,
+                        )
+                    }
+                }
+            },
             coverArt = { modifier, isPortrait ->
                 // Read coverUrl from state delegate (not snapshot) so
                 // the LazyColumn item recomposes when it changes after scraping.
@@ -542,55 +578,59 @@ private fun GameInfoContent(
     // Game info header — title, badges, and actions
     Column(verticalArrangement = Arrangement.spacedBy(SpSpacing.Default)) {
 
-    // Title row with trophy icon if achievements exist
-    Row(
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-    ) {
-        Text(
-            text = game.title,
-            style = SpTypography.DisplaySmall,
-            color = SpColor.OnBackground,
-            modifier = Modifier.weight(1f, fill = false).semantics { heading() },
-        )
-        if (state.achievements.isNotEmpty()) {
-            Icon(
-                imageVector = Icons.Filled.EmojiEvents,
-                contentDescription = "Has achievements",
-                tint = SpColor.Warning,
-                modifier = Modifier.size(24.dp),
+    // Title and badges are in the hero banner in portrait mode;
+    // only show them here in landscape mode.
+    if (!isPortrait) {
+        // Title row with trophy icon if achievements exist
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            Text(
+                text = game.title,
+                style = SpTypography.DisplaySmall,
+                color = SpColor.OnBackground,
+                modifier = Modifier.weight(1f, fill = false).semantics { heading() },
             )
+            if (state.achievements.isNotEmpty()) {
+                Icon(
+                    imageVector = Icons.Filled.EmojiEvents,
+                    contentDescription = "Has achievements",
+                    tint = SpColor.Warning,
+                    modifier = Modifier.size(24.dp),
+                )
+            }
         }
-    }
 
 
-    // Badges row: console, verification, region, IGDB rating, community rating
-    @OptIn(ExperimentalLayoutApi::class)
-    FlowRow(
-        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-        itemVerticalAlignment = Alignment.CenterVertically,
-    ) {
-        SpConsoleChip(
-            consoleName = game.consoleName,
-            consoleColor = getConsoleColor(game.consoleName),
-            onGradient = true,
-        )
-        VerificationChip(
-            verificationStatus = game.verificationStatus,
-            verificationTag = game.verificationTag,
-        )
-        game.region?.takeIf { it.isNotBlank() }?.let { region ->
-            SpRegionChip(region = region, onGradient = true)
-        }
-        if (game.rating > 0) {
-            IgdbRatingStars(rating = game.rating)
-        }
-        if (game.averageRating > 0) {
-            CommunityRatingBadge(
-                averageRating = game.averageRating,
-                ratingCount = game.ratingCount,
+        // Badges row: console, verification, region, IGDB rating, community rating
+        @OptIn(ExperimentalLayoutApi::class)
+        FlowRow(
+            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            itemVerticalAlignment = Alignment.CenterVertically,
+        ) {
+            SpConsoleChip(
+                consoleName = game.consoleName,
+                consoleColor = getConsoleColor(game.consoleName),
+                onGradient = true,
             )
+            VerificationChip(
+                verificationStatus = game.verificationStatus,
+                verificationTag = game.verificationTag,
+            )
+            game.region?.takeIf { it.isNotBlank() }?.let { region ->
+                SpRegionChip(region = region, onGradient = true)
+            }
+            if (game.rating > 0) {
+                IgdbRatingStars(rating = game.rating)
+            }
+            if (game.averageRating > 0) {
+                CommunityRatingBadge(
+                    averageRating = game.averageRating,
+                    ratingCount = game.ratingCount,
+                )
+            }
         }
     }
 

--- a/server/internal/api/enrichment_handler.go
+++ b/server/internal/api/enrichment_handler.go
@@ -285,6 +285,7 @@ type SeriesDetailResponse struct {
 	IGDBCollectionID int                   `json:"igdbCollectionId"`
 	Name             string                `json:"name"`
 	HeroURL          string                `json:"heroUrl,omitempty"`
+	LogoURL          string                `json:"logoUrl,omitempty"`
 	LibraryGames     int                   `json:"libraryGames"`
 	TotalGames       int                   `json:"totalGames"`
 	Consoles         []SeriesConsoleInfo   `json:"consoles"`
@@ -356,8 +357,9 @@ func (h *EnrichmentHandler) GetSeriesDetail(c *gin.Context) {
 	consoleInfoMap := make(map[uint]db.Console)  // consoleID -> Console
 	libraryGames := 0
 
-	// Track the best game for hero art (highest rated with hero art)
+	// Track best hero art (highest rated) and first available logo
 	var bestHeroURL string
+	var bestLogoURL string
 	var bestHeroRating float64 = -1
 
 	games := make([]SeriesGameResponse, len(series.Entries))
@@ -395,11 +397,14 @@ func (h *EnrichmentHandler) GetSeriesDetail(c *gin.Context) {
 						consoleInfoMap[g.Console.ID] = g.Console
 					}
 
-					// Track best hero art
+					// Track best hero art (highest rated) and first logo
 					if artwork, ok := artworkMap[*entry.GameID]; ok {
 						if g.Rating > bestHeroRating {
 							bestHeroRating = g.Rating
 							bestHeroURL = resolveImageURL(artwork.HeroURL)
+						}
+						if bestLogoURL == "" && artwork.LogoURL != "" {
+							bestLogoURL = resolveImageURL(artwork.LogoURL)
 						}
 					}
 				}
@@ -429,6 +434,7 @@ func (h *EnrichmentHandler) GetSeriesDetail(c *gin.Context) {
 		IGDBCollectionID: series.IGDBCollectionID,
 		Name:             series.Name,
 		HeroURL:          bestHeroURL,
+		LogoURL:          bestLogoURL,
 		LibraryGames:     libraryGames,
 		TotalGames:       len(series.Entries),
 		Consoles:         consoles,
@@ -542,6 +548,7 @@ type FranchiseDetailResponse struct {
 	IGDBFranchiseID int                  `json:"igdbFranchiseId"`
 	Name            string               `json:"name"`
 	HeroURL         string               `json:"heroUrl,omitempty"`
+	LogoURL         string               `json:"logoUrl,omitempty"`
 	LibraryGames    int                  `json:"libraryGames"`
 	TotalGames      int                  `json:"totalGames"`
 	Consoles        []SeriesConsoleInfo  `json:"consoles"`
@@ -598,6 +605,7 @@ func (h *EnrichmentHandler) GetFranchiseDetail(c *gin.Context) {
 	libraryGames := 0
 
 	var bestHeroURL string
+	var bestLogoURL string
 	var bestHeroRating float64 = -1
 
 	games := make([]SeriesGameResponse, len(franchise.Entries))
@@ -639,6 +647,9 @@ func (h *EnrichmentHandler) GetFranchiseDetail(c *gin.Context) {
 							bestHeroRating = g.Rating
 							bestHeroURL = resolveImageURL(artwork.HeroURL)
 						}
+						if bestLogoURL == "" && artwork.LogoURL != "" {
+							bestLogoURL = resolveImageURL(artwork.LogoURL)
+						}
 					}
 				}
 			} else {
@@ -668,6 +679,7 @@ func (h *EnrichmentHandler) GetFranchiseDetail(c *gin.Context) {
 		IGDBFranchiseID: franchise.IGDBFranchiseID,
 		Name:            franchise.Name,
 		HeroURL:         bestHeroURL,
+		LogoURL:         bestLogoURL,
 		LibraryGames:    libraryGames,
 		TotalGames:      len(franchise.Entries),
 		Consoles:        consoles,

--- a/server/internal/api/game_discovery_handler.go
+++ b/server/internal/api/game_discovery_handler.go
@@ -23,6 +23,7 @@ type GameDiscoveryHandler struct {
 
 // SimilarGameResponse is the API response for a similar game.
 type SimilarGameResponse struct {
+	IGDBGameID  int     `json:"igdbGameId"`
 	Name        string  `json:"name"`
 	CoverUrl    string  `json:"coverUrl"`
 	Rating      float64 `json:"rating"`
@@ -79,8 +80,9 @@ func (h *GameDiscoveryHandler) GetSimilarGames(c *gin.Context) {
 	result := make([]SimilarGameResponse, 0, len(cached))
 	for _, sg := range cached {
 		resp := SimilarGameResponse{
-			Name:   sg.Name,
-			Rating: sg.Rating,
+			IGDBGameID: sg.IGDBGameID,
+			Name:       sg.Name,
+			Rating:     sg.Rating,
 		}
 
 		// Check for local game match by case-insensitive title


### PR DESCRIPTION
## Summary

### Game Detail
- Hero banner with SteamGridDB art in both landscape and portrait layouts
- GameHeroContent composable: title, badges, ratings, action buttons — single source of truth
- Portrait: cover art centered (50% width, dynamic height) above info box
- Cover art uses ContentScale.Fit with max width/height constraints (no cropping)
- Resolved heroUrl and logoUrl on Game model

### Franchise/Series
- SpHeroBanner: reusable hero banner component
- Franchise logo from SteamGridDB (first game's logo artwork)
- SpGameGrid: responsive non-lazy grid matching ConsoleGamesScreen sizing
- Game card grid replaces timeline list

### Developer/Publisher
- Games grid section with up to 12 games using SpGameGrid

### Search
- Game results use SpWideGameCard
- All other results use new SpWideIconCard (icon slot + title + subtitle)
- Quick results wrapped in SpCard, custom TypeBadge replaced with SpChip
- Section header links use SpLinkText

### Components
- SpLinkText: underlined text links, works on any background
- SpWideIconCard: horizontal card with icon slot (for non-game items)
- SpHeroBanner: reusable hero banner with backdrop box
- SpGameGrid: non-lazy responsive grid for use inside LazyColumn
- SpTitledSection: increased bottom padding for symmetry
- SpWideGameCard: added fillWidth parameter

### Fixes
- SimilarGame igdbGameId added to fix duplicate LazyRow key error
- Floating back buttons use onGradient=true for transparent style
- ContentScale.Fit prevents cover art cropping

## Test plan
- [x] Server and player build
- [ ] Game detail hero banner shows in landscape and portrait
- [ ] Franchise page shows logo and game grid
- [ ] Developer page shows games grid
- [ ] Search results visually consistent
- [ ] No duplicate key errors on Castlevania Bloodlines