### PR TITLE
Fix Flatpak LD_LIBRARY_PATH for JNI native libraries

### DIFF
--- a/player/linux/flatpak/com.spela.player.yml
+++ b/player/linux/flatpak/com.spela.player.yml
@@ -39,6 +39,7 @@ modules:
         cat > /app/bin/spela << 'EOF'
         #!/bin/sh
         export PATH="/app/jre/bin:$PATH"
+        export LD_LIBRARY_PATH="/app/lib/runtime/lib:/app/lib/app:$LD_LIBRARY_PATH"
         exec /app/bin/Spela "$@"
         EOF
       - chmod +x /app/bin/spela


### PR DESCRIPTION
## Summary

- Add LD_LIBRARY_PATH to Flatpak launch script to find JRE and app native libraries

## Problem

The `libspela-libretro.so` native library depends on `libjawt.so` from the JRE. When the app launches, it fails with:
```
libjawt.so: cannot open shared object file: No such file or directory
```

## Solution

Set `LD_LIBRARY_PATH` in the launch script to include:
- `/app/lib/runtime/lib` - JRE native libraries (libjawt.so, etc.)
- `/app/lib/app` - App native libraries (libspela-libretro.so)

## Test plan

- [ ] CI passes
- [ ] Flatpak launches without library errors

🤖 Generated with [Claude Code](https://claude.com/code)