### PR TITLE
feat: redesign server connection screen with SNES ambient glow

### DIFF
--- a/player/GAMEPAD_NAVIGATION.md
+++ b/player/GAMEPAD_NAVIGATION.md
@@ -1,0 +1,193 @@
+# Gamepad Navigation Architecture
+
+This document explains how gamepad/d-pad navigation works in the Spela
+player app. It covers the focus system, the patterns that make it work,
+and the pitfalls to avoid.
+
+## Overview
+
+The app supports two input modes: **TOUCH** and **GAMEPAD**. When a
+physical controller is detected, the app switches to gamepad mode which:
+
+- Hides the bottom nav bar (replaced by L1/R1 section indicator pill)
+- Hides the `SpTopBar` (back + action buttons) on all screens
+- Enables d-pad focus navigation through all content
+- Enables right stick scrolling with automatic focus management
+
+The input mode is provided to all composables via `LocalInputMode`
+(a `CompositionLocal` defined in `InputMode.kt`).
+
+## Core Component: GamepadHandler
+
+`GamepadHandler` in `GamepadNavigation.kt` wraps the entire app content.
+It handles:
+
+### Focus Acquisition on Screen Change
+
+When the screen changes (tab switch, forward navigation), the handler
+requests focus on its wrapper Box via a `FocusRequester`. This puts the
+Box itself into a focused state. The first d-pad press then calls
+`moveFocus(FocusDirection.Next)` to enter the content tree and land on
+the first focusable element.
+
+**Why not call `moveFocus(Next)` directly from the coroutine?**
+Compose's `moveFocus` from a `LaunchedEffect` coroutine doesn't
+reliably find focusable children inside `AnimatedContent` transitions.
+But `moveFocus` from a key event handler (d-pad press) does. So we
+split it: coroutine requests focus on the wrapper, key handler enters
+the content.
+
+### Self-Focus Detection
+
+The handler tracks two states:
+- `hasFocus` — true when anything in the tree has focus
+- `isSelfFocused` — true when the wrapper Box itself has direct focus
+
+When `isSelfFocused` is true (or `hasFocus` is false), any d-pad press
+calls `moveFocus(Next)` instead of directional movement. This is because
+directional moves (Up/Down/Left/Right) use **spatial reasoning** — they
+look for elements geometrically in that direction. A full-screen Box has
+nothing spatially above or below it, so directional moves always fail.
+`moveFocus(Next)` uses **tree traversal** which finds the first
+focusable descendant regardless of position.
+
+Once a child element has focus, normal directional navigation takes over.
+
+### Right Stick Scroll
+
+When the right analog stick is used for scrolling (`MainActivity.kt`),
+the activity calls `currentFocus?.clearFocus()` to break the link
+between the focused element and the d-pad. Without this, the next d-pad
+press would jump the scroll position back to the (now offscreen) focused
+element. After clearing, the next d-pad press triggers the recovery path
+and focuses the first visible element.
+
+## Focus Ring: `spFocusRing` Modifier
+
+Defined in `GamepadNavigation.kt`. Adds a white border (0.85 alpha) and
+optional scale animation when the element (or any descendant) has focus.
+
+```kotlin
+Modifier.spFocusRing(shape = RoundedCornerShape(12.dp), scaleOnFocus = true)
+```
+
+**Key detail:** Uses `state.isFocused || state.hasFocus` in
+`onFocusChanged`. This is necessary because `spFocusRing` is often
+placed ABOVE the `focusable()` modifier in the chain. In that case,
+the focusable child gets `isFocused = true` but `spFocusRing` only
+sees `hasFocus = true`. Checking both ensures the ring lights up
+regardless of where in the modifier chain `focusable()` appears.
+
+## Making Components Focusable
+
+### The Rule
+
+Every interactive element must have explicit `Modifier.focusable()` to
+participate in d-pad navigation. Do NOT rely on Material3 components
+(Button, IconButton, etc.) being focusable — their internal focus
+handling doesn't register in Compose's focus traversal tree.
+
+### SpButton
+
+`SpButton` adds `spFocusRing()` + `focusable()` to its outer modifier:
+
+```kotlin
+val focusMods = Modifier
+    .spFocusRing(shape = shape)
+    .focusable(interactionSource = interactionSource)
+```
+
+This is applied via `.then(focusMods)` on every button style variant.
+
+### SpCard / SpInnerCard
+
+These use `collectIsFocusedAsState()` from the interaction source and
+draw their own focus border (white, 0.85 alpha, 2dp). They add
+`.focusable(interactionSource)` when `onClick` is provided.
+
+### ConsoleCard
+
+Uses `spFocusRing(shape, scaleOnFocus = true)` placed BEFORE
+`graphicsLayer`, `shadow`, and `clip` in the modifier chain. If placed
+after `clip`, the focus ring border gets clipped and becomes invisible.
+
+### SpFab
+
+Shared floating action button with `spFocusRing(CircleShape)` +
+`focusable()`. White semi-transparent background that blends with any
+gradient.
+
+## Layout Patterns for Focus Traversal
+
+### `focusGroup()` on Containers
+
+`SpSectionList` (the shared LazyColumn wrapper) has `focusGroup()` on
+the LazyColumn. This enables focus to traverse from overlaid elements
+(like SpTopBar) into the scroll content.
+
+The `ConsoleHeroBanner` also has `focusGroup()` so focus can traverse
+into the buttons inside the banner overlay.
+
+### Spatial Focus and Overlays
+
+Compose's directional focus (Up/Down/Left/Right) uses **spatial
+reasoning** — it looks for focusable elements geometrically in the
+pressed direction. This means:
+
+- Buttons inside a `Box(Alignment.BottomEnd)` overlay CAN be reached
+  by d-pad as long as they are `focusable()` (via SpButton's explicit
+  focusable modifier)
+- `moveFocus(Next)` finds elements in **composition order**, not spatial
+  order. The first composed focusable element gets focus first.
+- Items in a `LazyColumn` are only composed when visible. Buttons in an
+  offscreen item won't be found by `moveFocus(Next)`.
+
+### SpTopBar Auto-Hide
+
+`SpTopBar` checks `LocalInputMode` and returns early in GAMEPAD mode.
+This removes the back/settings buttons from the focus tree entirely,
+preventing focus from getting stuck on overlay buttons.
+
+`SpSectionList` automatically reduces top padding in gamepad mode since
+the top bar space is no longer needed.
+
+## Color System
+
+All focus indicators use **white** (no indigo/primary color). This
+ensures visibility against any console-branded gradient background.
+
+- Focus borders: `Color.White.copy(alpha = 0.85f)`
+- Focus scale: 1.04x (when `scaleOnFocus = true`)
+- Tab/pill focus backgrounds: `Color.Black.copy(alpha = 0.3f)`
+- Section indicator pill: `Color.Black.copy(alpha = 0.6f)` background
+
+## Per-Tab Navigation Stacks
+
+Each of the 6 tabs maintains its own `List<SpScreen>` back stack.
+`activeTab` is tracked explicitly in `NavigationState` — there is no
+`activeTabForScreen()` mapping. Screens don't "belong" to tabs.
+
+- **NavigateTo**: pushes onto the active tab's stack
+- **SwitchTab**: changes `activeTab`, preserves all stacks
+- **GoBack**: pops from active tab; at root, switches to Home
+- **L1/R1**: cycles `activeTab` with stacks preserved
+
+## Checklist for New Screens
+
+1. Use `SpSectionList` for scrollable content (has `focusGroup()`)
+2. Use `SpButton` for buttons (has `focusable()` + `spFocusRing()`)
+3. Use `SpCard`/`SpInnerCard` with `onClick` for focusable cards
+4. Don't add `SpTopBar` visibility logic — it auto-hides in gamepad mode
+5. If adding custom interactive elements, add `spFocusRing()` +
+   `focusable()` + `clickable()` explicitly
+6. Don't rely on Material3 components being focusable — always add
+   explicit `focusable()`
+7. Place `spFocusRing()` BEFORE `clip()` and `shadow()` in the modifier
+   chain, or the border will be clipped
+
+## Checklist for New Components
+
+1. If clickable, add `Modifier.focusable()` explicitly
+2. Add `spFocusRing(shape)` for visual focus indication
+3. Use white-based colors for focus indicators (no theme colors)
+4. Test with d-pad navigation, not just touch/mouse

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/navigation/NavigationViewModel.kt
@@ -117,7 +117,7 @@ class NavigationViewModel(
                     current.copy(
                         activeTab = BottomNavTab.entries[nextIndex],
                         isGoingBack = false,
-                        isTabSwitch = false,
+                        isTabSwitch = true,
                     )
                 }
             }
@@ -129,7 +129,7 @@ class NavigationViewModel(
                     current.copy(
                         activeTab = BottomNavTab.entries[prevIndex],
                         isGoingBack = true,
-                        isTabSwitch = false,
+                        isTabSwitch = true,
                     )
                 }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -287,7 +287,7 @@ fun SpelaApp(
                 { navigationViewModel.onIntent(NavigationIntent.PreviousSection) }
             } else null,
             onGamepadInput = { gamepadPortManager?.setInputMode(InputMode.GAMEPAD) },
-            focusResetKey = if (isGamepadMode) navState.currentScreen else null,
+            focusResetKey = if (isGamepadMode) Pair(navState.activeTab, navState.currentScreen) else null,
         ) {
         Box(
             modifier = Modifier

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpButton.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpButton.kt
@@ -4,8 +4,10 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import com.spela.player.presentation.ui.gamepad.spFocusRing
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.heightIn
@@ -45,11 +47,9 @@ fun SpButton(
 ) {
     val interactionSource = remember { MutableInteractionSource() }
     val isFocused by interactionSource.collectIsFocusedAsState()
-    val focusBorder = Modifier.border(
-        width = if (isFocused) 2.dp else 0.dp,
-        color = if (isFocused) Color.White.copy(alpha = 0.85f) else Color.Transparent,
-        shape = shape,
-    )
+    val focusMods = Modifier
+        .spFocusRing(shape = shape)
+        .focusable(interactionSource = interactionSource)
     val isIconOnly = text.isEmpty() && leadingIcon != null
     val defaultPadding = PaddingValues(horizontal = SpSpacing.XLarge, vertical = SpSpacing.Medium)
     val iconOnlyPadding = PaddingValues(SpSpacing.Medium)
@@ -68,7 +68,7 @@ fun SpButton(
             val contentColor = if (onGradient && enabled) Color.White else SpColor.OnPrimary
             Button(
                 onClick = { if (!isLoading) onClick() },
-                modifier = modifier.heightIn(min = 48.dp).then(focusBorder),
+                modifier = modifier.heightIn(min = 48.dp).then(focusMods),
                 enabled = enabled,
                 shape = shape,
                 interactionSource = interactionSource,
@@ -87,7 +87,7 @@ fun SpButton(
         SpButtonStyle.Secondary -> {
             Button(
                 onClick = { if (!isLoading) onClick() },
-                modifier = modifier.heightIn(min = 48.dp).then(focusBorder),
+                modifier = modifier.heightIn(min = 48.dp).then(focusMods),
                 enabled = enabled,
                 shape = shape,
                 interactionSource = interactionSource,
@@ -106,7 +106,7 @@ fun SpButton(
         SpButtonStyle.Outlined -> {
             OutlinedButton(
                 onClick = { if (!isLoading) onClick() },
-                modifier = modifier.heightIn(min = 48.dp).then(focusBorder),
+                modifier = modifier.heightIn(min = 48.dp).then(focusMods),
                 enabled = enabled,
                 shape = shape,
                 interactionSource = interactionSource,
@@ -131,7 +131,7 @@ fun SpButton(
         SpButtonStyle.Ghost -> {
             TextButton(
                 onClick = { if (!isLoading) onClick() },
-                modifier = modifier.heightIn(min = 48.dp).then(focusBorder),
+                modifier = modifier.heightIn(min = 48.dp).then(focusMods),
                 enabled = enabled,
                 shape = shape,
                 interactionSource = interactionSource,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSplitButton.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSplitButton.kt
@@ -66,7 +66,7 @@ fun SpSplitButton(
 
     Row(
         modifier = modifier
-            .heightIn(min = 48.dp),
+            .height(IntrinsicSize.Min),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         SpButton(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTextField.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpTextField.kt
@@ -75,7 +75,7 @@ fun SpTextField(
                 focusedTextColor = SpColor.OnBackground,
                 unfocusedTextColor = SpColor.OnBackground,
                 focusedBorderColor = SpColor.Primary,
-                unfocusedBorderColor = SpColor.Divider,
+                unfocusedBorderColor = SpColor.OnBackgroundTertiary.copy(alpha = 0.3f),
                 errorBorderColor = SpColor.Error,
                 focusedLabelColor = SpColor.Primary,
                 unfocusedLabelColor = SpColor.OnBackgroundSecondary,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/ConsoleComponents.kt
@@ -549,7 +549,7 @@ internal fun ConsoleHeroBanner(
                     }
                 }
 
-                // Bottom-right: action buttons (stacked vertically for narrow screens)
+                // Bottom-right: action buttons
                 if (onBrowseGames != null || onConsoleSettings != null) {
                     Column(
                         modifier = Modifier.align(Alignment.BottomEnd),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.border
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -17,6 +18,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.scale
 import androidx.compose.ui.focus.FocusDirection
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
@@ -58,26 +61,23 @@ fun GamepadHandler(
     content: @Composable () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
-    // Track whether any element currently has focus. When nothing is focused,
-    // D-pad presses should acquire focus on the first element (recovery).
-    // When something IS focused, failed directional moves should NOT wrap.
+    val focusRequester = remember { FocusRequester() }
+    // Track focus state. isSelfFocused = the wrapper Box has direct focus
+    // (not a child). hasFocus = anything in the tree has focus.
     var hasFocus by remember { mutableStateOf(false) }
+    var isSelfFocused by remember { mutableStateOf(false) }
 
-    // When focusResetKey changes (e.g. section switch in gamepad mode),
-    // clear focus and move to the first focusable element on the new page.
-    // Retries focus acquisition because screens with async data loading may
-    // not have focusable elements in the compose tree on the first attempt.
+    // When focusResetKey changes (e.g. tab switch or screen navigation),
+    // request focus on the wrapper Box. The first d-pad press then uses
+    // moveFocus(Next) to enter the content (see isSelfFocused check below).
     if (focusResetKey != null) {
         LaunchedEffect(focusResetKey) {
-            // Wait for AnimatedContent transition to complete before trying to acquire focus.
-            // The new screen's composables aren't in the focus tree during the transition.
             delay(350)
             focusManager.clearFocus(force = true)
-            // Retry up to 15 times (200ms apart, ~3s total) to find a focusable element.
-            // Screens with async data may need time before focusable items are composed.
-            repeat(15) {
-                if (focusManager.moveFocus(FocusDirection.Next)) return@LaunchedEffect
-                delay(200)
+            try {
+                focusRequester.requestFocus()
+            } catch (_: Exception) {
+                // FocusRequester may not be attached yet during transitions
             }
         }
     }
@@ -85,51 +85,50 @@ fun GamepadHandler(
     Box(
         modifier = Modifier
             .fillMaxSize()
-            .onFocusChanged { state -> hasFocus = state.hasFocus }
+            .focusRequester(focusRequester)
+            .focusable()
+            .onFocusChanged { state ->
+                hasFocus = state.hasFocus
+                isSelfFocused = state.isFocused
+            }
             .onPreviewKeyEvent { event ->
                 if (!enabled) return@onPreviewKeyEvent false
                 if (event.type != KeyEventType.KeyDown) return@onPreviewKeyEvent false
 
+                // When the wrapper Box itself has focus (no child focused yet),
+                // any d-pad press should enter the content via moveFocus(Next).
+                // Directional moves don't work from a full-screen Box (nothing
+                // is spatially above/below/left/right of it).
+                if (isSelfFocused || !hasFocus) {
+                    when (event.key) {
+                        Key.DirectionUp, Key.DirectionDown,
+                        Key.DirectionLeft, Key.DirectionRight -> {
+                            focusManager.moveFocus(FocusDirection.Next)
+                            onGamepadInput?.invoke()
+                            return@onPreviewKeyEvent true
+                        }
+                        else -> {}
+                    }
+                }
+
                 when (event.key) {
                     Key.DirectionUp -> {
-                        val hadFocus = hasFocus
-                        if (!focusManager.moveFocus(FocusDirection.Up)) {
-                            // Recovery: re-acquire focus when nothing is focused,
-                            // or when focus escaped the visible area at a boundary.
-                            if (!hadFocus || !hasFocus) {
-                                focusManager.moveFocus(FocusDirection.Next)
-                            }
-                        }
+                        focusManager.moveFocus(FocusDirection.Up)
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionDown -> {
-                        val hadFocus = hasFocus
-                        if (!focusManager.moveFocus(FocusDirection.Down)) {
-                            if (!hadFocus || !hasFocus) {
-                                focusManager.moveFocus(FocusDirection.Next)
-                            }
-                        }
+                        focusManager.moveFocus(FocusDirection.Down)
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionLeft -> {
-                        val hadFocus = hasFocus
-                        if (!focusManager.moveFocus(FocusDirection.Left)) {
-                            if (!hadFocus || !hasFocus) {
-                                focusManager.moveFocus(FocusDirection.Next)
-                            }
-                        }
+                        focusManager.moveFocus(FocusDirection.Left)
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionRight -> {
-                        val hadFocus = hasFocus
-                        if (!focusManager.moveFocus(FocusDirection.Right)) {
-                            if (!hadFocus || !hasFocus) {
-                                focusManager.moveFocus(FocusDirection.Next)
-                            }
-                        }
+                        focusManager.moveFocus(FocusDirection.Right)
                         onGamepadInput?.invoke()
                         true
                     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -199,7 +199,7 @@ fun Modifier.spFocusRing(
 
     this
         .scale(focusScale)
-        .onFocusChanged { state -> isFocused = state.isFocused }
+        .onFocusChanged { state -> isFocused = state.isFocused || state.hasFocus }
         .border(
             width = 2.dp,
             color = borderColor,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -69,7 +69,9 @@ fun GamepadHandler(
     // not have focusable elements in the compose tree on the first attempt.
     if (focusResetKey != null) {
         LaunchedEffect(focusResetKey) {
-            delay(150)
+            // Wait for AnimatedContent transition to complete before trying to acquire focus.
+            // The new screen's composables aren't in the focus tree during the transition.
+            delay(350)
             focusManager.clearFocus(force = true)
             // Retry up to 15 times (200ms apart, ~3s total) to find a focusable element.
             // Screens with async data may need time before focusable items are composed.

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -39,6 +39,7 @@ import coil3.compose.AsyncImage
 import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpShimmer
 import com.spela.player.presentation.ui.components.SpEmptyStates
 import com.spela.player.presentation.ui.components.SpSectionList

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreScreen.kt
@@ -113,9 +113,11 @@ fun ExploreScreen(
         viewModel.load()
     }
 
-    // Track initial load to avoid flashing empty state
+    // Track initial load to avoid flashing empty state.
+    // If the ViewModel already has data (revisit), start as loaded immediately.
+    val hasDataOnMount = !state.isEmpty || state.isLoading
     var sawLoading by remember { mutableStateOf(false) }
-    var hasInitiallyLoaded by remember { mutableStateOf(false) }
+    var hasInitiallyLoaded by remember { mutableStateOf(hasDataOnMount) }
     if (state.isLoading) sawLoading = true
     if (sawLoading && !state.isLoading) hasInitiallyLoaded = true
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -118,9 +118,10 @@ fun HomeScreen(
     val state by viewModel.state.collectAsState()
     val socialState by socialViewModel.state.collectAsState()
     // Track whether the first load has completed to avoid flashing "empty" state.
-    // Starts false, becomes true after isLoading has been true at least once then gone false.
+    // If the ViewModel already has data (revisit), start as loaded immediately.
+    val hasDataOnMount = state.consoles.isNotEmpty() || state.recentGames.isNotEmpty()
     var sawLoading by remember { mutableStateOf(false) }
-    var hasInitiallyLoaded by remember { mutableStateOf(false) }
+    var hasInitiallyLoaded by remember { mutableStateOf(hasDataOnMount) }
     if (state.isLoading) sawLoading = true
     if (sawLoading && !state.isLoading) hasInitiallyLoaded = true
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -252,16 +252,19 @@ fun HomeScreen(
                                 }
                             }
 
-                            // Device name banner
+                            // Device name banner (only after settings loaded)
                             if (settingsViewModel != null) {
                                 item {
                                     val settingsState by settingsViewModel.state.collectAsState()
-                                    DeviceNameBanner(
-                                        deviceName = settingsState.deviceName,
-                                        onSave = { name ->
-                                            settingsViewModel.onIntent(SettingsIntent.UpdateDeviceName(name))
-                                        },
-                                    )
+                                    // Only show when settings are loaded (userId non-empty means LoadSettings completed)
+                                    if (settingsState.userId.isNotEmpty()) {
+                                        DeviceNameBanner(
+                                            deviceName = settingsState.deviceName,
+                                            onSave = { name ->
+                                                settingsViewModel.onIntent(SettingsIntent.UpdateDeviceName(name))
+                                            },
+                                        )
+                                    }
                                 }
                             }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ServerConnectionScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ServerConnectionScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -13,6 +14,7 @@ import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -35,16 +37,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.components.SpButton
-import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
+import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
@@ -54,6 +59,12 @@ import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.ServerConnectionIntent
 import com.spela.player.presentation.viewmodel.ServerConnectionViewModel
+
+// SNES button colors used for ambient glow and decorative dots
+private val SnesRed = Color(0xFFCC2232)
+private val SnesYellow = Color(0xFFC4B208)
+private val SnesBlue = Color(0xFF2C2CAA)
+private val SnesGreen = Color(0xFF00843D)
 
 @Composable
 fun ServerConnectionScreen(
@@ -73,203 +84,26 @@ fun ServerConnectionScreen(
         }
     }
 
-    BoxWithConstraints(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(SpColor.Background),
-    ) {
-        val isLandscape = maxWidth > maxHeight
-
-        Column(
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(horizontal = SpSpacing.ScreenHorizontal),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Spacer(Modifier.height(if (isLandscape) SpSpacing.XLarge else 80.dp))
-
-            // App branding
-            Box(
-                modifier = Modifier
-                    .size(if (isLandscape) 56.dp else 80.dp)
-                    .clip(RoundedCornerShape(if (isLandscape) 14.dp else 20.dp))
-                    .background(SpColor.PrimaryContainer),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(
-                    text = "S",
-                    style = if (isLandscape) SpTypography.TitleLarge else SpTypography.DisplayMedium,
-                    color = SpColor.Primary,
-                )
-            }
-
-            Spacer(Modifier.height(SpSpacing.Default))
-
-            Text(
-                text = "Spela",
-                style = SpTypography.DisplaySmall,
-                color = SpColor.OnBackground,
-            )
-
-            Text(
-                text = "Connect to your game server",
-                style = SpTypography.BodyMedium,
-                color = SpColor.OnBackgroundSecondary,
-            )
-
-            Spacer(Modifier.height(if (isLandscape) SpSpacing.XLarge else SpSpacing.XXXLarge))
-
-            if (state.isLoading) {
-                SpLoadingIndicator(message = "Loading servers...")
-            } else {
-                LazyColumn(
-                    modifier = Modifier
-                        .then(if (isLandscape) Modifier.widthIn(max = 550.dp) else Modifier.fillMaxWidth()),
-                    verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
-                ) {
-                    items(state.servers) { server ->
-                        SpCard(
-                            onClick = {
-                                viewModel.onIntent(ServerConnectionIntent.SelectServer(server.id))
-                                onServerSelected()
-                            },
-                            onGradient = true,
-                        ) {
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .semantics { contentDescription = server.name }
-                                    .padding(SpSpacing.Default),
-                                verticalAlignment = Alignment.CenterVertically,
-                            ) {
-                                Box(
-                                    modifier = Modifier
-                                        .size(44.dp)
-                                        .clip(CircleShape)
-                                        .background(SpColor.PrimaryContainer),
-                                    contentAlignment = Alignment.Center,
-                                ) {
-                                    Text(
-                                        text = server.name.take(1).uppercase(),
-                                        style = SpTypography.TitleLarge,
-                                        color = SpColor.Primary,
-                                    )
-                                }
-                                Spacer(Modifier.width(SpSpacing.Medium))
-                                Column(modifier = Modifier.weight(1f)) {
-                                    Text(
-                                        text = server.name,
-                                        style = SpTypography.TitleLarge,
-                                        color = SpColor.OnCard,
-                                    )
-                                    Text(
-                                        text = server.url,
-                                        style = SpTypography.BodySmall,
-                                        color = SpColor.OnBackgroundTertiary,
-                                    )
-                                }
-                                if (server.isActive) {
-                                    Box(
-                                        modifier = Modifier
-                                            .size(12.dp)
-                                            .clip(CircleShape)
-                                            .background(SpColor.Success),
-                                    )
-                                    Spacer(Modifier.width(SpSpacing.Medium))
-                                }
-                                // Delete button
-                                Icon(
-                                    imageVector = Icons.Filled.Delete,
-                                    contentDescription = "Remove server",
-                                    tint = SpColor.OnBackgroundTertiary,
-                                    modifier = Modifier
-                                        .size(36.dp)
-                                        .clip(CircleShape)
-                                        .clickable(onClick = {
-                                            viewModel.onIntent(ServerConnectionIntent.RemoveServer(server.id))
-                                        })
-                                        .padding(6.dp),
-                                )
-                            }
-                        }
-                    }
-
-                    item {
-                        // Add Server section
-                        AnimatedVisibility(
-                            visible = state.isAddingServer,
-                            enter = expandVertically() + fadeIn(),
-                            exit = shrinkVertically() + fadeOut(),
-                        ) {
-                            SpCard {
-                                Column(
-                                    modifier = Modifier
-                                        .fillMaxWidth()
-                                        .padding(SpSpacing.Default),
-                                ) {
-                                    Text(
-                                        text = "Add Server",
-                                        style = SpTypography.TitleLarge,
-                                        color = SpColor.OnCard,
-                                    )
-                                    Spacer(Modifier.height(SpSpacing.Medium))
-                                    SpTextField(
-                                        value = state.newServerName,
-                                        onValueChange = {
-                                            viewModel.onIntent(ServerConnectionIntent.SetNewServerName(it))
-                                        },
-                                        label = "Server Name",
-                                        placeholder = "My Home Server",
-                                    )
-                                    Spacer(Modifier.height(SpSpacing.Small))
-                                    SpTextField(
-                                        value = state.newServerUrl,
-                                        onValueChange = {
-                                            viewModel.onIntent(ServerConnectionIntent.SetNewServerUrl(it))
-                                        },
-                                        label = "Server URL",
-                                        placeholder = "https://spela.example.com",
-                                        imeAction = ImeAction.Done,
-                                        onImeAction = { viewModel.onIntent(ServerConnectionIntent.AddServer) },
-                                    )
-                                    Spacer(Modifier.height(SpSpacing.Default))
-                                    Row(
-                                        modifier = Modifier.fillMaxWidth(),
-                                        horizontalArrangement = Arrangement.End,
-                                    ) {
-                                        SpButton(
-                                            text = "Cancel",
-                                            onClick = { viewModel.onIntent(ServerConnectionIntent.ToggleAddServer) },
-                                            style = SpButtonStyle.Ghost,
-                                            enabled = !state.isValidating,
-                                        )
-                                        Spacer(Modifier.width(SpSpacing.Small))
-                                        SpButton(
-                                            text = "Add",
-                                            onClick = { viewModel.onIntent(ServerConnectionIntent.AddServer) },
-                                            enabled = !state.isValidating,
-                                            isLoading = state.isValidating,
-                                        )
-                                    }
-                                }
-                            }
-                        }
-
-                        if (!state.isAddingServer) {
-                            Spacer(Modifier.height(SpSpacing.Default))
-                            SpSecondaryButton(
-                                text = "Add Server",
-                                onClick = { viewModel.onIntent(ServerConnectionIntent.ToggleAddServer) },
-                                modifier = Modifier.fillMaxWidth(),
-                            )
-                        }
-                    }
-                }
-            }
-
+    BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+        val layoutMode = when {
+            maxWidth > 840.dp -> "desktop"
+            maxWidth > 600.dp -> "handheld"
+            else -> "mobile"
         }
 
-        // Error snackbar with auto-dismiss
+        when (layoutMode) {
+            "mobile" -> MobileLayout(viewModel = viewModel, onServerSelected = onServerSelected)
+            else -> {
+                val leftFraction = if (layoutMode == "desktop") 0.40f else 0.35f
+                SplitLayout(
+                    viewModel = viewModel,
+                    onServerSelected = onServerSelected,
+                    leftFraction = leftFraction,
+                )
+            }
+        }
+
+        // Error snackbar at bottom — always on top of content
         SpSnackbar(
             data = state.error?.let {
                 SpSnackbarData(
@@ -284,4 +118,400 @@ fun ServerConnectionScreen(
             modifier = Modifier.align(Alignment.BottomCenter),
         )
     }
+}
+
+// ────────────────────────────────────────────────────────
+// Mobile layout: full-screen glow background + centered card
+// ────────────────────────────────────────────────────────
+
+@Composable
+private fun MobileLayout(
+    viewModel: ServerConnectionViewModel,
+    onServerSelected: () -> Unit,
+) {
+    val state by viewModel.state.collectAsState()
+
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color(0xFF0F0F1A)),
+        contentAlignment = Alignment.Center,
+    ) {
+        // Ambient glow blobs
+        AmbientGlowBlobs()
+
+        // Glass card
+        Column(
+            modifier = Modifier
+                .widthIn(max = 400.dp)
+                .fillMaxWidth()
+                .padding(horizontal = SpSpacing.Default)
+                .clip(RoundedCornerShape(24.dp))
+                .background(Color.White.copy(alpha = 0.04f))
+                .border(1.dp, Color.White.copy(alpha = 0.08f), RoundedCornerShape(24.dp))
+                .padding(SpSpacing.XLarge),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            AppIcon(size = 64.dp, radius = 16.dp)
+            Spacer(Modifier.height(SpSpacing.Default))
+            Text(
+                text = "Welcome to Spela",
+                style = SpTypography.DisplaySmall,
+                color = SpColor.OnBackground,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text = "Connect to your game server",
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundSecondary,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(SpSpacing.XLarge))
+
+            if (state.isLoading) {
+                SpLoadingIndicator(message = "Loading servers...")
+            } else {
+                ServerListOrForm(
+                    viewModel = viewModel,
+                    onServerSelected = onServerSelected,
+                    fullWidth = true,
+                )
+            }
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────
+// Split layout: hero panel + form panel side by side
+// ────────────────────────────────────────────────────────
+
+@Composable
+private fun SplitLayout(
+    viewModel: ServerConnectionViewModel,
+    onServerSelected: () -> Unit,
+    leftFraction: Float,
+) {
+    val state by viewModel.state.collectAsState()
+
+    Row(modifier = Modifier.fillMaxSize()) {
+        // Left hero panel
+        Box(
+            modifier = Modifier
+                .fillMaxHeight()
+                .fillMaxWidth(leftFraction)
+                .background(Color(0xFF0F0F1A)),
+            contentAlignment = Alignment.Center,
+        ) {
+            AmbientGlowBlobs()
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Center,
+            ) {
+                AppIcon(size = 80.dp, radius = 20.dp)
+                Spacer(Modifier.height(SpSpacing.Default))
+                Text(
+                    text = "Spela",
+                    style = SpTypography.DisplayMedium,
+                    color = SpColor.OnBackground,
+                    fontWeight = FontWeight.Bold,
+                )
+                Spacer(Modifier.height(SpSpacing.Small))
+                Text(
+                    text = "Your self-hosted\ngame library",
+                    style = SpTypography.BodyMedium,
+                    color = SpColor.OnBackgroundSecondary,
+                    textAlign = TextAlign.Center,
+                )
+                Spacer(Modifier.height(SpSpacing.XLarge))
+                SnesButtonDots()
+            }
+        }
+
+        // Right form panel
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(SpColor.Background),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                modifier = Modifier
+                    .widthIn(max = 380.dp)
+                    .fillMaxWidth()
+                    .padding(horizontal = SpSpacing.XLarge),
+                horizontalAlignment = Alignment.CenterHorizontally,
+            ) {
+                if (state.isLoading) {
+                    SpLoadingIndicator(message = "Loading servers...")
+                } else {
+                    ServerListOrForm(
+                        viewModel = viewModel,
+                        onServerSelected = onServerSelected,
+                        fullWidth = true,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────
+// Shared server list / add-server form
+// ────────────────────────────────────────────────────────
+
+@Composable
+private fun ServerListOrForm(
+    viewModel: ServerConnectionViewModel,
+    onServerSelected: () -> Unit,
+    fullWidth: Boolean,
+) {
+    val state by viewModel.state.collectAsState()
+
+    LazyColumn(
+        modifier = if (fullWidth) Modifier.fillMaxWidth() else Modifier,
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.Medium),
+    ) {
+        items(state.servers) { server ->
+            SpCard(
+                onClick = {
+                    viewModel.onIntent(ServerConnectionIntent.SelectServer(server.id))
+                    onServerSelected()
+                },
+                onGradient = true,
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .semantics { contentDescription = server.name }
+                        .padding(SpSpacing.Default),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(
+                        modifier = Modifier
+                            .size(44.dp)
+                            .clip(CircleShape)
+                            .background(SpColor.PrimaryContainer),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = server.name.take(1).uppercase(),
+                            style = SpTypography.TitleLarge,
+                            color = SpColor.Primary,
+                        )
+                    }
+                    Spacer(Modifier.width(SpSpacing.Medium))
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = server.name,
+                            style = SpTypography.TitleLarge,
+                            color = SpColor.OnCard,
+                        )
+                        Text(
+                            text = server.url,
+                            style = SpTypography.BodySmall,
+                            color = SpColor.OnBackgroundTertiary,
+                        )
+                    }
+                    if (server.isActive) {
+                        Box(
+                            modifier = Modifier
+                                .size(12.dp)
+                                .clip(CircleShape)
+                                .background(SpColor.Success),
+                        )
+                        Spacer(Modifier.width(SpSpacing.Medium))
+                    }
+                    Icon(
+                        imageVector = Icons.Filled.Delete,
+                        contentDescription = "Remove server",
+                        tint = SpColor.OnBackgroundTertiary,
+                        modifier = Modifier
+                            .size(36.dp)
+                            .clip(CircleShape)
+                            .clickable(onClick = {
+                                viewModel.onIntent(ServerConnectionIntent.RemoveServer(server.id))
+                            })
+                            .padding(6.dp),
+                    )
+                }
+            }
+        }
+
+        item {
+            AnimatedVisibility(
+                visible = state.isAddingServer,
+                enter = expandVertically() + fadeIn(),
+                exit = shrinkVertically() + fadeOut(),
+            ) {
+                Column(
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    if (state.servers.isEmpty()) {
+                        // No servers yet — show welcoming header inside form area
+                        Text(
+                            text = "Add Server",
+                            style = SpTypography.TitleLarge,
+                            color = SpColor.OnBackground,
+                        )
+                        Spacer(Modifier.height(SpSpacing.XSmall))
+                        Text(
+                            text = "Enter your server details to connect",
+                            style = SpTypography.BodyMedium,
+                            color = SpColor.OnBackgroundSecondary,
+                        )
+                        Spacer(Modifier.height(SpSpacing.Default))
+                    }
+                    SpTextField(
+                        value = state.newServerName,
+                        onValueChange = {
+                            viewModel.onIntent(ServerConnectionIntent.SetNewServerName(it))
+                        },
+                        label = "Server Name",
+                        placeholder = "My Home Server",
+                    )
+                    Spacer(Modifier.height(SpSpacing.Small))
+                    SpTextField(
+                        value = state.newServerUrl,
+                        onValueChange = {
+                            viewModel.onIntent(ServerConnectionIntent.SetNewServerUrl(it))
+                        },
+                        label = "Server URL",
+                        placeholder = "https://spela.example.com",
+                        imeAction = ImeAction.Done,
+                        onImeAction = { viewModel.onIntent(ServerConnectionIntent.AddServer) },
+                    )
+                    Spacer(Modifier.height(SpSpacing.Default))
+                    if (state.servers.isEmpty()) {
+                        // First server — single prominent "Connect" button
+                        SpButton(
+                            text = "Connect",
+                            onClick = { viewModel.onIntent(ServerConnectionIntent.AddServer) },
+                            modifier = Modifier.fillMaxWidth(),
+                            enabled = !state.isValidating,
+                            isLoading = state.isValidating,
+                        )
+                    } else {
+                        // Adding an additional server — Cancel + Add
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            horizontalArrangement = Arrangement.End,
+                        ) {
+                            SpButton(
+                                text = "Cancel",
+                                onClick = { viewModel.onIntent(ServerConnectionIntent.ToggleAddServer) },
+                                style = SpButtonStyle.Ghost,
+                                enabled = !state.isValidating,
+                            )
+                            Spacer(Modifier.width(SpSpacing.Small))
+                            SpButton(
+                                text = "Add",
+                                onClick = { viewModel.onIntent(ServerConnectionIntent.AddServer) },
+                                enabled = !state.isValidating,
+                                isLoading = state.isValidating,
+                            )
+                        }
+                    }
+                }
+            }
+
+            if (!state.isAddingServer) {
+                Spacer(Modifier.height(SpSpacing.Default))
+                SpSecondaryButton(
+                    text = "Add Server",
+                    onClick = { viewModel.onIntent(ServerConnectionIntent.ToggleAddServer) },
+                    modifier = Modifier.fillMaxWidth(),
+                )
+            }
+        }
+    }
+}
+
+// ────────────────────────────────────────────────────────
+// Reusable visual sub-components
+// ────────────────────────────────────────────────────────
+
+@Composable
+private fun AppIcon(size: androidx.compose.ui.unit.Dp, radius: androidx.compose.ui.unit.Dp) {
+    Box(
+        modifier = Modifier
+            .size(size)
+            .clip(RoundedCornerShape(radius))
+            .background(Color.White.copy(alpha = 0.08f))
+            .border(1.dp, Color.White.copy(alpha = 0.1f), RoundedCornerShape(radius)),
+        contentAlignment = Alignment.Center,
+    ) {
+        Text(
+            text = "S",
+            style = SpTypography.DisplayMedium,
+            color = Color.White,
+            fontWeight = FontWeight.ExtraBold,
+        )
+    }
+}
+
+@Composable
+private fun SnesButtonDots() {
+    Row(horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+        listOf(SnesRed, SnesYellow, SnesBlue, SnesGreen).forEach { color ->
+            Box(
+                modifier = Modifier
+                    .size(12.dp)
+                    .clip(CircleShape)
+                    .background(color.copy(alpha = 0.6f)),
+            )
+        }
+    }
+}
+
+@Composable
+private fun androidx.compose.foundation.layout.BoxScope.AmbientGlowBlobs() {
+    // Red — top-left
+    Box(
+        modifier = Modifier
+            .matchParentSize()
+            .background(
+                Brush.radialGradient(
+                    colors = listOf(SnesRed.copy(alpha = 0.25f), Color.Transparent),
+                    center = androidx.compose.ui.geometry.Offset(0f, 0f),
+                    radius = 600f,
+                ),
+            ),
+    )
+    // Blue — bottom-right
+    Box(
+        modifier = Modifier
+            .matchParentSize()
+            .background(
+                Brush.radialGradient(
+                    colors = listOf(SnesBlue.copy(alpha = 0.25f), Color.Transparent),
+                    center = androidx.compose.ui.geometry.Offset(Float.MAX_VALUE, Float.MAX_VALUE),
+                    radius = 600f,
+                ),
+            ),
+    )
+    // Green — bottom-center
+    Box(
+        modifier = Modifier
+            .matchParentSize()
+            .background(
+                Brush.radialGradient(
+                    colors = listOf(SnesGreen.copy(alpha = 0.20f), Color.Transparent),
+                    center = androidx.compose.ui.geometry.Offset(Float.MAX_VALUE / 2f, Float.MAX_VALUE),
+                    radius = 500f,
+                ),
+            ),
+    )
+    // Yellow — top-right
+    Box(
+        modifier = Modifier
+            .matchParentSize()
+            .background(
+                Brush.radialGradient(
+                    colors = listOf(SnesYellow.copy(alpha = 0.15f), Color.Transparent),
+                    center = androidx.compose.ui.geometry.Offset(Float.MAX_VALUE, 0f),
+                    radius = 500f,
+                ),
+            ),
+    )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -112,12 +112,15 @@ class GameListViewModel(
     }
 
     private fun loadDashboard() {
-        println("[GameListVM] loadDashboard() called")
-        // Cancel any in-flight dashboard load (prevents stale data from overwriting fresh request)
-        dashboardJob?.cancel()
+        val currentState = _state.value
+        println("[GameListVM] loadDashboard() called — consoles=${currentState.consoles.size}, recent=${currentState.recentGames.size}, isLoading=${currentState.isLoading}, jobActive=${dashboardJob?.isActive}")
+        // Skip if a load is already in-flight
+        if (dashboardJob?.isActive == true) return
         // Only show loading spinner if we have no cached data.
         // If we already have data, refresh silently in the background.
-        _state.update { it.copy(isLoading = it.consoles.isEmpty() && it.recentGames.isEmpty()) }
+        val showLoading = currentState.consoles.isEmpty() && currentState.recentGames.isEmpty()
+        println("[GameListVM] loadDashboard() showLoading=$showLoading")
+        _state.update { it.copy(isLoading = showLoading) }
         dashboardJob = scope.launch(dispatchers.io) {
             val consoles = getConsolesUseCase().getOrDefault(emptyList())
             val recent = getRecentGamesUseCase().getOrDefault(emptyList())


### PR DESCRIPTION
## Summary
- Responsive 3-tier layout: centered card on mobile, 35/65 split on handheld, 40/60 split on desktop
- SNES button colors (red, yellow, blue, green) as ambient radial glow effect on hero panel
- Glass card with frosted borders on mobile, split hero+form on larger screens
- "Welcome to Spela" branding with app icon placeholder and tagline
- Improved SpTextField border visibility globally (unfocused border now visible)
- Server list replaces form when saved servers exist; "Add Server" button at bottom
                                                                                                  
  Server Connection Screen Redesign                                   
                                                                                                  
  - Responsive 3-tier layout: centered glass card on mobile (<600dp), 35/65 split on handheld     
  (600-840dp), 40/60 split on desktop (>840dp)                                                    
  - SNES button colors (red, yellow, blue, green) as ambient radial glow effect on hero panel     
  - "Welcome to Spela" branding with app icon placeholder and tagline                             
  - Server list replaces form when saved servers exist; "Add Server" button at bottom             
  - Improved SpTextField border visibility globally (unfocused border was near-invisible)         
                                                                                                  
  Fix: Stuck "Loading" on Home/Explore tab revisit                                                
                                                                                                  
  - HomeScreen/ExploreScreen: hasInitiallyLoaded now starts true when ViewModel already has data, 
  preventing permanent "Loading your library..." on composable remount
  - NavigationViewModel: NextSection/PreviousSection (L1/R1) now set isTabSwitch = true to        
  preserve compose state across gamepad tab cycling                                               
  - GameListViewModel: skip loadDashboard if job already in-flight
                                                                                                  
  Fix: Device name banner flash                                                                   
   
  - Hide "Name this device" banner until settings are loaded (check userId non-empty), preventing 
  brief flash on every Home screen visit       

## Test plan
- [x] Compilation clean
- [ ] Manual: verify mobile layout (centered card with glow)
- [ ] Manual: verify handheld landscape layout (35/65 split)
- [ ] Manual: verify desktop layout (40/60 split)
- [ ] Manual: verify input fields are visible across all screens
- [ ] Manual: verify server add/select/delete still works