### PR TITLE
fix: poll scan/scrape status every 3s for reliable UI updates

### DIFF
--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -279,6 +279,7 @@ export function useScrapeStatus() {
   return useQuery({
     queryKey: ["admin", "scrape-status"],
     queryFn: () => api.get<ScrapeStatus>("/admin/scrape/status"),
+    refetchInterval: 3000, // Poll every 3s to catch status changes
   });
 }
 
@@ -294,6 +295,7 @@ export function useScanStatus() {
   return useQuery({
     queryKey: ["admin", "scan-status"],
     queryFn: () => api.get<ScanStatus>("/admin/games/scan/status"),
+    refetchInterval: 3000, // Poll every 3s to catch status changes
   });
 }
 

--- a/web/src/hooks/use-scan-progress.ts
+++ b/web/src/hooks/use-scan-progress.ts
@@ -44,18 +44,20 @@ export function useScanProgress(): ScanProgressState {
   const [total, setTotal] = useState(0);
   const [result, setResult] = useState<ScanCompletePayload | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [initialized, setInitialized] = useState(false);
-
+  // Sync from polled status — this runs on every status refetch (3s interval).
+  // Allows the UI to pick up status after page refresh or WebSocket disconnect.
   useEffect(() => {
-    if (!initialStatus || initialized) return;
-    setInitialized(true);
+    if (!initialStatus) return;
     if (initialStatus.active) {
       setPhase("active");
       setMessage(initialStatus.message ?? "Scanning...");
       setCurrent(initialStatus.current ?? 0);
       setTotal(initialStatus.total ?? 0);
+    } else if (phase === "active") {
+      // Status went from active to inactive — scan finished while we were polling
+      setPhase("idle");
     }
-  }, [initialStatus, initialized]);
+  }, [initialStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useWebSocketEvent(
     "scan_started",

--- a/web/src/hooks/use-scrape-progress.ts
+++ b/web/src/hooks/use-scrape-progress.ts
@@ -54,11 +54,10 @@ export function useScrapeProgress(): ScrapeProgressState {
   const [failures, setFailures] = useState(0);
   const [verified, setVerified] = useState(0);
   const [error, setError] = useState<string | null>(null);
-  const [initialized, setInitialized] = useState(false);
-
+  // Sync from polled status — this runs on every status refetch (3s interval).
+  // Allows the UI to pick up status after page refresh or WebSocket disconnect.
   useEffect(() => {
-    if (!initialStatus || initialized) return;
-    setInitialized(true);
+    if (!initialStatus) return;
     if (initialStatus.active) {
       setPhase("active");
       setCurrent(initialStatus.current ?? 0);
@@ -70,8 +69,11 @@ export function useScrapeProgress(): ScrapeProgressState {
       setSuccesses(initialStatus.successes ?? 0);
       setFailures(initialStatus.failures ?? 0);
       setVerified(initialStatus.verified ?? 0);
+    } else if (phase === "active") {
+      // Status went from active to inactive — scrape finished while we were polling
+      setPhase("idle");
     }
-  }, [initialStatus, initialized]);
+  }, [initialStatus]); // eslint-disable-line react-hooks/exhaustive-deps
 
   useWebSocketEvent(
     "scrape_started",


### PR DESCRIPTION
## Summary
- Scan and scrape status hooks now poll every 3 seconds instead of fetching once on mount
- Progress hooks sync from polled status on every update, not just initial mount
- UI recovers correctly after page refresh during active scan/scrape
- WebSocket events still provide instant updates; polling is the fallback

## Test plan
- [x] TypeScript compiles clean
- [ ] Refresh page during active scan — verify progress resumes
- [ ] Refresh page during active scrape — verify progress resumes
- [ ] Verify WebSocket events still update in real-time (no double-update flicker)