### PR TITLE
fix: UI polish — hero banner, console games, home empty state

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAreaSizedImage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpAreaSizedImage.kt
@@ -1,0 +1,93 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.widthIn
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import coil3.compose.SubcomposeAsyncImage
+import kotlin.math.sqrt
+
+/**
+ * DESIGN component — renders an image at a consistent visual area size.
+ *
+ * Instead of a fixed height or width, this component targets a consistent
+ * visual area (width × height in dp²). Wide images become shorter, tall
+ * images become narrower — but they all occupy roughly the same visual space.
+ *
+ * This solves the problem where logos of different aspect ratios look
+ * inconsistently sized when constrained by height alone.
+ *
+ * @param imageUrl The URL of the image to load.
+ * @param contentDescription Accessibility description.
+ * @param targetArea The target visual area in dp² (default: 8000 = ~89×89dp square equivalent).
+ * @param maxHeight Maximum height constraint to prevent extremely tall images.
+ * @param maxWidth Maximum width constraint to prevent extremely wide images.
+ * @param minHeight Minimum height to ensure very wide images remain visible.
+ * @param modifier Modifier for the outer container.
+ * @param loading Composable shown while the image loads.
+ * @param error Composable shown if loading fails.
+ */
+@Composable
+fun SpAreaSizedImage(
+    imageUrl: String,
+    contentDescription: String?,
+    modifier: Modifier = Modifier,
+    targetArea: Float = 8000f,
+    maxHeight: Dp = 120.dp,
+    maxWidth: Dp = 200.dp,
+    minHeight: Dp = 48.dp,
+    loading: @Composable () -> Unit = {},
+    error: @Composable () -> Unit = {},
+) {
+    // Track the resolved aspect ratio from the loaded image
+    var aspectRatio by remember { mutableFloatStateOf(0f) }
+
+    // Compute dimensions from target area and aspect ratio
+    // area = w * h, aspectRatio = w / h → w = sqrt(area * ar), h = sqrt(area / ar)
+    val density = LocalDensity.current
+
+    BoxWithConstraints(modifier = modifier) {
+        val computedHeight = if (aspectRatio > 0f) {
+            val h = sqrt(targetArea / aspectRatio).dp
+            h.coerceIn(minHeight, maxHeight)
+        } else {
+            // Before image loads, use a reasonable default
+            sqrt(targetArea).dp.coerceIn(minHeight, maxHeight)
+        }
+
+        val computedWidth = if (aspectRatio > 0f) {
+            val w = sqrt(targetArea * aspectRatio).dp
+            w.coerceAtMost(maxWidth)
+        } else {
+            maxWidth
+        }
+
+        SubcomposeAsyncImage(
+            model = imageUrl,
+            contentDescription = contentDescription,
+            modifier = Modifier
+                .heightIn(max = computedHeight)
+                .widthIn(max = computedWidth),
+            contentScale = ContentScale.Fit,
+            onSuccess = { result ->
+                val painter = result.painter
+                val intrinsicSize = painter.intrinsicSize
+                if (intrinsicSize.width > 0 && intrinsicSize.height > 0) {
+                    aspectRatio = intrinsicSize.width / intrinsicSize.height
+                }
+            },
+            loading = { loading() },
+            error = { error() },
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpGridGameCard.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpGridGameCard.kt
@@ -28,7 +28,7 @@ fun SpGridGameCard(
         subtitle = subtitle,
         coverUrl = coverUrl,
         onClick = onClick,
-        coverAspectRatio = null,
+        coverAspectRatio = if (coverUrl == null) 0.75f else null,
         rating = rating,
         isFavorite = isFavorite,
         isInPlayLater = isInPlayLater,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/HeroCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/HeroCarousel.kt
@@ -11,9 +11,11 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.ripple
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -50,6 +52,7 @@ import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.domain.model.FeaturedGame
 import com.spela.player.presentation.ui.components.LocalAnimationsEnabled
 import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpAreaSizedImage
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpConsoleChip
 import com.spela.player.presentation.ui.components.SpShimmer
@@ -232,104 +235,154 @@ private fun HeroSlide(
                 ),
         )
 
-        // Content overlay (centered)
-        Column(
-            horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier
-                .align(Alignment.BottomCenter)
-                .padding(SpSpacing.XLarge)
-                .padding(bottom = SpSpacing.XLarge)
-                .fillMaxWidth(),
-        ) {
-            // Logo or title text fallback
-            if (game.logoUrl != null) {
-                SubcomposeAsyncImage(
-                    model = game.logoUrl,
-                    contentDescription = "${game.title} logo",
+        // Content overlay — responsive: Row on wide screens, Column on narrow
+        BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val isWide = maxWidth > 700.dp
+
+            if (isWide) {
+                // Desktop: left info + right logo
+                Row(
                     modifier = Modifier
-                        .height(80.dp)
-                        .fillMaxWidth(0.7f),
-                    contentScale = ContentScale.Fit,
-                    loading = {
-                        Text(
-                            text = game.title,
-                            style = SpTypography.DisplaySmall,
-                            color = SpColor.OnBackground,
-                        )
-                    },
-                    error = {
-                        Text(
-                            text = game.title,
-                            style = SpTypography.DisplaySmall,
-                            color = SpColor.OnBackground,
-                        )
-                    },
-                )
-            } else {
-                Text(
-                    text = game.title,
-                    style = SpTypography.DisplaySmall,
-                    color = SpColor.OnBackground,
-                    maxLines = 2,
-                    overflow = TextOverflow.Ellipsis,
-                )
-            }
-
-            Spacer(Modifier.height(SpSpacing.Small))
-
-            // Metadata row: console badge, rating, genre
-            Row(
-                verticalAlignment = Alignment.CenterVertically,
-                horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-            ) {
-                // Console badge — full name since the hero has plenty of space
-                val consoleColor = parseHexColor(game.consoleColor, SpColor.Primary)
-                SpConsoleChip(
-                    consoleName = game.consoleName.ifEmpty { game.consoleAbbreviation.uppercase() },
-                    consoleColor = consoleColor,
-                    onGradient = true,
-                )
-
-                // Rating
-                if (game.rating > 0) {
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+                        .fillMaxSize()
+                        .padding(start = SpSpacing.XLarge, bottom = SpSpacing.XLarge, top = SpSpacing.XLarge)
+                        .padding(end = SpSpacing.XXXLarge),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(
+                        horizontalAlignment = Alignment.Start,
+                        verticalArrangement = Arrangement.Bottom,
+                        modifier = Modifier.weight(1f).fillMaxHeight(),
                     ) {
-                        Icon(
-                            imageVector = Icons.Filled.Star,
-                            contentDescription = null,
-                            tint = SpColor.Rating,
-                            modifier = Modifier.size(SpSpacing.IconSmall),
-                        )
-                        Text(
-                            text = formatRating(game.rating),
-                            style = SpTypography.LabelMedium,
-                            color = SpColor.OnBackground,
+                        HeroInfoContent(game, onGameSelected)
+                    }
+
+                    if (game.logoUrl != null) {
+                        SpAreaSizedImage(
+                            imageUrl = game.logoUrl!!,
+                            contentDescription = "${game.title} logo",
+                            targetArea = 28000f,
+                            maxHeight = 200.dp,
+                            maxWidth = 300.dp,
+                            minHeight = 90.dp,
+                            error = {
+                                Text(
+                                    text = game.title,
+                                    style = SpTypography.HeadlineMedium,
+                                    color = SpColor.OnBackground,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            },
                         )
                     }
                 }
+            } else {
+                // Mobile: logo centered above, info below
+                Column(
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Bottom,
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(SpSpacing.XLarge)
+                        .padding(bottom = SpSpacing.XLarge),
+                ) {
+                    if (game.logoUrl != null) {
+                        Spacer(Modifier.weight(1f))
+                        SpAreaSizedImage(
+                            imageUrl = game.logoUrl!!,
+                            contentDescription = "${game.title} logo",
+                            targetArea = 28000f,
+                            maxHeight = 200.dp,
+                            maxWidth = 300.dp,
+                            minHeight = 90.dp,
+                            error = {
+                                Text(
+                                    text = game.title,
+                                    style = SpTypography.HeadlineSmall,
+                                    color = SpColor.OnBackground,
+                                    maxLines = 2,
+                                    overflow = TextOverflow.Ellipsis,
+                                )
+                            },
+                        )
+                        Spacer(Modifier.weight(1f))
+                    }
 
-                // Genre
-                if (game.genre.isNotEmpty()) {
-                    SpChip(text = game.genre, onGradient = true)
+                    HeroInfoContent(game, onGameSelected, centerAligned = true)
                 }
             }
+        }
+    }
+}
 
-            Spacer(Modifier.height(SpSpacing.Medium))
+@Composable
+private fun HeroInfoContent(
+    game: FeaturedGame,
+    onGameSelected: () -> Unit,
+    centerAligned: Boolean = false,
+) {
+    val alignment = if (centerAligned) Alignment.CenterHorizontally else Alignment.Start
 
-            // Action button
-            SpButton(
-                text = "View Game",
-                onClick = onGameSelected,
-                leadingIcon = {
-                    Icon(
-                        imageVector = Icons.Filled.PlayArrow,
-                        contentDescription = null,
-                        modifier = Modifier.size(SpSpacing.IconDefault),
-                    )
-                },
+    // Title (only when no logo)
+    if (game.logoUrl == null) {
+        Text(
+            text = game.title,
+            style = if (centerAligned) SpTypography.HeadlineSmall else SpTypography.DisplaySmall,
+            color = SpColor.OnBackground,
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis,
+        )
+        Spacer(Modifier.height(SpSpacing.Small))
+    }
+
+    // Action button
+    SpButton(
+        text = "View Game",
+        onClick = onGameSelected,
+        leadingIcon = {
+            Icon(
+                imageVector = Icons.Filled.PlayArrow,
+                contentDescription = null,
+                modifier = Modifier.size(SpSpacing.IconDefault),
             )
+        },
+    )
+
+    Spacer(Modifier.height(SpSpacing.Medium))
+
+    // Badges
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+    ) {
+        val consoleColor = parseHexColor(game.consoleColor, SpColor.Primary)
+        SpConsoleChip(
+            consoleName = game.consoleName.ifEmpty { game.consoleAbbreviation.uppercase() },
+            consoleColor = consoleColor,
+            onGradient = true,
+        )
+
+        if (game.rating > 0) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Star,
+                    contentDescription = null,
+                    tint = SpColor.Rating,
+                    modifier = Modifier.size(SpSpacing.IconSmall),
+                )
+                Text(
+                    text = formatRating(game.rating),
+                    style = SpTypography.LabelMedium,
+                    color = SpColor.OnBackground,
+                )
+            }
+        }
+
+        if (game.genre.isNotEmpty()) {
+            SpChip(text = game.genre, onGradient = true)
         }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -44,6 +44,8 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.components.SpGameGrid
+import com.spela.player.presentation.ui.components.SpGridGameCard
 import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.feature.explore.ConsoleEssentials
 import com.spela.player.presentation.ui.feature.explore.ConsoleHiddenGems
@@ -151,17 +153,6 @@ fun ConsoleScreen(
                         }
                     }
 
-                    // Browse All Games (quick access)
-                    if (state.games.isNotEmpty()) {
-                        item {
-                            SpButton(
-                                text = "Browse All ${state.games.size} Games",
-                                onClick = onBrowseAllGames,
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                        }
-                    }
-
                     // BIOS warning
                     if (consoleId in state.consolesWithMissingBios) {
                         item {
@@ -197,6 +188,39 @@ fun ConsoleScreen(
                     // Top Developers
                     if (exploreViewModel != null) {
                         item { ConsoleTopDevelopers(exploreViewModel, onDeveloperSelected) }
+                    }
+
+                    // Browse All Games — at the bottom: inline grid for small libraries, button for large
+                    if (state.games.isNotEmpty()) {
+                        if (state.games.size <= 15) {
+                            item {
+                                SpTitledSection(title = "All Games") {
+                                    SpGameGrid(
+                                        items = state.games.map { game ->
+                                            {
+                                                SpGridGameCard(
+                                                    title = game.title,
+                                                    subtitle = game.consoleName,
+                                                    coverUrl = game.coverUrl,
+                                                    onClick = { onGameSelected(game.id) },
+                                                    rating = game.rating,
+                                                    isFavorite = game.isFavorite,
+                                                    isInPlayLater = game.isInPlayLater,
+                                                )
+                                            }
+                                        },
+                                    )
+                                }
+                            }
+                        } else {
+                            item {
+                                SpButton(
+                                    text = "Browse All ${state.games.size} Games",
+                                    onClick = onBrowseAllGames,
+                                    modifier = Modifier.fillMaxWidth(),
+                                )
+                            }
+                        }
                     }
 
                     // Loading / Empty

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -550,28 +550,7 @@ private fun GameInfoContent(
     onNavigateToPublisher: ((name: String) -> Unit)? = null,
     onNavigateToAchievements: (() -> Unit)? = null,
 ) {
-    // Game info content — title, badges, and action buttons are in the hero banner
-
-    if (state.isScraping) {
-        Row(
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-        ) {
-            CircularProgressIndicator(
-                modifier = Modifier.size(16.dp),
-                strokeWidth = 2.dp,
-                color = Color.White.copy(alpha = 0.75f),
-            )
-            Text(
-                text = "Scraping metadata\u2026",
-                style = SpTypography.BodySmall,
-                color = SpColor.OnBackgroundTertiary,
-            )
-        }
-    }
-
-
-    // Title, badges, and action buttons are now in the hero banner (GameHeroContent)
+    // Title, badges, and action buttons are in the hero banner (GameHeroContent)
 
     // Sync status row (shown while pre-launch or post-exit sync is in progress)
     syncState?.takeIf { !it.isTimedOut }?.let { sync ->
@@ -1100,6 +1079,25 @@ private fun GameHeroContent(
                 onAddToCollection = onAddToCollection,
                 onGradient = true,
             )
+
+            // Scraping indicator
+            if (state.isScraping) {
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                ) {
+                    CircularProgressIndicator(
+                        modifier = Modifier.size(14.dp),
+                        strokeWidth = 2.dp,
+                        color = Color.White.copy(alpha = 0.65f),
+                    )
+                    Text(
+                        text = "Scraping\u2026",
+                        style = SpTypography.LabelSmall,
+                        color = Color.White.copy(alpha = 0.65f),
+                    )
+                }
+            }
 
             // Playtime + last played grouped so they wrap together
             if (game.totalPlayTime > 0 || game.lastPlayedAt != null) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -119,9 +119,22 @@ fun HomeScreen(
     val socialState by socialViewModel.state.collectAsState()
 
     LaunchedEffect(Unit) {
+        println("[HomeScreen] LaunchedEffect(Unit) fired — loading dashboard")
         viewModel.onIntent(GameListIntent.LoadDashboard)
         socialViewModel.onIntent(SocialIntent.RefreshAll)
         settingsViewModel?.onIntent(SettingsIntent.LoadSettings)
+    }
+
+    // Retry if dashboard loaded empty (server may still be scanning on startup)
+    val isEmpty = state.consoles.isEmpty() && state.recentGames.isEmpty() && !state.isLoading
+    LaunchedEffect(isEmpty) {
+        if (isEmpty) {
+            println("[HomeScreen] Dashboard empty, retrying in 3s (consoles=${state.consoles.size}, recent=${state.recentGames.size}, loading=${state.isLoading})")
+            kotlinx.coroutines.delay(3000)
+            println("[HomeScreen] Retrying dashboard load")
+            viewModel.onIntent(GameListIntent.LoadDashboard)
+            socialViewModel.onIntent(SocialIntent.RefreshAll)
+        }
     }
 
     val gradientColors = listOf(
@@ -163,7 +176,8 @@ fun HomeScreen(
                     },
                     modifier = Modifier.fillMaxSize(),
                 ) {
-                    val isEmpty = state.recentGames.isEmpty() &&
+                    val isEmpty = state.consoles.isEmpty() &&
+                            state.recentGames.isEmpty() &&
                             state.favoriteGames.isEmpty() &&
                             state.playLaterGames.isEmpty() &&
                             state.recentAchievements.isEmpty() &&

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -109,12 +109,14 @@ class GameListViewModel(
     }
 
     private fun loadDashboard() {
+        println("[GameListVM] loadDashboard() called")
         _state.update { it.copy(isLoading = true) }
         scope.launch(dispatchers.io) {
             val consoles = getConsolesUseCase().getOrDefault(emptyList())
             val recent = getRecentGamesUseCase().getOrDefault(emptyList())
             val favorites = getFavoriteGamesUseCase().getOrDefault(emptyList())
             val playLater = getPlayLaterGamesUseCase().getOrDefault(emptyList())
+            println("[GameListVM] loadDashboard() result: consoles=${consoles.size}, recent=${recent.size}, favorites=${favorites.size}, playLater=${playLater.size}")
             _state.update {
                 it.copy(
                     consoles = consoles,


### PR DESCRIPTION
## Summary
- **Hero banner**: left-aligned info + right-aligned logo with new `SpAreaSizedImage` (consistent visual area sizing). Responsive mobile/desktop layouts.
- **Console screen**: inline game grid for ≤15 games, "Browse All" button for larger libraries. Moved to bottom.
- **Game detail**: scraping indicator in hero action row instead of content area
- **Home screen**: fixed false "library is empty" when consoles exist but no play history. Auto-retry on empty.
- **SpGridGameCard**: placeholder maintains size when no cover art

## Test plan
- [x] Player app builds
- [ ] CI passes