### PR TITLE
feat: add volume slider to in-game overlay

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -21,6 +21,7 @@ sealed interface EmulationIntent {
     data object LoadState : EmulationIntent
     data object ToggleOverlay : EmulationIntent
     data object ToggleFastForward : EmulationIntent
+    data class SetVolume(val volume: Float) : EmulationIntent
     data object TakeScreenshot : EmulationIntent
 
     data object ShowExitConfirm : EmulationIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -72,6 +72,7 @@ data class EmulationState(
     val fps: Float = 0f,
     val frameTime: Float = 0f,
     val isFastForward: Boolean = false,
+    val volume: Float = 1f,
     val showKeyMapping: Boolean = false,
     val showGamepadConfig: Boolean = false,
     val error: String? = null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSlider.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSlider.kt
@@ -1,0 +1,100 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.theme.SpColor
+
+/**
+ * Minimal slider with a thin track and round thumb.
+ *
+ * @param value Current value in 0..1 range.
+ * @param onValueChange Called when the user drags or taps.
+ * @param activeColor Color of the filled portion of the track.
+ * @param inactiveColor Color of the unfilled portion.
+ * @param thumbColor Color of the round thumb.
+ * @param trackHeight Thickness of the track.
+ * @param thumbRadius Radius of the thumb circle.
+ */
+@Composable
+fun SpSlider(
+    value: Float,
+    onValueChange: (Float) -> Unit,
+    modifier: Modifier = Modifier,
+    activeColor: Color = SpColor.Primary,
+    inactiveColor: Color = SpColor.OnBackgroundTertiary.copy(alpha = 0.3f),
+    thumbColor: Color = SpColor.OnBackground,
+    trackHeight: Dp = 4.dp,
+    thumbRadius: Dp = 7.dp,
+) {
+    var dragging by remember { mutableFloatStateOf(-1f) }
+
+    Canvas(
+        modifier = modifier
+            .height(44.dp) // Large touch target for accessibility
+            .pointerInput(Unit) {
+                detectTapGestures { offset ->
+                    val fraction = (offset.x / size.width).coerceIn(0f, 1f)
+                    onValueChange(fraction)
+                }
+            }
+            .pointerInput(Unit) {
+                detectHorizontalDragGestures(
+                    onDragStart = { offset ->
+                        dragging = (offset.x / size.width).coerceIn(0f, 1f)
+                        onValueChange(dragging)
+                    },
+                    onDragEnd = { dragging = -1f },
+                    onDragCancel = { dragging = -1f },
+                    onHorizontalDrag = { change, _ ->
+                        val fraction = (change.position.x / size.width).coerceIn(0f, 1f)
+                        dragging = fraction
+                        onValueChange(fraction)
+                    },
+                )
+            },
+    ) {
+        val trackY = size.height / 2
+        val trackH = trackHeight.toPx()
+        val thumbR = thumbRadius.toPx()
+        val thumbX = value * size.width
+
+        // Inactive track (full width)
+        drawLine(
+            color = inactiveColor,
+            start = Offset(0f, trackY),
+            end = Offset(size.width, trackY),
+            strokeWidth = trackH,
+            cap = StrokeCap.Round,
+        )
+        // Active track (up to thumb)
+        if (thumbX > 0f) {
+            drawLine(
+                color = activeColor,
+                start = Offset(0f, trackY),
+                end = Offset(thumbX, trackY),
+                strokeWidth = trackH,
+                cap = StrokeCap.Round,
+            )
+        }
+        // Round thumb
+        drawCircle(
+            color = thumbColor,
+            radius = thumbR,
+            center = Offset(thumbX.coerceIn(thumbR, size.width - thumbR), trackY),
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
@@ -28,7 +28,11 @@ import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.SportsEsports
 import androidx.compose.material.icons.filled.Stop
+import androidx.compose.material.icons.filled.VolumeUp
+import androidx.compose.material.icons.filled.VolumeOff
+import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
+import com.spela.player.presentation.ui.components.SpSlider
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -282,7 +286,32 @@ internal fun InGameOverlayPanel(
                         )
                     }
 
-                    Spacer(Modifier.height(if (isLandscape) SpSpacing.Medium else SpSpacing.XLarge))
+                    Spacer(Modifier.height(if (isLandscape) SpSpacing.Medium else SpSpacing.Large))
+
+                    // Volume slider
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                    ) {
+                        Icon(
+                            imageVector = if (state.volume < 0.01f) Icons.Filled.VolumeOff else Icons.Filled.VolumeUp,
+                            contentDescription = "Volume",
+                            tint = SpColor.OnBackgroundSecondary,
+                        )
+                        SpSlider(
+                            value = state.volume,
+                            onValueChange = { viewModel.onIntent(EmulationIntent.SetVolume(it)) },
+                            modifier = Modifier.weight(1f),
+                        )
+                        Text(
+                            text = "${(state.volume * 100).toInt()}%",
+                            style = SpTypography.LabelSmall,
+                            color = SpColor.OnBackgroundSecondary,
+                        )
+                    }
+
+                    Spacer(Modifier.height(if (isLandscape) SpSpacing.Medium else SpSpacing.Large))
 
                     Row(
                         modifier = Modifier.fillMaxWidth(),
@@ -381,3 +410,4 @@ internal fun OverlayAction(
         isActive = isActive,
     )
 }
+

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -123,6 +123,11 @@ class EmulationViewModel(
                 if (wasShowing) resumeGame() else pauseGame()
             }
             EmulationIntent.ToggleFastForward -> toggleFastForward()
+            is EmulationIntent.SetVolume -> {
+                val vol = intent.volume.coerceIn(0f, 1f)
+                libretroController.setVolume(vol)
+                _state.update { it.copy(volume = vol) }
+            }
             EmulationIntent.TakeScreenshot -> { /* Platform-specific capture */ }
 
             EmulationIntent.ShowExitConfirm -> {
@@ -1078,6 +1083,9 @@ interface LibretroController {
 
     /** Set pointer/touch state for the given port (used for DS touch screen). */
     fun setPointer(port: Int, x: Int, y: Int, pressed: Boolean) {}
+
+    /** Set audio volume (0.0 = mute, 1.0 = full). */
+    fun setVolume(volume: Float) {}
 
     /** Set a core option variable (e.g. DeSmuME screen layout). */
     fun setCoreVariable(key: String, value: String) {}

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopAudioPlayer.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopAudioPlayer.kt
@@ -26,6 +26,10 @@ class DesktopAudioPlayer(private val controller: DesktopLibretroController) {
     private var sourceDataLine: SourceDataLine? = null
     private var initAttempted = false
 
+    /** Volume level 0.0 (mute) to 1.0 (full). Applied to samples in writeSync. */
+    @Volatile
+    var volume: Float = 1.0f
+
     // Pre-allocated conversion buffer (resized if needed)
     private var conversionBuffer = ByteBuffer.allocate(0).order(ByteOrder.LITTLE_ENDIAN)
 
@@ -99,7 +103,19 @@ class DesktopAudioPlayer(private val controller: DesktopLibretroController) {
             conversionBuffer = ByteBuffer.allocate(needed).order(ByteOrder.LITTLE_ENDIAN)
         }
         conversionBuffer.clear()
-        conversionBuffer.asShortBuffer().put(samples)
+        // Apply logarithmic volume curve: human hearing is logarithmic, so
+        // a linear slider position needs exponential scaling to feel natural.
+        // vol^3 gives a good perceptual curve (50% slider ≈ 12.5% amplitude).
+        val linear = volume
+        val vol = linear * linear * linear
+        val shortBuf = conversionBuffer.asShortBuffer()
+        if (vol >= 0.999f) {
+            shortBuf.put(samples)
+        } else {
+            for (s in samples) {
+                shortBuf.put((s * vol).toInt().coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt()).toShort())
+            }
+        }
         line.write(conversionBuffer.array(), 0, needed)
         return true
     }

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
@@ -168,6 +168,10 @@ class DesktopLibretroController(
         fastForward = enabled
     }
 
+    override fun setVolume(volume: Float) {
+        audioPlayer?.volume = volume.coerceIn(0f, 1f)
+    }
+
     override fun performanceStats(): Flow<Pair<Float, Float>> = flow {
         while (running) {
             emit(currentFps to currentFrameTime)


### PR DESCRIPTION
## Summary
- New `SpSlider` reusable component with minimal design (thin track, round thumb, customizable colors)
- Volume slider in the pause overlay between action buttons and Exit/Continue
- Cubic volume curve for natural perceptual response
- 44dp touch target, visual separation from surrounding buttons
- Desktop audio applies volume scaling in `writeSync`

## Test plan
- [x] Slider appears in pause overlay
- [x] Dragging adjusts volume in real-time
- [x] 50% slider position noticeably reduces volume
- [x] Icon changes to mute at 0%
- [ ] Android volume control (future — needs AudioTrack gain)