### PR TITLE
fix: gamepad focus — auto-focus on navigate, SpButton focusable, d-pad recovery

### DIFF
--- a/player/android/src/main/java/com/spela/player/android/MainActivity.kt
+++ b/player/android/src/main/java/com/spela/player/android/MainActivity.kt
@@ -387,10 +387,6 @@ class MainActivity : ComponentActivity() {
         analogDpadDown = nowDown
 
         if (Math.abs(rY) > 0.15f) {
-            // Clear Compose focus so the next d-pad press focuses the first
-            // visible element instead of jumping back to the off-screen element.
-            currentFocus?.clearFocus()
-
             val props = MotionEvent.PointerProperties().apply {
                 id = 0
                 toolType = MotionEvent.TOOL_TYPE_MOUSE

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -288,6 +288,7 @@ fun SpelaApp(
             } else null,
             onGamepadInput = { gamepadPortManager?.setInputMode(InputMode.GAMEPAD) },
             focusResetKey = if (isGamepadMode) Pair(navState.activeTab, navState.currentScreen) else null,
+            isGoingBack = navState.isGoingBack,
         ) {
         Box(
             modifier = Modifier

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionList.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionList.kt
@@ -6,7 +6,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.gamepad.InputMode
@@ -42,8 +45,12 @@ fun SpSectionList(
         topPadding
     }
 
+    val focusFallback = remember { FocusRequester() }
+
     LazyColumn(
-        modifier = modifier.focusGroup(),
+        modifier = modifier
+            .focusRestorer(focusFallback)
+            .focusGroup(),
         contentPadding = PaddingValues(
             start = SpSpacing.ScreenHorizontal,
             end = SpSpacing.ScreenHorizontal,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionList.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionList.kt
@@ -6,10 +6,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListScope
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.focus.FocusRequester
-import androidx.compose.ui.focus.focusRestorer
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.spela.player.presentation.ui.gamepad.InputMode
@@ -45,12 +42,8 @@ fun SpSectionList(
         topPadding
     }
 
-    val focusFallback = remember { FocusRequester() }
-
     LazyColumn(
-        modifier = modifier
-            .focusRestorer(focusFallback)
-            .focusGroup(),
+        modifier = modifier.focusGroup(),
         contentPadding = PaddingValues(
             start = SpSpacing.ScreenHorizontal,
             end = SpSpacing.ScreenHorizontal,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/GamepadNavigation.kt
@@ -58,6 +58,7 @@ fun GamepadHandler(
     onPreviousSection: (() -> Unit)? = null,
     onGamepadInput: (() -> Unit)? = null,
     focusResetKey: Any? = null,
+    isGoingBack: Boolean = false,
     content: @Composable () -> Unit,
 ) {
     val focusManager = LocalFocusManager.current
@@ -68,14 +69,24 @@ fun GamepadHandler(
     var isSelfFocused by remember { mutableStateOf(false) }
 
     // When focusResetKey changes (e.g. tab switch or screen navigation),
-    // request focus on the wrapper Box. The first d-pad press then uses
-    // moveFocus(Next) to enter the content (see isSelfFocused check below).
+    // auto-focus the first visible focusable element.
+    //
+    // Forward navigation: focus the first element on the new screen.
+    // Back navigation: focus the first VISIBLE element — scroll position is
+    // restored by saveableStateHolder, so this lands near where the user was.
     if (focusResetKey != null) {
         LaunchedEffect(focusResetKey) {
             delay(350)
             focusManager.clearFocus(force = true)
             try {
                 focusRequester.requestFocus()
+                // Auto-enter content: find the first visible focusable child.
+                // On back navigation, scroll position is already restored so
+                // the first visible element is near where the user left off.
+                repeat(10) {
+                    if (focusManager.moveFocus(FocusDirection.Next)) return@LaunchedEffect
+                    delay(200)
+                }
             } catch (_: Exception) {
                 // FocusRequester may not be attached yet during transitions
             }
@@ -113,22 +124,36 @@ fun GamepadHandler(
 
                 when (event.key) {
                     Key.DirectionUp -> {
-                        focusManager.moveFocus(FocusDirection.Up)
+                        if (!focusManager.moveFocus(FocusDirection.Up)) {
+                            // Directional move failed — focused element may be offscreen
+                            // after joystick scroll. Clear and re-enter content.
+                            focusManager.clearFocus(force = true)
+                            focusManager.moveFocus(FocusDirection.Next)
+                        }
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionDown -> {
-                        focusManager.moveFocus(FocusDirection.Down)
+                        if (!focusManager.moveFocus(FocusDirection.Down)) {
+                            focusManager.clearFocus(force = true)
+                            focusManager.moveFocus(FocusDirection.Next)
+                        }
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionLeft -> {
-                        focusManager.moveFocus(FocusDirection.Left)
+                        if (!focusManager.moveFocus(FocusDirection.Left)) {
+                            focusManager.clearFocus(force = true)
+                            focusManager.moveFocus(FocusDirection.Next)
+                        }
                         onGamepadInput?.invoke()
                         true
                     }
                     Key.DirectionRight -> {
-                        focusManager.moveFocus(FocusDirection.Right)
+                        if (!focusManager.moveFocus(FocusDirection.Right)) {
+                            focusManager.clearFocus(force = true)
+                            focusManager.moveFocus(FocusDirection.Next)
+                        }
                         onGamepadInput?.invoke()
                         true
                     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryList.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryList.kt
@@ -2,6 +2,9 @@ package com.spela.player.presentation.ui.screen
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.focusable
+import com.spela.player.presentation.ui.gamepad.spFocusRing
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -46,7 +49,7 @@ fun SettingsCategoryList(
     topPadding: androidx.compose.ui.unit.Dp = 0.dp,
 ) {
     LazyColumn(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier.fillMaxSize().focusGroup(),
         contentPadding = PaddingValues(
             start = SpSpacing.Medium,
             end = SpSpacing.Medium,
@@ -89,9 +92,11 @@ fun SettingsCategoryList(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
+                    .spFocusRing(shape = RoundedCornerShape(8.dp))
                     .clip(RoundedCornerShape(8.dp))
                     .background(bgColor)
                     .clickable { onSelectCategory(category) }
+                    .focusable()
                     .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Medium)
                     .semantics { contentDescription = category.label },
                 verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## Summary

Comprehensive gamepad focus navigation fixes. All changes are in shared Compose code affecting all screens.

### SpButton explicit focusable
Material3 Button's internal focus handling doesn't register in Compose's focus traversal tree. Added explicit `spFocusRing()` + `focusable()` on SpButton's outer modifier so d-pad can reach all buttons — including "Browse games", "Console settings", "Resume", and every other SpButton in the app.

### Auto-focus on screen navigation
On both forward and back navigation, the first visible focusable element is automatically focused after the AnimatedContent transition completes. On back navigation, scroll position is restored by saveableStateHolder, so the auto-focused element is near where the user was.

`focusRestorer()` was investigated but breaks focus entirely on Compose Multiplatform — it intercepts focus entry and fails to restore or pass through.

### GamepadHandler improvements
- Track `isSelfFocused` vs `hasFocus` separately. When wrapper Box has focus (after screen change), any d-pad press uses `moveFocus(Next)` to enter content.
- D-pad recovery: when directional move fails (offscreen element after joystick scroll), clear focus and `moveFocus(Next)` to re-enter from first visible element.
- Removed `currentFocus?.clearFocus()` from MainActivity joystick handler — was destroying Android-level focus entirely, preventing key events from reaching Compose.
- `focusResetKey` includes `activeTab` and uses 350ms delay for AnimatedContent transitions.

### spFocusRing descendant detection
Check `state.isFocused || state.hasFocus` so the ring lights up when `focusable()` is deeper in the modifier chain than `spFocusRing()`.

### Other fixes
- SpSplitButton: `IntrinsicSize.Min` so divider matches button height
- ConsoleHeroBanner: buttons back inside banner overlay (now reachable thanks to SpButton fix)
- Settings category list: `focusGroup()` + `spFocusRing()` + `focusable()` on category items
- Added `player/GAMEPAD_NAVIGATION.md` documenting the full architecture

## Test plan
- [x] Builds successfully
- [x] Manually tested on AYN Thor (gamepad + touch)
- [x] Console list: d-pad navigable with focus ring
- [x] Console detail: Browse games + Console settings reachable
- [x] Game detail: Resume button reachable
- [x] L1/R1 tab switching auto-focuses first element
- [x] Joystick scroll then d-pad re-enters content
- [x] Back navigation focuses near previous position
- [x] Settings category list navigable