### PR TITLE
feat: achievement showcase on web user profile

### DIFF
--- a/web/src/features/user-profile/components/achievement-showcase.tsx
+++ b/web/src/features/user-profile/components/achievement-showcase.tsx
@@ -1,0 +1,152 @@
+import { useState } from "react";
+import { Trophy, Pencil } from "lucide-react";
+import { cn } from "@/lib/cn";
+import { useAuth } from "@/hooks/use-auth";
+import { usePublicShowcase } from "@/hooks/use-showcase";
+import type { ShowcaseAchievement } from "@/types/api";
+import { ShowcaseEditor } from "./showcase-editor";
+
+type RarityTier = "Common" | "Uncommon" | "Rare" | "Ultra Rare" | "Legendary";
+
+function getRarityBorder(rarityPercent: number): {
+  tier: RarityTier;
+  borderClass: string;
+} {
+  if (rarityPercent < 1) {
+    return {
+      tier: "Legendary",
+      borderClass: "border-purple-400 ring-1 ring-purple-500/50",
+    };
+  }
+  if (rarityPercent < 5) {
+    return { tier: "Ultra Rare", borderClass: "border-purple-500" };
+  }
+  if (rarityPercent < 20) {
+    return { tier: "Rare", borderClass: "border-yellow-400" };
+  }
+  if (rarityPercent <= 50) {
+    return { tier: "Uncommon", borderClass: "border-gray-400" };
+  }
+  return { tier: "Common", borderClass: "border-surface-700" };
+}
+
+function getRarityPillClass(tier: RarityTier): string | null {
+  switch (tier) {
+    case "Legendary":
+    case "Ultra Rare":
+      return "bg-purple-900/60 text-purple-300 border border-purple-500";
+    case "Rare":
+      return "bg-yellow-900/60 text-yellow-300 border border-yellow-500";
+    default:
+      return null;
+  }
+}
+
+function ShowcaseCard({
+  achievement,
+}: {
+  achievement: ShowcaseAchievement;
+}) {
+  const rarity = getRarityBorder(achievement.rarityPercent ?? 100);
+  const pillClass = getRarityPillClass(rarity.tier);
+
+  return (
+    <div className="flex flex-col items-center gap-2 w-36 flex-shrink-0">
+      {/* Badge */}
+      <div
+        className={cn(
+          "w-16 h-16 rounded-lg border-2 overflow-hidden bg-surface-800",
+          rarity.borderClass,
+        )}
+      >
+        {achievement.badgeUrl ? (
+          <img
+            src={achievement.badgeUrl}
+            alt={achievement.title ?? "Achievement"}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center">
+            <Trophy className="h-6 w-6 text-surface-500" />
+          </div>
+        )}
+      </div>
+
+      {/* Title */}
+      <p className="text-sm font-medium text-surface-200 text-center line-clamp-2 leading-tight">
+        {achievement.title || "Unknown"}
+      </p>
+
+      {/* Game title */}
+      <p className="text-xs text-surface-500 text-center line-clamp-1 -mt-1">
+        {achievement.gameTitle || ""}
+      </p>
+
+      {/* Rarity + points */}
+      <div className="flex items-center gap-1.5">
+        {achievement.points != null && achievement.points > 0 && (
+          <span className="text-xs text-surface-400">
+            {achievement.points} pts
+          </span>
+        )}
+        {pillClass && (
+          <span
+            className={cn("text-[10px] px-1.5 py-0.5 rounded-full", pillClass)}
+          >
+            {rarity.tier}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function AchievementShowcase({ userId }: { userId: string }) {
+  const { user } = useAuth();
+  const { data: showcase, isLoading } = usePublicShowcase(userId);
+  const [isEditorOpen, setIsEditorOpen] = useState(false);
+
+  const isOwnProfile = user?.id?.toString() === userId;
+  const hasShowcase = showcase && showcase.length > 0;
+
+  if (isLoading) return null;
+  if (!hasShowcase && !isOwnProfile) return null;
+
+  return (
+    <section>
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2.5">
+          <Trophy className="h-5 w-5 text-brand-400" />
+          <h2 className="text-lg font-bold text-surface-100">
+            Featured Achievements
+          </h2>
+        </div>
+        {isOwnProfile && (
+          <button
+            onClick={() => setIsEditorOpen(true)}
+            className="flex items-center gap-1.5 text-sm text-surface-400 hover:text-brand-400 transition-colors"
+          >
+            <Pencil className="h-3.5 w-3.5" />
+            Edit
+          </button>
+        )}
+      </div>
+
+      {hasShowcase ? (
+        <div className="flex gap-4 overflow-x-auto pb-2">
+          {showcase.map((a) => (
+            <ShowcaseCard key={a.achievementRaId} achievement={a} />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-surface-500">
+          Pin your proudest achievements here
+        </p>
+      )}
+
+      {isEditorOpen && (
+        <ShowcaseEditor onClose={() => setIsEditorOpen(false)} />
+      )}
+    </section>
+  );
+}

--- a/web/src/features/user-profile/components/showcase-editor.tsx
+++ b/web/src/features/user-profile/components/showcase-editor.tsx
@@ -1,0 +1,280 @@
+import { useState, useMemo } from "react";
+import {
+  X,
+  Search,
+  Check,
+  ChevronUp,
+  ChevronDown,
+  Trophy,
+  Loader2,
+} from "lucide-react";
+import { cn } from "@/lib/cn";
+import {
+  useOwnShowcase,
+  useUnlockedAchievements,
+  useUpdateShowcase,
+} from "@/hooks/use-showcase";
+import type { ShowcaseAchievement, UnlockedAchievement } from "@/types/api";
+
+const MAX_SHOWCASE = 5;
+
+function getRarityColor(percent: number): string {
+  if (percent < 1) return "text-purple-400";
+  if (percent < 5) return "text-purple-400";
+  if (percent < 20) return "text-yellow-400";
+  if (percent <= 50) return "text-gray-400";
+  return "text-surface-500";
+}
+
+export function ShowcaseEditor({ onClose }: { onClose: () => void }) {
+  const { data: currentShowcase } = useOwnShowcase();
+  const { data: unlockedData, isLoading } = useUnlockedAchievements();
+  const updateMutation = useUpdateShowcase();
+
+  const [selections, setSelections] = useState<ShowcaseAchievement[]>(
+    () => currentShowcase ?? [],
+  );
+  const [searchQuery, setSearchQuery] = useState("");
+
+  const selectedIds = useMemo(
+    () => new Set(selections.map((s) => s.achievementRaId)),
+    [selections],
+  );
+
+  const filtered = useMemo(() => {
+    const all = unlockedData?.achievements ?? [];
+    const sorted = [...all].sort((a, b) => a.rarityPercent - b.rarityPercent);
+    if (!searchQuery.trim()) return sorted;
+    const q = searchQuery.toLowerCase();
+    return sorted.filter(
+      (a) =>
+        a.title.toLowerCase().includes(q) ||
+        a.gameTitle.toLowerCase().includes(q),
+    );
+  }, [unlockedData, searchQuery]);
+
+  function toggleAchievement(a: UnlockedAchievement) {
+    if (selectedIds.has(a.achievementRaId)) {
+      setSelections((prev) =>
+        prev.filter((s) => s.achievementRaId !== a.achievementRaId),
+      );
+    } else if (selections.length < MAX_SHOWCASE) {
+      setSelections((prev) => [
+        ...prev,
+        {
+          achievementRaId: a.achievementRaId,
+          raGameId: a.raGameId,
+          showcaseOrder: prev.length,
+          title: a.title,
+          description: a.description,
+          points: a.points,
+          badgeUrl: a.badgeUrl,
+          rarityPercent: a.rarityPercent,
+          gameTitle: a.gameTitle,
+        },
+      ]);
+    }
+  }
+
+  function moveSelection(index: number, direction: number) {
+    const newIndex = index + direction;
+    if (newIndex < 0 || newIndex >= selections.length) return;
+    setSelections((prev) => {
+      const list = [...prev];
+      const [item] = list.splice(index, 1);
+      list.splice(newIndex, 0, item);
+      return list;
+    });
+  }
+
+  function handleSave() {
+    const entries = selections.map((s) => ({
+      achievementRaId: s.achievementRaId,
+      raGameId: s.raGameId,
+    }));
+    updateMutation.mutate(entries, { onSuccess: () => onClose() });
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+      <div className="bg-surface-900 rounded-2xl w-full max-w-lg mx-4 max-h-[80vh] flex flex-col">
+        {/* Header */}
+        <div className="flex items-center justify-between p-5 border-b border-surface-800">
+          <div>
+            <h2 className="text-lg font-bold text-surface-100">
+              Edit Showcase
+            </h2>
+            <p className="text-xs text-surface-500 mt-0.5">
+              {selections.length}/{MAX_SHOWCASE} selected
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="p-1.5 rounded-lg hover:bg-surface-800 text-surface-400 hover:text-surface-200 transition-colors"
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        {/* Current selections */}
+        {selections.length > 0 && (
+          <div className="p-4 border-b border-surface-800 space-y-1.5">
+            <p className="text-xs font-medium text-surface-500 uppercase tracking-wider mb-2">
+              Your Showcase
+            </p>
+            {selections.map((entry, index) => (
+              <div
+                key={entry.achievementRaId}
+                className="flex items-center gap-2 rounded-lg bg-surface-800/50 px-3 py-2"
+              >
+                <span className="flex-1 text-sm text-surface-200 truncate">
+                  {entry.title || "Unknown"}
+                </span>
+                <span className="text-xs text-surface-500 truncate max-w-[100px]">
+                  {entry.gameTitle}
+                </span>
+                <button
+                  onClick={() => moveSelection(index, -1)}
+                  disabled={index === 0}
+                  className="p-0.5 text-surface-400 hover:text-surface-200 disabled:opacity-30"
+                >
+                  <ChevronUp className="h-4 w-4" />
+                </button>
+                <button
+                  onClick={() => moveSelection(index, 1)}
+                  disabled={index === selections.length - 1}
+                  className="p-0.5 text-surface-400 hover:text-surface-200 disabled:opacity-30"
+                >
+                  <ChevronDown className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Search */}
+        <div className="px-4 py-3 border-b border-surface-800">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-surface-500" />
+            <input
+              type="text"
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="Search achievements..."
+              className="w-full pl-9 pr-3 py-2 rounded-lg bg-surface-800 text-sm text-surface-200 placeholder:text-surface-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+            />
+          </div>
+        </div>
+
+        {/* Achievement list */}
+        <div className="flex-1 overflow-y-auto p-2 min-h-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-12">
+              <Loader2 className="h-6 w-6 animate-spin text-brand-400" />
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="text-center text-sm text-surface-500 py-8">
+              {searchQuery
+                ? "No achievements match your search"
+                : "No unlocked achievements yet"}
+            </p>
+          ) : (
+            <div className="space-y-0.5">
+              {filtered.map((a) => {
+                const isSelected = selectedIds.has(a.achievementRaId);
+                const canSelect = isSelected || selections.length < MAX_SHOWCASE;
+                return (
+                  <button
+                    key={a.achievementRaId}
+                    onClick={() => toggleAchievement(a)}
+                    disabled={!canSelect}
+                    className={cn(
+                      "w-full flex items-center gap-3 rounded-lg px-3 py-2.5 text-left transition-colors",
+                      isSelected
+                        ? "bg-brand-500/10"
+                        : "hover:bg-surface-800/50",
+                      !canSelect && "opacity-40 cursor-not-allowed",
+                    )}
+                  >
+                    {/* Checkbox */}
+                    <div
+                      className={cn(
+                        "w-5 h-5 rounded-full flex-shrink-0 flex items-center justify-center border",
+                        isSelected
+                          ? "bg-brand-500 border-brand-500"
+                          : "border-surface-600",
+                      )}
+                    >
+                      {isSelected && (
+                        <Check className="h-3 w-3 text-white" />
+                      )}
+                    </div>
+
+                    {/* Badge */}
+                    <div className="w-8 h-8 rounded bg-surface-800 overflow-hidden flex-shrink-0">
+                      {a.badgeUrl ? (
+                        <img
+                          src={a.badgeUrl}
+                          alt=""
+                          className="w-full h-full object-cover"
+                        />
+                      ) : (
+                        <div className="w-full h-full flex items-center justify-center">
+                          <Trophy className="h-4 w-4 text-surface-600" />
+                        </div>
+                      )}
+                    </div>
+
+                    {/* Info */}
+                    <div className="flex-1 min-w-0">
+                      <p className="text-sm text-surface-200 truncate">
+                        {a.title}
+                      </p>
+                      <div className="flex items-center gap-2">
+                        <span className="text-xs text-surface-500 truncate">
+                          {a.gameTitle}
+                        </span>
+                        {a.rarityPercent > 0 && a.rarityPercent < 50 && (
+                          <span
+                            className={cn(
+                              "text-xs",
+                              getRarityColor(a.rarityPercent),
+                            )}
+                          >
+                            {a.rarityPercent.toFixed(1)}%
+                          </span>
+                        )}
+                      </div>
+                    </div>
+
+                    {/* Points */}
+                    <span className="text-xs text-surface-500 flex-shrink-0">
+                      {a.points} pts
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="flex items-center justify-end gap-3 p-4 border-t border-surface-800">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 text-sm text-surface-400 hover:text-surface-200 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={updateMutation.isPending}
+            className="px-4 py-2 text-sm font-medium bg-brand-500 text-white rounded-lg hover:bg-brand-600 disabled:opacity-50 transition-colors"
+          >
+            {updateMutation.isPending ? "Saving..." : "Save"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/hooks/use-showcase.ts
+++ b/web/src/hooks/use-showcase.ts
@@ -1,0 +1,58 @@
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type {
+  ShowcaseAchievement,
+  UnlockedAchievementsResponse,
+} from "@/types/api";
+
+export function usePublicShowcase(userId: string) {
+  return useQuery({
+    queryKey: ["users", userId, "showcase"],
+    queryFn: () =>
+      api.get<ShowcaseAchievement[]>(
+        `/users/${userId}/achievements/showcase`,
+      ),
+    enabled: !!userId,
+  });
+}
+
+export function useOwnShowcase() {
+  return useQuery({
+    queryKey: ["user", "showcase"],
+    queryFn: () =>
+      api.get<ShowcaseAchievement[]>("/user/achievements/showcase"),
+  });
+}
+
+export function useUnlockedAchievements() {
+  return useQuery({
+    queryKey: ["user", "achievements", "unlocked"],
+    queryFn: () =>
+      api.get<UnlockedAchievementsResponse>(
+        "/user/achievements/unlocked",
+      ),
+  });
+}
+
+export function useUpdateShowcase() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (
+      entries: Array<{ achievementRaId: number; raGameId: number }>,
+    ) =>
+      api.put<ShowcaseAchievement[]>(
+        "/user/achievements/showcase",
+        entries,
+      ),
+    onSuccess: (data) => {
+      queryClient.setQueryData(["user", "showcase"], data);
+      // Also invalidate any public showcase queries
+      queryClient.invalidateQueries({
+        queryKey: ["users"],
+        predicate: (query) =>
+          query.queryKey.length >= 3 &&
+          query.queryKey[2] === "showcase",
+      });
+    },
+  });
+}

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -149,6 +149,9 @@ export type ApiGetPath = WithQuery<
   | "/user/ra/token"
   | "/user/taste-profile"
   | "/user/achievements/recent"
+  | "/user/achievements/showcase"
+  | "/user/achievements/unlocked"
+  | `/users/${string}/achievements/showcase`
   | "/user/saved-searches"
   | "/user/explorer-badges"
   | "/user/completionist-map"
@@ -334,6 +337,9 @@ export type ApiPutPath = WithQuery<
 
   // Netplay
   | `/netplay/sessions/${string}/settings`
+
+  // Achievement Showcase
+  | "/user/achievements/showcase"
 
   // Challenges
   | `/challenges/${string}`

--- a/web/src/pages/user-profile-page.tsx
+++ b/web/src/pages/user-profile-page.tsx
@@ -4,6 +4,7 @@ import { usePublicProfile } from "@/hooks/use-public-profile";
 import { useUserPlayHeatmap } from "@/hooks/use-play-heatmap";
 import { PlayerAvatar } from "@/components/player-avatar";
 import { PlayHeatmap } from "@/components/play-heatmap";
+import { AchievementShowcase } from "@/features/user-profile/components/achievement-showcase";
 import { Badge, Skeleton, EmptyState } from "@/components/ui";
 import type { PublicProfileGame } from "@/types/api";
 
@@ -187,6 +188,9 @@ export function UserProfilePage() {
           )}
         </section>
       )}
+
+      {/* Achievement Showcase */}
+      {id && <AchievementShowcase userId={id} />}
 
       {/* Game sections */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -297,6 +297,34 @@ export interface GameAchievementProgressResponse {
   progress: GameAchievementProgress[];
 }
 
+export interface ShowcaseAchievement {
+  achievementRaId: number;
+  raGameId: number;
+  showcaseOrder: number;
+  title?: string;
+  description?: string;
+  points?: number;
+  badgeUrl?: string;
+  rarityPercent?: number;
+  gameTitle?: string;
+}
+
+export interface UnlockedAchievement {
+  achievementRaId: number;
+  raGameId: number;
+  title: string;
+  description: string;
+  points: number;
+  badgeUrl: string;
+  rarityPercent: number;
+  gameTitle: string;
+  consoleName: string;
+}
+
+export interface UnlockedAchievementsResponse {
+  achievements: UnlockedAchievement[];
+}
+
 export interface GameStats {
   totalPlayers: number;
   totalPlayTime: number;


### PR DESCRIPTION
## Summary
- New `AchievementShowcase` component on the web user profile page
- Showcase cards with rarity-tier borders (silver/gold/purple) and tier pills
- "Edit" button for own profile with full `ShowcaseEditor` modal
- Editor: searchable picker sorted by rarity, selection checkmarks (max 5), up/down reorder
- New TanStack Query hooks for showcase CRUD + unlocked achievements

Completes the web side of Achievement Showcase from Phase 1.

## Test plan
- [x] Web build succeeds
- [x] All 1411 web tests pass
- [x] API routes typed for showcase endpoints
- [ ] CI passes