### PR TITLE
fix: merge duplicate env blocks in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,8 +12,6 @@ on:
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
-env:
   RELEASE_TAG: ${{ github.event.inputs.tag || github.ref_name }}
 
 permissions:


### PR DESCRIPTION
## Summary
The release workflow had two separate `env:` blocks which is invalid YAML — caused every release.yml run to fail with a workflow file error since the Node24 env var was added.

## Test plan
- [ ] Release workflow should no longer fail with "workflow file issue"