### PR TITLE
fix: improve gamepad focus recovery after section switching

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
@@ -144,4 +144,93 @@ class GamepadNavigationTest {
         advanceQuick(harness)
         snesCard.assertIsFocused()
     }
+
+    // --- Focus recovery after L1/R1 section switching ---
+
+    @Test
+    fun focusRecoveredAfterSectionSwitchToConsoles() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        advance(harness)
+
+        // Enter gamepad mode
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        advanceQuick(harness)
+
+        // Switch to Consoles section via NextSection (Home → Explore → Consoles)
+        harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
+        harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
+        advance(harness)
+
+        // Focus should have been recovered — first console card should be focused
+        val nesCard = onNodeWithContentDescription("Nintendo Entertainment System, 3 games")
+        nesCard.assertIsDisplayed()
+        nesCard.assertIsFocused()
+    }
+
+    @Test
+    fun focusRecoveredAfterSectionSwitchToSettings() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        advance(harness)
+
+        // Enter gamepad mode
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        advanceQuick(harness)
+
+        // Switch to Settings (last section)
+        harness.navigationViewModel.onIntent(NavigationIntent.PreviousSection)
+        advance(harness)
+
+        // Something on the Settings screen should be focused
+        // (General category is selected by default on wide screens)
+        val focusedNodes = onAllNodes(hasAnyAncestor(isRoot()).and(isFocused()))
+        focusedNodes.fetchSemanticsNodes().isNotEmpty()
+    }
+
+    @Test
+    fun focusRecoveredAfterMultipleSectionCycles() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        advance(harness)
+
+        // Enter gamepad mode
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        advanceQuick(harness)
+
+        // Cycle through all 6 sections
+        repeat(6) {
+            harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
+            advance(harness)
+        }
+
+        // Back to Home — something should be focused
+        val focusedNodes = onAllNodes(isFocused())
+        focusedNodes.fetchSemanticsNodes().isNotEmpty()
+    }
+
+    @Test
+    fun dpadRecoversFocusAfterSectionSwitch() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        advance(harness)
+
+        // Enter gamepad mode and go to Consoles
+        harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
+        harness.navigationViewModel.onIntent(NavigationIntent.NextSection) // Explore
+        harness.navigationViewModel.onIntent(NavigationIntent.NextSection) // Consoles
+        advance(harness)
+
+        // Even if auto-focus didn't work, pressing D-pad Down should recover focus
+        onRoot().performKeyInput { pressKey(Key.DirectionDown) }
+        advanceQuick(harness)
+
+        // Some focusable element should now be focused
+        val nesCard = onNodeWithContentDescription("Nintendo Entertainment System, 3 games")
+        val snesCard = onNodeWithContentDescription("Super Nintendo, 2 games")
+        // One of the console cards should have focus
+        val nesFocused = try { nesCard.assertIsFocused(); true } catch (_: AssertionError) { false }
+        val snesFocused = try { snesCard.assertIsFocused(); true } catch (_: AssertionError) { false }
+        assert(nesFocused || snesFocused) { "Expected one of the console cards to be focused after D-pad press" }
+    }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -58,43 +58,62 @@ fun GamepadHandler(
     content: @Composable () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
+    // Track whether any element currently has focus. When nothing is focused,
+    // D-pad presses should acquire focus on the first element (recovery).
+    // When something IS focused, failed directional moves should NOT wrap.
+    var hasFocus by remember { mutableStateOf(false) }
 
     // When focusResetKey changes (e.g. section switch in gamepad mode),
     // clear focus and move to the first focusable element on the new page.
+    // Retries focus acquisition because screens with async data loading may
+    // not have focusable elements in the compose tree on the first attempt.
     if (focusResetKey != null) {
         LaunchedEffect(focusResetKey) {
-            // Wait for new content to compose
             delay(100)
             focusManager.clearFocus(force = true)
-            focusManager.moveFocus(FocusDirection.Next)
+            // Retry up to 5 times (100ms apart) to find a focusable element.
+            // moveFocus returns true if focus was successfully moved.
+            repeat(5) {
+                if (focusManager.moveFocus(FocusDirection.Next)) return@LaunchedEffect
+                delay(100)
+            }
         }
     }
 
     Box(
         modifier = Modifier
             .fillMaxSize()
+            .onFocusChanged { state -> hasFocus = state.hasFocus }
             .onPreviewKeyEvent { event ->
                 if (!enabled) return@onPreviewKeyEvent false
                 if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
 
                 when (event.key) {
                     Key.DirectionUp -> {
-                        focusManager.moveFocus(FocusDirection.Up)
+                        if (!focusManager.moveFocus(FocusDirection.Up) && !hasFocus) {
+                            focusManager.moveFocus(FocusDirection.Next)
+                        }
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionDown -> {
-                        focusManager.moveFocus(FocusDirection.Down)
+                        if (!focusManager.moveFocus(FocusDirection.Down) && !hasFocus) {
+                            focusManager.moveFocus(FocusDirection.Next)
+                        }
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionLeft -> {
-                        focusManager.moveFocus(FocusDirection.Left)
+                        if (!focusManager.moveFocus(FocusDirection.Left) && !hasFocus) {
+                            focusManager.moveFocus(FocusDirection.Next)
+                        }
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionRight -> {
-                        focusManager.moveFocus(FocusDirection.Right)
+                        if (!focusManager.moveFocus(FocusDirection.Right) && !hasFocus) {
+                            focusManager.moveFocus(FocusDirection.Next)
+                        }
                         onGamepadInput?.invoke()
                         true
                     }
@@ -104,12 +123,14 @@ fun GamepadHandler(
                     }
                     Key.RightBracket -> {
                         focusManager.clearFocus(force = true)
+                        hasFocus = false
                         onNextSection?.invoke()
                         onGamepadInput?.invoke()
                         onNextSection != null
                     }
                     Key.LeftBracket -> {
                         focusManager.clearFocus(force = true)
+                        hasFocus = false
                         onPreviousSection?.invoke()
                         onGamepadInput?.invoke()
                         onPreviousSection != null
@@ -119,11 +140,13 @@ fun GamepadHandler(
                         // Otherwise let it do default focus movement (e.g., login form).
                         if (event.isShiftPressed && onPreviousSection != null) {
                             focusManager.clearFocus(force = true)
+                            hasFocus = false
                             onPreviousSection.invoke()
                             onGamepadInput?.invoke()
                             true
                         } else if (!event.isShiftPressed && onNextSection != null) {
                             focusManager.clearFocus(force = true)
+                            hasFocus = false
                             onNextSection.invoke()
                             onGamepadInput?.invoke()
                             true


### PR DESCRIPTION
## Summary
Two fixes to the GamepadHandler focus management:

1. **Focus reset retry**: When L1/R1 switches sections, retry `moveFocus(Next)` up to 5 times at 100ms intervals, handling screens where focusable elements aren't composed immediately (async data loading)
2. **D-pad focus recovery**: When no element is focused and D-pad is pressed, fall back to `moveFocus(Next)` to acquire focus. Only triggers when `hasFocus == false`, preserving boundary no-wrap behavior

## Test plan
- [x] All 10 GamepadNavigationTest pass (6 existing + 4 new)
- [x] All 5 InputModeTest pass
- [x] All 8 SectionNavigationTest pass
- [x] All 6 SectionIndicatorTest pass
- [x] Boundary tests (no-wrap on Left/Up) still pass
- [ ] Manual test on AYN Thor: L1/R1 section switching recovers focus
- [ ] Manual test: D-pad recovers focus from unfocused state