### PR TITLE
feat: RetroAchievements config card in admin settings

### DIFF
--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -251,6 +251,31 @@ func (h *AdminHandler) GetSteamGridDBStatus(c *gin.Context) {
 	})
 }
 
+// RASource returns "env" if RA API key is set via environment variables,
+// "database" if set via admin settings, or "none" if not configured.
+func RASource(database *gorm.DB) string {
+	if os.Getenv("SPELA_RA_API_KEY") != "" {
+		return "env"
+	}
+	var count int64
+	database.Model(&db.ServerSetting{}).
+		Where("key = ? AND value != ''", "ra_api_key").
+		Count(&count)
+	if count == 1 {
+		return "database"
+	}
+	return "none"
+}
+
+// GetRAStatus returns the current RetroAchievements API configuration status.
+func (h *AdminHandler) GetRAStatus(c *gin.Context) {
+	source := RASource(h.DB)
+	c.JSON(http.StatusOK, gin.H{
+		"configured": source != "none",
+		"source":     source,
+	})
+}
+
 // IGDBSource returns "env" if IGDB credentials are set via environment variables,
 // "database" if set via admin settings, or "none" if not configured.
 func IGDBSource(database *gorm.DB) string {

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -541,6 +541,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 			admin.POST("/igdb/test", igdbHandler.TestIGDB)
 			admin.GET("/igdb/status", igdbHandler.GetIGDBStatus)
 			admin.GET("/steamgriddb/status", adminHandler.GetSteamGridDBStatus)
+			admin.GET("/ra/status", adminHandler.GetRAStatus)
 			admin.GET("/stats", adminHandler.GetStats)
 			admin.GET("/users/:id/rate-limit", adminHandler.GetUserRateLimit)
 			admin.DELETE("/users/:id/rate-limit", adminHandler.ResetUserRateLimit)

--- a/web/src/features/admin/components/ra-config-card.tsx
+++ b/web/src/features/admin/components/ra-config-card.tsx
@@ -1,0 +1,121 @@
+import { useState } from "react";
+import {
+  Trophy,
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+} from "lucide-react";
+import {
+  Badge,
+  Card,
+  CardHeader,
+  CardContent,
+  Input,
+} from "@/components/ui";
+import { useRAStatus } from "@/hooks/use-admin";
+
+interface RAConfigCardProps {
+  apiKey: string;
+  onApiKeyChange: (value: string) => void;
+  envConfigured?: boolean;
+}
+
+export function RAConfigCard({
+  apiKey,
+  onApiKeyChange,
+  envConfigured,
+}: RAConfigCardProps) {
+  const { data: status } = useRAStatus();
+  const [instructionsExpanded, setInstructionsExpanded] = useState(!apiKey);
+
+  const statusBadge = (() => {
+    if (!status) return null;
+    if (status.configured) {
+      return <Badge variant="success">Connected</Badge>;
+    }
+    return <Badge variant="warning">Not configured</Badge>;
+  })();
+
+  return (
+    <Card>
+      <CardHeader>
+        <div
+          className="flex items-center justify-between"
+          id="ra-config"
+        >
+          <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+            <Trophy className="h-5 w-5 text-brand-400" />
+            RetroAchievements
+          </h2>
+          {statusBadge}
+        </div>
+        <p className="text-xs text-surface-500 mt-1">
+          RetroAchievements provides achievement data for retro games. When
+          configured, achievement lists are fetched automatically during game
+          scanning and shown to all users.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {envConfigured ? (
+          <div className="rounded-xl bg-surface-800/50 border border-surface-700/50 p-4">
+            <div className="flex items-center gap-2">
+              <CheckCircle2 className="h-4 w-4 text-success-500 flex-shrink-0" />
+              <p className="text-sm text-surface-200">
+                Configured via environment variables
+              </p>
+            </div>
+            <p className="mt-1.5 ml-6 text-xs text-surface-500">
+              RA API key is set through{" "}
+              <code className="px-1 py-0.5 rounded bg-surface-800 text-surface-300 font-mono">
+                SPELA_RA_API_KEY
+              </code>
+              . To change it, update your environment and restart the server.
+            </p>
+          </div>
+        ) : (
+          <>
+            <div>
+              <button
+                type="button"
+                onClick={() => setInstructionsExpanded((prev) => !prev)}
+                className="flex items-center gap-1.5 text-sm font-medium text-surface-300 hover:text-surface-100 transition-colors"
+              >
+                {instructionsExpanded ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )}
+                How to get your API key
+              </button>
+              {instructionsExpanded && (
+                <ol className="mt-2 ml-6 list-decimal text-sm text-surface-400 space-y-1">
+                  <li>
+                    Go to{" "}
+                    <a
+                      href="https://retroachievements.org/controlpanel.php"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-brand-400 hover:text-brand-300 underline"
+                    >
+                      RetroAchievements Control Panel
+                    </a>
+                  </li>
+                  <li>Sign in with your RA account</li>
+                  <li>Find the &quot;Keys&quot; section and copy your Web API Key</li>
+                </ol>
+              )}
+            </div>
+
+            <Input
+              label="Web API Key"
+              type="password"
+              placeholder="RetroAchievements Web API Key"
+              value={apiKey}
+              onChange={(e) => onApiKeyChange(e.target.value)}
+            />
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -320,6 +320,17 @@ export function useSteamGridDBStatus() {
   });
 }
 
+export function useRAStatus() {
+  return useQuery({
+    queryKey: ["admin", "ra-status"],
+    queryFn: () =>
+      api.get<{
+        configured: boolean;
+        source: "env" | "database" | "none";
+      }>("/admin/ra/status"),
+  });
+}
+
 export function useUpdateGameMetadata() {
   const queryClient = useQueryClient();
 

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -216,6 +216,7 @@ export type ApiGetPath = WithQuery<
   | "/admin/metadata-matches"
   | "/admin/igdb/status"
   | "/admin/steamgriddb/status"
+  | "/admin/ra/status"
   | "/admin/cheats/stats"
   | "/admin/uploads"
   | "/admin/uploads/writable"

--- a/web/src/pages/admin/settings-page.test.tsx
+++ b/web/src/pages/admin/settings-page.test.tsx
@@ -28,6 +28,7 @@ vi.mock("@/hooks/use-admin", () => ({
   useTestIgdbCredentials: vi.fn(),
   useIgdbStatus: vi.fn(),
   useSteamGridDBStatus: vi.fn(),
+  useRAStatus: vi.fn(),
 }));
 
 vi.mock("@/components/ui", async () => {
@@ -45,6 +46,7 @@ import {
   useTestIgdbCredentials,
   useIgdbStatus,
   useSteamGridDBStatus,
+  useRAStatus,
 } from "@/hooks/use-admin";
 
 const mockUseServerSettings = useServerSettings as ReturnType<typeof vi.fn>;
@@ -56,6 +58,7 @@ const mockUseIgdbStatus = useIgdbStatus as ReturnType<typeof vi.fn>;
 const mockUseSteamGridDBStatus = useSteamGridDBStatus as ReturnType<
   typeof vi.fn
 >;
+const mockUseRAStatus = useRAStatus as ReturnType<typeof vi.fn>;
 
 function renderPage() {
   const queryClient = new QueryClient({
@@ -88,6 +91,9 @@ beforeEach(() => {
     data: { configured: true, status: "connected" },
   });
   mockUseSteamGridDBStatus.mockReturnValue({
+    data: { configured: false, source: "none" },
+  });
+  mockUseRAStatus.mockReturnValue({
     data: { configured: false, source: "none" },
   });
 });

--- a/web/src/pages/admin/settings-page.tsx
+++ b/web/src/pages/admin/settings-page.tsx
@@ -12,17 +12,20 @@ import {
   useUpdateSettings,
   useIgdbStatus,
   useSteamGridDBStatus,
+  useRAStatus,
 } from "@/hooks/use-admin";
 import { useToast } from "@/components/ui";
 import { Skeleton } from "@/components/ui";
 import { IgdbConfigCard } from "@/features/admin/components/igdb-config-card";
 import { IgdbWarningBanner } from "@/features/admin/components/igdb-warning-banner";
 import { SteamGridDBConfigCard } from "@/features/admin/components/steamgriddb-config-card";
+import { RAConfigCard } from "@/features/admin/components/ra-config-card";
 
 export function AdminSettingsPage() {
   const { data: settings, isLoading } = useServerSettings();
   const { data: igdbStatus } = useIgdbStatus();
   const { data: steamgriddbStatus } = useSteamGridDBStatus();
+  const { data: raStatus } = useRAStatus();
   const updateSettings = useUpdateSettings();
   const { toast } = useToast();
 
@@ -34,6 +37,7 @@ export function AdminSettingsPage() {
   const [igdbClientId, setIgdbClientId] = useState("");
   const [igdbClientSecret, setIgdbClientSecret] = useState("");
   const [steamgriddbApiKey, setSteamgriddbApiKey] = useState("");
+  const [raApiKey, setRaApiKey] = useState("");
 
   useEffect(() => {
     if (settings) {
@@ -45,6 +49,7 @@ export function AdminSettingsPage() {
       setIgdbClientId(settings["igdb_client_id"] ?? "");
       setIgdbClientSecret(settings["igdb_client_secret"] ?? "");
       setSteamgriddbApiKey(settings["steamgriddb_api_key"] ?? "");
+      setRaApiKey(settings["ra_api_key"] ?? "");
     }
   }, [settings]);
 
@@ -63,6 +68,9 @@ export function AdminSettingsPage() {
     }
     if (!steamgriddbEnvConfigured) {
       payload.steamgriddb_api_key = steamgriddbApiKey;
+    }
+    if (!raEnvConfigured) {
+      payload.ra_api_key = raApiKey;
     }
     updateSettings.mutate(payload, {
       onSuccess: () => toast("success", "Settings saved"),
@@ -83,6 +91,7 @@ export function AdminSettingsPage() {
   const igdbNotConfigured = igdbStatus && !igdbStatus.configured;
   const igdbEnvConfigured = igdbStatus?.source === "env";
   const steamgriddbEnvConfigured = steamgriddbStatus?.source === "env";
+  const raEnvConfigured = raStatus?.source === "env";
 
   return (
     <div className="space-y-6 max-w-3xl">
@@ -194,6 +203,12 @@ export function AdminSettingsPage() {
         apiKey={steamgriddbApiKey}
         onApiKeyChange={setSteamgriddbApiKey}
         envConfigured={steamgriddbEnvConfigured}
+      />
+
+      <RAConfigCard
+        apiKey={raApiKey}
+        onApiKeyChange={setRaApiKey}
+        envConfigured={raEnvConfigured}
       />
 
       <div className="flex justify-end">


### PR DESCRIPTION
## Summary
- Server: new `GET /api/admin/ra/status` endpoint (env/database/none)
- Web: `RAConfigCard` on admin settings page with API key input or "configured via environment variables" message
- Follows same pattern as IGDB and SteamGridDB config cards

## Test plan
- [x] Server and web build
- [ ] CI passes