### PR TITLE
fix: prevent silent HTTP upload failures

### DIFF
--- a/player/desktop/build.gradle.kts
+++ b/player/desktop/build.gradle.kts
@@ -294,6 +294,13 @@ if (org.gradle.internal.os.OperatingSystem.current().isMacOsX) {
     }
 }
 
+// Forward JVM stdout/stderr so emulation logs, native printf, and debug output
+// are visible in the terminal. Without this, Gradle's forked JVM process swallows all output.
+tasks.withType<JavaExec>().configureEach {
+    standardOutput = System.out
+    errorOutput = System.err
+}
+
 // Pass native library path to Compose Hot Reload tasks.
 tasks.withType<JavaExec>().matching { it.name.startsWith("hotRun") || it.name.startsWith("hotDev") }.configureEach {
     jvmArgs("-Djava.library.path=${nativeBuildDir.get().asFile.absolutePath}")

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -36,6 +36,9 @@ class SpelaApiClient(
     }
 
     private val client = HttpClient(engineFactory) {
+        // Throw on non-2xx responses so HTTP errors are never silently swallowed.
+        expectSuccess = true
+
         install(ContentNegotiation) {
             json(this@SpelaApiClient.json)
         }
@@ -118,8 +121,12 @@ class SpelaApiClient(
     // Health
 
     suspend fun healthCheck(): Boolean {
-        val response = client.get("$baseUrl/api/health")
-        return response.status.isSuccess()
+        return try {
+            client.get("$baseUrl/api/health")
+            true
+        } catch (_: Exception) {
+            false
+        }
     }
 
     // Auth

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -434,16 +434,22 @@ internal fun ConsoleHeroBanner(
             val isWide = maxWidth > 500.dp
 
             // Logo or text fallback (shared)
+            // Scale logo dynamically with banner width — wider banners get bigger logos
+            val widthDp = maxWidth
+            val logoArea = (widthDp.value * 22f).coerceIn(8000f, 30000f)
+            val logoMaxH = (widthDp.value * 0.14f).coerceIn(60f, 140f).dp
+            val logoMaxW = (widthDp.value * 0.4f).coerceIn(160f, 400f).dp
+
             var logoFailed by remember { mutableStateOf(false) }
             val logoContent: @Composable () -> Unit = {
                 if (console.logoUrl.isNotEmpty() && !logoFailed) {
                     SpAreaSizedImage(
                         imageUrl = console.logoUrl,
                         contentDescription = console.name,
-                        targetArea = if (isWide) 8000f else 6000f,
-                        maxHeight = if (isWide) 80.dp else 60.dp,
-                        maxWidth = if (isWide) 200.dp else 160.dp,
-                        minHeight = 32.dp,
+                        targetArea = logoArea,
+                        maxHeight = logoMaxH,
+                        maxWidth = logoMaxW,
+                        minHeight = 40.dp,
                         error = {
                             logoFailed = true
                             Text(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -6,14 +6,16 @@ import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Icon
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
@@ -36,6 +38,7 @@ import coil3.compose.AsyncImage
 import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpSectionList
 import com.spela.player.presentation.ui.components.SpIconButton
@@ -138,6 +141,11 @@ fun ConsoleScreen(
                                 onBrowseGames = if (state.games.size > 15) onBrowseAllGames else null,
                             )
                         }
+                    }
+
+                    // Shimmer loading skeleton when switching consoles
+                    if (state.isLoading && state.games.isEmpty()) {
+                        item { ConsoleScreenSkeleton() }
                     }
 
                     // Continue Playing (most relevant — always first)
@@ -280,4 +288,36 @@ fun ConsoleScreen(
             modifier = Modifier.align(Alignment.BottomCenter),
         )
     } // outer Box
+}
+
+@Composable
+private fun ConsoleScreenSkeleton() {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = SpSpacing.ScreenHorizontal),
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.XLarge),
+    ) {
+        // Section title shimmer
+        SpShimmer(width = 140.dp, height = 20.dp)
+        // Game row shimmer (cards)
+        Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium)) {
+            repeat(3) {
+                Column(verticalArrangement = Arrangement.spacedBy(SpSpacing.Small)) {
+                    SpShimmer(width = 140.dp, height = 190.dp)
+                    SpShimmer(width = 100.dp, height = 14.dp)
+                }
+            }
+        }
+        // Second section
+        SpShimmer(width = 120.dp, height = 20.dp)
+        Row(horizontalArrangement = Arrangement.spacedBy(SpSpacing.Medium)) {
+            repeat(3) {
+                Column(verticalArrangement = Arrangement.spacedBy(SpSpacing.Small)) {
+                    SpShimmer(width = 140.dp, height = 190.dp)
+                    SpShimmer(width = 80.dp, height = 14.dp)
+                }
+            }
+        }
+    }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -231,7 +231,16 @@ class GameListViewModel(
     }
 
     private fun loadGamesForConsole(consoleId: String) {
-        _state.update { it.copy(isLoading = true, selectedConsoleId = consoleId) }
+        _state.update {
+            it.copy(
+                isLoading = true,
+                selectedConsoleId = consoleId,
+                // Clear stale data from previous console so the UI shows
+                // a loading state instead of the old console's games.
+                games = emptyList(),
+                topRatedGames = emptyList(),
+            )
+        }
         scope.launch(dispatchers.io) {
             getGamesForConsoleUseCase(consoleId).fold(
                 onSuccess = { games ->

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -206,15 +206,24 @@ class SaveManager(
      */
     suspend fun autoSaveOnStop(gameId: String) {
         try {
-            println("[SaveManager] autoSaveOnStop: serializing game $gameId")
             val saveData = libretroController.serialize()
-            println("[SaveManager] autoSaveOnStop: serialize returned ${saveData?.size ?: "null"} bytes")
             if (saveData != null) {
                 val sessionId = currentSessionId
                 if (sessionId != null) {
                     val screenshot = screenshotCapture?.captureScreenshot()
                     val result = sessionRepository.uploadSessionAutoSave(sessionId, saveData, screenshot, currentCoreName)
-                    println("[SaveManager] autoSaveOnStop: session upload result=${result.isSuccess}")
+                    if (result.isFailure) {
+                        val msg = result.exceptionOrNull()?.message ?: "Unknown error"
+                        println("[SaveManager] autoSaveOnStop: upload failed: $msg")
+                        val userMsg = if (msg.contains("413") || msg.contains("quota", ignoreCase = true)) {
+                            "Auto-save failed: storage quota exceeded. Delete old saves to free space."
+                        } else {
+                            "Auto-save upload failed: $msg"
+                        }
+                        withContext(dispatchers.main) {
+                            _state.update { it.copy(error = userMsg) }
+                        }
+                    }
                 }
             }
         } catch (e: Exception) {

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/libretro/DesktopLibretroController.kt
@@ -147,6 +147,7 @@ class DesktopLibretroController(
         emulationThread?.join()
         emulationThread = null
         deinitOnEmuThread = false
+        latestRenderedFrame = null // Clear frame so next game doesn't flash the old one
         // Don't deinit GPU here — it persists across game sessions on desktop.
         // The composable's onDispose handles GPU cleanup when the user leaves
         // the emulation screen. This prevents stop() (called as precautionary


### PR DESCRIPTION
## Summary
- Enable `expectSuccess = true` on Ktor HttpClient so non-2xx responses throw instead of being silently swallowed
- Surface auto-save upload errors to the user (e.g. "storage quota exceeded")
- Forward JVM stdout/stderr in Gradle so emulation logs are visible in the terminal
- Clear stale rendered frame on emulation stop to prevent flash of previous game

## Context
N64 save states appeared broken — auto-save reported success but auto-load always got 404. Root cause: the server was returning HTTP 413 (storage quota exceeded) but the Ktor client never checked the response status, so `runCatching { ... }.isSuccess` was always `true`.

## Test plan
- [ ] Start an N64 game, exit, re-enter — verify auto-save/load works when under quota
- [ ] Fill quota, exit a game — verify user sees "storage quota exceeded" error message
- [ ] Run `./gradlew :desktop:run` — verify emulation logs appear in terminal