### PR TITLE
fix: resolve cover URL for similar games + achievement count in metadata

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
@@ -244,7 +244,10 @@ class GameRepositoryImpl(
 
     override suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>> {
         return runCatching {
-            apiClient.getSimilarGames(gameId).map { it.toDomain() }
+            apiClient.getSimilarGames(gameId).map { dto ->
+                val game = dto.toDomain()
+                game.copy(coverUrl = apiClient.resolveUrl(game.coverUrl))
+            }
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SocialDiscoverySection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SocialDiscoverySection.kt
@@ -48,7 +48,6 @@ fun TrendingSection(
         items(games, key = { it.game.id }) { item ->
             Column(
                 modifier = Modifier
-                    .width(CardWidth)
                     .semantics { contentDescription = "${item.game.title}, ${item.playersThisWeek} players this week" },
             ) {
                 ExploreGameCard(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
@@ -46,6 +46,8 @@ internal fun MetadataGrid(
     modifier: Modifier = Modifier,
     onGradient: Boolean = false,
     isDemoConsole: Boolean = false,
+    achievementTotal: Int = 0,
+    achievementUnlocked: Int = 0,
     onDeveloperClick: ((name: String) -> Unit)? = null,
     onPublisherClick: ((name: String) -> Unit)? = null,
 ) {
@@ -69,6 +71,14 @@ internal fun MetadataGrid(
         }
         if (!isDemoConsole && game.players > 0) {
             add(MetaItem(Icons.Filled.Group, "Players", "${game.players}"))
+        }
+        if (achievementTotal > 0) {
+            val value = if (achievementUnlocked > 0) {
+                "$achievementUnlocked / $achievementTotal"
+            } else {
+                "$achievementTotal"
+            }
+            add(MetaItem(Icons.Filled.EmojiEvents, "Achievements", value))
         }
         if (game.fileSize > 0) {
             add(MetaItem(Icons.Filled.SdStorage, "Size", formatBytes(game.fileSize)))

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -675,11 +675,13 @@ private fun GameInfoContent(
         )
     }
 
-    // Metadata grid (Developer, Publisher, Released, Genre, Players, Size, Discs)
+    // Metadata grid (Developer, Publisher, Released, Genre, Players, Achievements, Size, Discs)
     MetadataGrid(
         game = game,
         onGradient = true,
         isDemoConsole = isDemoConsole,
+        achievementTotal = state.achievements.size,
+        achievementUnlocked = state.achievementProgress.size,
         onDeveloperClick = onNavigateToDeveloper,
         onPublisherClick = onNavigateToPublisher,
     )


### PR DESCRIPTION
## Summary
- Fix missing cover art in Similar Games section — coverUrl wasn't resolved through apiClient.resolveUrl()
- (More commits coming: achievement count in game detail metadata table)

## Test plan
- [x] Build succeeds
- [ ] CI passes