### PR TITLE
fix: shimmer skeleton when switching console screens

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -434,16 +434,22 @@ internal fun ConsoleHeroBanner(
             val isWide = maxWidth > 500.dp
 
             // Logo or text fallback (shared)
+            // Scale logo dynamically with banner width — wider banners get bigger logos
+            val widthDp = maxWidth
+            val logoArea = (widthDp.value * 22f).coerceIn(8000f, 30000f)
+            val logoMaxH = (widthDp.value * 0.14f).coerceIn(60f, 140f).dp
+            val logoMaxW = (widthDp.value * 0.4f).coerceIn(160f, 400f).dp
+
             var logoFailed by remember { mutableStateOf(false) }
             val logoContent: @Composable () -> Unit = {
                 if (console.logoUrl.isNotEmpty() && !logoFailed) {
                     SpAreaSizedImage(
                         imageUrl = console.logoUrl,
                         contentDescription = console.name,
-                        targetArea = if (isWide) 8000f else 6000f,
-                        maxHeight = if (isWide) 80.dp else 60.dp,
-                        maxWidth = if (isWide) 200.dp else 160.dp,
-                        minHeight = 32.dp,
+                        targetArea = logoArea,
+                        maxHeight = logoMaxH,
+                        maxWidth = logoMaxW,
+                        minHeight = 40.dp,
                         error = {
                             logoFailed = true
                             Text(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -6,14 +6,16 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
@@ -36,6 +38,7 @@ import coil3.compose.AsyncImage
 import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpIconButton
@@ -138,6 +141,11 @@ fun ConsoleScreen(
                                 onBrowseGames = if (state.games.size > 15) onBrowseAllGames else null,
                             )
                         }
+                    }
+
+                    // Shimmer loading skeleton when switching consoles
+                    if (state.isLoading && state.games.isEmpty()) {
+                        item { ConsoleScreenSkeleton() }
                     }
 
                     // Continue Playing (most relevant — always first)
@@ -280,4 +288,36 @@ fun ConsoleScreen(
             modifier = Modifier.align(Alignment.BottomCenter),
         )
     } // outer Box
+}
+
+@Composable
+private fun ConsoleScreenSkeleton() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = SpSpacing.ScreenHorizontal),
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.XLarge),
+    ) {
+        // Section title shimmer
+        SpShimmer(width = 140.dp, height = 20.dp)
+        // Game row shimmer (cards)
+        Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium)) {
+            repeat(3) {
+                Column(verticalArrangement = Arrangement.spacedBy(SpSpacing.Small)) {
+                    SpShimmer(width = 140.dp, height = 190.dp)
+                    SpShimmer(width = 100.dp, height = 14.dp)
+                }
+            }
+        }
+        // Second section
+        SpShimmer(width = 120.dp, height = 20.dp)
+        Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium)) {
+            repeat(3) {
+                Column(verticalArrangement = Arrangement.spacedBy(SpSpacing.Small)) {
+                    SpShimmer(width = 140.dp, height = 190.dp)
+                    SpShimmer(width = 80.dp, height = 14.dp)
+                }
+            }
+        }
+    }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -231,7 +231,16 @@ class GameListViewModel(
     }
 
     private fun loadGamesForConsole(consoleId: String) {
-        _state.update { it.copy(isLoading = true, selectedConsoleId = consoleId) }
+        _state.update {
+            it.copy(
+                isLoading = true,
+                selectedConsoleId = consoleId,
+                // Clear stale data from previous console so the UI shows
+                // a loading state instead of the old console's games.
+                games = emptyList(),
+                topRatedGames = emptyList(),
+            )
+        }
         scope.launch(dispatchers.io) {
             getGamesForConsoleUseCase(consoleId).fold(
                 onSuccess = { games ->


### PR DESCRIPTION
## Summary
- Clear stale game data when switching consoles — shows shimmer skeleton instead of previous console's games
- Shimmer skeleton with card placeholders while loading
- Larger console banner logos (targetArea 8000→14000 wide, 6000→10000 narrow)

## Test plan
- [x] Navigate between console screens — shimmer shows instead of stale data
- [x] Console logo properly sized in banner