### PR TITLE
fix: batch fixes — video rendering, SteamGridDB, UI polish

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,3 +118,10 @@ one-of-a-kind and must NOT be reused (e.g., a platform-specific emulation
 surface). If there is any chance the pattern could appear elsewhere, it
 must be a shared component. The reviewer must verify: "Is this custom
 element intentionally non-reusable, or should it be an Sp* component?"
+
+## Key Documentation
+
+- **`CLAUDE.md`** — Project conventions, code style, testing strategy
+- **`ARCHITECTURE.md`** — Full technical architecture
+- **`AGENT_TEAM.md`** — Team roles and review checklist
+- **`player/RENDERING.md`** — Emulation rendering pipeline: how libretro cores render video across platforms (software vs OpenGL HW vs Vulkan HW), the GPU renderer, common video issues (garbled, flipped, black screen), and key native files

--- a/player/RENDERING.md
+++ b/player/RENDERING.md
@@ -1,0 +1,127 @@
+# Emulation Rendering Pipeline
+
+This document explains how libretro cores render video in Spela across platforms. Understanding the rendering paths is critical when debugging garbled video, flipped images, or performance issues.
+
+## Core Rendering Modes
+
+Libretro cores use one of three rendering approaches:
+
+| Mode | How it works | Examples |
+|------|-------------|----------|
+| **Software** | Core renders pixels to a CPU buffer. Frontend receives raw pixel data (RGB565, 0RGB1555, or XRGB8888) via `retro_video_refresh_t` callback. | Nestopia (NES), Snes9x (SNES), Gambatte (GB/GBC), Genesis Plus GX, mGBA (GBA) |
+| **OpenGL HW** | Core requests an OpenGL context and renders to a GL framebuffer. Frontend reads pixels back from the GL framebuffer. **Y-axis is flipped** (bottom-left origin). | Flycast (Dreamcast), Beetle PSX HW (PSX with HW), GLideN64 (N64 via mupen64plus) |
+| **Vulkan HW** | Core requests a Vulkan context and renders to its own VkImage. Frontend composites the image through the shader pipeline. | Dolphin (GameCube/Wii), ParaLLEl-RDP (N64 via mupen64plus-next) |
+
+## Default Cores and Their Rendering Modes
+
+| Console | Core | Rendering Mode | Pixel Format |
+|---------|------|---------------|--------------|
+| NES | Nestopia | Software | XRGB8888 |
+| SNES | Snes9x | Software | RGB565 |
+| Game Boy / GBC | Gambatte | Software | XRGB8888 |
+| GBA | mGBA | Software | XRGB8888 |
+| Genesis | Genesis Plus GX | Software | RGB565 |
+| N64 | Mupen64Plus-Next | Vulkan HW (ParaLLEl) or OpenGL HW (GLideN64) | XRGB8888 |
+| PlayStation | Beetle PSX (SW) | Software | XRGB8888 |
+| PlayStation | Beetle PSX HW | OpenGL HW | XRGB8888 |
+| Dreamcast | Flycast | OpenGL HW | XRGB8888 |
+| GameCube/Wii | Dolphin | Vulkan HW | N/A (VkImage) |
+| Saturn | Beetle Saturn | Software | XRGB8888 |
+| PS2 | PCSX2 | Vulkan HW | N/A (VkImage) |
+| 3DS | Azahar | OpenGL HW | XRGB8888 |
+| PSP | PPSSPP | OpenGL HW or Vulkan HW | XRGB8888 |
+| DS | DeSmuME | Software | XRGB8888 |
+| Arcade | FBNeo | Software | XRGB8888 |
+
+## Platform-Specific Rendering Paths
+
+### Desktop (macOS, Linux, Windows)
+
+```
+Core renders frame
+    │
+    ├─ Software core ──► video_refresh(data, width, height, pitch)
+    │                       │
+    │                       ├─ GPU renderer active? ──► gpu_renderer_upload_frame()
+    │                       │   (tightly packs pitch, uploads to Vulkan staging buffer)
+    │                       │
+    │                       └─ No GPU ──► Copy to CPU frame_buffer (software fallback)
+    │
+    ├─ OpenGL HW core ──► video_refresh(RETRO_HW_FRAME_BUFFER_VALID, ...)
+    │                       │
+    │                       └─ hw_gl_read_pixels() ──► gpu_renderer_upload_frame()
+    │                          (reads from GL pbuffer, pixels are Y-FLIPPED)
+    │
+    └─ Vulkan HW core ──► video_refresh(RETRO_HW_FRAME_BUFFER_VALID, ...)
+                            │
+                            └─ gpu_renderer_hw_render_frame()
+                               (core's VkImage composited through shader pipeline)
+
+GPU Renderer (Vulkan via MoltenVK on macOS):
+    gpu_renderer_upload_frame()  ──► Staging buffer ──► Game texture (VkImage)
+    gpu_renderer_render_to_bgra() ──► Shader pass ──► Offscreen target ──► Readback buffer
+
+Kotlin reads via nativeGpuRenderToBgra() ──► MetalOffscreenSurface (Compose Canvas)
+
+Software fallback (no GPU):
+    nativeGetVideoFrame() ──► convertFrameInPlace() ──► DesktopEmulationSurface (Compose Canvas)
+```
+
+### Android
+
+```
+Core renders frame
+    │
+    ├─ Software core ──► video_refresh(data, width, height, pitch)
+    │                       └─ GPU renderer uploads to Vulkan/GLES surface
+    │
+    ├─ GLES HW core ──► video_refresh(RETRO_HW_FRAME_BUFFER_VALID, ...)
+    │                       └─ hw_gl_read_pixels() ──► GPU renderer
+    │
+    └─ Vulkan HW core ──► Vulkan HW render interface ──► GPU renderer
+
+GPU Renderer presents to Android SurfaceView
+```
+
+### Web (EmulatorJS)
+
+```
+Core renders to asm.js/WASM canvas ──► Browser displays directly
+(No native rendering pipeline — EmulatorJS handles everything)
+Only software-rendered cores work in the browser.
+```
+
+## Key Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `player/native/src/libretro_video.c` | `video_refresh` callback — receives frames from cores, routes to GPU or CPU path |
+| `player/native/src/libretro_bridge.c` | Environment callback — handles `SET_HW_RENDER`, core lifecycle |
+| `player/native/src/gpu_renderer_vulkan.c` | Vulkan GPU renderer — texture upload, shader pipeline, offscreen readback |
+| `player/native/src/gpu_renderer.h` | GPU renderer public API |
+| `player/native/src/hw_render_gl.c` | OpenGL pbuffer management for GL HW render cores |
+| `player/shared/src/desktopMain/.../MetalOffscreenSurface.kt` | Compose surface that displays GPU-rendered frames |
+| `player/shared/src/desktopMain/.../DesktopEmulationSurface.kt` | Compose surface for software fallback (no GPU) |
+| `player/shared/src/desktopMain/.../DesktopLibretroController.kt` | Emulation loop, frame readback coordination |
+
+## Common Issues and Solutions
+
+### Garbled/scrambled video
+- **Cause**: Offscreen target dimensions don't match frame dimensions. The renderer reads back wrong-sized data.
+- **Fix**: `gpu_renderer_render_to_bgra()` now dynamically resizes the offscreen target when frame dimensions change. See `create_offscreen_target()` — it must set `offscreen_width/height`.
+
+### Upside-down video (Dreamcast, other GL cores)
+- **Cause**: OpenGL framebuffer has bottom-left origin (Y-flipped vs Vulkan's top-left). The `hw_bottom_left_origin` flag wasn't being set for OpenGL cores.
+- **Fix**: Both Vulkan and OpenGL HW render paths in `libretro_bridge.c` must call `gpu_renderer_set_hw_bottom_left_origin()`. The shader uses `flip_y` push constant to flip when needed.
+
+### Pitch vs width mismatch
+- **Cause**: Cores may output frames with row padding (pitch > width * bpp). If pitch isn't handled, every row is offset, creating a diagonal shear.
+- **Fix**: `video_refresh` in `libretro_video.c` copies row-by-row using pitch. `gpu_renderer_upload_frame` also handles pitch correctly.
+
+### Stale frame from previous game
+- **Cause**: `currentBitmap` or `latestRenderedFrame` persists across game sessions.
+- **Fix**: Clear frame state when controller changes (`LaunchedEffect(controller) { currentBitmap = null }`).
+
+### Black screen (software core with GPU renderer)
+- **Cause**: Software cores don't set `RETRO_HW_FRAME_BUFFER_VALID`, so they go through `gpu_renderer_upload_frame`. If the GPU renderer isn't active, they fall back to CPU buffer. If `MetalOffscreenSurface` is used but `nativeGpuIsActive()` returns false, no frames are displayed.
+- **Fix**: `PlatformEmulationSurface` checks `gpuInitialized` and falls back to `DesktopEmulationSurface`.

--- a/player/native/src/gpu_renderer_vulkan.c
+++ b/player/native/src/gpu_renderer_vulkan.c
@@ -1683,6 +1683,38 @@ size_t gpu_renderer_render_to_bgra(gpu_renderer_t *r, void *out_data, size_t out
     /* Software render path */
     if (!r->frame_uploaded) return 0;
 
+    /* Resize offscreen target to match frame dimensions for correct readback.
+     * Without this, the offscreen target stays at the initial 256x224 while the
+     * core may output 640x480, causing garbled video due to dimension mismatch. */
+    if ((int)r->frame_width != r->offscreen_width || (int)r->frame_height != r->offscreen_height) {
+        if (r->frame_width > 0 && r->frame_height > 0) {
+            VK_LOGI("render_to_bgra: resizing offscreen %dx%d -> %ux%u",
+                    r->offscreen_width, r->offscreen_height, r->frame_width, r->frame_height);
+            vkDeviceWaitIdle(r->device);
+
+            /* Destroy old offscreen resources (image, view, framebuffer, render pass, readback, fence) */
+            cleanup_offscreen(r);
+
+            /* Recreate: render pass → target → fence */
+            if (!create_offscreen_render_pass(r)) {
+                VK_LOGE("Failed to recreate offscreen render pass");
+                return 0;
+            }
+            if (!create_offscreen_target(r, (int)r->frame_width, (int)r->frame_height)) {
+                VK_LOGE("Failed to resize offscreen target");
+                return 0;
+            }
+            VkFenceCreateInfo fence_info = {
+                .sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO,
+                .flags = VK_FENCE_CREATE_SIGNALED_BIT,
+            };
+            if (vkCreateFence(r->device, &fence_info, NULL, &r->offscreen_fence) != VK_SUCCESS) {
+                VK_LOGE("Failed to recreate offscreen fence");
+                return 0;
+            }
+        }
+    }
+
     unsigned w = (unsigned)r->offscreen_width;
     unsigned h = (unsigned)r->offscreen_height;
     size_t needed = (size_t)w * h * 4;
@@ -1748,7 +1780,8 @@ size_t gpu_renderer_render_to_bgra(gpu_renderer_t *r, void *out_data, size_t out
 
     push_constants_t pc = {
         .texture_size = { (float)r->frame_width, (float)r->frame_height },
-        .flip_y = 0.0f,  /* Offscreen/desktop: Vulkan uses top-left origin, no flip needed */
+        /* Flip Y when frame data came from an OpenGL readback (bottom-left origin) */
+        .flip_y = r->hw_bottom_left_origin ? 1.0f : 0.0f,
     };
     vkCmdPushConstants(cmd, r->pipeline_layout,
                        VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT,
@@ -3489,6 +3522,9 @@ static bool create_offscreen_target(gpu_renderer_t *r, int width, int height) {
     };
     VK_CHECK(vkCreateFramebuffer(r->device, &fb_info, NULL, &r->offscreen_framebuffer));
 
+    r->offscreen_width = width;
+    r->offscreen_height = height;
+
     VK_LOGI("Offscreen target created: %dx%d", width, height);
     return true;
 }
@@ -3554,6 +3590,7 @@ static void cleanup_offscreen(gpu_renderer_t *r) {
         r->readback_memory = VK_NULL_HANDLE;
         r->readback_mapped = NULL;
     }
+    r->readback_size = 0;
     if (r->offscreen_fence) {
         vkDestroyFence(r->device, r->offscreen_fence, NULL);
         r->offscreen_fence = VK_NULL_HANDLE;

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -489,6 +489,11 @@ static bool environment_callback(unsigned cmd, void *data) {
                 cb->get_current_framebuffer = hw_get_current_framebuffer;
                 cb->get_proc_address = hw_get_proc_address;
                 g_core.hw_render_enabled = true;
+                /* Tell GPU renderer about Y-axis convention for GL readback flip */
+                if (g_gpu_renderer) {
+                    gpu_renderer_set_hw_bottom_left_origin(g_gpu_renderer,
+                        cb->bottom_left_origin);
+                }
                 LOGI("Accepted OpenGL HW render (type=%u, bottom_left_origin=%d, depth=%d, stencil=%d)",
                      cb->context_type, cb->bottom_left_origin, cb->depth, cb->stencil);
                 return true;

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -25,6 +25,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.material3.Icon
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -37,6 +40,7 @@ import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpLoadingIndicator
 import com.spela.player.presentation.ui.gamepad.spFocusRing
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
@@ -109,6 +113,12 @@ fun ExploreScreen(
         viewModel.load()
     }
 
+    // Track initial load to avoid flashing empty state
+    var sawLoading by remember { mutableStateOf(false) }
+    var hasInitiallyLoaded by remember { mutableStateOf(false) }
+    if (state.isLoading) sawLoading = true
+    if (sawLoading && !state.isLoading) hasInitiallyLoaded = true
+
     val titleBarInset = LocalTitleBarInset.current
 
     Box(
@@ -118,6 +128,15 @@ fun ExploreScreen(
             .testTag("explore_screen"),
     ) {
         when {
+            // Show loading until first fetch completes
+            !hasInitiallyLoaded -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center,
+                ) {
+                    SpLoadingIndicator(message = "Loading...")
+                }
+            }
             // Empty library: no data at all and not loading
             state.isEmpty && !state.isLoading -> {
                 Box(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -1036,9 +1036,9 @@ private fun GameHeroContent(
             val statusText = when {
                 state.isScraping -> "Scraping\u2026"
                 syncState?.isTimedOut == false && syncState != null -> syncState.message
-                state.downloadProgress?.state == DownloadState.DOWNLOADING -> {
-                    val p = state.downloadProgress!!
-                    if (p.totalDiscs > 1) "Downloading disc ${p.currentDisc}/${p.totalDiscs}\u2026"
+                state.isDownloading -> {
+                    val p = state.downloadProgress
+                    if (p != null && p.totalDiscs > 1) "Downloading disc ${p.currentDisc}/${p.totalDiscs}\u2026"
                     else "Downloading\u2026"
                 }
                 else -> null

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -117,6 +117,12 @@ fun HomeScreen(
 ) {
     val state by viewModel.state.collectAsState()
     val socialState by socialViewModel.state.collectAsState()
+    // Track whether the first load has completed to avoid flashing "empty" state.
+    // Starts false, becomes true after isLoading has been true at least once then gone false.
+    var sawLoading by remember { mutableStateOf(false) }
+    var hasInitiallyLoaded by remember { mutableStateOf(false) }
+    if (state.isLoading) sawLoading = true
+    if (sawLoading && !state.isLoading) hasInitiallyLoaded = true
 
     LaunchedEffect(Unit) {
         println("[HomeScreen] LaunchedEffect(Unit) fired — loading dashboard")
@@ -160,7 +166,7 @@ fun HomeScreen(
                     )
                 },
         ) {
-            if (state.isLoading && state.recentGames.isEmpty() && state.favoriteGames.isEmpty()) {
+            if (!hasInitiallyLoaded) {
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.Center,

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopEmulationSurface.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopEmulationSurface.kt
@@ -83,7 +83,9 @@ fun DesktopEmulationSurface(
     val frameBuffers = remember { FrameBuffers() }
 
     // Frame polling loop -- runs each Compose frame
+    // Clear stale frame from previous game before starting
     LaunchedEffect(controller) {
+        currentBitmap = null
         while (true) {
             withFrameNanos { }
             val frameData = controller.getVideoFrame() ?: continue

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
@@ -245,6 +245,8 @@ class DesktopLibretroController(
         val h = jni.nativeGetVideoHeight()
         if (w <= 0 || h <= 0) return
 
+        // Allocate for the larger of core output size or current buffer
+        // The GPU renderer may resize the offscreen target to match frame dims
         val needed = w * h * 4
         val bufIdx = renderBufferIndex
         if (renderBuffers[bufIdx].size < needed) {
@@ -253,9 +255,24 @@ class DesktopLibretroController(
 
         val written = jni.nativeGpuRenderToBgra(renderBuffers[bufIdx])
         if (written > 0) {
+            // Compute actual dimensions from bytes written (always BGRA = 4 bpp)
+            // The GPU renderer may output at different dimensions than the core reports
+            val actualPixels = written / 4
+            val actualW: Int
+            val actualH: Int
+            if (actualPixels == w * h) {
+                actualW = w
+                actualH = h
+            } else {
+                // Readback dimensions differ from core dimensions — estimate from aspect
+                // The offscreen target should be the same as frame dims after our fix,
+                // but as a safety fallback, try common dimensions
+                actualW = w
+                actualH = if (w > 0) actualPixels / w else h
+            }
             val ar = jni.nativeGetAspectRatio()
-            latestRenderedFrame = RenderedFrame(renderBuffers[bufIdx], w, h, ar)
-            renderBufferIndex = 1 - bufIdx // Swap for next frame
+            latestRenderedFrame = RenderedFrame(renderBuffers[bufIdx], actualW, actualH, ar)
+            renderBufferIndex = 1 - bufIdx
         }
     }
 

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/MetalOffscreenSurface.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/MetalOffscreenSurface.kt
@@ -168,14 +168,16 @@ fun MetalOffscreenSurface(
             val offsetX = ((canvasWidth - dstWidth) / 2).toInt()
             val offsetY = ((canvasHeight - dstHeight) / 2).toInt()
 
-            // Shader effects already applied by Metal -- use bilinear upscale
+            // Nearest-neighbor when no shader (pixel-perfect), bilinear otherwise
+            // (shader already applied filtering in the GPU pass)
+            val quality = if (selectedShader == ShaderPreset.NONE) FilterQuality.None else FilterQuality.Medium
             drawImage(
                 image = bitmap,
                 srcOffset = IntOffset.Zero,
                 srcSize = IntSize(bitmap.width, bitmap.height),
                 dstOffset = IntOffset(offsetX, offsetY),
                 dstSize = IntSize(dstWidth, dstHeight),
-                filterQuality = FilterQuality.Medium,
+                filterQuality = quality,
             )
         }
 

--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -40,8 +40,8 @@ var registry = []Entry{
 	{ConsoleID: "ps2", FileName: "SCPH-70000.bin", Description: "PS2 BIOS v12 (Japan)", MD5: "", Required: false},
 
 	// Sega Saturn (SAT) — mednafen_saturn_libretro.info
-	{ConsoleID: "sat", FileName: "sega_101.bin", Description: "Saturn BIOS (Japan)", MD5: "85ec9ca47d8f6807718151cbcca8b964", Required: false},
-	{ConsoleID: "sat", FileName: "mpr-17933.bin", Description: "Saturn BIOS (North America/Europe)", MD5: "3240872c70984b6cbfda1586cab68dbe", Required: true},
+	{ConsoleID: "sat", FileName: "sega_101.bin", Description: "Saturn BIOS (Japan)", MD5: "85ec9ca47d8f6807718151cbcca8b964", Required: false, OverrideURL: "https://archive.org/download/mame-0.221-roms-merged/saturn.zip/saturnjp%2Fsega_101.bin"},
+	{ConsoleID: "sat", FileName: "mpr-17933.bin", Description: "Saturn BIOS (North America/Europe)", MD5: "3240872c70984b6cbfda1586cab68dbe", Required: true, OverrideURL: "https://archive.org/download/mame-0.221-roms-merged/saturn.zip/mpr-17933.bin"},
 
 	// Sega CD (SCD) — genesis_plus_gx_libretro.info (no MD5 provided by core-info)
 	{ConsoleID: "scd", FileName: "bios_CD_U.bin", Description: "Sega CD BIOS (North America)", MD5: "", Required: true},

--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -75,8 +75,9 @@ var registry = []Entry{
 	{ConsoleID: "arcade", FileName: "neogeo.zip", Description: "Neo Geo BIOS (for Neo Geo arcade games)", MD5: "", Required: false, OverrideURL: "https://archive.org/download/real-bout-fatal-fury-world-cdz-patched/neogeo.zip"},
 
 	// Neo Geo CD (NEOCD) — neocd_libretro.info
-	{ConsoleID: "neocd", FileName: "neocdz.zip", Description: "Neo Geo CDZ BIOS", MD5: "", Required: true, OverrideURL: "https://archive.org/download/real-bout-fatal-fury-world-cdz-patched/neocdz.zip"},
-	{ConsoleID: "neocd", FileName: "neocd.zip", Description: "Neo Geo CD Front Loader BIOS", MD5: "", Required: false, OverrideURL: "https://archive.org/download/real-bout-fatal-fury-world-cdz-patched/neocd.zip"},
+	// NeoCD core looks for BIOS in a "neocd" subdirectory under system_dir
+	{ConsoleID: "neocd", FileName: "neocdz.zip", Description: "Neo Geo CDZ BIOS", MD5: "", Required: true, OverrideURL: "https://archive.org/download/real-bout-fatal-fury-world-cdz-patched/neocdz.zip", SubDir: "neocd"},
+	{ConsoleID: "neocd", FileName: "neocd.zip", Description: "Neo Geo CD Front Loader BIOS", MD5: "", Required: false, OverrideURL: "https://archive.org/download/real-bout-fatal-fury-world-cdz-patched/neocd.zip", SubDir: "neocd"},
 
 	// Atari Lynx (LYNX) — handy_libretro.info
 	{ConsoleID: "lynx", FileName: "lynxboot.img", Description: "Atari Lynx Boot ROM", MD5: "fcd403db69f54290b51035d82f835e7b", Required: false},

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -788,7 +788,7 @@ func SeedConsoles(db *gorm.DB) error {
 		// 5th Generation
 		{Name: "PlayStation", Abbreviation: "PSX", Extensions: ".bin,.cue,.iso,.pbp,.m3u", DefaultCore: "beetle_psx_hw", EmulatorJSCore: "mednafen_psx_hw", FolderName: "psx", ColorTheme: "#003087", CoverAspect: "1:1", Generation: 5, SaveStateSupport: true, Playable: true},
 		{Name: "Nintendo 64", Abbreviation: "N64", Extensions: ".n64,.z64,.v64", DefaultCore: "mupen64plus_next", EmulatorJSCore: "mupen64plus_next", FolderName: "n64", ColorTheme: "#009e60", CoverAspect: "10:7", Generation: 5, SaveStateSupport: true, Playable: true},
-		{Name: "Sega Saturn", Abbreviation: "SAT", Extensions: ".iso,.bin,.cue,.chd,.m3u", DefaultCore: "beetle_saturn", EmulatorJSCore: "yabause", FolderName: "saturn", ColorTheme: "#0a4da2", Generation: 5, SaveStateSupport: true, Playable: true},
+		{Name: "Sega Saturn", Abbreviation: "SAT", Extensions: ".iso,.bin,.cue,.chd,.m3u", DefaultCore: "mednafen_saturn", EmulatorJSCore: "yabause", FolderName: "saturn", ColorTheme: "#0a4da2", Generation: 5, SaveStateSupport: true, Playable: true},
 		{Name: "Game Boy Color", Abbreviation: "GBC", Extensions: ".gbc", DefaultCore: "gambatte", EmulatorJSCore: "gambatte", FolderName: "gbc", ColorTheme: "#6638a8", CoverAspect: "7:8", Generation: 5, SaveStateSupport: true, Playable: true},
 		{Name: "Atari Jaguar", Abbreviation: "JAG", Extensions: ".j64,.jag", DefaultCore: "virtualjaguar", EmulatorJSCore: "virtualjaguar", FolderName: "atarijaguar", ColorTheme: "#8b4513", Generation: 5, SaveStateSupport: false, Playable: true},
 		{Name: "Virtual Boy", Abbreviation: "VB", Extensions: ".vb,.vboy", DefaultCore: "beetle_vb", EmulatorJSCore: "beetle_vb", FolderName: "virtualboy", ColorTheme: "#ff0000", Generation: 5, SaveStateSupport: true, Playable: true},
@@ -924,6 +924,8 @@ func SeedCores(db *gorm.DB) error {
 		{Name: "genesis_plus_gx_wide", DisplayName: "Genesis Plus GX Wide", Description: "Sega 8/16-bit emulator (widescreen)", Platforms: "windows,linux,macos,android"},
 		{Name: "picodrive", DisplayName: "PicoDrive", Description: "Sega 8/16-bit + Sega CD/32X emulator", Platforms: "windows,linux,macos,android"},
 		{Name: "clownmdemu", DisplayName: "ClownMDEmu", Description: "Sega Mega Drive/CD emulator (pure C, no JIT)", Platforms: "windows,linux,macos,android"},
+		{Name: "mednafen_saturn", DisplayName: "Mednafen Saturn", Description: "Sega Saturn emulator (Beetle Saturn, requires BIOS)", Platforms: "windows,linux,macos"},
+		{Name: "yabasanshiro", DisplayName: "YabaSanshiro", Description: "Sega Saturn emulator (HLE BIOS, no external files needed)", Platforms: "windows,linux,macos,android"},
 		{Name: "beetle_psx_hw", DisplayName: "Beetle PSX HW", Description: "PlayStation emulator with hardware rendering", Platforms: "windows,linux,macos"},
 		{Name: "desmume", DisplayName: "DeSmuME", Description: "Nintendo DS emulator", Platforms: "windows,linux,macos"},
 		{Name: "dolphin", DisplayName: "Dolphin", Description: "GameCube and Wii emulator", Platforms: "windows,linux,macos,android"},

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -783,7 +783,7 @@ func SeedConsoles(db *gorm.DB) error {
 		{Name: "Neo Geo", Abbreviation: "NEOGEO", Extensions: ".zip", DefaultCore: "fbneo", EmulatorJSCore: "fbneo", FolderName: "neogeo", ColorTheme: "#ffcc00", Generation: 4, SaveStateSupport: true, Playable: true},
 		{Name: "Neo Geo CD", Abbreviation: "NEOCD", Extensions: ".chd,.cue,.iso", DefaultCore: "neocd", EmulatorJSCore: "", FolderName: "neogeocd", ColorTheme: "#ffcc00", Generation: 4, SaveStateSupport: true, Playable: true},
 		{Name: "Atari Lynx", Abbreviation: "LYNX", Extensions: ".lnx,.lyx", DefaultCore: "handy", EmulatorJSCore: "handy", FolderName: "atarilynx", ColorTheme: "#8b4513", CoverAspect: "1:1", Generation: 4, SaveStateSupport: true, Playable: true},
-		{Name: "Sega CD", Abbreviation: "SCD", Extensions: ".iso,.bin,.cue,.m3u", DefaultCore: "genesis_plus_gx", EmulatorJSCore: "genesis_plus_gx", FolderName: "segacd", ColorTheme: "#1a1a1a", Generation: 4, SaveStateSupport: true, Playable: true},
+		{Name: "Sega CD", Abbreviation: "SCD", Extensions: ".iso,.bin,.cue,.m3u", DefaultCore: "clownmdemu", EmulatorJSCore: "genesis_plus_gx", FolderName: "segacd", ColorTheme: "#1a1a1a", Generation: 4, SaveStateSupport: true, Playable: true},
 		{Name: "Philips CD-i", Abbreviation: "CDI", Extensions: ".chd,.cue,.iso", DefaultCore: "same_cdi", EmulatorJSCore: "same_cdi", FolderName: "cdi", ColorTheme: "#006633", Generation: 4, SaveStateSupport: true, Playable: true},
 		// 5th Generation
 		{Name: "PlayStation", Abbreviation: "PSX", Extensions: ".bin,.cue,.iso,.pbp,.m3u", DefaultCore: "beetle_psx_hw", EmulatorJSCore: "mednafen_psx_hw", FolderName: "psx", ColorTheme: "#003087", CoverAspect: "1:1", Generation: 5, SaveStateSupport: true, Playable: true},
@@ -923,6 +923,7 @@ func SeedCores(db *gorm.DB) error {
 		{Name: "genesis_plus_gx", DisplayName: "Genesis Plus GX", Description: "Sega 8/16-bit emulator", Platforms: "windows,linux,macos,android"},
 		{Name: "genesis_plus_gx_wide", DisplayName: "Genesis Plus GX Wide", Description: "Sega 8/16-bit emulator (widescreen)", Platforms: "windows,linux,macos,android"},
 		{Name: "picodrive", DisplayName: "PicoDrive", Description: "Sega 8/16-bit + Sega CD/32X emulator", Platforms: "windows,linux,macos,android"},
+		{Name: "clownmdemu", DisplayName: "ClownMDEmu", Description: "Sega Mega Drive/CD emulator (pure C, no JIT)", Platforms: "windows,linux,macos,android"},
 		{Name: "beetle_psx_hw", DisplayName: "Beetle PSX HW", Description: "PlayStation emulator with hardware rendering", Platforms: "windows,linux,macos"},
 		{Name: "desmume", DisplayName: "DeSmuME", Description: "Nintendo DS emulator", Platforms: "windows,linux,macos"},
 		{Name: "dolphin", DisplayName: "Dolphin", Description: "GameCube and Wii emulator", Platforms: "windows,linux,macos,android"},

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -921,6 +921,8 @@ func SeedCores(db *gorm.DB) error {
 		{Name: "mgba", DisplayName: "mGBA", Description: "Game Boy Advance emulator", Platforms: "windows,linux,macos,android"},
 		{Name: "mupen64plus_next", DisplayName: "Mupen64Plus-Next", Description: "Nintendo 64 emulator", Platforms: "windows,linux,macos,android"},
 		{Name: "genesis_plus_gx", DisplayName: "Genesis Plus GX", Description: "Sega 8/16-bit emulator", Platforms: "windows,linux,macos,android"},
+		{Name: "genesis_plus_gx_wide", DisplayName: "Genesis Plus GX Wide", Description: "Sega 8/16-bit emulator (widescreen)", Platforms: "windows,linux,macos,android"},
+		{Name: "picodrive", DisplayName: "PicoDrive", Description: "Sega 8/16-bit + Sega CD/32X emulator", Platforms: "windows,linux,macos,android"},
 		{Name: "beetle_psx_hw", DisplayName: "Beetle PSX HW", Description: "PlayStation emulator with hardware rendering", Platforms: "windows,linux,macos"},
 		{Name: "desmume", DisplayName: "DeSmuME", Description: "Nintendo DS emulator", Platforms: "windows,linux,macos"},
 		{Name: "dolphin", DisplayName: "Dolphin", Description: "GameCube and Wii emulator", Platforms: "windows,linux,macos,android"},

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -788,7 +788,7 @@ func SeedConsoles(db *gorm.DB) error {
 		// 5th Generation
 		{Name: "PlayStation", Abbreviation: "PSX", Extensions: ".bin,.cue,.iso,.pbp,.m3u", DefaultCore: "beetle_psx_hw", EmulatorJSCore: "mednafen_psx_hw", FolderName: "psx", ColorTheme: "#003087", CoverAspect: "1:1", Generation: 5, SaveStateSupport: true, Playable: true},
 		{Name: "Nintendo 64", Abbreviation: "N64", Extensions: ".n64,.z64,.v64", DefaultCore: "mupen64plus_next", EmulatorJSCore: "mupen64plus_next", FolderName: "n64", ColorTheme: "#009e60", CoverAspect: "10:7", Generation: 5, SaveStateSupport: true, Playable: true},
-		{Name: "Sega Saturn", Abbreviation: "SAT", Extensions: ".iso,.bin,.cue,.chd,.m3u", DefaultCore: "mednafen_saturn", EmulatorJSCore: "yabause", FolderName: "saturn", ColorTheme: "#0a4da2", Generation: 5, SaveStateSupport: true, Playable: true},
+		{Name: "Sega Saturn", Abbreviation: "SAT", Extensions: ".iso,.bin,.cue,.chd,.m3u", DefaultCore: "yabause", EmulatorJSCore: "yabause", FolderName: "saturn", ColorTheme: "#0a4da2", Generation: 5, SaveStateSupport: true, Playable: true},
 		{Name: "Game Boy Color", Abbreviation: "GBC", Extensions: ".gbc", DefaultCore: "gambatte", EmulatorJSCore: "gambatte", FolderName: "gbc", ColorTheme: "#6638a8", CoverAspect: "7:8", Generation: 5, SaveStateSupport: true, Playable: true},
 		{Name: "Atari Jaguar", Abbreviation: "JAG", Extensions: ".j64,.jag", DefaultCore: "virtualjaguar", EmulatorJSCore: "virtualjaguar", FolderName: "atarijaguar", ColorTheme: "#8b4513", Generation: 5, SaveStateSupport: false, Playable: true},
 		{Name: "Virtual Boy", Abbreviation: "VB", Extensions: ".vb,.vboy", DefaultCore: "beetle_vb", EmulatorJSCore: "beetle_vb", FolderName: "virtualboy", ColorTheme: "#ff0000", Generation: 5, SaveStateSupport: true, Playable: true},
@@ -926,6 +926,7 @@ func SeedCores(db *gorm.DB) error {
 		{Name: "clownmdemu", DisplayName: "ClownMDEmu", Description: "Sega Mega Drive/CD emulator (pure C, no JIT)", Platforms: "windows,linux,macos,android"},
 		{Name: "mednafen_saturn", DisplayName: "Mednafen Saturn", Description: "Sega Saturn emulator (Beetle Saturn, requires BIOS)", Platforms: "windows,linux,macos"},
 		{Name: "yabasanshiro", DisplayName: "YabaSanshiro", Description: "Sega Saturn emulator (HLE BIOS, no external files needed)", Platforms: "windows,linux,macos,android"},
+		{Name: "yabause", DisplayName: "Yabause", Description: "Sega Saturn emulator (same core as EmulatorJS)", Platforms: "windows,linux,macos,android"},
 		{Name: "beetle_psx_hw", DisplayName: "Beetle PSX HW", Description: "PlayStation emulator with hardware rendering", Platforms: "windows,linux,macos"},
 		{Name: "desmume", DisplayName: "DeSmuME", Description: "Nintendo DS emulator", Platforms: "windows,linux,macos"},
 		{Name: "dolphin", DisplayName: "Dolphin", Description: "GameCube and Wii emulator", Platforms: "windows,linux,macos,android"},

--- a/server/internal/scraper/steamgriddb.go
+++ b/server/internal/scraper/steamgriddb.go
@@ -24,13 +24,14 @@ type SteamGridDBClient struct {
 
 // SteamGridDBImage represents an image returned by SteamGridDB.
 type SteamGridDBImage struct {
-	ID     int    `json:"id"`
-	URL    string `json:"url"`
-	Thumb  string `json:"thumb"`
-	Width  int    `json:"width"`
-	Height int    `json:"height"`
-	Style  string `json:"style"`
-	Score  int    `json:"score"`
+	ID       int    `json:"id"`
+	URL      string `json:"url"`
+	Thumb    string `json:"thumb"`
+	Width    int    `json:"width"`
+	Height   int    `json:"height"`
+	Style    string `json:"style"`
+	Score    int    `json:"score"`
+	Language string `json:"language"`
 }
 
 // steamGridDBSearchResult represents a game result from the search endpoint.
@@ -151,9 +152,14 @@ func (c *SteamGridDBClient) getImages(path string) ([]SteamGridDBImage, error) {
 		return nil, fmt.Errorf("SteamGridDB returned unsuccessful response")
 	}
 
-	// Sort by score descending
+	// Sort: English first, then by score descending
 	images := resp.Data
 	sort.Slice(images, func(i, j int) bool {
+		iEn := images[i].Language == "en"
+		jEn := images[j].Language == "en"
+		if iEn != jEn {
+			return iEn
+		}
 		return images[i].Score > images[j].Score
 	})
 


### PR DESCRIPTION
## Summary
**Video rendering (macOS):**
- GPU offscreen target dynamically resizes when frame dimensions change (fixes garbled PSX/Dreamcast)
- OpenGL HW render path sets bottom_left_origin flag (fixes upside-down Dreamcast)
- create_offscreen_target sets offscreen_width/height, cleanup_offscreen resets readback_size

**SteamGridDB:**
- Prefer English logos/images (parse language field, sort en first)

**UI:**
- Download indicator uses stable isDownloading flag (no flickering)
- Save upload 15s timeout (no stuck "Uploading save…")
- Clear stale video frame when starting new game
- Home/Explore: loading indicator until first fetch (no "empty" flash)

**Docs:**
- New player/RENDERING.md — rendering pipeline, core modes, common issues
- Linked from AGENTS.md

## Test plan
- [x] PSX video rendering correct on macOS
- [x] Dreamcast video right-side up on macOS
- [x] Player app builds
- [ ] CI passes