### PR TITLE
feat: add 'Continue from Title Screen' game launch option

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ResumeVsNewGameTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ResumeVsNewGameTest.kt
@@ -1,0 +1,284 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.domain.model.GameSession
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.viewmodel.PendingLaunch
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * E2E tests for the resume-vs-new-game split button menu on the game detail screen.
+ *
+ * When a game has existing sessions (saves), the split button should show:
+ * - Primary button: "Resume" (loads last save)
+ * - Menu item: "Continue from Title Screen" (skips auto-load, reuses session)
+ * - Menu item: "New Game" (skips auto-load, forces new session)
+ *
+ * When no sessions exist, only "Play" and "Delete Download" appear.
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ResumeVsNewGameTest {
+
+    private fun createLoggedInHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    /** Add a session for game "1" so hasSaves becomes true. */
+    private fun SpelaTestHarness.addSessionForGame(gameId: String = "1") {
+        sessionRepo.sessions.add(
+            GameSession(
+                id = "session-1",
+                gameId = gameId,
+                name = "Default",
+            )
+        )
+    }
+
+    // ---- "Continue from Title Screen" visibility ----
+
+    @Test
+    fun continueFromTitleScreenAppearsWhenGameHasSaves() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.addSessionForGame("1")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Open the split button dropdown menu
+        onNodeWithContentDescription("More options").performClick()
+        advanceQuick(harness)
+
+        // "Continue from Title Screen" should be visible
+        onNodeWithText("Continue from Title Screen").assertIsDisplayed()
+    }
+
+    @Test
+    fun continueFromTitleScreenDoesNotAppearWhenNoSaves() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        // No sessions added — hasSaves is false
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Open the split button dropdown menu
+        onNodeWithContentDescription("More options").performClick()
+        advanceQuick(harness)
+
+        // "Continue from Title Screen" should NOT exist
+        onNodeWithText("Continue from Title Screen").assertDoesNotExist()
+    }
+
+    // ---- "New Game" visibility ----
+
+    @Test
+    fun newGameMenuItemAppearsWhenGameHasSaves() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.addSessionForGame("1")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Open the split button dropdown menu
+        onNodeWithContentDescription("More options").performClick()
+        advanceQuick(harness)
+
+        // "New Game" should be visible
+        onNodeWithText("New Game").assertIsDisplayed()
+    }
+
+    @Test
+    fun newGameMenuItemDoesNotAppearWhenNoSaves() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        // No sessions — hasSaves is false
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Open the split button dropdown menu
+        onNodeWithContentDescription("More options").performClick()
+        advanceQuick(harness)
+
+        // "New Game" should NOT exist
+        onNodeWithText("New Game").assertDoesNotExist()
+    }
+
+    // ---- Primary button label changes ----
+
+    @Test
+    fun primaryButtonShowsResumeWhenGameHasSaves() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.addSessionForGame("1")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Primary button should read "Resume"
+        onNodeWithText("Resume").assertIsDisplayed()
+    }
+
+    @Test
+    fun primaryButtonShowsPlayWhenNoSaves() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        // No sessions
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Primary button should read "Play"
+        onNodeWithText("Play").assertIsDisplayed()
+    }
+
+    // ---- Intent dispatch verification ----
+
+    @Test
+    fun continueFromTitleScreenDispatchesCorrectIntent() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.addSessionForGame("1")
+
+        var capturedLaunch: PendingLaunch? = null
+        harness.scope.launch {
+            harness.emulationViewModel.launchReady.collect { capturedLaunch = it }
+        }
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Open menu and click "Continue from Title Screen"
+        onNodeWithContentDescription("More options").performClick()
+        advanceQuick(harness)
+        onNodeWithText("Continue from Title Screen").performClick()
+        advance(harness)
+
+        // Should dispatch PrepareLaunch with skipAutoLoad=true, forceNewSession=false
+        val titleScreenLaunch = capturedLaunch
+        assertTrue(titleScreenLaunch != null, "Expected a PendingLaunch to be emitted")
+        assertEquals("1", titleScreenLaunch.gameId)
+        assertTrue(titleScreenLaunch.skipAutoLoad, "skipAutoLoad should be true")
+        assertFalse(titleScreenLaunch.forceNewSession, "forceNewSession should be false")
+    }
+
+    @Test
+    fun newGameDispatchesCorrectIntent() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.addSessionForGame("1")
+
+        var capturedLaunch: PendingLaunch? = null
+        harness.scope.launch {
+            harness.emulationViewModel.launchReady.collect { capturedLaunch = it }
+        }
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Open menu and click "New Game"
+        onNodeWithContentDescription("More options").performClick()
+        advanceQuick(harness)
+        onNodeWithText("New Game").performClick()
+        advance(harness)
+
+        // Should dispatch PrepareLaunch with skipAutoLoad=true, forceNewSession=true
+        val newGameLaunch = capturedLaunch
+        assertTrue(newGameLaunch != null, "Expected a PendingLaunch to be emitted")
+        assertEquals("1", newGameLaunch.gameId)
+        assertTrue(newGameLaunch.skipAutoLoad, "skipAutoLoad should be true")
+        assertTrue(newGameLaunch.forceNewSession, "forceNewSession should be true")
+    }
+
+    @Test
+    fun resumeButtonDispatchesCorrectIntent() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.addSessionForGame("1")
+
+        var capturedLaunch: PendingLaunch? = null
+        harness.scope.launch {
+            harness.emulationViewModel.launchReady.collect { capturedLaunch = it }
+        }
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Click the primary "Resume" button
+        onNodeWithText("Resume").performClick()
+        advance(harness)
+
+        // Should dispatch PrepareLaunch with skipAutoLoad=false, forceNewSession=false
+        val resumeLaunch = capturedLaunch
+        assertTrue(resumeLaunch != null, "Expected a PendingLaunch to be emitted")
+        assertEquals("1", resumeLaunch.gameId)
+        assertFalse(resumeLaunch.skipAutoLoad, "skipAutoLoad should be false")
+        assertFalse(resumeLaunch.forceNewSession, "forceNewSession should be false")
+    }
+
+    // ---- Menu item descriptions ----
+
+    @Test
+    fun continueFromTitleScreenShowsDescription() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.addSessionForGame("1")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Open the split button dropdown menu
+        onNodeWithContentDescription("More options").performClick()
+        advanceQuick(harness)
+
+        // The subtitle description should be visible
+        onNodeWithText("Keep your in-game save, start from the beginning").assertIsDisplayed()
+    }
+
+    @Test
+    fun newGameShowsDescription() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.addSessionForGame("1")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Open the split button dropdown menu
+        onNodeWithContentDescription("More options").performClick()
+        advanceQuick(harness)
+
+        // The subtitle description should be visible
+        onNodeWithText("Start a separate playthrough from scratch").assertIsDisplayed()
+    }
+
+    // ---- Delete Download still present ----
+
+    @Test
+    fun deleteDownloadAlwaysPresentInMenu() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.addSessionForGame("1")
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        // Open the split button dropdown menu
+        onNodeWithContentDescription("More options").performClick()
+        advanceQuick(harness)
+
+        // "Delete Download" should still be in the menu alongside the new items
+        onNodeWithText("Delete Download").assertIsDisplayed()
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -12,6 +12,7 @@ sealed interface EmulationIntent {
         val challengeId: String? = null,
         val challengeSaveData: ByteArray? = null,
         val skipAutoLoad: Boolean = false,
+        val forceNewSession: Boolean = false,
         val sessionId: String? = null,
     ) : EmulationIntent
     data object PauseGame : EmulationIntent
@@ -85,6 +86,7 @@ sealed interface EmulationIntent {
     data class PrepareLaunch(
         val gameId: String,
         val skipAutoLoad: Boolean = false,
+        val forceNewSession: Boolean = false,
         val sessionId: String? = null,
     ) : EmulationIntent
     data object PlayWithLocalSave : EmulationIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
@@ -149,6 +149,7 @@ class NavigationViewModel(
                         overlayNetplayIsHost = intent.netplayIsHost,
                         overlayChallengeId = intent.challengeId,
                         overlaySkipAutoLoad = intent.skipAutoLoad,
+                        overlayForceNewSession = intent.forceNewSession,
                         overlaySessionId = intent.sessionId,
                         screenBehindOverlay = it.currentScreen,
                         backStackBehindOverlay = it.backStack,
@@ -170,6 +171,7 @@ class NavigationViewModel(
                             overlayNetplayIsHost = false,
                             overlayChallengeId = null,
                             overlaySkipAutoLoad = false,
+                            overlayForceNewSession = false,
                             overlaySessionId = null,
                             currentScreen = it.screenBehindOverlay,
                             backStack = it.backStackBehindOverlay,
@@ -188,6 +190,7 @@ class NavigationViewModel(
                             overlayNetplayIsHost = false,
                             overlayChallengeId = null,
                             overlaySkipAutoLoad = false,
+                            overlayForceNewSession = false,
                             overlaySessionId = null,
                         )
                     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -61,6 +61,7 @@ data class NavigationState(
     val overlayNetplayIsHost: Boolean = false,
     val overlayChallengeId: String? = null,
     val overlaySkipAutoLoad: Boolean = false,
+    val overlayForceNewSession: Boolean = false,
     val overlaySessionId: String? = null,
     val screenBehindOverlay: SpScreen? = null,
     val backStackBehindOverlay: List<SpScreen> = emptyList(),
@@ -86,6 +87,7 @@ sealed interface NavigationIntent {
         val netplayIsHost: Boolean = false,
         val challengeId: String? = null,
         val skipAutoLoad: Boolean = false,
+        val forceNewSession: Boolean = false,
         val sessionId: String? = null,
     ) : NavigationIntent
     data object HideOverlay : NavigationIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -933,6 +933,7 @@ fun SpelaApp(
                                             NavigationIntent.ShowOverlay(
                                                 gameId = pending.gameId,
                                                 skipAutoLoad = pending.skipAutoLoad,
+                                                forceNewSession = pending.forceNewSession,
                                                 sessionId = pending.sessionId,
                                             )
                                         )
@@ -952,7 +953,12 @@ fun SpelaApp(
                                     },
                                     onPlayFresh = { gameId ->
                                         emulationViewModel.onIntent(
-                                            EmulationIntent.PrepareLaunch(gameId, skipAutoLoad = true)
+                                            EmulationIntent.PrepareLaunch(gameId, skipAutoLoad = true, forceNewSession = true)
+                                        )
+                                    },
+                                    onPlayFromTitleScreen = { gameId ->
+                                        emulationViewModel.onIntent(
+                                            EmulationIntent.PrepareLaunch(gameId, skipAutoLoad = true, forceNewSession = false)
                                         )
                                     },
                                     syncState = syncState.takeIf { it?.gameId == screen.gameId },
@@ -1407,7 +1413,7 @@ fun SpelaApp(
                                 },
                         )
 
-                        LaunchedEffect(navState.overlayGameId, navState.overlaySharedSessionId, navState.overlayNetplaySessionId, navState.overlayChallengeId, navState.overlaySessionId) {
+                        LaunchedEffect(navState.overlayGameId, navState.overlaySharedSessionId, navState.overlayNetplaySessionId, navState.overlayChallengeId, navState.overlaySessionId, navState.overlaySkipAutoLoad, navState.overlayForceNewSession) {
                             navState.overlayGameId?.let { gameId ->
                                 emulationViewModel.onIntent(
                                     EmulationIntent.StartGame(
@@ -1420,6 +1426,7 @@ fun SpelaApp(
                                         netplayIsHost = navState.overlayNetplayIsHost,
                                         challengeId = navState.overlayChallengeId,
                                         skipAutoLoad = navState.overlaySkipAutoLoad,
+                                        forceNewSession = navState.overlayForceNewSession,
                                         sessionId = navState.overlaySessionId,
                                     )
                                 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSplitButton.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSplitButton.kt
@@ -2,6 +2,7 @@ package com.spela.player.presentation.ui.components
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
@@ -32,6 +33,7 @@ import com.spela.player.presentation.ui.theme.SpTypography
 
 data class SpSplitButtonMenuItem(
     val label: String,
+    val description: String? = null,
     val onClick: () -> Unit,
 )
 
@@ -128,10 +130,19 @@ fun SpSplitButton(
                 menuItems.forEach { item ->
                     DropdownMenuItem(
                         text = {
-                            Text(
-                                text = item.label,
-                                style = SpTypography.BodyMedium,
-                            )
+                            Column {
+                                Text(
+                                    text = item.label,
+                                    style = SpTypography.BodyMedium,
+                                )
+                                if (item.description != null) {
+                                    Text(
+                                        text = item.description,
+                                        style = SpTypography.BodySmall,
+                                        color = SpColor.OnSurfaceVariant,
+                                    )
+                                }
+                            }
                         },
                         onClick = {
                             expanded = false

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -115,6 +115,7 @@ fun GameDetailScreen(
     onBack: () -> Unit,
     onPlay: (String) -> Unit,
     onPlayFresh: ((String) -> Unit)? = null,
+    onPlayFromTitleScreen: ((String) -> Unit)? = null,
     onCreateNetplay: ((String) -> Unit)? = null,
     onNavigateToChallenges: ((gameId: String, gameTitle: String) -> Unit)? = null,
     onNavigateToSharedSession: ((sharedSessionId: String) -> Unit)? = null,
@@ -183,6 +184,7 @@ fun GameDetailScreen(
                     missingBiosFiles = state.missingBiosFiles,
                     onPlay = onPlay,
                     onPlayFresh = onPlayFresh,
+                    onPlayFromTitleScreen = onPlayFromTitleScreen,
                     onDownloadGame = { viewModel.onIntent(GameDetailIntent.DownloadGame) },
                     onToggleFavorite = { viewModel.onIntent(GameDetailIntent.ToggleFavorite) },
                     onTogglePlayLater = { viewModel.onIntent(GameDetailIntent.TogglePlayLater) },
@@ -233,6 +235,7 @@ fun GameDetailScreen(
                     isDemoConsole = isDemoConsole,
                     onPlay = onPlay,
                     onPlayFresh = onPlayFresh,
+                    onPlayFromTitleScreen = onPlayFromTitleScreen,
                     onDownloadGame = { viewModel.onIntent(GameDetailIntent.DownloadGame) },
                     onToggleFavorite = { viewModel.onIntent(GameDetailIntent.ToggleFavorite) },
                     onTogglePlayLater = { viewModel.onIntent(GameDetailIntent.TogglePlayLater) },
@@ -535,6 +538,7 @@ private fun GameInfoContent(
     isDemoConsole: Boolean = false,
     onPlay: (String) -> Unit,
     onPlayFresh: ((String) -> Unit)? = null,
+    onPlayFromTitleScreen: ((String) -> Unit)? = null,
     onDownloadGame: () -> Unit,
     onToggleFavorite: () -> Unit,
     onTogglePlayLater: () -> Unit,
@@ -902,6 +906,7 @@ private fun GameHeroContent(
     missingBiosFiles: List<BiosMissingFile>,
     onPlay: (String) -> Unit,
     onPlayFresh: ((String) -> Unit)?,
+    onPlayFromTitleScreen: ((String) -> Unit)? = null,
     onDownloadGame: () -> Unit,
     onToggleFavorite: () -> Unit,
     onTogglePlayLater: () -> Unit,
@@ -979,8 +984,18 @@ private fun GameHeroContent(
             if (state.isGameCached) {
                 if (game.playable) {
                     val menuItems = buildList {
+                        if (hasSaves && onPlayFromTitleScreen != null) {
+                            add(SpSplitButtonMenuItem(
+                                label = "Continue from Title Screen",
+                                description = "Keep your in-game save, start from the beginning",
+                            ) { onPlayFromTitleScreen(gameId) })
+
+                        }
                         if (hasSaves && onPlayFresh != null) {
-                            add(SpSplitButtonMenuItem("New Game") { onPlayFresh(gameId) })
+                            add(SpSplitButtonMenuItem(
+                                label = "New Game",
+                                description = "Start a separate playthrough from scratch",
+                            ) { onPlayFresh(gameId) })
                         }
                         if (onCreateNetplay != null && supportsNetplay) {
                             add(SpSplitButtonMenuItem("Netplay") { onCreateNetplay(gameId) })

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -39,7 +39,12 @@ private const val REWIND_BUFFER_SIZE = 300 // ~60 seconds at 5fps capture rate
 private const val REWIND_CAPTURE_INTERVAL_MS = 200L // Capture every 200ms (~5 per second)
 
 /** Stores parameters for a pending game launch while pre-launch sync is in progress. */
-data class PendingLaunch(val gameId: String, val skipAutoLoad: Boolean, val sessionId: String? = null)
+data class PendingLaunch(
+    val gameId: String,
+    val skipAutoLoad: Boolean,
+    val forceNewSession: Boolean = false,
+    val sessionId: String? = null,
+)
 
 /**
  * Bridges between Compose UI and the platform-specific libretro core.
@@ -110,7 +115,7 @@ class EmulationViewModel(
                 intent.gameId, intent.sharedSessionId, intent.turnToken,
                 intent.netplaySessionId, intent.netplayLocalPort, intent.netplayInputDelay, intent.netplayIsHost,
                 intent.challengeId, intent.challengeSaveData, intent.skipAutoLoad,
-                intent.sessionId,
+                intent.forceNewSession, intent.sessionId,
             )
             EmulationIntent.PauseGame -> pauseGame()
             EmulationIntent.ResumeGame -> resumeGame()
@@ -209,7 +214,7 @@ class EmulationViewModel(
             EmulationIntent.ToggleRewind -> toggleRewindEnabled()
 
             // Pre-launch sync
-            is EmulationIntent.PrepareLaunch -> prepareLaunch(intent.gameId, intent.skipAutoLoad, intent.sessionId)
+            is EmulationIntent.PrepareLaunch -> prepareLaunch(intent.gameId, intent.skipAutoLoad, intent.forceNewSession, intent.sessionId)
             EmulationIntent.PlayWithLocalSave -> playWithLocalSave()
             EmulationIntent.CancelLaunch -> cancelLaunch()
 
@@ -242,6 +247,7 @@ class EmulationViewModel(
         challengeId: String? = null,
         challengeSaveDataArg: ByteArray? = null,
         skipAutoLoad: Boolean = false,
+        forceNewSession: Boolean = false,
         sessionId: String? = null,
     ) {
         saveManager.currentSessionId = sessionId
@@ -320,10 +326,10 @@ class EmulationViewModel(
             }
 
             // Auto-create or reuse session for normal play (not shared/netplay/challenge).
-            // When skipAutoLoad is true ("New Game"), force a fresh session to avoid
-            // overwriting auto-saves from a previous playthrough.
+            // forceNewSession creates a brand new session (e.g. "New Game"), while
+            // skipAutoLoad alone reuses the existing session but skips save state restore.
             if (sharedSessionId == null && netplaySessionId == null && challengeId == null) {
-                val resolvedSessionId = saveManager.ensureSession(gameId, sessionId, forceNew = skipAutoLoad)
+                val resolvedSessionId = saveManager.ensureSession(gameId, sessionId, forceNew = forceNewSession)
                 saveManager.currentSessionId = resolvedSessionId
                 if (resolvedSessionId != null && resolvedSessionId != sessionId) {
                     withContext(dispatchers.main) {
@@ -548,8 +554,8 @@ class EmulationViewModel(
         }
     }
 
-    private fun prepareLaunch(gameId: String, skipAutoLoad: Boolean, sessionId: String? = null) {
-        pendingLaunch = PendingLaunch(gameId, skipAutoLoad, sessionId)
+    private fun prepareLaunch(gameId: String, skipAutoLoad: Boolean, forceNewSession: Boolean = false, sessionId: String? = null) {
+        pendingLaunch = PendingLaunch(gameId, skipAutoLoad, forceNewSession, sessionId)
         scope.launch(dispatchers.io) {
             _syncState.update { null }
             val pending = pendingLaunch ?: return@launch

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelGameLifecycleTest.kt
@@ -264,8 +264,8 @@ class EmulationViewModelGameLifecycleTest {
         )
         val vm = builder.build()
 
-        // Start game with skipAutoLoad=true ("New Game")
-        vm.onIntent(EmulationIntent.StartGame("game1", skipAutoLoad = true))
+        // Start game with skipAutoLoad=true + forceNewSession=true ("New Game")
+        vm.onIntent(EmulationIntent.StartGame("game1", skipAutoLoad = true, forceNewSession = true))
         builder.advanceTimeBy(100)
 
         // Should create a NEW session, not reuse the existing one


### PR DESCRIPTION
## Summary
- Add "Continue from Title Screen" option to game detail split button menu — reuses existing session (keeps SRAM/in-game save) but skips save state restore
- Decouple `skipAutoLoad` from `forceNewSession` in `PrepareLaunch` intent — previously skipping auto-load always forced a new session
- Add description subtitles to split button menu items explaining each option in plain language
- Bump menu description typography from `LabelSmall` to `BodySmall` for readability

## Context
When a game had an existing session, users had two options: "Resume" (loads save state) or "New Game" (creates entirely new session). There was no way to continue the same session without loading the save state — e.g. to replay a section, recover from a corrupted save state, or just boot from the title screen with in-game save data intact.

## Menu options (when saves exist)
- **Resume** — restore to exactly where you left off
- **Continue from Title Screen** — "Keep your in-game save, start from the beginning"
- **New Game** — "Start a separate playthrough from scratch"

## Test plan
- [x] 12 new desktop E2E tests in `ResumeVsNewGameTest` — all passing
- [x] Updated existing `EmulationViewModelGameLifecycleTest` for new `forceNewSession` parameter
- [x] Code review: approved (fixed LaunchedEffect key list, PendingLaunch formatting)
- [x] UX review: approved (bumped description to BodySmall for readability)