### PR TITLE
fix: gamepad navigation, greyscale theme, cached screen revisit

### DIFF
--- a/docs/superpowers/specs/2026-03-28-server-connection-redesign.md
+++ b/docs/superpowers/specs/2026-03-28-server-connection-redesign.md
@@ -1,0 +1,127 @@
+# Server Connection Screen Redesign
+
+**Date:** 2026-03-28
+**Status:** Approved
+
+## Overview
+
+Redesign the server connection screen (first screen users see) with a responsive layout, SNES-inspired ambient glow styling, improved input visibility, and a welcoming first impression.
+
+## Responsive Layout
+
+Three tiers based on available width (same breakpoints as the nav rail):
+
+### Phone (<600dp) — Centered Card
+
+```
+┌──────────────────────┐
+│                      │
+│  ┌────────────────┐  │
+│  │    [icon]      │  │
+│  │  Welcome to    │  │
+│  │    Spela       │  │
+│  │                │  │
+│  │  [Server List] │  │
+│  │  or [Form]     │  │
+│  │                │  │
+│  └────────────────┘  │
+│                      │
+└──────────────────────┘
+```
+
+- Vertically and horizontally centered glass card
+- Dark gradient background with SNES ambient glow (color blobs)
+- Icon + "Welcome to Spela" + tagline above the form
+- Card: `rgba(255,255,255,0.04)` background, `1px solid rgba(255,255,255,0.08)` border, 24dp radius
+
+### Handheld Landscape (600-840dp) — Split 35/65
+
+```
+┌──────────┬───────────────┐
+│          │               │
+│  [icon]  │ [Server List] │
+│  Spela   │  or [Form]    │
+│ tagline  │               │
+│          │               │
+│  (35%)   │    (65%)      │
+└──────────┴───────────────┘
+```
+
+- Hero panel: 35% width, compact sizing (56dp icon, tighter padding)
+- Everything above the fold — no scrolling on 1080p landscape
+
+### Tablet/Desktop (>840dp) — Split 40/60
+
+Same as handheld but hero panel is 40% width with full-size elements (80dp icon, larger text).
+
+## Hero Panel — SNES Ambient Glow
+
+Dark base color (`#0f0f1a`) with four soft radial color blobs positioned in corners, using the SNES button colors at low opacity:
+
+- **Red** (`rgba(204,34,50,0.25)`) — top-left
+- **Blue** (`rgba(44,44,170,0.25)`) — bottom-right
+- **Green** (`rgba(0,132,61,0.2)`) — bottom-center
+- **Yellow** (`rgba(196,178,8,0.15)`) — top-right
+
+The effect is atmospheric colored lights behind a dark panel — visible but not overwhelming. White text remains highly readable.
+
+On mobile (<600dp), the ambient glow is applied to the full background behind the centered card.
+
+### Hero Content
+
+- App icon: rounded square (16dp radius) with `rgba(255,255,255,0.08)` background and subtle border. "S" in white bold text as placeholder until a proper SVG logo is available.
+- "Spela" title: large, bold, white
+- Tagline: "Your personal retro gaming library" in `rgba(255,255,255,0.6)`
+- Small SNES button dots (4 colored circles, 12dp, 60% opacity) below the tagline as a subtle nod
+
+## Right Panel Content
+
+### No saved servers (first launch)
+
+Show the "Add Server" form directly:
+- "Add Server" heading + "Enter your server details to connect" subtitle
+- Server Name field
+- Server URL field
+- "Connect" button (gradient, full width)
+
+### Saved servers exist
+
+Show server list as cards:
+- Each card: server name (bold), URL (small, muted), active indicator (green dot)
+- Delete button (trash icon) on each card
+- "Add Server" button at the bottom (secondary style)
+- Tapping a server card connects immediately
+
+## Input Field Improvements
+
+These apply to `SpTextField` globally (not just this screen):
+
+- Background: `rgba(255,255,255,0.06)` (currently too transparent)
+- Border: `1px solid rgba(255,255,255,0.12)` (currently invisible)
+- Border radius: 10dp
+- Labels: positioned above the field, uppercase, small size, `OnBackgroundTertiary` color
+- Placeholder text: `OnBackgroundTertiary` color (currently too dark)
+
+## Implementation Notes
+
+- Uses `BoxWithConstraints` for responsive breakpoints (existing pattern)
+- The ambient glow effect uses positioned `Box` elements with radial gradients — no custom drawing needed
+- The glass card effect uses the existing `SpCard` component or a simple `Box` with the frosted glass styling
+- Detection: `maxWidth > 840.dp` → full split, `maxWidth > 600.dp` → compact split, else → centered card
+
+## Testing
+
+Desktop E2E tests:
+- Server list renders saved servers
+- Tapping a server card triggers connection
+- "Add Server" button shows the form
+- Form submits with name and URL
+- Delete button removes a server
+
+No visual tests for the ambient glow (purely cosmetic).
+
+## Out of Scope
+
+- Real SVG logo (placeholder "S" icon for now)
+- Login screen redesign (separate task)
+- Input field improvements on other screens (SpTextField changes will apply globally)

--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -387,6 +387,10 @@ class MainActivity : ComponentActivity() {
         analogDpadDown = nowDown
 
         if (Math.abs(rY) > 0.15f) {
+            // Clear Compose focus so the next d-pad press focuses the first
+            // visible element instead of jumping back to the off-screen element.
+            currentFocus?.clearFocus()
+
             val props = MotionEvent.PointerProperties().apply {
                 id = 0
                 toolType = MotionEvent.TOOL_TYPE_MOUSE

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -126,6 +126,7 @@ import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.ui.gamepad.GamepadHandler
 import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.gamepad.LocalInputMode
 import com.spela.player.presentation.ui.components.LocalScrapeService
 import com.spela.player.presentation.ui.components.ScrapeUpdates
 import com.spela.player.presentation.ui.theme.SpelaTheme
@@ -195,7 +196,10 @@ fun SpelaApp(
     val currentTheme by settingsViewModel.selectedTheme.collectAsState()
 
     SpelaTheme(theme = currentTheme) {
-    CompositionLocalProvider(LocalScrapeService provides scrapeService) {
+    CompositionLocalProvider(
+        LocalScrapeService provides scrapeService,
+        LocalInputMode provides (gamepadPortManager?.inputMode?.collectAsState()?.value ?: InputMode.TOUCH),
+    ) {
         // Observe scrape completions and update cover art reactively
         LaunchedEffect(scrapeService) {
             scrapeService?.scrapedGames?.collect { game ->

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenshotLightbox.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/ScreenshotLightbox.kt
@@ -48,6 +48,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import androidx.compose.ui.window.PopupProperties
 import coil3.compose.AsyncImage
+import com.spela.player.presentation.ui.gamepad.spFocusRing
+import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import kotlinx.coroutines.launch
@@ -114,12 +116,11 @@ fun ScreenshotLightbox(
                     .fillMaxSize()
                     .background(Color.Black.copy(alpha = 0.92f * (1f - dismissProgress * 0.4f))),
             ) {
-                // Pager with mouse-drag support
+                // Pager with mouse-drag support (fullscreen)
                 HorizontalPager(
                     state = pagerState,
                     modifier = Modifier
                         .fillMaxSize()
-                        .padding(vertical = SpSpacing.XXXLarge)
                         .offset { IntOffset(0, verticalDragOffset.roundToInt()) }
                         .alpha(1f - dismissProgress * 0.3f)
                         .mouseDragPager(
@@ -169,7 +170,7 @@ fun ScreenshotLightbox(
                 Text(
                     text = "${pagerState.currentPage + 1} / ${screenshotUrls.size}",
                     style = SpTypography.BodySmall,
-                    color = Color.White.copy(alpha = 0.5f),
+                    color = SpColor.OnBackground,
                     modifier = Modifier
                         .align(Alignment.TopCenter)
                         .padding(top = SpSpacing.XLarge),
@@ -184,7 +185,8 @@ fun ScreenshotLightbox(
                     ),
                     modifier = Modifier
                         .align(Alignment.TopEnd)
-                        .padding(SpSpacing.Medium),
+                        .padding(SpSpacing.Medium)
+                        .spFocusRing(shape = androidx.compose.foundation.shape.CircleShape),
                 ) {
                     Icon(Icons.Filled.Close, "Close", Modifier.size(24.dp))
                 }
@@ -205,6 +207,7 @@ fun ScreenshotLightbox(
                             containerColor = NavButtonColor, contentColor = NavButtonContentColor,
                             disabledContainerColor = NavButtonDisabledColor, disabledContentColor = NavButtonDisabledContentColor,
                         ),
+                        modifier = Modifier.spFocusRing(shape = androidx.compose.foundation.shape.CircleShape),
                     ) { Icon(Icons.AutoMirrored.Filled.KeyboardArrowLeft, "Previous", Modifier.size(36.dp)) }
 
                     val hasNext = pagerState.currentPage < screenshotUrls.size - 1
@@ -215,6 +218,7 @@ fun ScreenshotLightbox(
                             containerColor = NavButtonColor, contentColor = NavButtonContentColor,
                             disabledContainerColor = NavButtonDisabledColor, disabledContentColor = NavButtonDisabledContentColor,
                         ),
+                        modifier = Modifier.spFocusRing(shape = androidx.compose.foundation.shape.CircleShape),
                     ) { Icon(Icons.AutoMirrored.Filled.KeyboardArrowRight, "Next", Modifier.size(36.dp)) }
                 }
 
@@ -222,7 +226,7 @@ fun ScreenshotLightbox(
                 Text(
                     text = "Drag to navigate \u00b7 Scroll to zoom \u00b7 Swipe up/down to close",
                     style = SpTypography.BodySmall,
-                    color = Color.White.copy(alpha = 0.35f),
+                    color = SpColor.OnBackgroundSecondary,
                     modifier = Modifier
                         .align(Alignment.BottomCenter)
                         .padding(bottom = SpSpacing.XLarge),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpBottomNavBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpBottomNavBar.kt
@@ -78,8 +78,8 @@ fun SpBottomNavBar(
                 val interactionSource = remember { MutableInteractionSource() }
                 val isFocused by interactionSource.collectIsFocusedAsState()
                 val color = when {
-                    isSelected -> SpColor.PrimaryLight
-                    isFocused -> SpColor.PrimaryLight.copy(alpha = 0.7f)
+                    isSelected -> Color.White
+                    isFocused -> Color.White.copy(alpha = 0.7f)
                     else -> SpColor.OnBackgroundSecondary
                 }
 
@@ -89,7 +89,7 @@ fun SpBottomNavBar(
                         .height(64.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .background(
-                            if (isFocused) SpColor.Primary.copy(alpha = 0.1f) else Color.Transparent,
+                            if (isFocused) Color.White.copy(alpha = 0.1f) else Color.Transparent,
                         )
                         .clickable(
                             interactionSource = interactionSource,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpBottomNavBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpBottomNavBar.kt
@@ -89,7 +89,7 @@ fun SpBottomNavBar(
                         .height(64.dp)
                         .clip(RoundedCornerShape(8.dp))
                         .background(
-                            if (isFocused) Color.White.copy(alpha = 0.1f) else Color.Transparent,
+                            if (isFocused) Color.Black.copy(alpha = 0.3f) else Color.Transparent,
                         )
                         .clickable(
                             interactionSource = interactionSource,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpButton.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpButton.kt
@@ -47,7 +47,7 @@ fun SpButton(
     val isFocused by interactionSource.collectIsFocusedAsState()
     val focusBorder = Modifier.border(
         width = if (isFocused) 2.dp else 0.dp,
-        color = if (isFocused) SpColor.PrimaryLight else Color.Transparent,
+        color = if (isFocused) Color.White.copy(alpha = 0.85f) else Color.Transparent,
         shape = shape,
     )
     val isIconOnly = text.isEmpty() && leadingIcon != null

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCard.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCard.kt
@@ -157,7 +157,7 @@ fun SpInnerCard(
         modifier = modifier
             .border(
                 width = if (isFocused) 2.dp else 1.dp,
-                color = if (isFocused) SpColor.Primary.copy(alpha = 0.85f)
+                color = if (isFocused) Color.White.copy(alpha = 0.85f)
                         else Color.White.copy(alpha = 0.08f),
                 shape = shape,
             )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCard.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpCard.kt
@@ -81,7 +81,7 @@ fun SpCard(
     }
 
     val borderColor = if (isFocused) {
-        SpColor.Primary.copy(alpha = 0.85f)
+        Color.White.copy(alpha = 0.85f)
     } else if (onGradient) {
         Color.White.copy(alpha = 0.08f)
     } else {
@@ -191,7 +191,7 @@ fun SpGradientCard(
             .shadow(8.dp, shape)
             .border(
                 width = if (isFocused) 2.dp else 0.dp,
-                color = if (isFocused) SpColor.Primary.copy(alpha = 0.85f) else Color.Transparent,
+                color = if (isFocused) Color.White.copy(alpha = 0.85f) else Color.Transparent,
                 shape = shape,
             )
             .clip(shape)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpChip.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpChip.kt
@@ -53,7 +53,7 @@ fun SpChip(
         else -> Color.Transparent
     }
     val borderColor = when {
-        isFocused -> SpColor.PrimaryLight.copy(alpha = 0.85f)
+        isFocused -> Color.White.copy(alpha = 0.85f)
         onGradient -> Color.White.copy(alpha = 0.25f)
         isSelected -> color.copy(alpha = 0.4f)
         else -> SpColor.Divider

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpEmptyState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpEmptyState.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.ui.components
 
 import androidx.compose.foundation.background
+import androidx.compose.ui.graphics.Color
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -56,13 +57,13 @@ fun SpEmptyState(
             modifier = Modifier
                 .size(80.dp)
                 .clip(RoundedCornerShape(SpSpacing.RadiusXLarge))
-                .background(SpColor.SurfaceVariant),
+                .background(Color.Black.copy(alpha = 0.25f)),
             contentAlignment = Alignment.Center,
         ) {
             Icon(
                 imageVector = icon,
                 contentDescription = null,
-                tint = SpColor.OnBackgroundTertiary,
+                tint = Color.White.copy(alpha = 0.5f),
                 modifier = Modifier.size(40.dp),
             )
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpFab.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpFab.kt
@@ -1,0 +1,61 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.gamepad.spFocusRing
+import com.spela.player.presentation.ui.theme.SpSpacing
+
+/**
+ * Shared floating action button with focus ring support for gamepad navigation.
+ * Round shape, white semi-transparent background that blends with any gradient.
+ */
+@Composable
+fun SpFab(
+    icon: ImageVector,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+    description: String = "",
+    size: Dp = 56.dp,
+    iconSize: Dp = 24.dp,
+) {
+    Box(
+        modifier = modifier
+            .size(size)
+            .spFocusRing(shape = CircleShape, scaleOnFocus = true)
+            .shadow(8.dp, CircleShape)
+            .clip(CircleShape)
+            .background(Color.White.copy(alpha = 0.15f))
+            .clickable(onClick = onClick)
+            .focusable()
+            .semantics {
+                contentDescription = description
+                role = Role.Button
+            },
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = Color.White,
+            modifier = Modifier.size(iconSize),
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt
@@ -106,8 +106,8 @@ private fun RailItem(
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
     val color = when {
-        isSelected -> SpColor.PrimaryLight
-        isFocused -> SpColor.PrimaryLight.copy(alpha = 0.7f)
+        isSelected -> Color.White
+        isFocused -> Color.White.copy(alpha = 0.7f)
         else -> SpColor.OnBackgroundSecondary
     }
 
@@ -122,7 +122,7 @@ private fun RailItem(
             )
             .clip(RoundedCornerShape(8.dp))
             .background(
-                if (isFocused) SpColor.Primary.copy(alpha = 0.1f) else Color.Transparent,
+                if (isFocused) Color.White.copy(alpha = 0.1f) else Color.Transparent,
             )
             .clickable(
                 interactionSource = interactionSource,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt
@@ -122,7 +122,7 @@ private fun RailItem(
             )
             .clip(RoundedCornerShape(8.dp))
             .background(
-                if (isFocused) Color.White.copy(alpha = 0.1f) else Color.Transparent,
+                if (isFocused) Color.Black.copy(alpha = 0.3f) else Color.Transparent,
             )
             .clickable(
                 interactionSource = interactionSource,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
@@ -43,7 +43,7 @@ fun SpSectionIndicator(
         Row(
             modifier = Modifier
                 .background(
-                    color = SpColor.SurfaceElevated.copy(alpha = 0.9f),
+                    color = Color.Black.copy(alpha = 0.6f),
                     shape = RoundedCornerShape(24.dp),
                 )
                 .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.compose.ui.graphics.Color
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 
@@ -63,7 +64,7 @@ fun SpSectionIndicator(
                     Icon(
                         imageVector = tab.icon,
                         contentDescription = if (isActive) "Section: ${tab.label}, active" else "Section: ${tab.label}",
-                        tint = if (isActive) SpColor.Primary else SpColor.OnBackgroundTertiary,
+                        tint = if (isActive) Color.White else SpColor.OnBackgroundTertiary,
                         modifier = Modifier.size(24.dp),
                     )
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionList.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionList.kt
@@ -9,6 +9,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.gamepad.LocalInputMode
 import com.spela.player.presentation.ui.theme.SpSpacing
 
 /**
@@ -32,12 +34,20 @@ fun SpSectionList(
     topPadding: Dp = 0.dp,
     content: LazyListScope.() -> Unit,
 ) {
+    // In gamepad mode the SpTopBar is hidden, so reduce the top padding
+    // that was reserving space for it.
+    val effectiveTopPadding = if (LocalInputMode.current == InputMode.GAMEPAD) {
+        SpSpacing.Large
+    } else {
+        topPadding
+    }
+
     LazyColumn(
         modifier = modifier.focusGroup(),
         contentPadding = PaddingValues(
             start = SpSpacing.ScreenHorizontal,
             end = SpSpacing.ScreenHorizontal,
-            top = topPadding,
+            top = effectiveTopPadding,
             bottom = SpSpacing.XLarge,
         ),
         verticalArrangement = Arrangement.spacedBy(SpSpacing.Large),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionList.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionList.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.ui.components
 
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
@@ -32,7 +33,7 @@ fun SpSectionList(
     content: LazyListScope.() -> Unit,
 ) {
     LazyColumn(
-        modifier = modifier,
+        modifier = modifier.focusGroup(),
         contentPadding = PaddingValues(
             start = SpSpacing.ScreenHorizontal,
             end = SpSpacing.ScreenHorizontal,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTileCard.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTileCard.kt
@@ -68,7 +68,7 @@ fun SpTileCard(
         label = "tileScale",
     )
 
-    val borderColor = if (isFocused) SpColor.PrimaryLight.copy(alpha = 0.85f)
+    val borderColor = if (isFocused) Color.White.copy(alpha = 0.85f)
                       else Color.White.copy(alpha = 0.08f)
 
     Box(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTitledSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTitledSection.kt
@@ -76,7 +76,7 @@ fun SpTitledSection(
                     Icon(
                         imageVector = icon,
                         contentDescription = null,
-                        tint = SpColor.Accent,
+                        tint = Color.White.copy(alpha = 0.55f),
                         modifier = Modifier.size(SpSpacing.IconDefault),
                     )
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTopBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTopBar.kt
@@ -33,6 +33,8 @@ import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.gamepad.LocalInputMode
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -48,6 +50,10 @@ fun SpTopBar(
     onGradient: Boolean = false,
     actions: @Composable () -> Unit = {},
 ) {
+    // Hide in gamepad mode — user navigates with B button for back,
+    // and action buttons should be placed in the screen content instead.
+    if (LocalInputMode.current == InputMode.GAMEPAD) return
+
     Column(
         modifier = modifier
             .fillMaxWidth()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameCommunityStatsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameCommunityStatsSection.kt
@@ -28,6 +28,7 @@ import com.spela.player.presentation.ui.components.SpInnerCard
 import com.spela.player.presentation.ui.components.SpTitledSection
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.TrendingUp
+import androidx.compose.ui.graphics.Color
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
@@ -108,7 +109,7 @@ private fun StatMiniCard(
             Text(
                 text = value,
                 style = SpTypography.TitleLarge,
-                color = SpColor.Accent,
+                color = SpColor.OnBackground,
             )
             Text(
                 text = label,
@@ -174,14 +175,14 @@ private fun TopPlayerRow(
                     .weight(1f)
                     .height(8.dp)
                     .clip(RoundedCornerShape(4.dp))
-                    .background(SpColor.Accent.copy(alpha = 0.15f)),
+                    .background(Color.White.copy(alpha = 0.10f)),
             ) {
                 Box(
                     modifier = Modifier
                         .fillMaxWidth(barFraction)
                         .height(8.dp)
                         .clip(RoundedCornerShape(4.dp))
-                        .background(SpColor.Accent),
+                        .background(Color.White.copy(alpha = 0.60f)),
                 )
             }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
@@ -1,6 +1,9 @@
 package com.spela.player.presentation.ui.feature.gamedetail
 
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.shape.RoundedCornerShape
+import com.spela.player.presentation.ui.gamepad.spFocusRing
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
@@ -134,7 +137,11 @@ private fun MetadataItem(
         modifier = modifier
             .padding(vertical = SpSpacing.XSmall)
             .then(
-                if (isClickable) Modifier.clickable(onClick = onClick!!) else Modifier
+                if (isClickable) Modifier
+                    .spFocusRing(shape = RoundedCornerShape(SpSpacing.Small))
+                    .clickable(onClick = onClick!!)
+                    .focusable()
+                else Modifier
             ),
         verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
@@ -223,8 +223,8 @@ private fun SessionItem(
     val isMultiplayer = session.memberCount > 1
 
     SpInnerCard(
+        onClick = onClick,
         modifier = modifier
-            .clickable(onClick = onClick)
             .testTag("session_item_${session.id}"),
     ) {
         Row(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/TimeToBeatSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/TimeToBeatSection.kt
@@ -70,7 +70,7 @@ internal fun TimeToBeatSection(
                     label = "Main Story",
                     seconds = hastily,
                     maxSeconds = maxSeconds,
-                    color = SpColor.Accent,
+                    color = Color.White.copy(alpha = 0.85f),
                     animationStarted = animationStarted,
                 )
             }
@@ -80,7 +80,7 @@ internal fun TimeToBeatSection(
                     label = "Main + Extras",
                     seconds = normally,
                     maxSeconds = maxSeconds,
-                    color = SpColor.Warning,
+                    color = Color.White.copy(alpha = 0.65f),
                     animationStarted = animationStarted,
                 )
             }
@@ -90,7 +90,7 @@ internal fun TimeToBeatSection(
                     label = "Completionist",
                     seconds = completely,
                     maxSeconds = maxSeconds,
-                    color = SpColor.Primary,
+                    color = Color.White.copy(alpha = 0.50f),
                     animationStarted = animationStarted,
                 )
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
+import com.spela.player.presentation.ui.gamepad.spFocusRing
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material.icons.filled.ExpandLess
@@ -166,6 +167,7 @@ internal fun ConsoleCard(
         modifier = modifier
             .height(180.dp)
             .graphicsLayer { scaleX = scale; scaleY = scale }
+            .spFocusRing(shape = shape, scaleOnFocus = true)
             .shadow(8.dp, shape)
             .clip(shape)
             .drawBehind {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.focusable
 import androidx.compose.foundation.hoverable
 import androidx.compose.foundation.interaction.MutableInteractionSource
@@ -378,6 +379,7 @@ internal fun ConsoleHeroBanner(
         modifier = modifier
             .fillMaxWidth()
             .height(200.dp)
+            .focusGroup()
             .clip(shape)
             // CSS 135deg-equivalent gradient: fixed 45° diagonal (top-left → bottom-right)
             // regardless of aspect ratio, matching the visual appearance on the web.
@@ -547,11 +549,12 @@ internal fun ConsoleHeroBanner(
                     }
                 }
 
-                // Bottom-right: action buttons
+                // Bottom-right: action buttons (stacked vertically for narrow screens)
                 if (onBrowseGames != null || onConsoleSettings != null) {
-                    Row(
+                    Column(
                         modifier = Modifier.align(Alignment.BottomEnd),
-                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                        horizontalAlignment = Alignment.End,
                     ) {
                         if (onConsoleSettings != null) {
                             SpButton(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -29,6 +29,7 @@ import androidx.compose.foundation.interaction.collectIsPressedAsState
 import com.spela.player.presentation.ui.gamepad.spFocusRing
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material.icons.filled.Language
@@ -355,6 +356,7 @@ internal fun ConsoleHeroBanner(
     console: Console,
     modifier: Modifier = Modifier,
     onBrowseGames: (() -> Unit)? = null,
+    onConsoleSettings: (() -> Unit)? = null,
 ) {
     val shape = RoundedCornerShape(SpSpacing.CardCornerRadius)
 
@@ -545,15 +547,35 @@ internal fun ConsoleHeroBanner(
                     }
                 }
 
-                // Bottom-right: browse button
-                if (onBrowseGames != null) {
-                    Box(modifier = Modifier.align(Alignment.BottomEnd)) {
-                        SpButton(
-                            text = "Browse games",
-                            onClick = onBrowseGames,
-                            style = SpButtonStyle.Secondary,
-                            onGradient = true,
-                        )
+                // Bottom-right: action buttons
+                if (onBrowseGames != null || onConsoleSettings != null) {
+                    Row(
+                        modifier = Modifier.align(Alignment.BottomEnd),
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                    ) {
+                        if (onConsoleSettings != null) {
+                            SpButton(
+                                text = "Console settings",
+                                onClick = onConsoleSettings,
+                                style = SpButtonStyle.Outlined,
+                                onGradient = true,
+                                leadingIcon = {
+                                    Icon(
+                                        Icons.Filled.Settings,
+                                        contentDescription = null,
+                                        modifier = Modifier.size(16.dp),
+                                    )
+                                },
+                            )
+                        }
+                        if (onBrowseGames != null) {
+                            SpButton(
+                                text = "Browse games",
+                                onClick = onBrowseGames,
+                                style = SpButtonStyle.Secondary,
+                                onGradient = true,
+                            )
+                        }
                     }
                 }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -515,26 +515,26 @@ internal fun ConsoleHeroBanner(
                     ConsoleInfoSection(console = console)
                 }
 
-                // Center: logo + badges
-                // Center: logo
+                // Center: logo + game count badge
                 Column(
                     modifier = Modifier.fillMaxSize(),
                     horizontalAlignment = Alignment.CenterHorizontally,
                     verticalArrangement = Arrangement.Center,
                 ) {
                     logoContent()
+                    Spacer(modifier = Modifier.height(SpSpacing.Small))
+                    MetadataBadge(
+                        icon = { Icon(Icons.Filled.SportsEsports, null, Modifier.size(12.dp), tint = HeroTextPrimary) },
+                        label = "${console.gameCount} ${if (console.gameCount == 1) "game" else "games"}",
+                    )
                 }
 
-                // Top-right: game count + feature badges
+                // Top-right: feature badges
                 Column(
                     modifier = Modifier.align(Alignment.TopEnd),
                     horizontalAlignment = Alignment.End,
                     verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
                 ) {
-                    MetadataBadge(
-                        icon = { Icon(Icons.Filled.SportsEsports, null, Modifier.size(12.dp), tint = HeroTextPrimary) },
-                        label = "${console.gameCount} ${if (console.gameCount == 1) "game" else "games"}",
-                    )
                     if (console.saveStateSupport) {
                         MetadataBadge(
                             icon = { Icon(Icons.Filled.Check, null, Modifier.size(12.dp), tint = HeroTextPrimary) },

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -166,8 +166,8 @@ internal fun ConsoleCard(
     Box(
         modifier = modifier
             .height(180.dp)
-            .graphicsLayer { scaleX = scale; scaleY = scale }
             .spFocusRing(shape = shape, scaleOnFocus = true)
+            .graphicsLayer { scaleX = scale; scaleY = scale }
             .shadow(8.dp, shape)
             .clip(shape)
             .drawBehind {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -188,7 +188,7 @@ fun Modifier.spFocusRing(
     var isFocused by remember { mutableStateOf(false) }
 
     val borderColor by animateColorAsState(
-        targetValue = if (isFocused) SpColor.Primary.copy(alpha = 0.85f) else Color.Transparent,
+        targetValue = if (isFocused) Color.White.copy(alpha = 0.85f) else Color.Transparent,
         animationSpec = tween(150),
     )
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -90,29 +90,43 @@ fun GamepadHandler(
 
                 when (event.key) {
                     Key.DirectionUp -> {
-                        if (!focusManager.moveFocus(FocusDirection.Up) && !hasFocus) {
-                            focusManager.moveFocus(FocusDirection.Next)
+                        val hadFocus = hasFocus
+                        if (!focusManager.moveFocus(FocusDirection.Up)) {
+                            // Recovery: re-acquire focus when nothing is focused,
+                            // or when focus escaped the visible area at a boundary.
+                            if (!hadFocus || !hasFocus) {
+                                focusManager.moveFocus(FocusDirection.Next)
+                            }
                         }
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionDown -> {
-                        if (!focusManager.moveFocus(FocusDirection.Down) && !hasFocus) {
-                            focusManager.moveFocus(FocusDirection.Next)
+                        val hadFocus = hasFocus
+                        if (!focusManager.moveFocus(FocusDirection.Down)) {
+                            if (!hadFocus || !hasFocus) {
+                                focusManager.moveFocus(FocusDirection.Next)
+                            }
                         }
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionLeft -> {
-                        if (!focusManager.moveFocus(FocusDirection.Left) && !hasFocus) {
-                            focusManager.moveFocus(FocusDirection.Next)
+                        val hadFocus = hasFocus
+                        if (!focusManager.moveFocus(FocusDirection.Left)) {
+                            if (!hadFocus || !hasFocus) {
+                                focusManager.moveFocus(FocusDirection.Next)
+                            }
                         }
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionRight -> {
-                        if (!focusManager.moveFocus(FocusDirection.Right) && !hasFocus) {
-                            focusManager.moveFocus(FocusDirection.Next)
+                        val hadFocus = hasFocus
+                        if (!focusManager.moveFocus(FocusDirection.Right)) {
+                            if (!hadFocus || !hasFocus) {
+                                focusManager.moveFocus(FocusDirection.Next)
+                            }
                         }
                         onGamepadInput?.invoke()
                         true

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -69,13 +69,13 @@ fun GamepadHandler(
     // not have focusable elements in the compose tree on the first attempt.
     if (focusResetKey != null) {
         LaunchedEffect(focusResetKey) {
-            delay(100)
+            delay(150)
             focusManager.clearFocus(force = true)
-            // Retry up to 5 times (100ms apart) to find a focusable element.
-            // moveFocus returns true if focus was successfully moved.
-            repeat(5) {
+            // Retry up to 15 times (200ms apart, ~3s total) to find a focusable element.
+            // Screens with async data may need time before focusable items are composed.
+            repeat(15) {
                 if (focusManager.moveFocus(FocusDirection.Next)) return@LaunchedEffect
-                delay(100)
+                delay(200)
             }
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/InputMode.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/InputMode.kt
@@ -1,3 +1,11 @@
 package com.spela.player.presentation.ui.gamepad
 
+import androidx.compose.runtime.compositionLocalOf
+
 enum class InputMode { TOUCH, GAMEPAD }
+
+/**
+ * Provides the current input mode to any composable in the tree.
+ * Defaults to TOUCH so screens render normally without a gamepad.
+ */
+val LocalInputMode = compositionLocalOf { InputMode.TOUCH }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/CollectionsScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Add
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
@@ -40,6 +39,7 @@ import androidx.compose.ui.unit.dp
 import com.spela.player.domain.model.GameCollection
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpCoverArt
+import com.spela.player.presentation.ui.components.SpFab
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
 import com.spela.player.presentation.ui.components.SpSnackbar
@@ -184,21 +184,14 @@ fun CollectionsScreen(
         }
 
         // FAB
-        FloatingActionButton(
+        SpFab(
+            icon = Icons.Filled.Add,
             onClick = { viewModel.onIntent(CollectionsIntent.ShowCreateDialog) },
-            containerColor = SpColor.Primary,
-            contentColor = SpColor.OnPrimary,
-            shape = RoundedCornerShape(SpSpacing.RadiusXLarge),
+            description = "Create collection",
             modifier = Modifier
                 .align(Alignment.BottomEnd)
-                .padding(SpSpacing.Default)
-                .semantics { contentDescription = "Create collection" },
-        ) {
-            Icon(
-                imageVector = Icons.Filled.Add,
-                contentDescription = null,
-            )
-        }
+                .padding(SpSpacing.Default),
+        )
 
         // Success snackbar
         SpSnackbar(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -2,8 +2,6 @@ package com.spela.player.presentation.ui.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
-import com.spela.player.presentation.ui.gamepad.InputMode
-import com.spela.player.presentation.ui.gamepad.LocalInputMode
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -128,17 +126,14 @@ fun ConsoleScreen(
                     )
                 },
         ) {
-            val isGamepadMode = LocalInputMode.current == InputMode.GAMEPAD
-
             PullToRefreshBox(
                 isRefreshing = state.isLoading,
                 onRefresh = { viewModel.onIntent(GameListIntent.SelectConsole(consoleId)) },
                 modifier = Modifier.fillMaxSize(),
             ) {
-
                 SpSectionList(
                     modifier = Modifier.fillMaxSize(),
-                    topPadding = if (isGamepadMode) SpSpacing.Large else SpSpacing.TopBarHeight + LocalTitleBarInset.current,
+                    topPadding = SpSpacing.TopBarHeight + LocalTitleBarInset.current,
                 ) {
                     // Console hero banner
                     if (console != null) {
@@ -146,7 +141,7 @@ fun ConsoleScreen(
                             ConsoleHeroBanner(
                                 console = console,
                                 onBrowseGames = if (state.games.size > 15) onBrowseAllGames else null,
-                                onConsoleSettings = if (isGamepadMode) onNavigateToConsoleSettings else null,
+                                onConsoleSettings = onNavigateToConsoleSettings,
                             )
                         }
                     }
@@ -256,33 +251,31 @@ fun ConsoleScreen(
                 }
             }
 
-            // Fixed top bar overlaid on top of scrollable content (hidden in gamepad mode —
-            // user navigates with B for back, settings button is in the hero banner)
-            if (!isGamepadMode) {
-                SpTopBar(
-                    title = consoleName,
-                    showBack = true,
-                    onGradient = true,
-                    onBack = onBack,
-                    titleLeadingContent = if (console?.iconUrl?.isNotEmpty() == true) {
-                        {
-                            AsyncImage(
-                                model = console.iconUrl,
-                                contentDescription = null,
-                                modifier = Modifier.size(28.dp),
-                            )
-                        }
-                    } else null,
-                    actions = {
-                        SpIconButton(
-                            icon = Icons.Filled.Settings,
-                            contentDescription = "Console settings",
-                            onGradient = true,
-                            onClick = onNavigateToConsoleSettings,
+            // Fixed top bar overlaid on top of scrollable content
+            // (auto-hidden in gamepad mode by SpTopBar)
+            SpTopBar(
+                title = consoleName,
+                showBack = true,
+                onGradient = true,
+                onBack = onBack,
+                titleLeadingContent = if (console?.iconUrl?.isNotEmpty() == true) {
+                    {
+                        AsyncImage(
+                            model = console.iconUrl,
+                            contentDescription = null,
+                            modifier = Modifier.size(28.dp),
                         )
-                    },
-                )
-            }
+                    }
+                } else null,
+                actions = {
+                    SpIconButton(
+                        icon = Icons.Filled.Settings,
+                        contentDescription = "Console settings",
+                        onGradient = true,
+                        onClick = onNavigateToConsoleSettings,
+                    )
+                },
+            )
         }
 
         // Error snackbar

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -1,6 +1,7 @@
 package com.spela.player.presentation.ui.screen
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.focusGroup
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -111,6 +112,7 @@ fun ConsoleScreen(
         Box(
             modifier = Modifier
                 .fillMaxSize()
+                .focusGroup()
                 .drawBehind {
                     val cx = size.width / 2f
                     val cy = size.height / 2f

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -2,6 +2,8 @@ package com.spela.player.presentation.ui.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
+import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.gamepad.LocalInputMode
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
@@ -126,14 +128,17 @@ fun ConsoleScreen(
                     )
                 },
         ) {
+            val isGamepadMode = LocalInputMode.current == InputMode.GAMEPAD
+
             PullToRefreshBox(
                 isRefreshing = state.isLoading,
                 onRefresh = { viewModel.onIntent(GameListIntent.SelectConsole(consoleId)) },
                 modifier = Modifier.fillMaxSize(),
             ) {
+
                 SpSectionList(
                     modifier = Modifier.fillMaxSize(),
-                    topPadding = SpSpacing.TopBarHeight + LocalTitleBarInset.current,
+                    topPadding = if (isGamepadMode) SpSpacing.Large else SpSpacing.TopBarHeight + LocalTitleBarInset.current,
                 ) {
                     // Console hero banner
                     if (console != null) {
@@ -141,6 +146,7 @@ fun ConsoleScreen(
                             ConsoleHeroBanner(
                                 console = console,
                                 onBrowseGames = if (state.games.size > 15) onBrowseAllGames else null,
+                                onConsoleSettings = if (isGamepadMode) onNavigateToConsoleSettings else null,
                             )
                         }
                     }
@@ -250,30 +256,33 @@ fun ConsoleScreen(
                 }
             }
 
-            // Fixed top bar overlaid on top of scrollable content
-            SpTopBar(
-                title = consoleName,
-                showBack = true,
-                onGradient = true,
-                onBack = onBack,
-                titleLeadingContent = if (console?.iconUrl?.isNotEmpty() == true) {
-                    {
-                        AsyncImage(
-                            model = console.iconUrl,
-                            contentDescription = null,
-                            modifier = Modifier.size(28.dp),
+            // Fixed top bar overlaid on top of scrollable content (hidden in gamepad mode —
+            // user navigates with B for back, settings button is in the hero banner)
+            if (!isGamepadMode) {
+                SpTopBar(
+                    title = consoleName,
+                    showBack = true,
+                    onGradient = true,
+                    onBack = onBack,
+                    titleLeadingContent = if (console?.iconUrl?.isNotEmpty() == true) {
+                        {
+                            AsyncImage(
+                                model = console.iconUrl,
+                                contentDescription = null,
+                                modifier = Modifier.size(28.dp),
+                            )
+                        }
+                    } else null,
+                    actions = {
+                        SpIconButton(
+                            icon = Icons.Filled.Settings,
+                            contentDescription = "Console settings",
+                            onGradient = true,
+                            onClick = onNavigateToConsoleSettings,
                         )
-                    }
-                } else null,
-                actions = {
-                    SpIconButton(
-                        icon = Icons.Filled.Settings,
-                        contentDescription = "Console settings",
-                        onGradient = true,
-                        onClick = onNavigateToConsoleSettings,
-                    )
-                },
-            )
+                    },
+                )
+            }
         }
 
         // Error snackbar

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
@@ -13,8 +13,8 @@ object SpColor {
     val PrimaryDark = Color(0xFF4834D4)
     val PrimaryContainer = Color(0xFF1E1640)
 
-    // Link color — brighter than Primary for readable text on dark backgrounds
-    val Link = Color(0xFF9B8FEF)
+    // Link color — bright white for readable text on dark/gradient backgrounds
+    val Link = Color(0xFFDDDDDD)
 
     // Secondary palette - vivid coral/rose
     val Secondary = Color(0xFFFF6B81)
@@ -27,26 +27,26 @@ object SpColor {
     val AccentLight = Color(0xFF69E4FF)
     val AccentDark = Color(0xFF009FCC)
 
-    // Background surfaces - true dark with subtle blue tint
-    val Background = Color(0xFF0A0A10)
-    val Surface = Color(0xFF12121C)
-    val SurfaceVariant = Color(0xFF1A1A28)
-    val SurfaceElevated = Color(0xFF222236)
-    val SurfaceBright = Color(0xFF2A2A42)
+    // Background surfaces - true dark, neutral (no blue tint)
+    val Background = Color(0xFF0A0A0C)
+    val Surface = Color(0xFF121214)
+    val SurfaceVariant = Color(0xFF1A1A1E)
+    val SurfaceElevated = Color(0xFF222226)
+    val SurfaceBright = Color(0xFF2A2A30)
 
     // Card surfaces
-    val Card = Color(0xFF16162A)
-    val CardHovered = Color(0xFF1E1E38)
+    val Card = Color(0xFF161618)
+    val CardHovered = Color(0xFF1E1E22)
 
-    // Text
-    val OnBackground = Color(0xFFF0F0F8)
-    val OnBackgroundSecondary = Color(0xFFB0B0C8)
-    val OnBackgroundTertiary = Color(0xFF707090)
+    // Text - greyscale only, no color tint
+    val OnBackground = Color(0xFFF0F0F0)
+    val OnBackgroundSecondary = Color(0xFFCCCCCC)
+    val OnBackgroundTertiary = Color(0xFF888888)
     val OnPrimary = Color(0xFFFFFFFF)
     val OnSecondary = Color(0xFFFFFFFF)
-    val OnSurface = Color(0xFFE8E8F0)
-    val OnSurfaceVariant = Color(0xFFA0A0B8)
-    val OnCard = Color(0xFFE0E0F0)
+    val OnSurface = Color(0xFFE8E8E8)
+    val OnSurfaceVariant = Color(0xFFA0A0A0)
+    val OnCard = Color(0xFFE0E0E0)
 
     // Semantic interaction colors
     val Favorite = Color(0xFFFF4757)  // heart / like
@@ -89,12 +89,12 @@ object SpColor {
     val ScrimLight = Color(0x80000000)
 
     // Divider
-    val Divider = Color(0xFF2A2A3A)
-    val DividerLight = Color(0xFF3A3A4A)
+    val Divider = Color(0xFF2A2A2E)
+    val DividerLight = Color(0xFF3A3A3E)
 
-    // Default screen background gradient (dark, non-black)
-    val ScreenGradientStart = Color(0xFF1E1E3A)
-    val ScreenGradientEnd = Color(0xFF162030)
+    // Default screen background gradient (dark, neutral)
+    val ScreenGradientStart = Color(0xFF1A1A20)
+    val ScreenGradientEnd = Color(0xFF141418)
 }
 
 /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -427,7 +427,7 @@ class ExploreViewModel(
 
     private fun loadFeatured() {
         if (featuredJob?.isActive == true) return
-        _state.update { it.copy(isLoadingFeatured = true) }
+        _state.update { it.copy(isLoadingFeatured = it.featuredGames.isEmpty()) }
         featuredJob = scope.launch(dispatchers.io) {
             exploreRepository.getFeaturedGames().fold(
                 onSuccess = { featured ->
@@ -442,7 +442,7 @@ class ExploreViewModel(
 
     private fun loadRows() {
         if (rowsJob?.isActive == true) return
-        _state.update { it.copy(isLoadingRows = true) }
+        _state.update { it.copy(isLoadingRows = it.rows.isEmpty()) }
         rowsJob = scope.launch(dispatchers.io) {
             exploreRepository.getExploreRows().fold(
                 onSuccess = { rows ->
@@ -457,7 +457,7 @@ class ExploreViewModel(
 
     private fun loadThemes() {
         if (themesJob?.isActive == true) return
-        _state.update { it.copy(isLoadingThemes = true) }
+        _state.update { it.copy(isLoadingThemes = it.themes.isEmpty()) }
         themesJob = scope.launch(dispatchers.io) {
             exploreRepository.getThemes().fold(
                 onSuccess = { themes ->
@@ -472,7 +472,7 @@ class ExploreViewModel(
 
     private fun loadKeywords() {
         if (keywordsJob?.isActive == true) return
-        _state.update { it.copy(isLoadingKeywords = true) }
+        _state.update { it.copy(isLoadingKeywords = it.keywords.isEmpty()) }
         keywordsJob = scope.launch(dispatchers.io) {
             exploreRepository.getKeywords().fold(
                 onSuccess = { keywords ->
@@ -487,7 +487,7 @@ class ExploreViewModel(
 
     private fun loadFeaturedSeries() {
         if (featuredSeriesJob?.isActive == true) return
-        _state.update { it.copy(isLoadingFeaturedSeries = true) }
+        _state.update { it.copy(isLoadingFeaturedSeries = it.featuredSeries.isEmpty()) }
         featuredSeriesJob = scope.launch(dispatchers.io) {
             exploreRepository.getFeaturedSeries().fold(
                 onSuccess = { series ->
@@ -503,7 +503,7 @@ class ExploreViewModel(
 
     private fun loadMoods() {
         if (moodsJob?.isActive == true) return
-        _state.update { it.copy(isLoadingMoods = true) }
+        _state.update { it.copy(isLoadingMoods = it.moods.isEmpty()) }
         moodsJob = scope.launch(dispatchers.io) {
             exploreRepository.getMoods().fold(
                 onSuccess = { moods ->
@@ -518,7 +518,7 @@ class ExploreViewModel(
 
     private fun loadForYou() {
         if (forYouJob?.isActive == true) return
-        _state.update { it.copy(isLoadingForYou = true) }
+        _state.update { it.copy(isLoadingForYou = it.forYouRows.isEmpty()) }
         forYouJob = scope.launch(dispatchers.io) {
             exploreRepository.getForYou().fold(
                 onSuccess = { rows ->
@@ -570,7 +570,7 @@ class ExploreViewModel(
 
     private fun loadDeveloperSpotlight() {
         if (developerSpotlightJob?.isActive == true) return
-        _state.update { it.copy(isLoadingDeveloperSpotlight = true) }
+        _state.update { it.copy(isLoadingDeveloperSpotlight = it.developerSpotlight == null) }
         developerSpotlightJob = scope.launch(dispatchers.io) {
             exploreRepository.getDeveloperSpotlight().fold(
                 onSuccess = { spotlight ->
@@ -639,7 +639,7 @@ class ExploreViewModel(
 
     private fun loadConsoleHighlights() {
         if (consoleHighlightsJob?.isActive == true) return
-        _state.update { it.copy(isLoadingConsoleHighlights = true) }
+        _state.update { it.copy(isLoadingConsoleHighlights = it.consoleHighlights.isEmpty()) }
         consoleHighlightsJob = scope.launch(dispatchers.io) {
             exploreRepository.getConsoleHighlights().fold(
                 onSuccess = { highlights ->
@@ -675,7 +675,7 @@ class ExploreViewModel(
 
     private fun loadArtworkShowcase() {
         if (artworkShowcaseJob?.isActive == true) return
-        _state.update { it.copy(isLoadingArtwork = true) }
+        _state.update { it.copy(isLoadingArtwork = it.artworkShowcase.isEmpty()) }
         artworkShowcaseJob = scope.launch(dispatchers.io) {
             exploreRepository.getArtworkGallery(page = 1).fold(
                 onSuccess = { artworks ->
@@ -690,7 +690,7 @@ class ExploreViewModel(
 
     private fun loadSocialData() {
         if (socialJob?.isActive == true) return
-        _state.update { it.copy(isLoadingSocial = true) }
+        _state.update { it.copy(isLoadingSocial = it.trendingGames.isEmpty() && it.communityTopGames.isEmpty()) }
         socialJob = scope.launch(dispatchers.io) {
             // Load all social endpoints concurrently
             val trendingDeferred = async { exploreRepository.getTrending() }
@@ -716,7 +716,7 @@ class ExploreViewModel(
 
     private fun loadTemporalData() {
         if (temporalJob?.isActive == true) return
-        _state.update { it.copy(isLoadingTemporal = true) }
+        _state.update { it.copy(isLoadingTemporal = it.onThisDayGames.isEmpty() && it.anniversaries.isEmpty()) }
         temporalJob = scope.launch(dispatchers.io) {
             val onThisDayDeferred = async { exploreRepository.getOnThisDay() }
             val anniversariesDeferred = async { exploreRepository.getYourAnniversaries() }
@@ -737,7 +737,7 @@ class ExploreViewModel(
 
     private fun loadAchievementData() {
         if (achievementJob?.isActive == true) return
-        _state.update { it.copy(isLoadingAchievement = true) }
+        _state.update { it.copy(isLoadingAchievement = it.easyToCompleteGames.isEmpty() && it.hardestGames.isEmpty()) }
         achievementJob = scope.launch(dispatchers.io) {
             val easyDeferred = async { exploreRepository.getEasyToComplete() }
             val hardestDeferred = async { exploreRepository.getHardestGames() }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -113,8 +113,8 @@ class GameListViewModel(
 
     private fun loadDashboard() {
         println("[GameListVM] loadDashboard() called")
-        // Skip if a dashboard load is already in-flight
-        if (dashboardJob?.isActive == true) return
+        // Cancel any in-flight dashboard load (prevents stale data from overwriting fresh request)
+        dashboardJob?.cancel()
         // Only show loading spinner if we have no cached data.
         // If we already have data, refresh silently in the background.
         _state.update { it.copy(isLoading = it.consoles.isEmpty() && it.recentGames.isEmpty()) }
@@ -213,7 +213,7 @@ class GameListViewModel(
     }
 
     private fun loadConsoles() {
-        if (consolesJob?.isActive == true) return
+        consolesJob?.cancel()
         _state.update { it.copy(isLoading = it.consoles.isEmpty()) }
         consolesJob = scope.launch(dispatchers.io) {
             getConsolesUseCase().fold(


### PR DESCRIPTION
## Summary

Large UX improvement pass covering gamepad navigation, theme consistency, and screen loading behavior.

### Gamepad navigation
- **SpTopBar auto-hides in gamepad mode** — user navigates with B for back, no sticky buttons stealing focus. Applies to all 27 screens via shared component.
- **SpSectionList gets focusGroup()** — enables d-pad traversal from overlay top bars into scroll content across all screens.
- **Focus recovery at boundaries** — when d-pad fails at edge, captures focus state before move to detect escape and recover.
- **Right stick scroll clears focus** — so next d-pad press focuses the first visible element instead of jumping back to offscreen element.
- **Focus reset retry window** increased to 3s for async screens.
- **Console card focus highlights** via shared `spFocusRing`.
- **Console detail**: settings button moved to hero banner (accessible via d-pad), `focusGroup()` on hero banner.
- **Metadata links** (developer, publisher, achievements) now have `spFocusRing` + `focusable`.
- **Session cards** use `SpInnerCard(onClick=)` for proper focus.
- **Screenshot lightbox** buttons get `spFocusRing`, made fullscreen.
- **SpFab** — new shared round FAB with focus ring for gamepad.
- **LocalInputMode** CompositionLocal for any screen to read input mode.

### Greyscale theme
- All text colors are pure greyscale (no blue/indigo tint)
- Secondary text brightened (#B0B0C8 → #CCCCCC), tertiary (#707090 → #888888)
- All surfaces, cards, dividers are neutral dark greys
- Focus color changed from indigo to white across all components
- Tab/pill menu focus backgrounds changed to black transparent
- Section indicator pill background changed to black transparent
- SpTitledSection icon: white at 55% opacity (blends with background gradient)
- Time-to-beat bars: white/transparent (picks up console color)
- Top player bars: white/transparent
- Community stat values: greyscale
- Empty state icons: black transparent background
- Link color: neutral grey

### Screen loading
- ExploreViewModel: 13 section loaders only show loading skeleton when data is empty (cached data shows immediately on revisit)
- GameListViewModel: `loadDashboard`/`loadConsoles` cancel previous jobs instead of skipping (prevents stuck spinner)

## Test plan

- [x] Builds successfully (Android + Desktop)
- [x] Manually tested on AYN Thor (gamepad + touch)