### PR TITLE
fix: prevent resume button compression on game detail screen

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSplitButton.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSplitButton.kt
@@ -66,8 +66,7 @@ fun SpSplitButton(
 
     Row(
         modifier = modifier
-            .heightIn(min = 48.dp)
-            .height(IntrinsicSize.Min),
+            .heightIn(min = 48.dp),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SpButton(


### PR DESCRIPTION
## Summary
- Fixes sporadic bug where the resume/play button appeared compressed on the game detail screen
- Root cause: `SpSplitButton` used `.height(IntrinsicSize.Min)` which could override `.heightIn(min = 48.dp)`
- Fix: remove `IntrinsicSize.Min`, let children's `heightIn` constraints control minimum height

## Test plan
- [x] Compilation clean
- [ ] Verify resume button renders at proper height on DS game detail (AYN Thor landscape)