### PR TITLE
feat: achievement rarity badges — Phase 1 of making achievements fun

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -369,6 +369,7 @@ fun GameAchievementDto.toDomain(): GameAchievement = GameAchievement(
     badgeUrl = badgeUrl,
     type = type,
     displayOrder = displayOrder,
+    rarityPercent = rarityPercent,
 )
 
 fun AchievementProgressEntryDto.toDomain(): AchievementProgress = AchievementProgress(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -845,6 +845,7 @@ data class GameAchievementDto(
     val badgeUrl: String? = null,
     val type: String? = null,
     val displayOrder: Int? = null,
+    val rarityPercent: Double = 0.0,
 )
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -525,6 +525,7 @@ data class GameAchievement(
     val badgeUrl: String?,
     val type: String?,
     val displayOrder: Int?,
+    val rarityPercent: Double = 0.0,
 )
 
 data class AchievementProgress(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAchievementBadge.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAchievementBadge.kt
@@ -1,0 +1,129 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Displays an achievement badge image with a rarity-tier colored border.
+ *
+ * Rarity tiers (by unlock percentage):
+ * - Common    (> 50%):  subtle divider border
+ * - Uncommon  (20–50%): silver border
+ * - Rare      ( 5–20%): gold border
+ * - Ultra Rare( 1– 5%): primary (indigo) border, thicker
+ * - Legendary (<  1%):  primary (indigo) border, thicker
+ *
+ * When [isUnlocked] is false the entire badge is dimmed to 40% opacity.
+ *
+ * @param badgeUrl       RA badge image URL (may be null while loading or unavailable)
+ * @param rarityPercent  Unlock percentage in the range 0–100
+ * @param modifier       Modifier applied to the root Box
+ * @param size           Diameter of the square badge
+ * @param isUnlocked     Whether the achievement has been unlocked by the current user
+ */
+@Composable
+fun SpAchievementBadge(
+    badgeUrl: String?,
+    rarityPercent: Double,
+    modifier: Modifier = Modifier,
+    size: Dp = 48.dp,
+    isUnlocked: Boolean = true,
+) {
+    val rarity = AchievementRarity.from(rarityPercent)
+    val borderColor = rarity.borderColor
+    val borderWidth = rarity.borderWidth
+    val shape = RoundedCornerShape(SpSpacing.RadiusMedium)
+
+    Box(
+        modifier = modifier
+            .size(size)
+            .alpha(if (isUnlocked) 1f else 0.4f)
+            .clip(shape)
+            .border(width = borderWidth, color = borderColor, shape = shape),
+        contentAlignment = Alignment.Center,
+    ) {
+        if (badgeUrl != null) {
+            SubcomposeAsyncImage(
+                model = badgeUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Crop,
+                loading = {
+                    BadgeFallback(rarityColor = borderColor)
+                },
+                error = {
+                    BadgeFallback(rarityColor = borderColor)
+                },
+            )
+        } else {
+            BadgeFallback(rarityColor = borderColor)
+        }
+    }
+}
+
+@Composable
+private fun BadgeFallback(rarityColor: Color) {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SpColor.SurfaceElevated),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "?",
+            style = SpTypography.TitleMedium,
+            color = rarityColor,
+        )
+    }
+}
+
+private enum class AchievementRarity {
+    Common,
+    Uncommon,
+    Rare,
+    UltraRare,
+    Legendary;
+
+    val borderColor: Color
+        get() = when (this) {
+            Common -> SpColor.Divider
+            Uncommon -> Color(0xFFC0C0C0)
+            Rare -> Color(0xFFFFD700)
+            UltraRare -> SpColor.Primary
+            Legendary -> SpColor.Primary
+        }
+
+    val borderWidth: Dp
+        get() = when (this) {
+            Common, Uncommon -> 2.dp
+            Rare, UltraRare, Legendary -> 3.dp
+        }
+
+    companion object {
+        fun from(rarityPercent: Double): AchievementRarity = when {
+            rarityPercent > 50.0 -> Common
+            rarityPercent > 20.0 -> Uncommon
+            rarityPercent > 5.0 -> Rare
+            rarityPercent > 1.0 -> UltraRare
+            else -> Legendary
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpRarityChip.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpRarityChip.kt
@@ -1,0 +1,68 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import com.spela.player.presentation.ui.theme.SpColor
+
+/**
+ * CONTENT component — small chip showing rarity tier and percentage.
+ *
+ * Displays nothing for Common (> 50%) since it's not interesting.
+ * For all other tiers shows: "Tier · X.X%"
+ *
+ * Uses [SpChip] with `isSelected = true` and a tier-appropriate color.
+ */
+@Composable
+fun SpRarityChip(
+    rarityPercent: Double,
+    modifier: Modifier = Modifier,
+) {
+    val tier = RarityTier.from(rarityPercent)
+    if (tier == RarityTier.Common) return
+
+    val label = "${tier.label} · ${"%.1f".format(rarityPercent)}%"
+
+    SpChip(
+        text = label,
+        color = tier.color,
+        isSelected = true,
+        modifier = modifier,
+    )
+}
+
+private enum class RarityTier {
+    Common,
+    Uncommon,
+    Rare,
+    UltraRare,
+    Legendary;
+
+    val label: String
+        get() = when (this) {
+            Common -> "Common"
+            Uncommon -> "Uncommon"
+            Rare -> "Rare"
+            UltraRare -> "Ultra Rare"
+            Legendary -> "Legendary"
+        }
+
+    val color: Color
+        get() = when (this) {
+            Common -> Color.Transparent
+            Uncommon -> Color(0xFFC0C0C0) // silver
+            Rare -> Color(0xFFFFD700)     // gold
+            UltraRare -> SpColor.Primary
+            Legendary -> SpColor.Primary
+        }
+
+    companion object {
+        fun from(rarityPercent: Double): RarityTier = when {
+            rarityPercent > 50.0 -> Common
+            rarityPercent > 20.0 -> Uncommon
+            rarityPercent > 5.0 -> Rare
+            rarityPercent > 1.0 -> UltraRare
+            else -> Legendary
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/AchievementComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/AchievementComponents.kt
@@ -30,8 +30,10 @@ import com.spela.player.domain.model.AchievementPlayerRanking
 import com.spela.player.domain.model.AchievementProgress
 import com.spela.player.domain.model.AchievementTimelineEntry
 import com.spela.player.domain.model.GameAchievement
+import com.spela.player.presentation.ui.components.SpAchievementBadge
 import com.spela.player.presentation.ui.components.SpAvatar
 import com.spela.player.presentation.ui.components.SpInnerCard
+import com.spela.player.presentation.ui.components.SpRarityChip
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -56,23 +58,12 @@ internal fun AchievementCard(
                 .padding(SpSpacing.Default),
             verticalAlignment = Alignment.CenterVertically,
         ) {
-            // Badge placeholder (colored circle)
-            Box(
-                modifier = Modifier
-                    .size(40.dp)
-                    .clip(RoundedCornerShape(SpSpacing.RadiusDefault))
-                    .background(
-                        if (isUnlocked) SpColor.Gold.copy(alpha = 0.2f)
-                        else SpColor.SurfaceBright,
-                    ),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = "${achievement.points}",
-                    style = SpTypography.LabelMedium,
-                    color = if (isUnlocked) SpColor.Gold else SpColor.OnBackgroundTertiary,
-                )
-            }
+            SpAchievementBadge(
+                badgeUrl = achievement.badgeUrl,
+                rarityPercent = achievement.rarityPercent,
+                size = 40.dp,
+                isUnlocked = isUnlocked,
+            )
 
             Spacer(Modifier.width(SpSpacing.Medium))
 
@@ -91,6 +82,10 @@ internal fun AchievementCard(
                     maxLines = 2,
                     overflow = TextOverflow.Ellipsis,
                 )
+                if (isUnlocked && achievement.rarityPercent > 0.0) {
+                    Spacer(Modifier.height(SpSpacing.XSmall))
+                    SpRarityChip(rarityPercent = achievement.rarityPercent)
+                }
             }
         }
     }

--- a/server/internal/retroachievements/client.go
+++ b/server/internal/retroachievements/client.go
@@ -27,12 +27,13 @@ func NewRAClient() *RAClient {
 
 // Achievement represents a single RA achievement.
 type Achievement struct {
-	ID          uint   `json:"id"`
-	Title       string `json:"title"`
-	Description string `json:"description"`
-	Points      int    `json:"points"`
-	BadgeURL    string `json:"badgeUrl"`
-	Type        string `json:"type"`
+	ID            uint    `json:"id"`
+	Title         string  `json:"title"`
+	Description   string  `json:"description"`
+	Points        int     `json:"points"`
+	BadgeURL      string  `json:"badgeUrl"`
+	Type          string  `json:"type"`
+	RarityPercent float64 `json:"rarityPercent"`
 }
 
 // GameInfo contains achievement data for a game.
@@ -159,16 +160,20 @@ func (c *RAClient) GetGameInfoAndUserProgress(username, token string, raGameID u
 
 	// The RA API returns a flat object with an Achievements map
 	var raw struct {
-		ID           uint   `json:"ID"`
-		Title        string `json:"Title"`
+		ID                        uint   `json:"ID"`
+		Title                     string `json:"Title"`
+		NumDistinctPlayersCasual  int    `json:"NumDistinctPlayersCasual"`
+		NumDistinctPlayersHardcore int   `json:"NumDistinctPlayersHardcore"`
 		Achievements map[string]struct {
-			ID            uint   `json:"ID"`
-			Title         string `json:"Title"`
-			Description   string `json:"Description"`
-			Points        int    `json:"Points"`
-			BadgeName     string `json:"BadgeName"`
-			Type          int    `json:"type"` // 3 = core, 5 = unofficial
-			DateEarned    string `json:"DateEarned"`
+			ID                 uint   `json:"ID"`
+			Title              string `json:"Title"`
+			Description        string `json:"Description"`
+			Points             int    `json:"Points"`
+			BadgeName          string `json:"BadgeName"`
+			Type               int    `json:"type"` // 3 = core, 5 = unofficial
+			NumAwarded         int    `json:"NumAwarded"`
+			NumAwardedHardcore int    `json:"NumAwardedHardcore"`
+			DateEarned         string `json:"DateEarned"`
 			DateEarnedHardcore string `json:"DateEarnedHardcore"`
 		} `json:"Achievements"`
 	}
@@ -184,6 +189,11 @@ func (c *RAClient) GetGameInfoAndUserProgress(username, token string, raGameID u
 	var progress []UserProgress
 	totalPoints := 0
 
+	numDistinctPlayers := raw.NumDistinctPlayersCasual
+	if raw.NumDistinctPlayersHardcore > numDistinctPlayers {
+		numDistinctPlayers = raw.NumDistinctPlayersHardcore
+	}
+
 	for _, a := range raw.Achievements {
 		achType := "core"
 		if a.Type == 5 {
@@ -195,13 +205,19 @@ func (c *RAClient) GetGameInfoAndUserProgress(username, token string, raGameID u
 			badgeURL = fmt.Sprintf("https://media.retroachievements.org/Badge/%s.png", a.BadgeName)
 		}
 
+		rarityPercent := 0.0
+		if numDistinctPlayers > 0 {
+			rarityPercent = float64(a.NumAwarded) / float64(numDistinctPlayers) * 100.0
+		}
+
 		gameInfo.Achievements = append(gameInfo.Achievements, Achievement{
-			ID:          a.ID,
-			Title:       a.Title,
-			Description: a.Description,
-			Points:      a.Points,
-			BadgeURL:    badgeURL,
-			Type:        achType,
+			ID:            a.ID,
+			Title:         a.Title,
+			Description:   a.Description,
+			Points:        a.Points,
+			BadgeURL:      badgeURL,
+			Type:          achType,
+			RarityPercent: rarityPercent,
 		})
 
 		if achType == "core" {

--- a/web/src/features/game-detail/components/achievement-card.tsx
+++ b/web/src/features/game-detail/components/achievement-card.tsx
@@ -5,6 +5,50 @@ import type {
   GameAchievementProgress as AchievementProgress,
 } from "@/types/api";
 
+type RarityTier = "Common" | "Uncommon" | "Rare" | "Ultra Rare" | "Legendary";
+
+interface RarityInfo {
+  tier: RarityTier;
+  borderClass: string;
+  pillClass: string | null;
+}
+
+function getRarityInfo(rarityPercent: number): RarityInfo {
+  if (rarityPercent < 1) {
+    return {
+      tier: "Legendary",
+      borderClass: "border-purple-400 ring-1 ring-purple-500/50",
+      pillClass: "bg-purple-900/60 text-purple-300 border border-purple-500",
+    };
+  }
+  if (rarityPercent < 5) {
+    return {
+      tier: "Ultra Rare",
+      borderClass: "border-purple-500",
+      pillClass: "bg-purple-900/60 text-purple-300 border border-purple-500",
+    };
+  }
+  if (rarityPercent < 20) {
+    return {
+      tier: "Rare",
+      borderClass: "border-yellow-400",
+      pillClass: "bg-yellow-900/60 text-yellow-300 border border-yellow-500",
+    };
+  }
+  if (rarityPercent <= 50) {
+    return {
+      tier: "Uncommon",
+      borderClass: "border-gray-400",
+      pillClass: null,
+    };
+  }
+  return {
+    tier: "Common",
+    borderClass: "border-surface-700",
+    pillClass: null,
+  };
+}
+
 interface AchievementCardProps {
   achievement: Achievement;
   unlocked: AchievementProgress | undefined;
@@ -14,13 +58,19 @@ export function AchievementCard({
   achievement,
   unlocked,
 }: AchievementCardProps) {
+  const rarity = getRarityInfo(achievement.rarityPercent);
+  const showRarityDetails =
+    unlocked && rarity.tier !== "Common" && rarity.tier !== "Uncommon";
+  const showRarityPercent = unlocked && rarity.tier !== "Common";
+
   return (
     <div
       className={cn(
         "flex items-start gap-3 rounded-lg border p-3",
         unlocked
-          ? "border-surface-700 bg-surface-800"
+          ? rarity.borderClass
           : "border-surface-800 bg-surface-900 opacity-50",
+        unlocked && "bg-surface-800",
       )}
       data-testid={`achievement-${achievement.id}`}
     >
@@ -37,13 +87,28 @@ export function AchievementCard({
           {unlocked && (
             <Trophy className="h-3.5 w-3.5 flex-shrink-0 text-amber-400" />
           )}
+          {showRarityDetails && rarity.pillClass && (
+            <span
+              className={cn(
+                "flex-shrink-0 rounded-full px-1.5 py-0.5 text-xs font-medium",
+                rarity.pillClass,
+              )}
+            >
+              {rarity.tier}
+            </span>
+          )}
         </div>
         <p className="text-xs text-surface-400 line-clamp-2">
           {achievement.description}
         </p>
-        <p className="text-xs text-surface-500 mt-1">
-          {achievement.points} pts
-        </p>
+        <div className="flex items-center gap-2 mt-1">
+          <p className="text-xs text-surface-500">{achievement.points} pts</p>
+          {showRarityPercent && (
+            <p className="text-xs text-surface-400">
+              {achievement.rarityPercent.toFixed(1)}% of players
+            </p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -275,6 +275,7 @@ export interface Achievement {
   points: number;
   badgeUrl: string;
   type: string;
+  rarityPercent: number;
 }
 
 export interface GameAchievements {


### PR DESCRIPTION
## Summary
Phase 1 of making RetroAchievements more fun. Adds global rarity percentages to every achievement with tier-based visual treatment.

### Server
- Parse `NumAwarded` and `NumDistinctPlayers` from RA API (already returned, not captured)
- Compute `rarityPercent` per achievement, cache alongside existing data

### Player App
- `SpAchievementBadge` — CONTENT component with rarity-tier colored borders (Common/Uncommon/Rare/Ultra Rare/Legendary)
- `SpRarityChip` — CONTENT component showing tier label + percentage
- Achievement cards now show rarity borders and chips when unlocked

### Web App
- `AchievementCard` updated with tier-based border colors and rarity text
- Rarity pill badges for Rare and above

### Rarity Tiers
| Tier | % | Visual |
|---|---|---|
| Common | >50% | Default |
| Uncommon | 20-50% | Silver border |
| Rare | 5-20% | Gold border |
| Ultra Rare | 1-5% | Purple border |
| Legendary | <1% | Purple + glow |

## Test plan
- [x] Server builds
- [x] Player builds
- [x] Web builds
- [ ] Achievement cards show rarity borders for games with RA data
- [ ] Common achievements have no special styling
- [ ] Rare+ achievements show SpRarityChip