### PR TITLE
fix: prevent secondary display from stealing gamepad input focus

### DIFF
--- a/player/shared/src/androidMain/kotlin/com/spela/player/platform/secondarydisplay/SecondaryDisplayPresentation.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/platform/secondarydisplay/SecondaryDisplayPresentation.kt
@@ -47,15 +47,16 @@ class SecondaryDisplayPresentation(
         window?.apply {
             // Keep secondary screen on while presentation is visible
             addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON)
-            // Ensure window is focusable so it receives touch input on secondary displays
-            clearFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
+            // Keep window non-focusable so gamepad/key events always route to the
+            // Activity (and thus to the emulation thread). Touch events still work
+            // with FLAG_NOT_FOCUSABLE — only key event focus is affected.
+            addFlags(WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE)
             clearFlags(WindowManager.LayoutParams.FLAG_NOT_TOUCHABLE)
         }
 
         val composeView = ComposeView(context).apply {
             setViewTreeLifecycleOwner(this@SecondaryDisplayPresentation)
             setViewTreeSavedStateRegistryOwner(this@SecondaryDisplayPresentation)
-            isFocusableInTouchMode = true
             setContent {
                 SpelaTheme {
                     content()


### PR DESCRIPTION
## Summary
- Fixes long-standing bug where touching the secondary screen caused gamepad input to stop reaching the game
- Root cause: `clearFlags(FLAG_NOT_FOCUSABLE)` allowed the secondary display window to steal key event focus
- Fix: keep `FLAG_NOT_FOCUSABLE` set — touch events still work, only key focus routing is affected

## Test plan
- [x] Verified on AYN Thor: gamepad input continues working after touching secondary screen
- [x] Touch input on secondary screen companion still works (swipe pages, tap buttons)