### PR TITLE
fix: remove duplicate spinner during game download

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -1067,11 +1067,15 @@ private fun GameHeroContent(
                     verticalAlignment = Alignment.CenterVertically,
                     horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
                 ) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(14.dp),
-                        strokeWidth = 2.dp,
-                        color = Color.White.copy(alpha = 0.65f),
-                    )
+                    // Show spinner for non-download statuses (scraping, sync).
+                    // Downloads already have a spinner in the button.
+                    if (!state.isDownloading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(14.dp),
+                            strokeWidth = 2.dp,
+                            color = Color.White.copy(alpha = 0.65f),
+                        )
+                    }
                     Text(
                         text = statusText,
                         style = SpTypography.LabelSmall,


### PR DESCRIPTION
## Summary
- Removes the extra CircularProgressIndicator from the download status row below the button
- The SpSplitButton already shows a spinner via `isLoading = true` — the status row now shows only the text

## Test plan
- [ ] Download a game, verify single spinner on the button + status text below (no second spinner)