### PR TITLE
feat: responsive side navigation rail for larger screens

### DIFF
--- a/docs/superpowers/specs/2026-03-26-responsive-navigation-design.md
+++ b/docs/superpowers/specs/2026-03-26-responsive-navigation-design.md
@@ -1,0 +1,105 @@
+# Responsive Navigation — Bottom Bar to Side Rail
+
+**Date:** 2026-03-26
+**Status:** Approved
+
+## Overview
+
+Make the app's tab navigation responsive: phones keep the bottom bar, larger screens get a side rail. Three tiers based on available width. Gamepad mode (L1/R1 section indicator) is completely unaffected.
+
+## Responsive Breakpoints
+
+| Width | Layout | Nav Style |
+|-------|--------|-----------|
+| < 600dp | Bottom bar | Current `SpBottomNavBar` (unchanged) |
+| 600–840dp | Icon-only side rail | ~72dp wide, icons vertically listed |
+| > 840dp | Labeled side rail | ~200dp wide, icon + label |
+
+Detection uses `BoxWithConstraints` checking `maxWidth`, following the existing pattern in `GameDetailLayout`.
+
+```kotlin
+enum class NavigationLayoutMode {
+    BOTTOM_BAR,      // < 600dp
+    ICON_RAIL,       // 600-840dp
+    LABELED_RAIL,    // > 840dp
+}
+```
+
+## Side Rail Layout
+
+- **Top-aligned:** First 5 items (Home, Explore, Consoles, Collections, Activity) at the top
+- **Settings at bottom:** Separated by a weighted spacer, anchored to the bottom of the rail
+- **Background:** `SurfaceVariant`, no border or shadow
+- **Selected item:** `Primary` color icon (+ text in labeled mode)
+- **Unselected item:** `OnBackgroundTertiary` dimmed
+- **Item height:** ~56dp (comfortable touch/click target)
+- **Icon-only width:** ~72dp
+- **Labeled width:** ~200dp
+
+## Integration into SpelaApp
+
+The layout in `SpelaApp.kt` changes from a vertical `Column` (content + bottom bar) to a conditional layout:
+
+```
+BoxWithConstraints {
+    Row {
+        // Side rail (if >= 600dp, touch mode, nav visible)
+        SpNavigationRail(...)
+
+        Column(weight 1f) {
+            content (weight 1f)
+            // Bottom bar (if < 600dp, touch mode, nav visible)
+            SpBottomNavBar(...)
+        }
+    }
+
+    // Gamepad section indicator overlay (unchanged)
+    SpSectionIndicator(...)
+}
+```
+
+## What Changes
+
+**New:**
+- `SpNavigationRail` composable — side rail with `showLabels: Boolean` parameter
+- `NavigationLayoutMode` enum — three layout tiers
+- Layout switch logic in `SpelaApp.kt` — `BoxWithConstraints` + `Row` wrapping
+
+**Unchanged:**
+- `SpBottomNavBar` — still used for phones, no modifications
+- `SpSectionIndicator` — still used for gamepad mode at all sizes, no modifications
+- `NavigationViewModel` — no changes to navigation state or intents
+- L1/R1 tab switching — completely unaffected
+- All screen composables — no changes needed
+- Tab visibility rules — same conditions (hidden on login/connection screens, hidden in gamepad mode)
+
+## New Composable: SpNavigationRail
+
+Takes the same core parameters as `SpBottomNavBar`:
+- `selectedTab: BottomNavTab`
+- `onTabClick: (BottomNavTab) -> Unit`
+
+Plus:
+- `showLabels: Boolean` — false for icon-only (600-840dp), true for labeled (>840dp)
+
+Renders a `Column` with the 6 `BottomNavTab` entries. Settings is separated from the first 5 by `Spacer(Modifier.weight(1f))`.
+
+## Testing
+
+Desktop E2E tests:
+- Rail renders with icons when container width > 600dp
+- Rail renders with labels when container width > 840dp
+- Bottom bar renders when container width < 600dp
+- Tab click on rail triggers navigation callback
+- Settings item is bottom-aligned (separated by spacer)
+- Rail hidden in gamepad mode (section indicator shown instead)
+- Rail hidden on login/connection screens
+
+No Android smoke tests needed — purely shared UI code.
+
+## Out of Scope
+
+- Collapsible/expandable rail (hover to expand)
+- Rail width configuration or user preference
+- Changes to gamepad mode or section indicator
+- Changes to screen composables or navigation logic

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -12,8 +12,11 @@ import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -56,7 +59,9 @@ import com.spela.player.presentation.navigation.NavigationViewModel
 import com.spela.player.presentation.navigation.SpScreen
 import com.spela.player.presentation.ui.components.BottomNavTab
 import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.NavigationLayoutMode
 import com.spela.player.presentation.ui.components.SpBottomNavBar
+import com.spela.player.presentation.ui.components.SpNavigationRail
 import com.spela.player.presentation.ui.components.SpAuthExpiredDialog
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpDatabaseErrorScreen
@@ -312,7 +317,38 @@ fun SpelaApp(
                     }
                 },
         ) {
-            Column(modifier = Modifier.fillMaxSize()) {
+            BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+            val navLayoutMode = when {
+                maxWidth > 840.dp -> NavigationLayoutMode.LABELED_RAIL
+                maxWidth > 600.dp -> NavigationLayoutMode.ICON_RAIL
+                else -> NavigationLayoutMode.BOTTOM_BAR
+            }
+            val showNavArea = !navState.showInGameOverlay && shouldShowBottomNav(navState.currentScreen)
+            val showSideRail = navLayoutMode != NavigationLayoutMode.BOTTOM_BAR && showNavArea && !isGamepadMode
+
+            Row(modifier = Modifier.fillMaxSize()) {
+            // Side navigation rail (larger screens, touch mode only)
+            if (showSideRail) {
+                SpNavigationRail(
+                    activeTab = activeTabForScreen(navState.currentScreen),
+                    onTabSelected = { tab ->
+                        val targetScreen = when (tab) {
+                            BottomNavTab.HOME -> SpScreen.Home
+                            BottomNavTab.EXPLORE -> SpScreen.Explore
+                            BottomNavTab.CONSOLES -> SpScreen.Consoles
+                            BottomNavTab.COLLECTIONS -> SpScreen.Collections
+                            BottomNavTab.ACTIVITY -> SpScreen.Activity
+                            BottomNavTab.SETTINGS -> SpScreen.Settings
+                        }
+                        navigationViewModel.onIntent(
+                            NavigationIntent.SwitchTab(targetScreen)
+                        )
+                    },
+                    showLabels = navLayoutMode == NavigationLayoutMode.LABELED_RAIL,
+                )
+            }
+
+            Column(modifier = Modifier.weight(1f).fillMaxHeight()) {
                 // Connection state
                 val currentConnectionState by connectivityMonitor.connectionState.collectAsState()
                 var serverWarningDismissed by remember { mutableStateOf(false) }
@@ -1567,9 +1603,8 @@ fun SpelaApp(
                     )
                 }
 
-                // Bottom navigation bar (hidden when in gamepad mode)
-                val showNavArea = !navState.showInGameOverlay && shouldShowBottomNav(navState.currentScreen)
-                if (showNavArea && !isGamepadMode) {
+                // Bottom navigation bar (phones only, hidden when in gamepad mode or side rail is showing)
+                if (navLayoutMode == NavigationLayoutMode.BOTTOM_BAR && showNavArea && !isGamepadMode) {
                     SpBottomNavBar(
                         activeTab = activeTabForScreen(navState.currentScreen),
                         onTabSelected = { tab ->
@@ -1588,10 +1623,10 @@ fun SpelaApp(
                     )
                 }
                 } // else (not DatabaseError)
-            }
+            } // Column (content + bottom bar)
+            } // Row (side rail + content column)
 
             // Section indicator overlay (shown when in gamepad mode)
-            val showNavArea = !navState.showInGameOverlay && shouldShowBottomNav(navState.currentScreen)
             if (showNavArea && isGamepadMode) {
                 Box(
                     modifier = Modifier.fillMaxSize(),
@@ -1604,11 +1639,12 @@ fun SpelaApp(
                     )
                 }
             }
-        }
-        }
+            } // BoxWithConstraints
+        } // Box
+        } // GamepadNavigation
     } // CompositionLocalProvider
-    }
-}
+    } // SpelaTheme
+} // SpelaApp
 
 private fun shouldShowBottomNav(screen: SpScreen): Boolean = when (screen) {
     is SpScreen.ServerConnection, is SpScreen.Login -> false

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt
@@ -1,0 +1,165 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Layout mode for the app's main navigation, determined by available width.
+ */
+enum class NavigationLayoutMode {
+    /** < 600dp — standard bottom tab bar (phones in portrait). */
+    BOTTOM_BAR,
+    /** 600–840dp — icon-only side rail (landscape phones, small tablets). */
+    ICON_RAIL,
+    /** > 840dp — icon + label side rail (tablets, desktop). */
+    LABELED_RAIL,
+}
+
+/**
+ * Side navigation rail for larger screens.
+ *
+ * Renders the same tabs as [SpBottomNavBar] in a vertical column.
+ * Settings is pushed to the bottom, separated from the other tabs
+ * by a weighted spacer.
+ *
+ * @param showLabels When true, shows icon + label (~200dp wide).
+ *   When false, shows icon only (~72dp wide).
+ */
+@Composable
+fun SpNavigationRail(
+    activeTab: BottomNavTab,
+    onTabSelected: (BottomNavTab) -> Unit,
+    showLabels: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val railWidth = if (showLabels) 200.dp else 72.dp
+
+    Column(
+        modifier = modifier
+            .width(railWidth)
+            .fillMaxHeight()
+            .background(SpColor.SurfaceVariant)
+            .padding(vertical = SpSpacing.Medium),
+        horizontalAlignment = if (showLabels) Alignment.Start else Alignment.CenterHorizontally,
+    ) {
+        // Main tabs (everything except Settings)
+        BottomNavTab.entries.filter { it != BottomNavTab.SETTINGS }.forEach { tab ->
+            RailItem(
+                tab = tab,
+                isSelected = tab == activeTab,
+                showLabel = showLabels,
+                onClick = { onTabSelected(tab) },
+            )
+        }
+
+        // Push Settings to the bottom
+        Spacer(Modifier.weight(1f))
+
+        // Settings tab
+        RailItem(
+            tab = BottomNavTab.SETTINGS,
+            isSelected = BottomNavTab.SETTINGS == activeTab,
+            showLabel = showLabels,
+            onClick = { onTabSelected(BottomNavTab.SETTINGS) },
+        )
+    }
+}
+
+@Composable
+private fun RailItem(
+    tab: BottomNavTab,
+    isSelected: Boolean,
+    showLabel: Boolean,
+    onClick: () -> Unit,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+    val color = when {
+        isSelected -> SpColor.PrimaryLight
+        isFocused -> SpColor.PrimaryLight.copy(alpha = 0.7f)
+        else -> SpColor.OnBackgroundSecondary
+    }
+
+    Box(
+        modifier = Modifier
+            .then(
+                if (showLabel) Modifier.padding(horizontal = SpSpacing.Small) else Modifier
+            )
+            .height(56.dp)
+            .then(
+                if (showLabel) Modifier.width(184.dp) else Modifier.width(56.dp)
+            )
+            .clip(RoundedCornerShape(8.dp))
+            .background(
+                if (isFocused) SpColor.Primary.copy(alpha = 0.1f) else Color.Transparent,
+            )
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+            ) { onClick() }
+            .focusable(interactionSource = interactionSource)
+            .semantics {
+                contentDescription = tab.label
+                role = Role.Tab
+            },
+        contentAlignment = if (showLabel) Alignment.CenterStart else Alignment.Center,
+    ) {
+        if (showLabel) {
+            Row(
+                verticalAlignment = Alignment.CenterVertically,
+                modifier = Modifier.padding(horizontal = SpSpacing.Medium),
+            ) {
+                Icon(
+                    imageVector = tab.icon,
+                    contentDescription = null,
+                    tint = color,
+                    modifier = Modifier.size(24.dp),
+                )
+                Spacer(Modifier.width(SpSpacing.Medium))
+                Text(
+                    text = tab.label,
+                    style = SpTypography.LabelMedium,
+                    color = color,
+                )
+            }
+        } else {
+            Icon(
+                imageVector = tab.icon,
+                contentDescription = null,
+                tint = color,
+                modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds responsive navigation: phones keep bottom bar, larger screens get a side rail
- Three width breakpoints: <600dp bottom bar, 600-840dp icon-only rail, >840dp icon+label rail
- Settings tab pushed to bottom of rail, separated from content tabs
- Gamepad mode (L1/R1 section indicator) completely unaffected

## Test plan
- [x] Compilation clean
- [x] All 420 shared unit tests pass
- [x] SectionIndicatorTest and SectionNavigationTest pass (gamepad mode unaffected)
- [x] InputModeTest passes (touch/gamepad switching unaffected)
- [ ] Manual test on desktop (1280x720): verify labeled rail shows
- [ ] Manual test on AYN Thor (1920x1080 landscape): verify icon-only rail shows
- [ ] Manual test on phone: verify bottom bar still shows
- [ ] Verify tab switching works via rail clicks
- [ ] Verify gamepad L1/R1 still cycles tabs with pill indicator