### PR TITLE
feat: add per-session 'Continue from Title Screen' option

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionLaunchOptionsTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionLaunchOptionsTest.kt
@@ -1,0 +1,215 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.viewmodel.PendingLaunch
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Desktop E2E tests for the session row launch options dropdown.
+ *
+ * When a session has been played (lastPlayedAt != null), a dropdown chevron
+ * appears next to the play button. Clicking it reveals "Continue from Title
+ * Screen" which launches the session with skipAutoLoad=true.
+ *
+ * Covers:
+ * - Dropdown chevron appears on played sessions (lastPlayedAt set)
+ * - Dropdown chevron does NOT appear on unplayed sessions
+ * - Clicking the dropdown shows "Continue from Title Screen"
+ * - Primary play button still works (continues with save state)
+ * - "Continue from Title Screen" dispatches correct intent (skipAutoLoad=true, sessionId set)
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class SessionLaunchOptionsTest {
+
+    private fun createHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    private fun ComposeUiTest.scrollToSessions() {
+        onNodeWithTag("game_detail_content")
+            .performScrollToNode(hasTestTag("sessions_section"))
+    }
+
+    // ── Dropdown chevron appears on played sessions ──
+
+    @Test
+    fun dropdownChevronAppearsOnPlayedSession() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "My Run",
+            lastPlayedAt = "2024-01-15T10:30:00Z",
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+
+        // The "More play options" chevron should be visible
+        onNodeWithContentDescription("More play options").assertIsDisplayed()
+    }
+
+    // ── Dropdown chevron does NOT appear on unplayed sessions ──
+
+    @Test
+    fun dropdownChevronHiddenOnUnplayedSession() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Fresh Run",
+            // lastPlayedAt is null (default) — session has never been played
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+
+        // The "More play options" chevron should NOT exist
+        onNodeWithContentDescription("More play options").assertDoesNotExist()
+    }
+
+    // ── Mixed: only played session shows chevron ──
+
+    @Test
+    fun onlyPlayedSessionShowsChevron() = runComposeUiTest {
+        val harness = createHarness()
+        // Session that has been played
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "Played Run",
+            lastPlayedAt = "2024-01-10T08:00:00Z",
+        )
+        // Session that has NOT been played
+        harness.sessionRepo.preAddSession(
+            id = "s2",
+            gameId = "1",
+            name = "Unplayed Run",
+            // lastPlayedAt = null
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+        onNodeWithTag("session_item_s1").assertIsDisplayed()
+        onNodeWithTag("session_item_s2").assertIsDisplayed()
+
+        // Exactly one chevron should exist (for the played session)
+        onAllNodesWithContentDescription("More play options").assertCountEquals(1)
+    }
+
+    // ── Clicking the dropdown chevron shows "Continue from Title Screen" ──
+
+    @Test
+    fun dropdownShowsContinueFromTitleScreen() = runComposeUiTest {
+        val harness = createHarness()
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "My Run",
+            lastPlayedAt = "2024-01-15T10:30:00Z",
+        )
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+
+        // Click the dropdown chevron
+        onNodeWithContentDescription("More play options").performClick()
+        advanceQuick(harness)
+
+        // "Continue from Title Screen" menu item should appear
+        onNodeWithText("Continue from Title Screen").assertIsDisplayed()
+    }
+
+    // ── Primary play button continues with save state (default behavior) ──
+
+    @Test
+    fun primaryPlayButtonContinuesWithSaveState() = runComposeUiTest {
+        val harness = createHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "My Run",
+            lastPlayedAt = "2024-01-15T10:30:00Z",
+        )
+
+        var capturedLaunch: PendingLaunch? = null
+        harness.scope.launch {
+            harness.emulationViewModel.launchReady.collect { capturedLaunch = it }
+        }
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+
+        // Click the primary play button (not the chevron)
+        onNodeWithContentDescription("Continue session").performClick()
+        advance(harness)
+
+        // Should dispatch PrepareLaunch with skipAutoLoad=false and the correct sessionId
+        val launch = capturedLaunch
+        assertTrue(launch != null, "Expected a PendingLaunch to be emitted")
+        assertEquals("1", launch.gameId)
+        assertEquals("s1", launch.sessionId)
+        assertFalse(launch.skipAutoLoad, "skipAutoLoad should be false for normal continue")
+    }
+
+    // ── "Continue from Title Screen" dispatches skipAutoLoad=true with sessionId ──
+
+    @Test
+    fun continueFromTitleScreenDispatchesCorrectIntent() = runComposeUiTest {
+        val harness = createHarness()
+        harness.downloadRepo.preCacheGame("1")
+        harness.sessionRepo.preAddSession(
+            id = "s1",
+            gameId = "1",
+            name = "My Run",
+            lastPlayedAt = "2024-01-15T10:30:00Z",
+        )
+
+        var capturedLaunch: PendingLaunch? = null
+        harness.scope.launch {
+            harness.emulationViewModel.launchReady.collect { capturedLaunch = it }
+        }
+
+        setContent { harness.App() }
+        navigateToGameDetail(harness, "1")
+
+        scrollToSessions()
+
+        // Open the dropdown and click "Continue from Title Screen"
+        onNodeWithContentDescription("More play options").performClick()
+        advanceQuick(harness)
+        onNodeWithText("Continue from Title Screen").performClick()
+        advance(harness)
+
+        // Should dispatch PrepareLaunch with skipAutoLoad=true and the correct sessionId
+        val launch = capturedLaunch
+        assertTrue(launch != null, "Expected a PendingLaunch to be emitted")
+        assertEquals("1", launch.gameId)
+        assertEquals("s1", launch.sessionId)
+        assertTrue(launch.skipAutoLoad, "skipAutoLoad should be true for title screen continue")
+        assertFalse(launch.forceNewSession, "forceNewSession should be false")
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -973,6 +973,11 @@ fun SpelaApp(
                                             EmulationIntent.PrepareLaunch(gameId, sessionId = sessionId)
                                         )
                                     },
+                                    onPlaySessionFromTitleScreen = { gameId, sessionId ->
+                                        emulationViewModel.onIntent(
+                                            EmulationIntent.PrepareLaunch(gameId, skipAutoLoad = true, sessionId = sessionId)
+                                        )
+                                    },
                                     onCreateNetplay = { gameId ->
                                         netplayViewModel.onIntent(
                                             NetplayIntent.CreateSession(gameId)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowDropDown
 import androidx.compose.material.icons.filled.ContentCopy
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.Edit
@@ -20,6 +21,8 @@ import androidx.compose.material.icons.filled.People
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.outlined.Gamepad
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
@@ -55,6 +58,7 @@ internal fun SessionsSection(
     sessions: List<GameSession>,
     isLoading: Boolean,
     onContinueSession: (GameSession) -> Unit,
+    onContinueSessionFromTitleScreen: ((GameSession) -> Unit)? = null,
     onCreateSession: (String) -> Unit,
     onRenameSession: (String, String) -> Unit,
     onDeleteSession: (String) -> Unit,
@@ -98,6 +102,7 @@ internal fun SessionsSection(
                     }
                 },
                 onContinue = { onContinueSession(session) },
+                onContinueFromTitleScreen = onContinueSessionFromTitleScreen?.let { callback -> { callback(session) } },
                 onRename = { showRenameDialog = session },
                 onDelete = { showDeleteDialog = session },
                 onDuplicate = { onDuplicateSession(session.id) },
@@ -209,6 +214,7 @@ private fun SessionItem(
     isCurrent: Boolean,
     onClick: () -> Unit,
     onContinue: () -> Unit,
+    onContinueFromTitleScreen: (() -> Unit)?,
     onRename: () -> Unit,
     onDelete: () -> Unit,
     onDuplicate: () -> Unit,
@@ -314,12 +320,51 @@ private fun SessionItem(
                         tint = SpColor.OnBackgroundSecondary,
                     )
                 }
-                IconButton(onClick = onContinue) {
-                    Icon(
-                        Icons.Filled.PlayArrow,
-                        contentDescription = "Continue session",
-                        tint = SpColor.Accent,
-                    )
+                // Play button with optional dropdown for "Continue from Title Screen"
+                val showChevron = session.lastPlayedAt != null && onContinueFromTitleScreen != null
+                Box {
+                    var showPlayMenu by remember { mutableStateOf(false) }
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        IconButton(onClick = onContinue) {
+                            Icon(
+                                Icons.Filled.PlayArrow,
+                                contentDescription = "Continue session",
+                                tint = SpColor.Accent,
+                            )
+                        }
+                        if (showChevron) {
+                            IconButton(
+                                onClick = { showPlayMenu = true },
+                                modifier = Modifier.size(SpSpacing.IconLarge),
+                            ) {
+                                Icon(
+                                    Icons.Filled.ArrowDropDown,
+                                    contentDescription = "More play options",
+                                    tint = SpColor.Accent,
+                                    modifier = Modifier.size(SpSpacing.IconDefault),
+                                )
+                            }
+                        }
+                    }
+                    if (showChevron) {
+                        DropdownMenu(
+                            expanded = showPlayMenu,
+                            onDismissRequest = { showPlayMenu = false },
+                        ) {
+                            DropdownMenuItem(
+                                text = {
+                                    Text(
+                                        text = "Continue from Title Screen",
+                                        style = SpTypography.BodyMedium,
+                                    )
+                                },
+                                onClick = {
+                                    showPlayMenu = false
+                                    onContinueFromTitleScreen?.invoke()
+                                },
+                            )
+                        }
+                    }
                 }
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -130,6 +130,7 @@ fun GameDetailScreen(
     onPlayWithLocalSave: () -> Unit = {},
     onCancelLaunch: () -> Unit = {},
     onPlaySession: ((gameId: String, sessionId: String) -> Unit)? = null,
+    onPlaySessionFromTitleScreen: ((gameId: String, sessionId: String) -> Unit)? = null,
     onNavigateToSession: ((sessionId: String) -> Unit)? = null,
 ) {
     PlatformBackHandler { onBack() }
@@ -277,6 +278,9 @@ fun GameDetailScreen(
                         isLoading = state.isLoadingSessions,
                         onContinueSession = { session ->
                             onPlaySession?.invoke(game.id, session.id)
+                        },
+                        onContinueSessionFromTitleScreen = { session ->
+                            onPlaySessionFromTitleScreen?.invoke(game.id, session.id)
                         },
                         onCreateSession = { name ->
                             viewModel.onIntent(GameDetailIntent.CreateSession(game.id, name))


### PR DESCRIPTION
## Summary
- Add dropdown chevron next to the play button on each session row in the sessions list
- Clicking the chevron reveals "Continue from Title Screen" — reuses the session but skips save state loading
- Chevron only appears for sessions that have been played (have save states to skip)
- Uses nullable callback pattern for conditional rendering, matching the hero split button approach

## Context
Complements PR #305 which added "Continue from Title Screen" to the hero split button. This PR extends the same option to individual sessions in the sessions list (P1 Story 3 from the game launch options feature).

## Reviews
- Code review: approved — fixed hardcoded dp values to SpSpacing tokens, changed no-op lambda to nullable callback
- UX review: approved — chevron pattern is discoverable and consistent with established split-button conventions

## Test plan
- [x] 6 new desktop E2E tests in `SessionLaunchOptionsTest` — all passing
- [x] Existing `ResumeVsNewGameTest` (12 tests) — still passing
- [x] Existing `EmulationViewModelGameLifecycleTest` — still passing