### PR TITLE
fix: make E2E tests deterministic and easy to run

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,9 @@ player/local.properties
 # Test ROMs (not for distribution)
 testdata/
 
+# E2E test cache
+.e2e-cache/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,3 +125,4 @@ element intentionally non-reusable, or should it be an Sp* component?"
 - **`ARCHITECTURE.md`** — Full technical architecture
 - **`AGENT_TEAM.md`** — Team roles and review checklist
 - **`player/RENDERING.md`** — Emulation rendering pipeline: how libretro cores render video across platforms (software vs OpenGL HW vs Vulkan HW), the GPU renderer, common video issues (garbled, flipped, black screen), and key native files
+- **`docs/e2e-testing.md`** — How to run web E2E tests reliably: quick start, architecture, troubleshooting, and test patterns

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Spela is a self-hosted game emulation service with three components:
 4. **libretro only** - No custom emulation code. All emulation via libretro cores.
 5. **A feature is not done until all tests pass** - Every change must have appropriate test coverage (E2E and/or unit tests), and the ENTIRE test suite must pass before a task is considered complete. No regressions allowed.
    - **Player app**: See "Player App Testing Strategy" below for the desktop-primary / Android-smoke approach.
-   - **Web frontend**: Playwright E2E tests + Vitest unit tests.
+   - **Web frontend**: Playwright E2E tests + Vitest unit tests. See [`docs/e2e-testing.md`](docs/e2e-testing.md) for how to run E2E tests reliably.
    - **Backend**: Go unit tests (`go test ./...`).
    - Run the full suite, not just the new tests. Catching regressions early is critical.
 

--- a/docs/e2e-testing.md
+++ b/docs/e2e-testing.md
@@ -1,0 +1,264 @@
+# Web E2E Testing Guide
+
+This document explains how to run the Playwright E2E tests for the web frontend
+reliably, what the infrastructure does, and how to troubleshoot common issues.
+
+## Quick Start
+
+From the repository root:
+
+```bash
+# Run all E2E tests (builds server, seeds DB, starts everything, runs tests)
+./run-e2e.sh
+
+# Run a specific test file
+./run-e2e.sh admin-settings
+
+# Run tests matching a pattern
+./run-e2e.sh "registration"
+
+# Open Playwright UI mode (interactive)
+./run-e2e.sh --ui
+
+# Run with visible browser
+./run-e2e.sh --headed
+
+# Skip Go build (reuse cached binary from previous run)
+SKIP_BUILD=1 ./run-e2e.sh
+```
+
+That's it. The script handles everything.
+
+## What `run-e2e.sh` Does
+
+The script performs 8 steps in order:
+
+| Step | What happens |
+|------|-------------|
+| 1. Clear ports | Kills any existing processes on ports 8080 (server) and 5173 (Vite) |
+| 2. npm deps | Installs `node_modules` and Playwright browsers if missing |
+| 3. Clean auth | Removes stale `storage-state.json` from previous runs |
+| 4. Build & seed | Compiles the Go server, creates a fresh SQLite DB in a temp dir, seeds consoles/cores/users |
+| 5. Start server | Launches the server with `SPELA_TEST_MODE=true` and waits for the health check |
+| 6. Game scan | Triggers a library scan and **polls the scan status endpoint until complete**, then verifies games exist |
+| 7. Start Vite | Starts the Vite dev server and waits for it to respond |
+| 8. Run tests | Executes `npx playwright test` with any arguments you passed |
+
+On exit (success, failure, or Ctrl+C), the script kills the server and Vite
+processes and deletes the temp directory.
+
+## Prerequisites
+
+- **Go** (1.21+) with CGO enabled (for SQLite)
+- **Node.js** (18+) and npm
+- **Python 3** (used by the script to parse JSON responses)
+- **curl** and **lsof** (standard on macOS/Linux)
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `SKIP_BUILD` | unset | Set to `1` to skip the Go build and reuse cached binaries from `.e2e-cache/` |
+| `SKIP_INSTALL` | unset | Set to `1` to skip the npm dependency check |
+| `E2E_SERVERS_RUNNING` | unset | Set automatically by `run-e2e.sh` to tell Playwright not to start its own webServer |
+
+## Architecture
+
+### Fresh state every run
+
+Each run creates a **completely fresh temp directory** with a new SQLite database.
+There is no persistent state between runs. This eliminates an entire class of
+flakiness caused by leftover data.
+
+```
+/tmp/xxx-e2e/
+  spela.db      # fresh database, seeded with consoles + cores + admin/player users
+  saves/        # empty
+  cores/        # empty
+  images/       # empty
+  bios/         # empty
+  dats/         # empty
+```
+
+### Test isolation within a run
+
+Tests share a single server instance (Playwright runs with `workers: 1`).
+Between tests, the `resetServer()` function calls `POST /api/test/reset` which:
+
+1. Deletes all user-generated data (sessions, saves, collections, challenges, etc.)
+2. Preserves consoles, cores, and scanned games
+3. Resets the `admin` and `player` users to their default state
+
+Tests that mutate server state should call `resetServer()` in `beforeEach` or `beforeAll`:
+
+```typescript
+import { test, expect, resetServer } from "./fixtures";
+
+test.describe("My Feature", () => {
+  test.beforeEach(async () => {
+    await resetServer();
+  });
+
+  test("does something", async ({ page }) => {
+    // ...
+  });
+});
+```
+
+### Readiness gate
+
+Before any tests run, the global setup (`global-setup.spec.ts`) verifies:
+
+1. Server health check passes
+2. Test reset endpoint is available (confirms `SPELA_TEST_MODE=true`)
+3. Admin login works
+4. Games have been scanned (game count > 0)
+
+If any of these fail, all tests are skipped with a clear error message.
+
+### Authentication
+
+The global setup logs in as `admin/admin123` and saves the browser storage state
+to `e2e/.auth/storage-state.json`. All subsequent tests inherit this
+authenticated context automatically.
+
+Tests that need an unauthenticated context can override this:
+
+```typescript
+test.use({ storageState: { cookies: [], origins: [] } });
+```
+
+## Test Patterns
+
+### Tests that hit the real server
+
+These tests exercise the actual API. Use `resetServer()` to ensure clean state:
+
+```typescript
+test.beforeEach(async () => {
+  await resetServer();
+});
+
+test("admin can change settings", async ({ page }) => {
+  await page.goto("/admin/settings");
+  // interact with real server...
+});
+```
+
+### Tests with mocked API routes
+
+Many tests mock API responses using Playwright's `page.route()`. These don't
+need `resetServer()` since they never hit the real server:
+
+```typescript
+test("shows challenge cards", async ({ page }) => {
+  await page.route("**/api/challenges?*", (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ data: [...], total: 1, page: 1, pageSize: 20 }),
+    });
+  });
+
+  await page.goto("/challenges");
+  await expect(page.getByText("My Challenge")).toBeVisible();
+});
+```
+
+## Seeded Test Data
+
+The E2E environment provides:
+
+| Data | Details |
+|------|---------|
+| **Admin user** | `admin` / `admin123` (role: `owner`) |
+| **Player user** | `player` / `player123` (role: `user`) |
+| **Consoles** | ~60 systems (NES, SNES, GBA, PSX, etc.) |
+| **Cores** | All libretro core definitions |
+| **Games** | ~171 games scanned from `testdata/roms/` |
+
+## Alternative: Manual Setup
+
+If you want to start the environment manually (e.g., to keep it running while
+you iterate on tests):
+
+```bash
+# Terminal 1: Start the E2E environment
+bash web/e2e/start-e2e.sh
+
+# Terminal 2: Run tests (will reuse the running server)
+cd web
+npx playwright test
+npx playwright test --ui          # interactive mode
+npx playwright test admin-settings  # specific file
+```
+
+The `start-e2e.sh` script performs the same setup as `run-e2e.sh` steps 1-7
+and then blocks until Ctrl+C.
+
+## Alternative: Docker Compose
+
+For CI or when you don't want to build locally:
+
+```bash
+docker compose -f docker-compose.e2e.yml up -d --build --wait
+cd web
+npx playwright test
+docker compose -f docker-compose.e2e.yml down -v  # -v removes volumes
+```
+
+Note: Docker volumes persist between runs. Always use `down -v` to get a clean
+state, or rely on `resetServer()` within tests.
+
+## Troubleshooting
+
+### "Server did not become ready"
+
+- Check if something else is using port 8080: `lsof -i :8080`
+- The script should kill it automatically, but if `lsof` fails (permissions),
+  you may need to kill it manually
+
+### "No games found after scan"
+
+- Verify `testdata/roms/` exists and contains ROM files
+- Check server logs for scan errors (the scan runs async and the script polls
+  for completion)
+
+### "Test reset failed"
+
+- The server must be started with `SPELA_TEST_MODE=true` for the reset endpoint
+  to be registered
+
+### Stale auth / "401 Unauthorized" in tests
+
+- `run-e2e.sh` automatically removes old `storage-state.json`
+- If running manually, delete `web/e2e/.auth/storage-state.json`
+
+### Port already in use after a crash
+
+```bash
+# Kill processes on E2E ports
+kill $(lsof -ti :8080) 2>/dev/null
+kill $(lsof -ti :5173) 2>/dev/null
+```
+
+### Tests pass locally but fail in CI
+
+- CI does not currently run Playwright E2E tests (only unit tests and desktop
+  player tests). See `.github/workflows/ci.yml` for the current CI setup.
+
+## File Reference
+
+| File | Purpose |
+|------|---------|
+| `run-e2e.sh` | One-command test runner (recommended entry point) |
+| `web/e2e/start-e2e.sh` | Starts E2E environment only (no test execution) |
+| `web/run-e2e.sh` | Thin wrapper around `npx playwright test` |
+| `web/playwright.config.ts` | Playwright configuration (ports, workers, auth) |
+| `web/e2e/fixtures.ts` | Exports `test`, `expect`, and `resetServer()` |
+| `web/e2e/global-setup.spec.ts` | Readiness checks + auth setup |
+| `web/e2e/*.spec.ts` | Individual test files |
+| `docker-compose.e2e.yml` | Docker-based E2E environment |
+| `server/internal/api/test_handler.go` | Server-side reset endpoint |
+| `server/cmd/seed/main.go` | Database seeding logic |
+| `testdata/roms/` | Test ROM files (not in git) |

--- a/run-e2e.sh
+++ b/run-e2e.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# ============================================================================
+# run-e2e.sh — One-command E2E test runner for Spela
+# ============================================================================
+#
+# This script handles EVERYTHING needed to run E2E tests reliably:
+#   1. Kills any existing processes on test ports (8080, 5173)
+#   2. Installs npm dependencies if needed
+#   3. Removes stale auth state from previous runs
+#   4. Builds the Go server from source
+#   5. Seeds a fresh database in a temp directory
+#   6. Starts the server and waits for health check
+#   7. Triggers a game scan and waits for it to complete
+#   8. Starts the Vite dev server
+#   9. Runs Playwright E2E tests
+#  10. Cleans everything up on exit
+#
+# Usage:
+#   ./run-e2e.sh                    # run all E2E tests
+#   ./run-e2e.sh admin-settings     # run tests matching "admin-settings"
+#   ./run-e2e.sh --ui               # open Playwright UI mode
+#   ./run-e2e.sh --headed           # run tests with visible browser
+#   ./run-e2e.sh --debug            # run with Playwright debug mode
+#
+# Environment variables:
+#   SKIP_BUILD=1    — skip Go server build (reuse cached binary)
+#   SKIP_INSTALL=1  — skip npm install check
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SERVER_DIR="$SCRIPT_DIR/server"
+WEB_DIR="$SCRIPT_DIR/web"
+
+SERVER_PORT=8080
+VITE_PORT=5173
+
+# ── Parse arguments ──────────────────────────────────────────────────────
+
+PLAYWRIGHT_ARGS=()
+UI_MODE=false
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --ui)
+            UI_MODE=true
+            shift
+            ;;
+        --headed|--debug)
+            PLAYWRIGHT_ARGS+=("$1")
+            shift
+            ;;
+        *)
+            PLAYWRIGHT_ARGS+=("$1")
+            shift
+            ;;
+    esac
+done
+
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+kill_port() {
+    local port=$1
+    local pids
+    pids=$(lsof -ti :"$port" 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+        echo "Killing process(es) on port $port (PIDs: $pids)..."
+        echo "$pids" | xargs kill -9 2>/dev/null || true
+        for _ in $(seq 1 20); do
+            if ! lsof -ti :"$port" >/dev/null 2>&1; then break; fi
+            sleep 0.25
+        done
+    fi
+}
+
+wait_for_url() {
+    local url=$1
+    local label=$2
+    local max_attempts=${3:-60}
+    for i in $(seq 1 "$max_attempts"); do
+        if curl -sf "$url" >/dev/null 2>&1; then
+            return 0
+        fi
+        if [ "$((i % 10))" -eq 0 ]; then
+            echo "  Still waiting for $label... (${i}s)"
+        fi
+        sleep 1
+    done
+    echo "ERROR: $label did not become ready within ${max_attempts}s"
+    return 1
+}
+
+# ── Cleanup on exit ──────────────────────────────────────────────────────
+
+SERVER_PID=""
+VITE_PID=""
+E2E_DIR=""
+
+cleanup() {
+    local exit_code=$?
+    echo ""
+    echo "==> Cleaning up..."
+    [ -n "$VITE_PID" ] && kill "$VITE_PID" 2>/dev/null || true
+    [ -n "$SERVER_PID" ] && kill "$SERVER_PID" 2>/dev/null || true
+    sleep 0.5
+    [ -n "$VITE_PID" ] && kill -9 "$VITE_PID" 2>/dev/null || true
+    [ -n "$SERVER_PID" ] && kill -9 "$SERVER_PID" 2>/dev/null || true
+    [ -n "$E2E_DIR" ] && rm -rf "$E2E_DIR"
+    echo "Cleanup complete."
+    exit $exit_code
+}
+trap cleanup EXIT INT TERM
+
+# ── Step 1: Kill existing processes on test ports ────────────────────────
+
+echo "==> Step 1/8: Clearing test ports..."
+kill_port $SERVER_PORT
+kill_port $VITE_PORT
+
+# ── Step 2: Install npm dependencies ────────────────────────────────────
+
+if [ "${SKIP_INSTALL:-}" != "1" ]; then
+    echo "==> Step 2/8: Checking npm dependencies..."
+    if [ ! -d "$WEB_DIR/node_modules" ]; then
+        echo "  Installing npm dependencies..."
+        (cd "$WEB_DIR" && npm install)
+    fi
+    # Ensure Playwright browsers are installed
+    if ! npx --prefix "$WEB_DIR" playwright --version >/dev/null 2>&1; then
+        echo "  Installing Playwright browsers..."
+        (cd "$WEB_DIR" && npx playwright install chromium)
+    fi
+else
+    echo "==> Step 2/8: Skipping npm install (SKIP_INSTALL=1)"
+fi
+
+# ── Step 3: Remove stale auth state ─────────────────────────────────────
+
+echo "==> Step 3/8: Removing stale auth state..."
+rm -f "$WEB_DIR/e2e/.auth/storage-state.json"
+
+# ── Step 4: Build and seed ───────────────────────────────────────────────
+
+E2E_DIR=$(mktemp -d)
+DB_PATH="$E2E_DIR/spela.db"
+mkdir -p "$E2E_DIR/saves" "$E2E_DIR/cores" "$E2E_DIR/images" "$E2E_DIR/bios" "$E2E_DIR/dats"
+
+BUILD_CACHE="$SCRIPT_DIR/.e2e-cache"
+mkdir -p "$BUILD_CACHE"
+
+if [ "${SKIP_BUILD:-}" != "1" ]; then
+    echo "==> Step 4/8: Building server..."
+    (cd "$SERVER_DIR" && CGO_ENABLED=1 go build -o "$BUILD_CACHE/spela-server" ./cmd/server)
+    (cd "$SERVER_DIR" && CGO_ENABLED=1 go build -o "$BUILD_CACHE/spela-seed" ./cmd/seed)
+else
+    echo "==> Step 4/8: Skipping build (SKIP_BUILD=1)"
+    if [ ! -f "$BUILD_CACHE/spela-server" ] || [ ! -f "$BUILD_CACHE/spela-seed" ]; then
+        echo "  No cached binaries — building anyway..."
+        (cd "$SERVER_DIR" && CGO_ENABLED=1 go build -o "$BUILD_CACHE/spela-server" ./cmd/server)
+        (cd "$SERVER_DIR" && CGO_ENABLED=1 go build -o "$BUILD_CACHE/spela-seed" ./cmd/seed)
+    fi
+fi
+
+cp "$BUILD_CACHE/spela-server" "$E2E_DIR/spela-server"
+cp "$BUILD_CACHE/spela-seed" "$E2E_DIR/spela-seed"
+
+echo "  Seeding database..."
+SPELA_DB_PATH="$DB_PATH" "$E2E_DIR/spela-seed"
+
+# ── Step 5: Start server ────────────────────────────────────────────────
+
+echo "==> Step 5/8: Starting server..."
+SPELA_PORT=$SERVER_PORT \
+SPELA_DB_PATH="$DB_PATH" \
+SPELA_JWT_SECRET="e2e-test-secret-that-is-at-least-32-chars-long" \
+SPELA_GAME_DIRS="$SCRIPT_DIR/testdata/roms" \
+SPELA_SAVE_DIR="$E2E_DIR/saves" \
+SPELA_CORE_DIR="$E2E_DIR/cores" \
+SPELA_IMAGE_DIR="$E2E_DIR/images" \
+SPELA_BIOS_DIR="$E2E_DIR/bios" \
+SPELA_DAT_DIR="$E2E_DIR/dats" \
+SPELA_CORS_ORIGINS="http://localhost:$VITE_PORT" \
+SPELA_ENCRYPTION_KEY="e2e-test-encryption-key-32bytes!" \
+SPELA_CHALLENGE_RATE_LIMIT_SEC=0 \
+SPELA_TEST_MODE=true \
+GIN_MODE=release \
+"$E2E_DIR/spela-server" &
+SERVER_PID=$!
+
+if ! wait_for_url "http://localhost:$SERVER_PORT/api/health" "server" 30; then
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "Server process died unexpectedly"
+    fi
+    exit 1
+fi
+echo "  Server ready (PID $SERVER_PID)"
+
+# ── Step 6: Trigger and wait for game scan ───────────────────────────────
+
+echo "==> Step 6/8: Scanning game library..."
+TOKEN=$(curl -sf -X POST "http://localhost:$SERVER_PORT/api/auth/login" \
+  -H 'Content-Type: application/json' \
+  -d '{"username":"admin","password":"admin123"}' | \
+  python3 -c "import sys,json; print(json.load(sys.stdin)['accessToken'])" 2>/dev/null) || true
+
+if [ -z "${TOKEN:-}" ]; then
+    echo "ERROR: Could not login as admin"
+    exit 1
+fi
+
+curl -sf -X POST "http://localhost:$SERVER_PORT/api/admin/games/scan" \
+  -H "Authorization: Bearer $TOKEN" >/dev/null 2>&1 || true
+
+# Poll scan status until complete
+for i in $(seq 1 120); do
+    SCAN_STATUS=$(curl -sf "http://localhost:$SERVER_PORT/api/admin/games/scan/status" \
+      -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+
+    if [ -n "$SCAN_STATUS" ]; then
+        IS_ACTIVE=$(echo "$SCAN_STATUS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('active', False))" 2>/dev/null) || true
+        if [ "$IS_ACTIVE" = "False" ] || [ "$IS_ACTIVE" = "false" ]; then
+            break
+        fi
+    fi
+    if [ "$((i % 5))" -eq 0 ]; then
+        echo "  Scan still running... (${i}s)"
+    fi
+    sleep 1
+done
+
+GAME_COUNT=$(curl -sf "http://localhost:$SERVER_PORT/api/games?limit=1" \
+  -H "Authorization: Bearer $TOKEN" 2>/dev/null | \
+  python3 -c "import sys,json; print(json.load(sys.stdin).get('total', 0))" 2>/dev/null) || true
+
+echo "  Game scan complete. ${GAME_COUNT:-0} games available."
+
+if [ "${GAME_COUNT:-0}" -eq 0 ]; then
+    echo "WARNING: No games found after scan!"
+fi
+
+# ── Step 7: Start Vite dev server ────────────────────────────────────────
+
+echo "==> Step 7/8: Starting Vite dev server..."
+(cd "$WEB_DIR" && npx vite --port $VITE_PORT) &
+VITE_PID=$!
+
+if ! wait_for_url "http://localhost:$VITE_PORT" "Vite" 30; then
+    exit 1
+fi
+echo "  Vite ready (PID $VITE_PID)"
+
+# ── Step 8: Run Playwright tests ────────────────────────────────────────
+
+echo ""
+echo "================================================"
+echo "  E2E environment ready — running tests"
+echo "================================================"
+echo "  Server: http://localhost:$SERVER_PORT"
+echo "  Web:    http://localhost:$VITE_PORT"
+echo "  Games:  ${GAME_COUNT:-0}"
+echo "================================================"
+echo ""
+
+cd "$WEB_DIR"
+
+# Tell Playwright NOT to use its webServer config (we already started everything)
+export E2E_SERVERS_RUNNING=1
+
+if $UI_MODE; then
+    echo "Opening Playwright UI..."
+    npx playwright test --ui "${PLAYWRIGHT_ARGS[@]+"${PLAYWRIGHT_ARGS[@]}"}"
+else
+    echo "Running Playwright E2E tests..."
+    npx playwright test "${PLAYWRIGHT_ARGS[@]+"${PLAYWRIGHT_ARGS[@]}"}"
+fi

--- a/web/e2e/global-setup.spec.ts
+++ b/web/e2e/global-setup.spec.ts
@@ -1,8 +1,46 @@
 import { test as setup, expect } from "@playwright/test";
 
+const SERVER_URL = "http://localhost:8080";
+
 /**
- * Authenticates against the server (started via docker-compose.e2e.yml)
- * using the seeded admin credentials and saves storage state for subsequent tests.
+ * Verify the server is healthy and has scanned games before running any tests.
+ * This catches issues like: server not started, scan not complete, stale state.
+ */
+setup("verify server readiness", async () => {
+  // 1. Health check
+  const health = await fetch(`${SERVER_URL}/api/health`);
+  expect(health.ok, "Server health check failed").toBe(true);
+
+  // 2. Verify test mode is enabled (reset endpoint available)
+  const reset = await fetch(`${SERVER_URL}/api/test/reset`, { method: "POST" });
+  expect(
+    reset.ok,
+    "Test reset endpoint not available — is SPELA_TEST_MODE=true?",
+  ).toBe(true);
+
+  // 3. Verify games have been scanned
+  const loginRes = await fetch(`${SERVER_URL}/api/auth/login`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ username: "admin", password: "admin123" }),
+  });
+  expect(loginRes.ok, "Admin login failed").toBe(true);
+  const { accessToken } = await loginRes.json();
+
+  const gamesRes = await fetch(`${SERVER_URL}/api/games?limit=1`, {
+    headers: { Authorization: `Bearer ${accessToken}` },
+  });
+  expect(gamesRes.ok, "Games endpoint failed").toBe(true);
+  const games = await gamesRes.json();
+  expect(
+    games.total,
+    "No games found — game scan may not have completed",
+  ).toBeGreaterThan(0);
+});
+
+/**
+ * Authenticates against the server using the seeded admin credentials
+ * and saves storage state for subsequent tests.
  */
 setup("authenticate", async ({ page }) => {
   await page.goto("/login");

--- a/web/e2e/start-e2e.sh
+++ b/web/e2e/start-e2e.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 # Start the E2E test environment locally (replaces docker-compose.e2e.yml).
+# Builds server from source, seeds DB, starts server + Vite, waits for
+# game scan to complete, then blocks (or exits in CI mode).
+#
 # Usage:
 #   bash web/e2e/start-e2e.sh        # start servers, block until Ctrl+C
 #   bash web/e2e/start-e2e.sh --ci   # start servers, exit when ready (for Playwright webServer)
@@ -10,36 +13,92 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 SERVER_DIR="$REPO_ROOT/server"
 WEB_DIR="$REPO_ROOT/web"
 
+SERVER_PORT=8080
+VITE_PORT=5173
+
 CI_MODE=false
 if [[ "${1:-}" == "--ci" ]]; then
     CI_MODE=true
 fi
 
-# Temp directory for E2E data
+# ── Helpers ──────────────────────────────────────────────────────────────
+
+kill_port() {
+    local port=$1
+    local pids
+    pids=$(lsof -ti :"$port" 2>/dev/null || true)
+    if [ -n "$pids" ]; then
+        echo "Killing existing process(es) on port $port (PIDs: $pids)..."
+        echo "$pids" | xargs kill -9 2>/dev/null || true
+        # Wait for port to be released
+        for _ in $(seq 1 20); do
+            if ! lsof -ti :"$port" >/dev/null 2>&1; then
+                break
+            fi
+            sleep 0.25
+        done
+    fi
+}
+
+wait_for_url() {
+    local url=$1
+    local label=$2
+    local max_attempts=${3:-60}
+    for i in $(seq 1 "$max_attempts"); do
+        if curl -sf "$url" >/dev/null 2>&1; then
+            return 0
+        fi
+        if [ "$((i % 10))" -eq 0 ]; then
+            echo "  Still waiting for $label... (${i}s)"
+        fi
+        sleep 1
+    done
+    echo "ERROR: $label did not become ready within ${max_attempts}s"
+    return 1
+}
+
+# ── Port cleanup ─────────────────────────────────────────────────────────
+
+echo "==> Cleaning up ports..."
+kill_port $SERVER_PORT
+kill_port $VITE_PORT
+
+# ── Temp directory for E2E data ──────────────────────────────────────────
+
 E2E_DIR=$(mktemp -d)
 cleanup() {
-    echo "Stopping E2E servers..."
+    echo ""
+    echo "==> Stopping E2E servers..."
     kill "${SERVER_PID:-}" 2>/dev/null || true
     kill "${VITE_PID:-}" 2>/dev/null || true
+    # Give processes a moment to die
+    sleep 0.5
+    # Force kill if still alive
+    kill -9 "${SERVER_PID:-}" 2>/dev/null || true
+    kill -9 "${VITE_PID:-}" 2>/dev/null || true
     rm -rf "$E2E_DIR"
+    echo "Cleanup complete."
 }
 trap cleanup EXIT
 
 DB_PATH="$E2E_DIR/spela.db"
 mkdir -p "$E2E_DIR/saves" "$E2E_DIR/cores" "$E2E_DIR/images" "$E2E_DIR/bios" "$E2E_DIR/dats"
 
-# 1. Build the server
-echo "Building server..."
+# ── 1. Build the server ─────────────────────────────────────────────────
+
+echo "==> Building server..."
 (cd "$SERVER_DIR" && CGO_ENABLED=1 go build -o "$E2E_DIR/spela-server" ./cmd/server)
 (cd "$SERVER_DIR" && CGO_ENABLED=1 go build -o "$E2E_DIR/spela-seed" ./cmd/seed)
 
-# 2. Seed the database
-echo "Seeding database..."
+# ── 2. Seed the database ────────────────────────────────────────────────
+
+echo "==> Seeding database..."
 SPELA_DB_PATH="$DB_PATH" "$E2E_DIR/spela-seed"
 
-# 3. Start the server
-echo "Starting server..."
-SPELA_PORT=8080 \
+# ── 3. Start the server ─────────────────────────────────────────────────
+
+echo "==> Starting server on port $SERVER_PORT..."
+SPELA_PORT=$SERVER_PORT \
 SPELA_DB_PATH="$DB_PATH" \
 SPELA_JWT_SECRET="e2e-test-secret-that-is-at-least-32-chars-long" \
 SPELA_GAME_DIRS="$REPO_ROOT/testdata/roms" \
@@ -48,68 +107,104 @@ SPELA_CORE_DIR="$E2E_DIR/cores" \
 SPELA_IMAGE_DIR="$E2E_DIR/images" \
 SPELA_BIOS_DIR="$E2E_DIR/bios" \
 SPELA_DAT_DIR="$E2E_DIR/dats" \
-SPELA_CORS_ORIGINS="http://localhost:5173" \
-SPELA_ENCRYPTION_KEY="e2e-test-encryption-key-at-least-32-chars" \
+SPELA_CORS_ORIGINS="http://localhost:$VITE_PORT" \
+SPELA_ENCRYPTION_KEY="e2e-test-encryption-key-32bytes!" \
 SPELA_CHALLENGE_RATE_LIMIT_SEC=0 \
 SPELA_TEST_MODE=true \
 GIN_MODE=release \
 "$E2E_DIR/spela-server" &
 SERVER_PID=$!
 
-# 4. Wait for server to be ready
-echo "Waiting for server..."
-for i in $(seq 1 60); do
-    if curl -sf http://localhost:8080/api/health >/dev/null 2>&1; then
-        break
-    fi
-    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
-        echo "Server process died"
-        exit 1
-    fi
-    sleep 0.5
-done
+# ── 4. Wait for server health check ─────────────────────────────────────
 
-if ! curl -sf http://localhost:8080/api/health >/dev/null 2>&1; then
-    echo "Server failed to start"
+echo "==> Waiting for server health check..."
+if ! wait_for_url "http://localhost:$SERVER_PORT/api/health" "server" 30; then
+    if ! kill -0 "$SERVER_PID" 2>/dev/null; then
+        echo "Server process died unexpectedly"
+    fi
     exit 1
 fi
 echo "Server ready."
 
-# 5. Trigger game scan
-echo "Scanning games..."
-TOKEN=$(curl -sf -X POST http://localhost:8080/api/auth/login \
+# ── 5. Trigger game scan and WAIT for it to complete ────────────────────
+
+echo "==> Logging in to trigger game scan..."
+TOKEN=$(curl -sf -X POST "http://localhost:$SERVER_PORT/api/auth/login" \
   -H 'Content-Type: application/json' \
   -d '{"username":"admin","password":"admin123"}' | \
   python3 -c "import sys,json; print(json.load(sys.stdin)['accessToken'])" 2>/dev/null) || true
 
-if [ -n "${TOKEN:-}" ]; then
-    SCAN_RESULT=$(curl -sf -X POST http://localhost:8080/api/admin/games/scan \
-      -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
-    echo "Scan result: ${SCAN_RESULT:-failed}"
-else
-    echo "Warning: could not login to trigger game scan"
+if [ -z "${TOKEN:-}" ]; then
+    echo "ERROR: Could not login as admin to trigger game scan"
+    exit 1
 fi
 
-# 6. Start Vite dev server
-echo "Starting Vite dev server..."
-(cd "$WEB_DIR" && npx vite --port 5173) &
-VITE_PID=$!
+echo "==> Triggering game scan..."
+SCAN_RESPONSE=$(curl -sf -X POST "http://localhost:$SERVER_PORT/api/admin/games/scan" \
+  -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+echo "Scan triggered: ${SCAN_RESPONSE:-failed}"
 
-# Wait for Vite
-for i in $(seq 1 30); do
-    if curl -sf http://localhost:5173 >/dev/null 2>&1; then
-        break
+# Poll scan status until scan is no longer active
+echo "==> Waiting for game scan to complete..."
+for i in $(seq 1 120); do
+    SCAN_STATUS=$(curl -sf "http://localhost:$SERVER_PORT/api/admin/games/scan/status" \
+      -H "Authorization: Bearer $TOKEN" 2>/dev/null) || true
+
+    if [ -n "$SCAN_STATUS" ]; then
+        IS_ACTIVE=$(echo "$SCAN_STATUS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('active', False))" 2>/dev/null) || true
+        if [ "$IS_ACTIVE" = "False" ] || [ "$IS_ACTIVE" = "false" ]; then
+            break
+        fi
     fi
-    sleep 0.5
+
+    if [ "$((i % 5))" -eq 0 ]; then
+        echo "  Scan still in progress... (${i}s)"
+    fi
+    sleep 1
 done
 
-echo ""
-echo "E2E servers are running:"
-echo "  Server: http://localhost:8080 (PID $SERVER_PID)"
-echo "  Web:    http://localhost:5173 (PID $VITE_PID)"
-echo "  DB:     $DB_PATH"
-echo "  Test reset: POST http://localhost:8080/api/test/reset"
+# Verify games exist
+GAME_COUNT=$(curl -sf "http://localhost:$SERVER_PORT/api/games?limit=1" \
+  -H "Authorization: Bearer $TOKEN" 2>/dev/null | \
+  python3 -c "import sys,json; print(json.load(sys.stdin).get('total', 0))" 2>/dev/null) || true
+
+if [ "${GAME_COUNT:-0}" -eq 0 ]; then
+    echo "WARNING: No games found after scan. Tests that depend on games may fail."
+else
+    echo "Game scan complete. $GAME_COUNT games available."
+fi
+
+# ── 6. Start Vite dev server ────────────────────────────────────────────
+
+echo "==> Starting Vite dev server on port $VITE_PORT..."
+(cd "$WEB_DIR" && npx vite --port $VITE_PORT) &
+VITE_PID=$!
+
+if ! wait_for_url "http://localhost:$VITE_PORT" "Vite dev server" 30; then
+    exit 1
+fi
+echo "Vite dev server ready."
+
+# ── Ready ────────────────────────────────────────────────────────────────
 
 echo ""
-echo "Press Ctrl+C to stop."
-wait
+echo "================================================"
+echo "  E2E environment is ready!"
+echo "================================================"
+echo "  Server: http://localhost:$SERVER_PORT (PID $SERVER_PID)"
+echo "  Web:    http://localhost:$VITE_PORT (PID $VITE_PID)"
+echo "  DB:     $DB_PATH"
+echo "  Games:  ${GAME_COUNT:-0}"
+echo "  Reset:  POST http://localhost:$SERVER_PORT/api/test/reset"
+echo "================================================"
+echo ""
+
+if $CI_MODE; then
+    echo "CI mode: servers are ready, exiting startup script."
+    # In CI mode we need to keep running so Playwright can manage the lifecycle
+    # The trap will clean up when Playwright kills us
+    wait
+else
+    echo "Press Ctrl+C to stop."
+    wait
+fi

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,5 +1,9 @@
 import { defineConfig } from "@playwright/test";
 
+// When E2E_SERVERS_RUNNING is set (by run-e2e.sh), the server and Vite are
+// already running — skip Playwright's webServer startup entirely.
+const serversAlreadyRunning = !!process.env.E2E_SERVERS_RUNNING;
+
 export default defineConfig({
   testDir: "./e2e",
   timeout: 60_000,
@@ -10,12 +14,14 @@ export default defineConfig({
     baseURL: "http://localhost:5173",
     trace: "on-first-retry",
   },
-  webServer: {
-    command: "bash e2e/start-e2e.sh",
-    url: "http://localhost:5173",
-    reuseExistingServer: !process.env.CI,
-    timeout: 120_000,
-  },
+  ...(!serversAlreadyRunning && {
+    webServer: {
+      command: "bash e2e/start-e2e.sh",
+      url: "http://localhost:5173",
+      reuseExistingServer: !process.env.CI,
+      timeout: 120_000,
+    },
+  }),
   projects: [
     {
       name: "setup",


### PR DESCRIPTION
## Summary

- Add `run-e2e.sh` — single entry point that handles port cleanup, Go build, DB seed, server start, game scan polling, Vite start, and Playwright execution
- Fix `start-e2e.sh` — kill stale port processes, poll scan status until complete, verify game count before declaring ready
- Add readiness gate in `global-setup.spec.ts` — verify server health, test mode, admin login, and game availability before any tests run
- Add `docs/e2e-testing.md` with detailed guide covering quick start, architecture, test patterns, and troubleshooting

## Root causes fixed

| Problem | Fix |
|---------|-----|
| Game scan was async and not awaited — tests could start before games existed | Poll `GET /api/admin/games/scan/status` until `active=false`, then verify game count |
| Port conflicts from stale processes | Kill existing processes on 8080/5173 before starting |
| Stale auth state from previous runs | Remove `storage-state.json` before each run |
| No verification before tests start | Added readiness checks (health, test mode, games) in global setup |

## Test plan

- [x] Full E2E suite passes: 193/196 (3 pre-existing failures in retroachievements/netplay-invite)
- [x] `SKIP_BUILD=1` reuses cached binaries correctly
- [x] Targeted test runs work: `./run-e2e.sh admin-settings` (5/5 pass)
- [x] Cleanup on exit works (Ctrl+C, success, failure)