### PR TITLE
fix: RA achievement scraping — handle string type field

### DIFF
--- a/server/internal/retroachievements/client.go
+++ b/server/internal/retroachievements/client.go
@@ -93,21 +93,24 @@ func (c *RAClient) GetGameExtended(apiKey string, raGameID uint) (*GameInfo, err
 		return nil, fmt.Errorf("RA game extended returned status %d: %s", resp.StatusCode, string(body))
 	}
 
-	// The RA API returns a flat object with an Achievements map (same structure as GetGameInfoAndUserProgress)
+	// The RA API returns a flat object with an Achievements map.
+	// Note: GetGameExtended returns type as a string ("progression", "win_condition", "missable", null)
+	// while GetGameInfoAndUserProgress returns type as an int (3=core, 5=unofficial).
+	// We use json.RawMessage to handle both formats.
 	var raw struct {
 		ID                         uint   `json:"ID"`
 		Title                      string `json:"Title"`
 		NumDistinctPlayersCasual   int    `json:"NumDistinctPlayersCasual"`
 		NumDistinctPlayersHardcore int    `json:"NumDistinctPlayersHardcore"`
 		Achievements               map[string]struct {
-			ID                 uint   `json:"ID"`
-			Title              string `json:"Title"`
-			Description        string `json:"Description"`
-			Points             int    `json:"Points"`
-			BadgeName          string `json:"BadgeName"`
-			Type               int    `json:"type"`
-			NumAwarded         int    `json:"NumAwarded"`
-			NumAwardedHardcore int    `json:"NumAwardedHardcore"`
+			ID                 uint             `json:"ID"`
+			Title              string           `json:"Title"`
+			Description        string           `json:"Description"`
+			Points             int              `json:"Points"`
+			BadgeName          string           `json:"BadgeName"`
+			Type               json.RawMessage  `json:"type"`
+			NumAwarded         int              `json:"NumAwarded"`
+			NumAwardedHardcore int              `json:"NumAwardedHardcore"`
 		} `json:"Achievements"`
 	}
 	if err := json.Unmarshal(body, &raw); err != nil {
@@ -127,9 +130,14 @@ func (c *RAClient) GetGameExtended(apiKey string, raGameID uint) (*GameInfo, err
 	}
 
 	for _, a := range raw.Achievements {
+		// Parse type: string ("progression", "win_condition", "missable", null) from GetGameExtended
 		achType := "core"
-		if a.Type == 5 {
-			achType = "unofficial"
+		if len(a.Type) > 0 {
+			var typeInt int
+			if json.Unmarshal(a.Type, &typeInt) == nil && typeInt == 5 {
+				achType = "unofficial"
+			}
+			// String types are all "core" variants (progression, win_condition, etc.)
 		}
 
 		badgeURL := ""

--- a/server/internal/retroachievements/client_integration_test.go
+++ b/server/internal/retroachievements/client_integration_test.go
@@ -1,0 +1,53 @@
+package retroachievements
+
+import (
+	"os"
+	"testing"
+)
+
+// TestGetGameExtendedIntegration calls the real RA API.
+// Run with: SPELA_RA_API_KEY=... go test ./internal/retroachievements/ -run TestGetGameExtendedIntegration -v
+func TestGetGameExtendedIntegration(t *testing.T) {
+	apiKey := os.Getenv("SPELA_RA_API_KEY")
+	if apiKey == "" {
+		t.Skip("SPELA_RA_API_KEY not set, skipping integration test")
+	}
+
+	client := NewRAClient()
+
+	// Super Mario World = RA game ID 228
+	gameInfo, err := client.GetGameExtended(apiKey, 228)
+	if err != nil {
+		t.Fatalf("GetGameExtended failed: %v", err)
+	}
+
+	if gameInfo.Title == "" {
+		t.Error("expected non-empty title")
+	}
+	t.Logf("Title: %s", gameInfo.Title)
+
+	if gameInfo.TotalCount == 0 {
+		t.Error("expected achievements, got 0")
+	}
+	t.Logf("Total achievements: %d", gameInfo.TotalCount)
+	t.Logf("Total points: %d", gameInfo.TotalPoints)
+
+	// Verify at least one achievement has proper data
+	if len(gameInfo.Achievements) > 0 {
+		a := gameInfo.Achievements[0]
+		if a.ID == 0 {
+			t.Error("expected achievement ID > 0")
+		}
+		if a.Title == "" {
+			t.Error("expected achievement title")
+		}
+		if a.BadgeURL == "" {
+			t.Error("expected badge URL")
+		}
+		t.Logf("Sample: %s (%d pts, rarity %.1f%%, type=%s)", a.Title, a.Points, a.RarityPercent, a.Type)
+	}
+
+	// Verify hash lookup also works
+	// Super Mario World (USA) MD5 varies by ROM, so let's just test the game ID lookup
+	t.Logf("SUCCESS: Parsed %d achievements for %s", gameInfo.TotalCount, gameInfo.Title)
+}


### PR DESCRIPTION
## Summary
The RA `API_GetGameExtended` endpoint returns the achievement `type` field as a **string** ("progression", "win_condition", "missable") while `API_GetGameInfoAndUserProgress` returns it as an **int** (3, 5). Our parser used `int`, causing `json.Unmarshal` to fail for every game — **no achievement data was ever cached during scraping**.

Fix: use `json.RawMessage` for the type field, try int parsing first (for backward compat with user-progress endpoint), fall back to treating string types as "core".

Added integration test calling real RA API (skipped when API key not set).

## Verified
- Integration test: Super Mario World — 89 achievements, 711 points parsed correctly
- All server tests pass

## Test plan
- [x] Integration test passes with real RA API
- [x] Server builds
- [ ] CI passes