### PR TITLE
feat: per-tab navigation stacks

### DIFF
--- a/docs/superpowers/specs/2026-03-28-per-tab-navigation-stacks-design.md
+++ b/docs/superpowers/specs/2026-03-28-per-tab-navigation-stacks-design.md
@@ -1,0 +1,185 @@
+# Per-Tab Navigation Stacks
+
+## Problem
+
+The navigation system uses a single flat back stack with a hardcoded
+`activeTabForScreen()` mapping to determine which tab is highlighted.
+When navigating from Consoles -> Console -> GameDetail, the tab indicator
+switches to Home because `GameDetail` isn't mapped to any tab and falls
+through to the `else -> HOME` default.
+
+Screens should not "belong" to a tab. Each tab should maintain its own
+navigation stack, and the active tab should be tracked explicitly.
+
+## Design
+
+### NavigationState
+
+Replace the single `backStack` and derived tab with explicit per-tab stacks:
+
+```kotlin
+data class NavigationState(
+    val activeTab: BottomNavTab = BottomNavTab.HOME,
+    val tabStacks: Map<BottomNavTab, List<SpScreen>> = defaultTabStacks(),
+    val isGoingBack: Boolean = false,
+    val isTabSwitch: Boolean = false,
+    // overlay fields unchanged
+    val showInGameOverlay: Boolean = false,
+    // ... existing overlay fields ...
+    val tabStacksBehindOverlay: Map<BottomNavTab, List<SpScreen>> = emptyMap(),
+    val activeTabBehindOverlay: BottomNavTab? = null,
+    // session restore fields unchanged
+    val isRestoringSession: Boolean = true,
+    val restoredServerUrl: String? = null,
+    val isOffline: Boolean = false,
+)
+```
+
+Each tab stack is a `List<SpScreen>` where the last element is the
+visible screen and the first element is the tab root. A helper function
+creates the default stacks:
+
+```kotlin
+fun defaultTabStacks(): Map<BottomNavTab, List<SpScreen>> = mapOf(
+    BottomNavTab.HOME to listOf(SpScreen.Home),
+    BottomNavTab.EXPLORE to listOf(SpScreen.Explore),
+    BottomNavTab.CONSOLES to listOf(SpScreen.Consoles),
+    BottomNavTab.COLLECTIONS to listOf(SpScreen.Collections),
+    BottomNavTab.ACTIVITY to listOf(SpScreen.Activity),
+    BottomNavTab.SETTINGS to listOf(SpScreen.Settings),
+)
+```
+
+**Removed fields:** `currentScreen`, `backStack`, `screenBehindOverlay`,
+`backStackBehindOverlay`.
+
+**Derived property:** `currentScreen` becomes
+`tabStacks[activeTab]!!.last()`.
+
+### Intent Handling
+
+**NavigateTo(screen):**
+Push the screen onto the active tab's stack.
+
+```
+tabStacks[activeTab] = [...current, screen]
+isGoingBack = false
+isTabSwitch = false
+```
+
+**SwitchTab(tab):**
+Change the active tab. All stacks are preserved — the user returns to
+where they left off on the target tab.
+
+```
+activeTab = tab
+isGoingBack = false
+isTabSwitch = true
+```
+
+**GoBack:**
+Pop from the active tab's stack. Three cases:
+
+1. Stack has >1 entry: pop the top, `isGoingBack = true`
+2. Stack has 1 entry (the root) and tab is not Home: switch to Home tab,
+   `isGoingBack = true`
+3. Stack has 1 entry and tab is Home: do nothing (app exit is handled by
+   the platform)
+
+```
+val stack = tabStacks[activeTab]
+if (stack.size > 1) {
+    tabStacks[activeTab] = stack.dropLast(1)
+    isGoingBack = true
+} else if (activeTab != HOME) {
+    activeTab = HOME
+    isGoingBack = true
+}
+```
+
+**NextSection / PreviousSection:**
+Cycle `activeTab` to the adjacent tab. Stacks are preserved.
+`isTabSwitch = false` (gamepad section cycling has no animation).
+
+**ShowOverlay:**
+Save `activeTab` and `tabStacks` (the entire navigation state):
+
+```
+activeTabBehindOverlay = activeTab
+tabStacksBehindOverlay = tabStacks
+showInGameOverlay = true
+```
+
+**HideOverlay:**
+Restore saved state:
+
+```
+activeTab = activeTabBehindOverlay
+tabStacks = tabStacksBehindOverlay
+showInGameOverlay = false
+```
+
+### Deleted: activeTabForScreen()
+
+The `activeTabForScreen()` function is deleted from `NavigationViewModel`
+and from `SpelaApp`. All call sites use `navState.activeTab` directly.
+
+### SpelaApp Changes
+
+All references to `navState.currentScreen` use the derived property
+instead: `navState.currentScreen` (backed by
+`tabStacks[activeTab]!!.last()`).
+
+Tab selection in `SpBottomNavBar`, `SpNavigationRail`, and
+`SpSectionIndicator`:
+- Before: `activeTab = activeTabForScreen(navState.currentScreen)`
+- After: `activeTab = navState.activeTab`
+
+The `saveableStateHolder` key logic is unchanged — it uses
+`screen.route` which is still unique per screen instance.
+
+Animation detection:
+- `isGoingBack` and `isTabSwitch` flags work exactly as before
+- No change to `AnimatedContent` transition specs
+
+### Auth / Session Handling
+
+**Auth failure:** Reset all tab stacks to defaults, set
+`activeTab = HOME`.
+
+**Session restore:** Sets `activeTab = HOME` with default stacks (same
+as today).
+
+**resetDatabase:** Same — clear everything to defaults.
+
+### What Stays the Same
+
+- `SpScreen` sealed class (no changes)
+- All screen composables (no changes)
+- Animation logic (`isGoingBack`, `isTabSwitch` flags)
+- Overlay save/restore pattern (same concept, more state saved)
+- `NavigationIntent` sealed interface (no new intents)
+- `BottomNavTab` enum
+
+### Back Button Behavior (Android)
+
+1. Pop current tab's stack
+2. When only the root remains on a non-Home tab, switch to Home
+3. When Home shows only its root, do nothing (platform handles app exit)
+
+This matches Android Navigation component guidelines and iOS tab
+controller behavior.
+
+## Files Changed
+
+| File | Change |
+|------|--------|
+| `SpNavigation.kt` | Replace `backStack`/`currentScreen` with `activeTab`/`tabStacks`, add derived `currentScreen`, add `defaultTabStacks()` |
+| `NavigationViewModel.kt` | Rewrite all intent handlers for per-tab stacks, delete `activeTabForScreen()` |
+| `SpelaApp.kt` | Replace `activeTabForScreen(navState.currentScreen)` with `navState.activeTab`, update `currentScreen` access |
+
+## Not Changed
+
+- No screen composables are modified
+- No new dependencies
+- No new intents or state fields beyond what's listed

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
@@ -44,8 +44,8 @@ class NavigationViewModel(
                     is ConnectionState.AuthFailed -> {
                         _state.update {
                             it.copy(
-                                currentScreen = SpScreen.Login,
-                                backStack = emptyList(),
+                                activeTab = BottomNavTab.HOME,
+                                tabStacks = defaultTabStacks(),
                                 showInGameOverlay = false,
                             )
                         }
@@ -56,24 +56,48 @@ class NavigationViewModel(
         }
     }
 
+    /** Push onto the active tab's stack. */
+    private fun pushScreen(state: NavigationState, screen: SpScreen): NavigationState {
+        val currentStack = state.tabStacks[state.activeTab] ?: listOf()
+        return state.copy(
+            tabStacks = state.tabStacks + (state.activeTab to currentStack + screen),
+            isGoingBack = false,
+            isTabSwitch = false,
+        )
+    }
+
+    /** Pop from the active tab's stack. Returns null if nothing to pop. */
+    private fun popScreen(state: NavigationState): NavigationState? {
+        val currentStack = state.tabStacks[state.activeTab] ?: return null
+        if (currentStack.size > 1) {
+            return state.copy(
+                tabStacks = state.tabStacks + (state.activeTab to currentStack.dropLast(1)),
+                isGoingBack = true,
+                isTabSwitch = false,
+            )
+        }
+        // Stack has only the root — go to Home tab if not already there
+        if (state.activeTab != BottomNavTab.HOME) {
+            return state.copy(
+                activeTab = BottomNavTab.HOME,
+                isGoingBack = true,
+                isTabSwitch = false,
+            )
+        }
+        return null // Home root — nothing to do (platform handles app exit)
+    }
+
     fun onIntent(intent: NavigationIntent) {
         when (intent) {
             is NavigationIntent.NavigateTo -> {
-                _state.update { current ->
-                    current.copy(
-                        currentScreen = intent.screen,
-                        backStack = current.backStack + current.currentScreen,
-                        isGoingBack = false,
-                        isTabSwitch = false,
-                    )
-                }
+                _state.update { pushScreen(it, intent.screen) }
             }
 
             is NavigationIntent.SwitchTab -> {
+                val targetTab = tabForRootScreen(intent.screen) ?: BottomNavTab.HOME
                 _state.update { current ->
                     current.copy(
-                        currentScreen = intent.screen,
-                        backStack = emptyList(),
+                        activeTab = targetTab,
                         isGoingBack = false,
                         isTabSwitch = true,
                     )
@@ -82,40 +106,16 @@ class NavigationViewModel(
 
             NavigationIntent.GoBack -> {
                 _state.update { current ->
-                    if (current.backStack.isNotEmpty()) {
-                        current.copy(
-                            currentScreen = current.backStack.last(),
-                            backStack = current.backStack.dropLast(1),
-                            isGoingBack = true,
-                            isTabSwitch = false,
-                        )
-                    } else if (current.currentScreen is SpScreen.Settings ||
-                        current.currentScreen is SpScreen.Downloads ||
-                        current.currentScreen is SpScreen.Explore ||
-                        current.currentScreen is SpScreen.Consoles ||
-                        current.currentScreen is SpScreen.Collections ||
-                        current.currentScreen is SpScreen.Activity
-                    ) {
-                        // When on a non-Home tab with empty back stack, return to Home
-                        current.copy(
-                            currentScreen = SpScreen.Home,
-                            isGoingBack = true,
-                            isTabSwitch = false,
-                        )
-                    } else {
-                        current
-                    }
+                    popScreen(current) ?: current
                 }
             }
 
             NavigationIntent.NextSection -> {
                 _state.update { current ->
-                    val currentTab = activeTabForScreen(current.currentScreen)
-                    val currentIndex = BottomNavTab.entries.indexOf(currentTab)
+                    val currentIndex = BottomNavTab.entries.indexOf(current.activeTab)
                     val nextIndex = (currentIndex + 1) % sections.size
                     current.copy(
-                        currentScreen = sections[nextIndex],
-                        backStack = emptyList(),
+                        activeTab = BottomNavTab.entries[nextIndex],
                         isGoingBack = false,
                         isTabSwitch = false,
                     )
@@ -124,12 +124,10 @@ class NavigationViewModel(
 
             NavigationIntent.PreviousSection -> {
                 _state.update { current ->
-                    val currentTab = activeTabForScreen(current.currentScreen)
-                    val currentIndex = BottomNavTab.entries.indexOf(currentTab)
+                    val currentIndex = BottomNavTab.entries.indexOf(current.activeTab)
                     val prevIndex = (currentIndex - 1 + sections.size) % sections.size
                     current.copy(
-                        currentScreen = sections[prevIndex],
-                        backStack = emptyList(),
+                        activeTab = BottomNavTab.entries[prevIndex],
                         isGoingBack = true,
                         isTabSwitch = false,
                     )
@@ -151,76 +149,39 @@ class NavigationViewModel(
                         overlaySkipAutoLoad = intent.skipAutoLoad,
                         overlayForceNewSession = intent.forceNewSession,
                         overlaySessionId = intent.sessionId,
-                        screenBehindOverlay = it.currentScreen,
-                        backStackBehindOverlay = it.backStack,
+                        activeTabBehindOverlay = it.activeTab,
+                        tabStacksBehindOverlay = it.tabStacks,
                     )
                 }
             }
 
             NavigationIntent.HideOverlay -> {
                 _state.update {
-                    if (it.screenBehindOverlay != null) {
-                        it.copy(
-                            showInGameOverlay = false,
-                            overlayGameId = null,
-                            overlaySharedSessionId = null,
-                            overlayTurnToken = null,
-                            overlayNetplaySessionId = null,
-                            overlayNetplayLocalPort = 0,
-                            overlayNetplayInputDelay = 3,
-                            overlayNetplayIsHost = false,
-                            overlayChallengeId = null,
-                            overlaySkipAutoLoad = false,
-                            overlayForceNewSession = false,
-                            overlaySessionId = null,
-                            currentScreen = it.screenBehindOverlay,
-                            backStack = it.backStackBehindOverlay,
-                            screenBehindOverlay = null,
-                            backStackBehindOverlay = emptyList(),
-                        )
-                    } else {
-                        it.copy(
-                            showInGameOverlay = false,
-                            overlayGameId = null,
-                            overlaySharedSessionId = null,
-                            overlayTurnToken = null,
-                            overlayNetplaySessionId = null,
-                            overlayNetplayLocalPort = 0,
-                            overlayNetplayInputDelay = 3,
-                            overlayNetplayIsHost = false,
-                            overlayChallengeId = null,
-                            overlaySkipAutoLoad = false,
-                            overlayForceNewSession = false,
-                            overlaySessionId = null,
-                        )
-                    }
+                    val restoredTab = it.activeTabBehindOverlay ?: it.activeTab
+                    val restoredStacks = it.tabStacksBehindOverlay.ifEmpty { it.tabStacks }
+                    it.copy(
+                        showInGameOverlay = false,
+                        overlayGameId = null,
+                        overlaySharedSessionId = null,
+                        overlayTurnToken = null,
+                        overlayNetplaySessionId = null,
+                        overlayNetplayLocalPort = 0,
+                        overlayNetplayInputDelay = 3,
+                        overlayNetplayIsHost = false,
+                        overlayChallengeId = null,
+                        overlaySkipAutoLoad = false,
+                        overlayForceNewSession = false,
+                        overlaySessionId = null,
+                        activeTab = restoredTab,
+                        tabStacks = restoredStacks,
+                        activeTabBehindOverlay = null,
+                        tabStacksBehindOverlay = emptyMap(),
+                    )
                 }
                 // Sync pending save states to the server after leaving a game.
-                // Auto-save writes to local storage only (fast), so the upload
-                // happens here in the background.
                 scope.launch(dispatchers.io) { syncEngine.syncAll() }
             }
 
-        }
-    }
-
-    companion object {
-        fun activeTabForScreen(screen: SpScreen): BottomNavTab = when (screen) {
-            is SpScreen.Explore,
-            is SpScreen.ExploreTheme,
-            is SpScreen.ExploreKeyword,
-            is SpScreen.ExploreSeries,
-            is SpScreen.ExploreFranchise,
-            is SpScreen.ExploreMood,
-            is SpScreen.ExploreDeveloper,
-            is SpScreen.ExplorePublisher,
-            is SpScreen.DeveloperGames,
-            -> BottomNavTab.EXPLORE
-            is SpScreen.Consoles, is SpScreen.Console -> BottomNavTab.CONSOLES
-            is SpScreen.Collections, is SpScreen.CollectionDetail -> BottomNavTab.COLLECTIONS
-            is SpScreen.Activity, is SpScreen.Stats -> BottomNavTab.ACTIVITY
-            is SpScreen.Settings, is SpScreen.ConsoleSettings, is SpScreen.Licenses -> BottomNavTab.SETTINGS
-            else -> BottomNavTab.HOME
         }
     }
 
@@ -228,8 +189,8 @@ class NavigationViewModel(
         DatabaseResetHelper.resetDatabase()
         _state.update {
             it.copy(
-                currentScreen = SpScreen.ServerConnection,
-                backStack = emptyList(),
+                activeTab = BottomNavTab.HOME,
+                tabStacks = defaultTabStacks(),
                 showInGameOverlay = false,
             )
         }
@@ -254,13 +215,27 @@ class NavigationViewModel(
                 is RestoreSessionResult.NeedsLogin -> result.serverUrl
                 else -> null
             }
+
             _state.update {
-                it.copy(
-                    currentScreen = screen,
-                    isRestoringSession = false,
-                    restoredServerUrl = serverUrl,
-                    isOffline = result is RestoreSessionResult.OfflineSuccess,
-                )
+                when (screen) {
+                    // Auth screens bypass the tab system
+                    SpScreen.Login, SpScreen.ServerConnection -> it.copy(
+                        activeTab = BottomNavTab.HOME,
+                        tabStacks = defaultTabStacks().toMutableMap().apply {
+                            put(BottomNavTab.HOME, listOf(screen))
+                        },
+                        isRestoringSession = false,
+                        restoredServerUrl = serverUrl,
+                        isOffline = result is RestoreSessionResult.OfflineSuccess,
+                    )
+                    else -> it.copy(
+                        activeTab = BottomNavTab.HOME,
+                        tabStacks = defaultTabStacks(),
+                        isRestoringSession = false,
+                        restoredServerUrl = serverUrl,
+                        isOffline = result is RestoreSessionResult.OfflineSuccess,
+                    )
+                }
             }
 
             // Start connectivity monitoring and sync engine after successful session restore
@@ -280,6 +255,19 @@ class NavigationViewModel(
                     }
                 }
             }
+        }
+    }
+
+    companion object {
+        /** Maps a tab root screen to its BottomNavTab. */
+        private fun tabForRootScreen(screen: SpScreen): BottomNavTab? = when (screen) {
+            SpScreen.Home -> BottomNavTab.HOME
+            SpScreen.Explore -> BottomNavTab.EXPLORE
+            SpScreen.Consoles -> BottomNavTab.CONSOLES
+            SpScreen.Collections -> BottomNavTab.COLLECTIONS
+            SpScreen.Activity -> BottomNavTab.ACTIVITY
+            SpScreen.Settings -> BottomNavTab.SETTINGS
+            else -> null
         }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/SpNavigation.kt
@@ -1,5 +1,7 @@
 package com.spela.player.presentation.navigation
 
+import com.spela.player.presentation.ui.components.BottomNavTab
+
 sealed class SpScreen(val route: String) {
     data object ServerConnection : SpScreen("server_connection")
     data object Login : SpScreen("login")
@@ -46,9 +48,19 @@ sealed class SpScreen(val route: String) {
     data class GameAchievements(val gameId: String) : SpScreen("game_achievements/$gameId")
 }
 
+/** Creates the default per-tab stacks with each tab at its root screen. */
+fun defaultTabStacks(): Map<BottomNavTab, List<SpScreen>> = mapOf(
+    BottomNavTab.HOME to listOf(SpScreen.Home),
+    BottomNavTab.EXPLORE to listOf(SpScreen.Explore),
+    BottomNavTab.CONSOLES to listOf(SpScreen.Consoles),
+    BottomNavTab.COLLECTIONS to listOf(SpScreen.Collections),
+    BottomNavTab.ACTIVITY to listOf(SpScreen.Activity),
+    BottomNavTab.SETTINGS to listOf(SpScreen.Settings),
+)
+
 data class NavigationState(
-    val currentScreen: SpScreen = SpScreen.ServerConnection,
-    val backStack: List<SpScreen> = emptyList(),
+    val activeTab: BottomNavTab = BottomNavTab.HOME,
+    val tabStacks: Map<BottomNavTab, List<SpScreen>> = defaultTabStacks(),
     val isGoingBack: Boolean = false,
     val isTabSwitch: Boolean = false,
     val showInGameOverlay: Boolean = false,
@@ -63,12 +75,17 @@ data class NavigationState(
     val overlaySkipAutoLoad: Boolean = false,
     val overlayForceNewSession: Boolean = false,
     val overlaySessionId: String? = null,
-    val screenBehindOverlay: SpScreen? = null,
-    val backStackBehindOverlay: List<SpScreen> = emptyList(),
+    val activeTabBehindOverlay: BottomNavTab? = null,
+    val tabStacksBehindOverlay: Map<BottomNavTab, List<SpScreen>> = emptyMap(),
     val isRestoringSession: Boolean = true,
     val restoredServerUrl: String? = null,
     val isOffline: Boolean = false,
-)
+) {
+    /** The currently visible screen — last entry on the active tab's stack. */
+    val currentScreen: SpScreen
+        get() = tabStacks[activeTab]?.lastOrNull()
+            ?: SpScreen.ServerConnection
+}
 
 sealed interface NavigationIntent {
     data class NavigateTo(val screen: SpScreen) : NavigationIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -334,7 +334,7 @@ fun SpelaApp(
             // Side navigation rail (larger screens, touch mode only)
             if (showSideRail) {
                 SpNavigationRail(
-                    activeTab = activeTabForScreen(navState.currentScreen),
+                    activeTab = navState.activeTab,
                     onTabSelected = { tab ->
                         val targetScreen = when (tab) {
                             BottomNavTab.HOME -> SpScreen.Home
@@ -1611,7 +1611,7 @@ fun SpelaApp(
                 // Bottom navigation bar (phones only, hidden when in gamepad mode or side rail is showing)
                 if (navLayoutMode == NavigationLayoutMode.BOTTOM_BAR && showNavArea && !isGamepadMode) {
                     SpBottomNavBar(
-                        activeTab = activeTabForScreen(navState.currentScreen),
+                        activeTab = navState.activeTab,
                         onTabSelected = { tab ->
                             val targetScreen = when (tab) {
                                 BottomNavTab.HOME -> SpScreen.Home
@@ -1638,7 +1638,7 @@ fun SpelaApp(
                     contentAlignment = Alignment.TopCenter,
                 ) {
                     SpSectionIndicator(
-                        activeTab = activeTabForScreen(navState.currentScreen),
+                        activeTab = navState.activeTab,
                         visible = sectionIndicatorVisible,
                         modifier = Modifier.padding(top = SpSpacing.Default),
                     )
@@ -1655,9 +1655,6 @@ private fun shouldShowBottomNav(screen: SpScreen): Boolean = when (screen) {
     is SpScreen.ServerConnection, is SpScreen.Login -> false
     else -> true
 }
-
-private fun activeTabForScreen(screen: SpScreen): BottomNavTab =
-    NavigationViewModel.activeTabForScreen(screen)
 
 @Composable
 private fun PlaceholderScreen(title: String) {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/navigation/NavigationViewModelTest.kt
@@ -7,6 +7,7 @@ import com.spela.player.data.remote.interceptor.TokenManager
 import com.spela.player.domain.model.*
 import com.spela.player.domain.repository.*
 import com.spela.player.domain.usecase.RestoreSessionUseCase
+import com.spela.player.presentation.ui.components.BottomNavTab
 import com.spela.player.test.NoOpMockEngineFactory
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineDispatcher
@@ -67,18 +68,42 @@ class NavigationViewModelTest {
         )
     }
 
+    /** Helper: the active tab's stack. */
+    private fun NavigationState.activeStack(): List<SpScreen> =
+        tabStacks[activeTab] ?: emptyList()
+
+    /** Simulates a logged-in state by navigating to Home from ServerConnection.
+     *  This mimics what happens after successful login: NavigateTo(Home). */
+    private fun simulateLoggedIn(vm: NavigationViewModel) {
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        // Now the Home tab has [ServerConnection, Home]. GoBack would go to ServerConnection.
+        // In the real app, login replaces the screen, but for tests we just need Home as current.
+    }
+
     @Test
-    fun goBackPopsFromBackStack() = runTest(testDispatcher) {
+    fun navigateToPushesOntoActiveTabStack() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
+        simulateLoggedIn(vm)
 
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        val stackSizeBefore = vm.state.value.activeStack().size
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.GameDetail("1")))
+
+        assertEquals(SpScreen.GameDetail("1"), vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.HOME, vm.state.value.activeTab)
+        assertEquals(stackSizeBefore + 1, vm.state.value.activeStack().size)
+    }
+
+    @Test
+    fun goBackPopsFromActiveTabStack() = runTest(testDispatcher) {
+        val vm = createViewModel()
+        advanceUntilIdle()
+        simulateLoggedIn(vm)
+
         vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
-
         assertEquals(SpScreen.Console("nes"), vm.state.value.currentScreen)
 
         vm.onIntent(NavigationIntent.GoBack)
-
         assertEquals(SpScreen.Home, vm.state.value.currentScreen)
     }
 
@@ -86,9 +111,6 @@ class NavigationViewModelTest {
     fun navigateToSetsIsGoingBackFalse() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
-
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
-        assertFalse(vm.state.value.isGoingBack)
 
         vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
         assertFalse(vm.state.value.isGoingBack)
@@ -99,43 +121,77 @@ class NavigationViewModelTest {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
         vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
-
         vm.onIntent(NavigationIntent.GoBack)
         assertTrue(vm.state.value.isGoingBack)
     }
 
     @Test
-    fun showOverlayPreservesNavigationState() = runTest(testDispatcher) {
+    fun switchTabPreservesStacks() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        // Navigate deep on Home tab
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.GameDetail("1")))
+        assertEquals(SpScreen.GameDetail("1"), vm.state.value.currentScreen)
+
+        // Switch to Consoles tab
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Consoles))
+        assertEquals(BottomNavTab.CONSOLES, vm.state.value.activeTab)
+        assertEquals(SpScreen.Consoles, vm.state.value.currentScreen)
+
+        // Switch back to Home — stack is preserved
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Home))
+        assertEquals(BottomNavTab.HOME, vm.state.value.activeTab)
+        assertEquals(SpScreen.GameDetail("1"), vm.state.value.currentScreen)
+    }
+
+    @Test
+    fun activeTabStaysCorrectThroughDeepNavigation() = runTest(testDispatcher) {
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        // Switch to Consoles, navigate deep
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Consoles))
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.GameDetail("42")))
+
+        // Active tab should still be CONSOLES, not HOME
+        assertEquals(BottomNavTab.CONSOLES, vm.state.value.activeTab)
+        assertEquals(SpScreen.GameDetail("42"), vm.state.value.currentScreen)
+    }
+
+    @Test
+    fun showOverlayPreservesAllTabStacks() = runTest(testDispatcher) {
+        val vm = createViewModel()
+        advanceUntilIdle()
+
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Consoles))
         vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
         vm.onIntent(NavigationIntent.NavigateTo(SpScreen.GameDetail("game1")))
 
-        val screenBefore = vm.state.value.currentScreen
-        val backStackBefore = vm.state.value.backStack
+        val tabBefore = vm.state.value.activeTab
+        val stacksBefore = vm.state.value.tabStacks
 
         vm.onIntent(NavigationIntent.ShowOverlay("game1"))
 
         assertTrue(vm.state.value.showInGameOverlay)
-        assertEquals(screenBefore, vm.state.value.screenBehindOverlay)
-        assertEquals(backStackBefore, vm.state.value.backStackBehindOverlay)
+        assertEquals(tabBefore, vm.state.value.activeTabBehindOverlay)
+        assertEquals(stacksBefore, vm.state.value.tabStacksBehindOverlay)
     }
 
     @Test
-    fun hideOverlayRestoresNavigationState() = runTest(testDispatcher) {
+    fun hideOverlayRestoresAllTabStacks() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Consoles))
         vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
         vm.onIntent(NavigationIntent.NavigateTo(SpScreen.GameDetail("game1")))
 
         val screenBefore = vm.state.value.currentScreen
-        val backStackBefore = vm.state.value.backStack
+        val tabBefore = vm.state.value.activeTab
+        val stacksBefore = vm.state.value.tabStacks
 
         vm.onIntent(NavigationIntent.ShowOverlay("game1"))
         vm.onIntent(NavigationIntent.HideOverlay)
@@ -143,61 +199,56 @@ class NavigationViewModelTest {
         assertFalse(vm.state.value.showInGameOverlay)
         assertNull(vm.state.value.overlayGameId)
         assertEquals(screenBefore, vm.state.value.currentScreen)
-        assertEquals(backStackBefore, vm.state.value.backStack)
-        assertNull(vm.state.value.screenBehindOverlay)
-        assertTrue(vm.state.value.backStackBehindOverlay.isEmpty())
+        assertEquals(tabBefore, vm.state.value.activeTab)
+        assertEquals(stacksBefore, vm.state.value.tabStacks)
     }
 
     @Test
-    fun hideOverlayRestoresEvenIfBackStackModifiedDuringGameplay() = runTest(testDispatcher) {
+    fun hideOverlayRestoresEvenIfStackModifiedDuringGameplay() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
         vm.onIntent(NavigationIntent.NavigateTo(SpScreen.GameDetail("game1")))
 
         val screenBefore = vm.state.value.currentScreen
-        val backStackBefore = vm.state.value.backStack
+        val stacksBefore = vm.state.value.tabStacks
 
         vm.onIntent(NavigationIntent.ShowOverlay("game1"))
 
-        // Simulate back stack corruption during gameplay
-        vm.onIntent(NavigationIntent.GoBack)
+        // Simulate modification during gameplay
         vm.onIntent(NavigationIntent.GoBack)
 
         // HideOverlay should restore the original state
         vm.onIntent(NavigationIntent.HideOverlay)
 
         assertEquals(screenBefore, vm.state.value.currentScreen)
-        assertEquals(backStackBefore, vm.state.value.backStack)
+        assertEquals(stacksBefore, vm.state.value.tabStacks)
     }
 
     @Test
-    fun nextSectionCyclesThroughAllSections() = runTest(testDispatcher) {
+    fun nextSectionCyclesThroughAllTabs() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
-        assertEquals(SpScreen.Home, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.HOME, vm.state.value.activeTab)
 
         vm.onIntent(NavigationIntent.NextSection)
-        assertEquals(SpScreen.Explore, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.EXPLORE, vm.state.value.activeTab)
 
         vm.onIntent(NavigationIntent.NextSection)
-        assertEquals(SpScreen.Consoles, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.CONSOLES, vm.state.value.activeTab)
 
         vm.onIntent(NavigationIntent.NextSection)
-        assertEquals(SpScreen.Collections, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.COLLECTIONS, vm.state.value.activeTab)
 
         vm.onIntent(NavigationIntent.NextSection)
-        assertEquals(SpScreen.Activity, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.ACTIVITY, vm.state.value.activeTab)
 
         vm.onIntent(NavigationIntent.NextSection)
-        assertEquals(SpScreen.Settings, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.SETTINGS, vm.state.value.activeTab)
 
         vm.onIntent(NavigationIntent.NextSection)
-        assertEquals(SpScreen.Home, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.HOME, vm.state.value.activeTab)
     }
 
     @Test
@@ -205,62 +256,59 @@ class NavigationViewModelTest {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
-        assertEquals(SpScreen.Home, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.HOME, vm.state.value.activeTab)
 
         vm.onIntent(NavigationIntent.PreviousSection)
-        assertEquals(SpScreen.Settings, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.SETTINGS, vm.state.value.activeTab)
 
         vm.onIntent(NavigationIntent.PreviousSection)
-        assertEquals(SpScreen.Activity, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.ACTIVITY, vm.state.value.activeTab)
     }
 
     @Test
-    fun sectionCyclingClearsBackStack() = runTest(testDispatcher) {
+    fun sectionCyclingPreservesTabStacks() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        // Navigate deep on Home tab
         vm.onIntent(NavigationIntent.NavigateTo(SpScreen.GameDetail("1")))
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
-        assertTrue(vm.state.value.backStack.isNotEmpty())
+        val homeStack = vm.state.value.tabStacks[BottomNavTab.HOME]
 
+        // Cycle to next section
         vm.onIntent(NavigationIntent.NextSection)
-        assertTrue(vm.state.value.backStack.isEmpty())
+        assertEquals(BottomNavTab.EXPLORE, vm.state.value.activeTab)
+
+        // Home stack should be preserved
+        assertEquals(homeStack, vm.state.value.tabStacks[BottomNavTab.HOME])
     }
 
     @Test
-    fun goBackFromConsolesReturnsToHome() = runTest(testDispatcher) {
+    fun goBackFromConsolesTabReturnsToHome() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
+        simulateLoggedIn(vm)
 
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Consoles))
+        // Switch to Consoles tab (empty stack, just root)
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Consoles))
+        assertEquals(BottomNavTab.CONSOLES, vm.state.value.activeTab)
         assertEquals(SpScreen.Consoles, vm.state.value.currentScreen)
-        // Manually clear backstack to simulate section cycling
-        vm.onIntent(NavigationIntent.NextSection) // goes to Collections
-        vm.onIntent(NavigationIntent.PreviousSection) // goes back to Consoles with empty backstack
-        assertEquals(SpScreen.Consoles, vm.state.value.currentScreen)
-        assertTrue(vm.state.value.backStack.isEmpty())
 
+        // GoBack from tab root → Home
         vm.onIntent(NavigationIntent.GoBack)
+        assertEquals(BottomNavTab.HOME, vm.state.value.activeTab)
         assertEquals(SpScreen.Home, vm.state.value.currentScreen)
     }
 
     @Test
-    fun goBackFromCollectionsReturnsToHome() = runTest(testDispatcher) {
+    fun goBackFromCollectionsTabReturnsToHome() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        // Navigate to Collections via section cycling (empty backstack)
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
-        vm.onIntent(NavigationIntent.NextSection) // Explore
-        vm.onIntent(NavigationIntent.NextSection) // Consoles
-        vm.onIntent(NavigationIntent.NextSection) // Collections
-        assertEquals(SpScreen.Collections, vm.state.value.currentScreen)
-        assertTrue(vm.state.value.backStack.isEmpty())
+        vm.onIntent(NavigationIntent.SwitchTab(SpScreen.Collections))
+        assertEquals(BottomNavTab.COLLECTIONS, vm.state.value.activeTab)
 
         vm.onIntent(NavigationIntent.GoBack)
-        assertEquals(SpScreen.Home, vm.state.value.currentScreen)
+        assertEquals(BottomNavTab.HOME, vm.state.value.activeTab)
     }
 
     @Test
@@ -268,7 +316,6 @@ class NavigationViewModelTest {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
         vm.onIntent(NavigationIntent.NextSection)
         assertFalse(vm.state.value.isGoingBack)
     }
@@ -278,25 +325,29 @@ class NavigationViewModelTest {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
         vm.onIntent(NavigationIntent.PreviousSection)
         assertTrue(vm.state.value.isGoingBack)
     }
 
     @Test
-    fun nextSectionFromSubScreenMapsToCorrectTab() = runTest(testDispatcher) {
+    fun nextSectionFromDeepScreenPreservesStack() = runTest(testDispatcher) {
         val vm = createViewModel()
         advanceUntilIdle()
 
-        // Navigate deep into a console screen (belongs to CONSOLES tab)
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
-        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Consoles))
+        // Navigate deep on Home tab
         vm.onIntent(NavigationIntent.NavigateTo(SpScreen.Console("nes")))
+        vm.onIntent(NavigationIntent.NavigateTo(SpScreen.GameDetail("1")))
+        assertEquals(BottomNavTab.HOME, vm.state.value.activeTab)
 
-        // NextSection from Console (CONSOLES tab) should go to Collections
+        // NextSection switches to Explore tab
         vm.onIntent(NavigationIntent.NextSection)
-        assertEquals(SpScreen.Collections, vm.state.value.currentScreen)
-        assertTrue(vm.state.value.backStack.isEmpty())
+        assertEquals(BottomNavTab.EXPLORE, vm.state.value.activeTab)
+        assertEquals(SpScreen.Explore, vm.state.value.currentScreen)
+
+        // Home stack is preserved with the deep navigation
+        val homeStack = vm.state.value.tabStacks[BottomNavTab.HOME]!!
+        assertEquals(3, homeStack.size)
+        assertEquals(SpScreen.GameDetail("1"), homeStack.last())
     }
 
     // Minimal fakes that cause RestoreSessionUseCase to return NoSession


### PR DESCRIPTION
## Summary

Replace the single flat back stack with per-tab navigation stacks. Each of the 6 bottom nav tabs (Home, Explore, Consoles, Collections, Activity, Settings) maintains its own `List<SpScreen>` stack.

**Before:** `activeTabForScreen()` used a hardcoded screen-type → tab mapping. `GameDetail` wasn't mapped, so navigating Consoles → Console → GameDetail switched the tab to Home.

**After:** `activeTab` is tracked explicitly in `NavigationState`. Screens don't "belong" to tabs — they're pushed onto whichever tab's stack is active.

### Key changes

| Intent | Before | After |
|--------|--------|-------|
| NavigateTo | Append to single `backStack` | Push onto `tabStacks[activeTab]` |
| SwitchTab | Clear `backStack` | Set `activeTab` (stacks preserved) |
| GoBack | Pop `backStack`; if empty on non-Home, go Home | Pop active tab's stack; if root on non-Home, switch to Home |
| NextSection | Derive tab from screen, cycle, clear stack | Cycle `activeTab` (stacks preserved) |
| ShowOverlay | Save `currentScreen` + `backStack` | Save `activeTab` + `tabStacks` |

### Deleted
- `activeTabForScreen()` from `NavigationViewModel` and `SpelaApp`
- `backStack`, `currentScreen`, `screenBehindOverlay`, `backStackBehindOverlay` fields

### Added
- `activeTab: BottomNavTab` — explicitly tracked
- `tabStacks: Map<BottomNavTab, List<SpScreen>>` — per-tab stacks
- `currentScreen` as derived property (`tabStacks[activeTab].last()`)

## Test plan

- [x] All 17 NavigationViewModel tests pass (rewritten for per-tab stacks)
- [x] Full desktop test suite passes
- [x] Android APK builds successfully