### PR TITLE
Fix native library not included in distributable

### DIFF
--- a/player/desktop/build.gradle.kts
+++ b/player/desktop/build.gradle.kts
@@ -202,6 +202,25 @@ tasks.matching { it.name == "createDistributable" || it.name == "createReleaseDi
                     logger.lifecycle("Patched native library path in ${cfg.name}")
                 }
             }
+
+        // Copy native library to the app's lib directory so it can be found at runtime.
+        // $APPDIR resolves to lib/app/ (Linux/Windows) or Contents/app/ (macOS).
+        val nativeDir = nativeBuildDir.get().asFile
+        val possibleLibDirs = listOf(
+            appImageDir.resolve("Spela/lib/app"),           // Linux
+            appImageDir.resolve("Spela/app"),               // Windows
+            appImageDir.resolve("Spela.app/Contents/app"),  // macOS
+        )
+        val appLibDir = possibleLibDirs.firstOrNull { it.exists() }
+        if (appLibDir != null) {
+            nativeDir.listFiles()?.filter { it.extension in listOf("so", "dylib", "dll") }?.forEach { lib ->
+                val dest = appLibDir.resolve(lib.name)
+                lib.copyTo(dest, overwrite = true)
+                logger.lifecycle("Copied native library ${lib.name} to ${dest.relativeTo(appImageDir)}")
+            }
+        } else {
+            logger.warn("Could not find app lib directory to copy native libraries")
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Copy native libraries (.so/.dylib/.dll) to the app's lib directory after createDistributable
- Fixes `UnsatisfiedLinkError: no spela-libretro in java.library.path` on Linux Flatpak

## Problem

The `spela-libretro` JNI native library was not being copied to the distributable. The `.cfg` file was patched to use `$APPDIR` as the library path, but the actual library file was never copied there.

## Solution

Add a post-processing step that copies native libraries from `build/native/` to the app's lib directory. Supports all platform structures:
- Linux: `Spela/lib/app/`
- Windows: `Spela/app/`
- macOS: `Spela.app/Contents/app/`

## Test plan

- [ ] CI builds pass
- [ ] Linux Flatpak launches and loads libretro cores
- [ ] Windows/macOS still work (no regression)

🤖 Generated with [Claude Code](https://claude.com/code)