### PR TITLE
fix: stabilize 3 failing E2E tests (retroachievements + netplay)

### DIFF
--- a/web/e2e/netplay-invite-flow.spec.ts
+++ b/web/e2e/netplay-invite-flow.spec.ts
@@ -20,15 +20,6 @@ async function apiLogin(
   return data.accessToken;
 }
 
-/** Trigger a library scan (admin-only, synchronous). */
-async function triggerScan(token: string): Promise<void> {
-  const res = await fetch(`${API}/admin/games/scan`, {
-    method: "POST",
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  if (!res.ok) throw new Error(`Scan failed: ${res.status}`);
-}
-
 /** Get the first game from a netplay-supported console. */
 async function getNetplayGame(
   token: string,
@@ -97,10 +88,7 @@ test.describe("Netplay invite flow (two browsers)", () => {
     // Get tokens
     adminToken = await apiLogin("admin", "admin123");
 
-    // Ensure games exist by triggering a scan
-    await triggerScan(adminToken);
-
-    // Find a netplay-supported game
+    // Games are already scanned by the E2E startup script — just find one
     const game = await getNetplayGame(adminToken);
     gameId = game.id;
   });
@@ -134,28 +122,25 @@ test.describe("Netplay invite flow (two browsers)", () => {
       // Click "Invite Player" button
       await adminPage.getByRole("button", { name: /invite player/i }).click();
 
-      // Type "player" in the search input (label is "Username")
-      const searchInput = adminPage.getByLabel(/username/i);
+      // Type "player" in the search input (aria-label is "Search users")
+      const searchInput = adminPage.getByLabel(/search users/i);
       await searchInput.fill("player");
 
-      // Wait for the debounced search dropdown and select "player"
-      // The dropdown items are plain <button> elements containing a <span> with username
-      const dropdown = adminPage.locator(".absolute.z-50");
-      await dropdown.waitFor({ timeout: 5_000 });
-      await dropdown.locator("button", { hasText: "player" }).first().click();
+      // Wait for search results to appear (debounced 300ms + API call)
+      // Then click the "Invite" button next to the "player" user row.
+      // Use the dialog scope to avoid matching the "Invite Player" button behind the modal.
+      const modal = adminPage.getByRole("dialog");
+      const inviteButton = modal.getByRole("button", { name: "Invite", exact: true });
+      await expect(inviteButton).toBeVisible({ timeout: 5_000 });
+      await inviteButton.click();
 
-      // Click "Send Invite"
-      await adminPage
-        .getByRole("button", { name: /send invite/i })
-        .click();
-
-      // Wait for success feedback — the modal shows invited user chip
+      // Wait for success feedback — the modal shows "Invited this session" chip
       await expect(
-        adminPage.getByText(/invited this session/i),
+        modal.getByText(/invited this session/i),
       ).toBeVisible({ timeout: 5_000 });
 
-      // Close the modal (use exact match to avoid matching "Close dialog" X button)
-      await adminPage
+      // Close the modal
+      await modal
         .getByRole("button", { name: "Close", exact: true })
         .click();
 

--- a/web/e2e/retroachievements.spec.ts
+++ b/web/e2e/retroachievements.spec.ts
@@ -492,11 +492,12 @@ test.describe("RetroAchievements - Game Detail", () => {
     // Mock social/ratings/shared-saves endpoints for the game detail page
     await setupGameDetailSocialRoutes(page, "1");
 
-    await page.goto("/games/1");
+    await page.goto("/games/1/achievements");
 
-    // Achievements section should be visible
+    // Achievements section should be visible (use exact match to avoid
+    // ambiguity with the page-level h1 "Super Mario Bros. — Achievements")
     await expect(
-      page.getByRole("heading", { name: "Achievements" }),
+      page.getByRole("heading", { name: "Achievements", exact: true }),
     ).toBeVisible({ timeout: 10_000 });
 
     // Browser warning banner
@@ -610,7 +611,7 @@ test.describe("RetroAchievements - Game Detail", () => {
     // Mock social/ratings/shared-saves endpoints for the game detail page
     await setupGameDetailSocialRoutes(page, "1");
 
-    await page.goto("/games/1");
+    await page.goto("/games/1/achievements");
 
     await expect(page.getByTestId("achievement-101")).toBeVisible({
       timeout: 10_000,


### PR DESCRIPTION
## Summary

- Fix 2 RetroAchievements E2E tests: navigate to `/games/1/achievements` sub-page (achievements were moved from the game detail page), use exact heading match
- Fix netplay invite flow E2E test: correct search input selector (`aria-label="Search users"`), scope button selectors to the dialog to avoid matching elements behind the modal, remove redundant game scan

## Root causes

| Test | Root cause | Fix |
|------|-----------|-----|
| RA: browser warning banner | Test navigated to `/games/1` but `GameAchievements` was moved to `/games/1/achievements` sub-page | Navigate to correct URL |
| RA: unlocked styling | Same URL issue + heading ambiguity (h1 and h2 both match "Achievements") | Navigate to sub-page + `exact: true` |
| Netplay invite flow | Search input selector used `/username/i` but actual `aria-label` is "Search users"; "Invite" button matched "Invite Player" behind modal | Fix selectors, scope to dialog |

## Test plan

- [x] All 12 retroachievements tests pass
- [x] Both netplay-invite-flow tests pass
- [x] Full E2E suite: 196 passed, 0 failed (was 193 passed, 3 failed)