### PR TITLE
feat: auto-scrape and reactively update cover art

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
@@ -148,7 +148,10 @@ class PresenceService(
             when (type) {
                 "game_scraped" -> {
                     val gameDto = json.decodeFromJsonElement<GameDto>(payload)
-                    scrapeService?.onGameScraped(gameDto.toDomain())
+                    val game = gameDto.toDomain().copy(
+                        coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                    )
+                    scrapeService?.onGameScraped(game)
                 }
             }
         } catch (_: Exception) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
@@ -17,6 +17,7 @@ import com.spela.player.presentation.viewmodel.SharedSessionsViewModel
 import com.spela.player.presentation.viewmodel.SettingsViewModel
 import com.spela.player.data.remote.ConnectivityMonitor
 import com.spela.player.data.remote.PresenceService
+import com.spela.player.data.remote.ScrapeService
 import com.spela.player.presentation.navigation.NavigationEventBus
 import com.spela.player.presentation.viewmodel.NetplayLobbyViewModel
 import com.spela.player.presentation.viewmodel.SessionDetailViewModel
@@ -68,6 +69,7 @@ fun App() {
     val exploreViewModel: ExploreViewModel = koinInject()
     val topListsViewModel: TopListsViewModel = koinInject()
     val gamepadConfigViewModel: GamepadConfigViewModel = koinInject()
+    val scrapeService: ScrapeService = koinInject()
 
     SpelaApp(
         navigationViewModel = navigationViewModel,
@@ -99,5 +101,6 @@ fun App() {
         exploreViewModel = exploreViewModel,
         topListsViewModel = topListsViewModel,
         gamepadConfigViewModel = gamepadConfigViewModel,
+        scrapeService = scrapeService,
     )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -122,6 +122,7 @@ import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.ui.gamepad.GamepadHandler
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.components.LocalScrapeService
+import com.spela.player.presentation.ui.components.ScrapeUpdates
 import com.spela.player.presentation.ui.theme.SpelaTheme
 import com.spela.player.data.remote.ScrapeService
 import androidx.compose.runtime.CompositionLocalProvider
@@ -190,6 +191,13 @@ fun SpelaApp(
 
     SpelaTheme(theme = currentTheme) {
     CompositionLocalProvider(LocalScrapeService provides scrapeService) {
+        // Observe scrape completions and update cover art reactively
+        LaunchedEffect(scrapeService) {
+            scrapeService?.scrapedGames?.collect { game ->
+                ScrapeUpdates.onGameScraped(game)
+            }
+        }
+
         val navState by navigationViewModel.state.collectAsState()
 
         // Input mode detection: TOUCH shows tab bar, GAMEPAD shows section indicator

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -121,7 +121,10 @@ import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.ui.gamepad.GamepadHandler
 import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.components.LocalScrapeService
 import com.spela.player.presentation.ui.theme.SpelaTheme
+import com.spela.player.data.remote.ScrapeService
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.input.pointer.PointerEventPass
 import com.spela.player.presentation.viewmodel.DownloadsViewModel
 import com.spela.player.presentation.viewmodel.EmulationViewModel
@@ -181,10 +184,12 @@ fun SpelaApp(
     navigationEventBus: NavigationEventBus? = null,
     gamepadPortManager: GamepadPortManager? = null,
     globalSearchViewModel: GlobalSearchViewModel? = null,
+    scrapeService: ScrapeService? = null,
 ) {
     val currentTheme by settingsViewModel.selectedTheme.collectAsState()
 
     SpelaTheme(theme = currentTheme) {
+    CompositionLocalProvider(LocalScrapeService provides scrapeService) {
         val navState by navigationViewModel.state.collectAsState()
 
         // Input mode detection: TOUCH shows tab bar, GAMEPAD shows section indicator
@@ -216,7 +221,7 @@ fun SpelaApp(
                     CircularProgressIndicator(color = SpColor.Primary)
                 }
             }
-            return@SpelaTheme
+            return@CompositionLocalProvider
         }
 
         // Connect/disconnect WebSocket presence based on authentication state
@@ -1581,6 +1586,7 @@ fun SpelaApp(
             }
         }
         }
+    } // CompositionLocalProvider
     }
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/LocalScrapeService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/LocalScrapeService.kt
@@ -1,0 +1,27 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.compositionLocalOf
+import com.spela.player.data.remote.ScrapeService
+
+/**
+ * Provides the ScrapeService to the composable tree so any game card
+ * can trigger scrape-if-needed without threading callbacks through every layer.
+ */
+val LocalScrapeService = compositionLocalOf<ScrapeService?> { null }
+
+/**
+ * Triggers a scrape-if-needed for a game when it enters composition.
+ * Only fires if the game has no cover art and scrapeAttempts is 0.
+ * Safe to call for any game — ScrapeService deduplicates and throttles.
+ */
+@Composable
+fun AutoScrapeIfNeeded(gameId: String, coverUrl: String?, scrapeAttempts: Int) {
+    val scrapeService = LocalScrapeService.current
+    LaunchedEffect(gameId) {
+        if (coverUrl.isNullOrEmpty() && scrapeAttempts == 0 && scrapeService != null) {
+            scrapeService.enqueueScrape(gameId)
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/LocalScrapeService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/LocalScrapeService.kt
@@ -2,8 +2,14 @@ package com.spela.player.presentation.ui.components
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
+import androidx.compose.runtime.getValue
 import com.spela.player.data.remote.ScrapeService
+import com.spela.player.domain.model.Game
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
 
 /**
  * Provides the ScrapeService to the composable tree so any game card
@@ -12,16 +18,36 @@ import com.spela.player.data.remote.ScrapeService
 val LocalScrapeService = compositionLocalOf<ScrapeService?> { null }
 
 /**
+ * Holds a map of game ID → updated cover URL from scrape events.
+ * Composables can observe this to reactively update cover art.
+ */
+object ScrapeUpdates {
+    private val _updatedCovers = MutableStateFlow<Map<String, String>>(emptyMap())
+    val updatedCovers: StateFlow<Map<String, String>> = _updatedCovers.asStateFlow()
+
+    fun onGameScraped(game: Game) {
+        if (!game.coverUrl.isNullOrEmpty()) {
+            _updatedCovers.value = _updatedCovers.value + (game.id to game.coverUrl!!)
+        }
+    }
+}
+
+/**
  * Triggers a scrape-if-needed for a game when it enters composition.
  * Only fires if the game has no cover art and scrapeAttempts is 0.
  * Safe to call for any game — ScrapeService deduplicates and throttles.
+ *
+ * Returns the resolved cover URL — either the original or one from a scrape update.
  */
 @Composable
-fun AutoScrapeIfNeeded(gameId: String, coverUrl: String?, scrapeAttempts: Int) {
+fun rememberResolvedCoverUrl(gameId: String, coverUrl: String?, scrapeAttempts: Int): String? {
     val scrapeService = LocalScrapeService.current
     LaunchedEffect(gameId) {
         if (coverUrl.isNullOrEmpty() && scrapeAttempts == 0 && scrapeService != null) {
             scrapeService.enqueueScrape(gameId)
         }
     }
+
+    val updatedCovers by ScrapeUpdates.updatedCovers.collectAsState()
+    return updatedCovers[gameId] ?: coverUrl
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.ui.feature.explore
 
+import com.spela.player.presentation.ui.components.AutoScrapeIfNeeded
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -51,6 +52,7 @@ internal fun ExploreGameCard(
     game: Game,
     onClick: () -> Unit,
 ) {
+    AutoScrapeIfNeeded(gameId = game.id, coverUrl = game.coverUrl, scrapeAttempts = game.scrapeAttempts)
     SpCarouselGameCard(
         title = game.title,
         subtitle = game.consoleName,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/GameShelf.kt
@@ -1,6 +1,6 @@
 package com.spela.player.presentation.ui.feature.explore
 
-import com.spela.player.presentation.ui.components.AutoScrapeIfNeeded
+import com.spela.player.presentation.ui.components.rememberResolvedCoverUrl
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -52,11 +52,11 @@ internal fun ExploreGameCard(
     game: Game,
     onClick: () -> Unit,
 ) {
-    AutoScrapeIfNeeded(gameId = game.id, coverUrl = game.coverUrl, scrapeAttempts = game.scrapeAttempts)
+    val resolvedCoverUrl = rememberResolvedCoverUrl(gameId = game.id, coverUrl = game.coverUrl, scrapeAttempts = game.scrapeAttempts)
     SpCarouselGameCard(
         title = game.title,
         subtitle = game.consoleName,
-        coverUrl = game.coverUrl,
+        coverUrl = resolvedCoverUrl,
         onClick = onClick,
         rating = game.rating,
         isFavorite = game.isFavorite,


### PR DESCRIPTION
## Summary
Games without cover art in the Explore page now get scraped automatically and update in-place via WebSocket — no navigation needed.

- `LocalScrapeService` CompositionLocal + `ScrapeUpdates` state
- `rememberResolvedCoverUrl` composable: triggers scrape + observes reactive updates
- Cover URL resolved in `PresenceService` before emitting to flow

## Test plan
- [x] Player app builds
- [ ] CI passes