### PR TITLE
Fix missing java.sql module in bundled JRE

### DIFF
--- a/player/desktop/build.gradle.kts
+++ b/player/desktop/build.gradle.kts
@@ -153,6 +153,17 @@ compose.desktop {
             linux {
                 packageName = "spela-player"
             }
+
+            // Include required Java modules for the bundled JRE.
+            // java.sql is needed by SQLDelight's JDBC SQLite driver.
+            modules(
+                "java.base",
+                "java.desktop",
+                "java.logging",
+                "java.prefs",
+                "java.sql",           // Required for SQLDelight JDBC driver
+                "jdk.unsupported"     // Required for some Compose/Skia internals
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add explicit `modules()` configuration to include required Java modules in the bundled JRE
- Fixes crash on startup with `NoClassDefFoundError: java/sql/DriverManager`

## Problem

The Linux Flatpak (and likely Windows MSI and macOS DMG) crashes on startup because jpackage/jlink creates a minimal JRE that doesn't include the `java.sql` module. SQLDelight's JDBC SQLite driver requires this module at runtime.

## Solution

Add explicit module configuration to `nativeDistributions` in `build.gradle.kts`:
- `java.sql` - Required for SQLDelight JDBC driver
- `java.desktop`, `java.logging`, `java.prefs` - Required for Compose
- `jdk.unsupported` - Required for Compose/Skia internals

This applies to all platforms (macOS, Windows, Linux).

## Test plan

- [ ] CI builds pass for all platforms
- [ ] Linux Flatpak launches without crash
- [ ] Windows MSI launches without crash
- [ ] macOS DMG launches without crash

🤖 Generated with [Claude Code](https://claude.com/code)