### PR TITLE
fix: broadcast scrape_cancelled immediately on cancel request

### DIFF
--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -100,6 +100,12 @@ func (h *AdminHandler) CancelScrape(c *gin.Context) {
 		return
 	}
 
+	// Broadcast immediately so the frontend stops spinning.
+	// The goroutine will also broadcast when it detects the cancel, but that
+	// can be delayed by seconds while the current game finishes scraping.
+	// Receiving the event twice is harmless (frontend just sets phase="complete").
+	h.Hub.Broadcast(ws.Event{Type: "scrape_cancelled", Payload: gin.H{}})
+
 	adminID, _ := c.Get("userId")
 	slog.Info("audit: admin cancelled scrape", "admin_id", adminID)
 	c.JSON(http.StatusOK, gin.H{"message": "scrape cancellation requested"})


### PR DESCRIPTION
## Summary

The cancel scrape handler only cancelled the context — the `scrape_cancelled` WebSocket event didn't fire until the current game finished scraping (4-5+ seconds). If the WS reconnected in that window, the event was lost and the UI stayed stuck spinning.

Now broadcasts `scrape_cancelled` immediately when the admin clicks cancel. The goroutine's later broadcast is harmless (frontend idempotently sets phase to complete).

## Test plan

- [x] Compiles, no test changes needed (existing cancel tests cover the HTTP response)