### PR TITLE
fix: avoid nativeSerializeSize crash on GL HW render cores

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -475,11 +475,14 @@ class EmulationViewModel(
                         // Populate save slot thumbnails for the secondary screen
                         saveManager.refreshSaveSlots()
 
-                        // Re-check save state support after core has run a few frames
+                        // Re-check save state support after core has run a few frames.
+                        // Skip for GL HW render cores (e.g. PPSSPP) — calling
+                        // nativeSerializeSize triggers GL calls that crash on the
+                        // IO dispatcher thread. Default of true (set above) is fine.
                         println("[Emulation] Starting 3-second delay for HW render init")
                         kotlinx.coroutines.delay(3000)
                         println("[Emulation] 3-second delay completed, checking save state support")
-                        val saveStatesSupported = libretroController.supportsSaveStates()
+                        val saveStatesSupported = if (hwRender) true else libretroController.supportsSaveStates()
                         println("[Emulation] saveStatesSupported=$saveStatesSupported")
                         withContext(dispatchers.main) {
                             _state.update { it.copy(supportsSaveStates = saveStatesSupported) }

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
@@ -154,7 +154,11 @@ class DesktopLibretroController(
         clearNetplayMode()
     }
 
-    override fun supportsSaveStates(): Boolean = jni.nativeSerializeSize() > 0
+    // Always report true — calling nativeSerializeSize() from a non-GL thread
+    // crashes PPSSPP (and potentially other GL HW render cores) because they
+    // flush their GL render queue during serialize. If a core doesn't support
+    // save states, serialize() itself will return null gracefully.
+    override fun supportsSaveStates(): Boolean = true
 
     override fun serialize(): ByteArray? = jni.nativeSerialize()
 


### PR DESCRIPTION
## Summary
- PPSSPP crashes in `glActiveTexture` when `retro_serialize_size` is called from a non-GL thread
- Desktop `supportsSaveStates()` now always returns `true` (serialize returns null if unsupported)
- Skip deferred save state re-check for HW render cores in EmulationViewModel

## Test plan
- [x] PSP no longer crashes on game start
- [ ] Save states still work for software cores (NES, SNES, etc.)