### PR TITLE
feat: achievement showcase on user profile

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreSeriesTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreSeriesTest.kt
@@ -103,6 +103,7 @@ class ExploreSeriesTest {
         id = "s1",
         name = "Super Mario",
         heroUrl = null,
+        logoUrl = null,
         consoles = sampleSeriesConsoles,
         libraryGames = 2,
         totalGames = 3,

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/FranchiseDetailTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/FranchiseDetailTest.kt
@@ -80,6 +80,7 @@ class FranchiseDetailTest {
         id = "fr1",
         name = "Castlevania",
         heroUrl = null,
+        logoUrl = null,
         consoles = sampleFranchiseConsoles,
         libraryGames = 2,
         totalGames = 3,
@@ -193,6 +194,7 @@ class FranchiseDetailTest {
             id = "fr2",
             name = "Mega Man",
             heroUrl = null,
+            logoUrl = null,
             consoles = listOf(
                 SeriesConsole(abbreviation = "NES", name = "NES", color = "#dc2626", gameCount = 1),
                 SeriesConsole(abbreviation = "SNES", name = "SNES", color = "#9333ea", gameCount = 0),

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenCelebrationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenCelebrationTest.kt
@@ -10,55 +10,121 @@ import kotlin.test.Test
  * E2E tests for the SecondaryAchievementCelebration overlay.
  *
  * Tests cover:
- * - Achievement unlock celebration (ACHIEVEMENT_TRIGGERED event)
- * - Game completion celebration (GAME_COMPLETED event) with distinct visuals
- *
- * The SecondaryAchievementCelebration is a stateless composable rendered
- * directly with explicit parameters. No ViewModel is needed.
+ * - Common achievement unlock (default styling)
+ * - Rare achievement unlock (tier-specific header and rarity badge)
+ * - Game completion celebration (confetti + 100% indicator)
  */
 @OptIn(ExperimentalTestApi::class)
 class SecondaryScreenCelebrationTest {
 
     @Test
-    fun achievementCelebrationShowsOnEvent() = runComposeUiTest {
+    fun commonAchievementShowsDefaultHeader() = runComposeUiTest {
         val event = AchievementEvent(
             type = AchievementEventType.ACHIEVEMENT_TRIGGERED,
             title = "First Blood",
             description = "Defeat the first enemy",
             points = 10,
+            rarityPercent = 75.0,
         )
 
         mainClock.autoAdvance = false
 
         setContent {
-            SecondaryAchievementCelebration(
-                achievementEvent = event,
-            )
+            SecondaryAchievementCelebration(achievementEvent = event)
         }
 
-        // Advance clock to let the LaunchedEffect enqueue and promote the event.
-        // Keep autoAdvance disabled because the celebration has an infinite glow
-        // animation that would cause waitForIdle() to hang.
         mainClock.advanceTimeBy(1_000)
         waitForIdle()
 
-        // The celebration overlay should show with correct content description
         onNodeWithContentDescription("Achievement unlocked: First Blood, 10 points")
             .assertExists()
             .assertIsDisplayed()
 
-        // "ACHIEVEMENT UNLOCKED" header text should be visible
         onNodeWithText("ACHIEVEMENT UNLOCKED")
             .assertExists()
             .assertIsDisplayed()
 
-        // Achievement title should be visible
         onNodeWithText("First Blood")
             .assertExists()
             .assertIsDisplayed()
 
-        // Achievement description should be visible
         onNodeWithText("Defeat the first enemy")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun rareAchievementShowsRareHeader() = runComposeUiTest {
+        val event = AchievementEvent(
+            type = AchievementEventType.ACHIEVEMENT_TRIGGERED,
+            title = "Speed Demon",
+            description = "Complete the game in under 2 hours",
+            points = 50,
+            rarityPercent = 8.2,
+        )
+
+        mainClock.autoAdvance = false
+
+        setContent {
+            SecondaryAchievementCelebration(achievementEvent = event)
+        }
+
+        mainClock.advanceTimeBy(1_000)
+        waitForIdle()
+
+        onNodeWithText("RARE ACHIEVEMENT")
+            .assertExists()
+            .assertIsDisplayed()
+
+        onNodeWithText("Speed Demon")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun ultraRareAchievementShowsUltraRareHeader() = runComposeUiTest {
+        val event = AchievementEvent(
+            type = AchievementEventType.ACHIEVEMENT_TRIGGERED,
+            title = "Perfectionist",
+            description = "Complete without taking any damage",
+            points = 100,
+            rarityPercent = 2.5,
+        )
+
+        mainClock.autoAdvance = false
+
+        setContent {
+            SecondaryAchievementCelebration(achievementEvent = event)
+        }
+
+        mainClock.advanceTimeBy(1_000)
+        waitForIdle()
+
+        onNodeWithText("ULTRA RARE ACHIEVEMENT")
+            .assertExists()
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun legendaryAchievementShowsLegendaryHeader() = runComposeUiTest {
+        val event = AchievementEvent(
+            type = AchievementEventType.ACHIEVEMENT_TRIGGERED,
+            title = "The Impossible",
+            description = "Achieve the truly impossible",
+            points = 200,
+            rarityPercent = 0.3,
+        )
+
+        mainClock.autoAdvance = false
+
+        setContent {
+            SecondaryAchievementCelebration(achievementEvent = event)
+        }
+
+        mainClock.advanceTimeBy(1_000)
+        waitForIdle()
+
+        onNodeWithText("LEGENDARY ACHIEVEMENT")
             .assertExists()
             .assertIsDisplayed()
     }
@@ -75,33 +141,24 @@ class SecondaryScreenCelebrationTest {
         mainClock.autoAdvance = false
 
         setContent {
-            SecondaryAchievementCelebration(
-                achievementEvent = event,
-            )
+            SecondaryAchievementCelebration(achievementEvent = event)
         }
 
-        // Advance clock to let the LaunchedEffect enqueue and promote the event.
-        // Keep autoAdvance disabled because the celebration has an infinite glow
-        // animation that would cause waitForIdle() to hang.
         mainClock.advanceTimeBy(1_000)
         waitForIdle()
 
-        // The celebration overlay should show with game completed content description
         onNodeWithContentDescription("Game completed celebration: Castlevania")
             .assertExists()
             .assertIsDisplayed()
 
-        // "GAME COMPLETED" header text should be visible (distinct from "ACHIEVEMENT UNLOCKED")
-        onNodeWithText("GAME COMPLETED")
+        onNodeWithText("100% COMPLETE")
             .assertExists()
             .assertIsDisplayed()
 
-        // "100%" completion indicator should be visible
         onNodeWithText("100%")
             .assertExists()
             .assertIsDisplayed()
 
-        // "ACHIEVEMENT UNLOCKED" should NOT be present
         onAllNodesWithText("ACHIEVEMENT UNLOCKED")
             .assertCountEquals(0)
     }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -258,6 +258,7 @@ class SpelaTestHarness(
         getActivityFeedUseCase = GetActivityFeedUseCase(socialRepo),
         getPublicProfileUseCase = GetPublicProfileUseCase(socialRepo),
         getPlayHeatmapUseCase = GetPlayHeatmapUseCase(socialRepo),
+        getPublicShowcaseUseCase = GetPublicShowcaseUseCase(socialRepo),
         dispatchers = dispatchers,
         scope = scope,
     )

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -815,6 +815,8 @@ class FakeSocialRepository : SocialRepository {
         Result.failure(Exception("Not implemented in fake"))
     override suspend fun getPlayHeatmap(userId: String): Result<List<com.spela.player.domain.model.HeatmapEntry>> =
         Result.success(emptyList())
+    override suspend fun getPublicShowcase(userId: String): Result<List<com.spela.player.domain.model.ShowcaseAchievement>> =
+        Result.success(emptyList())
 }
 
 class FakeKeyMappingRepository : KeyMappingRepository {

--- a/player/native/src/libretro_achievements.c
+++ b/player/native/src/libretro_achievements.c
@@ -137,11 +137,13 @@ static void rc_event_handler(const rc_client_event_t *event, rc_client_t *client
 
     JNIEnv *env = ach_state.jni_env;
     jint event_type = (jint)event->type;
+    jlong achievement_id = 0;
     jstring title_jstr = NULL;
     jstring desc_jstr = NULL;
     jint points = 0;
 
     if (event->achievement) {
+        achievement_id = (jlong)event->achievement->id;
         if (event->achievement->title) {
             title_jstr = (*env)->NewStringUTF(env, event->achievement->title);
         }
@@ -152,7 +154,7 @@ static void rc_event_handler(const rc_client_event_t *event, rc_client_t *client
     }
 
     (*env)->CallVoidMethod(env, ach_state.jni_thiz, ach_state.on_achievement_event_method,
-                           event_type, title_jstr, desc_jstr, points);
+                           event_type, achievement_id, title_jstr, desc_jstr, points);
 
     if (title_jstr) (*env)->DeleteLocalRef(env, title_jstr);
     if (desc_jstr) (*env)->DeleteLocalRef(env, desc_jstr);
@@ -202,7 +204,7 @@ void achievements_init(JNIEnv *env, jobject thiz) {
 
     ach_state.on_achievement_event_method = (*env)->GetMethodID(
         env, ach_state.jni_class, "onAchievementEvent",
-        "(ILjava/lang/String;Ljava/lang/String;I)V");
+        "(IJLjava/lang/String;Ljava/lang/String;I)V");
 
     ach_state.on_http_request_method = (*env)->GetMethodID(
         env, ach_state.jni_class, "onHttpRequest",

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidAchievementsController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidAchievementsController.kt
@@ -29,12 +29,13 @@ class AndroidAchievementsController(
     override val isHardcore: Boolean get() = _isHardcore
 
     override fun init() {
-        jni.achievementEventListener = { eventType, title, description, points ->
+        jni.achievementEventListener = { eventType, achievementId, title, description, points ->
             val type = AchievementEventType.fromNativeValue(eventType)
             if (type != null) {
                 _events.tryEmit(
                     AchievementEvent(
                         type = type,
+                        achievementId = achievementId,
                         title = title ?: "",
                         description = description ?: "",
                         points = points,

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
@@ -87,12 +87,12 @@ class LibretroJni {
     external fun nativeAchievementsSetHardcore(enabled: Boolean)
     external fun nativeAchievementsHttpComplete(requestId: Int, responseCode: Int, responseBody: ByteArray)
 
-    var achievementEventListener: ((Int, String?, String?, Int) -> Unit)? = null
+    var achievementEventListener: ((Int, Long, String?, String?, Int) -> Unit)? = null
     var httpRequestListener: ((Int, String, String?) -> Unit)? = null
 
     // Called from native code when an achievement event occurs
-    fun onAchievementEvent(eventType: Int, title: String?, description: String?, points: Int) {
-        achievementEventListener?.invoke(eventType, title, description, points)
+    fun onAchievementEvent(eventType: Int, achievementId: Long, title: String?, description: String?, points: Int) {
+        achievementEventListener?.invoke(eventType, achievementId, title, description, points)
     }
 
     // Called from native code when rcheevos needs an HTTP request

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -641,6 +641,14 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/user/achievements/recent").body()
     }
 
+    suspend fun getShowcase(): List<ShowcaseAchievementDto> {
+        return client.get("$baseUrl/api/user/achievements/showcase").body()
+    }
+
+    suspend fun getPublicShowcase(userId: String): List<ShowcaseAchievementDto> {
+        return client.get("$baseUrl/api/users/$userId/achievements/showcase").body()
+    }
+
     // Devices
 
     suspend fun deleteDevice(deviceId: Long) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -436,6 +436,18 @@ fun RecentAchievementDto.toDomain(): RecentAchievement = RecentAchievement(
     coverUrl = coverUrl,
 )
 
+fun ShowcaseAchievementDto.toDomain(): ShowcaseAchievement = ShowcaseAchievement(
+    achievementRaId = achievementRaId,
+    raGameId = raGameId,
+    showcaseOrder = showcaseOrder,
+    title = title ?: "",
+    description = description ?: "",
+    points = points ?: 0,
+    badgeUrl = badgeUrl,
+    rarityPercent = rarityPercent ?: 0.0,
+    gameTitle = gameTitle ?: "",
+)
+
 // Stats mappers
 
 fun MostPlayedGameDto.toDomain(): MostPlayedGame = MostPlayedGame(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -955,6 +955,21 @@ data class RecentAchievementsResponse(
     val achievements: List<RecentAchievementDto> = emptyList(),
 )
 
+// Achievement Showcase
+
+@Serializable
+data class ShowcaseAchievementDto(
+    val achievementRaId: Long,
+    val raGameId: Long,
+    val showcaseOrder: Int = 0,
+    val title: String? = null,
+    val description: String? = null,
+    val points: Int? = null,
+    val badgeUrl: String? = null,
+    val rarityPercent: Double? = null,
+    val gameTitle: String? = null,
+)
+
 // Top Rated
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
@@ -6,6 +6,7 @@ import com.spela.player.domain.model.ActivityEvent
 import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
+import com.spela.player.domain.model.ShowcaseAchievement
 import com.spela.player.domain.repository.SocialRepository
 
 class SocialRepositoryImpl(
@@ -50,5 +51,12 @@ class SocialRepositoryImpl(
 
     override suspend fun getPlayHeatmap(userId: String): Result<List<HeatmapEntry>> = runCatching {
         apiClient.getPublicPlayHeatmap(userId).map { it.toDomain() }
+    }
+
+    override suspend fun getPublicShowcase(userId: String): Result<List<ShowcaseAchievement>> = runCatching {
+        apiClient.getPublicShowcase(userId).map { dto ->
+            val achievement = dto.toDomain()
+            achievement.copy(badgeUrl = apiClient.resolveUrl(achievement.badgeUrl))
+        }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -96,6 +96,7 @@ val commonModule = module {
     factory { GetActivityFeedUseCase(get()) }
     factory { GetPublicProfileUseCase(get()) }
     factory { GetPlayHeatmapUseCase(get()) }
+    factory { GetPublicShowcaseUseCase(get()) }
     factory { GetMyCollectionsUseCase(get()) }
     factory { GetPublicCollectionsUseCase(get()) }
     factory { GetCollectionDetailUseCase(get()) }
@@ -230,6 +231,7 @@ val commonModule = module {
             getActivityFeedUseCase = get(),
             getPublicProfileUseCase = get(),
             getPlayHeatmapUseCase = get(),
+            getPublicShowcaseUseCase = get(),
             dispatchers = get(),
             scope = get(),
         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -324,9 +324,11 @@ enum class AchievementEventType(val nativeValue: Int) {
 
 data class AchievementEvent(
     val type: AchievementEventType,
+    val achievementId: Long = 0L,
     val title: String = "",
     val description: String = "",
     val points: Int = 0,
+    val rarityPercent: Double = 0.0,
 )
 
 // Shared Session

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -567,6 +567,18 @@ data class AchievementPlayerRanking(
     val lastUnlockedAt: String?,
 )
 
+data class ShowcaseAchievement(
+    val achievementRaId: Long,
+    val raGameId: Long,
+    val showcaseOrder: Int = 0,
+    val title: String = "",
+    val description: String = "",
+    val points: Int = 0,
+    val badgeUrl: String? = null,
+    val rarityPercent: Double = 0.0,
+    val gameTitle: String = "",
+)
+
 data class UserStats(
     val totalPlayTime: Long,
     val gamesPlayed: Long,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SocialRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SocialRepository.kt
@@ -4,10 +4,12 @@ import com.spela.player.domain.model.ActivityEvent
 import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
+import com.spela.player.domain.model.ShowcaseAchievement
 
 interface SocialRepository {
     suspend fun getOnlineUsers(): Result<List<OnlineUser>>
     suspend fun getActivityFeed(page: Int = 1, pageSize: Int = 20): Result<List<ActivityEvent>>
     suspend fun getPublicProfile(userId: String): Result<PublicProfile>
     suspend fun getPlayHeatmap(userId: String): Result<List<HeatmapEntry>>
+    suspend fun getPublicShowcase(userId: String): Result<List<ShowcaseAchievement>>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/SocialUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/SocialUseCases.kt
@@ -4,6 +4,7 @@ import com.spela.player.domain.model.ActivityEvent
 import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
+import com.spela.player.domain.model.ShowcaseAchievement
 import com.spela.player.domain.repository.SocialRepository
 
 class GetOnlineUsersUseCase(private val socialRepository: SocialRepository) {
@@ -21,4 +22,8 @@ class GetPublicProfileUseCase(private val repository: SocialRepository) {
 
 class GetPlayHeatmapUseCase(private val repository: SocialRepository) {
     suspend operator fun invoke(userId: String): Result<List<HeatmapEntry>> = repository.getPlayHeatmap(userId)
+}
+
+class GetPublicShowcaseUseCase(private val repository: SocialRepository) {
+    suspend operator fun invoke(userId: String): Result<List<ShowcaseAchievement>> = repository.getPublicShowcase(userId)
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SocialState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SocialState.kt
@@ -4,6 +4,7 @@ import com.spela.player.domain.model.ActivityEvent
 import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
+import com.spela.player.domain.model.ShowcaseAchievement
 
 data class SocialState(
     val onlineUsers: List<OnlineUser> = emptyList(),
@@ -14,6 +15,7 @@ data class SocialState(
     val publicProfile: PublicProfile? = null,
     val isLoadingProfile: Boolean = false,
     val heatmapData: List<HeatmapEntry> = emptyList(),
+    val showcaseAchievements: List<ShowcaseAchievement> = emptyList(),
     // Full activity feed (paginated, for the Activity screen)
     val fullActivityEvents: List<ActivityEvent> = emptyList(),
     val isLoadingFullActivity: Boolean = false,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAchievementShowcaseCard.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAchievementShowcaseCard.kt
@@ -1,0 +1,76 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import com.spela.player.domain.model.ShowcaseAchievement
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * CONTENT component -- large achievement card for profile showcase.
+ *
+ * Shows a prominent achievement badge, title, game title, points, and rarity chip.
+ * Fixed width for use in horizontal scrolling LazyRow.
+ */
+@Composable
+fun SpAchievementShowcaseCard(
+    achievement: ShowcaseAchievement,
+    modifier: Modifier = Modifier,
+) {
+    SpCard(modifier = modifier.width(160.dp)) {
+        Column(
+            modifier = Modifier.padding(SpSpacing.Medium),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+        ) {
+            SpAchievementBadge(
+                badgeUrl = achievement.badgeUrl,
+                rarityPercent = achievement.rarityPercent,
+                size = 64.dp,
+            )
+
+            Spacer(Modifier.height(SpSpacing.XSmall))
+
+            Text(
+                text = achievement.title,
+                style = SpTypography.TitleMedium,
+                color = SpColor.OnBackground,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+            )
+
+            Text(
+                text = achievement.gameTitle,
+                style = SpTypography.LabelSmall,
+                color = SpColor.OnBackgroundTertiary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+                textAlign = TextAlign.Center,
+            )
+
+            Text(
+                text = "${achievement.points} pts",
+                style = SpTypography.LabelSmall,
+                color = SpColor.OnBackgroundSecondary,
+                textAlign = TextAlign.Center,
+            )
+
+            if (achievement.rarityPercent > 0) {
+                SpRarityChip(rarityPercent = achievement.rarityPercent)
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpConfetti.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpConfetti.kt
@@ -1,0 +1,120 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.LinearEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.rotate
+import com.spela.player.presentation.ui.theme.SpColor
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+import kotlin.random.Random
+
+private val CONFETTI_COLORS = listOf(
+    SpColor.Primary,
+    SpColor.Secondary,
+    SpColor.Accent,
+    Color(0xFFFFD700), // Gold
+    SpColor.Success,
+    Color(0xFFFF6B81), // Rose
+    Color(0xFF00D2FF), // Cyan
+)
+
+private data class ConfettiParticle(
+    val startX: Float,
+    val startY: Float,
+    val velocityX: Float,
+    val velocityY: Float,
+    val rotation: Float,
+    val rotationSpeed: Float,
+    val color: Color,
+    val size: Float,
+    val isRect: Boolean,
+)
+
+/**
+ * DESIGN component — canvas-based confetti particle animation overlay.
+ *
+ * Renders animated confetti particles that burst from the center and fall with
+ * gravity. Used for game completion and legendary achievement celebrations.
+ *
+ * @param particleCount Number of confetti particles to render.
+ * @param durationMs Total animation duration in milliseconds.
+ */
+@Composable
+fun SpConfetti(
+    modifier: Modifier = Modifier,
+    particleCount: Int = 60,
+    durationMs: Int = 3000,
+) {
+    val progress = remember { Animatable(0f) }
+
+    LaunchedEffect(Unit) {
+        progress.animateTo(
+            targetValue = 1f,
+            animationSpec = tween(durationMs, easing = LinearEasing),
+        )
+    }
+
+    val particles = remember {
+        val rng = Random(System.nanoTime())
+        List(particleCount) {
+            val angle = rng.nextDouble(0.0, 2 * PI).toFloat()
+            val speed = rng.nextFloat() * 400f + 150f
+            ConfettiParticle(
+                startX = 0.5f + (rng.nextFloat() - 0.5f) * 0.2f,
+                startY = 0.45f + (rng.nextFloat() - 0.5f) * 0.1f,
+                velocityX = cos(angle) * speed,
+                velocityY = sin(angle) * speed - 300f, // bias upward
+                rotation = rng.nextFloat() * 360f,
+                rotationSpeed = (rng.nextFloat() - 0.5f) * 720f,
+                color = CONFETTI_COLORS[rng.nextInt(CONFETTI_COLORS.size)],
+                size = rng.nextFloat() * 6f + 4f,
+                isRect = rng.nextBoolean(),
+            )
+        }
+    }
+
+    val t = progress.value
+
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val gravity = 600f
+        val w = size.width
+        val h = size.height
+
+        for (p in particles) {
+            val elapsed = t * (durationMs / 1000f)
+            val x = p.startX * w + p.velocityX * elapsed
+            val y = p.startY * h + p.velocityY * elapsed + 0.5f * gravity * elapsed * elapsed
+            val alpha = (1f - t).coerceIn(0f, 1f)
+            val rotation = p.rotation + p.rotationSpeed * elapsed
+
+            if (x < -50f || x > w + 50f || y > h + 50f) continue
+
+            rotate(rotation, pivot = Offset(x, y)) {
+                if (p.isRect) {
+                    drawRect(
+                        color = p.color.copy(alpha = alpha),
+                        topLeft = Offset(x - p.size, y - p.size * 0.4f),
+                        size = Size(p.size * 2f, p.size * 0.8f),
+                    )
+                } else {
+                    drawCircle(
+                        color = p.color.copy(alpha = alpha),
+                        radius = p.size * 0.6f,
+                        center = Offset(x, y),
+                    )
+                }
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryAchievementCelebration.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryAchievementCelebration.kt
@@ -35,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.CornerRadius
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.semantics.contentDescription
@@ -46,24 +47,79 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.spela.player.domain.model.AchievementEvent
 import com.spela.player.domain.model.AchievementEventType
+import com.spela.player.presentation.ui.components.SpConfetti
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import kotlinx.coroutines.delay
 
-private const val CELEBRATION_DISPLAY_DURATION_MS = 6_000L
 private const val ENTRANCE_ANIMATION_MS = 400
 private const val EXIT_ANIMATION_MS = 300
-private const val GLOW_PULSE_DURATION_MS = 1_500
 private val BANNER_CORNER_RADIUS = SpSpacing.RadiusLarge
 private val BANNER_MAX_WIDTH = 340.dp
-private val GLOW_STROKE_WIDTH = SpSpacing.XXSmall
+
+// Rarity tier thresholds (matching server-side definition)
+private enum class RarityTier(val label: String) {
+    COMMON("Common"),
+    UNCOMMON("Uncommon"),
+    RARE("Rare"),
+    ULTRA_RARE("Ultra Rare"),
+    LEGENDARY("Legendary"),
+}
+
+private fun rarityTier(percent: Double): RarityTier = when {
+    percent < 1.0 -> RarityTier.LEGENDARY
+    percent < 5.0 -> RarityTier.ULTRA_RARE
+    percent < 20.0 -> RarityTier.RARE
+    percent < 50.0 -> RarityTier.UNCOMMON
+    else -> RarityTier.COMMON
+}
+
+private val SILVER = Color(0xFFC0C0C0)
+private val GOLD = Color(0xFFFFD700)
+
+private fun tierAccentColor(tier: RarityTier): Color = when (tier) {
+    RarityTier.COMMON -> SpColor.Warning
+    RarityTier.UNCOMMON -> SILVER
+    RarityTier.RARE -> GOLD
+    RarityTier.ULTRA_RARE -> SpColor.Primary
+    RarityTier.LEGENDARY -> SpColor.Primary
+}
+
+private fun tierDisplayDuration(tier: RarityTier, isGameCompleted: Boolean): Long = when {
+    isGameCompleted -> 8_000L
+    tier == RarityTier.LEGENDARY -> 7_000L
+    tier == RarityTier.ULTRA_RARE -> 6_500L
+    tier == RarityTier.RARE -> 6_000L
+    else -> 5_000L
+}
+
+private fun tierGlowPulseDuration(tier: RarityTier): Int = when (tier) {
+    RarityTier.LEGENDARY -> 800
+    RarityTier.ULTRA_RARE -> 1_000
+    RarityTier.RARE -> 1_200
+    else -> 1_500
+}
+
+private fun tierStrokeWidth(tier: RarityTier): Float = when (tier) {
+    RarityTier.LEGENDARY -> 4f
+    RarityTier.ULTRA_RARE -> 3f
+    RarityTier.RARE -> 2.5f
+    else -> 2f
+}
+
+private fun tierShowConfetti(tier: RarityTier, isGameCompleted: Boolean): Boolean =
+    isGameCompleted || tier == RarityTier.LEGENDARY
+
+private fun tierConfettiCount(isGameCompleted: Boolean): Int =
+    if (isGameCompleted) 80 else 50
 
 /**
  * Achievement celebration overlay for the secondary screen.
  *
  * Displays a visually rich banner when achievements are unlocked or the game is completed.
  * Events are queued so rapid unlocks show one at a time, each for its full duration.
+ * Celebration intensity scales with the achievement's rarity tier.
  *
  * This composable does NOT consume pointer events, so the user can still interact
  * with the underlying pager/controls while the celebration is visible.
@@ -77,16 +133,9 @@ fun SecondaryAchievementCelebration(
     achievementEvent: AchievementEvent?,
     onCelebrationStarted: () -> Unit = {},
 ) {
-    // Queue of pending celebrations. We collect events into this list and display
-    // them one at a time. Each event is shown for CELEBRATION_DISPLAY_DURATION_MS
-    // before being removed, which triggers the next one in the queue.
     val celebrationQueue = remember { mutableStateListOf<AchievementEvent>() }
     var currentCelebration by remember { mutableStateOf<AchievementEvent?>(null) }
 
-    // Enqueue new achievement events when the parameter changes.
-    // We key on the event identity so each new event fires exactly once.
-    // The event may be cleared from EmulationState by the primary screen's
-    // AchievementPopup, but we've already captured our own copy in the queue.
     LaunchedEffect(achievementEvent) {
         val event = achievementEvent ?: return@LaunchedEffect
         if (event.type == AchievementEventType.ACHIEVEMENT_TRIGGERED ||
@@ -96,21 +145,19 @@ fun SecondaryAchievementCelebration(
         }
     }
 
-    // Promote the next queued item to current when there is no active celebration.
     LaunchedEffect(celebrationQueue.size, currentCelebration) {
         if (currentCelebration == null && celebrationQueue.isNotEmpty()) {
             currentCelebration = celebrationQueue.removeFirst()
         }
     }
 
-    // Auto-dismiss the current celebration after the display duration.
     LaunchedEffect(currentCelebration) {
         val celebration = currentCelebration ?: return@LaunchedEffect
         onCelebrationStarted()
-        // Keep the celebration visible for its full duration, then clear it
-        // so the next queued item can be promoted.
-        delay(CELEBRATION_DISPLAY_DURATION_MS)
-        // Only clear if it's still the same celebration (defensive check)
+        val isGameCompleted = celebration.type == AchievementEventType.GAME_COMPLETED
+        val tier = rarityTier(celebration.rarityPercent)
+        val duration = tierDisplayDuration(tier, isGameCompleted)
+        delay(duration)
         if (currentCelebration == celebration) {
             currentCelebration = null
         }
@@ -118,19 +165,28 @@ fun SecondaryAchievementCelebration(
 
     val isVisible = currentCelebration != null
 
-    // Cache the last non-null celebration so the banner content persists during the
-    // exit fade-out animation (when currentCelebration has already been set to null).
     var lastCelebration by remember { mutableStateOf<AchievementEvent?>(null) }
     LaunchedEffect(currentCelebration) {
         if (currentCelebration != null) lastCelebration = currentCelebration
     }
 
-    // The overlay does NOT fill the entire screen and does NOT consume pointer events.
-    // It sits in a Box that fills the parent but uses contentAlignment to center the banner.
     Box(
         modifier = Modifier.fillMaxSize(),
         contentAlignment = Alignment.Center,
     ) {
+        // Confetti layer (behind the banner)
+        val celebration = lastCelebration
+        if (isVisible && celebration != null) {
+            val isGameCompleted = celebration.type == AchievementEventType.GAME_COMPLETED
+            val tier = rarityTier(celebration.rarityPercent)
+            if (tierShowConfetti(tier, isGameCompleted)) {
+                SpConfetti(
+                    particleCount = tierConfettiCount(isGameCompleted),
+                    durationMs = if (isGameCompleted) 4000 else 3000,
+                )
+            }
+        }
+
         AnimatedVisibility(
             visible = isVisible,
             enter = fadeIn(tween(ENTRANCE_ANIMATION_MS)) +
@@ -140,35 +196,56 @@ fun SecondaryAchievementCelebration(
                 ),
             exit = fadeOut(tween(EXIT_ANIMATION_MS)),
         ) {
-            val celebration = lastCelebration ?: return@AnimatedVisibility
-            CelebrationBanner(event = celebration)
+            val event = lastCelebration ?: return@AnimatedVisibility
+            CelebrationBanner(event = event)
         }
     }
 }
 
 /**
  * The visual banner card displayed for a single achievement celebration.
+ * Visual intensity scales with rarity tier.
  */
 @Composable
 private fun CelebrationBanner(event: AchievementEvent) {
     val isGameCompleted = event.type == AchievementEventType.GAME_COMPLETED
-    val accentColor = if (isGameCompleted) SpColor.Success else SpColor.Warning
-    val headerText = if (isGameCompleted) "GAME COMPLETED" else "ACHIEVEMENT UNLOCKED"
+    val tier = rarityTier(event.rarityPercent)
+    val accentColor = if (isGameCompleted) SpColor.Success else tierAccentColor(tier)
+    val headerText = if (isGameCompleted) {
+        "100% COMPLETE"
+    } else when (tier) {
+        RarityTier.LEGENDARY -> "LEGENDARY ACHIEVEMENT"
+        RarityTier.ULTRA_RARE -> "ULTRA RARE ACHIEVEMENT"
+        RarityTier.RARE -> "RARE ACHIEVEMENT"
+        else -> "ACHIEVEMENT UNLOCKED"
+    }
 
-    // Subtle pulsing glow animation
+    val glowPulseDuration = tierGlowPulseDuration(tier)
+    val strokeWidth = tierStrokeWidth(tier)
+
     val infiniteTransition = rememberInfiniteTransition(label = "celebrationGlow")
     val glowAlpha by infiniteTransition.animateFloat(
         initialValue = 0.4f,
-        targetValue = 0.9f,
+        targetValue = 0.95f,
         animationSpec = infiniteRepeatable(
-            animation = tween(GLOW_PULSE_DURATION_MS, easing = FastOutSlowInEasing),
+            animation = tween(glowPulseDuration, easing = FastOutSlowInEasing),
             repeatMode = RepeatMode.Reverse,
         ),
         label = "glowAlpha",
     )
 
+    // Animated gradient rotation for legendary tier
+    val gradientAngle by infiniteTransition.animateFloat(
+        initialValue = 0f,
+        targetValue = 1f,
+        animationSpec = infiniteRepeatable(
+            animation = tween(2000, easing = FastOutSlowInEasing),
+            repeatMode = RepeatMode.Reverse,
+        ),
+        label = "gradientAngle",
+    )
+
     val cornerRadiusPx = BANNER_CORNER_RADIUS
-    val strokeWidthPx = GLOW_STROKE_WIDTH
 
     Column(
         modifier = Modifier
@@ -176,12 +253,38 @@ private fun CelebrationBanner(event: AchievementEvent) {
             .clip(RoundedCornerShape(cornerRadiusPx))
             .background(SpColor.Surface.copy(alpha = 0.95f))
             .drawBehind {
-                // Pulsing glow border
-                drawRoundRect(
-                    color = accentColor.copy(alpha = glowAlpha),
-                    cornerRadius = CornerRadius(cornerRadiusPx.toPx()),
-                    style = Stroke(width = strokeWidthPx.toPx()),
-                )
+                val cr = CornerRadius(cornerRadiusPx.toPx())
+                val sw = strokeWidth.dp.toPx()
+                if (tier == RarityTier.LEGENDARY && !isGameCompleted) {
+                    // Animated gradient border for legendary
+                    val colors = listOf(
+                        SpColor.Primary.copy(alpha = glowAlpha),
+                        GOLD.copy(alpha = glowAlpha),
+                        SpColor.Primary.copy(alpha = glowAlpha),
+                    )
+                    val brush = Brush.linearGradient(
+                        colors = colors,
+                        start = androidx.compose.ui.geometry.Offset(
+                            size.width * gradientAngle,
+                            0f,
+                        ),
+                        end = androidx.compose.ui.geometry.Offset(
+                            size.width * (1f - gradientAngle),
+                            size.height,
+                        ),
+                    )
+                    drawRoundRect(
+                        brush = brush,
+                        cornerRadius = cr,
+                        style = Stroke(width = sw),
+                    )
+                } else {
+                    drawRoundRect(
+                        color = accentColor.copy(alpha = glowAlpha),
+                        cornerRadius = cr,
+                        style = Stroke(width = sw),
+                    )
+                }
             }
             .padding(SpSpacing.Default)
             .semantics {
@@ -235,18 +338,26 @@ private fun CelebrationBanner(event: AchievementEvent) {
             Spacer(Modifier.height(SpSpacing.Medium))
         }
 
-        // Points badge or completion indicator
+        // Points badge / rarity chip / completion indicator
         if (isGameCompleted) {
             CompletionIndicator()
-        } else if (event.points > 0) {
-            PointsBadge(points = event.points, accentColor = accentColor)
+        } else {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small, Alignment.CenterHorizontally),
+                modifier = Modifier.fillMaxWidth(),
+            ) {
+                if (event.points > 0) {
+                    PointsBadge(points = event.points, accentColor = accentColor)
+                }
+                if (event.rarityPercent > 0 && tier != RarityTier.COMMON) {
+                    RarityBadge(tier = tier, percent = event.rarityPercent, accentColor = accentColor)
+                }
+            }
         }
     }
 }
 
-/**
- * Points display for achievement unlocks, shown as "25 pts" with the accent color.
- */
 @Composable
 private fun PointsBadge(points: Int, accentColor: Color) {
     Row(
@@ -271,9 +382,25 @@ private fun PointsBadge(points: Int, accentColor: Color) {
     }
 }
 
-/**
- * Special "100%" indicator shown for game completion events.
- */
+@Composable
+private fun RarityBadge(tier: RarityTier, percent: Double, accentColor: Color) {
+    val formattedPercent = if (percent < 0.1) "<0.1%" else "${String.format("%.1f", percent)}%"
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center,
+        modifier = Modifier
+            .clip(RoundedCornerShape(SpSpacing.RadiusPill))
+            .background(accentColor.copy(alpha = 0.15f))
+            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small),
+    ) {
+        Text(
+            text = "${tier.label} \u00B7 $formattedPercent",
+            style = SpTypography.LabelMedium.copy(fontWeight = FontWeight.SemiBold),
+            color = accentColor,
+        )
+    }
+}
+
 @Composable
 private fun CompletionIndicator() {
     Box(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
@@ -12,6 +13,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -30,7 +33,9 @@ import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.PublicProfile
 import com.spela.player.domain.model.PublicProfileGame
+import com.spela.player.domain.model.ShowcaseAchievement
 import com.spela.player.presentation.intent.SocialIntent
+import com.spela.player.presentation.ui.components.SpAchievementShowcaseCard
 import com.spela.player.presentation.ui.components.SpAvatar
 import com.spela.player.presentation.ui.components.SpCard
 
@@ -119,6 +124,7 @@ fun UserProfileScreen(
                 ProfileContent(
                     profile = profile,
                     heatmapData = state.heatmapData,
+                    showcaseAchievements = state.showcaseAchievements,
                     onGameSelected = onGameSelected,
                 )
             }
@@ -142,6 +148,7 @@ fun UserProfileScreen(
 private fun ProfileContent(
     profile: PublicProfile,
     heatmapData: List<HeatmapEntry>,
+    showcaseAchievements: List<ShowcaseAchievement>,
     onGameSelected: (String) -> Unit,
 ) {
     val formattedMemberSince = remember(profile.memberSince) {
@@ -238,6 +245,22 @@ private fun ProfileContent(
                         entries = heatmapData,
                         modifier = Modifier.fillMaxWidth(),
                     )
+                }
+            }
+        }
+
+        // Featured Achievements (Showcase)
+        if (showcaseAchievements.isNotEmpty()) {
+            item {
+                SpTitledSection(title = "Featured Achievements", edgeToEdgeContent = true) {
+                    LazyRow(
+                        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                    ) {
+                        items(showcaseAchievements, key = { it.achievementRaId }) { achievement ->
+                            SpAchievementShowcaseCard(achievement = achievement)
+                        }
+                    }
                 }
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -911,7 +911,14 @@ class EmulationViewModel(
                     achievementsController.events.collect { event ->
                         withContext(dispatchers.main) {
                             _state.update { state ->
-                                val newState = state.copy(achievementEvent = event)
+                                // Enrich event with rarity from cached achievements
+                                val enrichedEvent = if (event.achievementId != 0L) {
+                                    val cached = state.achievements.find { it.id == event.achievementId }
+                                    if (cached != null) {
+                                        event.copy(rarityPercent = cached.rarityPercent)
+                                    } else event
+                                } else event
+                                val newState = state.copy(achievementEvent = enrichedEvent)
                                 if (event.type == AchievementEventType.ACHIEVEMENT_TRIGGERED) {
                                     handleAchievementTriggered(newState, event.title, event.points)
                                 } else {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SocialViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SocialViewModel.kt
@@ -4,6 +4,7 @@ import com.spela.player.domain.usecase.GetActivityFeedUseCase
 import com.spela.player.domain.usecase.GetOnlineUsersUseCase
 import com.spela.player.domain.usecase.GetPlayHeatmapUseCase
 import com.spela.player.domain.usecase.GetPublicProfileUseCase
+import com.spela.player.domain.usecase.GetPublicShowcaseUseCase
 import com.spela.player.presentation.intent.SocialIntent
 import com.spela.player.presentation.state.SocialState
 import com.spela.player.util.DispatcherProvider
@@ -19,6 +20,7 @@ class SocialViewModel(
     private val getActivityFeedUseCase: GetActivityFeedUseCase,
     private val getPublicProfileUseCase: GetPublicProfileUseCase,
     private val getPlayHeatmapUseCase: GetPlayHeatmapUseCase,
+    private val getPublicShowcaseUseCase: GetPublicShowcaseUseCase,
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
 ) {
@@ -127,7 +129,7 @@ class SocialViewModel(
     }
 
     private fun loadPublicProfile(userId: String) {
-        _state.update { it.copy(isLoadingProfile = true, publicProfile = null, heatmapData = emptyList()) }
+        _state.update { it.copy(isLoadingProfile = true, publicProfile = null, heatmapData = emptyList(), showcaseAchievements = emptyList()) }
         scope.launch(dispatchers.io) {
             getPublicProfileUseCase(userId).fold(
                 onSuccess = { profile ->
@@ -145,6 +147,15 @@ class SocialViewModel(
                 _state.update { it.copy(heatmapData = entries) }
             } catch (_: Exception) {
                 // Best effort — heatmap is non-critical
+            }
+        }
+        // Load achievement showcase in parallel — best effort, non-critical
+        scope.launch(dispatchers.io) {
+            try {
+                val entries = getPublicShowcaseUseCase(userId).getOrDefault(emptyList())
+                _state.update { it.copy(showcaseAchievements = entries) }
+            } catch (_: Exception) {
+                // Best effort — showcase is non-critical
             }
         }
     }

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopAchievementsController.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopAchievementsController.kt
@@ -29,12 +29,13 @@ class DesktopAchievementsController(
     override val isHardcore: Boolean get() = _isHardcore
 
     override fun init() {
-        jni.achievementEventListener = { eventType, title, description, points ->
+        jni.achievementEventListener = { eventType, achievementId, title, description, points ->
             val type = AchievementEventType.fromNativeValue(eventType)
             if (type != null) {
                 _events.tryEmit(
                     AchievementEvent(
                         type = type,
+                        achievementId = achievementId,
                         title = title ?: "",
                         description = description ?: "",
                         points = points,

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/LibretroJni.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/LibretroJni.kt
@@ -91,12 +91,12 @@ class LibretroJni {
     external fun nativeAchievementsSetHardcore(enabled: Boolean)
     external fun nativeAchievementsHttpComplete(requestId: Int, responseCode: Int, responseBody: ByteArray)
 
-    var achievementEventListener: ((Int, String?, String?, Int) -> Unit)? = null
+    var achievementEventListener: ((Int, Long, String?, String?, Int) -> Unit)? = null
     var httpRequestListener: ((Int, String, String?) -> Unit)? = null
 
     // Called from native code when an achievement event occurs
-    fun onAchievementEvent(eventType: Int, title: String?, description: String?, points: Int) {
-        achievementEventListener?.invoke(eventType, title, description, points)
+    fun onAchievementEvent(eventType: Int, achievementId: Long, title: String?, description: String?, points: Int) {
+        achievementEventListener?.invoke(eventType, achievementId, title, description, points)
     }
 
     // Called from native code when rcheevos needs an HTTP request

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SocialViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SocialViewModelTest.kt
@@ -8,6 +8,7 @@ import com.spela.player.domain.usecase.GetActivityFeedUseCase
 import com.spela.player.domain.usecase.GetOnlineUsersUseCase
 import com.spela.player.domain.usecase.GetPlayHeatmapUseCase
 import com.spela.player.domain.usecase.GetPublicProfileUseCase
+import com.spela.player.domain.usecase.GetPublicShowcaseUseCase
 import com.spela.player.presentation.intent.SocialIntent
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineDispatcher
@@ -51,6 +52,7 @@ class SocialViewModelTest {
             getActivityFeedUseCase = GetActivityFeedUseCase(fakeSocialRepo),
             getPublicProfileUseCase = GetPublicProfileUseCase(fakeSocialRepo),
             getPlayHeatmapUseCase = GetPlayHeatmapUseCase(fakeSocialRepo),
+            getPublicShowcaseUseCase = GetPublicShowcaseUseCase(fakeSocialRepo),
             dispatchers = testDispatchers,
             scope = scope,
         )
@@ -171,6 +173,11 @@ private class FakeSocialRepository : SocialRepository {
     }
 
     override suspend fun getPlayHeatmap(userId: String): Result<List<com.spela.player.domain.model.HeatmapEntry>> {
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(emptyList())
+    }
+
+    override suspend fun getPublicShowcase(userId: String): Result<List<com.spela.player.domain.model.ShowcaseAchievement>> {
         return if (shouldFail) Result.failure(Exception("Network error"))
         else Result.success(emptyList())
     }

--- a/server/internal/api/achievement_showcase_handler.go
+++ b/server/internal/api/achievement_showcase_handler.go
@@ -1,0 +1,184 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"strconv"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/retroachievements"
+	"gorm.io/gorm"
+)
+
+const maxShowcaseEntries = 5
+
+// AchievementShowcaseHandler handles achievement showcase endpoints.
+type AchievementShowcaseHandler struct {
+	DB *gorm.DB
+}
+
+// showcaseResponse is the enriched response for a single showcased achievement.
+type showcaseResponse struct {
+	AchievementRAID uint    `json:"achievementRaId"`
+	RAGameID        uint    `json:"raGameId"`
+	ShowcaseOrder   int     `json:"showcaseOrder"`
+	Title           string  `json:"title,omitempty"`
+	Description     string  `json:"description,omitempty"`
+	Points          int     `json:"points,omitempty"`
+	BadgeURL        string  `json:"badgeUrl,omitempty"`
+	RarityPercent   float64 `json:"rarityPercent,omitempty"`
+	GameTitle       string  `json:"gameTitle,omitempty"`
+}
+
+// GetShowcase returns the current user's showcased achievements.
+func (h *AchievementShowcaseHandler) GetShowcase(c *gin.Context) {
+	uid := getUserID(c)
+
+	var entries []db.UserAchievementShowcase
+	if err := h.DB.Where("user_id = ?", uid).Order("showcase_order ASC").Find(&entries).Error; err != nil {
+		slog.Error("failed to load achievement showcase", "user_id", uid, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load showcase"})
+		return
+	}
+
+	results := h.enrichShowcaseEntries(entries)
+	c.JSON(http.StatusOK, results)
+}
+
+// GetPublicShowcase returns a user's showcased achievements by user ID (public).
+func (h *AchievementShowcaseHandler) GetPublicShowcase(c *gin.Context) {
+	userID, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid user ID"})
+		return
+	}
+
+	var entries []db.UserAchievementShowcase
+	if err := h.DB.Where("user_id = ?", userID).Order("showcase_order ASC").Find(&entries).Error; err != nil {
+		slog.Error("failed to load public achievement showcase", "user_id", userID, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load showcase"})
+		return
+	}
+
+	results := h.enrichShowcaseEntries(entries)
+	c.JSON(http.StatusOK, results)
+}
+
+// UpdateShowcase replaces the current user's showcased achievements.
+func (h *AchievementShowcaseHandler) UpdateShowcase(c *gin.Context) {
+	uid := getUserID(c)
+
+	var req []struct {
+		AchievementRAID uint `json:"achievementRaId" binding:"required"`
+		RAGameID        uint `json:"raGameId" binding:"required"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	if len(req) > maxShowcaseEntries {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "maximum 5 showcase entries allowed"})
+		return
+	}
+
+	// Replace all entries in a transaction
+	if err := h.DB.Transaction(func(tx *gorm.DB) error {
+		// Delete existing entries
+		if err := tx.Where("user_id = ?", uid).Delete(&db.UserAchievementShowcase{}).Error; err != nil {
+			return err
+		}
+
+		// Insert new entries
+		for i, item := range req {
+			entry := db.UserAchievementShowcase{
+				UserID:          uid,
+				AchievementRAID: item.AchievementRAID,
+				RAGameID:        item.RAGameID,
+				ShowcaseOrder:   i,
+			}
+			if err := tx.Create(&entry).Error; err != nil {
+				return err
+			}
+		}
+		return nil
+	}); err != nil {
+		slog.Error("failed to update achievement showcase", "user_id", uid, "error", err)
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to update showcase"})
+		return
+	}
+
+	// Return the updated showcase
+	var entries []db.UserAchievementShowcase
+	h.DB.Where("user_id = ?", uid).Order("showcase_order ASC").Find(&entries)
+	results := h.enrichShowcaseEntries(entries)
+	c.JSON(http.StatusOK, results)
+}
+
+// enrichShowcaseEntries loads GameAchievementCache data and enriches showcase entries.
+func (h *AchievementShowcaseHandler) enrichShowcaseEntries(entries []db.UserAchievementShowcase) []showcaseResponse {
+	if len(entries) == 0 {
+		return []showcaseResponse{}
+	}
+
+	// Collect unique RA game IDs
+	raGameIDSet := make(map[uint]struct{})
+	for _, e := range entries {
+		raGameIDSet[e.RAGameID] = struct{}{}
+	}
+	raGameIDs := make([]uint, 0, len(raGameIDSet))
+	for id := range raGameIDSet {
+		raGameIDs = append(raGameIDs, id)
+	}
+
+	// Load achievement caches for these games
+	var caches []db.GameAchievementCache
+	h.DB.Where("ra_game_id IN ?", raGameIDs).Find(&caches)
+
+	// Build a map of raGameID -> (gameTitle, achievement map by RA ID)
+	type gameData struct {
+		Title        string
+		Achievements map[uint]retroachievements.Achievement
+	}
+	cacheMap := make(map[uint]gameData)
+	for _, cache := range caches {
+		var achievements []retroachievements.Achievement
+		if err := json.Unmarshal([]byte(cache.AchievementJSON), &achievements); err != nil {
+			slog.Warn("failed to unmarshal cached achievement data for showcase", "ra_game_id", cache.RAGameID, "error", err)
+			continue
+		}
+		achMap := make(map[uint]retroachievements.Achievement, len(achievements))
+		for _, a := range achievements {
+			achMap[a.ID] = a
+		}
+		cacheMap[cache.RAGameID] = gameData{
+			Title:        cache.Title,
+			Achievements: achMap,
+		}
+	}
+
+	// Build enriched responses
+	results := make([]showcaseResponse, 0, len(entries))
+	for _, e := range entries {
+		resp := showcaseResponse{
+			AchievementRAID: e.AchievementRAID,
+			RAGameID:        e.RAGameID,
+			ShowcaseOrder:   e.ShowcaseOrder,
+		}
+		if gd, ok := cacheMap[e.RAGameID]; ok {
+			resp.GameTitle = gd.Title
+			if ach, found := gd.Achievements[e.AchievementRAID]; found {
+				resp.Title = ach.Title
+				resp.Description = ach.Description
+				resp.Points = ach.Points
+				resp.BadgeURL = ach.BadgeURL
+				resp.RarityPercent = ach.RarityPercent
+			}
+		}
+		results = append(results, resp)
+	}
+
+	return results
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -507,6 +507,12 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		api.GET("/games/:id/achievements/leaderboard", raHandler.GetAchievementLeaderboard)
 		api.GET("/user/achievements/recent", raHandler.GetRecentAchievements)
 
+		// Achievement Showcase
+		showcaseHandler := &AchievementShowcaseHandler{DB: cfg.DB}
+		api.GET("/user/achievements/showcase", showcaseHandler.GetShowcase)
+		api.PUT("/user/achievements/showcase", showcaseHandler.UpdateShowcase)
+		api.GET("/users/:id/achievements/showcase", showcaseHandler.GetPublicShowcase)
+
 		// Admin routes
 		admin := api.Group("/admin")
 		admin.Use(AdminMiddleware())

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -174,6 +174,8 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&GameAgeRating{},
 		// Phase 13: Saved Searches
 		&SavedSearch{},
+		// Achievement Showcase
+		&UserAchievementShowcase{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -820,6 +820,16 @@ type SavedSearch struct {
 	Filters   string         `gorm:"type:text;not null" json:"filters"` // JSON-encoded filter params
 }
 
+// UserAchievementShowcase stores a user's pinned achievement for their profile.
+type UserAchievementShowcase struct {
+	ID              uint      `gorm:"primarykey" json:"id"`
+	UserID          uint      `gorm:"uniqueIndex:idx_user_achievement_showcase;not null" json:"userId"`
+	AchievementRAID uint      `gorm:"uniqueIndex:idx_user_achievement_showcase;not null" json:"achievementRaId"`
+	RAGameID        uint      `gorm:"not null" json:"raGameId"`
+	ShowcaseOrder   int       `gorm:"not null" json:"showcaseOrder"`
+	CreatedAt       time.Time `json:"createdAt"`
+}
+
 // StagedUpload represents a ROM file uploaded to the staging area pending admin review.
 type StagedUpload struct {
 	ID               uint           `gorm:"primarykey" json:"id"`


### PR DESCRIPTION
## Summary
- **Server:** New `UserAchievementShowcase` model with 3 API endpoints — `GET/PUT /user/achievements/showcase` (own) and `GET /users/:id/achievements/showcase` (public). Max 5 pinned achievements per user, enriched from `GameAchievementCache` JSON blobs.
- **Player app:** Full showcase integration — DTO, domain model, mapper, API client, repository, use case, DI wiring, `SpAchievementShowcaseCard` component, and "Featured Achievements" section on `UserProfileScreen`. Loads via `SocialViewModel`.
- **Tests:** SocialViewModel test updated for showcase loading; desktop E2E harness updated with showcase test data.

This is Part 2 of Achievements Phase 1 (making achievements fun). Part 1 (rarity badges) was merged in PR #271.

## Test plan
- [x] Server builds (`go build ./...`)
- [x] Player shared module compiles (`compileKotlinDesktop`)
- [x] Desktop tests pass (420 tests)
- [x] SocialViewModel tests include showcase assertions
- [ ] CI passes