### PR TITLE
feat: user profile heatmap, UX review fixes, console gradient updates

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -257,6 +257,7 @@ class SpelaTestHarness(
         getOnlineUsersUseCase = GetOnlineUsersUseCase(socialRepo),
         getActivityFeedUseCase = GetActivityFeedUseCase(socialRepo),
         getPublicProfileUseCase = GetPublicProfileUseCase(socialRepo),
+        getPlayHeatmapUseCase = GetPlayHeatmapUseCase(socialRepo),
         dispatchers = dispatchers,
         scope = scope,
     )

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -813,6 +813,8 @@ class FakeSocialRepository : SocialRepository {
         Result.success(activityEvents)
     override suspend fun getPublicProfile(userId: String): Result<com.spela.player.domain.model.PublicProfile> =
         Result.failure(Exception("Not implemented in fake"))
+    override suspend fun getPlayHeatmap(userId: String): Result<List<com.spela.player.domain.model.HeatmapEntry>> =
+        Result.success(emptyList())
 }
 
 class FakeKeyMappingRepository : KeyMappingRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -809,6 +809,10 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/users/$userId/profile").body()
     }
 
+    suspend fun getPublicPlayHeatmap(userId: String): List<HeatmapEntryDto> {
+        return client.get("$baseUrl/api/users/$userId/play-heatmap").body()
+    }
+
     suspend fun updatePlayTime(gameId: String, seconds: Long) {
         client.post("$baseUrl/api/games/$gameId/play-time") {
             setBody(mapOf("seconds" to seconds))

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -219,6 +219,11 @@ fun LibretroCoreDto.toDomain(): LibretroCore = LibretroCore(
     downloadUrl = downloadUrl,
 )
 
+fun HeatmapEntryDto.toDomain(): HeatmapEntry = HeatmapEntry(
+    date = date,
+    playTime = playTime,
+)
+
 fun PublicProfileGameDto.toDomain(): PublicProfileGame = PublicProfileGame(
     id = id,
     title = title,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -425,6 +425,12 @@ data class PublicProfileDto(
     val topGames: List<PublicProfileGameDto> = emptyList(),
 )
 
+@Serializable
+data class HeatmapEntryDto(
+    val date: String,
+    val playTime: Long = 0,
+)
+
 // Shared Session
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.spela.player.data.repository
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.ActivityEvent
+import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
 import com.spela.player.domain.repository.SocialRepository
@@ -45,5 +46,9 @@ class SocialRepositoryImpl(
             recentGames = profile.recentGames.map { it.copy(coverUrl = apiClient.resolveUrl(it.coverUrl)) },
             topGames = profile.topGames.map { it.copy(coverUrl = apiClient.resolveUrl(it.coverUrl)) },
         )
+    }
+
+    override suspend fun getPlayHeatmap(userId: String): Result<List<HeatmapEntry>> = runCatching {
+        apiClient.getPublicPlayHeatmap(userId).map { it.toDomain() }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -95,6 +95,7 @@ val commonModule = module {
     factory { GetOnlineUsersUseCase(get()) }
     factory { GetActivityFeedUseCase(get()) }
     factory { GetPublicProfileUseCase(get()) }
+    factory { GetPlayHeatmapUseCase(get()) }
     factory { GetMyCollectionsUseCase(get()) }
     factory { GetPublicCollectionsUseCase(get()) }
     factory { GetCollectionDetailUseCase(get()) }
@@ -228,6 +229,7 @@ val commonModule = module {
             getOnlineUsersUseCase = get(),
             getActivityFeedUseCase = get(),
             getPublicProfileUseCase = get(),
+            getPlayHeatmapUseCase = get(),
             dispatchers = get(),
             scope = get(),
         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -624,6 +624,11 @@ data class PublicProfile(
     val topGames: List<PublicProfileGame>,
 )
 
+data class HeatmapEntry(
+    val date: String,
+    val playTime: Long,
+)
+
 data class PublicProfileGame(
     val id: String,
     val title: String,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SocialRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SocialRepository.kt
@@ -1,6 +1,7 @@
 package com.spela.player.domain.repository
 
 import com.spela.player.domain.model.ActivityEvent
+import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
 
@@ -8,4 +9,5 @@ interface SocialRepository {
     suspend fun getOnlineUsers(): Result<List<OnlineUser>>
     suspend fun getActivityFeed(page: Int = 1, pageSize: Int = 20): Result<List<ActivityEvent>>
     suspend fun getPublicProfile(userId: String): Result<PublicProfile>
+    suspend fun getPlayHeatmap(userId: String): Result<List<HeatmapEntry>>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/SocialUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/SocialUseCases.kt
@@ -1,6 +1,7 @@
 package com.spela.player.domain.usecase
 
 import com.spela.player.domain.model.ActivityEvent
+import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
 import com.spela.player.domain.repository.SocialRepository
@@ -16,4 +17,8 @@ class GetActivityFeedUseCase(private val socialRepository: SocialRepository) {
 
 class GetPublicProfileUseCase(private val repository: SocialRepository) {
     suspend operator fun invoke(userId: String): Result<PublicProfile> = repository.getPublicProfile(userId)
+}
+
+class GetPlayHeatmapUseCase(private val repository: SocialRepository) {
+    suspend operator fun invoke(userId: String): Result<List<HeatmapEntry>> = repository.getPlayHeatmap(userId)
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SocialState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SocialState.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.state
 
 import com.spela.player.domain.model.ActivityEvent
+import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
 
@@ -12,6 +13,7 @@ data class SocialState(
     val error: String? = null,
     val publicProfile: PublicProfile? = null,
     val isLoadingProfile: Boolean = false,
+    val heatmapData: List<HeatmapEntry> = emptyList(),
     // Full activity feed (paginated, for the Activity screen)
     val fullActivityEvents: List<ActivityEvent> = emptyList(),
     val isLoadingFullActivity: Boolean = false,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpPlayHeatmap.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpPlayHeatmap.kt
@@ -1,14 +1,12 @@
 package com.spela.player.presentation.ui.components
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -16,13 +14,11 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.CornerRadius
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
-import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.drawText
 import androidx.compose.ui.text.rememberTextMeasurer
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -31,20 +27,15 @@ import kotlinx.datetime.DateTimeUnit
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import kotlinx.datetime.plus
+import kotlin.math.min
 import kotlin.time.Clock
 
-private val HeatmapNone = Color(0xFF161b22)
-private val HeatmapLow = Color(0xFF0e4429)
-private val HeatmapMedium = Color(0xFF006d32)
-private val HeatmapHigh = Color(0xFF26a641)
-private val HeatmapVeryHigh = Color(0xFF39d353)
-
-private fun colorForPlayTime(seconds: Long): Color = when {
-    seconds <= 0 -> HeatmapNone
-    seconds < 30 * 60 -> HeatmapLow       // < 30 minutes
-    seconds < 60 * 60 -> HeatmapMedium     // 30-60 minutes
-    seconds < 120 * 60 -> HeatmapHigh      // 60-120 minutes
-    else -> HeatmapVeryHigh                // 120+ minutes
+private fun colorForPlayTime(seconds: Long) = when {
+    seconds <= 0 -> SpColor.SurfaceBright.copy(alpha = 0.3f)
+    seconds < 30 * 60 -> SpColor.Primary.copy(alpha = 0.2f)     // < 30 minutes
+    seconds < 60 * 60 -> SpColor.Primary.copy(alpha = 0.4f)     // 30-60 minutes
+    seconds < 120 * 60 -> SpColor.Primary.copy(alpha = 0.7f)    // 60-120 minutes
+    else -> SpColor.Primary                                      // 120+ minutes
 }
 
 private val MonthNames = listOf(
@@ -69,14 +60,13 @@ fun SpPlayHeatmap(
 ) {
     val tz = TimeZone.currentSystemDefault()
     val today = remember { Clock.System.now().toLocalDateTime(tz).date }
-    val weeks = 52
     val rows = 7
     val cellSize = 12.dp
-    val cellGap = 2.dp
+    val cellGap = SpSpacing.XXSmall
     val cellStep = cellSize + cellGap
     val monthLabelHeight = 14.dp
-    val monthLabelGap = 4.dp
-    val cornerRadius = 2.dp
+    val monthLabelGap = SpSpacing.XSmall
+    val cornerRadius = SpSpacing.XXSmall
 
     // Build lookup: date string -> playTime (seconds)
     val playTimeMap = remember(entries) {
@@ -84,113 +74,129 @@ fun SpPlayHeatmap(
     }
 
     val textMeasurer = rememberTextMeasurer()
-    val monthLabelStyle = TextStyle(fontSize = 10.sp, color = SpColor.OnBackgroundTertiary)
+    val monthLabelStyle = SpTypography.LabelSmall.copy(color = SpColor.OnBackgroundTertiary)
 
-    // Calculate grid data
-    val gridData = remember(today, playTimeMap) {
-        // Today's day-of-week: Monday=1 .. Sunday=7 (ISO)
-        // DayOfWeek ordinal: MONDAY=0 .. SUNDAY=6, so ISO day number = ordinal + 1
-        val todayDow = today.dayOfWeek.ordinal + 1
-        // The last column ends on today's row. Total days covered:
-        val totalDays = (weeks - 1) * 7 + todayDow
-        // Start date is totalDays-1 before today
-        val startDate = today.plus(-(totalDays - 1), DateTimeUnit.DAY)
+    val density = LocalDensity.current
 
-        // Build grid: weeks x 7 (rows: 0=Mon, 6=Sun)
-        val grid = Array(weeks) { col ->
-            Array(rows) { row ->
-                val dayOffset = col * 7 + row
-                if (dayOffset < totalDays) {
-                    val date = startDate.plus(dayOffset, DateTimeUnit.DAY)
-                    val dateStr = date.toString()
-                    val playTime = playTimeMap[dateStr] ?: 0L
-                    HeatmapCell(dateStr, playTime)
-                } else {
-                    null
-                }
-            }
-        }
+    // Day label column width estimate (enough for "Wed")
+    val dayLabelWidth = 28.dp
+    val dayLabelSpacing = SpSpacing.XSmall
 
-        // Month labels: find columns where a new month starts
-        val labels = mutableListOf<MonthLabel>()
-        var lastMonthOrdinal = -1
-        for (col in 0 until weeks) {
-            val dayOffset = col * 7
-            if (dayOffset < totalDays) {
-                val date = startDate.plus(dayOffset, DateTimeUnit.DAY)
-                val monthOrdinal = date.month.ordinal
-                if (monthOrdinal != lastMonthOrdinal) {
-                    labels.add(MonthLabel(col, MonthNames[monthOrdinal]))
-                    lastMonthOrdinal = monthOrdinal
-                }
-            }
-        }
-
-        HeatmapGridData(grid, labels)
-    }
-
-    val gridWidth = cellStep * weeks - cellGap
-    val gridHeight = monthLabelHeight + monthLabelGap + cellStep * rows - cellGap
-
-    Row(
-        modifier = modifier
-            .testTag("user_profile_heatmap")
-            .horizontalScroll(rememberScrollState()),
+    BoxWithConstraints(
+        modifier = modifier.testTag("user_profile_heatmap"),
     ) {
-        // Day labels on the left
-        Column(modifier = Modifier.padding(top = monthLabelHeight + monthLabelGap)) {
-            DayLabels.forEach { label ->
-                if (label.isNotEmpty()) {
-                    Text(
-                        text = label,
-                        style = SpTypography.LabelSmall,
-                        color = SpColor.OnBackgroundTertiary,
-                        modifier = Modifier.height(cellStep),
-                    )
-                } else {
-                    Spacer(Modifier.height(cellStep))
+        val availableWidthDp = maxWidth - dayLabelWidth - dayLabelSpacing
+        val cellStepPx = with(density) { cellStep.toPx() }
+        val availableWidthPx = with(density) { availableWidthDp.toPx() }
+        val weeks = min(52, (availableWidthPx / cellStepPx).toInt())
+
+        // Calculate grid data
+        val gridData = remember(today, playTimeMap, weeks) {
+            // Today's day-of-week: Monday=1 .. Sunday=7 (ISO)
+            // DayOfWeek ordinal: MONDAY=0 .. SUNDAY=6, so ISO day number = ordinal + 1
+            val todayDow = today.dayOfWeek.ordinal + 1
+            // The last column ends on today's row. Total days covered:
+            val totalDays = (weeks - 1) * 7 + todayDow
+            // Start date is totalDays-1 before today
+            val startDate = today.plus(-(totalDays - 1), DateTimeUnit.DAY)
+
+            // Build grid: weeks x 7 (rows: 0=Mon, 6=Sun)
+            val grid = Array(weeks) { col ->
+                Array(rows) { row ->
+                    val dayOffset = col * 7 + row
+                    if (dayOffset < totalDays) {
+                        val date = startDate.plus(dayOffset, DateTimeUnit.DAY)
+                        val dateStr = date.toString()
+                        val playTime = playTimeMap[dateStr] ?: 0L
+                        HeatmapCell(dateStr, playTime)
+                    } else {
+                        null
+                    }
                 }
             }
-        }
 
-        Spacer(Modifier.width(SpSpacing.XSmall))
-
-        // Heatmap grid with month labels drawn on Canvas
-        Canvas(
-            modifier = Modifier
-                .width(gridWidth)
-                .height(gridHeight),
-        ) {
-            val cellSizePx = cellSize.toPx()
-            val cellStepPx = cellStep.toPx()
-            val cornerRadiusPx = cornerRadius.toPx()
-            val gridTopPx = (monthLabelHeight + monthLabelGap).toPx()
-
-            // Draw month labels
-            for (monthLabel in gridData.monthLabels) {
-                drawText(
-                    textMeasurer = textMeasurer,
-                    text = monthLabel.name,
-                    topLeft = Offset(monthLabel.column * cellStepPx, 0f),
-                    style = monthLabelStyle,
-                )
+            // Month labels: find columns where a new month starts
+            val labels = mutableListOf<MonthLabel>()
+            var lastMonthOrdinal = -1
+            for (col in 0 until weeks) {
+                val dayOffset = col * 7
+                if (dayOffset < (weeks - 1) * 7 + todayDow) {
+                    val date = startDate.plus(dayOffset, DateTimeUnit.DAY)
+                    val monthOrdinal = date.month.ordinal
+                    if (monthOrdinal != lastMonthOrdinal) {
+                        labels.add(MonthLabel(col, MonthNames[monthOrdinal]))
+                        lastMonthOrdinal = monthOrdinal
+                    }
+                }
             }
 
-            // Draw cells
-            for (col in gridData.grid.indices) {
-                val column = gridData.grid[col]
-                for (row in 0 until rows) {
-                    val cell = column[row] ?: continue
-                    val color = colorForPlayTime(cell.playTime)
-                    drawRoundRect(
-                        color = color,
-                        topLeft = Offset(
-                            x = col * cellStepPx,
-                            y = gridTopPx + row * cellStepPx,
-                        ),
-                        size = Size(cellSizePx, cellSizePx),
-                        cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx),
+            HeatmapGridData(grid, labels)
+        }
+
+        val gridWidth = cellStep * weeks - cellGap
+        val gridHeight = monthLabelHeight + monthLabelGap + cellStep * rows - cellGap
+
+        Row {
+            // Day labels on the left
+            Column(
+                modifier = Modifier
+                    .width(dayLabelWidth)
+                    .height(gridHeight + monthLabelHeight + monthLabelGap),
+            ) {
+                Spacer(Modifier.height(monthLabelHeight + monthLabelGap))
+                DayLabels.forEach { label ->
+                    if (label.isNotEmpty()) {
+                        Text(
+                            text = label,
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                            modifier = Modifier.height(cellStep),
+                        )
+                    } else {
+                        Spacer(Modifier.height(cellStep))
+                    }
+                }
+            }
+
+            Spacer(Modifier.width(dayLabelSpacing))
+
+            // Heatmap grid with month labels drawn on Canvas
+            Canvas(
+                modifier = Modifier
+                    .width(gridWidth)
+                    .height(gridHeight),
+            ) {
+                val cellSizePx = cellSize.toPx()
+                val cellStepCanvasPx = cellStep.toPx()
+                val cornerRadiusPx = cornerRadius.toPx()
+                val gridTopPx = (monthLabelHeight + monthLabelGap).toPx()
+
+                // Draw month labels
+                for (monthLabel in gridData.monthLabels) {
+                    drawText(
+                        textMeasurer = textMeasurer,
+                        text = monthLabel.name,
+                        topLeft = Offset(monthLabel.column * cellStepCanvasPx, 0f),
+                        style = monthLabelStyle,
                     )
+                }
+
+                // Draw cells
+                for (col in gridData.grid.indices) {
+                    val column = gridData.grid[col]
+                    for (row in 0 until rows) {
+                        val cell = column[row] ?: continue
+                        val color = colorForPlayTime(cell.playTime)
+                        drawRoundRect(
+                            color = color,
+                            topLeft = Offset(
+                                x = col * cellStepCanvasPx,
+                                y = gridTopPx + row * cellStepCanvasPx,
+                            ),
+                            size = Size(cellSizePx, cellSizePx),
+                            cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx),
+                        )
+                    }
                 }
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpPlayHeatmap.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpPlayHeatmap.kt
@@ -1,0 +1,198 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.drawText
+import androidx.compose.ui.text.rememberTextMeasurer
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.spela.player.domain.model.HeatmapEntry
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+import kotlinx.datetime.DateTimeUnit
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import kotlinx.datetime.plus
+import kotlin.time.Clock
+
+private val HeatmapNone = Color(0xFF161b22)
+private val HeatmapLow = Color(0xFF0e4429)
+private val HeatmapMedium = Color(0xFF006d32)
+private val HeatmapHigh = Color(0xFF26a641)
+private val HeatmapVeryHigh = Color(0xFF39d353)
+
+private fun colorForPlayTime(seconds: Long): Color = when {
+    seconds <= 0 -> HeatmapNone
+    seconds < 30 * 60 -> HeatmapLow       // < 30 minutes
+    seconds < 60 * 60 -> HeatmapMedium     // 30-60 minutes
+    seconds < 120 * 60 -> HeatmapHigh      // 60-120 minutes
+    else -> HeatmapVeryHigh                // 120+ minutes
+}
+
+private val MonthNames = listOf(
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+)
+
+private val DayLabels = listOf("", "Mon", "", "Wed", "", "Fri", "")
+
+private data class HeatmapCell(val date: String, val playTime: Long)
+private data class MonthLabel(val column: Int, val name: String)
+
+private data class HeatmapGridData(
+    val grid: Array<Array<HeatmapCell?>>,
+    val monthLabels: List<MonthLabel>,
+)
+
+@Composable
+fun SpPlayHeatmap(
+    entries: List<HeatmapEntry>,
+    modifier: Modifier = Modifier,
+) {
+    val tz = TimeZone.currentSystemDefault()
+    val today = remember { Clock.System.now().toLocalDateTime(tz).date }
+    val weeks = 52
+    val rows = 7
+    val cellSize = 12.dp
+    val cellGap = 2.dp
+    val cellStep = cellSize + cellGap
+    val monthLabelHeight = 14.dp
+    val monthLabelGap = 4.dp
+    val cornerRadius = 2.dp
+
+    // Build lookup: date string -> playTime (seconds)
+    val playTimeMap = remember(entries) {
+        entries.associate { it.date to it.playTime }
+    }
+
+    val textMeasurer = rememberTextMeasurer()
+    val monthLabelStyle = TextStyle(fontSize = 10.sp, color = SpColor.OnBackgroundTertiary)
+
+    // Calculate grid data
+    val gridData = remember(today, playTimeMap) {
+        // Today's day-of-week: Monday=1 .. Sunday=7 (ISO)
+        // DayOfWeek ordinal: MONDAY=0 .. SUNDAY=6, so ISO day number = ordinal + 1
+        val todayDow = today.dayOfWeek.ordinal + 1
+        // The last column ends on today's row. Total days covered:
+        val totalDays = (weeks - 1) * 7 + todayDow
+        // Start date is totalDays-1 before today
+        val startDate = today.plus(-(totalDays - 1), DateTimeUnit.DAY)
+
+        // Build grid: weeks x 7 (rows: 0=Mon, 6=Sun)
+        val grid = Array(weeks) { col ->
+            Array(rows) { row ->
+                val dayOffset = col * 7 + row
+                if (dayOffset < totalDays) {
+                    val date = startDate.plus(dayOffset, DateTimeUnit.DAY)
+                    val dateStr = date.toString()
+                    val playTime = playTimeMap[dateStr] ?: 0L
+                    HeatmapCell(dateStr, playTime)
+                } else {
+                    null
+                }
+            }
+        }
+
+        // Month labels: find columns where a new month starts
+        val labels = mutableListOf<MonthLabel>()
+        var lastMonthOrdinal = -1
+        for (col in 0 until weeks) {
+            val dayOffset = col * 7
+            if (dayOffset < totalDays) {
+                val date = startDate.plus(dayOffset, DateTimeUnit.DAY)
+                val monthOrdinal = date.month.ordinal
+                if (monthOrdinal != lastMonthOrdinal) {
+                    labels.add(MonthLabel(col, MonthNames[monthOrdinal]))
+                    lastMonthOrdinal = monthOrdinal
+                }
+            }
+        }
+
+        HeatmapGridData(grid, labels)
+    }
+
+    val gridWidth = cellStep * weeks - cellGap
+    val gridHeight = monthLabelHeight + monthLabelGap + cellStep * rows - cellGap
+
+    Row(
+        modifier = modifier
+            .testTag("user_profile_heatmap")
+            .horizontalScroll(rememberScrollState()),
+    ) {
+        // Day labels on the left
+        Column(modifier = Modifier.padding(top = monthLabelHeight + monthLabelGap)) {
+            DayLabels.forEach { label ->
+                if (label.isNotEmpty()) {
+                    Text(
+                        text = label,
+                        style = SpTypography.LabelSmall,
+                        color = SpColor.OnBackgroundTertiary,
+                        modifier = Modifier.height(cellStep),
+                    )
+                } else {
+                    Spacer(Modifier.height(cellStep))
+                }
+            }
+        }
+
+        Spacer(Modifier.width(SpSpacing.XSmall))
+
+        // Heatmap grid with month labels drawn on Canvas
+        Canvas(
+            modifier = Modifier
+                .width(gridWidth)
+                .height(gridHeight),
+        ) {
+            val cellSizePx = cellSize.toPx()
+            val cellStepPx = cellStep.toPx()
+            val cornerRadiusPx = cornerRadius.toPx()
+            val gridTopPx = (monthLabelHeight + monthLabelGap).toPx()
+
+            // Draw month labels
+            for (monthLabel in gridData.monthLabels) {
+                drawText(
+                    textMeasurer = textMeasurer,
+                    text = monthLabel.name,
+                    topLeft = Offset(monthLabel.column * cellStepPx, 0f),
+                    style = monthLabelStyle,
+                )
+            }
+
+            // Draw cells
+            for (col in gridData.grid.indices) {
+                val column = gridData.grid[col]
+                for (row in 0 until rows) {
+                    val cell = column[row] ?: continue
+                    val color = colorForPlayTime(cell.playTime)
+                    drawRoundRect(
+                        color = color,
+                        topLeft = Offset(
+                            x = col * cellStepPx,
+                            y = gridTopPx + row * cellStepPx,
+                        ),
+                        size = Size(cellSizePx, cellSizePx),
+                        cornerRadius = CornerRadius(cornerRadiusPx, cornerRadiusPx),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleMetadata.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleMetadata.kt
@@ -388,16 +388,16 @@ fun getConsoleGradient(abbreviation: String, colorTheme: String?): Pair<Color, C
         "neocd" -> Color(0xFFeab308) to Color(0xFFb91c1c)       // yellow-500 → red-700
         "pce" -> Color(0xFFf97316) to Color(0xFF991b1b)         // orange-500 → red-800
         "pcecd" -> Color(0xFFf97316) to Color(0xFF991b1b)       // orange-500 → red-800
-        "a26" -> Color(0xFFd97706) to Color(0xFF78350f)         // amber-600 → amber-900
+        "a26" -> Color(0xFF1e293b) to Color(0xFF0f172a)         // slate-800 → slate-900 (complements red Atari logo)
         "gg" -> Color(0xFF2563eb) to Color(0xFF1e3a8a)          // blue-600 → blue-900
         "scd" -> Color(0xFF374151) to Color(0xFF1e3a8a)         // gray-700 → blue-900
         "32x" -> Color(0xFF1f2937) to Color(0xFF000000)         // gray-800 → black
         "dc" -> Color(0xFFf97316) to Color(0xFF1d4ed8)          // orange-500 → blue-700
         "vb" -> Color(0xFF991b1b) to Color(0xFF450a0a)          // red-800 → red-950
-        "3ds" -> Color(0xFFef4444) to Color(0xFF991b1b)         // red-500 → red-800
+        "3ds" -> Color(0xFF1e3a5f) to Color(0xFF0c1a2e)         // dark teal-blue (complements red 3DS logo)
         "gc" -> Color(0xFF6366f1) to Color(0xFF6b21a8)           // indigo-500 → purple-800
         "a52" -> Color(0xFFb45309) to Color(0xFF451a03)         // amber-700 → amber-950
-        "a78" -> Color(0xFFd97706) to Color(0xFF78350f)         // amber-600 → amber-900
+        "a78" -> Color(0xFF1e293b) to Color(0xFF0f172a)         // slate-800 → slate-900 (complements red logo)
         "lynx" -> Color(0xFFca8a04) to Color(0xFF713f12)        // yellow-600 → yellow-900
         "jag" -> Color(0xFFb91c1c) to Color(0xFF111827)         // red-700 → gray-900
         "ngp" -> Color(0xFF6b7280) to Color(0xFF1f2937)         // gray-500 → gray-800

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
@@ -33,11 +33,12 @@ import com.spela.player.domain.model.PublicProfileGame
 import com.spela.player.presentation.intent.SocialIntent
 import com.spela.player.presentation.ui.components.SpAvatar
 import com.spela.player.presentation.ui.components.SpCard
-import com.spela.player.presentation.ui.components.SpCoverArt
+
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
 import com.spela.player.presentation.ui.components.SpPlayHeatmap
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.components.SpWideGameCard
 import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.theme.SpColor
@@ -343,45 +344,20 @@ private fun ProfileGameItem(
     showPlayTime: Boolean,
     onClick: () -> Unit,
 ) {
-    SpCard(
-        onGradient = true,
-        modifier = Modifier.fillMaxWidth(),
+    SpWideGameCard(
+        title = game.title,
+        subtitle = game.consoleName,
+        coverUrl = game.coverUrl,
         onClick = onClick,
-    ) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(SpSpacing.Small),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            SpCoverArt(
-                imageUrl = game.coverUrl,
-                contentDescription = "${game.title} cover",
-                modifier = Modifier.size(width = 40.dp, height = 56.dp),
-                cornerRadius = SpSpacing.RadiusDefault,
-            )
-            Spacer(Modifier.width(SpSpacing.Medium))
-            Column(modifier = Modifier.weight(1f)) {
+        fillWidth = true,
+        extraContent = if (showPlayTime && game.playTime > 0) {
+            {
                 Text(
-                    text = game.title,
-                    style = SpTypography.TitleSmall,
-                    color = SpColor.OnCard,
-                    maxLines = 1,
-                    overflow = TextOverflow.Ellipsis,
-                )
-                Text(
-                    text = game.consoleName,
+                    text = formatPlayTime(game.playTime),
                     style = SpTypography.LabelSmall,
-                    color = SpColor.OnBackgroundTertiary,
+                    color = SpColor.OnBackgroundSecondary,
                 )
-                if (showPlayTime && game.playTime > 0) {
-                    Text(
-                        text = formatPlayTime(game.playTime),
-                        style = SpTypography.LabelSmall,
-                        color = SpColor.OnBackgroundSecondary,
-                    )
-                }
             }
-        }
-    }
+        } else null,
+    )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.PublicProfile
 import com.spela.player.domain.model.PublicProfileGame
 import com.spela.player.presentation.intent.SocialIntent
@@ -34,6 +35,8 @@ import com.spela.player.presentation.ui.components.SpAvatar
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.SpPlayHeatmap
+import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.theme.SpColor
@@ -82,6 +85,7 @@ fun UserProfileScreen(
                 val profile = state.publicProfile ?: return
                 ProfileContent(
                     profile = profile,
+                    heatmapData = state.heatmapData,
                     onGameSelected = onGameSelected,
                 )
             }
@@ -104,6 +108,7 @@ fun UserProfileScreen(
 @Composable
 private fun ProfileContent(
     profile: PublicProfile,
+    heatmapData: List<HeatmapEntry>,
     onGameSelected: (String) -> Unit,
 ) {
     LazyColumn(
@@ -159,6 +164,13 @@ private fun ProfileContent(
                             color = SpColor.Success,
                         )
                     }
+                    if (profile.memberSince.isNotBlank()) {
+                        Text(
+                            text = "Member since ${profile.memberSince}",
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
                 }
             }
         }
@@ -181,6 +193,18 @@ private fun ProfileContent(
                     value = profile.gamesPlayed.toString(),
                     modifier = Modifier.weight(1f),
                 )
+            }
+        }
+
+        // Activity Heatmap
+        if (heatmapData.isNotEmpty()) {
+            item {
+                SpTitledSection(title = "Activity") {
+                    SpPlayHeatmap(
+                        entries = heatmapData,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                }
             }
         }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -13,16 +12,17 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
@@ -36,6 +36,7 @@ import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpCoverArt
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
 import com.spela.player.presentation.ui.components.SpPlayHeatmap
+import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.PlatformBackHandler
@@ -45,6 +46,36 @@ import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.ui.theme.spScreenBackground
 import com.spela.player.presentation.viewmodel.SocialViewModel
 import com.spela.player.util.formatPlayTime
+
+private val MonthNames = listOf(
+    "January", "February", "March", "April", "May", "June",
+    "July", "August", "September", "October", "November", "December",
+)
+
+/**
+ * Format an ISO 8601 date string (e.g. "2024-01-15T10:30:00Z") to "Month Year"
+ * (e.g. "January 2024"). Falls back to the raw string if parsing fails.
+ */
+private fun formatMemberSince(raw: String): String {
+    return try {
+        // Take "YYYY-MM" from the ISO string
+        val yearMonth = raw.take(7) // "2024-01"
+        val parts = yearMonth.split("-")
+        if (parts.size >= 2) {
+            val year = parts[0]
+            val monthIndex = parts[1].toIntOrNull()?.minus(1) ?: return raw
+            if (monthIndex in 0..11) {
+                "${MonthNames[monthIndex]} $year"
+            } else {
+                raw
+            }
+        } else {
+            raw
+        }
+    } catch (_: Exception) {
+        raw
+    }
+}
 
 @Composable
 fun UserProfileScreen(
@@ -64,7 +95,8 @@ fun UserProfileScreen(
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .spScreenBackground(),
+            .spScreenBackground()
+            .testTag("user_profile_screen"),
     ) {
         SpTopBar(
             title = state.publicProfile?.username ?: "Profile",
@@ -111,17 +143,17 @@ private fun ProfileContent(
     heatmapData: List<HeatmapEntry>,
     onGameSelected: (String) -> Unit,
 ) {
-    LazyColumn(
+    val formattedMemberSince = remember(profile.memberSince) {
+        formatMemberSince(profile.memberSince)
+    }
+
+    SpSectionList(
         modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(SpSpacing.Default),
-        verticalArrangement = Arrangement.spacedBy(SpSpacing.Default),
     ) {
         // Avatar + name + online status
         item {
             Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = SpSpacing.ScreenHorizontal),
+                modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
                 Box(modifier = Modifier.size(64.dp)) {
@@ -134,13 +166,14 @@ private fun ProfileContent(
                     if (profile.isOnline) {
                         Box(
                             modifier = Modifier
-                                .size(16.dp)
+                                .size(SpSpacing.Default)
                                 .align(Alignment.BottomEnd)
                                 .clip(CircleShape)
                                 .background(SpColor.Background)
-                                .padding(2.dp)
+                                .padding(SpSpacing.XXSmall)
                                 .clip(CircleShape)
-                                .background(SpColor.Success),
+                                .background(SpColor.Success)
+                                .semantics { contentDescription = "Online" },
                         )
                     }
                 }
@@ -155,7 +188,7 @@ private fun ProfileContent(
                         Text(
                             text = "Playing ${profile.currentGame.title}",
                             style = SpTypography.BodySmall,
-                            color = SpColor.Link,
+                            color = SpColor.Primary,
                         )
                     } else if (profile.isOnline) {
                         Text(
@@ -166,7 +199,7 @@ private fun ProfileContent(
                     }
                     if (profile.memberSince.isNotBlank()) {
                         Text(
-                            text = "Member since ${profile.memberSince}",
+                            text = "Member since $formattedMemberSince",
                             style = SpTypography.LabelSmall,
                             color = SpColor.OnBackgroundTertiary,
                         )
@@ -180,7 +213,7 @@ private fun ProfileContent(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = SpSpacing.ScreenHorizontal),
+                    .testTag("user_profile_stats"),
                 horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
             ) {
                 StatCard(
@@ -211,35 +244,66 @@ private fun ProfileContent(
         // Most Played
         if (profile.topGames.isNotEmpty()) {
             item {
-                GameSection(
+                SpTitledSection(
                     title = "Most Played",
-                    games = profile.topGames,
-                    onGameSelected = onGameSelected,
-                    showPlayTime = true,
-                )
+                    modifier = Modifier.testTag("user_profile_most_played"),
+                ) {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                    ) {
+                        profile.topGames.forEach { game ->
+                            ProfileGameItem(
+                                game = game,
+                                showPlayTime = true,
+                                onClick = { onGameSelected(game.id) },
+                            )
+                        }
+                    }
+                }
             }
         }
 
         // Favorites
         if (profile.favoriteGames.isNotEmpty()) {
             item {
-                GameSection(
+                SpTitledSection(
                     title = "Favorites",
-                    games = profile.favoriteGames,
-                    onGameSelected = onGameSelected,
-                )
+                    modifier = Modifier.testTag("user_profile_favorites"),
+                ) {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                    ) {
+                        profile.favoriteGames.forEach { game ->
+                            ProfileGameItem(
+                                game = game,
+                                showPlayTime = false,
+                                onClick = { onGameSelected(game.id) },
+                            )
+                        }
+                    }
+                }
             }
         }
 
         // Recently Played
         if (profile.recentGames.isNotEmpty()) {
             item {
-                GameSection(
+                SpTitledSection(
                     title = "Recently Played",
-                    games = profile.recentGames,
-                    onGameSelected = onGameSelected,
-                    showPlayTime = true,
-                )
+                    modifier = Modifier.testTag("user_profile_recently_played"),
+                ) {
+                    Column(
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                    ) {
+                        profile.recentGames.forEach { game ->
+                            ProfileGameItem(
+                                game = game,
+                                showPlayTime = true,
+                                onClick = { onGameSelected(game.id) },
+                            )
+                        }
+                    }
+                }
             }
         }
     }
@@ -261,42 +325,13 @@ private fun StatCard(
             Text(
                 text = value,
                 style = SpTypography.HeadlineLarge,
-                color = SpColor.Link,
+                color = SpColor.OnBackground,
             )
             Spacer(Modifier.height(SpSpacing.XXSmall))
             Text(
                 text = label,
                 style = SpTypography.BodySmall,
                 color = SpColor.OnBackgroundSecondary,
-            )
-        }
-    }
-}
-
-@Composable
-private fun GameSection(
-    title: String,
-    games: List<PublicProfileGame>,
-    onGameSelected: (String) -> Unit,
-    showPlayTime: Boolean = false,
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = SpSpacing.ScreenHorizontal),
-    ) {
-        Text(
-            text = title,
-            style = SpTypography.TitleLarge,
-            color = SpColor.OnBackground,
-            modifier = Modifier.semantics { contentDescription = "$title section" },
-        )
-        Spacer(Modifier.height(SpSpacing.Small))
-        games.forEach { game ->
-            ProfileGameItem(
-                game = game,
-                showPlayTime = showPlayTime,
-                onClick = { onGameSelected(game.id) },
             )
         }
     }
@@ -310,9 +345,7 @@ private fun ProfileGameItem(
 ) {
     SpCard(
         onGradient = true,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(vertical = SpSpacing.XXSmall),
+        modifier = Modifier.fillMaxWidth(),
         onClick = onClick,
     ) {
         Row(
@@ -352,4 +385,3 @@ private fun ProfileGameItem(
         }
     }
 }
-

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SocialViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SocialViewModel.kt
@@ -2,6 +2,7 @@ package com.spela.player.presentation.viewmodel
 
 import com.spela.player.domain.usecase.GetActivityFeedUseCase
 import com.spela.player.domain.usecase.GetOnlineUsersUseCase
+import com.spela.player.domain.usecase.GetPlayHeatmapUseCase
 import com.spela.player.domain.usecase.GetPublicProfileUseCase
 import com.spela.player.presentation.intent.SocialIntent
 import com.spela.player.presentation.state.SocialState
@@ -17,6 +18,7 @@ class SocialViewModel(
     private val getOnlineUsersUseCase: GetOnlineUsersUseCase,
     private val getActivityFeedUseCase: GetActivityFeedUseCase,
     private val getPublicProfileUseCase: GetPublicProfileUseCase,
+    private val getPlayHeatmapUseCase: GetPlayHeatmapUseCase,
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
 ) {
@@ -125,7 +127,7 @@ class SocialViewModel(
     }
 
     private fun loadPublicProfile(userId: String) {
-        _state.update { it.copy(isLoadingProfile = true, publicProfile = null) }
+        _state.update { it.copy(isLoadingProfile = true, publicProfile = null, heatmapData = emptyList()) }
         scope.launch(dispatchers.io) {
             getPublicProfileUseCase(userId).fold(
                 onSuccess = { profile ->
@@ -135,6 +137,15 @@ class SocialViewModel(
                     _state.update { it.copy(error = error.message, isLoadingProfile = false) }
                 },
             )
+        }
+        // Load heatmap data in parallel — best effort, non-critical
+        scope.launch(dispatchers.io) {
+            try {
+                val entries = getPlayHeatmapUseCase(userId).getOrDefault(emptyList())
+                _state.update { it.copy(heatmapData = entries) }
+            } catch (_: Exception) {
+                // Best effort — heatmap is non-critical
+            }
         }
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SocialViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SocialViewModelTest.kt
@@ -6,6 +6,7 @@ import com.spela.player.domain.model.OnlineUserGame
 import com.spela.player.domain.repository.SocialRepository
 import com.spela.player.domain.usecase.GetActivityFeedUseCase
 import com.spela.player.domain.usecase.GetOnlineUsersUseCase
+import com.spela.player.domain.usecase.GetPlayHeatmapUseCase
 import com.spela.player.domain.usecase.GetPublicProfileUseCase
 import com.spela.player.presentation.intent.SocialIntent
 import com.spela.player.util.DispatcherProvider
@@ -49,6 +50,7 @@ class SocialViewModelTest {
             getOnlineUsersUseCase = GetOnlineUsersUseCase(fakeSocialRepo),
             getActivityFeedUseCase = GetActivityFeedUseCase(fakeSocialRepo),
             getPublicProfileUseCase = GetPublicProfileUseCase(fakeSocialRepo),
+            getPlayHeatmapUseCase = GetPlayHeatmapUseCase(fakeSocialRepo),
             dispatchers = testDispatchers,
             scope = scope,
         )
@@ -166,5 +168,10 @@ private class FakeSocialRepository : SocialRepository {
     override suspend fun getPublicProfile(userId: String): Result<com.spela.player.domain.model.PublicProfile> {
         return if (shouldFail) Result.failure(Exception("Network error"))
         else Result.failure(Exception("Not implemented in fake"))
+    }
+
+    override suspend fun getPlayHeatmap(userId: String): Result<List<com.spela.player.domain.model.HeatmapEntry>> {
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(emptyList())
     }
 }

--- a/web/src/lib/console-metadata.ts
+++ b/web/src/lib/console-metadata.ts
@@ -95,8 +95,8 @@ const consoleStyles: Record<string, ConsoleStyle> = {
   },
   atari2600: {
     icon: Tv,
-    gradient: "from-amber-600 to-brown-900",
-    color: "#d69e2e",
+    gradient: "from-slate-800 to-slate-900",
+    color: "#1e293b",
   },
   gg: {
     icon: Smartphone,
@@ -125,8 +125,8 @@ const consoleStyles: Record<string, ConsoleStyle> = {
   },
   "3ds": {
     icon: Smartphone,
-    gradient: "from-red-500 to-red-800",
-    color: "#ef4444",
+    gradient: "from-sky-950 to-slate-950",
+    color: "#0c4a6e",
   },
   gc: {
     icon: Gamepad2,
@@ -140,8 +140,8 @@ const consoleStyles: Record<string, ConsoleStyle> = {
   },
   a78: {
     icon: Tv,
-    gradient: "from-amber-600 to-amber-900",
-    color: "#d97706",
+    gradient: "from-slate-800 to-slate-900",
+    color: "#1e293b",
   },
   lynx: {
     icon: Smartphone,


### PR DESCRIPTION
## Summary

### User Profile
- Added member since date (formatted "Month Year" from ISO 8601)
- Added activity heatmap (52-week GitHub-style grid, responsive, theme-colored)
- Full stack: API client → repository → use case → ViewModel → SpPlayHeatmap composable
- Game items use SpWideGameCard instead of custom layout
- Game sections wrapped in SpTitledSection
- SpSectionList replaces custom LazyColumn
- SpColor.Link replaced with proper theme colors
- Test tags and accessibility descriptions added

### Console Gradients
- Atari 2600: amber → slate (complements red logo)
- Atari 7800: amber → slate (complements red logo)
- 3DS: red → dark teal-blue (complements red logo)

## Test plan
- [x] Build passes
- [ ] User profile shows member since date
- [ ] Activity heatmap renders and is responsive to window width
- [ ] Game lists use SpWideGameCard styling
- [ ] Console pages show updated gradients with readable logos