### PR TITLE
feat: RA public API for server-wide achievement data

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
@@ -244,7 +244,10 @@ class GameRepositoryImpl(
 
     override suspend fun getSimilarGames(gameId: String): Result<List<SimilarGame>> {
         return runCatching {
-            apiClient.getSimilarGames(gameId).map { it.toDomain() }
+            apiClient.getSimilarGames(gameId).map { dto ->
+                val game = dto.toDomain()
+                game.copy(coverUrl = apiClient.resolveUrl(game.coverUrl))
+            }
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SocialDiscoverySection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/SocialDiscoverySection.kt
@@ -48,7 +48,6 @@ fun TrendingSection(
         items(games, key = { it.game.id }) { item ->
             Column(
                 modifier = Modifier
-                    .width(CardWidth)
                     .semantics { contentDescription = "${item.game.title}, ${item.playersThisWeek} players this week" },
             ) {
                 ExploreGameCard(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
@@ -46,6 +46,8 @@ internal fun MetadataGrid(
     modifier: Modifier = Modifier,
     onGradient: Boolean = false,
     isDemoConsole: Boolean = false,
+    achievementTotal: Int = 0,
+    achievementUnlocked: Int = 0,
     onDeveloperClick: ((name: String) -> Unit)? = null,
     onPublisherClick: ((name: String) -> Unit)? = null,
 ) {
@@ -69,6 +71,14 @@ internal fun MetadataGrid(
         }
         if (!isDemoConsole && game.players > 0) {
             add(MetaItem(Icons.Filled.Group, "Players", "${game.players}"))
+        }
+        if (achievementTotal > 0) {
+            val value = if (achievementUnlocked > 0) {
+                "$achievementUnlocked / $achievementTotal"
+            } else {
+                "$achievementTotal"
+            }
+            add(MetaItem(Icons.Filled.EmojiEvents, "Achievements", value))
         }
         if (game.fileSize > 0) {
             add(MetaItem(Icons.Filled.SdStorage, "Size", formatBytes(game.fileSize)))

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -675,11 +675,13 @@ private fun GameInfoContent(
         )
     }
 
-    // Metadata grid (Developer, Publisher, Released, Genre, Players, Size, Discs)
+    // Metadata grid (Developer, Publisher, Released, Genre, Players, Achievements, Size, Discs)
     MetadataGrid(
         game = game,
         onGradient = true,
         isDemoConsole = isDemoConsole,
+        achievementTotal = state.achievements.size,
+        achievementUnlocked = state.achievementProgress.size,
         onDeveloperClick = onNavigateToDeveloper,
         onPublisherClick = onNavigateToPublisher,
     )

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -17,6 +17,7 @@ import (
 	"github.com/spela/server/internal/cheats"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/igdb"
+	"github.com/spela/server/internal/retroachievements"
 	"github.com/spela/server/internal/scanner"
 	"github.com/spela/server/internal/scraper"
 	"github.com/spela/server/internal/storage"
@@ -256,6 +257,19 @@ func main() {
 				metaScraper.IGDBClient = igdb.NewClient(clientID, clientSecret)
 			}
 		}
+		// Configure RA API key for achievement scraping
+		raAPIKey := os.Getenv("SPELA_RA_API_KEY")
+		if raAPIKey == "" {
+			var setting db.ServerSetting
+			database.Where("key = ?", "ra_api_key").First(&setting)
+			raAPIKey = setting.Value
+		}
+		if raAPIKey != "" {
+			metaScraper.RAClient = retroachievements.NewRAClient()
+			metaScraper.RAAPIKey = raAPIKey
+			slog.Info("RA API key configured for achievement scraping")
+		}
+
 		if result.NewGames > 0 && metaScraper.IsIGDBConfigured() {
 			// Configure SteamGridDB for hero art (env var or DB setting)
 			if sgdbKey := os.Getenv("SPELA_STEAMGRIDDB_API_KEY"); sgdbKey != "" {
@@ -280,6 +294,18 @@ func main() {
 				}
 				slog.Info("startup auto-scrape complete", "scraped", count, "total", total)
 				hub.Broadcast(websocket.Event{Type: "scrape_complete", Payload: map[string]interface{}{"scraped": count, "total": total}})
+			}
+		}
+
+		// Standalone RA achievement scraping for games that weren't covered by ScrapeAll
+		// (e.g., when IGDB is not configured but RA is, or for existing games)
+		if metaScraper.IsRAConfigured() {
+			slog.Info("scraping RetroAchievements data...")
+			raSuccesses, raTotal, raErr := metaScraper.ScrapeRAAchievements(context.Background(), nil)
+			if raErr != nil {
+				slog.Error("RA achievement scraping failed", "error", raErr)
+			} else if raSuccesses > 0 {
+				slog.Info("RA achievement scraping complete", "successes", raSuccesses, "total", raTotal)
 			}
 		}
 	}()

--- a/server/internal/api/admin_handler_settings.go
+++ b/server/internal/api/admin_handler_settings.go
@@ -12,6 +12,7 @@ import (
 var secretSettingKeys = map[string]bool{
 	"igdb_client_secret":   true,
 	"steamgriddb_api_key":  true,
+	"ra_api_key":           true,
 }
 
 // GetSettings returns server settings (admin only).
@@ -47,6 +48,7 @@ var allowedSettingKeys = map[string]bool{
 	"steamgriddb_api_key":     true,
 	"default_region":          true,
 	"hide_pre_release_default": true,
+	"ra_api_key":              true,
 }
 
 // UpdateSettings updates server settings (admin only).

--- a/server/internal/api/ra_handler.go
+++ b/server/internal/api/ra_handler.go
@@ -1,14 +1,9 @@
 package api
 
 import (
-	"crypto/md5"
-	"encoding/hex"
 	"encoding/json"
-	"fmt"
-	"io"
 	"log/slog"
 	"net/http"
-	"os"
 	"path/filepath"
 	"sort"
 	"strconv"
@@ -188,9 +183,16 @@ func (h *RAHandler) GetToken(c *gin.Context) {
 }
 
 // GetGameAchievements returns achievements for a game, using cache when available.
+// If the game has a cached RAGameID (from batch scraping), the hash computation is skipped.
+// Cached achievement data is served to ALL authenticated users, even those without RA credentials.
+// Only falls back to user-credential-based fetch if cache is stale AND user has RA credentials.
 func (h *RAHandler) GetGameAchievements(c *gin.Context) {
 	uid := getUserID(c)
 	gameID := c.Param("id")
+
+	emptyResponse := gin.H{
+		"raGameId": 0, "totalCount": 0, "totalPoints": 0, "achievements": []any{},
+	}
 
 	// Look up the game
 	var game db.Game
@@ -204,44 +206,36 @@ func (h *RAHandler) GetGameAchievements(c *gin.Context) {
 		return
 	}
 
-	// Get user's RA credentials — return empty achievements if not linked
-	var cred db.RetroAchievementCredential
-	if err := h.DB.Where("user_id = ?", uid).First(&cred).Error; err != nil {
-		c.JSON(http.StatusOK, gin.H{
-			"raGameId": 0, "totalCount": 0, "totalPoints": 0, "achievements": []any{},
-		})
-		return
+	// Determine RA game ID: use cached value if available, otherwise compute hash and look up
+	raGameID := game.RAGameID
+	if raGameID == 0 {
+		// No cached RA game ID — compute hash and look up
+		romPath := filepath.Join(h.GameDir, game.FilePath)
+		if !storage.ValidateROMPath(romPath, []string{h.GameDir}) {
+			slog.Warn("RA: ROM path failed validation", "path", romPath, "gameId", gameID)
+			c.JSON(http.StatusOK, emptyResponse)
+			return
+		}
+		hash, err := computeMD5(romPath)
+		if err != nil {
+			slog.Error("failed to compute ROM hash", "path", romPath, "error", err)
+			c.JSON(http.StatusOK, emptyResponse)
+			return
+		}
+
+		var lookupErr error
+		raGameID, lookupErr = h.RAClient.GetGameIDFromHash(hash)
+		if lookupErr != nil {
+			slog.Warn("RA game ID lookup failed", "hash", hash, "error", lookupErr)
+			c.JSON(http.StatusOK, emptyResponse)
+			return
+		}
+
+		// Cache the RA game ID on the game record for future requests
+		h.DB.Model(&db.Game{}).Where("id = ?", game.ID).Update("ra_game_id", raGameID)
 	}
 
-	// Compute MD5 hash of the ROM file
-	romPath := filepath.Join(h.GameDir, game.FilePath)
-	if !storage.ValidateROMPath(romPath, []string{h.GameDir}) {
-		slog.Warn("RA: ROM path failed validation", "path", romPath, "gameId", gameID)
-		c.JSON(http.StatusOK, gin.H{
-			"raGameId": 0, "totalCount": 0, "totalPoints": 0, "achievements": []any{},
-		})
-		return
-	}
-	hash, err := computeMD5(romPath)
-	if err != nil {
-		slog.Error("failed to compute ROM hash", "path", romPath, "error", err)
-		c.JSON(http.StatusOK, gin.H{
-			"raGameId": 0, "totalCount": 0, "totalPoints": 0, "achievements": []any{},
-		})
-		return
-	}
-
-	// Look up RA game ID from hash
-	raGameID, err := h.RAClient.GetGameIDFromHash(hash)
-	if err != nil {
-		slog.Warn("RA game ID lookup failed", "hash", hash, "error", err)
-		c.JSON(http.StatusOK, gin.H{
-			"raGameId": 0, "totalCount": 0, "totalPoints": 0, "achievements": []any{},
-		})
-		return
-	}
-
-	// Check cache (valid for 24 hours)
+	// Check cache (valid for 24 hours) — this is available to ALL authenticated users
 	var cache db.GameAchievementCache
 	cacheHit := h.DB.Where("ra_game_id = ?", raGameID).First(&cache).Error == nil
 	if cacheHit && time.Since(cache.CachedAt) < 24*time.Hour {
@@ -258,6 +252,27 @@ func (h *RAHandler) GetGameAchievements(c *gin.Context) {
 			})
 			return
 		}
+	}
+
+	// Cache is stale or missing — try to refresh using user's RA credentials
+	var cred db.RetroAchievementCredential
+	if err := h.DB.Where("user_id = ?", uid).First(&cred).Error; err != nil {
+		// User has no RA credentials. If we have a stale cache, return it anyway.
+		if cacheHit {
+			var achievements []retroachievements.Achievement
+			if err := json.Unmarshal([]byte(cache.AchievementJSON), &achievements); err == nil {
+				c.JSON(http.StatusOK, gin.H{
+					"raGameId":     raGameID,
+					"title":        cache.Title,
+					"achievements": achievements,
+					"totalCount":   cache.TotalCount,
+					"totalPoints":  cache.TotalPoints,
+				})
+				return
+			}
+		}
+		c.JSON(http.StatusOK, emptyResponse)
+		return
 	}
 
 	// Decrypt RA token for API call
@@ -334,25 +349,27 @@ func (h *RAHandler) GetAchievementProgress(c *gin.Context) {
 		return
 	}
 
-	// Compute MD5 hash of the ROM file
-	romPath := filepath.Join(h.GameDir, game.FilePath)
-	if !storage.ValidateROMPath(romPath, []string{h.GameDir}) {
-		slog.Warn("RA: ROM path failed validation", "path", romPath, "gameId", gameID)
-		c.JSON(http.StatusOK, []any{})
-		return
-	}
-	hash, err := computeMD5(romPath)
-	if err != nil {
-		slog.Error("failed to compute ROM hash", "path", romPath, "error", err)
-		c.JSON(http.StatusOK, []any{})
-		return
-	}
-
-	// Look up RA game ID from hash
-	raGameID, err := h.RAClient.GetGameIDFromHash(hash)
-	if err != nil {
-		c.JSON(http.StatusOK, []any{})
-		return
+	// Use cached RA game ID if available, otherwise compute hash and look up
+	raGameID := game.RAGameID
+	if raGameID == 0 {
+		romPath := filepath.Join(h.GameDir, game.FilePath)
+		if !storage.ValidateROMPath(romPath, []string{h.GameDir}) {
+			c.JSON(http.StatusOK, []any{})
+			return
+		}
+		hash, err := computeMD5(romPath)
+		if err != nil {
+			c.JSON(http.StatusOK, []any{})
+			return
+		}
+		var lookupErr error
+		raGameID, lookupErr = h.RAClient.GetGameIDFromHash(hash)
+		if lookupErr != nil {
+			c.JSON(http.StatusOK, []any{})
+			return
+		}
+		// Cache for next time
+		h.DB.Model(&db.Game{}).Where("id = ?", game.ID).Update("ra_game_id", raGameID)
 	}
 
 	// Decrypt RA token for API call
@@ -895,17 +912,7 @@ func (h *RAHandler) GetAchievementLeaderboard(c *gin.Context) {
 }
 
 // computeMD5 calculates the MD5 hash of a file.
+// computeMD5 delegates to the shared implementation in the retroachievements package.
 func computeMD5(path string) (string, error) {
-	f, err := os.Open(path)
-	if err != nil {
-		return "", fmt.Errorf("opening file for hash: %w", err)
-	}
-	defer f.Close()
-
-	h := md5.New()
-	if _, err := io.Copy(h, f); err != nil {
-		return "", fmt.Errorf("computing file hash: %w", err)
-	}
-
-	return hex.EncodeToString(h.Sum(nil)), nil
+	return retroachievements.ComputeMD5(path)
 }

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -124,6 +124,7 @@ type Game struct {
 	ParentGameID        *uint          `gorm:"index:idx_game_parent" json:"parentGameId,omitempty"` // links standalone ROM hacks to their base game
 	PartyInfo           string         `gorm:"size:512" json:"partyInfo,omitempty"`                // Demo party and placement, e.g. "Assembly 1993, 1st place"
 	CRC32               string         `gorm:"size:16" json:"-"`
+	RAGameID            uint           `gorm:"index" json:"-"` // RetroAchievements game ID (cached from hash lookup)
 	Screenshots      []GameScreenshot      `gorm:"foreignKey:GameID" json:"-"`
 	ReleaseDates     []GameReleaseDate     `gorm:"foreignKey:GameID" json:"-"`
 	Videos           []GameVideo           `gorm:"foreignKey:GameID" json:"-"`

--- a/server/internal/retroachievements/client.go
+++ b/server/internal/retroachievements/client.go
@@ -1,11 +1,14 @@
 package retroachievements
 
 import (
+	"crypto/md5"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"os"
 	"time"
 )
 
@@ -50,6 +53,114 @@ type UserProgress struct {
 	AchievementID uint   `json:"achievementId"`
 	UnlockedAt    string `json:"unlockedAt"`
 	IsHardcore    bool   `json:"isHardcore"`
+}
+
+// ComputeMD5 computes the MD5 hash of a file and returns it as a hex string.
+// This is a shared utility used by both the API handler and the scraper.
+func ComputeMD5(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", fmt.Errorf("opening file for hash: %w", err)
+	}
+	defer f.Close()
+
+	h := md5.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return "", fmt.Errorf("computing file hash: %w", err)
+	}
+
+	return hex.EncodeToString(h.Sum(nil)), nil
+}
+
+// GetGameExtended fetches game achievements using the public Web API.
+// Requires a server-level API key (not a user token).
+func (c *RAClient) GetGameExtended(apiKey string, raGameID uint) (*GameInfo, error) {
+	u := fmt.Sprintf("%s/API/API_GetGameExtended.php?y=%s&i=%d",
+		c.BaseURL, url.QueryEscape(apiKey), raGameID)
+
+	resp, err := c.HTTPClient.Get(u)
+	if err != nil {
+		return nil, fmt.Errorf("calling RA game extended API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading RA game extended response: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("RA game extended returned status %d: %s", resp.StatusCode, string(body))
+	}
+
+	// The RA API returns a flat object with an Achievements map (same structure as GetGameInfoAndUserProgress)
+	var raw struct {
+		ID                         uint   `json:"ID"`
+		Title                      string `json:"Title"`
+		NumDistinctPlayersCasual   int    `json:"NumDistinctPlayersCasual"`
+		NumDistinctPlayersHardcore int    `json:"NumDistinctPlayersHardcore"`
+		Achievements               map[string]struct {
+			ID                 uint   `json:"ID"`
+			Title              string `json:"Title"`
+			Description        string `json:"Description"`
+			Points             int    `json:"Points"`
+			BadgeName          string `json:"BadgeName"`
+			Type               int    `json:"type"`
+			NumAwarded         int    `json:"NumAwarded"`
+			NumAwardedHardcore int    `json:"NumAwardedHardcore"`
+		} `json:"Achievements"`
+	}
+	if err := json.Unmarshal(body, &raw); err != nil {
+		return nil, fmt.Errorf("parsing RA game extended response: %w", err)
+	}
+
+	gameInfo := &GameInfo{
+		ID:    raw.ID,
+		Title: raw.Title,
+	}
+
+	totalPoints := 0
+
+	numDistinctPlayers := raw.NumDistinctPlayersCasual
+	if raw.NumDistinctPlayersHardcore > numDistinctPlayers {
+		numDistinctPlayers = raw.NumDistinctPlayersHardcore
+	}
+
+	for _, a := range raw.Achievements {
+		achType := "core"
+		if a.Type == 5 {
+			achType = "unofficial"
+		}
+
+		badgeURL := ""
+		if a.BadgeName != "" {
+			badgeURL = fmt.Sprintf("https://media.retroachievements.org/Badge/%s.png", a.BadgeName)
+		}
+
+		rarityPercent := 0.0
+		if numDistinctPlayers > 0 {
+			rarityPercent = float64(a.NumAwarded) / float64(numDistinctPlayers) * 100.0
+		}
+
+		gameInfo.Achievements = append(gameInfo.Achievements, Achievement{
+			ID:            a.ID,
+			Title:         a.Title,
+			Description:   a.Description,
+			Points:        a.Points,
+			BadgeURL:      badgeURL,
+			Type:          achType,
+			RarityPercent: rarityPercent,
+		})
+
+		if achType == "core" {
+			totalPoints += a.Points
+		}
+	}
+
+	gameInfo.TotalCount = len(gameInfo.Achievements)
+	gameInfo.TotalPoints = totalPoints
+
+	return gameInfo, nil
 }
 
 // LoginWithPassword calls the RA API to exchange username+password for a token.

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spela/server/internal/igdb"
 	"github.com/spela/server/internal/pouet"
+	"github.com/spela/server/internal/retroachievements"
 	"github.com/spela/server/internal/storage"
 	"gorm.io/gorm"
 )
@@ -20,6 +21,8 @@ type Scraper struct {
 	IGDBClient       *igdb.Client
 	SteamGridDBClient *SteamGridDBClient
 	PouetClient       *pouet.Client
+	RAClient          *retroachievements.RAClient
+	RAAPIKey          string
 	DATCache         *DATCache
 	GameDirs         []string
 	cache            *nameCache
@@ -55,6 +58,11 @@ func NewScraper(database *gorm.DB, store *storage.Storage, datDir string, gameDi
 // IsIGDBConfigured returns whether the scraper has a configured IGDB client.
 func (s *Scraper) IsIGDBConfigured() bool {
 	return s.IGDBClient != nil && s.IGDBClient.IsConfigured()
+}
+
+// IsRAConfigured returns whether the scraper has a configured RA client and API key.
+func (s *Scraper) IsRAConfigured() bool {
+	return s.RAClient != nil && s.RAAPIKey != ""
 }
 
 // TryStartScrape attempts to acquire the scrape lock.

--- a/server/internal/scraper/scraper_ra.go
+++ b/server/internal/scraper/scraper_ra.go
@@ -1,0 +1,133 @@
+package scraper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/retroachievements"
+)
+
+// ScrapeRAAchievements fetches RetroAchievements data for games that don't have
+// a cached RA game ID yet. It uses the server-level API key (not user credentials)
+// so achievement data is available to all users.
+//
+// For each game:
+//  1. Compute MD5 hash of the ROM file
+//  2. Look up the RA game ID from the hash
+//  3. Store the RA game ID on the game record
+//  4. Fetch achievement data via GetGameExtended (public API)
+//  5. Cache in GameAchievementCache
+//
+// Returns (successes, total, error).
+func (s *Scraper) ScrapeRAAchievements(ctx context.Context, onProgress func(current, total int)) (int, int, error) {
+	if !s.IsRAConfigured() {
+		return 0, 0, fmt.Errorf("RA client or API key not configured")
+	}
+
+	// Find all games without an RA game ID that are on playable consoles
+	var games []db.Game
+	if err := s.DB.Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.playable = ?", true).
+		Where("games.ra_game_id = 0 OR games.ra_game_id IS NULL").
+		Where("games.deleted_at IS NULL").
+		Preload("Console").
+		Find(&games).Error; err != nil {
+		return 0, 0, fmt.Errorf("loading games for RA scraping: %w", err)
+	}
+
+	total := len(games)
+	successes := 0
+
+	slog.Info("starting RA achievement scraping", "total", total)
+
+	for i, game := range games {
+		// Check for cancellation
+		if ctx.Err() != nil {
+			slog.Info("RA scrape cancelled", "completed", i, "total", total)
+			return successes, total, ctx.Err()
+		}
+
+		if onProgress != nil {
+			onProgress(i, total)
+		}
+
+		// Build ROM path and compute hash — try each game dir
+		var hash string
+		for _, dir := range s.GameDirs {
+			candidate := filepath.Join(dir, game.FilePath)
+			if h, err := retroachievements.ComputeMD5(candidate); err == nil {
+				hash = h
+				break
+			}
+		}
+		if hash == "" {
+			slog.Debug("RA: ROM file not found for game", "game", game.Title, "path", game.FilePath)
+			continue
+		}
+
+		// Look up RA game ID from hash (API call — rate limit before)
+		time.Sleep(500 * time.Millisecond)
+		raGameID, err := s.RAClient.GetGameIDFromHash(hash)
+		if err != nil {
+			slog.Debug("RA: no game ID for hash", "game", game.Title, "hash", hash, "error", err)
+			continue
+		}
+
+		// Store the RA game ID on the game record
+		if err := s.DB.Model(&db.Game{}).Where("id = ?", game.ID).Update("ra_game_id", raGameID).Error; err != nil {
+			slog.Warn("RA: failed to update game with RA ID", "game", game.Title, "raGameId", raGameID, "error", err)
+			continue
+		}
+
+		// Fetch achievement data via public API (API call — rate limit before)
+		time.Sleep(500 * time.Millisecond)
+		gameInfo, err := s.RAClient.GetGameExtended(s.RAAPIKey, raGameID)
+		if err != nil {
+			slog.Warn("RA: failed to fetch game extended", "game", game.Title, "raGameId", raGameID, "error", err)
+			continue
+		}
+
+		// Cache the achievement data
+		achJSON, err := json.Marshal(gameInfo.Achievements)
+		if err != nil {
+			slog.Warn("RA: failed to marshal achievements", "game", game.Title, "error", err)
+			continue
+		}
+
+		var existing db.GameAchievementCache
+		if err := s.DB.Where("ra_game_id = ?", raGameID).First(&existing).Error; err == nil {
+			// Update existing cache
+			existing.Title = gameInfo.Title
+			existing.AchievementJSON = string(achJSON)
+			existing.TotalCount = gameInfo.TotalCount
+			existing.TotalPoints = gameInfo.TotalPoints
+			existing.CachedAt = time.Now()
+			existing.GameID = game.ID
+			s.DB.Save(&existing)
+		} else {
+			// Create new cache entry
+			s.DB.Create(&db.GameAchievementCache{
+				RAGameID:        raGameID,
+				GameID:          game.ID,
+				Title:           gameInfo.Title,
+				AchievementJSON: string(achJSON),
+				TotalCount:      gameInfo.TotalCount,
+				TotalPoints:     gameInfo.TotalPoints,
+				CachedAt:        time.Now(),
+			})
+		}
+
+		successes++
+		slog.Info("RA: cached achievements", "game", game.Title, "raGameId", raGameID, "achievements", gameInfo.TotalCount)
+	}
+
+	if onProgress != nil {
+		onProgress(total, total)
+	}
+
+	return successes, total, nil
+}


### PR DESCRIPTION
## Summary
- **Server-level RA API key** (`SPELA_RA_API_KEY` env var or `ra_api_key` admin setting) for fetching achievement data without user credentials
- **Batch RA scraping** during game import: computes ROM hash → looks up RA game ID → fetches achievements via public API → caches in GameAchievementCache
- **All users see achievements** — cached data served to any authenticated user, not just RA-linked users
- **RAGameID cached on Game model** — eliminates repeated hash computation and RA API lookups
- **Similar games cover art fix** — coverUrl now resolved through apiClient.resolveUrl()
- **Achievement count in metadata grid** — shows "X / Y" unlocked in game detail

Rate limited at 500ms between RA API calls. Context cancellation supported.

## Test plan
- [x] Server builds and all tests pass
- [x] Player app builds
- [x] Code reviewed — all critical/important issues fixed
- [ ] CI passes