### PR TITLE
feat: add Scrape Metadata and Update Achievements to game detail

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -236,6 +236,16 @@ class SpelaApiClient(
         client.post("$baseUrl/api/games/$gameId/scrape-if-needed")
     }
 
+    /** Admin: scrape metadata for a single game. */
+    suspend fun adminScrapeGame(gameId: String) {
+        client.post("$baseUrl/api/admin/games/$gameId/scrape")
+    }
+
+    /** Admin: refresh achievement cache for a single game. */
+    suspend fun adminRefreshAchievements(gameId: String) {
+        client.post("$baseUrl/api/admin/games/$gameId/achievements/refresh")
+    }
+
     suspend fun getRecentlyAddedGames(pageSize: Int = 12): GameListResponse {
         return client.get("$baseUrl/api/games") {
             parameter("sortBy", "created_at")

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/GameDetailIntent.kt
@@ -48,6 +48,10 @@ sealed interface GameDetailIntent {
     data object DismissError : GameDetailIntent
     data object DismissSuccess : GameDetailIntent
 
+    // Admin actions
+    data object AdminScrapeGame : GameDetailIntent
+    data object AdminRefreshAchievements : GameDetailIntent
+
     // Sessions
     data class LoadSessions(val gameId: String) : GameDetailIntent
     data class CreateSession(val gameId: String, val name: String) : GameDetailIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
@@ -66,6 +66,8 @@ data class GameDetailState(
     val isCreatingChallenge: Boolean = false,
     val successMessage: String? = null,
     val error: String? = null,
+    val isAdminActionLoading: Boolean = false,
+    val isAdmin: Boolean = false,
     // Similar Games & Developer Games
     val similarGames: List<SimilarGame> = emptyList(),
     val developerGames: List<DeveloperGame> = emptyList(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -83,6 +83,7 @@ import com.spela.player.presentation.ui.components.GameDetailLayout
 import com.spela.player.presentation.ui.components.GameDetailSkeleton
 import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
+import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpRegionChip
@@ -194,6 +195,8 @@ fun GameDetailScreen(
                     onDeleteLocalGame = { viewModel.onIntent(GameDetailIntent.ShowDeleteDownloadDialog) },
                     syncState = syncState,
                     onNavigateToAchievements = { onNavigateToAchievements?.invoke(gameId) },
+                    onAdminScrape = if (state.isAdmin) {{ viewModel.onIntent(GameDetailIntent.AdminScrapeGame) }} else null,
+                    onAdminRefreshAchievements = if (state.isAdmin) {{ viewModel.onIntent(GameDetailIntent.AdminRefreshAchievements) }} else null,
                 )
             },
             coverArt = { modifier, isPortrait ->
@@ -919,6 +922,8 @@ private fun GameHeroContent(
     onDeleteLocalGame: () -> Unit,
     syncState: GameSyncState?,
     onNavigateToAchievements: () -> Unit = {},
+    onAdminScrape: (() -> Unit)? = null,
+    onAdminRefreshAchievements: (() -> Unit)? = null,
 ) {
     val supportsNetplay = game.playable && game.consoleId.lowercase() in NETPLAY_SUPPORTED_CONSOLES
 
@@ -1081,6 +1086,30 @@ private fun GameHeroContent(
                         style = SpTypography.LabelSmall,
                         color = Color.White.copy(alpha = 0.65f),
                     )
+                }
+            }
+
+            // Admin actions (scrape + refresh achievements)
+            if (onAdminScrape != null || onAdminRefreshAchievements != null) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                ) {
+                    if (onAdminScrape != null) {
+                        SpSecondaryButton(
+                            text = "Scrape Metadata",
+                            onClick = onAdminScrape,
+                            isLoading = state.isAdminActionLoading,
+                            onGradient = true,
+                        )
+                    }
+                    if (onAdminRefreshAchievements != null) {
+                        SpSecondaryButton(
+                            text = "Update Achievements",
+                            onClick = onAdminRefreshAchievements,
+                            isLoading = state.isAdminActionLoading,
+                            onGradient = true,
+                        )
+                    }
                 }
             }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -112,6 +112,42 @@ class GameDetailViewModel(
             is GameDetailIntent.RenameSession -> renameSession(intent.sessionId, intent.name)
             is GameDetailIntent.DeleteSession -> deleteSession(intent.sessionId)
             is GameDetailIntent.DuplicateSession -> duplicateSession(intent.sessionId)
+
+            // Admin actions
+            GameDetailIntent.AdminScrapeGame -> adminScrapeGame()
+            GameDetailIntent.AdminRefreshAchievements -> adminRefreshAchievements()
+        }
+    }
+
+    private fun adminScrapeGame() {
+        val gameId = currentGameId ?: return
+        _state.update { it.copy(isAdminActionLoading = true) }
+        scope.launch(dispatchers.io) {
+            runCatching { apiClient.adminScrapeGame(gameId) }
+                .onSuccess {
+                    // Reload game detail to show updated metadata
+                    loadGame(gameId)
+                    _state.update { it.copy(isAdminActionLoading = false, successMessage = "Metadata scraped") }
+                }
+                .onFailure { error ->
+                    _state.update { it.copy(isAdminActionLoading = false, error = error.message) }
+                }
+        }
+    }
+
+    private fun adminRefreshAchievements() {
+        val gameId = currentGameId ?: return
+        _state.update { it.copy(isAdminActionLoading = true) }
+        scope.launch(dispatchers.io) {
+            runCatching { apiClient.adminRefreshAchievements(gameId) }
+                .onSuccess {
+                    // Reload achievements
+                    loadAchievements(gameId)
+                    _state.update { it.copy(isAdminActionLoading = false, successMessage = "Achievements refreshed") }
+                }
+                .onFailure { error ->
+                    _state.update { it.copy(isAdminActionLoading = false, error = error.message) }
+                }
         }
     }
 
@@ -141,6 +177,13 @@ class GameDetailViewModel(
                             ratingSummary = summary,
                             isLoading = false,
                         )
+                    }
+                    // Check admin status asynchronously (non-blocking)
+                    scope.launch(dispatchers.io) {
+                        val isAdmin = runCatching { apiClient.getCurrentUser() }
+                            .map { it.role == "admin" || it.role == "owner" }
+                            .getOrDefault(false)
+                        _state.update { it.copy(isAdmin = isAdmin) }
                     }
                     if (detail.game.scrapeAttempts == 0) {
                         scrapeAndRefresh(gameId)

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -159,6 +159,30 @@ func (h *AdminHandler) ScrapeGame(c *gin.Context) {
 	c.JSON(http.StatusOK, ToGameResponse(game, h.DB, uid))
 }
 
+// RefreshAchievements invalidates the achievement cache for a single game,
+// forcing the next request to re-fetch from RetroAchievements.
+func (h *AdminHandler) RefreshAchievements(c *gin.Context) {
+	id := c.Param("id")
+	var game db.Game
+	if err := h.DB.First(&game, id).Error; err != nil {
+		c.JSON(http.StatusNotFound, gin.H{"error": "game not found"})
+		return
+	}
+
+	// Delete achievement cache entries for this game (by game_id or ra_game_id)
+	deleted := int64(0)
+	if game.RAGameID > 0 {
+		result := h.DB.Where("ra_game_id = ?", game.RAGameID).Delete(&db.GameAchievementCache{})
+		deleted = result.RowsAffected
+	}
+	// Also try by game_id in case ra_game_id wasn't set
+	result := h.DB.Where("game_id = ?", game.ID).Delete(&db.GameAchievementCache{})
+	deleted += result.RowsAffected
+
+	slog.Info("refreshed achievement cache", "game", game.Title, "deleted", deleted)
+	c.JSON(http.StatusOK, gin.H{"message": "Achievement cache cleared", "game": game.Title})
+}
+
 // tryConfigureIGDB loads IGDB credentials and configures the scraper's IGDB client.
 // Environment variables take precedence over database settings.
 func (h *AdminHandler) tryConfigureIGDB() {

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -538,6 +538,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 			admin.DELETE("/scrape", adminHandler.CancelScrape)
 			admin.GET("/scrape/status", adminHandler.ScrapeStatus)
 			admin.POST("/games/:id/scrape", adminHandler.ScrapeGame)
+			admin.POST("/games/:id/achievements/refresh", adminHandler.RefreshAchievements)
 			admin.GET("/games/:id/covers", adminHandler.GetGameCovers)
 			admin.PUT("/games/:id/covers", adminHandler.SetGameCover)
 			admin.GET("/metadata-matches", adminHandler.MetadataMatches)

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -42,6 +42,7 @@ interface GameHeroProps {
   isInPlayLater: boolean;
   isPlayLaterPending?: boolean;
   isScraping: boolean;
+  isRefreshingAchievements?: boolean;
   hasAchievements?: boolean;
   achievementCount?: number;
   achievementUnlocked?: number;
@@ -49,6 +50,7 @@ interface GameHeroProps {
   isDemo?: boolean;
   onPlay: () => void;
   onScrape: () => void;
+  onRefreshAchievements?: () => void;
   onToggleFavorite: () => void;
   onTogglePlayLater: () => void;
   onAddToCollection?: () => void;
@@ -66,6 +68,7 @@ export function GameHero({
   isInPlayLater,
   isPlayLaterPending,
   isScraping,
+  isRefreshingAchievements,
   hasAchievements,
   achievementCount,
   achievementUnlocked,
@@ -73,6 +76,7 @@ export function GameHero({
   isDemo,
   onPlay,
   onScrape,
+  onRefreshAchievements,
   onToggleFavorite,
   onTogglePlayLater,
   onAddToCollection,
@@ -92,6 +96,16 @@ export function GameHero({
             onClick: onScrape,
             loading: isScraping,
           },
+          ...(onRefreshAchievements
+            ? [
+                {
+                  label: "Update Achievements",
+                  icon: <Trophy className="h-4 w-4" />,
+                  onClick: onRefreshAchievements,
+                  loading: isRefreshingAchievements,
+                },
+              ]
+            : []),
         ]
       : []),
     {

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -192,6 +192,20 @@ export function useScrapeGame() {
   });
 }
 
+export function useRefreshAchievements() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (gameId: string) => {
+      await api.post(`/admin/games/${gameId}/achievements/refresh`);
+    },
+    onSuccess: (_data, gameId) => {
+      queryClient.invalidateQueries({ queryKey: ["game", gameId] });
+      queryClient.invalidateQueries({ queryKey: ["achievements", gameId] });
+    },
+  });
+}
+
 export function useAdminStats() {
   return useQuery({
     queryKey: ["admin", "stats"],

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -293,6 +293,7 @@ export type ApiPostPath = WithQuery<
   // Admin
   | "/admin/users"
   | `/admin/games/${string}/scrape`
+  | `/admin/games/${string}/achievements/refresh`
   | `/admin/games/${string}/metadata`
   | `/admin/games/${string}/igdb-match`
   | "/admin/games/scan"

--- a/web/src/pages/__tests__/game-detail-page.test.tsx
+++ b/web/src/pages/__tests__/game-detail-page.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@/hooks/use-auth", () => ({
 
 vi.mock("@/hooks/use-admin", () => ({
   useScrapeGame: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
+  useRefreshAchievements: vi.fn(() => ({ mutate: vi.fn(), isPending: false })),
 }));
 
 vi.mock("@/hooks/use-consoles", () => ({

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/hooks/use-games";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
 import { useAuth } from "@/hooks/use-auth";
-import { useScrapeGame } from "@/hooks/use-admin";
+import { useScrapeGame, useRefreshAchievements } from "@/hooks/use-admin";
 import { useConsoles } from "@/hooks/use-consoles";
 import { useEffect } from "react";
 import {
@@ -115,6 +115,7 @@ export function GameDetailPage() {
   const togglePlayLater = useTogglePlayLater();
   const { user: currentUser } = useAuth();
   const scrapeGame = useScrapeGame();
+  const refreshAchievements = useRefreshAchievements();
   const scrapeIfNeeded = useScrapeIfNeeded();
   const { data: consoles } = useConsoles();
   const isAdmin =
@@ -216,6 +217,8 @@ export function GameDetailPage() {
         isDemo={isDemo}
         onPlay={() => navigate(`/games/${game.id}/play/${sessions && sessions.length > 0 ? sessions[0].id : "new"}`)}
         onScrape={() => scrapeGame.mutate(game.id)}
+        onRefreshAchievements={() => refreshAchievements.mutate(game.id)}
+        isRefreshingAchievements={refreshAchievements.isPending}
         onToggleFavorite={() =>
           toggleFavorite.mutate({ gameId: game.id, isFavorite })
         }


### PR DESCRIPTION
## Summary
- **Server:** New `POST /api/admin/games/:id/achievements/refresh` endpoint that clears the achievement cache
- **Web:** "Update Achievements" button added to game hero actions menu (admin/owner only, next to existing "Scrape Metadata")
- **Player app:** Both "Scrape Metadata" and "Update Achievements" buttons shown on game detail screen for admin/owner users

## Test plan
- [x] Server builds clean
- [x] Web TypeScript compiles clean
- [x] Player compiles clean
- [ ] Web: verify buttons appear for admin users, hidden for regular users
- [ ] Player: verify buttons appear for admin users
- [ ] Verify achievement cache is cleared after clicking Update Achievements