### PR TITLE
fix: clean up orphaned images on re-scrape, fix fallback mode propagation

### DIFF
--- a/server/internal/scraper/scraper_batch.go
+++ b/server/internal/scraper/scraper_batch.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"net/http"
 	"strconv"
+	"strings"
 
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/scanner"
@@ -278,7 +279,10 @@ func (s *Scraper) ScrapeAll(ctx context.Context, mode string, consoleID uint, on
 		// Smart scraping: if this game belongs to a variant group, try to
 		// propagate metadata from an already-scraped sibling instead of
 		// hitting external APIs again.
-		if game.GroupKey != "" && mode != "all" {
+		// Skip propagation in "all" mode (re-scrape everything) and "fallback"
+		// mode (retry IGDB for games that only had LibRetro matches — propagating
+		// from other LibRetro siblings would defeat the purpose).
+		if game.GroupKey != "" && mode == "new" {
 			groupID := fmt.Sprintf("%d:%s", game.ConsoleID, game.GroupKey)
 
 			// Check if we've already scraped a game in this group during this run
@@ -413,16 +417,24 @@ func (s *Scraper) propagateGroupMetadata(game *db.Game) bool {
 }
 
 // propagateToGroup copies metadata from a freshly scraped game to all unscraped
-// siblings in the same variant group.
+// siblings in the same variant group. Also upgrades LibRetro-only siblings when
+// the source has IGDB metadata (so fallback re-scrapes benefit the whole group).
 func (s *Scraper) propagateToGroup(source *db.Game) {
 	if source.GroupKey == "" {
 		return
 	}
 
 	var siblings []db.Game
-	s.DB.Where("console_id = ? AND group_key = ? AND id != ? AND (scraper_id = '' OR scraper_id IS NULL)",
-		source.ConsoleID, source.GroupKey, source.ID).
-		Find(&siblings)
+	q := s.DB.Where("console_id = ? AND group_key = ? AND id != ?",
+		source.ConsoleID, source.GroupKey, source.ID)
+
+	// If the source has IGDB metadata, also upgrade LibRetro-only siblings
+	if strings.HasPrefix(source.ScraperID, "igdb:") {
+		q = q.Where("scraper_id = '' OR scraper_id IS NULL OR scraper_id = 'libretro'")
+	} else {
+		q = q.Where("scraper_id = '' OR scraper_id IS NULL")
+	}
+	q.Find(&siblings)
 
 	for i := range siblings {
 		s.propagateGroupMetadata(&siblings[i])

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -172,6 +172,10 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 		return fmt.Errorf("saving scraped metadata: %w", err)
 	}
 
+	// Clean up orphaned image files from previous scrapes.
+	// Only runs after a successful save, so cancelled scrapes keep old files.
+	s.cleanGameImages(game, console.Abbreviation, gameIDStr)
+
 	slog.Info("scraped metadata", "game", game.Title, "scraperId", game.ScraperID, "rating", game.Rating)
 	return nil
 }
@@ -608,8 +612,48 @@ func (s *Scraper) ScrapeGameWithIGDBMatch(game *db.Game, igdbID int) error {
 	// Enrichment: fetch themes, keywords, perspectives, franchises, artworks
 	s.enrichGameMetadata(game, igdbID)
 
+	// Clean up orphaned image files from previous scrapes
+	s.cleanGameImages(game, console.Abbreviation, gameIDStr)
+
 	slog.Info("re-scraped with manual IGDB match", "game", game.Title, "igdbId", igdbID, "scraperId", game.ScraperID)
 	return nil
+}
+
+// cleanGameImages removes orphaned image files from a game's image directory.
+// It collects all currently-referenced image paths from the game's DB fields
+// and screenshots/artwork, then deletes any other files in the directory.
+func (s *Scraper) cleanGameImages(game *db.Game, consoleAbbr, gameIDStr string) {
+	var keep []string
+	for _, path := range []string{
+		game.CoverURL, game.IGDBCoverURL, game.LibRetroCoverURL, game.ScreenshotURL,
+	} {
+		if path != "" {
+			keep = append(keep, path)
+		}
+	}
+
+	// Collect screenshot paths from DB
+	var screenshots []db.GameScreenshot
+	s.DB.Where("game_id = ?", game.ID).Find(&screenshots)
+	for _, ss := range screenshots {
+		if ss.URL != "" {
+			keep = append(keep, ss.URL)
+		}
+	}
+
+	// Collect artwork paths from DB
+	var artwork db.GameArtwork
+	if err := s.DB.Where("game_id = ?", game.ID).First(&artwork).Error; err == nil {
+		for _, path := range []string{artwork.HeroURL, artwork.GridURL, artwork.LogoURL, artwork.IconURL} {
+			if path != "" {
+				keep = append(keep, path)
+			}
+		}
+	}
+
+	if err := s.Storage.CleanGameImageDir(consoleAbbr, gameIDStr, keep); err != nil {
+		slog.Warn("failed to clean game image dir", "game", game.Title, "error", err)
+	}
 }
 
 // earliestPlatformReleaseDate returns the earliest release date (unix timestamp)

--- a/server/internal/storage/storage.go
+++ b/server/internal/storage/storage.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -77,6 +78,58 @@ func (s *Storage) WriteImage(subpath string, data io.Reader) (string, error) {
 // ImagePath returns the full filesystem path for a stored image subpath.
 func (s *Storage) ImagePath(subpath string) string {
 	return filepath.Join(s.ImageDir, subpath)
+}
+
+// CleanGameImageDir removes image files in {ImageDir}/{consoleAbbr}/{gameID}/
+// that are NOT in the keepPaths set. keepPaths should contain relative subpaths
+// (e.g. "NES/42/boxart-libretro.png"). Files matching a keep path are preserved;
+// everything else in the directory is deleted. This is safe to call after a
+// successful scrape to remove orphaned images from a previous scrape.
+func (s *Storage) CleanGameImageDir(consoleAbbr, gameIDStr string, keepPaths []string) error {
+	dir := filepath.Join(s.ImageDir, consoleAbbr, gameIDStr)
+
+	// Verify the directory is inside the image directory (defense-in-depth)
+	absDir, err := filepath.Abs(dir)
+	if err != nil {
+		return fmt.Errorf("resolving game image dir: %w", err)
+	}
+	absImageDir, err := filepath.Abs(s.ImageDir)
+	if err != nil {
+		return fmt.Errorf("resolving image dir: %w", err)
+	}
+	if !strings.HasPrefix(absDir, absImageDir+string(filepath.Separator)) {
+		return fmt.Errorf("game image dir outside image directory")
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // nothing to clean
+		}
+		return fmt.Errorf("reading game image dir: %w", err)
+	}
+
+	// Build a set of filenames to keep
+	keep := make(map[string]bool, len(keepPaths))
+	for _, p := range keepPaths {
+		keep[filepath.Base(p)] = true
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !keep[entry.Name()] {
+			path := filepath.Join(dir, entry.Name())
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+				slog.Warn("failed to remove orphaned image", "path", path, "error", err)
+			} else {
+				slog.Debug("removed orphaned image", "path", path)
+			}
+		}
+	}
+
+	return nil
 }
 
 // BiosFilePath returns the filesystem path for a BIOS file, using sanitizeFilename

--- a/server/internal/storage/storage_test.go
+++ b/server/internal/storage/storage_test.go
@@ -154,3 +154,55 @@ func TestValidateROMPath(t *testing.T) {
 		})
 	}
 }
+
+func TestCleanGameImageDir(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStorage(filepath.Join(dir, "saves"), filepath.Join(dir, "cores"), filepath.Join(dir, "images"), filepath.Join(dir, "bios"))
+	require.NoError(t, err)
+
+	// Create a game image directory with several files
+	gameDir := filepath.Join(store.ImageDir, "NES", "42")
+	require.NoError(t, os.MkdirAll(gameDir, 0755))
+
+	kept := filepath.Join(gameDir, "boxart-libretro.png")
+	orphaned1 := filepath.Join(gameDir, "screenshot_3.jpg")
+	orphaned2 := filepath.Join(gameDir, "boxart-igdb.jpg")
+
+	for _, f := range []string{kept, orphaned1, orphaned2} {
+		require.NoError(t, os.WriteFile(f, []byte("img"), 0644))
+	}
+
+	// Clean, keeping only the libretro cover
+	err = store.CleanGameImageDir("NES", "42", []string{"NES/42/boxart-libretro.png"})
+	require.NoError(t, err)
+
+	assert.FileExists(t, kept)
+	assert.NoFileExists(t, orphaned1)
+	assert.NoFileExists(t, orphaned2)
+}
+
+func TestCleanGameImageDir_NonExistentDir(t *testing.T) {
+	dir := t.TempDir()
+	store := &Storage{ImageDir: filepath.Join(dir, "images")}
+	require.NoError(t, os.MkdirAll(store.ImageDir, 0755))
+
+	// Should not error when the game directory doesn't exist
+	err := store.CleanGameImageDir("NES", "999", nil)
+	assert.NoError(t, err)
+}
+
+func TestCleanGameImageDir_EmptyKeepDeletesAll(t *testing.T) {
+	dir := t.TempDir()
+	store, err := NewStorage(filepath.Join(dir, "saves"), filepath.Join(dir, "cores"), filepath.Join(dir, "images"), filepath.Join(dir, "bios"))
+	require.NoError(t, err)
+
+	gameDir := filepath.Join(store.ImageDir, "SNES", "7")
+	require.NoError(t, os.MkdirAll(gameDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(gameDir, "old.jpg"), []byte("x"), 0644))
+
+	err = store.CleanGameImageDir("SNES", "7", nil)
+	require.NoError(t, err)
+
+	entries, _ := os.ReadDir(gameDir)
+	assert.Empty(t, entries)
+}


### PR DESCRIPTION
## Summary

- Add `Storage.CleanGameImageDir()` — after a successful re-scrape, removes image files no longer referenced in the DB (orphaned screenshots, old covers). Cancelled scrapes preserve existing files.
- Fix fallback mode variant propagation — games with `scraper_id='libretro'` were propagating LibRetro metadata from each other instead of retrying IGDB. Now fallback mode skips propagation so each game gets a real IGDB lookup.
- After a successful IGDB scrape, `propagateToGroup` now also upgrades LibRetro-only siblings.

## Test plan

- [x] New unit tests for `CleanGameImageDir` (3 cases: keep+delete, nonexistent dir, empty keep list)
- [x] Full Go test suite passes (storage, scraper, api, scanner, etc.)