### PR TITLE
fix: pause play time heartbeat when game is paused or device sleeps

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
@@ -34,6 +34,9 @@ class PresenceService(
     private var heartbeatJob: Job? = null
     private var currentGameId: String? = null
 
+    @Volatile
+    var paused: Boolean = false
+
     private val json = Json {
         ignoreUnknownKeys = true
         isLenient = true
@@ -92,6 +95,7 @@ class PresenceService(
      */
     fun startHeartbeat(gameId: String) {
         stopHeartbeat()
+        paused = false
         currentGameId = gameId
 
         // Send initial heartbeat immediately
@@ -106,6 +110,7 @@ class PresenceService(
         heartbeatJob = scope.launch(dispatchers.io) {
             while (isActive) {
                 delay(HEARTBEAT_INTERVAL_MS)
+                if (paused) continue // Don't report play time while paused/backgrounded
                 val gid = currentGameId ?: break
                 try {
                     val seconds = HEARTBEAT_INTERVAL_MS / 1000

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -580,11 +580,13 @@ class EmulationViewModel(
 
     private fun pauseGame() {
         libretroController.pause()
+        presenceService.paused = true
         _state.update { it.copy(isPaused = true) }
     }
 
     private fun resumeGame() {
         libretroController.resume()
+        presenceService.paused = false
         _state.update { it.copy(isPaused = false) }
     }
 
@@ -592,6 +594,7 @@ class EmulationViewModel(
         val current = _state.value
         if (current.isRunning && !current.isPaused) {
             libretroController.pause()
+            presenceService.paused = true
             _state.update { it.copy(isLifecyclePaused = true, isPaused = true) }
         }
     }
@@ -602,6 +605,7 @@ class EmulationViewModel(
             _state.update { it.copy(isLifecyclePaused = false) }
             // Only resume emulation if it wasn't user-paused before lifecycle pause
             libretroController.resume()
+            presenceService.paused = false
             _state.update { it.copy(isPaused = false) }
         }
     }


### PR DESCRIPTION
## Summary
- Add `paused` flag to `PresenceService` that the heartbeat loop checks before reporting play time
- Set flag from `pauseGame()`/`resumeGame()` (user-initiated) and `lifecyclePause()`/`lifecycleResume()` (Android lifecycle)
- Reset flag on `startHeartbeat()` so new games start clean

## Bug
The presence heartbeat ran on a fixed 30-second interval and always reported 30 seconds of play time, regardless of whether the game was paused or the device was asleep. Closing the AYN Thor clamshell (which triggers `onPause`) or pausing via the overlay would still accumulate phantom play time on the server.

## Test plan
- [x] All EmulationViewModel tests passing
- [x] Compilation verified
- [ ] Manual: pause game, verify no heartbeat requests in server logs; resume, verify heartbeats resume