### PR TITLE
fix: SteamGridDB release year disambiguation + web hero art

### DIFF
--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -955,8 +955,8 @@ func SeedCores(db *gorm.DB) error {
 			DisplayName: "Azahar",
 			Description: "Nintendo 3DS emulator (Citra successor)",
 			Platforms:   "windows,linux,macos,android",
-			Version:     "2125.0-rc5",
-			DownloadURL: "https://github.com/azahar-emu/azahar/releases/download/2125.0-rc5/azahar-libretro-2125.0-rc5-{platform}.zip",
+			Version:     "2125.0.1",
+			DownloadURL: "https://github.com/azahar-emu/azahar/releases/download/2125.0.1/azahar-libretro-{platform}-2125.0.1.zip",
 		},
 		{Name: "scummvm", DisplayName: "ScummVM", Description: "Point-and-click adventure game engine", Platforms: "windows,linux,macos,android"},
 	}

--- a/server/internal/scraper/scraper_batch.go
+++ b/server/internal/scraper/scraper_batch.go
@@ -13,6 +13,19 @@ import (
 	"gorm.io/gorm"
 )
 
+// parseReleaseYear extracts the year from a release date string like "1983-01-15".
+// Returns 0 if the string is empty or unparseable.
+func parseReleaseYear(releaseDate string) int {
+	if len(releaseDate) < 4 {
+		return 0
+	}
+	year, err := strconv.Atoi(releaseDate[:4])
+	if err != nil {
+		return 0
+	}
+	return year
+}
+
 // EnrichProgress holds progress information for a metadata enrichment operation.
 type EnrichProgress struct {
 	Current   int    `json:"current"`
@@ -162,7 +175,7 @@ func (s *Scraper) scrapeSteamGridDBArtwork(game *db.Game, console db.Console) {
 		return
 	}
 
-	artwork, err := s.SteamGridDBClient.GetBestArtwork(game.Title, console.Abbreviation)
+	artwork, err := s.SteamGridDBClient.GetBestArtwork(game.Title, console.Abbreviation, parseReleaseYear(game.ReleaseDate))
 	if err != nil {
 		slog.Debug("SteamGridDB artwork fetch failed", "game", game.Title, "error", err)
 		errStr := err.Error()
@@ -226,7 +239,7 @@ func (s *Scraper) scrapeSteamGridDBArtworkResult(game *db.Game, console db.Conso
 		return "matched", "" // already exists
 	}
 
-	artwork, err := s.SteamGridDBClient.GetBestArtwork(game.Title, console.Abbreviation)
+	artwork, err := s.SteamGridDBClient.GetBestArtwork(game.Title, console.Abbreviation, parseReleaseYear(game.ReleaseDate))
 	if err != nil {
 		slog.Debug("SteamGridDB artwork fetch failed", "game", game.Title, "error", err)
 		errStr := err.Error()

--- a/server/internal/scraper/steamgriddb.go
+++ b/server/internal/scraper/steamgriddb.go
@@ -36,8 +36,9 @@ type SteamGridDBImage struct {
 
 // steamGridDBSearchResult represents a game result from the search endpoint.
 type steamGridDBSearchResult struct {
-	ID   int    `json:"id"`
-	Name string `json:"name"`
+	ID          int    `json:"id"`
+	Name        string `json:"name"`
+	ReleaseDate *int64 `json:"release_date"`
 }
 
 // steamGridDBResponse wraps the common API response structure.
@@ -95,8 +96,10 @@ func (c *SteamGridDBClient) doRequest(path string) ([]byte, error) {
 }
 
 // SearchGame searches SteamGridDB for a game by name and returns the best match game ID.
-// The platform parameter is currently unused (search is name-based) but reserved for future filtering.
-func (c *SteamGridDBClient) SearchGame(name string, platform string) (int, error) {
+// When releaseYear is provided (> 0), results are filtered to prefer entries whose
+// release date is closest to that year. This prevents a modern game (e.g. "The Witness" 2016)
+// from being matched when searching for a retro game with the same name.
+func (c *SteamGridDBClient) SearchGame(name string, platform string, releaseYear int) (int, error) {
 	encodedName := url.PathEscape(name)
 	body, err := c.doRequest("/search/autocomplete/" + encodedName)
 	if err != nil {
@@ -112,7 +115,34 @@ func (c *SteamGridDBClient) SearchGame(name string, platform string) (int, error
 		return 0, fmt.Errorf("no results found for %q", name)
 	}
 
-	// Return the first (best) match
+	// When we have a release year, pick the result with the closest release date.
+	if releaseYear > 0 {
+		bestIdx := 0
+		bestDist := -1
+		for i, r := range resp.Data {
+			if r.ReleaseDate == nil {
+				continue
+			}
+			year := time.Unix(*r.ReleaseDate, 0).UTC().Year()
+			dist := year - releaseYear
+			if dist < 0 {
+				dist = -dist
+			}
+			if bestDist < 0 || dist < bestDist {
+				bestDist = dist
+				bestIdx = i
+			}
+		}
+		if bestDist >= 0 {
+			chosen := resp.Data[bestIdx]
+			chosenYear := time.Unix(*chosen.ReleaseDate, 0).UTC().Year()
+			slog.Debug("SteamGridDB: picked result by release year",
+				"query", name, "chosen", chosen.Name,
+				"chosenYear", chosenYear, "targetYear", releaseYear)
+			return chosen.ID, nil
+		}
+	}
+
 	return resp.Data[0].ID, nil
 }
 
@@ -177,8 +207,9 @@ func bestImageURL(images []SteamGridDBImage) string {
 // GetBestArtwork searches SteamGridDB for a game and fetches the highest-scored artwork
 // of each type (hero, grid, logo, icon). Returns a GameArtwork with URLs populated.
 // Returns nil if the game is not found on SteamGridDB.
-func (c *SteamGridDBClient) GetBestArtwork(name string, platform string) (*db.GameArtwork, error) {
-	gameID, err := c.SearchGame(name, platform)
+// releaseYear helps disambiguate games with identical names across eras.
+func (c *SteamGridDBClient) GetBestArtwork(name string, platform string, releaseYear int) (*db.GameArtwork, error) {
+	gameID, err := c.SearchGame(name, platform, releaseYear)
 	if err != nil {
 		return nil, fmt.Errorf("searching game: %w", err)
 	}

--- a/server/internal/scraper/steamgriddb_test.go
+++ b/server/internal/scraper/steamgriddb_test.go
@@ -33,7 +33,7 @@ func TestSteamGridDBClient_SearchGame(t *testing.T) {
 		HTTPClient: server.Client(),
 	}
 
-	gameID, err := client.SearchGame("Super Mario World", "")
+	gameID, err := client.SearchGame("Super Mario World", "", 0)
 	require.NoError(t, err)
 	assert.Equal(t, 5432, gameID)
 }
@@ -55,9 +55,49 @@ func TestSteamGridDBClient_SearchGame_NoResults(t *testing.T) {
 		HTTPClient: server.Client(),
 	}
 
-	_, err := client.SearchGame("NonexistentGame12345", "")
+	_, err := client.SearchGame("NonexistentGame12345", "", 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no results found")
+}
+
+func TestSteamGridDBClient_SearchGame_ReleaseYearDisambiguation(t *testing.T) {
+	// Simulates "The Witness" scenario: modern PC game (2016) vs retro Amiga game (1983)
+	releaseDate1983 := int64(410227200) // 1983-01-01
+	releaseDate2016 := int64(1453795200) // 2016-01-26
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := steamGridDBResponse[[]steamGridDBSearchResult]{
+			Success: true,
+			Data: []steamGridDBSearchResult{
+				{ID: 2014, Name: "The Witness", ReleaseDate: &releaseDate2016},
+				{ID: 5335694, Name: "The Witness", ReleaseDate: &releaseDate1983},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := &SteamGridDBClient{
+		APIKey:     "test-api-key",
+		BaseURL:    server.URL + "/api/v2",
+		HTTPClient: server.Client(),
+	}
+
+	// Without release year, should return first result (modern game)
+	gameID, err := client.SearchGame("The Witness", "AMIGA", 0)
+	require.NoError(t, err)
+	assert.Equal(t, 2014, gameID)
+
+	// With release year 1983, should pick the retro game
+	gameID, err = client.SearchGame("The Witness", "AMIGA", 1983)
+	require.NoError(t, err)
+	assert.Equal(t, 5335694, gameID)
+
+	// With release year 2016, should pick the modern game
+	gameID, err = client.SearchGame("The Witness", "", 2016)
+	require.NoError(t, err)
+	assert.Equal(t, 2014, gameID)
 }
 
 func TestSteamGridDBClient_SearchGame_Unauthorized(t *testing.T) {
@@ -73,7 +113,7 @@ func TestSteamGridDBClient_SearchGame_Unauthorized(t *testing.T) {
 		HTTPClient: server.Client(),
 	}
 
-	_, err := client.SearchGame("Test", "")
+	_, err := client.SearchGame("Test", "", 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unauthorized")
 }
@@ -247,7 +287,7 @@ func TestSteamGridDBClient_GetBestArtwork(t *testing.T) {
 		HTTPClient: server.Client(),
 	}
 
-	artwork, err := client.GetBestArtwork("Zelda", "")
+	artwork, err := client.GetBestArtwork("Zelda", "", 0)
 	require.NoError(t, err)
 	require.NotNil(t, artwork)
 
@@ -309,7 +349,7 @@ func TestSteamGridDBClient_GetBestArtwork_PartialFailure(t *testing.T) {
 		HTTPClient: server.Client(),
 	}
 
-	artwork, err := client.GetBestArtwork("Tetris", "")
+	artwork, err := client.GetBestArtwork("Tetris", "", 0)
 	require.NoError(t, err)
 	require.NotNil(t, artwork)
 
@@ -332,7 +372,7 @@ func TestSteamGridDBClient_RateLimited(t *testing.T) {
 		HTTPClient: server.Client(),
 	}
 
-	_, err := client.SearchGame("Test", "")
+	_, err := client.SearchGame("Test", "", 0)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "rate limited")
 }

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -87,8 +87,8 @@ export function GameHero({
   const [showCoverModal, setShowCoverModal] = useState(false);
   const consoleName = game.consoleName ?? "";
 
-  // Use first screenshot as hero background, or null for gradient-only fallback
-  const heroImage = game.screenshotUrls?.[0] || null;
+  // Prefer hero art (from SteamGridDB), fall back to first screenshot
+  const heroImage = game.heroUrl || game.screenshotUrls?.[0] || null;
 
   const actionsMenuItems = [
     ...(isAdmin

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -106,6 +106,7 @@ export interface Game {
   discs?: GameDisc[];
   coverUrl?: string;
   screenshotUrls: string[];
+  heroUrl?: string;
   description?: string;
   developer?: string;
   publisher?: string;


### PR DESCRIPTION
## Summary
- **SteamGridDB disambiguation**: Search now parses `release_date` from results and picks the entry closest to the game's known release year. Fixes wrong artwork for retro games with names shared by modern titles (e.g. "The Witness" 1983 Amiga vs 2016 PC).
- **Web hero art**: Game detail page now uses `heroUrl` (SteamGridDB artwork) with screenshot fallback, matching the player app behavior. Added `heroUrl` to the TypeScript `Game` interface.

## Test plan
- [ ] Re-scrape "The Witness" on Amiga and verify it gets 1983 artwork, not the 2016 PC game
- [ ] Verify web game detail background shows hero art instead of screenshots
- [ ] Run `go test ./internal/scraper/` — all pass including new disambiguation test