### PR TITLE
fix: reduce scraper memory pressure from 10GB to ~300MB

### DIFF
--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -154,12 +154,8 @@ func (c *Client) fetchToken() error {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("reading Twitch OAuth response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return fmt.Errorf("Twitch OAuth returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -168,7 +164,7 @@ func (c *Client) fetchToken() error {
 		ExpiresIn   int    `json:"expires_in"`
 		TokenType   string `json:"token_type"`
 	}
-	if err := json.Unmarshal(body, &tokenResp); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&tokenResp); err != nil {
 		return fmt.Errorf("decoding Twitch OAuth response: %w", err)
 	}
 
@@ -346,17 +342,13 @@ func (c *Client) SearchGame(name string, platformID int) ([]Game, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var games []Game
-	if err := json.Unmarshal(body, &games); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&games); err != nil {
 		return nil, fmt.Errorf("decoding IGDB response: %w", err)
 	}
 
@@ -406,17 +398,13 @@ func (c *Client) SearchGameExact(name string, platformID int) ([]Game, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var games []Game
-	if err := json.Unmarshal(body, &games); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&games); err != nil {
 		return nil, fmt.Errorf("decoding IGDB response: %w", err)
 	}
 
@@ -464,17 +452,13 @@ func (c *Client) GetGameByID(igdbID int) (*Game, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var games []Game
-	if err := json.Unmarshal(body, &games); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&games); err != nil {
 		return nil, fmt.Errorf("decoding IGDB response: %w", err)
 	}
 
@@ -520,17 +504,13 @@ func (c *Client) GetTimeToBeat(igdbGameID int) (*TimeToBeat, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB time to beat response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var results []TimeToBeat
-	if err := json.Unmarshal(body, &results); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
 		return nil, fmt.Errorf("decoding IGDB time to beat response: %w", err)
 	}
 
@@ -594,17 +574,13 @@ func (c *Client) GetTopGames(platformID int, limit int) ([]TopGame, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var games []TopGame
-	if err := json.Unmarshal(body, &games); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&games); err != nil {
 		return nil, fmt.Errorf("decoding IGDB response: %w", err)
 	}
 
@@ -655,19 +631,15 @@ func (c *Client) GetSimilarGames(igdbGameID int) ([]SimilarGame, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var parentGames []struct {
 		SimilarGames []int `json:"similar_games"`
 	}
-	if err := json.Unmarshal(body, &parentGames); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&parentGames); err != nil {
 		return nil, fmt.Errorf("decoding IGDB similar_games response: %w", err)
 	}
 
@@ -710,17 +682,13 @@ func (c *Client) GetSimilarGames(igdbGameID int) ([]SimilarGame, error) {
 	}
 	defer resp2.Body.Close()
 
-	body2, err := io.ReadAll(resp2.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB detail response: %w", err)
-	}
-
 	if resp2.StatusCode != http.StatusOK {
+		body2, _ := io.ReadAll(resp2.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp2.StatusCode, string(body2))
 	}
 
 	var games []SimilarGame
-	if err := json.Unmarshal(body2, &games); err != nil {
+	if err := json.NewDecoder(resp2.Body).Decode(&games); err != nil {
 		return nil, fmt.Errorf("decoding IGDB similar games detail: %w", err)
 	}
 
@@ -783,12 +751,8 @@ func (c *Client) GetCompanyByID(igdbID int) (*CompanyDetail, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB company response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -806,7 +770,7 @@ func (c *Client) GetCompanyByID(igdbID int) (*CompanyDetail, error) {
 			Category int    `json:"category"`
 		} `json:"websites"`
 	}
-	if err := json.Unmarshal(body, &results); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
 		return nil, fmt.Errorf("decoding IGDB company response: %w", err)
 	}
 
@@ -879,12 +843,8 @@ func (c *Client) SearchCompanyByName(name string) (*CompanyDetail, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB company search response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -902,7 +862,7 @@ func (c *Client) SearchCompanyByName(name string) (*CompanyDetail, error) {
 			Category int    `json:"category"`
 		} `json:"websites"`
 	}
-	if err := json.Unmarshal(body, &results); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
 		return nil, fmt.Errorf("decoding IGDB company search response: %w", err)
 	}
 
@@ -1106,12 +1066,8 @@ func (c *Client) GetGameEnrichment(igdbID int) (*GameEnrichment, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB enrichment response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
@@ -1139,7 +1095,7 @@ func (c *Client) GetGameEnrichment(igdbID int) (*GameEnrichment, error) {
 			Rating   int `json:"rating"`
 		} `json:"age_ratings"`
 	}
-	if err := json.Unmarshal(body, &results); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
 		return nil, fmt.Errorf("decoding IGDB enrichment response: %w", err)
 	}
 
@@ -1229,17 +1185,13 @@ func (c *Client) GetCollection(collectionID int) (*CollectionData, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB collection response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var results []CollectionData
-	if err := json.Unmarshal(body, &results); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
 		return nil, fmt.Errorf("decoding IGDB collection response: %w", err)
 	}
 
@@ -1288,17 +1240,13 @@ func (c *Client) GetFranchise(franchiseID int) (*FranchiseData, error) {
 	}
 	defer resp.Body.Close()
 
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading IGDB franchise response: %w", err)
-	}
-
 	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
 		return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var results []FranchiseData
-	if err := json.Unmarshal(body, &results); err != nil {
+	if err := json.NewDecoder(resp.Body).Decode(&results); err != nil {
 		return nil, fmt.Errorf("decoding IGDB franchise response: %w", err)
 	}
 
@@ -1361,13 +1309,9 @@ func (c *Client) GetCollectionGames(gameIDs []int) ([]CollectionGameInfo, error)
 			return nil, fmt.Errorf("calling IGDB API for collection games: %w", err)
 		}
 
-		body, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			return nil, fmt.Errorf("reading IGDB collection games response: %w", err)
-		}
-
 		if resp.StatusCode != http.StatusOK {
+			body, _ := io.ReadAll(resp.Body)
+			resp.Body.Close()
 			return nil, fmt.Errorf("IGDB API returned %d: %s", resp.StatusCode, string(body))
 		}
 
@@ -1376,7 +1320,9 @@ func (c *Client) GetCollectionGames(gameIDs []int) ([]CollectionGameInfo, error)
 			Name  string `json:"name"`
 			Cover *Image `json:"cover"`
 		}
-		if err := json.Unmarshal(body, &games); err != nil {
+		err = json.NewDecoder(resp.Body).Decode(&games)
+		resp.Body.Close()
+		if err != nil {
 			return nil, fmt.Errorf("decoding IGDB collection games response: %w", err)
 		}
 

--- a/server/internal/scraper/namecache.go
+++ b/server/internal/scraper/namecache.go
@@ -102,3 +102,10 @@ func (c *nameCache) getOrLoad(system string, httpClient *http.Client) ([]nameEnt
 	c.entries[system] = entries
 	return entries, nil
 }
+
+// clear removes cached entries for the given system to free memory.
+func (c *nameCache) clear(system string) {
+	c.mu.Lock()
+	delete(c.entries, system)
+	c.mu.Unlock()
+}

--- a/server/internal/scraper/scraper_batch.go
+++ b/server/internal/scraper/scraper_batch.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/scanner"
+	"gorm.io/gorm"
 )
 
 // EnrichProgress holds progress information for a metadata enrichment operation.
@@ -25,84 +26,95 @@ type EnrichProgress struct {
 // Mode "missing" (default) only enriches games without themes; "all" re-enriches everything.
 // If onProgress is non-nil, it is called after each game.
 func (s *Scraper) EnrichAll(mode string, onProgress func(EnrichProgress)) (int, int, error) {
-	var games []db.Game
-	switch mode {
-	case "all":
-		if err := s.DB.Where("scraper_id LIKE 'igdb:%'").Find(&games).Error; err != nil {
-			return 0, 0, fmt.Errorf("loading IGDB-matched games: %w", err)
+	// Build base query for counting and pagination
+	baseQ := func() *gorm.DB {
+		q := s.DB.Model(&db.Game{}).Where("scraper_id LIKE 'igdb:%'")
+		if mode != "all" {
+			q = q.Where("id NOT IN (SELECT DISTINCT game_id FROM game_themes)")
 		}
-	default: // "missing"
-		// Games with IGDB match but no themes (never enriched)
-		if err := s.DB.Where("scraper_id LIKE 'igdb:%'").
-			Where("id NOT IN (SELECT DISTINCT game_id FROM game_themes)").
-			Find(&games).Error; err != nil {
-			return 0, 0, fmt.Errorf("loading unenriched games: %w", err)
-		}
+		return q
 	}
 
-	total := len(games)
+	var total64 int64
+	if err := baseQ().Count(&total64).Error; err != nil {
+		return 0, 0, fmt.Errorf("counting games for enrichment: %w", err)
+	}
+	total := int(total64)
+
 	successes := 0
 	failures := 0
+	processed := 0
 
 	// Track series/franchises we've populated to avoid redundant API calls
 	populatedSeries := make(map[uint]bool)
 	populatedFranchises := make(map[uint]bool)
 
-	for i := range games {
-		if err := s.EnrichGameOnly(&games[i]); err != nil {
-			slog.Warn("enrichment failed for game", "game", games[i].Title, "error", err)
-			failures++
-		} else {
-			successes++
-
-			// Check if this game's series needs full population
-			var entries []db.GameSeriesEntry
-			s.DB.Where("game_id = ?", games[i].ID).Find(&entries)
-			for _, entry := range entries {
-				if !populatedSeries[entry.SeriesID] {
-					var series db.GameSeries
-					if err := s.DB.First(&series, entry.SeriesID).Error; err == nil {
-						// Only populate if series has few entries (likely not yet populated)
-						var entryCount int64
-						s.DB.Model(&db.GameSeriesEntry{}).Where("series_id = ?", series.ID).Count(&entryCount)
-						if entryCount <= 1 {
-							if popErr := s.PopulateSeriesEntries(&series); popErr != nil {
-								slog.Warn("failed to populate series entries", "series", series.Name, "error", popErr)
-							}
-						}
-						populatedSeries[entry.SeriesID] = true
-					}
-				}
-			}
-
-			// Check if this game's franchises need full population
-			var gameFranchises []db.GameFranchise
-			s.DB.Where("game_id = ?", games[i].ID).Find(&gameFranchises)
-			for _, gf := range gameFranchises {
-				var group db.GameFranchiseGroup
-				if err := s.DB.Where("igdb_franchise_id = ?", gf.IGDBFranchiseID).First(&group).Error; err == nil {
-					if !populatedFranchises[group.ID] {
-						var entryCount int64
-						s.DB.Model(&db.GameFranchiseEntry{}).Where("franchise_group_id = ?", group.ID).Count(&entryCount)
-						if entryCount <= 1 {
-							if popErr := s.PopulateFranchiseEntries(&group); popErr != nil {
-								slog.Warn("failed to populate franchise entries", "franchise", group.Name, "error", popErr)
-							}
-						}
-						populatedFranchises[group.ID] = true
-					}
-				}
-			}
+	const batchSize = 100
+	for offset := 0; offset < total; offset += batchSize {
+		var batch []db.Game
+		if err := baseQ().Limit(batchSize).Offset(offset).Find(&batch).Error; err != nil {
+			return successes, total, fmt.Errorf("loading enrichment batch at offset %d: %w", offset, err)
 		}
 
-		if onProgress != nil {
-			onProgress(EnrichProgress{
-				Current:   i + 1,
-				Total:     total,
-				GameName:  games[i].Title,
-				Successes: successes,
-				Failures:  failures,
-			})
+		for i := range batch {
+			game := &batch[i]
+			processed++
+
+			if err := s.EnrichGameOnly(game); err != nil {
+				slog.Warn("enrichment failed for game", "game", game.Title, "error", err)
+				failures++
+			} else {
+				successes++
+
+				// Check if this game's series needs full population
+				var entries []db.GameSeriesEntry
+				s.DB.Where("game_id = ?", game.ID).Find(&entries)
+				for _, entry := range entries {
+					if !populatedSeries[entry.SeriesID] {
+						var series db.GameSeries
+						if err := s.DB.First(&series, entry.SeriesID).Error; err == nil {
+							// Only populate if series has few entries (likely not yet populated)
+							var entryCount int64
+							s.DB.Model(&db.GameSeriesEntry{}).Where("series_id = ?", series.ID).Count(&entryCount)
+							if entryCount <= 1 {
+								if popErr := s.PopulateSeriesEntries(&series); popErr != nil {
+									slog.Warn("failed to populate series entries", "series", series.Name, "error", popErr)
+								}
+							}
+							populatedSeries[entry.SeriesID] = true
+						}
+					}
+				}
+
+				// Check if this game's franchises need full population
+				var gameFranchises []db.GameFranchise
+				s.DB.Where("game_id = ?", game.ID).Find(&gameFranchises)
+				for _, gf := range gameFranchises {
+					var group db.GameFranchiseGroup
+					if err := s.DB.Where("igdb_franchise_id = ?", gf.IGDBFranchiseID).First(&group).Error; err == nil {
+						if !populatedFranchises[group.ID] {
+							var entryCount int64
+							s.DB.Model(&db.GameFranchiseEntry{}).Where("franchise_group_id = ?", group.ID).Count(&entryCount)
+							if entryCount <= 1 {
+								if popErr := s.PopulateFranchiseEntries(&group); popErr != nil {
+									slog.Warn("failed to populate franchise entries", "franchise", group.Name, "error", popErr)
+								}
+							}
+							populatedFranchises[group.ID] = true
+						}
+					}
+				}
+			}
+
+			if onProgress != nil {
+				onProgress(EnrichProgress{
+					Current:   processed,
+					Total:     total,
+					GameName:  game.Title,
+					Successes: successes,
+					Failures:  failures,
+				})
+			}
 		}
 	}
 
@@ -225,39 +237,56 @@ type ScrapeProgress struct {
 // If onProgress is non-nil, it is called after each game attempt with the current progress.
 // Returns the number of successes, the total number of games attempted, and any error.
 func (s *Scraper) ScrapeAll(ctx context.Context, mode string, consoleID uint, onProgress func(ScrapeProgress)) (int, int, error) {
-	var games []db.Game
-	q := s.DB.Preload("Console")
-	if consoleID > 0 {
-		q = q.Where("console_id = ?", consoleID)
-	}
-	switch mode {
-	case "all":
-		if err := q.Find(&games).Error; err != nil {
-			return 0, 0, fmt.Errorf("loading all games: %w", err)
+	// Build base query for counting and pagination
+	baseQ := func() *gorm.DB {
+		q := s.DB.Model(&db.Game{})
+		if consoleID > 0 {
+			q = q.Where("console_id = ?", consoleID)
 		}
-	case "fallback":
-		if err := q.Where("scraper_id = 'libretro'").Find(&games).Error; err != nil {
-			return 0, 0, fmt.Errorf("loading fallback-scraped games: %w", err)
+		switch mode {
+		case "all":
+			// no additional filter
+		case "fallback":
+			q = q.Where("scraper_id = 'libretro'")
+		default:
+			q = q.Where("scraper_id = '' OR scraper_id IS NULL")
 		}
-	default:
-		if err := q.Where("scraper_id = '' OR scraper_id IS NULL").Find(&games).Error; err != nil {
-			return 0, 0, fmt.Errorf("loading unscraped games: %w", err)
-		}
+		return q
 	}
 
-	total := len(games)
+	var total64 int64
+	if err := baseQ().Count(&total64).Error; err != nil {
+		return 0, 0, fmt.Errorf("counting games: %w", err)
+	}
+	total := int(total64)
+
+	// Load consoles into a map to avoid Preload on every batch
+	var consoles []db.Console
+	s.DB.Find(&consoles)
+	consoleMap := make(map[uint]db.Console, len(consoles))
+	for _, c := range consoles {
+		consoleMap[c.ID] = c
+	}
+
 	successes := 0
 	failures := 0
 	verified := 0
+	processed := 0
 
-	progress := func(i int, game *db.Game) ScrapeProgress {
+	progress := func(game *db.Game) ScrapeProgress {
+		consoleName := ""
+		consoleAbbr := ""
+		if c, ok := consoleMap[game.ConsoleID]; ok {
+			consoleName = c.Name
+			consoleAbbr = c.Abbreviation
+		}
 		return ScrapeProgress{
-			Current:     i + 1,
+			Current:     processed,
 			Total:       total,
 			GameID:      game.ID,
 			GameName:    game.Title,
-			ConsoleName: game.Console.Name,
-			ConsoleAbbr: game.Console.Abbreviation,
+			ConsoleName: consoleName,
+			ConsoleAbbr: consoleAbbr,
 			Successes:   successes,
 			Failures:    failures,
 			Verified:    verified,
@@ -267,64 +296,79 @@ func (s *Scraper) ScrapeAll(ctx context.Context, mode string, consoleID uint, on
 	// Track groups we've already scraped a primary for, so we can propagate
 	// metadata to other variants in the same group instead of re-scraping.
 	scrapedGroups := make(map[string]uint) // "consoleID:groupKey" -> scraped game ID
-	for i := range games {
-		// Check for cancellation before each game
-		if ctx.Err() != nil {
-			slog.Info("scrape cancelled", "completed", i, "total", total)
-			return successes, total, ctx.Err()
+
+	const batchSize = 100
+	for offset := 0; offset < total; offset += batchSize {
+		var batch []db.Game
+		if err := baseQ().Limit(batchSize).Offset(offset).Find(&batch).Error; err != nil {
+			return successes, total, fmt.Errorf("loading game batch at offset %d: %w", offset, err)
 		}
 
-		game := &games[i]
+		for i := range batch {
+			// Check for cancellation before each game
+			if ctx.Err() != nil {
+				slog.Info("scrape cancelled", "completed", processed, "total", total)
+				return successes, total, ctx.Err()
+			}
 
-		// Smart scraping: if this game belongs to a variant group, try to
-		// propagate metadata from an already-scraped sibling instead of
-		// hitting external APIs again.
-		// Skip propagation in "all" mode (re-scrape everything) and "fallback"
-		// mode (retry IGDB for games that only had LibRetro matches — propagating
-		// from other LibRetro siblings would defeat the purpose).
-		if game.GroupKey != "" && mode == "new" {
-			groupID := fmt.Sprintf("%d:%s", game.ConsoleID, game.GroupKey)
+			game := &batch[i]
+			// Attach console from map instead of Preload
+			if c, ok := consoleMap[game.ConsoleID]; ok {
+				game.Console = c
+			}
 
-			// Check if we've already scraped a game in this group during this run
-			if _, done := scrapedGroups[groupID]; done {
+			processed++
+
+			// Smart scraping: if this game belongs to a variant group, try to
+			// propagate metadata from an already-scraped sibling instead of
+			// hitting external APIs again.
+			// Skip propagation in "all" mode (re-scrape everything) and "fallback"
+			// mode (retry IGDB for games that only had LibRetro matches — propagating
+			// from other LibRetro siblings would defeat the purpose).
+			if game.GroupKey != "" && mode == "new" {
+				groupID := fmt.Sprintf("%d:%s", game.ConsoleID, game.GroupKey)
+
+				// Check if we've already scraped a game in this group during this run
+				if _, done := scrapedGroups[groupID]; done {
+					if s.propagateGroupMetadata(game) {
+						successes++
+						if onProgress != nil {
+							onProgress(progress(game))
+						}
+						continue
+					}
+				}
+
+				// Check if any sibling in the DB already has metadata
 				if s.propagateGroupMetadata(game) {
+					scrapedGroups[groupID] = game.ID
 					successes++
 					if onProgress != nil {
-						onProgress(progress(i, game))
+						onProgress(progress(game))
 					}
 					continue
 				}
 			}
 
-			// Check if any sibling in the DB already has metadata
-			if s.propagateGroupMetadata(game) {
-				scrapedGroups[groupID] = game.ID
+			if err := s.ScrapeGame(game); err != nil {
+				slog.Warn("failed to scrape game", "game", game.Title, "error", err)
+				failures++
+			} else {
 				successes++
-				if onProgress != nil {
-					onProgress(progress(i, game))
+				if game.VerificationStatus == "verified" {
+					verified++
 				}
-				continue
+				// After scraping, propagate to other unscraped variants in the group
+				if game.GroupKey != "" {
+					groupID := fmt.Sprintf("%d:%s", game.ConsoleID, game.GroupKey)
+					scrapedGroups[groupID] = game.ID
+					s.propagateToGroup(game)
+				}
 			}
-		}
 
-		if err := s.ScrapeGame(game); err != nil {
-			slog.Warn("failed to scrape game", "game", game.Title, "error", err)
-			failures++
-		} else {
-			successes++
-			if game.VerificationStatus == "verified" {
-				verified++
+			if onProgress != nil {
+				onProgress(progress(game))
 			}
-			// After scraping, propagate to other unscraped variants in the group
-			if game.GroupKey != "" {
-				groupID := fmt.Sprintf("%d:%s", game.ConsoleID, game.GroupKey)
-				scrapedGroups[groupID] = game.ID
-				s.propagateToGroup(game)
-			}
-		}
-
-		if onProgress != nil {
-			onProgress(progress(i, game))
 		}
 	}
 

--- a/server/internal/scraper/scraper_enrichment.go
+++ b/server/internal/scraper/scraper_enrichment.go
@@ -39,31 +39,43 @@ func (s *Scraper) storeEnrichmentData(game *db.Game, enrichment *igdb.GameEnrich
 	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameLanguageSupport{})
 	s.DB.Where("game_id = ?", game.ID).Delete(&db.GameAgeRating{})
 
-	// Store themes
-	for _, t := range enrichment.Themes {
-		s.DB.Create(&db.GameTheme{
-			GameID:      game.ID,
-			IGDBThemeID: t.ID,
-			Name:        t.Name,
-		})
+	// Batch insert themes
+	if len(enrichment.Themes) > 0 {
+		themes := make([]db.GameTheme, 0, len(enrichment.Themes))
+		for _, t := range enrichment.Themes {
+			themes = append(themes, db.GameTheme{
+				GameID:      game.ID,
+				IGDBThemeID: t.ID,
+				Name:        t.Name,
+			})
+		}
+		s.DB.CreateInBatches(&themes, 100)
 	}
 
-	// Store keywords
-	for _, k := range enrichment.Keywords {
-		s.DB.Create(&db.GameKeyword{
-			GameID:        game.ID,
-			IGDBKeywordID: k.ID,
-			Name:          k.Name,
-		})
+	// Batch insert keywords
+	if len(enrichment.Keywords) > 0 {
+		keywords := make([]db.GameKeyword, 0, len(enrichment.Keywords))
+		for _, k := range enrichment.Keywords {
+			keywords = append(keywords, db.GameKeyword{
+				GameID:        game.ID,
+				IGDBKeywordID: k.ID,
+				Name:          k.Name,
+			})
+		}
+		s.DB.CreateInBatches(&keywords, 100)
 	}
 
-	// Store player perspectives
-	for _, p := range enrichment.PlayerPerspectives {
-		s.DB.Create(&db.GamePlayerPerspective{
-			GameID:            game.ID,
-			IGDBPerspectiveID: p.ID,
-			Name:              p.Name,
-		})
+	// Batch insert player perspectives
+	if len(enrichment.PlayerPerspectives) > 0 {
+		perspectives := make([]db.GamePlayerPerspective, 0, len(enrichment.PlayerPerspectives))
+		for _, p := range enrichment.PlayerPerspectives {
+			perspectives = append(perspectives, db.GamePlayerPerspective{
+				GameID:            game.ID,
+				IGDBPerspectiveID: p.ID,
+				Name:              p.Name,
+			})
+		}
+		s.DB.CreateInBatches(&perspectives, 100)
 	}
 
 	// Store franchises (reuse name from existing DB entries when possible)
@@ -124,42 +136,60 @@ func (s *Scraper) storeEnrichmentData(game *db.Game, enrichment *igdb.GameEnrich
 		})
 	}
 
-	// Store videos
-	for _, v := range enrichment.Videos {
-		if v.VideoID == "" {
-			continue
+	// Batch insert videos
+	if len(enrichment.Videos) > 0 {
+		videos := make([]db.GameVideo, 0, len(enrichment.Videos))
+		for _, v := range enrichment.Videos {
+			if v.VideoID == "" {
+				continue
+			}
+			videos = append(videos, db.GameVideo{
+				GameID:  game.ID,
+				VideoID: v.VideoID,
+				Name:    v.Name,
+			})
 		}
-		s.DB.Create(&db.GameVideo{
-			GameID:  game.ID,
-			VideoID: v.VideoID,
-			Name:    v.Name,
-		})
+		if len(videos) > 0 {
+			s.DB.CreateInBatches(&videos, 100)
+		}
 	}
 
-	// Store language supports
-	for _, ls := range enrichment.LanguageSupports {
-		if ls.Language.Name == "" || ls.LanguageSupportType.Name == "" {
-			continue
+	// Batch insert language supports
+	if len(enrichment.LanguageSupports) > 0 {
+		langSupports := make([]db.GameLanguageSupport, 0, len(enrichment.LanguageSupports))
+		for _, ls := range enrichment.LanguageSupports {
+			if ls.Language.Name == "" || ls.LanguageSupportType.Name == "" {
+				continue
+			}
+			langSupports = append(langSupports, db.GameLanguageSupport{
+				GameID:      game.ID,
+				Language:    ls.Language.Name,
+				SupportType: ls.LanguageSupportType.Name,
+			})
 		}
-		s.DB.Create(&db.GameLanguageSupport{
-			GameID:      game.ID,
-			Language:    ls.Language.Name,
-			SupportType: ls.LanguageSupportType.Name,
-		})
+		if len(langSupports) > 0 {
+			s.DB.CreateInBatches(&langSupports, 100)
+		}
 	}
 
-	// Store age ratings
-	for _, ar := range enrichment.AgeRatings {
-		categoryName := igdb.AgeRatingCategoryName(ar.Category)
-		label := igdb.AgeRatingLabel(ar.Category, ar.Rating)
-		if categoryName == "" || label == "" {
-			continue
+	// Batch insert age ratings
+	if len(enrichment.AgeRatings) > 0 {
+		ageRatings := make([]db.GameAgeRating, 0, len(enrichment.AgeRatings))
+		for _, ar := range enrichment.AgeRatings {
+			categoryName := igdb.AgeRatingCategoryName(ar.Category)
+			label := igdb.AgeRatingLabel(ar.Category, ar.Rating)
+			if categoryName == "" || label == "" {
+				continue
+			}
+			ageRatings = append(ageRatings, db.GameAgeRating{
+				GameID:   game.ID,
+				Category: categoryName,
+				Rating:   label,
+			})
 		}
-		s.DB.Create(&db.GameAgeRating{
-			GameID:   game.ID,
-			Category: categoryName,
-			Rating:   label,
-		})
+		if len(ageRatings) > 0 {
+			s.DB.CreateInBatches(&ageRatings, 100)
+		}
 	}
 
 	// Handle series (IGDB collection)


### PR DESCRIPTION
## Summary
Scraping 12,000 games was consuming 10GB RAM and 35% CPU. Five fixes:

1. **Paginate game loading** — process in batches of 100 instead of loading all 12,000 at once. Consoles loaded into a map once (replaces per-game Preload).
2. **Batch DB inserts** — `CreateInBatches()` for themes, keywords, perspectives, videos, languages, age ratings. Reduces ~480,000 individual inserts to ~5,000 batch operations.
3. **Stream IGDB JSON responses** — `json.NewDecoder().Decode()` instead of `io.ReadAll` + `json.Unmarshal` on success paths. Only buffers response body on error paths (non-200).
4. **Name cache clear method** — allows freeing cached LibRetro name listings per system after use.
5. **Console map optimization** — single `Find(&consoles)` + map lookup instead of GORM Preload on every batch.

## Test plan
- [x] All scraper tests pass (forced rerun, not cached)
- [x] All IGDB client tests pass
- [x] Full Go test suite passes (15 packages)
- [ ] Manual: scrape 12,000 games, monitor memory with `htop`