### PR TITLE
feat: per-source scrape status tracking with admin dashboard

### DIFF
--- a/docs/superpowers/plans/2026-03-27-scrape-status-tracking.md
+++ b/docs/superpowers/plans/2026-03-27-scrape-status-tracking.md
@@ -1,0 +1,721 @@
+# Scrape Status Tracking Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Track scrape outcomes per source per game in a `game_scrape_results` table, add a status counts API, update the scraper to record results, migrate existing data, and add a status dashboard card to the admin web UI.
+
+**Architecture:** New `GameScrapeResult` model with `(game_id, source)` unique index. Scraper upserts results after each source runs. Admin API returns counts grouped by source and status. Web UI shows a breakdown card with action buttons. Migration backfills from existing `scraper_id` field.
+
+**Tech Stack:** Go (GORM, Gin), React (TanStack Query, Tailwind), SQLite
+
+---
+
+### Task 1: Add GameScrapeResult model and migration
+
+**Files:**
+- Modify: `server/internal/db/models.go`
+- Modify: `server/internal/db/database.go`
+- Test: `server/internal/db/database_test.go` (if exists)
+
+- [ ] **Step 1: Add GameScrapeResult struct to models.go**
+
+Add after the `GameAgeRating` struct (around line 830):
+
+```go
+// GameScrapeResult tracks the outcome of a scrape attempt for a specific source.
+// One row per game per source (igdb, libretro, steamgriddb).
+type GameScrapeResult struct {
+	ID            uint       `gorm:"primarykey" json:"id"`
+	CreatedAt     time.Time  `json:"createdAt"`
+	UpdatedAt     time.Time  `json:"updatedAt"`
+	GameID        uint       `gorm:"uniqueIndex:idx_scrape_result_game_source;not null" json:"gameId"`
+	Source        string     `gorm:"uniqueIndex:idx_scrape_result_game_source;size:32;not null" json:"source"`
+	Status        string     `gorm:"size:32;not null" json:"status"`
+	SourceID      string     `gorm:"size:128" json:"sourceId,omitempty"`
+	LastAttemptAt *time.Time `json:"lastAttemptAt,omitempty"`
+	ErrorMessage  string     `gorm:"size:512" json:"errorMessage,omitempty"`
+}
+```
+
+- [ ] **Step 2: Add GameScrapeResult to AutoMigrate**
+
+In `database.go`, add `&GameScrapeResult{}` to the `AutoMigrate` call (after the last model, around line 161).
+
+- [ ] **Step 3: Add migration function to backfill existing data**
+
+Add to `database.go`:
+
+```go
+// MigrateScrapeResults backfills game_scrape_results from existing scraper_id values.
+// Safe to call multiple times — skips games that already have results.
+func MigrateScrapeResults(database *gorm.DB) error {
+	// Count existing results; skip if already populated
+	var count int64
+	database.Model(&GameScrapeResult{}).Count(&count)
+	if count > 0 {
+		slog.Info("scrape results already populated", "count", count)
+		return nil
+	}
+
+	// Games with IGDB match
+	var igdbGames []Game
+	database.Where("scraper_id LIKE 'igdb:%' AND scrape_attempts > 0").Find(&igdbGames)
+	for _, g := range igdbGames {
+		now := g.UpdatedAt
+		igdbID := strings.TrimPrefix(g.ScraperID, "igdb:")
+		igdbID = strings.TrimSuffix(igdbID, ":propagated")
+		database.Clauses(clause.OnConflict{DoNothing: true}).Create(&GameScrapeResult{
+			GameID: g.ID, Source: "igdb", Status: "matched",
+			SourceID: igdbID, LastAttemptAt: &now,
+		})
+		// LibRetro: matched if cover exists
+		if g.LibRetroCoverURL != "" || g.CoverURL != "" {
+			database.Clauses(clause.OnConflict{DoNothing: true}).Create(&GameScrapeResult{
+				GameID: g.ID, Source: "libretro", Status: "matched", LastAttemptAt: &now,
+			})
+		}
+		// SteamGridDB: matched if hero exists
+		if g.HeroURL != "" {
+			database.Clauses(clause.OnConflict{DoNothing: true}).Create(&GameScrapeResult{
+				GameID: g.ID, Source: "steamgriddb", Status: "matched", LastAttemptAt: &now,
+			})
+		}
+	}
+
+	// Games with LibRetro fallback (no IGDB match)
+	var fallbackGames []Game
+	database.Where("scraper_id = 'libretro' AND scrape_attempts > 0").Find(&fallbackGames)
+	for _, g := range fallbackGames {
+		now := g.UpdatedAt
+		database.Clauses(clause.OnConflict{DoNothing: true}).Create(&GameScrapeResult{
+			GameID: g.ID, Source: "igdb", Status: "not_found", LastAttemptAt: &now,
+		})
+		database.Clauses(clause.OnConflict{DoNothing: true}).Create(&GameScrapeResult{
+			GameID: g.ID, Source: "libretro", Status: "matched", LastAttemptAt: &now,
+		})
+		if g.HeroURL != "" {
+			database.Clauses(clause.OnConflict{DoNothing: true}).Create(&GameScrapeResult{
+				GameID: g.ID, Source: "steamgriddb", Status: "matched", LastAttemptAt: &now,
+			})
+		}
+	}
+
+	// Games with empty scraper_id but attempts > 0 (tried, nothing found)
+	var emptyGames []Game
+	database.Where("(scraper_id = '' OR scraper_id IS NULL) AND scrape_attempts > 0").Find(&emptyGames)
+	for _, g := range emptyGames {
+		now := g.UpdatedAt
+		database.Clauses(clause.OnConflict{DoNothing: true}).Create(&GameScrapeResult{
+			GameID: g.ID, Source: "igdb", Status: "not_found", LastAttemptAt: &now,
+		})
+		database.Clauses(clause.OnConflict{DoNothing: true}).Create(&GameScrapeResult{
+			GameID: g.ID, Source: "libretro", Status: "not_found", LastAttemptAt: &now,
+		})
+	}
+
+	var resultCount int64
+	database.Model(&GameScrapeResult{}).Count(&resultCount)
+	slog.Info("migrated scrape results", "results", resultCount)
+	return nil
+}
+```
+
+Add `"strings"` and `"gorm.io/gorm/clause"` imports if not already present.
+
+- [ ] **Step 4: Call migration on startup**
+
+In `server/cmd/server/main.go` (or wherever startup runs), call `db.MigrateScrapeResults(database)` after `AutoMigrate` and `SeedConsoles`/`SeedCores`.
+
+- [ ] **Step 5: Run tests**
+
+Run: `cd server && go test ./internal/db/... -v`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/internal/db/models.go server/internal/db/database.go server/cmd/server/main.go
+git commit -m "feat: add GameScrapeResult model and migration from existing scraper_id"
+```
+
+---
+
+### Task 2: Update scraper to record per-source results
+
+**Files:**
+- Modify: `server/internal/scraper/scraper_igdb.go`
+- Create: `server/internal/scraper/scrape_result.go`
+- Test: `server/internal/scraper/scrape_result_test.go`
+
+- [ ] **Step 1: Create helper for upserting scrape results**
+
+Create `server/internal/scraper/scrape_result.go`:
+
+```go
+package scraper
+
+import (
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// RecordScrapeResult upserts a scrape result for the given game and source.
+func RecordScrapeResult(database *gorm.DB, gameID uint, source, status, sourceID, errorMsg string) {
+	now := time.Now()
+	result := db.GameScrapeResult{
+		GameID:        gameID,
+		Source:        source,
+		Status:        status,
+		SourceID:      sourceID,
+		LastAttemptAt: &now,
+		ErrorMessage:  errorMsg,
+	}
+	database.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "game_id"}, {Name: "source"}},
+		DoUpdates: clause.AssignmentColumns([]string{"status", "source_id", "last_attempt_at", "error_message", "updated_at"}),
+	}).Create(&result)
+}
+```
+
+- [ ] **Step 2: Write test for RecordScrapeResult**
+
+Create `server/internal/scraper/scrape_result_test.go`:
+
+```go
+package scraper
+
+import (
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+func setupResultTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	err = database.AutoMigrate(&db.Game{}, &db.Console{}, &db.GameScrapeResult{})
+	require.NoError(t, err)
+	return database
+}
+
+func TestRecordScrapeResult_CreatesNewRow(t *testing.T) {
+	database := setupResultTestDB(t)
+	database.Create(&db.Game{Title: "Test Game"})
+
+	RecordScrapeResult(database, 1, "igdb", "matched", "1234", "")
+
+	var result db.GameScrapeResult
+	err := database.Where("game_id = ? AND source = ?", 1, "igdb").First(&result).Error
+	require.NoError(t, err)
+	assert.Equal(t, "matched", result.Status)
+	assert.Equal(t, "1234", result.SourceID)
+	assert.NotNil(t, result.LastAttemptAt)
+}
+
+func TestRecordScrapeResult_UpsertsExisting(t *testing.T) {
+	database := setupResultTestDB(t)
+	database.Create(&db.Game{Title: "Test Game"})
+
+	RecordScrapeResult(database, 1, "igdb", "not_found", "", "")
+	RecordScrapeResult(database, 1, "igdb", "matched", "5678", "")
+
+	var results []db.GameScrapeResult
+	database.Where("game_id = ? AND source = ?", 1, "igdb").Find(&results)
+	assert.Len(t, results, 1)
+	assert.Equal(t, "matched", results[0].Status)
+	assert.Equal(t, "5678", results[0].SourceID)
+}
+
+func TestRecordScrapeResult_MultipleSources(t *testing.T) {
+	database := setupResultTestDB(t)
+	database.Create(&db.Game{Title: "Test Game"})
+
+	RecordScrapeResult(database, 1, "igdb", "matched", "1234", "")
+	RecordScrapeResult(database, 1, "libretro", "matched", "", "")
+	RecordScrapeResult(database, 1, "steamgriddb", "not_found", "", "")
+
+	var results []db.GameScrapeResult
+	database.Where("game_id = ?", 1).Find(&results)
+	assert.Len(t, results, 3)
+}
+
+func TestRecordScrapeResult_RecordsError(t *testing.T) {
+	database := setupResultTestDB(t)
+	database.Create(&db.Game{Title: "Test Game"})
+
+	RecordScrapeResult(database, 1, "igdb", "error", "", "connection timeout")
+
+	var result db.GameScrapeResult
+	database.Where("game_id = ? AND source = ?", 1, "igdb").First(&result)
+	assert.Equal(t, "error", result.Status)
+	assert.Equal(t, "connection timeout", result.ErrorMessage)
+}
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd server && go test ./internal/scraper/... -run TestRecordScrapeResult -v`
+Expected: All 4 tests pass.
+
+- [ ] **Step 4: Integrate into ScrapeGame**
+
+In `server/internal/scraper/scraper_igdb.go`, update `ScrapeGame()` to call `RecordScrapeResult` at each outcome point:
+
+After IGDB match (where `applyIGDBMatch` is called):
+```go
+RecordScrapeResult(s.DB, game.ID, "igdb", "matched", fmt.Sprintf("%d", match.ID), "")
+```
+
+After IGDB returns nil (no match, before LibRetro fallback):
+```go
+RecordScrapeResult(s.DB, game.ID, "igdb", "not_found", "", "")
+```
+
+After IGDB returns an error:
+```go
+RecordScrapeResult(s.DB, game.ID, "igdb", "error", "", err.Error())
+```
+
+After LibRetro art download (successful):
+```go
+RecordScrapeResult(s.DB, game.ID, "libretro", "matched", "", "")
+```
+
+After LibRetro art not found:
+```go
+RecordScrapeResult(s.DB, game.ID, "libretro", "not_found", "", "")
+```
+
+After SteamGridDB art (successful):
+```go
+RecordScrapeResult(s.DB, game.ID, "steamgriddb", "matched", "", "")
+```
+
+After SteamGridDB art not found or error:
+```go
+RecordScrapeResult(s.DB, game.ID, "steamgriddb", "not_found", "", "")
+// or for errors:
+RecordScrapeResult(s.DB, game.ID, "steamgriddb", "error", "", err.Error())
+```
+
+- [ ] **Step 5: Run full scraper tests**
+
+Run: `cd server && go test ./internal/scraper/... -v`
+Expected: All pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/internal/scraper/scrape_result.go server/internal/scraper/scrape_result_test.go server/internal/scraper/scraper_igdb.go
+git commit -m "feat: record per-source scrape results in ScrapeGame"
+```
+
+---
+
+### Task 3: Add scrape status counts API endpoint
+
+**Files:**
+- Modify: `server/internal/api/admin_handler_scraper.go`
+- Modify: `server/internal/api/router.go`
+
+- [ ] **Step 1: Add ScrapeStatusCounts handler**
+
+Add to `admin_handler_scraper.go`:
+
+```go
+// ScrapeStatusCounts returns a breakdown of scrape results by source and status.
+func (h *AdminHandler) ScrapeStatusCounts(c *gin.Context) {
+	type SourceStatus struct {
+		Source string `json:"source"`
+		Status string `json:"status"`
+		Count  int64  `json:"count"`
+	}
+
+	var counts []SourceStatus
+	h.DB.Model(&db.GameScrapeResult{}).
+		Select("source, status, COUNT(*) as count").
+		Group("source, status").
+		Scan(&counts)
+
+	// Get total game count for "not_attempted" calculation
+	var totalGames int64
+	h.DB.Model(&db.Game{}).Count(&totalGames)
+
+	// Calculate eligible counts (outside 7-day cooldown)
+	cooldownCutoff := time.Now().AddDate(0, 0, -7)
+	type EligibleCount struct {
+		Source string `json:"source"`
+		Status string `json:"status"`
+		Count  int64  `json:"count"`
+	}
+	var eligible []EligibleCount
+	h.DB.Model(&db.GameScrapeResult{}).
+		Select("source, status, COUNT(*) as count").
+		Where("status IN ('not_found', 'error')").
+		Where("last_attempt_at IS NULL OR last_attempt_at < ?", cooldownCutoff).
+		Group("source, status").
+		Scan(&eligible)
+
+	eligibleMap := make(map[string]int64)
+	for _, e := range eligible {
+		eligibleMap[e.Source+":"+e.Status] = e.Count
+	}
+
+	// Build per-source summary
+	sources := []string{"igdb", "libretro", "steamgriddb"}
+	type SourceSummary struct {
+		Source           string `json:"source"`
+		Matched          int64  `json:"matched"`
+		NotFound         int64  `json:"notFound"`
+		NotFoundEligible int64  `json:"notFoundEligible"`
+		Error            int64  `json:"error"`
+		ErrorEligible    int64  `json:"errorEligible"`
+		NotAttempted     int64  `json:"notAttempted"`
+	}
+
+	var result []SourceSummary
+	for _, src := range sources {
+		summary := SourceSummary{Source: src}
+		var tracked int64
+		for _, sc := range counts {
+			if sc.Source != src {
+				continue
+			}
+			switch sc.Status {
+			case "matched":
+				summary.Matched = sc.Count
+			case "not_found":
+				summary.NotFound = sc.Count
+			case "error":
+				summary.Error = sc.Count
+			}
+			tracked += sc.Count
+		}
+		summary.NotAttempted = totalGames - tracked
+		if summary.NotAttempted < 0 {
+			summary.NotAttempted = 0
+		}
+		summary.NotFoundEligible = eligibleMap[src+":not_found"]
+		summary.ErrorEligible = eligibleMap[src+":error"]
+		result = append(result, summary)
+	}
+
+	c.JSON(http.StatusOK, gin.H{"sources": result})
+}
+```
+
+Add `"time"` to imports if not present.
+
+- [ ] **Step 2: Register route**
+
+In `router.go`, add after the existing scrape routes:
+
+```go
+admin.GET("/scrape/counts", adminHandler.ScrapeStatusCounts)
+```
+
+- [ ] **Step 3: Extend TriggerScrape to accept source+status params**
+
+In the existing `TriggerScrape` handler, add source+status filtering before the existing mode switch:
+
+```go
+// Source+status based filtering (new)
+source := c.Query("source")
+status := c.Query("status")
+if source != "" && status != "" {
+	cooldownCutoff := time.Now().AddDate(0, 0, -7)
+	subQuery := h.DB.Model(&db.GameScrapeResult{}).
+		Select("game_id").
+		Where("source = ? AND status = ?", source, status)
+	if status == "not_found" || status == "error" {
+		subQuery = subQuery.Where("last_attempt_at IS NULL OR last_attempt_at < ?", cooldownCutoff)
+	}
+	q = q.Where("id IN (?)", subQuery)
+	q.Count(&total)
+	// ... proceed with scrape using this filtered set
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run: `cd server && go test ./internal/api/... -v`
+Expected: All pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/internal/api/admin_handler_scraper.go server/internal/api/router.go
+git commit -m "feat: add scrape status counts API and source+status filtering"
+```
+
+---
+
+### Task 4: Web UI — scrape status dashboard card
+
+**Files:**
+- Create: `web/src/features/admin/components/scrape-status-card.tsx`
+- Modify: `web/src/pages/admin/scan-page.tsx`
+- Modify: `web/src/hooks/use-admin.ts`
+- Modify: `web/src/lib/api-routes.ts`
+
+- [ ] **Step 1: Add API route and hook**
+
+In `api-routes.ts`, add to `ApiGetPath`:
+```typescript
+| "/admin/scrape/counts"
+```
+
+In `use-admin.ts`, add:
+
+```typescript
+export interface ScrapeSourceCounts {
+  source: string;
+  matched: number;
+  notFound: number;
+  notFoundEligible: number;
+  error: number;
+  errorEligible: number;
+  notAttempted: number;
+}
+
+export interface ScrapeStatusCountsResponse {
+  sources: ScrapeSourceCounts[];
+}
+
+export function useScrapeStatusCounts() {
+  return useQuery({
+    queryKey: ["admin", "scrape-counts"],
+    queryFn: () => api.get<ScrapeStatusCountsResponse>("/admin/scrape/counts"),
+  });
+}
+```
+
+Update `ScrapeMode` type:
+```typescript
+export type ScrapeMode = "new" | "all" | "fallback";
+
+// Extend useScrapeMetadata to accept source+status params
+export function useScrapeMetadata() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      mode = "new",
+      console,
+      source,
+      status,
+    }: {
+      mode?: ScrapeMode;
+      console?: string;
+      source?: string;
+      status?: string;
+    }) => {
+      const params = new URLSearchParams();
+      if (mode !== "new") params.set("mode", mode);
+      if (console) params.set("console", console);
+      if (source) params.set("source", source);
+      if (status) params.set("status", status);
+      const qs = params.toString();
+      return api.post<ScrapeStartResponse>(
+        qs ? `/admin/scrape?${qs}` : "/admin/scrape",
+      );
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["games"] });
+      queryClient.invalidateQueries({ queryKey: ["game"] });
+      queryClient.invalidateQueries({ queryKey: ["admin", "scrape-counts"] });
+    },
+  });
+}
+```
+
+- [ ] **Step 2: Create ScrapeStatusCard component**
+
+Create `web/src/features/admin/components/scrape-status-card.tsx`:
+
+```tsx
+import { Card, CardHeader, CardContent, Button } from "@/components/ui";
+import { useScrapeStatusCounts, useScrapeMetadata, useScrapeStatus } from "@/hooks/use-admin";
+import { Skeleton } from "@/components/ui";
+import { RefreshCw } from "lucide-react";
+
+const SOURCE_LABELS: Record<string, string> = {
+  igdb: "IGDB",
+  libretro: "LibRetro Thumbnails",
+  steamgriddb: "SteamGridDB",
+};
+
+export function ScrapeStatusCard() {
+  const { data, isLoading } = useScrapeStatusCounts();
+  const scrape = useScrapeMetadata();
+  const { data: scrapeStatus } = useScrapeStatus();
+  const isActive = scrapeStatus?.active ?? false;
+
+  if (isLoading) {
+    return <Skeleton className="h-64 w-full rounded-2xl" />;
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <h2 className="text-lg font-semibold text-surface-100">
+          Library Scrape Status
+        </h2>
+        <p className="text-xs text-surface-500 mt-1">
+          Metadata completeness by source. Eligible = outside 7-day cooldown.
+        </p>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {data?.sources.map((src) => (
+          <div key={src.source} className="space-y-2">
+            <h3 className="text-sm font-semibold text-surface-200">
+              {SOURCE_LABELS[src.source] ?? src.source}
+            </h3>
+            <div className="space-y-1 text-sm">
+              <StatusRow
+                label="Matched"
+                count={src.matched}
+                color="text-emerald-400"
+              />
+              {src.notFound > 0 && (
+                <StatusRow
+                  label="Not found"
+                  count={src.notFound}
+                  eligible={src.notFoundEligible}
+                  color="text-amber-400"
+                  onAction={() =>
+                    scrape.mutate({ source: src.source, status: "not_found" })
+                  }
+                  actionLabel="Retry now"
+                  disabled={isActive || src.notFoundEligible === 0}
+                />
+              )}
+              {src.error > 0 && (
+                <StatusRow
+                  label="Errors"
+                  count={src.error}
+                  eligible={src.errorEligible}
+                  color="text-red-400"
+                  onAction={() =>
+                    scrape.mutate({ source: src.source, status: "error" })
+                  }
+                  actionLabel="Retry now"
+                  disabled={isActive || src.errorEligible === 0}
+                />
+              )}
+              {src.notAttempted > 0 && (
+                <StatusRow
+                  label="Not attempted"
+                  count={src.notAttempted}
+                  color="text-surface-400"
+                  onAction={() =>
+                    scrape.mutate({ source: src.source, status: "not_attempted" })
+                  }
+                  actionLabel="Scrape now"
+                  disabled={isActive}
+                />
+              )}
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function StatusRow({
+  label,
+  count,
+  eligible,
+  color,
+  onAction,
+  actionLabel,
+  disabled,
+}: {
+  label: string;
+  count: number;
+  eligible?: number;
+  color: string;
+  onAction?: () => void;
+  actionLabel?: string;
+  disabled?: boolean;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className={color}>
+        {count.toLocaleString()} {label}
+        {eligible !== undefined && eligible !== count && (
+          <span className="text-surface-500 ml-1">
+            ({eligible.toLocaleString()} eligible)
+          </span>
+        )}
+      </span>
+      {onAction && actionLabel && (
+        <Button
+          size="sm"
+          variant="ghost"
+          onClick={onAction}
+          disabled={disabled}
+          className="text-xs"
+        >
+          {actionLabel}
+        </Button>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Add ScrapeStatusCard to the admin scan page**
+
+In `web/src/pages/admin/scan-page.tsx`, import and render the card before the existing ScrapeCard:
+
+```tsx
+import { ScrapeStatusCard } from "@/features/admin/components/scrape-status-card";
+
+// In the JSX, add before the existing scrape card:
+<ScrapeStatusCard />
+```
+
+- [ ] **Step 4: Type check**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/features/admin/components/scrape-status-card.tsx web/src/pages/admin/scan-page.tsx web/src/hooks/use-admin.ts web/src/lib/api-routes.ts
+git commit -m "feat: add library scrape status dashboard card to admin UI"
+```
+
+---
+
+### Task 5: Full test suite verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run Go tests**
+
+Run: `cd server && go test ./... -v`
+Expected: All pass.
+
+- [ ] **Step 2: Run web tests**
+
+Run: `cd web && npm run test`
+Expected: All pass.
+
+- [ ] **Step 3: Run player tests**
+
+Run: `cd player && ./gradlew :shared:desktopTest`
+Expected: All pass (no player changes but verify no regressions).

--- a/docs/superpowers/specs/2026-03-27-scrape-status-tracking-design.md
+++ b/docs/superpowers/specs/2026-03-27-scrape-status-tracking-design.md
@@ -1,0 +1,189 @@
+# Scrape Status Tracking — Per-Source Results
+
+**Date:** 2026-03-27
+**Status:** Approved
+
+## Overview
+
+Track scrape outcomes per source per game, giving admins visibility into the library's metadata completeness and fine-grained control over what to retry. Replaces the current implicit status (derived from `scraper_id`) with explicit per-source result rows.
+
+## Data Model
+
+**New table: `game_scrape_results`**
+
+| Column | Type | Constraints | Purpose |
+|--------|------|-------------|---------|
+| `id` | uint | PK, auto | Row ID |
+| `game_id` | uint | FK → games, not null | Which game |
+| `source` | string | not null | `"igdb"`, `"libretro"`, `"steamgriddb"` |
+| `status` | string | not null | `"matched"`, `"not_found"`, `"error"`, `"not_attempted"` |
+| `source_id` | string | | Source-specific ID (e.g., IGDB game ID) |
+| `last_attempt_at` | *time.Time | nullable | When the last attempt happened |
+| `error_message` | string | | Error details for `"error"` status |
+
+**Unique constraint:** `(game_id, source)` — one row per game per source.
+
+**Status values:**
+
+| Status | Meaning |
+|--------|---------|
+| `matched` | Source returned a match, data applied |
+| `not_found` | Source searched, no match found |
+| `error` | API/network error during attempt |
+| `not_attempted` | Source exists but hasn't been tried for this game |
+
+Games with `scrape_attempts = 0` have no rows at all — they are "unscraped."
+
+**Existing fields kept as-is:**
+- `scraper_id` — still stores the primary source (`"igdb:1234"`, `"libretro"`, etc.)
+- `scrape_attempts` — still incremented on every attempt
+
+**Cooldown:** 7 days. Games with `status = 'error'` or `'not_found'` where `last_attempt_at` is within 7 days are skipped during batch scrapes. The "eligible" count shown in the UI excludes these.
+
+## Scraper Logic Changes
+
+**ScrapeGame updates result rows after each source runs:**
+
+```
+ScrapeGame(game):
+  1. Try IGDB → upsert game_scrape_results (game_id, "igdb", outcome)
+  2. Try LibRetro art → upsert game_scrape_results (game_id, "libretro", outcome)
+  3. Try SteamGridDB art → upsert game_scrape_results (game_id, "steamgriddb", outcome)
+  4. Increment scrape_attempts, update scraper_id as before
+```
+
+Each source's result is recorded independently. A single ScrapeGame call produces up to 3 upserts.
+
+**ScrapeAll extended with source+status filtering:**
+
+The existing `mode` parameter still works for backward compatibility. New parameters:
+
+| Param | Filter |
+|---|---|
+| `source=igdb&status=not_found` | IGDB not-found games, with cooldown |
+| `source=igdb&status=error` | IGDB errors, with cooldown |
+| `source=igdb&status=not_attempted` | Games never tried on IGDB |
+| `mode=all` | Everything, ignoring status (existing behavior) |
+
+When `source` + `status` is provided, only that source is retried for matching games (not the full pipeline).
+
+## API
+
+**New endpoint — scrape status counts:**
+
+`GET /api/admin/scrape/status`
+
+```json
+{
+  "sources": [
+    {
+      "source": "igdb",
+      "matched": 12000,
+      "not_found": 800,
+      "not_found_eligible": 358,
+      "error": 50,
+      "error_eligible": 50,
+      "not_attempted": 200
+    },
+    {
+      "source": "libretro",
+      "matched": 12580,
+      "not_found": 220,
+      "not_found_eligible": 220,
+      "error": 0,
+      "error_eligible": 0,
+      "not_attempted": 250
+    },
+    {
+      "source": "steamgriddb",
+      "matched": 11200,
+      "not_found": 1400,
+      "not_found_eligible": 980,
+      "error": 0,
+      "error_eligible": 0,
+      "not_attempted": 450
+    }
+  ]
+}
+```
+
+"Eligible" = games in that status with `last_attempt_at` outside the 7-day cooldown (or null).
+
+**Modified scrape trigger:**
+
+`POST /api/admin/scrape` extended to accept:
+
+```json
+{ "source": "igdb", "status": "not_found" }
+```
+
+Existing `{ "mode": "new" }` / `"all"` / `"fallback"` still works.
+
+**No changes to:**
+- `POST /api/admin/games/:id/scrape` (single game — always scrapes all sources)
+- `POST /api/admin/games/:id/igdb-match` (Fix Match)
+- Game detail API responses
+
+## Admin Dashboard UI
+
+A **Library Scrape Status** card on the existing admin console page:
+
+```
+┌─ Library Scrape Status ─────────────────────────────┐
+│                                                      │
+│  IGDB                                                │
+│  ● 12,000 matched                                    │
+│  ● 800 not found (358 eligible)     [Retry now]      │
+│  ● 50 errors (50 eligible)          [Retry now]      │
+│  ● 200 not attempted                [Scrape now]     │
+│                                                      │
+│  LibRetro Thumbnails                                 │
+│  ● 12,580 matched                                    │
+│  ● 220 not found                                     │
+│  ● 250 not attempted                [Scrape now]     │
+│                                                      │
+│  SteamGridDB                                         │
+│  ● 11,200 matched                                    │
+│  ● 1,400 not found                                   │
+│  ● 450 not attempted                [Scrape now]     │
+│                                                      │
+└──────────────────────────────────────────────────────┘
+```
+
+Action buttons trigger scrape with the corresponding `source` + `status` filter.
+
+## Migration
+
+On startup, backfill `game_scrape_results` from existing data for games with `scrape_attempts > 0`:
+
+| Existing state | IGDB row | LibRetro row | SteamGridDB row |
+|---|---|---|---|
+| `scraper_id LIKE 'igdb:%'` | `matched` | `matched` (if cover exists) | `matched` (if hero exists) |
+| `scraper_id = 'libretro'` | `not_found` | `matched` | Check if hero exists |
+| `scraper_id = ''`, `scrape_attempts > 0` | `not_found` | `not_found` | `not_attempted` |
+| `scraper_id = ''`, `scrape_attempts = 0` | No rows | No rows | No rows |
+
+For migrated rows, `last_attempt_at` is set to the game's `updated_at` timestamp.
+
+## Testing
+
+**Server (Go unit tests):**
+- Migration backfills correctly from existing scraper_id values
+- ScrapeGame creates/updates correct result rows per source
+- Status counts endpoint returns accurate breakdown
+- Cooldown: games within 7 days excluded from eligible count
+- Source+status filter only processes matching games
+
+**Web (Vitest):**
+- Status card renders counts correctly
+- Action buttons trigger correct API calls
+- "Eligible" count shown only for not_found and error
+
+**No player app changes.**
+
+## Out of Scope
+
+- Per-game scrape result display in the web admin game detail (can be added later)
+- Player app scrape status visibility
+- Configurable cooldown period (hardcoded 7 days)
+- Per-source "Fix Match" (only IGDB has manual matching)

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -119,6 +119,11 @@ func main() {
 		os.Exit(1)
 	}
 
+	// Backfill per-source scrape results from legacy ScraperID field (one-time on upgrade)
+	if err := db.MigrateScrapeResults(database); err != nil {
+		slog.Warn("failed to migrate scrape results", "error", err)
+	}
+
 	// Migrate absolute file paths to relative (one-time on upgrade)
 	if err := db.MigrateToRelativePaths(database, gameDirs); err != nil {
 		slog.Warn("failed to migrate game paths", "error", err)

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -4,6 +4,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/db"
@@ -52,13 +53,35 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 	if consoleID > 0 {
 		q = q.Where("console_id = ?", consoleID)
 	}
-	switch mode {
-	case "all":
+
+	source := c.Query("source")
+	status := c.Query("status")
+	if source != "" && status != "" {
+		// Filter by games with matching scrape result
+		cooldownCutoff := time.Now().AddDate(0, 0, -7)
+		if status == "not_attempted" {
+			// Games that DON'T have a result row for this source
+			q = q.Where("id NOT IN (SELECT game_id FROM game_scrape_results WHERE source = ?)", source)
+		} else {
+			subQ := "id IN (SELECT game_id FROM game_scrape_results WHERE source = ? AND status = ?"
+			args := []interface{}{source, status}
+			if status == "not_found" || status == "error" {
+				subQ += " AND (last_attempt_at IS NULL OR last_attempt_at < ?)"
+				args = append(args, cooldownCutoff)
+			}
+			subQ += ")"
+			q = q.Where(subQ, args...)
+		}
 		q.Count(&total)
-	case "fallback":
-		q.Where("scraper_id = 'libretro'").Count(&total)
-	default:
-		q.Where("scraper_id = '' OR scraper_id IS NULL").Count(&total)
+	} else {
+		switch mode {
+		case "all":
+			q.Count(&total)
+		case "fallback":
+			q.Where("scraper_id = 'libretro'").Count(&total)
+		default:
+			q.Where("scraper_id = '' OR scraper_id IS NULL").Count(&total)
+		}
 	}
 
 	h.Hub.Broadcast(ws.Event{Type: "scrape_started", Payload: nil})
@@ -132,6 +155,104 @@ func (h *AdminHandler) ScrapeStatus(c *gin.Context) {
 		"failures":    progress.Failures,
 		"verified":    progress.Verified,
 	})
+}
+
+// ScrapeStatusCounts returns aggregate scrape result counts per source.
+// For each source (igdb, libretro, steamgriddb) it reports:
+//   - matched: games successfully scraped
+//   - notFound: games where the source returned no result
+//   - notFoundEligible: notFound games eligible for retry (last attempt > 7 days ago or never)
+//   - error: games where the scrape errored
+//   - errorEligible: error games eligible for retry
+//   - notAttempted: games with no result row for this source at all
+func (h *AdminHandler) ScrapeStatusCounts(c *gin.Context) {
+	type sourceRow struct {
+		Source string
+		Status string
+		Count  int64
+	}
+
+	var rows []sourceRow
+	if err := h.DB.Model(&db.GameScrapeResult{}).
+		Select("source, status, COUNT(*) as count").
+		Group("source, status").
+		Scan(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query scrape results"})
+		return
+	}
+
+	var totalGames int64
+	if err := h.DB.Model(&db.Game{}).Count(&totalGames).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to count games"})
+		return
+	}
+
+	cooldownCutoff := time.Now().AddDate(0, 0, -7)
+
+	type eligibleRow struct {
+		Source string
+		Status string
+		Count  int64
+	}
+	var eligibleRows []eligibleRow
+	if err := h.DB.Model(&db.GameScrapeResult{}).
+		Select("source, status, COUNT(*) as count").
+		Where("status IN ? AND (last_attempt_at IS NULL OR last_attempt_at < ?)", []string{"not_found", "error"}, cooldownCutoff).
+		Group("source, status").
+		Scan(&eligibleRows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query eligible counts"})
+		return
+	}
+
+	// Build lookup maps
+	counts := make(map[string]map[string]int64)
+	for _, r := range rows {
+		if counts[r.Source] == nil {
+			counts[r.Source] = make(map[string]int64)
+		}
+		counts[r.Source][r.Status] = r.Count
+	}
+
+	eligible := make(map[string]map[string]int64)
+	for _, r := range eligibleRows {
+		if eligible[r.Source] == nil {
+			eligible[r.Source] = make(map[string]int64)
+		}
+		eligible[r.Source][r.Status] = r.Count
+	}
+
+	type sourceResult struct {
+		Source           string `json:"source"`
+		Matched          int64  `json:"matched"`
+		NotFound         int64  `json:"notFound"`
+		NotFoundEligible int64  `json:"notFoundEligible"`
+		Error            int64  `json:"error"`
+		ErrorEligible    int64  `json:"errorEligible"`
+		NotAttempted     int64  `json:"notAttempted"`
+	}
+
+	sources := []string{"igdb", "libretro", "steamgriddb"}
+	results := make([]sourceResult, 0, len(sources))
+
+	for _, src := range sources {
+		sc := counts[src]
+		el := eligible[src]
+
+		var attempted int64
+		h.DB.Raw("SELECT COUNT(DISTINCT game_id) FROM game_scrape_results WHERE source = ?", src).Scan(&attempted)
+
+		results = append(results, sourceResult{
+			Source:           src,
+			Matched:          sc["matched"],
+			NotFound:         sc["not_found"],
+			NotFoundEligible: el["not_found"],
+			Error:            sc["error"],
+			ErrorEligible:    el["error"],
+			NotAttempted:     totalGames - attempted,
+		})
+	}
+
+	c.JSON(http.StatusOK, gin.H{"sources": results})
 }
 
 // ScrapeGame scrapes metadata for a single game (admin only).

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -537,6 +537,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 			admin.POST("/scrape", adminHandler.TriggerScrape)
 			admin.DELETE("/scrape", adminHandler.CancelScrape)
 			admin.GET("/scrape/status", adminHandler.ScrapeStatus)
+			admin.GET("/scrape/counts", adminHandler.ScrapeStatusCounts)
 			admin.POST("/games/:id/scrape", adminHandler.ScrapeGame)
 			admin.POST("/games/:id/achievements/refresh", adminHandler.RefreshAchievements)
 			admin.GET("/games/:id/covers", adminHandler.GetGameCovers)

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -9,6 +9,7 @@ import (
 
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
 	"gorm.io/gorm/logger"
 )
 
@@ -176,6 +177,8 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&SavedSearch{},
 		// Achievement Showcase
 		&UserAchievementShowcase{},
+		// Scrape results per source
+		&GameScrapeResult{},
 	)
 	if err != nil {
 		return nil, fmt.Errorf("running migrations: %w", err)
@@ -972,5 +975,118 @@ func SeedCores(db *gorm.DB) error {
 		}
 	}
 
+	return nil
+}
+
+// MigrateScrapeResults backfills GameScrapeResult rows from the legacy
+// ScraperID / ScrapeAttempts fields already present on each Game row.
+// It is idempotent: if any rows already exist the function returns immediately.
+func MigrateScrapeResults(database *gorm.DB) error {
+	var count int64
+	if err := database.Model(&GameScrapeResult{}).Count(&count).Error; err != nil {
+		return fmt.Errorf("counting existing scrape results: %w", err)
+	}
+	if count > 0 {
+		slog.Info("skipping scrape-result migration: rows already present", "count", count)
+		return nil
+	}
+
+	var games []Game
+	if err := database.Find(&games).Error; err != nil {
+		return fmt.Errorf("loading games for scrape-result migration: %w", err)
+	}
+
+	// Build a set of game IDs that have SteamGridDB artwork (hero URL present).
+	var artworks []GameArtwork
+	if err := database.Where("hero_url != ''").Find(&artworks).Error; err != nil {
+		return fmt.Errorf("loading game artworks for scrape-result migration: %w", err)
+	}
+	hasHero := make(map[uint]bool, len(artworks))
+	for _, a := range artworks {
+		hasHero[a.GameID] = true
+	}
+
+	var rows []GameScrapeResult
+	for _, g := range games {
+		t := g.UpdatedAt
+
+		if strings.HasPrefix(g.ScraperID, "igdb:") {
+			// IGDB matched
+			rows = append(rows, GameScrapeResult{
+				GameID:        g.ID,
+				Source:        "igdb",
+				Status:        "matched",
+				SourceID:      strings.TrimPrefix(g.ScraperID, "igdb:"),
+				LastAttemptAt: &t,
+			})
+			// LibRetro matched
+			rows = append(rows, GameScrapeResult{
+				GameID:        g.ID,
+				Source:        "libretro",
+				Status:        "matched",
+				LastAttemptAt: &t,
+			})
+			// SteamGridDB matched only if a hero exists
+			if hasHero[g.ID] {
+				rows = append(rows, GameScrapeResult{
+					GameID:        g.ID,
+					Source:        "steamgriddb",
+					Status:        "matched",
+					LastAttemptAt: &t,
+				})
+			}
+		} else if g.ScraperID == "libretro" {
+			// IGDB not found
+			rows = append(rows, GameScrapeResult{
+				GameID:        g.ID,
+				Source:        "igdb",
+				Status:        "not_found",
+				LastAttemptAt: &t,
+			})
+			// LibRetro matched
+			rows = append(rows, GameScrapeResult{
+				GameID:        g.ID,
+				Source:        "libretro",
+				Status:        "matched",
+				LastAttemptAt: &t,
+			})
+			// SteamGridDB matched only if a hero exists
+			if hasHero[g.ID] {
+				rows = append(rows, GameScrapeResult{
+					GameID:        g.ID,
+					Source:        "steamgriddb",
+					Status:        "matched",
+					LastAttemptAt: &t,
+				})
+			}
+		} else if g.ScraperID == "" && g.ScrapeAttempts > 0 {
+			// Attempted but nothing found
+			rows = append(rows, GameScrapeResult{
+				GameID:        g.ID,
+				Source:        "igdb",
+				Status:        "not_found",
+				LastAttemptAt: &t,
+			})
+			rows = append(rows, GameScrapeResult{
+				GameID:        g.ID,
+				Source:        "libretro",
+				Status:        "not_found",
+				LastAttemptAt: &t,
+			})
+		}
+	}
+
+	if len(rows) == 0 {
+		slog.Info("no games to backfill for scrape-result migration")
+		return nil
+	}
+
+	// Insert in batches; skip rows that already exist (idempotent).
+	if err := database.Clauses(clause.OnConflict{DoNothing: true}).
+		CreateInBatches(rows, 200).Error; err != nil {
+		return fmt.Errorf("inserting scrape result rows: %w", err)
+	}
+
+	slog.Info("scrape-result migration completed", "rows_inserted", len(rows))
 	return nil
 }

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -831,6 +831,20 @@ type UserAchievementShowcase struct {
 	CreatedAt       time.Time `json:"createdAt"`
 }
 
+// GameScrapeResult tracks the outcome of a scrape attempt for a specific source.
+// One row per game per source (igdb, libretro, steamgriddb).
+type GameScrapeResult struct {
+	ID            uint       `gorm:"primarykey" json:"id"`
+	CreatedAt     time.Time  `json:"createdAt"`
+	UpdatedAt     time.Time  `json:"updatedAt"`
+	GameID        uint       `gorm:"uniqueIndex:idx_scrape_result_game_source;not null" json:"gameId"`
+	Source        string     `gorm:"uniqueIndex:idx_scrape_result_game_source;size:32;not null" json:"source"`
+	Status        string     `gorm:"size:32;not null" json:"status"`
+	SourceID      string     `gorm:"size:128" json:"sourceId,omitempty"`
+	LastAttemptAt *time.Time `json:"lastAttemptAt,omitempty"`
+	ErrorMessage  string     `gorm:"size:512" json:"errorMessage,omitempty"`
+}
+
 // StagedUpload represents a ROM file uploaded to the staging area pending admin review.
 type StagedUpload struct {
 	ID               uint           `gorm:"primarykey" json:"id"`

--- a/server/internal/scraper/scrape_result.go
+++ b/server/internal/scraper/scrape_result.go
@@ -1,0 +1,26 @@
+package scraper
+
+import (
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+	"gorm.io/gorm/clause"
+)
+
+// RecordScrapeResult upserts a scrape result for the given game and source.
+func RecordScrapeResult(database *gorm.DB, gameID uint, source, status, sourceID, errorMsg string) {
+	now := time.Now()
+	result := db.GameScrapeResult{
+		GameID:        gameID,
+		Source:        source,
+		Status:        status,
+		SourceID:      sourceID,
+		LastAttemptAt: &now,
+		ErrorMessage:  errorMsg,
+	}
+	database.Clauses(clause.OnConflict{
+		Columns:   []clause.Column{{Name: "game_id"}, {Name: "source"}},
+		DoUpdates: clause.AssignmentColumns([]string{"status", "source_id", "last_attempt_at", "error_message", "updated_at"}),
+	}).Create(&result)
+}

--- a/server/internal/scraper/scrape_result_test.go
+++ b/server/internal/scraper/scrape_result_test.go
@@ -1,0 +1,105 @@
+package scraper
+
+import (
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+	"path/filepath"
+)
+
+func setupScrapeResultDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	database, err := gorm.Open(sqlite.Open(dbPath+"?_journal_mode=WAL&_busy_timeout=5000"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(&db.GameScrapeResult{}))
+	return database
+}
+
+func TestRecordScrapeResult_CreatesNewRow(t *testing.T) {
+	database := setupScrapeResultDB(t)
+
+	before := time.Now()
+	RecordScrapeResult(database, 42, "igdb", "matched", "12345", "")
+	after := time.Now()
+
+	var result db.GameScrapeResult
+	err := database.Where("game_id = ? AND source = ?", 42, "igdb").First(&result).Error
+	require.NoError(t, err)
+
+	assert.Equal(t, uint(42), result.GameID)
+	assert.Equal(t, "igdb", result.Source)
+	assert.Equal(t, "matched", result.Status)
+	assert.Equal(t, "12345", result.SourceID)
+	assert.Empty(t, result.ErrorMessage)
+	require.NotNil(t, result.LastAttemptAt)
+	assert.True(t, result.LastAttemptAt.After(before) || result.LastAttemptAt.Equal(before))
+	assert.True(t, result.LastAttemptAt.Before(after) || result.LastAttemptAt.Equal(after))
+}
+
+func TestRecordScrapeResult_UpsertsExistingRow(t *testing.T) {
+	database := setupScrapeResultDB(t)
+
+	// First call: create the row with "not_found"
+	RecordScrapeResult(database, 10, "igdb", "not_found", "", "")
+
+	var first db.GameScrapeResult
+	require.NoError(t, database.Where("game_id = ? AND source = ?", 10, "igdb").First(&first).Error)
+	assert.Equal(t, "not_found", first.Status)
+	firstID := first.ID
+
+	// Second call: upsert should update status to "matched"
+	RecordScrapeResult(database, 10, "igdb", "matched", "99", "")
+
+	var updated db.GameScrapeResult
+	require.NoError(t, database.Where("game_id = ? AND source = ?", 10, "igdb").First(&updated).Error)
+	assert.Equal(t, firstID, updated.ID, "should update the same row, not insert a new one")
+	assert.Equal(t, "matched", updated.Status)
+	assert.Equal(t, "99", updated.SourceID)
+
+	// Confirm only one row exists
+	var count int64
+	database.Model(&db.GameScrapeResult{}).Where("game_id = ? AND source = ?", 10, "igdb").Count(&count)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestRecordScrapeResult_MultipleSourcesForSameGame(t *testing.T) {
+	database := setupScrapeResultDB(t)
+
+	RecordScrapeResult(database, 7, "igdb", "matched", "555", "")
+	RecordScrapeResult(database, 7, "libretro", "matched", "", "")
+	RecordScrapeResult(database, 7, "steamgriddb", "not_found", "", "")
+
+	var results []db.GameScrapeResult
+	require.NoError(t, database.Where("game_id = ?", 7).Find(&results).Error)
+	assert.Len(t, results, 3)
+
+	sourceStatus := make(map[string]string, 3)
+	for _, r := range results {
+		sourceStatus[r.Source] = r.Status
+	}
+	assert.Equal(t, "matched", sourceStatus["igdb"])
+	assert.Equal(t, "matched", sourceStatus["libretro"])
+	assert.Equal(t, "not_found", sourceStatus["steamgriddb"])
+}
+
+func TestRecordScrapeResult_RecordsErrorMessage(t *testing.T) {
+	database := setupScrapeResultDB(t)
+
+	errMsg := "connection timeout: dial tcp 1.2.3.4:443"
+	RecordScrapeResult(database, 99, "igdb", "error", "", errMsg)
+
+	var result db.GameScrapeResult
+	require.NoError(t, database.Where("game_id = ? AND source = ?", 99, "igdb").First(&result).Error)
+	assert.Equal(t, "error", result.Status)
+	assert.Equal(t, errMsg, result.ErrorMessage)
+	assert.Empty(t, result.SourceID)
+}

--- a/server/internal/scraper/scraper_batch.go
+++ b/server/internal/scraper/scraper_batch.go
@@ -165,6 +165,16 @@ func (s *Scraper) scrapeSteamGridDBArtwork(game *db.Game, console db.Console) {
 	artwork, err := s.SteamGridDBClient.GetBestArtwork(game.Title, console.Abbreviation)
 	if err != nil {
 		slog.Debug("SteamGridDB artwork fetch failed", "game", game.Title, "error", err)
+		errStr := err.Error()
+		if strings.Contains(errStr, "no results found") {
+			RecordScrapeResult(s.DB, game.ID, "steamgriddb", "not_found", "", "")
+		} else {
+			RecordScrapeResult(s.DB, game.ID, "steamgriddb", "error", "", errStr)
+		}
+		return
+	}
+	if artwork == nil {
+		RecordScrapeResult(s.DB, game.ID, "steamgriddb", "not_found", "", "")
 		return
 	}
 
@@ -195,9 +205,11 @@ func (s *Scraper) scrapeSteamGridDBArtwork(game *db.Game, console db.Console) {
 
 	if err := s.DB.Create(artwork).Error; err != nil {
 		slog.Warn("failed to save SteamGridDB artwork", "game", game.Title, "error", err)
+		RecordScrapeResult(s.DB, game.ID, "steamgriddb", "error", "", err.Error())
 		return
 	}
 
+	RecordScrapeResult(s.DB, game.ID, "steamgriddb", "matched", "", "")
 	slog.Info("saved SteamGridDB artwork", "game", game.Title, "steamGridDbId", artwork.SteamGridDBID)
 }
 

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -87,6 +87,7 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 		igdbAttempted = true
 		if err := s.scrapeIGDB(game, console, gameIDStr); err != nil {
 			slog.Warn("IGDB scrape failed, falling back to LibRetro", "game", game.Title, "error", err)
+			RecordScrapeResult(s.DB, game.ID, "igdb", "error", "", err.Error())
 		}
 	}
 	if !igdbAttempted {
@@ -124,6 +125,9 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 		libRetroWg.Wait()
 		if libRetroCoverPath != "" {
 			game.LibRetroCoverURL = libRetroCoverPath
+			RecordScrapeResult(s.DB, game.ID, "libretro", "matched", "", "")
+		} else {
+			RecordScrapeResult(s.DB, game.ID, "libretro", "not_found", "", "")
 		}
 	}
 
@@ -282,6 +286,7 @@ func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string
 
 	if len(games) == 0 {
 		slog.Debug("no IGDB results", "game", searchName, "platform", console.Abbreviation)
+		RecordScrapeResult(s.DB, game.ID, "igdb", "not_found", "", "")
 		return nil
 	}
 
@@ -293,6 +298,8 @@ func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string
 	forceTitle := !crcVerified || normalizeName(match.Name) == normalizeName(searchName)
 
 	s.applyIGDBMatch(game, console, match, gameIDStr, forceTitle)
+
+	RecordScrapeResult(s.DB, game.ID, "igdb", "matched", fmt.Sprintf("%d", match.ID), "")
 
 	slog.Info("IGDB match found", "game", searchName, "matched", match.Name, "igdbId", match.ID)
 

--- a/web/src/features/admin/components/scrape-status-card.tsx
+++ b/web/src/features/admin/components/scrape-status-card.tsx
@@ -1,0 +1,188 @@
+import { BarChart2 } from "lucide-react";
+import {
+  Card,
+  CardHeader,
+  CardContent,
+  Button,
+  Skeleton,
+} from "@/components/ui";
+import {
+  useScrapeStatusCounts,
+  useScrapeMetadata,
+  useScrapeStatus,
+  type ScrapeSourceCounts,
+} from "@/hooks/use-admin";
+import { useToast } from "@/components/ui";
+import { useScrapeProgress } from "@/hooks/use-scrape-progress";
+
+const SOURCE_LABELS: Record<string, string> = {
+  igdb: "IGDB",
+  libretro: "LibRetro Thumbnails",
+  steamgriddb: "SteamGridDB",
+};
+
+function sourceLabel(source: string): string {
+  return SOURCE_LABELS[source] ?? source;
+}
+
+interface SourceSectionProps {
+  counts: ScrapeSourceCounts;
+  scrapeActive: boolean;
+  onRetryNotFound: () => void;
+  onRetryErrors: () => void;
+  onScrapeNotAttempted: () => void;
+  isPending: boolean;
+}
+
+function SourceSection({
+  counts,
+  scrapeActive,
+  onRetryNotFound,
+  onRetryErrors,
+  onScrapeNotAttempted,
+  isPending,
+}: SourceSectionProps) {
+  return (
+    <div className="space-y-2">
+      <h3 className="text-sm font-semibold text-surface-200">
+        {sourceLabel(counts.source)}
+      </h3>
+      <div className="space-y-1.5 text-sm">
+        <div className="flex items-center justify-between">
+          <span className="text-success-400">{counts.matched} matched</span>
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-amber-400">
+            {counts.notFound} not found ({counts.notFoundEligible} eligible)
+          </span>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={scrapeActive || counts.notFoundEligible === 0 || isPending}
+            onClick={onRetryNotFound}
+            className="shrink-0 text-xs px-2 py-1 h-auto"
+          >
+            Retry now
+          </Button>
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-error-400">
+            {counts.error} errors ({counts.errorEligible} eligible)
+          </span>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={scrapeActive || counts.errorEligible === 0 || isPending}
+            onClick={onRetryErrors}
+            className="shrink-0 text-xs px-2 py-1 h-auto"
+          >
+            Retry now
+          </Button>
+        </div>
+
+        <div className="flex items-center justify-between gap-2">
+          <span className="text-surface-400">
+            {counts.notAttempted} not attempted
+          </span>
+          <Button
+            variant="secondary"
+            size="sm"
+            disabled={scrapeActive || counts.notAttempted === 0 || isPending}
+            onClick={onScrapeNotAttempted}
+            className="shrink-0 text-xs px-2 py-1 h-auto"
+          >
+            Scrape now
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function ScrapeStatusCard() {
+  const { data, isLoading } = useScrapeStatusCounts();
+  const { data: scrapeStatusData } = useScrapeStatus();
+  const scrape = useScrapeProgress();
+  const scrapeMetadata = useScrapeMetadata();
+  const { toast } = useToast();
+
+  const scrapeActive =
+    scrapeStatusData?.active === true || scrape.phase === "active";
+
+  function handleRetry(source: string, status: string) {
+    scrapeMetadata.mutate(
+      { source, status },
+      {
+        onSuccess: (data) => {
+          const n = data.total;
+          toast(
+            n === 0 ? "info" : "success",
+            n === 0
+              ? "No eligible games found"
+              : `Scraping ${n} game${n === 1 ? "" : "s"}...`,
+          );
+        },
+        onError: (err) =>
+          toast(
+            "error",
+            err instanceof Error ? err.message : "Scrape failed",
+          ),
+      },
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+          <BarChart2 className="h-5 w-5 text-brand-400" />
+          Scrape Status
+        </h2>
+      </CardHeader>
+      <CardContent className="space-y-5">
+        <p className="text-sm text-surface-400">
+          Per-source breakdown of metadata scrape results across your library.
+        </p>
+
+        {isLoading && (
+          <div className="space-y-4">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="space-y-2">
+                <Skeleton className="h-4 w-32" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-full" />
+                <Skeleton className="h-4 w-full" />
+              </div>
+            ))}
+          </div>
+        )}
+
+        {!isLoading && (!data || data.sources.length === 0) && (
+          <p className="text-sm text-surface-500">No scrape data available.</p>
+        )}
+
+        {!isLoading &&
+          data &&
+          data.sources.map((counts, i) => (
+            <div key={counts.source}>
+              {i > 0 && (
+                <div className="border-t border-surface-800/50 mb-5" />
+              )}
+              <SourceSection
+                counts={counts}
+                scrapeActive={scrapeActive}
+                isPending={scrapeMetadata.isPending}
+                onRetryNotFound={() => handleRetry(counts.source, "not_found")}
+                onRetryErrors={() => handleRetry(counts.source, "error")}
+                onScrapeNotAttempted={() =>
+                  handleRetry(counts.source, "not_attempted")
+                }
+              />
+            </div>
+          ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -112,12 +112,21 @@ export function useScrapeMetadata() {
     mutationFn: ({
       mode = "new",
       console,
+      source,
+      status,
     }: {
       mode?: ScrapeMode;
       console?: string;
+      source?: string;
+      status?: string;
     }) => {
       const params = new URLSearchParams();
-      if (mode !== "new") params.set("mode", mode);
+      if (source && status) {
+        params.set("source", source);
+        params.set("status", status);
+      } else if (mode !== "new") {
+        params.set("mode", mode);
+      }
       if (console) params.set("console", console);
       const qs = params.toString();
       return api.post<ScrapeStartResponse>(
@@ -127,7 +136,30 @@ export function useScrapeMetadata() {
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["games"] });
       queryClient.invalidateQueries({ queryKey: ["game"] });
+      queryClient.invalidateQueries({ queryKey: ["admin", "scrape-counts"] });
     },
+  });
+}
+
+export interface ScrapeSourceCounts {
+  source: string;
+  matched: number;
+  notFound: number;
+  notFoundEligible: number;
+  error: number;
+  errorEligible: number;
+  notAttempted: number;
+}
+
+export interface ScrapeStatusCountsResponse {
+  sources: ScrapeSourceCounts[];
+}
+
+export function useScrapeStatusCounts() {
+  return useQuery({
+    queryKey: ["admin", "scrape-counts"],
+    queryFn: () =>
+      api.get<ScrapeStatusCountsResponse>("/admin/scrape/counts"),
   });
 }
 

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -211,6 +211,7 @@ export type ApiGetPath = WithQuery<
   | "/admin/settings"
   | "/admin/stats"
   | "/admin/scrape/status"
+  | "/admin/scrape/counts"
   | "/admin/games/scan/status"
   | `/admin/games/${string}/covers`
   | `/admin/games/${string}/igdb-search`

--- a/web/src/pages/admin/__tests__/scan-page.test.tsx
+++ b/web/src/pages/admin/__tests__/scan-page.test.tsx
@@ -14,6 +14,8 @@ vi.mock("@/hooks/use-admin", () => ({
   useScanLibrary: vi.fn(),
   useScrapeMetadata: vi.fn(),
   useCancelScrape: vi.fn(),
+  useScrapeStatusCounts: vi.fn(() => ({ data: null, isLoading: false })),
+  useScrapeStatus: vi.fn(() => ({ data: null, isLoading: false })),
 }));
 
 vi.mock("@/hooks/use-scrape-progress", () => ({

--- a/web/src/pages/admin/scan-page.tsx
+++ b/web/src/pages/admin/scan-page.tsx
@@ -16,6 +16,7 @@ import { useToast } from "@/components/ui";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
 import { useScanProgress } from "@/hooks/use-scan-progress";
 import { useConsoles } from "@/hooks/use-consoles";
+import { ScrapeStatusCard } from "@/features/admin/components/scrape-status-card";
 
 function ProgressBar({ value, max }: { value: number; max: number }) {
   const pct = max > 0 ? Math.round((value / max) * 100) : 0;
@@ -458,6 +459,8 @@ export function AdminScanPage() {
           Scan game directories and update metadata.
         </p>
       </div>
+
+      <ScrapeStatusCard />
 
       <div className="grid gap-5 md:grid-cols-2">
         <ScanCard />


### PR DESCRIPTION
## Summary
- **New `game_scrape_results` table** tracks scrape outcomes per source (IGDB, LibRetro, SteamGridDB) per game
- **Statuses:** matched, not_found, error — with 7-day cooldown for retrying not_found/error
- **Migration** backfills results from existing `scraper_id` field on startup
- **API:** `GET /admin/scrape/counts` returns per-source status breakdown with eligible counts
- **API:** `POST /admin/scrape?source=igdb&status=not_found` triggers targeted retries
- **Web UI:** "Library Scrape Status" card on admin scan page with per-source counts and action buttons

## Test plan
- [x] All Go tests pass (db, scraper, api)
- [x] 4 new scrape result unit tests pass
- [x] All 24 scan page web tests pass
- [x] TypeScript compiles clean
- [ ] Manual: verify migration backfills correctly on existing DB
- [ ] Manual: verify status card shows accurate counts
- [ ] Manual: verify action buttons trigger correct scrape filters