### PR TITLE
feat: console banner redesign, SVG logos, dynamic game cards

### DIFF
--- a/player/shared/build.gradle.kts
+++ b/player/shared/build.gradle.kts
@@ -42,6 +42,7 @@ kotlin {
 
                 implementation(libs.coil.compose)
                 implementation(libs.coil.network.ktor)
+                implementation(libs.coil.svg)
 
                 implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.kotlinx.serialization.json)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpConsoleTile.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpConsoleTile.kt
@@ -7,12 +7,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
@@ -22,7 +17,6 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import coil3.compose.AsyncImage
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -60,30 +54,36 @@ fun SpConsoleTile(
     ) {
         Column(
             horizontalAlignment = Alignment.CenterHorizontally,
-            modifier = Modifier.padding(SpSpacing.Medium),
+            modifier = Modifier.padding(SpSpacing.Default),
         ) {
             if (logoUrl.isNotEmpty()) {
-                var logoFailed by remember { mutableStateOf(false) }
-                if (!logoFailed) {
-                    AsyncImage(
-                        model = logoUrl,
-                        contentDescription = null,
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier
-                            .height(28.dp)
-                            .fillMaxWidth(),
-                        onError = { logoFailed = true },
-                    )
-                }
+                SpAreaSizedImage(
+                    imageUrl = logoUrl,
+                    contentDescription = name,
+                    targetArea = 3000f,
+                    maxHeight = 36.dp,
+                    maxWidth = 120.dp,
+                    minHeight = 20.dp,
+                    error = {
+                        Text(
+                            text = name,
+                            style = SpTypography.TitleSmall,
+                            color = SpColor.OnCard,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                        )
+                    },
+                )
+            } else {
+                Text(
+                    text = name,
+                    style = SpTypography.TitleSmall,
+                    color = SpColor.OnCard,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                )
             }
             Spacer(Modifier.height(SpSpacing.Small))
-            Text(
-                text = name,
-                style = SpTypography.TitleSmall,
-                color = SpColor.OnCard,
-                maxLines = 1,
-                overflow = TextOverflow.Ellipsis,
-            )
             Text(
                 text = "$gameCount ${if (gameCount == 1) "game" else "games"}",
                 style = SpTypography.BodySmall,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/AchievementDiscoverySection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/AchievementDiscoverySection.kt
@@ -170,7 +170,6 @@ internal fun FreshChallengesSection(
         items(games, key = { it.game.id }) { item ->
             Column(
                 modifier = Modifier
-                    .width(CardWidth)
                     .semantics {
                         contentDescription = "${item.game.title}, ${item.totalAchievements} achievements, ${item.totalPoints} pts"
                     },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -14,6 +15,7 @@ import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.animation.core.animateFloatAsState
@@ -60,6 +62,7 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.spela.player.domain.model.Console
+import com.spela.player.presentation.ui.components.SpAreaSizedImage
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpShimmer
@@ -349,6 +352,7 @@ internal fun ConsolesSkeletonGrid(
 internal fun ConsoleHeroBanner(
     console: Console,
     modifier: Modifier = Modifier,
+    onBrowseGames: (() -> Unit)? = null,
 ) {
     val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
 
@@ -421,54 +425,49 @@ internal fun ConsoleHeroBanner(
                 .background(overlayBrush),
         )
 
-        // Content: stats on left, logo + badges truly centered in full width.
-        Box(
+        // Content: responsive layout
+        BoxWithConstraints(
             modifier = Modifier
                 .fillMaxSize()
-                .padding(horizontal = SpSpacing.XLarge),
+                .padding(horizontal = SpSpacing.XLarge, vertical = SpSpacing.Medium),
         ) {
-            // Compact platform details on the left
-            Box(
-                modifier = Modifier
-                    .align(Alignment.CenterStart)
-                    .widthIn(max = 96.dp),
-            ) {
-                ConsoleInfoSection(console = console)
-            }
+            val isWide = maxWidth > 500.dp
 
-            // Logo + metadata badges centered in full banner width
-            Column(
-                modifier = Modifier.fillMaxSize(),
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center,
-            ) {
-                // Logo or text fallback
-                var logoFailed by remember { mutableStateOf(false) }
-
+            // Logo or text fallback (shared)
+            var logoFailed by remember { mutableStateOf(false) }
+            val logoContent: @Composable () -> Unit = {
                 if (console.logoUrl.isNotEmpty() && !logoFailed) {
-                    AsyncImage(
-                        model = console.logoUrl,
+                    SpAreaSizedImage(
+                        imageUrl = console.logoUrl,
                         contentDescription = console.name,
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .heightIn(max = 80.dp),
-                        contentScale = ContentScale.Fit,
-                        onError = { logoFailed = true },
+                        targetArea = if (isWide) 8000f else 6000f,
+                        maxHeight = if (isWide) 80.dp else 60.dp,
+                        maxWidth = if (isWide) 200.dp else 160.dp,
+                        minHeight = 32.dp,
+                        error = {
+                            logoFailed = true
+                            Text(
+                                text = console.name,
+                                style = if (isWide) SpTypography.HeadlineLarge else SpTypography.HeadlineMedium,
+                                fontWeight = FontWeight.Bold,
+                                color = Color.White,
+                            )
+                        },
                     )
                 }
-
                 if (console.logoUrl.isEmpty() || logoFailed) {
                     Text(
                         text = console.name,
-                        style = SpTypography.HeadlineLarge,
+                        style = if (isWide) SpTypography.HeadlineLarge else SpTypography.HeadlineMedium,
                         fontWeight = FontWeight.Bold,
                         color = Color.White,
                     )
                 }
+            }
 
-                // Metadata row: game count + badges
+            // Metadata badges (shared)
+            val badgesContent: @Composable () -> Unit = {
                 Row(
-                    modifier = Modifier.padding(top = SpSpacing.Default),
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
@@ -492,7 +491,94 @@ internal fun ConsoleHeroBanner(
                     }
                 }
             }
+
+            // Data table left, logo centered, feature info right, browse button bottom-right
+            Box(modifier = Modifier.fillMaxSize()) {
+                // Left: console stats
+                Box(
+                    modifier = Modifier
+                        .align(Alignment.TopStart)
+                        .widthIn(max = 96.dp),
+                ) {
+                    ConsoleInfoSection(console = console)
+                }
+
+                // Center: logo + badges
+                // Center: logo
+                Column(
+                    modifier = Modifier.fillMaxSize(),
+                    horizontalAlignment = Alignment.CenterHorizontally,
+                    verticalArrangement = Arrangement.Center,
+                ) {
+                    logoContent()
+                }
+
+                // Top-right: game count + feature badges
+                Column(
+                    modifier = Modifier.align(Alignment.TopEnd),
+                    horizontalAlignment = Alignment.End,
+                    verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    MetadataBadge(
+                        icon = { Icon(Icons.Filled.SportsEsports, null, Modifier.size(12.dp), tint = HeroTextPrimary) },
+                        label = "${console.gameCount} ${if (console.gameCount == 1) "game" else "games"}",
+                    )
+                    if (console.saveStateSupport) {
+                        MetadataBadge(
+                            icon = { Icon(Icons.Filled.Check, null, Modifier.size(12.dp), tint = HeroTextPrimary) },
+                            label = "Save states",
+                        )
+                    }
+                    if (console.browserPlayable) {
+                        MetadataBadge(
+                            icon = { Icon(Icons.Filled.Language, null, Modifier.size(12.dp), tint = HeroTextPrimary) },
+                            label = "Browser play",
+                        )
+                    }
+                }
+
+                // Bottom-right: browse button
+                if (onBrowseGames != null) {
+                    Box(modifier = Modifier.align(Alignment.BottomEnd)) {
+                        SpButton(
+                            text = "Browse games",
+                            onClick = onBrowseGames,
+                            style = SpButtonStyle.Secondary,
+                            onGradient = true,
+                        )
+                    }
+                }
+            }
         }
+    }
+}
+
+@Composable
+private fun FeatureInfoRow(label: String) {
+    Row(verticalAlignment = Alignment.Top) {
+        Column(
+            verticalArrangement = Arrangement.spacedBy(1.dp),
+            horizontalAlignment = Alignment.End,
+        ) {
+            Text(
+                text = "Yes",
+                style = SpTypography.BodySmall,
+                fontWeight = FontWeight.SemiBold,
+                color = Color.White.copy(alpha = 0.90f),
+            )
+            Text(
+                text = label,
+                style = SpTypography.LabelSmall,
+                color = Color.White.copy(alpha = 0.40f),
+            )
+        }
+        Spacer(Modifier.width(SpSpacing.XSmall))
+        Icon(
+            imageVector = Icons.Filled.Check,
+            contentDescription = null,
+            tint = Color.White.copy(alpha = 0.45f),
+            modifier = Modifier.size(SpSpacing.IconSmall),
+        )
     }
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleInfoSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleInfoSection.kt
@@ -10,6 +10,8 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Business
 import androidx.compose.material.icons.filled.CalendarToday
 import androidx.compose.material.icons.filled.Group
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Language
 import androidx.compose.material.icons.filled.Layers
 import androidx.compose.material.icons.filled.SdCard
 import androidx.compose.material3.Icon
@@ -42,6 +44,7 @@ private data class Stat(val icon: ImageVector, val value: String, val label: Str
 internal fun ConsoleInfoSection(
     console: Console,
     modifier: Modifier = Modifier,
+    showFeatureBadges: Boolean = false,
 ) {
     val info = getConsoleInfo(console.abbreviation) ?: return
 
@@ -54,6 +57,14 @@ internal fun ConsoleInfoSection(
         add(Stat(Icons.Filled.SdCard, info.mediaType, "Media"))
         if (info.unitsSold.isNotEmpty()) {
             add(Stat(Icons.Filled.Group, info.unitsSold, "Units sold"))
+        }
+        if (showFeatureBadges) {
+            if (console.saveStateSupport) {
+                add(Stat(Icons.Filled.Check, "Yes", "Save states"))
+            }
+            if (console.browserPlayable) {
+                add(Stat(Icons.Filled.Language, "Yes", "Browser play"))
+            }
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -133,7 +133,10 @@ fun ConsoleScreen(
                     // Console hero banner
                     if (console != null) {
                         item {
-                            ConsoleHeroBanner(console = console)
+                            ConsoleHeroBanner(
+                                console = console,
+                                onBrowseGames = if (state.games.size > 15) onBrowseAllGames else null,
+                            )
                         }
                     }
 
@@ -190,34 +193,25 @@ fun ConsoleScreen(
                         item { ConsoleTopDevelopers(exploreViewModel, onDeveloperSelected) }
                     }
 
-                    // Browse All Games — at the bottom: inline grid for small libraries, button for large
-                    if (state.games.isNotEmpty()) {
-                        if (state.games.size <= 15) {
-                            item {
-                                SpTitledSection(title = "All Games") {
-                                    SpGameGrid(
-                                        items = state.games.map { game ->
-                                            {
-                                                SpGridGameCard(
-                                                    title = game.title,
-                                                    subtitle = game.consoleName,
-                                                    coverUrl = game.coverUrl,
-                                                    onClick = { onGameSelected(game.id) },
-                                                    rating = game.rating,
-                                                    isFavorite = game.isFavorite,
-                                                    isInPlayLater = game.isInPlayLater,
-                                                )
-                                            }
-                                        },
-                                    )
-                                }
-                            }
-                        } else {
-                            item {
-                                SpButton(
-                                    text = "Browse All ${state.games.size} Games",
-                                    onClick = onBrowseAllGames,
-                                    modifier = Modifier.fillMaxWidth(),
+                    // All Games — inline grid at bottom for small libraries (≤15 games)
+                    // For larger libraries, the "Browse games" button is in the hero banner
+                    if (state.games.isNotEmpty() && state.games.size <= 15) {
+                        item {
+                            SpTitledSection(title = "All Games") {
+                                SpGameGrid(
+                                    items = state.games.map { game ->
+                                        {
+                                            SpGridGameCard(
+                                                title = game.title,
+                                                subtitle = game.consoleName,
+                                                coverUrl = game.coverUrl,
+                                                onClick = { onGameSelected(game.id) },
+                                                rating = game.rating,
+                                                isFavorite = game.isFavorite,
+                                                isInPlayLater = game.isInPlayLater,
+                                            )
+                                        }
+                                    },
                                 )
                             }
                         }


### PR DESCRIPTION
## Summary
- **Console banner**: responsive layout with data table left, logo center, badges top-right, browse button bottom-right
- **Console tiles**: SVG logos via coil-svg + SpAreaSizedImage, text fallback on 404
- **Fresh Challenges**: dynamic width game cards
- **Console screen**: inline grid for ≤15 games, browse button in banner for larger libraries

## Test plan
- [x] Player app builds
- [ ] CI passes