### PR TITLE
fix: update azahar core to 2125.0.1

### DIFF
--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -955,8 +955,8 @@ func SeedCores(db *gorm.DB) error {
 			DisplayName: "Azahar",
 			Description: "Nintendo 3DS emulator (Citra successor)",
 			Platforms:   "windows,linux,macos,android",
-			Version:     "2125.0-rc5",
-			DownloadURL: "https://github.com/azahar-emu/azahar/releases/download/2125.0-rc5/azahar-libretro-2125.0-rc5-{platform}.zip",
+			Version:     "2125.0.1",
+			DownloadURL: "https://github.com/azahar-emu/azahar/releases/download/2125.0.1/azahar-libretro-{platform}-2125.0.1.zip",
 		},
 		{Name: "scummvm", DisplayName: "ScummVM", Description: "Point-and-click adventure game engine", Platforms: "windows,linux,macos,android"},
 	}


### PR DESCRIPTION
## Summary
- Update Azahar libretro core from 2125.0-rc5 to 2125.0.1
- Fix Android download URL: new release uses `arm64-v8a` in asset names, matching the actual `currentArch()` value on Android. The old template used `arm64` which would not resolve correctly on device.

## Test plan
- [ ] Verify core downloads on desktop (macOS/Linux/Windows)
- [ ] Verify core downloads on Android (arm64-v8a)
- [ ] Confirm 3DS games launch with the updated core