### PR TITLE
feat: achievement showcase editing with picker dialog

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -259,6 +259,9 @@ class SpelaTestHarness(
         getPublicProfileUseCase = GetPublicProfileUseCase(socialRepo),
         getPlayHeatmapUseCase = GetPlayHeatmapUseCase(socialRepo),
         getPublicShowcaseUseCase = GetPublicShowcaseUseCase(socialRepo),
+        getUnlockedAchievementsUseCase = GetUnlockedAchievementsUseCase(socialRepo),
+        updateShowcaseUseCase = UpdateShowcaseUseCase(socialRepo),
+        authRepository = authRepo,
         dispatchers = dispatchers,
         scope = scope,
     )

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -817,6 +817,10 @@ class FakeSocialRepository : SocialRepository {
         Result.success(emptyList())
     override suspend fun getPublicShowcase(userId: String): Result<List<com.spela.player.domain.model.ShowcaseAchievement>> =
         Result.success(emptyList())
+    override suspend fun getUnlockedAchievements(): Result<List<com.spela.player.domain.model.UnlockedAchievement>> =
+        Result.success(emptyList())
+    override suspend fun updateShowcase(achievements: List<com.spela.player.domain.model.ShowcaseAchievement>): Result<List<com.spela.player.domain.model.ShowcaseAchievement>> =
+        Result.success(achievements)
 }
 
 class FakeKeyMappingRepository : KeyMappingRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -649,6 +649,17 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/users/$userId/achievements/showcase").body()
     }
 
+    suspend fun getUnlockedAchievements(): UnlockedAchievementsResponse {
+        return client.get("$baseUrl/api/user/achievements/unlocked").body()
+    }
+
+    suspend fun updateShowcase(entries: List<ShowcaseUpdateEntry>): List<ShowcaseAchievementDto> {
+        return client.put("$baseUrl/api/user/achievements/showcase") {
+            contentType(io.ktor.http.ContentType.Application.Json)
+            setBody(entries)
+        }.body()
+    }
+
     // Devices
 
     suspend fun deleteDevice(deviceId: Long) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -448,6 +448,18 @@ fun ShowcaseAchievementDto.toDomain(): ShowcaseAchievement = ShowcaseAchievement
     gameTitle = gameTitle ?: "",
 )
 
+fun UnlockedAchievementDto.toDomain(): UnlockedAchievement = UnlockedAchievement(
+    achievementRaId = achievementRaId,
+    raGameId = raGameId,
+    title = title,
+    description = description,
+    points = points,
+    badgeUrl = badgeUrl,
+    rarityPercent = rarityPercent,
+    gameTitle = gameTitle,
+    consoleName = consoleName,
+)
+
 // Stats mappers
 
 fun MostPlayedGameDto.toDomain(): MostPlayedGame = MostPlayedGame(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -970,6 +970,30 @@ data class ShowcaseAchievementDto(
     val gameTitle: String? = null,
 )
 
+@Serializable
+data class UnlockedAchievementDto(
+    val achievementRaId: Long,
+    val raGameId: Long,
+    val title: String = "",
+    val description: String = "",
+    val points: Int = 0,
+    val badgeUrl: String? = null,
+    val rarityPercent: Double = 0.0,
+    val gameTitle: String = "",
+    val consoleName: String = "",
+)
+
+@Serializable
+data class UnlockedAchievementsResponse(
+    val achievements: List<UnlockedAchievementDto> = emptyList(),
+)
+
+@Serializable
+data class ShowcaseUpdateEntry(
+    val achievementRaId: Long,
+    val raGameId: Long,
+)
+
 // Top Rated
 
 @Serializable

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
@@ -1,12 +1,14 @@
 package com.spela.player.data.repository
 
 import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.dto.ShowcaseUpdateEntry
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.ActivityEvent
 import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
 import com.spela.player.domain.model.ShowcaseAchievement
+import com.spela.player.domain.model.UnlockedAchievement
 import com.spela.player.domain.repository.SocialRepository
 
 class SocialRepositoryImpl(
@@ -55,6 +57,21 @@ class SocialRepositoryImpl(
 
     override suspend fun getPublicShowcase(userId: String): Result<List<ShowcaseAchievement>> = runCatching {
         apiClient.getPublicShowcase(userId).map { dto ->
+            val achievement = dto.toDomain()
+            achievement.copy(badgeUrl = apiClient.resolveUrl(achievement.badgeUrl))
+        }
+    }
+
+    override suspend fun getUnlockedAchievements(): Result<List<UnlockedAchievement>> = runCatching {
+        apiClient.getUnlockedAchievements().achievements.map { dto ->
+            val achievement = dto.toDomain()
+            achievement.copy(badgeUrl = apiClient.resolveUrl(achievement.badgeUrl))
+        }
+    }
+
+    override suspend fun updateShowcase(achievements: List<ShowcaseAchievement>): Result<List<ShowcaseAchievement>> = runCatching {
+        val entries = achievements.map { ShowcaseUpdateEntry(it.achievementRaId, it.raGameId) }
+        apiClient.updateShowcase(entries).map { dto ->
             val achievement = dto.toDomain()
             achievement.copy(badgeUrl = apiClient.resolveUrl(achievement.badgeUrl))
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -97,6 +97,8 @@ val commonModule = module {
     factory { GetPublicProfileUseCase(get()) }
     factory { GetPlayHeatmapUseCase(get()) }
     factory { GetPublicShowcaseUseCase(get()) }
+    factory { GetUnlockedAchievementsUseCase(get()) }
+    factory { UpdateShowcaseUseCase(get()) }
     factory { GetMyCollectionsUseCase(get()) }
     factory { GetPublicCollectionsUseCase(get()) }
     factory { GetCollectionDetailUseCase(get()) }
@@ -232,6 +234,9 @@ val commonModule = module {
             getPublicProfileUseCase = get(),
             getPlayHeatmapUseCase = get(),
             getPublicShowcaseUseCase = get(),
+            getUnlockedAchievementsUseCase = get(),
+            updateShowcaseUseCase = get(),
+            authRepository = get(),
             dispatchers = get(),
             scope = get(),
         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -581,6 +581,18 @@ data class ShowcaseAchievement(
     val gameTitle: String = "",
 )
 
+data class UnlockedAchievement(
+    val achievementRaId: Long,
+    val raGameId: Long,
+    val title: String = "",
+    val description: String = "",
+    val points: Int = 0,
+    val badgeUrl: String? = null,
+    val rarityPercent: Double = 0.0,
+    val gameTitle: String = "",
+    val consoleName: String = "",
+)
+
 data class UserStats(
     val totalPlayTime: Long,
     val gamesPlayed: Long,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SocialRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SocialRepository.kt
@@ -5,6 +5,7 @@ import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
 import com.spela.player.domain.model.ShowcaseAchievement
+import com.spela.player.domain.model.UnlockedAchievement
 
 interface SocialRepository {
     suspend fun getOnlineUsers(): Result<List<OnlineUser>>
@@ -12,4 +13,6 @@ interface SocialRepository {
     suspend fun getPublicProfile(userId: String): Result<PublicProfile>
     suspend fun getPlayHeatmap(userId: String): Result<List<HeatmapEntry>>
     suspend fun getPublicShowcase(userId: String): Result<List<ShowcaseAchievement>>
+    suspend fun getUnlockedAchievements(): Result<List<UnlockedAchievement>>
+    suspend fun updateShowcase(achievements: List<ShowcaseAchievement>): Result<List<ShowcaseAchievement>>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/SocialUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/SocialUseCases.kt
@@ -5,6 +5,7 @@ import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
 import com.spela.player.domain.model.ShowcaseAchievement
+import com.spela.player.domain.model.UnlockedAchievement
 import com.spela.player.domain.repository.SocialRepository
 
 class GetOnlineUsersUseCase(private val socialRepository: SocialRepository) {
@@ -26,4 +27,13 @@ class GetPlayHeatmapUseCase(private val repository: SocialRepository) {
 
 class GetPublicShowcaseUseCase(private val repository: SocialRepository) {
     suspend operator fun invoke(userId: String): Result<List<ShowcaseAchievement>> = repository.getPublicShowcase(userId)
+}
+
+class GetUnlockedAchievementsUseCase(private val repository: SocialRepository) {
+    suspend operator fun invoke(): Result<List<UnlockedAchievement>> = repository.getUnlockedAchievements()
+}
+
+class UpdateShowcaseUseCase(private val repository: SocialRepository) {
+    suspend operator fun invoke(achievements: List<ShowcaseAchievement>): Result<List<ShowcaseAchievement>> =
+        repository.updateShowcase(achievements)
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/SocialIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/SocialIntent.kt
@@ -1,5 +1,7 @@
 package com.spela.player.presentation.intent
 
+import com.spela.player.domain.model.UnlockedAchievement
+
 sealed interface SocialIntent {
     data object LoadOnlineUsers : SocialIntent
     data object LoadActivityFeed : SocialIntent
@@ -8,4 +10,11 @@ sealed interface SocialIntent {
     data class LoadPublicProfile(val userId: String) : SocialIntent
     data object LoadFullActivityFeed : SocialIntent
     data object LoadMoreActivity : SocialIntent
+    // Showcase editing
+    data object OpenShowcaseEditor : SocialIntent
+    data object CloseShowcaseEditor : SocialIntent
+    data class ToggleShowcaseAchievement(val achievement: UnlockedAchievement) : SocialIntent
+    data class MoveShowcaseAchievement(val index: Int, val direction: Int) : SocialIntent
+    data object SaveShowcase : SocialIntent
+    data class SetShowcaseSearchQuery(val query: String) : SocialIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SocialState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SocialState.kt
@@ -5,6 +5,7 @@ import com.spela.player.domain.model.HeatmapEntry
 import com.spela.player.domain.model.OnlineUser
 import com.spela.player.domain.model.PublicProfile
 import com.spela.player.domain.model.ShowcaseAchievement
+import com.spela.player.domain.model.UnlockedAchievement
 
 data class SocialState(
     val onlineUsers: List<OnlineUser> = emptyList(),
@@ -16,9 +17,17 @@ data class SocialState(
     val isLoadingProfile: Boolean = false,
     val heatmapData: List<HeatmapEntry> = emptyList(),
     val showcaseAchievements: List<ShowcaseAchievement> = emptyList(),
+    val isOwnProfile: Boolean = false,
     // Full activity feed (paginated, for the Activity screen)
     val fullActivityEvents: List<ActivityEvent> = emptyList(),
     val isLoadingFullActivity: Boolean = false,
     val fullActivityPage: Int = 1,
     val hasMoreActivity: Boolean = true,
+    // Showcase editor
+    val isShowcaseEditorOpen: Boolean = false,
+    val allUnlockedAchievements: List<UnlockedAchievement> = emptyList(),
+    val isLoadingUnlockedAchievements: Boolean = false,
+    val showcaseEditorSelections: List<ShowcaseAchievement> = emptyList(),
+    val showcaseSearchQuery: String = "",
+    val isSavingShowcase: Boolean = false,
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ShowcaseEditorDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ShowcaseEditorDialog.kt
@@ -1,0 +1,302 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.spela.player.domain.model.ShowcaseAchievement
+import com.spela.player.domain.model.UnlockedAchievement
+import com.spela.player.presentation.ui.components.SpButtonStyle
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+private val SILVER = Color(0xFFC0C0C0)
+private val GOLD = Color(0xFFFFD700)
+
+private fun rarityColor(percent: Double): Color = when {
+    percent < 1.0 -> SpColor.Primary
+    percent < 5.0 -> SpColor.Primary
+    percent < 20.0 -> GOLD
+    percent < 50.0 -> SILVER
+    else -> SpColor.OnBackgroundSecondary
+}
+
+@Composable
+fun ShowcaseEditorDialog(
+    selections: List<ShowcaseAchievement>,
+    allUnlocked: List<UnlockedAchievement>,
+    isLoading: Boolean,
+    searchQuery: String,
+    onSearchQueryChange: (String) -> Unit,
+    onToggle: (UnlockedAchievement) -> Unit,
+    onMove: (index: Int, direction: Int) -> Unit,
+    onSave: () -> Unit,
+    onDismiss: () -> Unit,
+) {
+    val selectedIds = selections.map { it.achievementRaId }.toSet()
+    val filtered = if (searchQuery.isBlank()) {
+        allUnlocked.sortedBy { it.rarityPercent }
+    } else {
+        val q = searchQuery.lowercase()
+        allUnlocked.filter {
+            it.title.lowercase().contains(q) || it.gameTitle.lowercase().contains(q)
+        }.sortedBy { it.rarityPercent }
+    }
+
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = SpSpacing.Default)
+                .clip(RoundedCornerShape(SpSpacing.RadiusLarge))
+                .background(SpColor.Surface)
+                .padding(SpSpacing.Default)
+                .testTag("showcase_editor_dialog"),
+        ) {
+            // Header
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text("Edit Showcase", style = SpTypography.HeadlineSmall, color = SpColor.OnBackground)
+                Text("${selections.size}/5", style = SpTypography.LabelMedium, color = SpColor.OnBackgroundSecondary)
+            }
+
+            Spacer(Modifier.height(SpSpacing.Medium))
+
+            // Current selections with reorder buttons
+            if (selections.isNotEmpty()) {
+                Text("Your Showcase", style = SpTypography.LabelMedium, color = SpColor.OnBackgroundSecondary)
+                Spacer(Modifier.height(SpSpacing.Small))
+                selections.forEachIndexed { index, entry ->
+                    Row(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(SpSpacing.RadiusMedium))
+                            .background(SpColor.Background)
+                            .padding(horizontal = SpSpacing.Small, vertical = SpSpacing.XSmall),
+                        verticalAlignment = Alignment.CenterVertically,
+                    ) {
+                        Column(modifier = Modifier.weight(1f)) {
+                            Text(
+                                entry.title,
+                                style = SpTypography.BodyMedium,
+                                color = SpColor.OnBackground,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                            Text(
+                                entry.gameTitle,
+                                style = SpTypography.LabelSmall,
+                                color = SpColor.OnBackgroundSecondary,
+                                maxLines = 1,
+                                overflow = TextOverflow.Ellipsis,
+                            )
+                        }
+                        IconButton(
+                            onClick = { onMove(index, -1) },
+                            enabled = index > 0,
+                            modifier = Modifier.size(32.dp),
+                        ) {
+                            Icon(
+                                Icons.Default.KeyboardArrowUp, "Move up",
+                                tint = if (index > 0) SpColor.OnBackground else SpColor.OnBackgroundSecondary,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                        IconButton(
+                            onClick = { onMove(index, 1) },
+                            enabled = index < selections.size - 1,
+                            modifier = Modifier.size(32.dp),
+                        ) {
+                            Icon(
+                                Icons.Default.KeyboardArrowDown, "Move down",
+                                tint = if (index < selections.size - 1) SpColor.OnBackground else SpColor.OnBackgroundSecondary,
+                                modifier = Modifier.size(20.dp),
+                            )
+                        }
+                    }
+                    Spacer(Modifier.height(SpSpacing.XSmall))
+                }
+                Spacer(Modifier.height(SpSpacing.Medium))
+            }
+
+            // Search
+            TextField(
+                value = searchQuery,
+                onValueChange = onSearchQueryChange,
+                placeholder = { Text("Search achievements...", color = SpColor.OnBackgroundSecondary) },
+                singleLine = true,
+                colors = TextFieldDefaults.colors(
+                    focusedContainerColor = SpColor.Background,
+                    unfocusedContainerColor = SpColor.Background,
+                    focusedTextColor = SpColor.OnBackground,
+                    unfocusedTextColor = SpColor.OnBackground,
+                    cursorColor = SpColor.Primary,
+                    focusedIndicatorColor = SpColor.Primary,
+                    unfocusedIndicatorColor = Color.Transparent,
+                ),
+                modifier = Modifier.fillMaxWidth().testTag("showcase_search"),
+            )
+
+            Spacer(Modifier.height(SpSpacing.Small))
+
+            // Achievement list
+            if (isLoading) {
+                Box(
+                    modifier = Modifier.fillMaxWidth().height(200.dp),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    CircularProgressIndicator(color = SpColor.Primary)
+                }
+            } else {
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth().height(300.dp),
+                    contentPadding = PaddingValues(vertical = SpSpacing.XSmall),
+                    verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                ) {
+                    itemsIndexed(filtered, key = { _, a -> a.achievementRaId }) { _, achievement ->
+                        val isSelected = achievement.achievementRaId in selectedIds
+                        val canSelect = isSelected || selections.size < 5
+                        AchievementPickerRow(
+                            achievement = achievement,
+                            isSelected = isSelected,
+                            enabled = canSelect,
+                            onClick = { onToggle(achievement) },
+                        )
+                    }
+                }
+            }
+
+            Spacer(Modifier.height(SpSpacing.Medium))
+
+            // Action buttons
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                SpButton(
+                    text = "Cancel",
+                    onClick = onDismiss,
+                    style = SpButtonStyle.Outlined,
+                )
+                Spacer(Modifier.width(SpSpacing.Small))
+                SpButton(
+                    text = "Save",
+                    onClick = onSave,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AchievementPickerRow(
+    achievement: UnlockedAchievement,
+    isSelected: Boolean,
+    enabled: Boolean,
+    onClick: () -> Unit,
+) {
+    val rColor = rarityColor(achievement.rarityPercent)
+
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(SpSpacing.RadiusMedium))
+            .background(if (isSelected) SpColor.PrimaryContainer else SpColor.Background)
+            .clickable(enabled = enabled) { onClick() }
+            .alpha(if (enabled) 1f else 0.5f)
+            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        // Selection indicator
+        Box(
+            modifier = Modifier
+                .size(24.dp)
+                .clip(CircleShape)
+                .background(if (isSelected) SpColor.Primary else SpColor.Surface),
+            contentAlignment = Alignment.Center,
+        ) {
+            if (isSelected) {
+                Icon(Icons.Default.Check, "Selected", tint = SpColor.OnPrimary, modifier = Modifier.size(16.dp))
+            }
+        }
+
+        Spacer(Modifier.width(SpSpacing.Medium))
+
+        // Achievement info
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                achievement.title,
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackground,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
+            )
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    achievement.gameTitle,
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundSecondary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f, fill = false),
+                )
+                if (achievement.rarityPercent > 0) {
+                    Spacer(Modifier.width(SpSpacing.Small))
+                    Text(
+                        "${String.format("%.1f", achievement.rarityPercent)}%",
+                        style = SpTypography.LabelSmall,
+                        color = rColor,
+                    )
+                }
+            }
+        }
+
+        // Points
+        Text(
+            "${achievement.points} pts",
+            style = SpTypography.LabelMedium,
+            color = SpColor.OnBackgroundSecondary,
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/UserProfileScreen.kt
@@ -35,8 +35,11 @@ import com.spela.player.domain.model.PublicProfile
 import com.spela.player.domain.model.PublicProfileGame
 import com.spela.player.domain.model.ShowcaseAchievement
 import com.spela.player.presentation.intent.SocialIntent
+import com.spela.player.presentation.ui.components.ShowcaseEditorDialog
 import com.spela.player.presentation.ui.components.SpAchievementShowcaseCard
 import com.spela.player.presentation.ui.components.SpAvatar
+import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpCard
 
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
@@ -98,6 +101,21 @@ fun UserProfileScreen(
         socialViewModel.onIntent(SocialIntent.LoadPublicProfile(userId))
     }
 
+    // Showcase Editor Dialog (must be outside Column/LazyColumn)
+    if (state.isShowcaseEditorOpen) {
+        ShowcaseEditorDialog(
+            selections = state.showcaseEditorSelections,
+            allUnlocked = state.allUnlockedAchievements,
+            isLoading = state.isLoadingUnlockedAchievements,
+            searchQuery = state.showcaseSearchQuery,
+            onSearchQueryChange = { socialViewModel.onIntent(SocialIntent.SetShowcaseSearchQuery(it)) },
+            onToggle = { socialViewModel.onIntent(SocialIntent.ToggleShowcaseAchievement(it)) },
+            onMove = { index, dir -> socialViewModel.onIntent(SocialIntent.MoveShowcaseAchievement(index, dir)) },
+            onSave = { socialViewModel.onIntent(SocialIntent.SaveShowcase) },
+            onDismiss = { socialViewModel.onIntent(SocialIntent.CloseShowcaseEditor) },
+        )
+    }
+
     Column(
         modifier = Modifier
             .fillMaxSize()
@@ -125,6 +143,8 @@ fun UserProfileScreen(
                     profile = profile,
                     heatmapData = state.heatmapData,
                     showcaseAchievements = state.showcaseAchievements,
+                    isOwnProfile = state.isOwnProfile,
+                    onEditShowcase = { socialViewModel.onIntent(SocialIntent.OpenShowcaseEditor) },
                     onGameSelected = onGameSelected,
                 )
             }
@@ -149,6 +169,8 @@ private fun ProfileContent(
     profile: PublicProfile,
     heatmapData: List<HeatmapEntry>,
     showcaseAchievements: List<ShowcaseAchievement>,
+    isOwnProfile: Boolean,
+    onEditShowcase: () -> Unit,
     onGameSelected: (String) -> Unit,
 ) {
     val formattedMemberSince = remember(profile.memberSince) {
@@ -250,16 +272,37 @@ private fun ProfileContent(
         }
 
         // Featured Achievements (Showcase)
-        if (showcaseAchievements.isNotEmpty()) {
+        if (showcaseAchievements.isNotEmpty() || isOwnProfile) {
             item {
-                SpTitledSection(title = "Featured Achievements", edgeToEdgeContent = true) {
-                    LazyRow(
-                        contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
-                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-                    ) {
-                        items(showcaseAchievements, key = { it.achievementRaId }) { achievement ->
-                            SpAchievementShowcaseCard(achievement = achievement)
+                SpTitledSection(
+                    title = "Featured Achievements",
+                    edgeToEdgeContent = true,
+                    titleTrailing = if (isOwnProfile) {
+                        {
+                            SpButton(
+                                text = "Edit",
+                                onClick = onEditShowcase,
+                                style = SpButtonStyle.Outlined,
+                            )
                         }
+                    } else null,
+                ) {
+                    if (showcaseAchievements.isNotEmpty()) {
+                        LazyRow(
+                            contentPadding = PaddingValues(horizontal = SpSpacing.ScreenHorizontal),
+                            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+                        ) {
+                            items(showcaseAchievements, key = { it.achievementRaId }) { achievement ->
+                                SpAchievementShowcaseCard(achievement = achievement)
+                            }
+                        }
+                    } else {
+                        Text(
+                            "Pin your proudest achievements here",
+                            style = SpTypography.BodyMedium,
+                            color = SpColor.OnBackgroundSecondary,
+                            modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                        )
                     }
                 }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SocialViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SocialViewModel.kt
@@ -1,10 +1,15 @@
 package com.spela.player.presentation.viewmodel
 
+import com.spela.player.domain.model.ShowcaseAchievement
+import com.spela.player.domain.model.UnlockedAchievement
 import com.spela.player.domain.usecase.GetActivityFeedUseCase
 import com.spela.player.domain.usecase.GetOnlineUsersUseCase
 import com.spela.player.domain.usecase.GetPlayHeatmapUseCase
 import com.spela.player.domain.usecase.GetPublicProfileUseCase
 import com.spela.player.domain.usecase.GetPublicShowcaseUseCase
+import com.spela.player.domain.usecase.GetUnlockedAchievementsUseCase
+import com.spela.player.domain.usecase.UpdateShowcaseUseCase
+import com.spela.player.domain.repository.AuthRepository
 import com.spela.player.presentation.intent.SocialIntent
 import com.spela.player.presentation.state.SocialState
 import com.spela.player.util.DispatcherProvider
@@ -21,6 +26,9 @@ class SocialViewModel(
     private val getPublicProfileUseCase: GetPublicProfileUseCase,
     private val getPlayHeatmapUseCase: GetPlayHeatmapUseCase,
     private val getPublicShowcaseUseCase: GetPublicShowcaseUseCase,
+    private val getUnlockedAchievementsUseCase: GetUnlockedAchievementsUseCase,
+    private val updateShowcaseUseCase: UpdateShowcaseUseCase,
+    private val authRepository: AuthRepository,
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
 ) {
@@ -36,6 +44,12 @@ class SocialViewModel(
             is SocialIntent.LoadPublicProfile -> loadPublicProfile(intent.userId)
             SocialIntent.LoadFullActivityFeed -> loadFullActivityFeed()
             SocialIntent.LoadMoreActivity -> loadMoreActivity()
+            SocialIntent.OpenShowcaseEditor -> openShowcaseEditor()
+            SocialIntent.CloseShowcaseEditor -> _state.update { it.copy(isShowcaseEditorOpen = false) }
+            is SocialIntent.ToggleShowcaseAchievement -> toggleShowcaseAchievement(intent.achievement)
+            is SocialIntent.MoveShowcaseAchievement -> moveShowcaseAchievement(intent.index, intent.direction)
+            SocialIntent.SaveShowcase -> saveShowcase()
+            is SocialIntent.SetShowcaseSearchQuery -> _state.update { it.copy(showcaseSearchQuery = intent.query) }
         }
     }
 
@@ -129,7 +143,13 @@ class SocialViewModel(
     }
 
     private fun loadPublicProfile(userId: String) {
-        _state.update { it.copy(isLoadingProfile = true, publicProfile = null, heatmapData = emptyList(), showcaseAchievements = emptyList()) }
+        _state.update { it.copy(isLoadingProfile = true, publicProfile = null, heatmapData = emptyList(), showcaseAchievements = emptyList(), isOwnProfile = false) }
+        // Detect own profile
+        scope.launch(dispatchers.io) {
+            authRepository.getCurrentUser().onSuccess { user ->
+                _state.update { it.copy(isOwnProfile = user.id == userId) }
+            }
+        }
         scope.launch(dispatchers.io) {
             getPublicProfileUseCase(userId).fold(
                 onSuccess = { profile ->
@@ -157,6 +177,78 @@ class SocialViewModel(
             } catch (_: Exception) {
                 // Best effort — showcase is non-critical
             }
+        }
+    }
+
+    private fun openShowcaseEditor() {
+        _state.update { it.copy(isShowcaseEditorOpen = true, isLoadingUnlockedAchievements = true, showcaseSearchQuery = "") }
+        // Initialize editor selections from current showcase
+        val currentShowcase = _state.value.showcaseAchievements
+        _state.update { it.copy(showcaseEditorSelections = currentShowcase) }
+        // Load all unlocked achievements for the picker
+        scope.launch(dispatchers.io) {
+            getUnlockedAchievementsUseCase().fold(
+                onSuccess = { achievements ->
+                    _state.update { it.copy(allUnlockedAchievements = achievements, isLoadingUnlockedAchievements = false) }
+                },
+                onFailure = {
+                    _state.update { it.copy(isLoadingUnlockedAchievements = false) }
+                },
+            )
+        }
+    }
+
+    private fun toggleShowcaseAchievement(achievement: UnlockedAchievement) {
+        _state.update { state ->
+            val current = state.showcaseEditorSelections
+            val existing = current.find { it.achievementRaId == achievement.achievementRaId }
+            if (existing != null) {
+                // Remove
+                state.copy(showcaseEditorSelections = current.filter { it.achievementRaId != achievement.achievementRaId })
+            } else if (current.size < 5) {
+                // Add
+                val newEntry = ShowcaseAchievement(
+                    achievementRaId = achievement.achievementRaId,
+                    raGameId = achievement.raGameId,
+                    showcaseOrder = current.size,
+                    title = achievement.title,
+                    description = achievement.description,
+                    points = achievement.points,
+                    badgeUrl = achievement.badgeUrl,
+                    rarityPercent = achievement.rarityPercent,
+                    gameTitle = achievement.gameTitle,
+                )
+                state.copy(showcaseEditorSelections = current + newEntry)
+            } else {
+                state // Max 5 reached
+            }
+        }
+    }
+
+    private fun moveShowcaseAchievement(index: Int, direction: Int) {
+        _state.update { state ->
+            val list = state.showcaseEditorSelections.toMutableList()
+            val newIndex = index + direction
+            if (newIndex < 0 || newIndex >= list.size) return@update state
+            val item = list.removeAt(index)
+            list.add(newIndex, item)
+            state.copy(showcaseEditorSelections = list)
+        }
+    }
+
+    private fun saveShowcase() {
+        val selections = _state.value.showcaseEditorSelections
+        // Optimistic update
+        _state.update { it.copy(showcaseAchievements = selections, isShowcaseEditorOpen = false, isSavingShowcase = true) }
+        scope.launch(dispatchers.io) {
+            updateShowcaseUseCase(selections).fold(
+                onSuccess = { updated ->
+                    _state.update { it.copy(showcaseAchievements = updated, isSavingShowcase = false) }
+                },
+                onFailure = {
+                    _state.update { it.copy(isSavingShowcase = false) }
+                },
+            )
         }
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SocialViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SocialViewModelTest.kt
@@ -9,6 +9,11 @@ import com.spela.player.domain.usecase.GetOnlineUsersUseCase
 import com.spela.player.domain.usecase.GetPlayHeatmapUseCase
 import com.spela.player.domain.usecase.GetPublicProfileUseCase
 import com.spela.player.domain.usecase.GetPublicShowcaseUseCase
+import com.spela.player.domain.usecase.GetUnlockedAchievementsUseCase
+import com.spela.player.domain.usecase.UpdateShowcaseUseCase
+import com.spela.player.domain.model.AuthTokens
+import com.spela.player.domain.model.User
+import com.spela.player.domain.repository.AuthRepository
 import com.spela.player.presentation.intent.SocialIntent
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineDispatcher
@@ -45,6 +50,17 @@ class SocialViewModelTest {
         Dispatchers.resetMain()
     }
 
+    private val fakeAuthRepo = object : AuthRepository {
+        override suspend fun login(serverUrl: String, username: String, password: String) = Result.failure<AuthTokens>(Exception("Not implemented"))
+        override suspend fun register(serverUrl: String, username: String, email: String, password: String) = Result.failure<AuthTokens>(Exception("Not implemented"))
+        override suspend fun refreshToken(serverUrl: String, refreshToken: String) = Result.failure<AuthTokens>(Exception("Not implemented"))
+        override suspend fun getCurrentUser() = Result.success(User("1", "testuser", "", "user"))
+        override suspend fun getStoredTokens(): AuthTokens? = null
+        override suspend fun storeTokens(tokens: AuthTokens) {}
+        override suspend fun clearTokens() {}
+        override fun isLoggedIn() = true
+    }
+
     private fun createViewModel(): SocialViewModel {
         val scope = CoroutineScope(testDispatcher)
         return SocialViewModel(
@@ -53,6 +69,9 @@ class SocialViewModelTest {
             getPublicProfileUseCase = GetPublicProfileUseCase(fakeSocialRepo),
             getPlayHeatmapUseCase = GetPlayHeatmapUseCase(fakeSocialRepo),
             getPublicShowcaseUseCase = GetPublicShowcaseUseCase(fakeSocialRepo),
+            getUnlockedAchievementsUseCase = GetUnlockedAchievementsUseCase(fakeSocialRepo),
+            updateShowcaseUseCase = UpdateShowcaseUseCase(fakeSocialRepo),
+            authRepository = fakeAuthRepo,
             dispatchers = testDispatchers,
             scope = scope,
         )
@@ -180,5 +199,13 @@ private class FakeSocialRepository : SocialRepository {
     override suspend fun getPublicShowcase(userId: String): Result<List<com.spela.player.domain.model.ShowcaseAchievement>> {
         return if (shouldFail) Result.failure(Exception("Network error"))
         else Result.success(emptyList())
+    }
+    override suspend fun getUnlockedAchievements(): Result<List<com.spela.player.domain.model.UnlockedAchievement>> {
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(emptyList())
+    }
+    override suspend fun updateShowcase(achievements: List<com.spela.player.domain.model.ShowcaseAchievement>): Result<List<com.spela.player.domain.model.ShowcaseAchievement>> {
+        return if (shouldFail) Result.failure(Exception("Network error"))
+        else Result.success(achievements)
     }
 }

--- a/server/internal/api/ra_handler.go
+++ b/server/internal/api/ra_handler.go
@@ -553,6 +553,109 @@ func (h *RAHandler) GetRecentAchievements(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"achievements": results})
 }
 
+// GetUnlockedAchievements returns ALL of the user's unlocked achievements across all games,
+// enriched with title, badge, rarity, and game context. Used by the showcase picker.
+func (h *RAHandler) GetUnlockedAchievements(c *gin.Context) {
+	uid := getUserID(c)
+
+	var progressRows []db.UserAchievementProgress
+	if err := h.DB.Where("user_id = ?", uid).
+		Order("unlocked_at DESC").
+		Find(&progressRows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch unlocked achievements"})
+		return
+	}
+
+	if len(progressRows) == 0 {
+		c.JSON(http.StatusOK, gin.H{"achievements": []any{}})
+		return
+	}
+
+	// Collect unique RA game IDs
+	raGameIDSet := make(map[uint]bool)
+	for _, p := range progressRows {
+		raGameIDSet[p.RAGameID] = true
+	}
+	raGameIDs := make([]uint, 0, len(raGameIDSet))
+	for id := range raGameIDSet {
+		raGameIDs = append(raGameIDs, id)
+	}
+
+	// Load achievement caches
+	var caches []db.GameAchievementCache
+	h.DB.Where("ra_game_id IN ?", raGameIDs).Find(&caches)
+
+	type cacheData struct {
+		Cache        db.GameAchievementCache
+		Achievements []retroachievements.Achievement
+	}
+	cacheMap := make(map[uint]cacheData)
+	for _, cache := range caches {
+		var achievements []retroachievements.Achievement
+		if err := json.Unmarshal([]byte(cache.AchievementJSON), &achievements); err != nil {
+			slog.Warn("failed to unmarshal cached achievement data", "ra_game_id", cache.RAGameID, "error", err)
+		}
+		cacheMap[cache.RAGameID] = cacheData{Cache: cache, Achievements: achievements}
+	}
+
+	// Load games
+	gameIDs := make([]uint, 0, len(caches))
+	for _, cache := range caches {
+		if cache.GameID > 0 {
+			gameIDs = append(gameIDs, cache.GameID)
+		}
+	}
+	var games []db.Game
+	if len(gameIDs) > 0 {
+		h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games)
+	}
+	gameMap := make(map[uint]db.Game)
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	type unlockedAchievement struct {
+		AchievementRAID uint    `json:"achievementRaId"`
+		RAGameID        uint    `json:"raGameId"`
+		Title           string  `json:"title"`
+		Description     string  `json:"description"`
+		Points          int     `json:"points"`
+		BadgeURL        string  `json:"badgeUrl"`
+		RarityPercent   float64 `json:"rarityPercent"`
+		GameTitle       string  `json:"gameTitle"`
+		ConsoleName     string  `json:"consoleName"`
+	}
+
+	results := make([]unlockedAchievement, 0, len(progressRows))
+	for _, p := range progressRows {
+		entry := unlockedAchievement{
+			AchievementRAID: p.AchievementRAID,
+			RAGameID:        p.RAGameID,
+		}
+
+		if cd, ok := cacheMap[p.RAGameID]; ok {
+			for _, a := range cd.Achievements {
+				if a.ID == p.AchievementRAID {
+					entry.Title = a.Title
+					entry.Description = a.Description
+					entry.Points = a.Points
+					entry.BadgeURL = a.BadgeURL
+					entry.RarityPercent = a.RarityPercent
+					break
+				}
+			}
+			if game, ok := gameMap[cd.Cache.GameID]; ok {
+				entry.GameTitle = game.Title
+				entry.ConsoleName = game.Console.Name
+			}
+		}
+
+		results = append(results, entry)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"achievements": results})
+}
+
 // GetAchievementTimeline returns the user's achievement timeline for a specific game.
 func (h *RAHandler) GetAchievementTimeline(c *gin.Context) {
 	uid := getUserID(c)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -506,6 +506,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		api.GET("/games/:id/achievements/timeline", raHandler.GetAchievementTimeline)
 		api.GET("/games/:id/achievements/leaderboard", raHandler.GetAchievementLeaderboard)
 		api.GET("/user/achievements/recent", raHandler.GetRecentAchievements)
+		api.GET("/user/achievements/unlocked", raHandler.GetUnlockedAchievements)
 
 		// Achievement Showcase
 		showcaseHandler := &AchievementShowcaseHandler{DB: cfg.DB}


### PR DESCRIPTION
## Summary
- **Server:** New `GET /api/user/achievements/unlocked` endpoint returning all unlocked achievements with rarity data for the showcase picker
- **Player app:** Full showcase editing flow with `ShowcaseEditorDialog` — searchable picker sorted by rarity, selection checkmarks (max 5), up/down reorder buttons, optimistic save
- **Own-profile detection:** "Edit" button only appears when viewing your own profile (via AuthRepository)

Completes the Achievement Showcase feature from Phase 1. Previous PRs: #271 (rarity badges), #272 (showcase display + celebrations).

## Test plan
- [x] Server builds and all tests pass
- [x] Player shared module compiles
- [x] Desktop unit tests pass (SocialViewModelTest, SecondaryScreenCelebrationTest)
- [x] All test fakes updated for new SocialRepository methods
- [ ] CI passes