### PR TITLE
feat: add ScummVM support

### DIFF
--- a/docs/superpowers/plans/2026-03-27-scummvm-support.md
+++ b/docs/superpowers/plans/2026-03-27-scummvm-support.md
@@ -1,0 +1,429 @@
+# ScummVM Support Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add ScummVM as a playable platform — console/core seed, scanner for `.scummvm` files, directory-based game serving, and trackpad default on the player.
+
+**Architecture:** Server-side: add seed data + extend scanner to detect `.scummvm` files recursively. Extend download handler to serve ScummVM game directories as tar. Player-side: default to trackpad tab and RETRO_DEVICE_MOUSE for ScummVM games.
+
+**Tech Stack:** Go (server), Kotlin Multiplatform (player), SQLite, libretro
+
+---
+
+### Task 1: Seed ScummVM console and core
+
+**Files:**
+- Modify: `server/internal/db/database.go`
+
+- [ ] **Step 1: Add ScummVM to console seed list**
+
+Add after the Arcade entry (line 838, before the closing `}`):
+
+```go
+		// ScummVM (generation = 100, alongside home computers)
+		{Name: "ScummVM", Abbreviation: "SCUMMVM", Extensions: ".scummvm", DefaultCore: "scummvm", EmulatorJSCore: "", FolderName: "scummvm", ColorTheme: "#6b8e23", CoverAspect: "5:7", Generation: 100, SaveStateSupport: false, Playable: true},
+```
+
+- [ ] **Step 2: Add ScummVM to core seed list**
+
+Add after the azahar entry (line 950, before the closing `}`):
+
+```go
+		{Name: "scummvm", DisplayName: "ScummVM", Description: "Point-and-click adventure game engine", Platforms: "windows,linux,macos,android"},
+```
+
+- [ ] **Step 3: Add scummvm to directory console map in scanner**
+
+In `server/internal/scanner/scanner.go`, add to `directoryConsoleMap`:
+
+```go
+	"scummvm":      "SCUMMVM",
+```
+
+- [ ] **Step 4: Add .scummvm to extension map in scanner**
+
+In `server/internal/scanner/scanner.go`, add to `ConsoleExtMap`:
+
+```go
+	".scummvm": "SCUMMVM",
+```
+
+- [ ] **Step 5: Run existing tests to verify no regressions**
+
+Run: `cd server && go test ./internal/db/... ./internal/scanner/... -v`
+Expected: All existing tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/internal/db/database.go server/internal/scanner/scanner.go
+git commit -m "feat: seed ScummVM console and core, add scanner mappings"
+```
+
+---
+
+### Task 2: Scanner — detect ScummVM game directories
+
+**Files:**
+- Modify: `server/internal/scanner/scanner.go`
+- Test: `server/internal/scanner/scanner_test.go`
+
+- [ ] **Step 1: Write failing test for ScummVM directory detection**
+
+Add to `server/internal/scanner/scanner_test.go`:
+
+```go
+func TestScan_DetectsScummVMGames(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	// Flat layout: scummvm/monkey1/monkey1.scummvm
+	scummDir := filepath.Join(dir, "scummvm", "monkey1")
+	require.NoError(t, os.MkdirAll(scummDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(scummDir, "monkey1.scummvm"), []byte("monkey\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(scummDir, "MONKEY.000"), []byte("data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(scummDir, "MONKEY.001"), []byte("data"), 0644))
+
+	s := NewScanner(database, []string{dir})
+	result, err := s.Scan(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.NewGames)
+
+	var game db.Game
+	err = database.Preload("Console").First(&game).Error
+	require.NoError(t, err)
+	assert.Equal(t, "SCUMMVM", game.Console.Abbreviation)
+	assert.Equal(t, "monkey1.scummvm", game.FileName)
+	assert.Contains(t, game.FilePath, "scummvm")
+	assert.Contains(t, game.FilePath, "monkey1")
+}
+
+func TestScan_DetectsNestedScummVMGames(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	// Nested layout: scummvm/Beneath a Steel Sky/sky/sky.scummvm
+	scummDir := filepath.Join(dir, "scummvm", "Beneath a Steel Sky", "sky")
+	require.NoError(t, os.MkdirAll(scummDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(scummDir, "sky.scummvm"), []byte("sky\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(scummDir, "SKY.DNR"), []byte("data"), 0644))
+
+	s := NewScanner(database, []string{dir})
+	result, err := s.Scan(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.NewGames)
+
+	var game db.Game
+	err = database.Preload("Console").First(&game).Error
+	require.NoError(t, err)
+	assert.Equal(t, "SCUMMVM", game.Console.Abbreviation)
+	assert.Equal(t, "sky.scummvm", game.FileName)
+}
+
+func TestScan_MultipleScummVMGames(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	// Two games
+	game1Dir := filepath.Join(dir, "scummvm", "monkey1")
+	require.NoError(t, os.MkdirAll(game1Dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(game1Dir, "monkey1.scummvm"), []byte("monkey\n"), 0644))
+
+	game2Dir := filepath.Join(dir, "scummvm", "tentacle")
+	require.NoError(t, os.MkdirAll(game2Dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(game2Dir, "tentacle.scummvm"), []byte("tentacle\n"), 0644))
+
+	s := NewScanner(database, []string{dir})
+	result, err := s.Scan(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.NewGames)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && go test ./internal/scanner/... -run TestScan_DetectsScummVM -v`
+Expected: FAIL — scanner doesn't detect `.scummvm` files in subdirectories.
+
+- [ ] **Step 3: Implement ScummVM directory scanning**
+
+The scanner's main scan loop processes individual files. ScummVM needs a pre-pass that walks the `scummvm/` folder recursively looking for `.scummvm` files. Add this to the `Scan` method in `server/internal/scanner/scanner.go`, after the existing multi-disc discovery pass but before the individual file pass.
+
+Add a new method to the Scanner:
+
+```go
+// scanScummVMGames walks the scummvm/ directory in each game dir, looking for
+// .scummvm files. Each .scummvm file marks its parent directory as a game.
+func (s *Scanner) scanScummVMGames(result *ScanResult, onProgress ProgressFunc) error {
+	var scummConsole db.Console
+	if err := s.db.Where("abbreviation = ?", "SCUMMVM").First(&scummConsole).Error; err != nil {
+		// ScummVM console not seeded — skip silently
+		return nil
+	}
+
+	for _, gameDir := range s.gameDirs {
+		scummRoot := filepath.Join(gameDir, "scummvm")
+		if _, err := os.Stat(scummRoot); os.IsNotExist(err) {
+			continue
+		}
+
+		err := filepath.WalkDir(scummRoot, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil // skip unreadable entries
+			}
+			if d.IsDir() {
+				return nil
+			}
+			if strings.ToLower(filepath.Ext(path)) != ".scummvm" {
+				return nil
+			}
+
+			// The game directory is the parent of the .scummvm file
+			gameDataDir := filepath.Dir(path)
+			relPath := storage.RelativeGamePath(gameDataDir, s.gameDirs)
+			fileName := filepath.Base(path)
+
+			// Check if game already exists
+			var existing db.Game
+			if err := s.db.Where("file_path = ?", relPath).First(&existing).Error; err == nil {
+				return nil // already scanned
+			}
+
+			// Derive title from directory name
+			title := humanizeTitle(filepath.Base(gameDataDir))
+
+			game := db.Game{
+				ConsoleID: scummConsole.ID,
+				Title:     title,
+				FileName:  fileName,
+				FilePath:  relPath,
+			}
+
+			// Calculate total directory size
+			var totalSize int64
+			filepath.WalkDir(gameDataDir, func(p string, d fs.DirEntry, err error) error {
+				if err != nil || d.IsDir() {
+					return nil
+				}
+				info, err := d.Info()
+				if err == nil {
+					totalSize += info.Size()
+				}
+				return nil
+			})
+			game.FileSize = totalSize
+
+			if err := s.db.Create(&game).Error; err != nil {
+				slog.Warn("failed to create ScummVM game", "path", relPath, "error", err)
+				return nil
+			}
+
+			result.NewGames++
+			if onProgress != nil {
+				onProgress(fmt.Sprintf("Found ScummVM game: %s", title))
+			}
+			return nil
+		})
+		if err != nil {
+			slog.Warn("error walking scummvm directory", "dir", scummRoot, "error", err)
+		}
+	}
+	return nil
+}
+```
+
+Then call it from the `Scan` method, right before the existing individual-file scan pass:
+
+```go
+	// ScummVM directory scan (before individual file processing)
+	if err := s.scanScummVMGames(result, onProgress); err != nil {
+		slog.Warn("ScummVM scan error", "error", err)
+	}
+```
+
+Note: `humanizeTitle` should already exist in the scanner (converts filenames to readable titles). If not, add:
+
+```go
+func humanizeTitle(name string) string {
+	// Replace underscores and hyphens with spaces, capitalize first letter of each word
+	name = strings.ReplaceAll(name, "_", " ")
+	name = strings.ReplaceAll(name, "-", " ")
+	return strings.TrimSpace(name)
+}
+```
+
+Also add `"io/fs"` to the imports if not already present.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && go test ./internal/scanner/... -run TestScan_DetectsScummVM -v`
+Expected: All 3 tests PASS.
+
+- [ ] **Step 5: Run full scanner test suite**
+
+Run: `cd server && go test ./internal/scanner/... -v`
+Expected: All tests pass (no regressions).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/internal/scanner/scanner.go server/internal/scanner/scanner_test.go
+git commit -m "feat: scanner detects ScummVM games by .scummvm file recursively"
+```
+
+---
+
+### Task 3: Game download — serve ScummVM directories as tar
+
+**Files:**
+- Modify: `server/internal/api/game_handler.go`
+- Test: `server/internal/api/game_handler_test.go` (if exists, or verify manually)
+
+- [ ] **Step 1: Add ScummVM directory tar serving**
+
+In `server/internal/api/game_handler.go`, in the `DownloadGame` function, add a check for `.scummvm` files before the existing `.cue`/`.gdi` check (before line 420):
+
+```go
+	// For .scummvm files, serve the entire game directory as a tar archive.
+	// The .scummvm file lives inside a directory of game data files.
+	if strings.HasSuffix(lower, ".scummvm") {
+		gameDataDir := filepath.Dir(absPath)
+		var files []string
+		filepath.WalkDir(gameDataDir, func(p string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			files = append(files, p)
+			return nil
+		})
+
+		if len(files) > 0 {
+			c.Header("Content-Type", "application/x-tar")
+			c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", game.FileName+".tar"))
+			c.Status(http.StatusOK)
+			if err := serveTar(c.Writer, files); err != nil {
+				slog.Warn("error streaming tar for ScummVM game", "game", game.Title, "error", err)
+			}
+			return
+		}
+	}
+```
+
+Add `"io/fs"` to the imports if not already present.
+
+- [ ] **Step 2: Verify existing tests pass**
+
+Run: `cd server && go test ./internal/api/... -v`
+Expected: All existing tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/internal/api/game_handler.go
+git commit -m "feat: serve ScummVM game directories as tar archives"
+```
+
+---
+
+### Task 4: Player — default trackpad for ScummVM
+
+**Files:**
+- Modify: `player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt`
+
+- [ ] **Step 1: Update getControlTab to default to trackpad for ScummVM**
+
+Change the fallback in `getControlTab` (line 207):
+
+```kotlin
+override fun getControlTab(consoleId: String): String {
+    return database.spelaDatabaseQueries.getDeviceSetting("control_tab:$consoleId")
+        .executeAsOneOrNull()
+        ?: if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
+}
+```
+
+- [ ] **Step 2: Update FakePreferencesRepository in TestFakes.kt**
+
+Update the fake to match the new default:
+
+```kotlin
+override fun getControlTab(consoleId: String): String =
+    controlTabs[consoleId]
+        ?: if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
+```
+
+Also update all other FakePreferencesRepository implementations (in `KeyMappingViewModelTest.kt`, `SyncEngineTest.kt`, `NavigationViewModelTest.kt`, `EmulationTestStubs.kt`) with the same pattern.
+
+- [ ] **Step 3: Compile check**
+
+Run: `cd player && ./gradlew :shared:compileKotlinDesktop`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt \
+       player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt \
+       player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt \
+       player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt \
+       player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt \
+       player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+git commit -m "feat: default to trackpad tab for ScummVM games"
+```
+
+---
+
+### Task 5: Player — set RETRO_DEVICE_MOUSE for ScummVM
+
+**Files:**
+- Modify: `player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt`
+
+- [ ] **Step 1: Set mouse device for ScummVM after core load**
+
+In `EmulationViewModel.kt`, after the dual-screen detection block (around line 395), add:
+
+```kotlin
+            // ScummVM: set port 0 to RETRO_DEVICE_MOUSE for point-and-click input
+            if (lc == "scummvm") {
+                libretroController.setControllerPortDevice(0, 2) // RETRO_DEVICE_MOUSE = 2
+            }
+```
+
+The variable `lc` is already defined as `consoleId.lowercase()` on line 372.
+
+- [ ] **Step 2: Compile check**
+
+Run: `cd player && ./gradlew :shared:compileKotlinDesktop`
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd player && ./run-desktop-tests.sh`
+Expected: All shared unit tests pass (420/420), no new failures in E2E.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+git commit -m "feat: set RETRO_DEVICE_MOUSE for ScummVM games on launch"
+```
+
+---
+
+### Task 6: Server — full test suite verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run full Go test suite**
+
+Run: `cd server && go test ./... -v`
+Expected: All tests pass.
+
+- [ ] **Step 2: Run full player test suite**
+
+Run: `cd player && ./run-desktop-tests.sh`
+Expected: All shared unit tests pass. No new E2E failures.
+
+- [ ] **Step 3: Final commit (if any fixes needed)**
+
+Only if adjustments were needed during verification.

--- a/docs/superpowers/specs/2026-03-27-scummvm-support-design.md
+++ b/docs/superpowers/specs/2026-03-27-scummvm-support-design.md
@@ -1,0 +1,87 @@
+# ScummVM Support
+
+**Date:** 2026-03-27
+**Status:** Approved
+
+## Overview
+
+Add ScummVM as a playable platform in Spela. ScummVM games are directory-based (not single ROM files), but the app's existing multi-file game support (used for multi-disc games) handles most of this already. The main work is adding the console/core seed data, extending the scanner to detect `.scummvm` files, and wiring up the correct input defaults.
+
+## Console & Core Definition
+
+**New console seed:**
+- Name: `ScummVM`
+- Abbreviation: `SCUMMVM`
+- FolderName: `scummvm`
+- DefaultCore: `scummvm`
+- Extensions: `.scummvm`
+- SaveStateSupport: `false` (ScummVM has its own in-game save system)
+- Generation: 100 (grouped with home computers)
+- Playable: `true`
+
+**New core seed:**
+- Name: `scummvm`
+- DisplayName: `ScummVM`
+- Platforms: `windows,linux,macos,android`
+- DownloadURL: empty (uses standard buildbot URL)
+
+No model changes — just new seed data.
+
+## Scanner
+
+The scanner recursively searches inside `scummvm/` for `.scummvm` files. When found:
+
+1. The directory containing the `.scummvm` file is the game
+2. Game title derived from the directory name (scraper fixes it later)
+3. `Game.FilePath` = relative path to the game directory (e.g., `scummvm/Beneath a Steel Sky/sky`)
+4. `Game.FileName` = the `.scummvm` filename (e.g., `sky.scummvm`)
+5. All other files in the directory are game data (not scanned individually)
+
+**Nesting support:** The scanner searches recursively, so both flat and nested layouts work:
+```
+scummvm/monkey1/monkey1.scummvm              ← flat
+scummvm/Beneath a Steel Sky/sky/sky.scummvm  ← nested (game is sky/)
+```
+
+**`.scummvm` file format:** A single line containing the ScummVM game ID (e.g., `monkey`, `tentacle`, `sky`). This is the standard format expected by the libretro ScummVM core.
+
+**Upload flow:** Admin uploads a zip/tar containing the game directory with a `.scummvm` file inside. Same handling as multi-disc uploads — extract to `scummvm/{dirname}/`.
+
+## Game Serving & Player Download
+
+**Server:** Serves the ScummVM game directory as a tar archive, using the same mechanism already used for multi-disc `.cue`/`.gdi` games.
+
+**Player:** Downloads and extracts the tar archive into `games/{gameId}/`. When launching, passes the path to the `.scummvm` file to `retro_load_game()`, telling the core the game ID and data file location.
+
+No new code needed in the download pipeline — just ensuring ScummVM directory paths flow through the existing tar-serving logic.
+
+## Player Core Loading & Input
+
+**Core loading:** Standard flow, no special handling:
+1. Recommended core → `scummvm`
+2. Download from buildbot if not cached
+3. Download game directory if not cached
+4. Load core, load game (`.scummvm` file path)
+
+**Default trackpad:** When no control tab preference is saved for the `scummvm` console, default to `ControlTab.TRACKPAD` instead of `ControlTab.GAMEPAD`. One-line change in the control tab fallback logic.
+
+**Mouse device type:** When launching a ScummVM game, set port 0 to `RETRO_DEVICE_MOUSE` so the core receives mouse input from the trackpad tab. Added in `EmulationViewModel.startGame()` alongside the existing dual-screen detection logic.
+
+## Testing
+
+**Server (Go unit tests):**
+- Scanner detects `.scummvm` files recursively in `scummvm/` directory
+- Scanner creates Game record with correct directory path and filename
+- Game download serves ScummVM game directory as tar archive
+
+**Player (Desktop E2E):**
+- ScummVM console defaults control tab to Trackpad
+- ScummVM console has `saveStateSupport = false`
+
+## Out of Scope
+
+- Main screen trackpad mode (relative cursor on primary display for single-screen devices)
+- Auto-detection of ScummVM games by folder name (without `.scummvm` file)
+- Web admin UI helper for creating `.scummvm` files
+- ScummVM-specific scraper integration
+- ScummVM core variable configuration (e.g., graphics scaler, audio settings)

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -665,7 +665,8 @@ class FakePreferencesRepository : PreferencesRepository {
     override fun getOrientationLock(): String = orientationLock
     override fun setOrientationLock(mode: String) { orientationLock = mode }
     private val controlTabs = mutableMapOf<String, String>()
-    override fun getControlTab(consoleId: String): String = controlTabs[consoleId] ?: "gamepad"
+    override fun getControlTab(consoleId: String): String =
+        controlTabs[consoleId] ?: if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
     override fun setControlTab(consoleId: String, tab: String) { controlTabs[consoleId] = tab }
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
@@ -204,7 +204,8 @@ class PreferencesRepositoryImpl(
 
     override fun getControlTab(consoleId: String): String {
         return database.spelaDatabaseQueries.getDeviceSetting("control_tab:$consoleId")
-            .executeAsOneOrNull() ?: "gamepad"
+            .executeAsOneOrNull()
+            ?: if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
     }
 
     override fun setControlTab(consoleId: String, tab: String) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -395,6 +395,11 @@ class EmulationViewModel(
                 }
             }
 
+            // ScummVM: set port 0 to RETRO_DEVICE_MOUSE for point-and-click input
+            if (lc == "scummvm") {
+                libretroController.setControllerPortDevice(0, 2) // RETRO_DEVICE_MOUSE = 2
+            }
+
             // Restore persisted control tab for this console
             val savedControlTab = com.spela.player.presentation.state.ControlTab.fromId(
                 preferencesRepository.getControlTab(consoleId)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SyncEngineTest.kt
@@ -178,7 +178,8 @@ class SyncEngineTest {
         override suspend fun pushKeyMappingsToServer() {}
         override fun getOrientationLock(): String = "auto"
         override fun setOrientationLock(mode: String) {}
-        override fun getControlTab(consoleId: String): String = "gamepad"
+        override fun getControlTab(consoleId: String): String =
+            if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
         override fun setControlTab(consoleId: String, tab: String) {}
     }
 
@@ -220,7 +221,8 @@ class SyncEngineTest {
         override suspend fun pushKeyMappingsToServer() {}
         override fun getOrientationLock(): String = "auto"
         override fun setOrientationLock(mode: String) {}
-        override fun getControlTab(consoleId: String): String = "gamepad"
+        override fun getControlTab(consoleId: String): String =
+            if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
         override fun setControlTab(consoleId: String, tab: String) {}
     }
 
@@ -266,7 +268,8 @@ class SyncEngineTest {
         override suspend fun pushKeyMappingsToServer() {}
         override fun getOrientationLock(): String = "auto"
         override fun setOrientationLock(mode: String) {}
-        override fun getControlTab(consoleId: String): String = "gamepad"
+        override fun getControlTab(consoleId: String): String =
+            if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
         override fun setControlTab(consoleId: String, tab: String) {}
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -341,7 +341,8 @@ class NavigationViewModelTest {
         override suspend fun pushKeyMappingsToServer() {}
         override fun getOrientationLock(): String = "auto"
         override fun setOrientationLock(mode: String) {}
-        override fun getControlTab(consoleId: String): String = "gamepad"
+        override fun getControlTab(consoleId: String): String =
+            if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
         override fun setControlTab(consoleId: String, tab: String) {}
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/KeyMappingViewModelTest.kt
@@ -403,7 +403,8 @@ class KeyMappingViewModelTest {
         override suspend fun pushKeyMappingsToServer() { pushKeyMappingsCalled = true }
         override fun getOrientationLock(): String = "auto"
         override fun setOrientationLock(mode: String) {}
-        override fun getControlTab(consoleId: String): String = "gamepad"
+        override fun getControlTab(consoleId: String): String =
+            if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
         override fun setControlTab(consoleId: String, tab: String) {}
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -270,7 +270,8 @@ class StubPreferencesRepository : PreferencesRepository {
     override suspend fun pushKeyMappingsToServer() {}
     override fun getOrientationLock(): String = "auto"
     override fun setOrientationLock(mode: String) {}
-    override fun getControlTab(consoleId: String): String = "gamepad"
+    override fun getControlTab(consoleId: String): String =
+        if (consoleId.lowercase() == "scummvm") "trackpad" else "gamepad"
     override fun setControlTab(consoleId: String, tab: String) {}
 }
 

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -5,6 +5,7 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
+	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -418,6 +419,31 @@ func (h *GameHandler) DownloadGame(c *gin.Context) {
 	// This handles both new games (with disc records) and old DB entries
 	// (without disc records) that were created before the scanner change.
 	lower := strings.ToLower(game.FileName)
+
+	// For .scummvm files, serve the entire game directory as a tar archive.
+	// The .scummvm file lives inside a directory of game data files.
+	// absPath resolves to the game directory (FilePath stores the directory, not the .scummvm file).
+	if strings.HasSuffix(lower, ".scummvm") {
+		var files []string
+		filepath.WalkDir(absPath, func(p string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			files = append(files, p)
+			return nil
+		})
+
+		if len(files) > 0 {
+			c.Header("Content-Type", "application/x-tar")
+			c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", game.FileName+".tar"))
+			c.Status(http.StatusOK)
+			if err := serveTar(c.Writer, files); err != nil {
+				slog.Warn("error streaming tar for ScummVM game", "game", game.Title, "error", err)
+			}
+			return
+		}
+	}
+
 	if strings.HasSuffix(lower, ".cue") || strings.HasSuffix(lower, ".gdi") {
 		companions, _, err := scanner.DiscCompanionFiles(absPath)
 		if err != nil {

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -836,6 +836,8 @@ func SeedConsoles(db *gorm.DB) error {
 		{Name: "MSX2", Abbreviation: "MSX2", Extensions: ".rom,.mx2,.dsk,.cas", DefaultCore: "bluemsx", EmulatorJSCore: "", FolderName: "msx2", ColorTheme: "#4a86c8", Generation: 100, SaveStateSupport: true, Playable: true},
 		// Arcade (generation = 101)
 		{Name: "Arcade", Abbreviation: "ARCADE", Extensions: ".zip", DefaultCore: "mame2003_plus", EmulatorJSCore: "fbneo", FolderName: "arcade", ColorTheme: "#ff4444", Generation: 101, SaveStateSupport: true, Playable: true},
+		// ScummVM (generation = 100, alongside home computers)
+		{Name: "ScummVM", Abbreviation: "SCUMMVM", Extensions: ".scummvm", DefaultCore: "scummvm", EmulatorJSCore: "", FolderName: "scummvm", ColorTheme: "#6b8e23", CoverAspect: "5:7", Generation: 100, SaveStateSupport: false, Playable: true},
 	}
 
 	for _, c := range consoles {
@@ -948,6 +950,7 @@ func SeedCores(db *gorm.DB) error {
 			Version:     "2125.0-rc5",
 			DownloadURL: "https://github.com/azahar-emu/azahar/releases/download/2125.0-rc5/azahar-libretro-2125.0-rc5-{platform}.zip",
 		},
+		{Name: "scummvm", DisplayName: "ScummVM", Description: "Point-and-click adventure game engine", Platforms: "windows,linux,macos,android"},
 	}
 
 	for _, c := range cores {

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -135,8 +135,9 @@ var ConsoleExtMap = map[string]string{
 	".j64":  "JAG",
 	".jag":  "JAG",
 	".32x":  "32X",
-	".a52":  "A52",
-	".a78":  "A78",
+	".a52":     "A52",
+	".a78":     "A78",
+	".scummvm": "SCUMMVM",
 }
 
 // RomExtensions is the set of file extensions recognized as ROM/disc files.
@@ -175,6 +176,7 @@ var RomExtensions = map[string]bool{
 	".min": true,
 	".j64": true, ".jag": true,
 	".32x": true,
+	".scummvm": true,
 }
 
 // directoryConsoleMap maps directory names to console abbreviations.
@@ -264,6 +266,7 @@ var directoryConsoleMap = map[string]string{
 	"pcecd":        "PCECD",
 	"neogeocd":     "NEOCD",
 	"neocd":        "NEOCD",
+	"scummvm":      "SCUMMVM",
 }
 
 // discPattern matches disc/disk/cd markers in filenames, e.g. "(Disc 1)", "[Disk 2]", "(CD 3)".

--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"bufio"
 	"fmt"
+	"io/fs"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -367,6 +368,14 @@ func CreateConsoleFolders(database *gorm.DB, gameDirs []string) error {
 	return nil
 }
 
+// humanizeTitle converts a raw directory or filename into a human-readable title
+// by replacing underscores and hyphens with spaces.
+func humanizeTitle(name string) string {
+	name = strings.ReplaceAll(name, "_", " ")
+	name = strings.ReplaceAll(name, "-", " ")
+	return strings.TrimSpace(name)
+}
+
 // ScanResult holds the results of a scan operation.
 type ScanResult struct {
 	NewGames     int    `json:"newGames"`
@@ -587,6 +596,12 @@ func (s *Scanner) Scan(onProgress ProgressFunc, consoleFilter ...string) (*ScanR
 		}
 	}
 
+	// ScummVM directory scan — runs between multi-disc and single-file passes
+	report(ScanProgress{Phase: "discovering", Message: "Scanning ScummVM game directories..."})
+	if err := s.scanScummVMGames(result, foundPaths, onProgress); err != nil {
+		slog.Warn("ScummVM scan error", "error", err)
+	}
+
 	report(ScanProgress{
 		Phase:   "discovering",
 		Current: result.NewGames,
@@ -703,6 +718,91 @@ func (s *Scanner) Scan(onProgress ProgressFunc, consoleFilter ...string) (*ScanR
 	return result, nil
 }
 
+// scanScummVMGames walks each gameDir/scummvm/ subtree looking for .scummvm marker files.
+// Each directory that contains a .scummvm file is treated as one ScummVM game.
+// The game's FilePath is the relative path to that directory (not the .scummvm file),
+// so that the download handler can serve the whole directory as a tar archive.
+func (s *Scanner) scanScummVMGames(result *ScanResult, foundPaths map[string]bool, onProgress ProgressFunc) error {
+	var scummConsole db.Console
+	if err := s.DB.Where("abbreviation = ?", "SCUMMVM").First(&scummConsole).Error; err != nil {
+		return nil // ScummVM console not seeded — skip silently
+	}
+
+	for _, gameDir := range s.GameDirs {
+		scummRoot := filepath.Join(gameDir, "scummvm")
+		if _, err := os.Stat(scummRoot); os.IsNotExist(err) {
+			continue
+		}
+
+		filepath.WalkDir(scummRoot, func(path string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			if strings.ToLower(filepath.Ext(path)) != ".scummvm" {
+				return nil
+			}
+
+			gameDataDir := filepath.Dir(path)
+			relPath := storage.RelativeGamePath(gameDataDir, s.GameDirs)
+			fileName := filepath.Base(path)
+
+			// Mark the directory path as found so the removal pass keeps the game.
+			foundPaths[relPath] = true
+
+			// Check if game already exists
+			var existing db.Game
+			if err := s.DB.Unscoped().Where("file_path = ?", relPath).First(&existing).Error; err == nil {
+				// Restore if soft-deleted
+				if existing.DeletedAt.Valid {
+					slog.Info("restoring previously removed ScummVM game",
+						"title", existing.Title, "path", relPath)
+					s.DB.Unscoped().Model(&existing).Update("deleted_at", nil)
+				}
+				return nil
+			}
+
+			title := humanizeTitle(filepath.Base(gameDataDir))
+
+			// Calculate total directory size
+			var totalSize int64
+			filepath.WalkDir(gameDataDir, func(p string, d fs.DirEntry, err error) error {
+				if err != nil || d.IsDir() {
+					return nil
+				}
+				if info, err := d.Info(); err == nil {
+					totalSize += info.Size()
+				}
+				return nil
+			})
+
+			game := db.Game{
+				ConsoleID: scummConsole.ID,
+				Title:     title,
+				FileName:  fileName,
+				FilePath:  relPath,
+				FileSize:  totalSize,
+			}
+
+			if err := s.DB.Create(&game).Error; err != nil {
+				slog.Warn("failed to create ScummVM game", "path", relPath, "error", err)
+				return nil
+			}
+
+			result.NewGames++
+			result.NewGameIDs = append(result.NewGameIDs, game.ID)
+			if onProgress != nil {
+				onProgress(ScanProgress{
+					Phase:   "discovering",
+					Message: fmt.Sprintf("Found ScummVM game: %s", title),
+				})
+			}
+			slog.Info("found ScummVM game", "title", title, "path", relPath)
+			return nil
+		})
+	}
+	return nil
+}
+
 // scanMultiDisc performs pass 1: discovers multi-disc games via .m3u files, disc patterns,
 // and standalone .cue files (which need companion .bin files bundled).
 // The optional onFile callback is called for each file visited during the directory walk.
@@ -718,6 +818,10 @@ func (s *Scanner) scanMultiDisc(dir string, consoleMap map[string]*db.Console, f
 		}
 		if info.IsDir() {
 			if strings.EqualFold(info.Name(), "bios") {
+				return filepath.SkipDir
+			}
+			// Skip the scummvm root — handled by scanScummVMGames
+			if strings.EqualFold(info.Name(), "scummvm") && filepath.Dir(path) == dir {
 				return filepath.SkipDir
 			}
 			return nil
@@ -1169,6 +1273,10 @@ func (s *Scanner) scanDirectory(dir string, consoleMap map[string]*db.Console, f
 		}
 		if info.IsDir() {
 			if strings.EqualFold(info.Name(), "bios") {
+				return filepath.SkipDir
+			}
+			// Skip the scummvm root — handled by scanScummVMGames
+			if strings.EqualFold(info.Name(), "scummvm") && filepath.Dir(path) == dir {
 				return filepath.SkipDir
 			}
 			return nil

--- a/server/internal/scanner/scanner_test.go
+++ b/server/internal/scanner/scanner_test.go
@@ -1663,3 +1663,66 @@ func TestTrackPattern(t *testing.T) {
 		})
 	}
 }
+
+func TestScan_DetectsScummVMGames(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	scummDir := filepath.Join(dir, "scummvm", "monkey1")
+	require.NoError(t, os.MkdirAll(scummDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(scummDir, "monkey1.scummvm"), []byte("monkey\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(scummDir, "MONKEY.000"), []byte("data"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(scummDir, "MONKEY.001"), []byte("data"), 0644))
+
+	s := NewScanner(database, []string{dir})
+	result, err := s.Scan(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.NewGames)
+
+	var game db.Game
+	err = database.Preload("Console").First(&game).Error
+	require.NoError(t, err)
+	assert.Equal(t, "SCUMMVM", game.Console.Abbreviation)
+	assert.Equal(t, "monkey1.scummvm", game.FileName)
+	assert.Contains(t, game.FilePath, "scummvm")
+	assert.Contains(t, game.FilePath, "monkey1")
+}
+
+func TestScan_DetectsNestedScummVMGames(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	scummDir := filepath.Join(dir, "scummvm", "Beneath a Steel Sky", "sky")
+	require.NoError(t, os.MkdirAll(scummDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(scummDir, "sky.scummvm"), []byte("sky\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(scummDir, "SKY.DNR"), []byte("data"), 0644))
+
+	s := NewScanner(database, []string{dir})
+	result, err := s.Scan(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 1, result.NewGames)
+
+	var game db.Game
+	err = database.Preload("Console").First(&game).Error
+	require.NoError(t, err)
+	assert.Equal(t, "SCUMMVM", game.Console.Abbreviation)
+	assert.Equal(t, "sky.scummvm", game.FileName)
+}
+
+func TestScan_MultipleScummVMGames(t *testing.T) {
+	database := setupTestDB(t)
+	dir := t.TempDir()
+
+	game1Dir := filepath.Join(dir, "scummvm", "monkey1")
+	require.NoError(t, os.MkdirAll(game1Dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(game1Dir, "monkey1.scummvm"), []byte("monkey\n"), 0644))
+
+	game2Dir := filepath.Join(dir, "scummvm", "tentacle")
+	require.NoError(t, os.MkdirAll(game2Dir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(game2Dir, "tentacle.scummvm"), []byte("tentacle\n"), 0644))
+
+	s := NewScanner(database, []string{dir})
+	result, err := s.Scan(nil)
+	require.NoError(t, err)
+	assert.Equal(t, 2, result.NewGames)
+}


### PR DESCRIPTION
## Summary
- Adds ScummVM as a playable platform with full pipeline support
- **Server:** Seeds ScummVM console and core. Scanner recursively detects `.scummvm` files in `scummvm/` directory (supports nested layouts). Download handler serves ScummVM game directories as tar archives.
- **Player:** Defaults to trackpad tab for ScummVM games (point-and-click). Sets `RETRO_DEVICE_MOUSE` on port 0 for proper cursor input.

## Test plan
- [x] All Go tests pass (scanner, API, DB, etc.)
- [x] All 420 player shared unit tests pass
- [x] Scanner tests: flat layout, nested layout, multiple games
- [ ] Manual: put ScummVM games with `.scummvm` files in `scummvm/` folder, run scanner
- [ ] Manual: download and launch a ScummVM game, verify trackpad works