### PR TITLE
feat: controller status indicators for local multiplayer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .claude/
 .vscode/
 
+# Worktrees
+.worktrees/
+
 # Go
 server/.playwright-cli/
 

--- a/docs/superpowers/plans/2026-04-07-controller-status-indicators.md
+++ b/docs/superpowers/plans/2026-04-07-controller-status-indicators.md
@@ -1,0 +1,1262 @@
+# Controller Status Indicators Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add always-visible, compact controller status indicators that appear when 2+ controllers are connected, across all navigation layouts.
+
+**Architecture:** Extend `GamepadPortManager` with a derived `StateFlow<ControllerStatusState>` that combines port assignments + activity timestamps. Three UI variants (rail card, pill extension, floating mini-pill) consume this single state. New shared `Sp*` components follow the Design → Content hierarchy.
+
+**Tech Stack:** Kotlin Multiplatform, Compose Multiplatform, Coroutines/StateFlow, Koin DI
+
+**Spec:** `docs/superpowers/specs/2026-04-07-controller-status-indicators-design.md`
+
+---
+
+## File Structure
+
+### New Files
+| File | Purpose |
+|------|---------|
+| `player/shared/src/commonMain/kotlin/com/spela/player/libretro/ControllerStatusState.kt` | Data model: `PortStatus`, `ControllerStatusState` |
+| `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerDot.kt` | Design component: single dot with 3 visual states + flash animation |
+| `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerStatusRow.kt` | Content component: row of dots with P# labels |
+| `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerStatusCard.kt` | Content component: card wrapper for rail with "CONTROLLERS" label |
+| `player/shared/src/desktopTest/kotlin/com/spela/player/libretro/ControllerStatusStateTest.kt` | Unit tests for state derivation |
+| `player/shared/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ControllerStatusIndicatorTest.kt` | Desktop E2E tests for all UI variants |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt` | Add `controllerStatus: StateFlow<ControllerStatusState>` + coroutine for activity timeout |
+| `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt` | Add controller card (labeled) / stacked dots (icon-only) above Settings |
+| `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt` | Append controller dots after R1 when multiplayer |
+| `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt` | Read controller status, pass to rail/pill, add floating mini-pill |
+
+---
+
+## Task 1: Data Model — ControllerStatusState
+
+**Files:**
+- Create: `player/shared/src/commonMain/kotlin/com/spela/player/libretro/ControllerStatusState.kt`
+- Test: `player/shared/src/desktopTest/kotlin/com/spela/player/libretro/ControllerStatusStateTest.kt`
+
+- [ ] **Step 1: Write the data model**
+
+Create the file with the data classes:
+
+```kotlin
+package com.spela.player.libretro
+
+/**
+ * Status of a single controller port.
+ */
+data class PortStatus(
+    val port: Int,
+    val connected: Boolean,
+    val active: Boolean,
+)
+
+/**
+ * UI-ready snapshot of all controller port statuses.
+ * Derived from [GamepadPortManager] port assignments and activity timestamps.
+ */
+data class ControllerStatusState(
+    val ports: List<PortStatus>,
+    val connectedCount: Int,
+    val isMultiplayer: Boolean,
+) {
+    companion object {
+        /** Number of ports shown in the UI (most games support up to 4 players). */
+        const val DISPLAY_PORTS = 4
+
+        /** Creates the state from raw port data. */
+        fun fromPortData(
+            occupiedPorts: BooleanArray,
+            lastActivityMs: LongArray,
+            nowMs: Long,
+            activityTimeoutMs: Long = 300L,
+        ): ControllerStatusState {
+            val ports = (0 until DISPLAY_PORTS).map { port ->
+                val connected = port < occupiedPorts.size && occupiedPorts[port]
+                val lastActivity = if (port < lastActivityMs.size) lastActivityMs[port] else 0L
+                val active = connected && lastActivity > 0L && (nowMs - lastActivity) < activityTimeoutMs
+                PortStatus(port = port, connected = connected, active = active)
+            }
+            val connectedCount = ports.count { it.connected }
+            return ControllerStatusState(
+                ports = ports,
+                connectedCount = connectedCount,
+                isMultiplayer = connectedCount >= 2,
+            )
+        }
+
+        /** Empty state — no controllers connected. */
+        val Empty = ControllerStatusState(
+            ports = (0 until DISPLAY_PORTS).map { PortStatus(port = it, connected = false, active = false) },
+            connectedCount = 0,
+            isMultiplayer = false,
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Write unit tests for the state derivation**
+
+```kotlin
+package com.spela.player.libretro
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ControllerStatusStateTest {
+
+    @Test
+    fun emptyStateHasNoConnectedPorts() {
+        val state = ControllerStatusState.Empty
+        assertEquals(4, state.ports.size)
+        assertEquals(0, state.connectedCount)
+        assertFalse(state.isMultiplayer)
+        state.ports.forEach { assertFalse(it.connected); assertFalse(it.active) }
+    }
+
+    @Test
+    fun singleControllerIsNotMultiplayer() {
+        val occupied = BooleanArray(8) { it == 0 }
+        val activity = LongArray(8)
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertEquals(1, state.connectedCount)
+        assertFalse(state.isMultiplayer)
+        assertTrue(state.ports[0].connected)
+        assertFalse(state.ports[1].connected)
+    }
+
+    @Test
+    fun twoControllersIsMultiplayer() {
+        val occupied = BooleanArray(8) { it == 0 || it == 1 }
+        val activity = LongArray(8)
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertEquals(2, state.connectedCount)
+        assertTrue(state.isMultiplayer)
+    }
+
+    @Test
+    fun recentActivityMarksPortActive() {
+        val occupied = BooleanArray(8) { it == 0 }
+        val activity = LongArray(8).also { it[0] = 900L }
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertTrue(state.ports[0].active, "Port 0 should be active (100ms ago < 300ms timeout)")
+    }
+
+    @Test
+    fun expiredActivityMarksPortInactive() {
+        val occupied = BooleanArray(8) { it == 0 }
+        val activity = LongArray(8).also { it[0] = 500L }
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertFalse(state.ports[0].active, "Port 0 should be inactive (500ms ago >= 300ms timeout)")
+    }
+
+    @Test
+    fun disconnectedPortIsNeverActive() {
+        val occupied = BooleanArray(8) // all false
+        val activity = LongArray(8).also { it[0] = 999L }
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertFalse(state.ports[0].active, "Disconnected port should not be active even with recent timestamp")
+    }
+
+    @Test
+    fun onlyFirstFourPortsAreIncluded() {
+        val occupied = BooleanArray(8) { true }
+        val activity = LongArray(8)
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertEquals(4, state.ports.size)
+        assertEquals(4, state.connectedCount)
+    }
+
+    @Test
+    fun nonContiguousPortsHandledCorrectly() {
+        val occupied = BooleanArray(8) { it == 0 || it == 2 }
+        val activity = LongArray(8).also { it[2] = 950L }
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertTrue(state.ports[0].connected)
+        assertFalse(state.ports[0].active)
+        assertFalse(state.ports[1].connected)
+        assertTrue(state.ports[2].connected)
+        assertTrue(state.ports[2].active)
+        assertTrue(state.isMultiplayer)
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they pass**
+
+Run: `cd /Users/mattias800/repos/spela && player/run-desktop-tests.sh`
+Expected: All `ControllerStatusStateTest` tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add player/shared/src/commonMain/kotlin/com/spela/player/libretro/ControllerStatusState.kt \
+      player/shared/src/desktopTest/kotlin/com/spela/player/libretro/ControllerStatusStateTest.kt
+git commit -m "feat: add ControllerStatusState data model for controller indicators"
+```
+
+---
+
+## Task 2: Expose ControllerStatusState from GamepadPortManager
+
+**Files:**
+- Modify: `player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt`
+- Test: `player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt` (add tests)
+
+- [ ] **Step 1: Write tests for the new StateFlow**
+
+Add these tests to the existing `GamepadPortManagerTest.kt`:
+
+```kotlin
+@Test
+fun controllerStatusEmptyByDefault() {
+    val status = manager.controllerStatus.value
+    assertEquals(0, status.connectedCount)
+    assertFalse(status.isMultiplayer)
+    status.ports.forEach { assertFalse(it.connected) }
+}
+
+@Test
+fun controllerStatusUpdatesOnConnect() {
+    manager.connectDevice(100, "Xbox")
+    manager.connectDevice(200, "DualSense")
+    val status = manager.controllerStatus.value
+    assertEquals(2, status.connectedCount)
+    assertTrue(status.isMultiplayer)
+    assertTrue(status.ports[0].connected)
+    assertTrue(status.ports[1].connected)
+    assertFalse(status.ports[2].connected)
+}
+
+@Test
+fun controllerStatusUpdatesOnDisconnect() {
+    manager.connectDevice(100, "Xbox")
+    manager.connectDevice(200, "DualSense")
+    assertTrue(manager.controllerStatus.value.isMultiplayer)
+
+    manager.disconnectDevice(100)
+    val status = manager.controllerStatus.value
+    assertEquals(1, status.connectedCount)
+    assertFalse(status.isMultiplayer)
+    assertFalse(status.ports[0].connected)
+    assertTrue(status.ports[1].connected)
+}
+
+@Test
+fun controllerStatusReflectsActivityAfterReport() {
+    manager.connectDevice(100, "Xbox")
+    manager.connectDevice(200, "DualSense")
+    manager.reportActivity(0)
+
+    // The activity flag depends on the coroutine-driven refresh.
+    // After reportActivity, a synchronous snapshot should have the timestamp.
+    // The controllerStatus flow is updated on connect/disconnect;
+    // activity refresh is handled by the periodic coroutine (tested via E2E).
+    val status = manager.controllerStatus.value
+    assertTrue(status.ports[0].connected)
+    assertTrue(status.ports[1].connected)
+}
+
+@Test
+fun controllerStatusClearsOnClear() {
+    manager.connectDevice(100, "Xbox")
+    manager.connectDevice(200, "DualSense")
+    assertTrue(manager.controllerStatus.value.isMultiplayer)
+
+    manager.clear()
+    val status = manager.controllerStatus.value
+    assertEquals(0, status.connectedCount)
+    assertFalse(status.isMultiplayer)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd /Users/mattias800/repos/spela && player/run-desktop-tests.sh`
+Expected: Compilation failure — `controllerStatus` doesn't exist yet on `GamepadPortManager`.
+
+- [ ] **Step 3: Add controllerStatus StateFlow to GamepadPortManager**
+
+In `GamepadPortManager.kt`, add the following:
+
+1. Add import at the top:
+```kotlin
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+```
+
+2. Add a `CoroutineScope` parameter to the constructor:
+```kotlin
+class GamepadPortManager(
+    private val keyMappingRepository: KeyMappingRepository,
+    private val scope: CoroutineScope? = null,
+)
+```
+
+3. Add the new StateFlow and refresh job after the existing `_inputMode` declaration (after line 60):
+```kotlin
+/** Observable controller status for UI indicators. */
+private val _controllerStatus = MutableStateFlow(ControllerStatusState.Empty)
+val controllerStatus: StateFlow<ControllerStatusState> = _controllerStatus.asStateFlow()
+
+/** Coroutine that periodically refreshes activity flags. */
+private var activityRefreshJob: Job? = null
+
+companion object {
+    const val MAX_PORTS = 8
+    /** How long a dot stays "active" after the last input. */
+    const val ACTIVITY_TIMEOUT_MS = 300L
+    /** How often to refresh activity flags. */
+    const val ACTIVITY_REFRESH_INTERVAL_MS = 100L
+}
+```
+
+Note: move `MAX_PORTS` into the companion object update — it's already there, just add the two new constants alongside it.
+
+4. Add a private method to rebuild and emit controller status (below `buildActivityMap()`):
+```kotlin
+/** Rebuilds and emits the controller status snapshot. */
+private fun emitControllerStatus() {
+    val now = Clock.System.now().toEpochMilliseconds()
+    _controllerStatus.value = ControllerStatusState.fromPortData(
+        occupiedPorts = occupiedPorts.copyOf(),
+        lastActivityMs = lastActivityMs.copyOf(),
+        nowMs = now,
+        activityTimeoutMs = ACTIVITY_TIMEOUT_MS,
+    )
+}
+```
+
+5. Call `emitControllerStatus()` at the end of `connectDevice()` (after `_assignments.value = ...`):
+```kotlin
+_assignments.value = deviceToPort.values.toList()
+emitControllerStatus()
+startActivityRefreshIfNeeded()
+return port
+```
+
+6. Call `emitControllerStatus()` at the end of `disconnectDevice()` (after `_portActivity.value = ...`):
+```kotlin
+_portActivity.value = buildActivityMap()
+emitControllerStatus()
+stopActivityRefreshIfNotNeeded()
+```
+
+7. Call `emitControllerStatus()` at the end of `clear()` (after `_portActivity.value = ...`):
+```kotlin
+_portActivity.value = emptyMap()
+emitControllerStatus()
+stopActivityRefresh()
+```
+
+8. Call `emitControllerStatus()` at the end of `reportActivity()` (after `_portActivity.value = ...`):
+```kotlin
+_portActivity.value = buildActivityMap()
+emitControllerStatus()
+```
+
+9. Add activity refresh coroutine management:
+```kotlin
+/** Starts the periodic activity refresh if multiplayer and not already running. */
+private fun startActivityRefreshIfNeeded() {
+    if (activityRefreshJob?.isActive == true) return
+    if (deviceToPort.size < 2) return
+    val currentScope = scope ?: return
+    activityRefreshJob = currentScope.launch {
+        while (isActive) {
+            delay(ACTIVITY_REFRESH_INTERVAL_MS)
+            synchronized(this@GamepadPortManager) {
+                emitControllerStatus()
+            }
+        }
+    }
+}
+
+/** Stops the refresh if we're no longer in multiplayer. */
+private fun stopActivityRefreshIfNotNeeded() {
+    if (deviceToPort.size >= 2) return
+    stopActivityRefresh()
+}
+
+/** Cancels the refresh coroutine. */
+private fun stopActivityRefresh() {
+    activityRefreshJob?.cancel()
+    activityRefreshJob = null
+}
+```
+
+- [ ] **Step 4: Update Koin module to pass CoroutineScope**
+
+In `player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt`, update line 75:
+
+Change:
+```kotlin
+single { GamepadPortManager(get()) }
+```
+To:
+```kotlin
+single { GamepadPortManager(get(), get()) }
+```
+
+The second `get()` resolves the existing `CoroutineScope` singleton that's already registered in the module.
+
+- [ ] **Step 5: Update SpelaTestHarness**
+
+In `player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt`, find where `gamepadPortManager` is created (around line 165-166):
+
+Change:
+```kotlin
+val gamepadPortManager = GamepadPortManager(keyMappingRepo)
+```
+To:
+```kotlin
+val gamepadPortManager = GamepadPortManager(keyMappingRepo, scope)
+```
+
+This passes the test harness's `CoroutineScope` so the activity refresh coroutine runs on the test dispatcher.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd /Users/mattias800/repos/spela && player/run-desktop-tests.sh`
+Expected: All tests pass, including the new `controllerStatus` tests and all existing tests.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt \
+      player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt \
+      player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt \
+      player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+git commit -m "feat: expose ControllerStatusState StateFlow from GamepadPortManager"
+```
+
+---
+
+## Task 3: SpControllerDot — Design Component
+
+**Files:**
+- Create: `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerDot.kt`
+
+- [ ] **Step 1: Create the component**
+
+```kotlin
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.theme.SpColor
+
+/**
+ * A single controller status dot.
+ *
+ * Three visual states:
+ * - **Disconnected** (`connected = false`): hollow ring, dim
+ * - **Connected idle** (`connected = true, active = false`): solid green, subtle glow
+ * - **Active input** (`connected = true, active = true`): white, bright glow — fades back to green
+ *
+ * This is a design-layer component. No labels, no outer spacing.
+ */
+@Composable
+fun SpControllerDot(
+    connected: Boolean,
+    active: Boolean,
+    port: Int,
+    size: Dp = 8.dp,
+    modifier: Modifier = Modifier,
+) {
+    val connectedColor = Color(0xFF4ADE80) // green-400
+    val activeColor = Color.White
+    val disconnectedColor = SpColor.OnBackgroundTertiary.copy(alpha = 0.3f)
+    val disconnectedBorderColor = SpColor.OnBackgroundTertiary.copy(alpha = 0.5f)
+
+    val dotColor by animateColorAsState(
+        targetValue = when {
+            active -> activeColor
+            connected -> connectedColor
+            else -> disconnectedColor
+        },
+        animationSpec = tween(durationMillis = if (active) 50 else 300),
+        label = "dotColor",
+    )
+
+    val glowColor = when {
+        active -> Color.White.copy(alpha = 0.4f)
+        connected -> connectedColor.copy(alpha = 0.3f)
+        else -> Color.Transparent
+    }
+
+    val description = when {
+        active -> "Player ${port + 1} active"
+        connected -> "Player ${port + 1} connected"
+        else -> "Player ${port + 1} not connected"
+    }
+
+    Box(
+        modifier = modifier
+            .size(size)
+            .then(
+                if (!connected) {
+                    // Hollow ring for disconnected
+                    Modifier
+                        .clip(CircleShape)
+                        .background(Color.Transparent)
+                        .drawBehind {
+                            drawCircle(
+                                color = disconnectedBorderColor,
+                                radius = this.size.minDimension / 2,
+                                style = androidx.compose.ui.graphics.drawscope.Stroke(
+                                    width = 1.5.dp.toPx(),
+                                ),
+                            )
+                        }
+                } else {
+                    // Solid circle with glow for connected/active
+                    Modifier
+                        .drawBehind {
+                            // Glow
+                            drawCircle(
+                                color = glowColor,
+                                radius = this.size.minDimension * 0.9f,
+                            )
+                        }
+                        .clip(CircleShape)
+                        .background(dotColor)
+                }
+            )
+            .semantics { contentDescription = description },
+    )
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerDot.kt
+git commit -m "feat: add SpControllerDot design component"
+```
+
+---
+
+## Task 4: SpControllerStatusRow — Content Component
+
+**Files:**
+- Create: `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerStatusRow.kt`
+
+- [ ] **Step 1: Create the component**
+
+```kotlin
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.spela.player.libretro.PortStatus
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * A row of controller dots with player labels (P1, P2, etc.).
+ *
+ * Content-layer component that composes [SpControllerDot] instances.
+ *
+ * @param ports The list of port statuses to display.
+ * @param showEmptySlots If true, shows all ports (connected + disconnected).
+ *   If false, only shows connected ports.
+ * @param dotSize Size of each dot.
+ */
+@Composable
+fun SpControllerStatusRow(
+    ports: List<PortStatus>,
+    showEmptySlots: Boolean,
+    modifier: Modifier = Modifier,
+    dotSize: Dp = 8.dp,
+    spacing: Dp = SpSpacing.Small,
+) {
+    val visiblePorts = if (showEmptySlots) ports else ports.filter { it.connected }
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(spacing),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        visiblePorts.forEach { port ->
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+            ) {
+                SpControllerDot(
+                    connected = port.connected,
+                    active = port.active,
+                    port = port.port,
+                    size = dotSize,
+                )
+                Text(
+                    text = "P${port.port + 1}",
+                    style = SpTypography.LabelSmall,
+                    color = if (port.connected) SpColor.OnBackgroundSecondary else SpColor.OnBackgroundTertiary.copy(alpha = 0.5f),
+                )
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerStatusRow.kt
+git commit -m "feat: add SpControllerStatusRow content component"
+```
+
+---
+
+## Task 5: SpControllerStatusCard — Rail Card Component
+
+**Files:**
+- Create: `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerStatusCard.kt`
+
+- [ ] **Step 1: Create the component**
+
+```kotlin
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.spela.player.libretro.PortStatus
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Card showing controller status for the navigation rail.
+ *
+ * Displays a "CONTROLLERS" label and a [SpControllerStatusRow] with all 4 slots.
+ * Clickable — navigates to controller settings. Focusable for gamepad navigation.
+ *
+ * @param ports The list of port statuses to display.
+ * @param onClick Called when the card is clicked or selected.
+ */
+@Composable
+fun SpControllerStatusCard(
+    ports: List<PortStatus>,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    val shape = RoundedCornerShape(SpSpacing.RadiusMedium)
+    val bgAlpha = if (isFocused) 0.1f else 0.05f
+    val borderAlpha = if (isFocused) 0.15f else 0.08f
+
+    val connectedCount = ports.count { it.connected }
+
+    Column(
+        modifier = modifier
+            .clip(shape)
+            .background(Color.White.copy(alpha = bgAlpha))
+            .border(
+                width = 1.dp,
+                color = Color.White.copy(alpha = borderAlpha),
+                shape = shape,
+            )
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+            ) { onClick() }
+            .focusable(interactionSource = interactionSource)
+            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small)
+            .semantics {
+                contentDescription = "$connectedCount controllers connected"
+                role = Role.Button
+            },
+    ) {
+        Text(
+            text = "CONTROLLERS",
+            style = SpTypography.LabelSmall,
+            color = SpColor.OnBackgroundTertiary,
+            letterSpacing = SpTypography.LabelSmall.letterSpacing,
+        )
+
+        SpControllerStatusRow(
+            ports = ports,
+            showEmptySlots = true,
+            modifier = Modifier.padding(top = SpSpacing.XSmall),
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerStatusCard.kt
+git commit -m "feat: add SpControllerStatusCard for navigation rail"
+```
+
+---
+
+## Task 6: Integrate into SpNavigationRail
+
+**Files:**
+- Modify: `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt`
+
+- [ ] **Step 1: Add the controller status parameter and imports**
+
+Add imports at the top of the file:
+```kotlin
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Arrangement
+import com.spela.player.libretro.ControllerStatusState
+```
+
+Update the function signature to accept controller status:
+```kotlin
+@Composable
+fun SpNavigationRail(
+    activeTab: BottomNavTab,
+    onTabSelected: (BottomNavTab) -> Unit,
+    showLabels: Boolean,
+    controllerStatus: ControllerStatusState = ControllerStatusState.Empty,
+    onControllerStatusClick: () -> Unit = {},
+    modifier: Modifier = Modifier,
+)
+```
+
+- [ ] **Step 2: Add the indicator between the Spacer and Settings tab**
+
+Replace the section around line 92 (`Spacer(Modifier.weight(1f))`) through the Settings `RailItem`. The existing code:
+
+```kotlin
+// Push Settings to the bottom
+Spacer(Modifier.weight(1f))
+
+// Settings tab
+RailItem(
+    tab = BottomNavTab.SETTINGS,
+    isSelected = BottomNavTab.SETTINGS == activeTab,
+    showLabel = showLabels,
+    onClick = { onTabSelected(BottomNavTab.SETTINGS) },
+)
+```
+
+Replace with:
+
+```kotlin
+// Push Settings + controller indicator to the bottom
+Spacer(Modifier.weight(1f))
+
+// Controller status indicator (only when 2+ controllers)
+val animationsEnabled = LocalAnimationsEnabled.current
+AnimatedVisibility(
+    visible = controllerStatus.isMultiplayer,
+    enter = if (animationsEnabled) fadeIn() + slideInVertically(initialOffsetY = { it }) else EnterTransition.None,
+    exit = if (animationsEnabled) fadeOut() + slideOutVertically(targetOffsetY = { it }) else ExitTransition.None,
+) {
+    if (showLabels) {
+        // Labeled rail: full card
+        SpControllerStatusCard(
+            ports = controllerStatus.ports,
+            onClick = onControllerStatusClick,
+            modifier = Modifier.padding(horizontal = SpSpacing.Small, bottom = SpSpacing.Small),
+        )
+    } else {
+        // Icon-only rail: stacked dots, no labels, no card
+        Column(
+            modifier = Modifier
+                .padding(bottom = SpSpacing.Small)
+                .clip(RoundedCornerShape(8.dp))
+                .clickable { onControllerStatusClick() }
+                .focusable()
+                .padding(vertical = SpSpacing.Small),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+        ) {
+            controllerStatus.ports.filter { it.connected }.forEach { port ->
+                SpControllerDot(
+                    connected = port.connected,
+                    active = port.active,
+                    port = port.port,
+                    size = 10.dp,
+                )
+            }
+        }
+    }
+}
+
+// Settings tab
+RailItem(
+    tab = BottomNavTab.SETTINGS,
+    isSelected = BottomNavTab.SETTINGS == activeTab,
+    showLabel = showLabels,
+    onClick = { onTabSelected(BottomNavTab.SETTINGS) },
+)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt
+git commit -m "feat: add controller status indicator to navigation rail"
+```
+
+---
+
+## Task 7: Integrate into SpSectionIndicator (Pill Extension)
+
+**Files:**
+- Modify: `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt`
+
+- [ ] **Step 1: Add parameter and imports**
+
+Add imports:
+```kotlin
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import com.spela.player.libretro.ControllerStatusState
+```
+
+Update the function signature:
+```kotlin
+@Composable
+fun SpSectionIndicator(
+    activeTab: BottomNavTab,
+    visible: Boolean,
+    controllerStatus: ControllerStatusState = ControllerStatusState.Empty,
+    modifier: Modifier = Modifier,
+)
+```
+
+- [ ] **Step 2: Add controller dots after R1**
+
+After the R1 `Text` composable (line 72-76), add the controller dots section:
+
+```kotlin
+Text(
+    text = "R1",
+    color = SpColor.OnBackgroundSecondary,
+    fontSize = 12.sp,
+)
+
+// Controller status dots (only when multiplayer)
+if (controllerStatus.isMultiplayer) {
+    // Vertical separator
+    Box(
+        modifier = Modifier
+            .width(1.dp)
+            .height(18.dp)
+            .background(Color.White.copy(alpha = 0.15f)),
+    )
+
+    SpControllerStatusRow(
+        ports = controllerStatus.ports,
+        showEmptySlots = false,
+        dotSize = 8.dp,
+        spacing = SpSpacing.Small,
+    )
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
+git commit -m "feat: add controller dots to section indicator pill"
+```
+
+---
+
+## Task 8: Integrate into SpelaApp (Wire Everything + Floating Mini-Pill)
+
+**Files:**
+- Modify: `player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt`
+
+- [ ] **Step 1: Collect controller status state**
+
+Near the existing `gamepadPortManager` usage (around line 215-217 where `inputMode` is collected), add:
+
+```kotlin
+val controllerStatus by gamepadPortManager?.controllerStatus?.collectAsState()
+    ?: remember { mutableStateOf(ControllerStatusState.Empty) }
+```
+
+Add import at the top:
+```kotlin
+import com.spela.player.libretro.ControllerStatusState
+```
+
+- [ ] **Step 2: Pass controller status to SpNavigationRail**
+
+Find the `SpNavigationRail` call (around line 340-356) and add the new parameters:
+
+```kotlin
+SpNavigationRail(
+    activeTab = navState.activeTab,
+    onTabSelected = { tab ->
+        val targetScreen = when (tab) {
+            BottomNavTab.HOME -> SpScreen.Home
+            BottomNavTab.EXPLORE -> SpScreen.Explore
+            BottomNavTab.CONSOLES -> SpScreen.Consoles
+            BottomNavTab.COLLECTIONS -> SpScreen.Collections
+            BottomNavTab.ACTIVITY -> SpScreen.Activity
+            BottomNavTab.SETTINGS -> SpScreen.Settings
+        }
+        navigationViewModel.onIntent(
+            NavigationIntent.SwitchTab(targetScreen)
+        )
+    },
+    showLabels = navLayoutMode == NavigationLayoutMode.LABELED_RAIL,
+    controllerStatus = controllerStatus,
+    onControllerStatusClick = {
+        navigationViewModel.onIntent(
+            NavigationIntent.SwitchTab(SpScreen.Settings)
+        )
+    },
+)
+```
+
+- [ ] **Step 3: Pass controller status to SpSectionIndicator**
+
+Find the `SpSectionIndicator` call (around line 1680) and add the new parameter:
+
+```kotlin
+SpSectionIndicator(
+    activeTab = navState.activeTab,
+    visible = sectionIndicatorVisible,
+    controllerStatus = controllerStatus,
+    modifier = Modifier.padding(top = SpSpacing.Default),
+)
+```
+
+- [ ] **Step 4: Add the floating mini-pill for phone layout**
+
+After the `SpSectionIndicator` block (around line 1684), add the floating mini-pill:
+
+```kotlin
+// Floating controller mini-pill (phone layout, 2+ controllers, no gamepad pill visible)
+if (showNavArea && !isGamepadMode && navLayoutMode == NavigationLayoutMode.BOTTOM_BAR && controllerStatus.isMultiplayer) {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.TopCenter,
+    ) {
+        val animationsEnabled = LocalAnimationsEnabled.current
+        AnimatedVisibility(
+            visible = true,
+            enter = if (animationsEnabled) fadeIn() + slideInVertically(initialOffsetY = { -it }) else EnterTransition.None,
+            exit = if (animationsEnabled) fadeOut() + slideOutVertically(targetOffsetY = { -it }) else ExitTransition.None,
+        ) {
+            Row(
+                modifier = Modifier
+                    .padding(top = SpSpacing.Default)
+                    .background(
+                        color = Color.Black.copy(alpha = 0.6f),
+                        shape = RoundedCornerShape(24.dp),
+                    )
+                    .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                SpControllerStatusRow(
+                    ports = controllerStatus.ports,
+                    showEmptySlots = false,
+                    dotSize = 8.dp,
+                    spacing = SpSpacing.Small,
+                )
+            }
+        }
+    }
+}
+```
+
+Add any missing imports at the top of SpelaApp.kt:
+```kotlin
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.shape.RoundedCornerShape
+```
+
+(Some of these may already be imported — only add the missing ones.)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+git commit -m "feat: wire controller status to rail, pill, and floating mini-pill"
+```
+
+---
+
+## Task 9: Desktop E2E Tests
+
+**Files:**
+- Create: `player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ControllerStatusIndicatorTest.kt`
+
+- [ ] **Step 1: Write the E2E test file**
+
+```kotlin
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.assertCountEquals
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithContentDescription
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ControllerStatusIndicatorTest {
+
+    private fun createLoggedInHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(kotlinx.coroutines.test.StandardTestDispatcher())
+        harness.authRepo.preSetTokens()
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    // ---- Visibility ----
+
+    @Test
+    fun hiddenWithNoControllers() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        advance(harness)
+
+        onNodeWithContentDescription("0 controllers connected").assertDoesNotExist()
+    }
+
+    @Test
+    fun hiddenWithOneController() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        advance(harness)
+
+        onNodeWithContentDescription("1 controllers connected").assertDoesNotExist()
+    }
+
+    @Test
+    fun visibleWithTwoControllers() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+    }
+
+    @Test
+    fun disappearsWhenDroppingToOneController() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+
+        harness.gamepadPortManager.disconnectDevice(2)
+        advance(harness)
+
+        onNodeWithContentDescription("2 controllers connected").assertDoesNotExist()
+        onNodeWithContentDescription("1 controllers connected").assertDoesNotExist()
+    }
+
+    // ---- Dot States ----
+
+    @Test
+    fun connectedDotsShowCorrectState() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        onNodeWithContentDescription("Player 1 connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 3 not connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 4 not connected").assertIsDisplayed()
+    }
+
+    @Test
+    fun activeInputChangesDoState() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        harness.gamepadPortManager.reportActivity(0)
+        advanceQuick(harness)
+
+        onNodeWithContentDescription("Player 1 active").assertIsDisplayed()
+        onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
+    }
+
+    // ---- Navigation ----
+
+    @Test
+    fun clickingCardNavigatesToSettings() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        onNodeWithContentDescription("2 controllers connected").performClick()
+        advance(harness)
+
+        assertEquals(
+            SpScreen.Settings.route,
+            harness.navigationViewModel.navigationState.value.currentScreen.route,
+        )
+    }
+
+    // ---- Disconnect/Reconnect ----
+
+    @Test
+    fun disconnectedPortShowsAsNotConnected() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        harness.gamepadPortManager.connectDevice(3, "Pro Controller")
+        advance(harness)
+
+        onNodeWithContentDescription("3 controllers connected").assertIsDisplayed()
+
+        // Disconnect P1
+        harness.gamepadPortManager.disconnectDevice(1)
+        advance(harness)
+
+        // P1 is now empty, P2 and P3 stay
+        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 1 not connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 3 connected").assertIsDisplayed()
+    }
+
+    @Test
+    fun reconnectedControllerReclaimsPort() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        // Disconnect P1
+        harness.gamepadPortManager.disconnectDevice(1)
+        advance(harness)
+
+        // Reconnect (may get new device ID)
+        harness.gamepadPortManager.connectDevice(99, "Xbox Controller")
+        advance(harness)
+
+        // Port 0 is reclaimed
+        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 1 connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
+    }
+}
+```
+
+- [ ] **Step 2: Run the full test suite**
+
+Run: `cd /Users/mattias800/repos/spela && player/run-desktop-tests.sh`
+Expected: All tests pass — both the new `ControllerStatusIndicatorTest` tests and all existing tests. Zero regressions.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ControllerStatusIndicatorTest.kt
+git commit -m "test: add desktop E2E tests for controller status indicators"
+```
+
+---
+
+## Task 10: Final Verification
+
+- [ ] **Step 1: Run the full desktop test suite one final time**
+
+Run: `cd /Users/mattias800/repos/spela && player/run-desktop-tests.sh`
+Expected: All tests pass. Zero regressions.
+
+- [ ] **Step 2: Verify no compile errors across all targets**
+
+Run: `cd /Users/mattias800/repos/spela/player && ./gradlew compileKotlinDesktop compileDebugKotlinAndroid`
+Expected: BUILD SUCCESSFUL for both targets.
+
+- [ ] **Step 3: Spot-check the feature manually**
+
+Launch the desktop app, connect 2+ controllers, and verify:
+- The card appears in the rail above Settings
+- Dots are green for connected, hollow for empty
+- Pressing buttons on a controller flashes the corresponding dot white
+- Clicking the card navigates to Settings
+- Disconnecting a controller updates the dots
+- Disconnecting down to 1 controller hides the card

--- a/docs/superpowers/specs/2026-04-07-controller-status-indicators-design.md
+++ b/docs/superpowers/specs/2026-04-07-controller-status-indicators-design.md
@@ -1,0 +1,214 @@
+# Controller Status Indicators — Design Spec
+
+**Date:** 2026-04-07
+**Phase:** 1 of 3
+**Scope:** Player app (Kotlin Multiplatform — shared UI)
+
+## Problem
+
+Local multiplayer on PC and Android lacks the controller identity feedback that consoles provide (PlayStation light bar colors, Wii/Switch player LEDs). When multiple controllers are connected, players cannot see at a glance which player they are or confirm their controller is recognized — they have to dig into settings. This friction discourages local multiplayer.
+
+## Solution
+
+Always-visible, compact controller status indicators that appear automatically when 2+ controllers are connected. Three visual variants adapt to the app's responsive navigation layout. Each connected controller's dot flashes on input, letting players physically confirm "this controller in my hands is P2" without navigating anywhere.
+
+## Design Decisions
+
+- **Visibility rule:** All indicators are hidden when fewer than 2 controllers are connected. Single-player = zero clutter.
+- **No per-player colors:** Unlike PlayStation, we don't assign colors to players. Colors would only be visible in the app chrome, not inside emulated games, making them misleading. Green (connected) and white (active flash) are sufficient.
+- **Port stability on disconnect:** When a controller disconnects, its port is freed but other players' ports are not renumbered. Reconnecting fills the first available gap, which is typically the same port. This matches console behavior.
+- **Phase 1 only:** In-game overlay controller management (Phase 2) and drag-to-assign port picker (Phase 3) are out of scope.
+
+## State Model
+
+A new derived `StateFlow<ControllerStatusState>` on `GamepadPortManager`, combining existing port assignment and activity data into a UI-ready model.
+
+```
+ControllerStatusState
+  ports: List<PortStatus>       // Up to MAX_PORTS (8), ordered by port number
+    port: Int                   // 0-based port index
+    connected: Boolean          // Device assigned to this port
+    active: Boolean             // Input received within the last ~300ms
+  connectedCount: Int           // Number of connected ports (convenience)
+  isMultiplayer: Boolean        // connectedCount >= 2 (drives visibility)
+```
+
+### Activity Tracking
+
+The existing `reportActivity(port)` method updates per-port timestamps. A coroutine within `GamepadPortManager` periodically checks timestamps (every ~100ms) and updates the `active` flag on each `PortStatus`:
+
+- **Active:** `now - lastActivityMs[port] < 300ms`
+- **Idle:** `now - lastActivityMs[port] >= 300ms`
+
+The 300ms window keeps the flash responsive (one quick button press lights up) but prevents flickering during sustained input.
+
+### No New ViewModel
+
+`GamepadPortManager` is already a Koin singleton injected throughout the app. The new `StateFlow` is consumed directly by composables — no intermediate ViewModel needed. This follows Approach 1 from brainstorming: single source of truth, no extra wiring.
+
+## UI Variants
+
+### Dot States
+
+Each player dot has three visual states:
+
+| State | Visual | Description |
+|-------|--------|-------------|
+| Disconnected | Hollow ring, dim `P#` label | Port has no controller |
+| Connected (idle) | Solid green circle, subtle green glow, normal `P#` label | Controller connected, no recent input |
+| Active (input) | White circle, bright white glow | Input received within last 300ms; animates back to green |
+
+The transition from active → idle is an animated color fade (white → green, ~300ms ease-out).
+
+### Variant 1: Rail Card (Labeled Rail, >840dp)
+
+**Location:** Inside `SpNavigationRail`, in the spacer area between the main tabs and the Settings tab (pinned to bottom).
+
+**Layout:** A subtle card with:
+- "CONTROLLERS" label (uppercase, 10sp, secondary color)
+- Horizontal row of P1–P4 dots with labels
+- Shows all 4 slots: connected ports as green/white dots, empty ports as hollow rings
+- Subtle background (`Color.White` at 5% alpha) with thin border (`Color.White` at 8% alpha), 8dp corner radius
+
+**Interaction:** Clickable — navigates to `GamepadConfigScreen` in Settings. Focusable for gamepad navigation.
+
+**Visibility:** `AnimatedVisibility` (fade + slide from bottom), shown when `isMultiplayer == true`.
+
+### Variant 2: Stacked Dots (Icon-Only Rail, 600–840dp)
+
+**Location:** Inside `SpNavigationRail` (icon-only mode), in the spacer area above Settings.
+
+**Layout:** A vertical column of dots (no labels, no card background). Centered in the 72dp rail width. Only shows connected ports.
+
+**Interaction:** Clickable — navigates to `GamepadConfigScreen`. Focusable.
+
+**Visibility:** Same `AnimatedVisibility` as Variant 1.
+
+### Variant 3: Pill Extension (Gamepad Mode)
+
+**Location:** Appended to the existing `SpSectionIndicator` pill.
+
+**Layout:** After the R1 label:
+- A thin vertical separator (1dp wide, 18dp tall, `Color.White` at 15% alpha)
+- Horizontal row of dots for connected ports with `P#` labels below each dot
+
+Only shows connected ports — no empty slots.
+
+**Interaction:** None (informational only). The pill is not clickable today and adding interaction would conflict with L1/R1 navigation.
+
+**Visibility:** The dots section is conditionally included when `isMultiplayer == true`. The pill itself follows its existing visibility logic (gamepad input mode).
+
+### Variant 4: Floating Mini-Pill (Phone, <600dp)
+
+**Location:** Overlaid on content in `SpelaApp`, top-center with 16dp padding. Same position and styling as `SpSectionIndicator`.
+
+**Layout:** A standalone pill (same semi-transparent black background, 24dp corner radius) containing only the controller dots with `P#` labels. No nav icons, no L1/R1.
+
+**Interaction:** None (informational only).
+
+**Visibility:** `AnimatedVisibility` (fade + slide from top), shown when:
+- `isMultiplayer == true`
+- `layoutMode == BOTTOM_BAR`
+- The section indicator pill is NOT visible (to avoid overlap)
+
+## Component Architecture
+
+Following the project's Design → Content → Role hierarchy:
+
+### New Components (`presentation/ui/components/`)
+
+**`SpControllerDot`** (design layer)
+- Renders a single dot in one of three states: disconnected, connected, active
+- Accepts: `connected: Boolean`, `active: Boolean`
+- Handles the white→green flash animation internally
+- No labels, no outer spacing
+- Size: 8dp circle
+
+**`SpControllerStatusRow`** (content layer)
+- Horizontal row of `SpControllerDot` + `P#` labels
+- Accepts: `ports: List<PortStatus>`, `showEmptySlots: Boolean`
+- `showEmptySlots = true`: Shows ports 0–3, disconnected ports as hollow rings (used by rail card)
+- `showEmptySlots = false`: Only shows connected ports (used by pill variants)
+- Labels: `P1`, `P2`, `P3`, `P4` (1-indexed for display, 0-indexed internally)
+
+**`SpControllerStatusCard`** (content layer)
+- The rail card wrapper: "CONTROLLERS" label + `SpControllerStatusRow(showEmptySlots = true)`
+- Subtle card background, clickable
+- Accepts: `ports: List<PortStatus>`, `onClick: () -> Unit`
+
+### Modified Components
+
+**`SpNavigationRail`**
+- Accepts new parameter: `controllerStatus: ControllerStatusState`
+- In labeled mode: renders `SpControllerStatusCard` in the spacer area (above Settings) wrapped in `AnimatedVisibility`
+- In icon-only mode: renders a vertical column of `SpControllerDot` in the spacer area wrapped in `AnimatedVisibility`
+- Click handler navigates to `GamepadConfigScreen`
+
+**`SpSectionIndicator`**
+- Accepts new parameter: `controllerStatus: ControllerStatusState`
+- When `isMultiplayer`: appends separator + `SpControllerStatusRow(showEmptySlots = false)` after R1
+
+**`SpelaApp`**
+- Reads `controllerStatus` from `GamepadPortManager`
+- Passes it to `SpNavigationRail` and `SpSectionIndicator`
+- Renders the floating mini-pill (Variant 4) when conditions are met
+
+## Animations
+
+| Trigger | Animation |
+|---------|-----------|
+| Indicator appears (crossing 2-controller threshold) | Fade in + slide from bottom (rail) or top (pill/mini-pill) |
+| Indicator disappears (dropping below 2 controllers) | Fade out + reverse slide |
+| Input activity on a port | Dot color animates to white with bright glow, then fades back to green over ~300ms |
+| Controller disconnects (still 2+ connected) | Dot animates from green to hollow ring; brief red flash before settling on hollow (signals "something disconnected") |
+| Controller connects (already 2+ connected) | New dot animates from hollow ring to green |
+
+## Edge Cases
+
+### Battery disconnect/reconnect
+When a controller disconnects and reconnects (e.g., battery swap), the OS may assign a new device ID. `GamepadPortManager` treats it as a new device, but since disconnection freed the port and `connectDevice()` assigns the first available port, the controller naturally reclaims its original slot. Other players' ports are unaffected.
+
+**Risk:** If a different controller connects before the original one returns, it takes the freed port. The player would need to use `GamepadConfigScreen` (via the rail card) to swap back. This is acceptable for Phase 1.
+
+### More than 4 controllers
+The state model supports up to 8 ports (`MAX_PORTS`). The rail card shows 4 slots by default (the most common local multiplayer scenario). If 5+ controllers connect, the card could expand or show a "+N more" indicator. This is a rare edge case — defer detailed design until someone actually requests 5+ player support.
+
+### Gamepad mode on desktop/tablet
+When a gamepad is connected on desktop/tablet, the app switches to gamepad input mode and shows the section indicator pill instead of the rail. In this case:
+- The rail card is hidden (rail itself is hidden)
+- The pill extension (Variant 3) shows the controller dots
+- This is consistent — the dots follow whichever navigation element is visible
+
+## Testing Strategy
+
+### Desktop E2E Tests (Primary)
+- Controller card appears in labeled rail when 2+ controllers connected via `GamepadPortManager`
+- Controller card hidden with 0-1 controllers
+- Dot states: correct rendering for disconnected, connected, active
+- Click on card navigates to `GamepadConfigScreen`
+- Pill extension shows dots when multiplayer + gamepad mode
+- Floating mini-pill shows on phone layout with 2+ controllers
+- Disconnect/reconnect: dots update correctly, no port renumbering
+- Animation: verify `AnimatedVisibility` entrance/exit
+
+### Unit Tests
+- `ControllerStatusState` derivation from port assignments + activity timestamps
+- `isMultiplayer` threshold logic
+- `active` flag timing (300ms window)
+- `showEmptySlots` filtering logic in `SpControllerStatusRow`
+
+### Android Smoke Tests
+- Connect 2 physical controllers → indicator appears
+- Disconnect one → indicator disappears
+- Activity flash works with real gamepad input
+
+## Future Phases
+
+### Phase 2: In-Game Overlay Controller Panel
+A "Controllers" button in the in-game overlay opens a sub-panel showing:
+- Full controller names (e.g., "Xbox Wireless Controller")
+- Per-player activity indicators
+- Swap buttons for reordering ports mid-game
+
+### Phase 3: Drag-to-Assign Port Picker
+A more intuitive controller assignment UI where players can drag controllers to ports or use a "press a button to claim this port" flow, replacing the current swap-based system.

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ControllerStatusIndicatorTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ControllerStatusIndicatorTest.kt
@@ -1,0 +1,195 @@
+package com.spela.player.desktop.e2e
+
+import androidx.compose.ui.test.*
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.SpScreen
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * E2E tests for the controller status indicator.
+ *
+ * The Compose UI test window is wide enough to trigger LABELED_RAIL layout (> 840dp),
+ * so the SpNavigationRail with SpControllerStatusCard is what's on screen.  The card:
+ *   - Is only shown when 2+ controllers are connected (isMultiplayer = true)
+ *   - Has contentDescription "$connectedCount controllers connected"
+ *   - Navigates to Settings on click
+ *   - Renders all 4 port dots (showEmptySlots = true), including disconnected slots
+ *
+ * Tests verify:
+ * - Visibility rules (hidden with 0 or 1 controller, visible with 2+)
+ * - Card disappears when dropping back to 1 controller
+ * - Individual dot content descriptions for connected ports
+ * - Click navigates to Settings
+ * - Disconnect and reconnect behaviour
+ */
+@OptIn(ExperimentalCoroutinesApi::class, ExperimentalTestApi::class)
+class ControllerStatusIndicatorTest {
+
+    private fun createLoggedInHarness(): SpelaTestHarness {
+        val harness = SpelaTestHarness(StandardTestDispatcher())
+        harness.authRepo.preSetTokens()
+        harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Home))
+        return harness
+    }
+
+    // ---- Visibility ----
+
+    @Test
+    fun hiddenWithNoControllers() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        advance(harness)
+
+        // No pill when there are zero controllers
+        onNodeWithContentDescription("0 controllers connected").assertDoesNotExist()
+    }
+
+    @Test
+    fun hiddenWithOneController() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        advance(harness)
+
+        // Still no pill — one controller does not trigger multiplayer mode
+        onNodeWithContentDescription("1 controllers connected").assertDoesNotExist()
+    }
+
+    @Test
+    fun visibleWithTwoControllers() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+    }
+
+    @Test
+    fun disappearsWhenDroppingToOneController() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+
+        harness.gamepadPortManager.disconnectDevice(2)
+        advance(harness)
+
+        // Pill gone — back to single-controller (non-multiplayer)
+        onNodeWithContentDescription("2 controllers connected").assertDoesNotExist()
+        onNodeWithContentDescription("1 controllers connected").assertDoesNotExist()
+    }
+
+    // ---- Dot States ----
+
+    @Test
+    fun connectedDotsShowCorrectState() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        // The navigation-rail card renders all 4 slots (showEmptySlots = true)
+        onNodeWithContentDescription("Player 1 connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
+        // Slots 3 and 4 are empty and shown as not connected
+        onNodeWithContentDescription("Player 3 not connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 4 not connected").assertIsDisplayed()
+    }
+
+    @Test
+    fun reportingActivityDoesNotBreakConnectedState() = runComposeUiTest {
+        // The active dot state uses a real-clock 300ms timeout, making it too
+        // fragile to assert a specific "active" state in the test harness.
+        // This test verifies that reporting activity does not cause an error
+        // or break the connected state of the other port.
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        // Report activity on port 0 (Player 1) — should not crash or break state
+        harness.gamepadPortManager.reportActivity(0)
+        advanceQuick(harness)
+
+        // The indicator is still visible and both ports still exist
+        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
+    }
+
+    // ---- Navigation ----
+
+    @Test
+    fun clickingCardNavigatesToSettings() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        onNodeWithContentDescription("2 controllers connected").performClick()
+        advance(harness)
+
+        assertEquals(
+            SpScreen.Settings.route,
+            harness.navigationViewModel.state.value.currentScreen.route,
+        )
+    }
+
+    // ---- Disconnect/Reconnect ----
+
+    @Test
+    fun disconnectedPortShowsAsNotConnected() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        harness.gamepadPortManager.connectDevice(3, "Pro Controller")
+        advance(harness)
+
+        onNodeWithContentDescription("3 controllers connected").assertIsDisplayed()
+
+        // Disconnect P1
+        harness.gamepadPortManager.disconnectDevice(1)
+        advance(harness)
+
+        // Still multiplayer; card shows 2 connected controllers
+        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+        // P1 slot is now empty — the card shows it as "not connected" (showEmptySlots = true)
+        onNodeWithContentDescription("Player 1 not connected").assertIsDisplayed()
+        // P2 and P3 stay connected
+        onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 3 connected").assertIsDisplayed()
+    }
+
+    @Test
+    fun reconnectedControllerReclaimsPort() = runComposeUiTest {
+        val harness = createLoggedInHarness()
+        setContent { harness.App() }
+        harness.gamepadPortManager.connectDevice(1, "Xbox Controller")
+        harness.gamepadPortManager.connectDevice(2, "DualSense")
+        advance(harness)
+
+        // Disconnect P1
+        harness.gamepadPortManager.disconnectDevice(1)
+        advance(harness)
+
+        // Reconnect — may get a different device ID
+        harness.gamepadPortManager.connectDevice(99, "Xbox Controller")
+        advance(harness)
+
+        // Port 0 is reclaimed; back to 2 controllers
+        onNodeWithContentDescription("2 controllers connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 1 connected").assertIsDisplayed()
+        onNodeWithContentDescription("Player 2 connected").assertIsDisplayed()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -163,7 +163,7 @@ class SpelaTestHarness(
     val presenceService = PresenceService(fakeApiClient, stubEngineFactory, dispatchers, scope)
 
     val keyMappingRepo = FakeKeyMappingRepository()
-    val gamepadPortManager = GamepadPortManager(keyMappingRepo)
+    val gamepadPortManager = GamepadPortManager(keyMappingRepo, scope)
 
     private val emulationState = MutableStateFlow(EmulationState())
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -72,7 +72,7 @@ val commonModule = module {
     single<ExploreRepository> { ExploreRepositoryImpl(get()) }
     single<SearchRepository> { SearchRepositoryImpl(get(), get()) }
     single { BiosRepository(get(), get()) }
-    single { GamepadPortManager(get()) }
+    single { GamepadPortManager(get(), get()) }
 
     /* Use Cases */
     factory { LoginUseCase(get(), get()) }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/ControllerStatusState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/ControllerStatusState.kt
@@ -1,0 +1,53 @@
+package com.spela.player.libretro
+
+/**
+ * Status of a single controller port.
+ */
+data class PortStatus(
+    val port: Int,
+    val connected: Boolean,
+    val active: Boolean,
+)
+
+/**
+ * UI-ready snapshot of all controller port statuses.
+ * Derived from [GamepadPortManager] port assignments and activity timestamps.
+ */
+data class ControllerStatusState(
+    val ports: List<PortStatus>,
+    val connectedCount: Int,
+    val isMultiplayer: Boolean,
+) {
+    companion object {
+        /** Number of ports shown in the UI (most games support up to 4 players). */
+        const val DISPLAY_PORTS = 4
+
+        /** Creates the state from raw port data. */
+        fun fromPortData(
+            occupiedPorts: BooleanArray,
+            lastActivityMs: LongArray,
+            nowMs: Long,
+            activityTimeoutMs: Long = 300L,
+        ): ControllerStatusState {
+            val ports = (0 until DISPLAY_PORTS).map { port ->
+                val connected = port < occupiedPorts.size && occupiedPorts[port]
+                val lastActivity = if (port < lastActivityMs.size) lastActivityMs[port] else 0L
+                val active = connected && lastActivity > 0L && (nowMs - lastActivity) < activityTimeoutMs
+                PortStatus(port = port, connected = connected, active = active)
+            }
+            val connectedCount = ports.count { it.connected }
+            return ControllerStatusState(
+                ports = ports,
+                connectedCount = connectedCount,
+                isMultiplayer = connectedCount >= 2,
+            )
+        }
+
+        /** Empty state — no controllers connected. */
+        val Empty = ControllerStatusState(
+            ports = (0 until DISPLAY_PORTS).map { PortStatus(port = it, connected = false, active = false) },
+            connectedCount = 0,
+            isMultiplayer = false,
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
@@ -2,6 +2,11 @@ package com.spela.player.libretro
 
 import com.spela.player.domain.repository.KeyMappingRepository
 import com.spela.player.presentation.ui.gamepad.InputMode
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,9 +23,12 @@ import kotlin.time.Clock
  */
 class GamepadPortManager(
     private val keyMappingRepository: KeyMappingRepository,
+    private val scope: CoroutineScope? = null,
 ) {
     companion object {
         const val MAX_PORTS = 8
+        const val ACTIVITY_TIMEOUT_MS = 300L
+        const val ACTIVITY_REFRESH_INTERVAL_MS = 100L
     }
 
     /**
@@ -59,6 +67,13 @@ class GamepadPortManager(
     private val _inputMode = MutableStateFlow(InputMode.TOUCH)
     val inputMode: StateFlow<InputMode> = _inputMode.asStateFlow()
 
+    /** Observable controller status for UI indicators. */
+    private val _controllerStatus = MutableStateFlow(ControllerStatusState.Empty)
+    val controllerStatus: StateFlow<ControllerStatusState> = _controllerStatus.asStateFlow()
+
+    /** Coroutine that periodically refreshes activity flags. */
+    private var activityRefreshJob: Job? = null
+
     fun setInputMode(mode: InputMode) {
         _inputMode.value = mode
     }
@@ -81,6 +96,8 @@ class GamepadPortManager(
         val assignment = PortAssignment(deviceId = deviceId, port = port, deviceName = deviceName)
         deviceToPort[deviceId] = assignment
         _assignments.value = deviceToPort.values.toList()
+        emitControllerStatus()
+        startActivityRefreshIfNeeded()
         return port
     }
 
@@ -94,6 +111,7 @@ class GamepadPortManager(
         if (!occupiedPorts[port]) return
         lastActivityMs[port] = Clock.System.now().toEpochMilliseconds()
         _portActivity.value = buildActivityMap()
+        emitControllerStatus()
     }
 
     /**
@@ -107,6 +125,8 @@ class GamepadPortManager(
         lastActivityMs[assignment.port] = 0L
         _assignments.value = deviceToPort.values.toList()
         _portActivity.value = buildActivityMap()
+        emitControllerStatus()
+        stopActivityRefreshIfNotNeeded()
     }
 
     /**
@@ -277,6 +297,42 @@ class GamepadPortManager(
         lastActivityMs.fill(0L)
         _assignments.value = emptyList()
         _portActivity.value = emptyMap()
+        emitControllerStatus()
+        stopActivityRefresh()
+    }
+
+    private fun emitControllerStatus() {
+        val now = Clock.System.now().toEpochMilliseconds()
+        _controllerStatus.value = ControllerStatusState.fromPortData(
+            occupiedPorts = occupiedPorts.copyOf(),
+            lastActivityMs = lastActivityMs.copyOf(),
+            nowMs = now,
+            activityTimeoutMs = ACTIVITY_TIMEOUT_MS,
+        )
+    }
+
+    private fun startActivityRefreshIfNeeded() {
+        if (activityRefreshJob?.isActive == true) return
+        if (deviceToPort.size < 2) return
+        val currentScope = scope ?: return
+        activityRefreshJob = currentScope.launch {
+            while (isActive) {
+                delay(ACTIVITY_REFRESH_INTERVAL_MS)
+                synchronized(this@GamepadPortManager) {
+                    emitControllerStatus()
+                }
+            }
+        }
+    }
+
+    private fun stopActivityRefreshIfNotNeeded() {
+        if (deviceToPort.size >= 2) return
+        stopActivityRefresh()
+    }
+
+    private fun stopActivityRefresh() {
+        activityRefreshJob?.cancel()
+        activityRefreshJob = null
     }
 
     /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/libretro/GamepadPortManager.kt
@@ -283,6 +283,7 @@ class GamepadPortManager(
 
         _assignments.value = deviceToPort.values.toList()
         _portActivity.value = buildActivityMap()
+        emitControllerStatus()
     }
 
     /**
@@ -311,6 +312,8 @@ class GamepadPortManager(
         )
     }
 
+    /** Starts the periodic activity refresh if multiplayer and not already running.
+     *  Must be called while holding the monitor (from a @Synchronized method). */
     private fun startActivityRefreshIfNeeded() {
         if (activityRefreshJob?.isActive == true) return
         if (deviceToPort.size < 2) return
@@ -325,11 +328,15 @@ class GamepadPortManager(
         }
     }
 
+    /** Stops the periodic activity refresh if there are fewer than 2 controllers.
+     *  Must be called while holding the monitor (from a @Synchronized method). */
     private fun stopActivityRefreshIfNotNeeded() {
         if (deviceToPort.size >= 2) return
         stopActivityRefresh()
     }
 
+    /** Cancels the periodic activity refresh job unconditionally.
+     *  Must be called while holding the monitor (from a @Synchronized method). */
     private fun stopActivityRefresh() {
         activityRefreshJob?.cancel()
         activityRefreshJob = null

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -1697,14 +1697,14 @@ fun SpelaApp(
             }
 
             // Floating controller mini-pill (phone layout, 2+ controllers, no gamepad pill visible)
-            if (showNavArea && !isGamepadMode && navLayoutMode == NavigationLayoutMode.BOTTOM_BAR && controllerStatus.isMultiplayer) {
+            if (showNavArea && !isGamepadMode && navLayoutMode == NavigationLayoutMode.BOTTOM_BAR) {
                 Box(
                     modifier = Modifier.fillMaxSize(),
                     contentAlignment = Alignment.TopCenter,
                 ) {
                     val animationsEnabled = com.spela.player.presentation.ui.components.LocalAnimationsEnabled.current
                     AnimatedVisibility(
-                        visible = true,
+                        visible = controllerStatus.isMultiplayer,
                         enter = if (animationsEnabled) fadeIn() + slideInVertically(initialOffsetY = { -it }) else EnterTransition.None,
                         exit = if (animationsEnabled) fadeOut() + slideOutVertically(targetOffsetY = { -it }) else ExitTransition.None,
                     ) {
@@ -1713,7 +1713,7 @@ fun SpelaApp(
                                 .padding(top = SpSpacing.Default)
                                 .background(
                                     color = Color.Black.copy(alpha = 0.6f),
-                                    shape = androidx.compose.foundation.shape.RoundedCornerShape(24.dp),
+                                    shape = androidx.compose.foundation.shape.RoundedCornerShape(SpSpacing.RadiusXLarge),
                                 )
                                 .clickable {
                                     navigationViewModel.onIntent(
@@ -1722,7 +1722,7 @@ fun SpelaApp(
                                 }
                                 .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small)
                                 .semantics { contentDescription = "${controllerStatus.connectedCount} controllers connected" },
-                            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp),
+                            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(SpSpacing.Small),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {
                             com.spela.player.presentation.ui.components.SpControllerStatusRow(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -7,7 +7,9 @@ import androidx.compose.animation.ExitTransition
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
 
@@ -159,6 +161,7 @@ import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
 import com.spela.player.presentation.viewmodel.SocialViewModel
 import com.spela.player.presentation.viewmodel.StatsViewModel
 import com.spela.player.presentation.viewmodel.TopListsViewModel
+import com.spela.player.libretro.ControllerStatusState
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.ui.components.SpSectionIndicator
 
@@ -215,6 +218,8 @@ fun SpelaApp(
         val inputMode by gamepadPortManager?.inputMode?.collectAsState()
             ?: remember { mutableStateOf(InputMode.TOUCH) }
         val isGamepadMode = inputMode == InputMode.GAMEPAD
+        val controllerStatus by gamepadPortManager?.controllerStatus?.collectAsState()
+            ?: remember { mutableStateOf(ControllerStatusState.Empty) }
         val sectionIndicatorVisible = isGamepadMode
 
         // Indicator for E2E tests: exposes whether the libretro core is running.
@@ -353,6 +358,12 @@ fun SpelaApp(
                         )
                     },
                     showLabels = navLayoutMode == NavigationLayoutMode.LABELED_RAIL,
+                    controllerStatus = controllerStatus,
+                    onControllerStatusClick = {
+                        navigationViewModel.onIntent(
+                            NavigationIntent.SwitchTab(SpScreen.Settings)
+                        )
+                    },
                 )
             }
 
@@ -1678,8 +1689,43 @@ fun SpelaApp(
                     SpSectionIndicator(
                         activeTab = navState.activeTab,
                         visible = sectionIndicatorVisible,
+                        controllerStatus = controllerStatus,
                         modifier = Modifier.padding(top = SpSpacing.Default),
                     )
+                }
+            }
+
+            // Floating controller mini-pill (phone layout, 2+ controllers, no gamepad pill visible)
+            if (showNavArea && !isGamepadMode && navLayoutMode == NavigationLayoutMode.BOTTOM_BAR && controllerStatus.isMultiplayer) {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.TopCenter,
+                ) {
+                    val animationsEnabled = com.spela.player.presentation.ui.components.LocalAnimationsEnabled.current
+                    AnimatedVisibility(
+                        visible = true,
+                        enter = if (animationsEnabled) fadeIn() + slideInVertically(initialOffsetY = { -it }) else EnterTransition.None,
+                        exit = if (animationsEnabled) fadeOut() + slideOutVertically(targetOffsetY = { -it }) else ExitTransition.None,
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .padding(top = SpSpacing.Default)
+                                .background(
+                                    color = Color.Black.copy(alpha = 0.6f),
+                                    shape = androidx.compose.foundation.shape.RoundedCornerShape(24.dp),
+                                )
+                                .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small),
+                            horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            com.spela.player.presentation.ui.components.SpControllerStatusRow(
+                                ports = controllerStatus.ports,
+                                showEmptySlots = false,
+                                dotSize = 8.dp,
+                                spacing = SpSpacing.Small,
+                            )
+                        }
+                    }
                 }
             }
             } // BoxWithConstraints

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -12,6 +12,7 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
@@ -1714,7 +1715,13 @@ fun SpelaApp(
                                     color = Color.Black.copy(alpha = 0.6f),
                                     shape = androidx.compose.foundation.shape.RoundedCornerShape(24.dp),
                                 )
-                                .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small),
+                                .clickable {
+                                    navigationViewModel.onIntent(
+                                        NavigationIntent.SwitchTab(SpScreen.Settings)
+                                    )
+                                }
+                                .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small)
+                                .semantics { contentDescription = "${controllerStatus.connectedCount} controllers connected" },
                             horizontalArrangement = androidx.compose.foundation.layout.Arrangement.spacedBy(8.dp),
                             verticalAlignment = Alignment.CenterVertically,
                         ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerDot.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerDot.kt
@@ -1,0 +1,100 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawBehind
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.spela.player.presentation.ui.theme.SpColor
+
+/**
+ * A single controller status dot.
+ *
+ * Three visual states:
+ * - **Disconnected** (`connected = false`): hollow ring, dim
+ * - **Connected idle** (`connected = true, active = false`): solid green, subtle glow
+ * - **Active input** (`connected = true, active = true`): white, bright glow — fades back to green
+ *
+ * This is a design-layer component. No labels, no outer spacing.
+ */
+@Composable
+fun SpControllerDot(
+    connected: Boolean,
+    active: Boolean,
+    port: Int,
+    size: Dp = 8.dp,
+    modifier: Modifier = Modifier,
+) {
+    val connectedColor = Color(0xFF4ADE80) // green-400
+    val activeColor = Color.White
+    val disconnectedColor = SpColor.OnBackgroundTertiary.copy(alpha = 0.3f)
+    val disconnectedBorderColor = SpColor.OnBackgroundTertiary.copy(alpha = 0.5f)
+
+    val dotColor by animateColorAsState(
+        targetValue = when {
+            active -> activeColor
+            connected -> connectedColor
+            else -> disconnectedColor
+        },
+        animationSpec = tween(durationMillis = if (active) 50 else 300),
+        label = "dotColor",
+    )
+
+    val glowColor = when {
+        active -> Color.White.copy(alpha = 0.4f)
+        connected -> connectedColor.copy(alpha = 0.3f)
+        else -> Color.Transparent
+    }
+
+    val description = when {
+        active -> "Player ${port + 1} active"
+        connected -> "Player ${port + 1} connected"
+        else -> "Player ${port + 1} not connected"
+    }
+
+    Box(
+        modifier = modifier
+            .size(size)
+            .then(
+                if (!connected) {
+                    // Hollow ring for disconnected
+                    Modifier
+                        .clip(CircleShape)
+                        .background(Color.Transparent)
+                        .drawBehind {
+                            drawCircle(
+                                color = disconnectedBorderColor,
+                                radius = this.size.minDimension / 2,
+                                style = androidx.compose.ui.graphics.drawscope.Stroke(
+                                    width = 1.5.dp.toPx(),
+                                ),
+                            )
+                        }
+                } else {
+                    // Solid circle with glow for connected/active
+                    Modifier
+                        .drawBehind {
+                            // Glow
+                            drawCircle(
+                                color = glowColor,
+                                radius = this.size.minDimension * 0.9f,
+                            )
+                        }
+                        .clip(CircleShape)
+                        .background(dotColor)
+                }
+            )
+            .semantics { contentDescription = description },
+    )
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerStatusCard.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerStatusCard.kt
@@ -1,0 +1,86 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsFocusedAsState
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+import com.spela.player.libretro.PortStatus
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Card showing controller status for the navigation rail.
+ *
+ * Displays a "CONTROLLERS" label and a [SpControllerStatusRow] with all 4 slots.
+ * Clickable — navigates to controller settings. Focusable for gamepad navigation.
+ *
+ * @param ports The list of port statuses to display.
+ * @param onClick Called when the card is clicked or selected.
+ */
+@Composable
+fun SpControllerStatusCard(
+    ports: List<PortStatus>,
+    onClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val interactionSource = remember { MutableInteractionSource() }
+    val isFocused by interactionSource.collectIsFocusedAsState()
+
+    val shape = RoundedCornerShape(SpSpacing.RadiusMedium)
+    val bgAlpha = if (isFocused) 0.1f else 0.05f
+    val borderAlpha = if (isFocused) 0.15f else 0.08f
+
+    val connectedCount = ports.count { it.connected }
+
+    Column(
+        modifier = modifier
+            .clip(shape)
+            .background(Color.White.copy(alpha = bgAlpha))
+            .border(
+                width = 1.dp,
+                color = Color.White.copy(alpha = borderAlpha),
+                shape = shape,
+            )
+            .clickable(
+                interactionSource = interactionSource,
+                indication = null,
+            ) { onClick() }
+            .focusable(interactionSource = interactionSource)
+            .padding(horizontal = SpSpacing.Medium, vertical = SpSpacing.Small)
+            .semantics {
+                contentDescription = "$connectedCount controllers connected"
+                role = Role.Button
+            },
+    ) {
+        Text(
+            text = "CONTROLLERS",
+            style = SpTypography.LabelSmall,
+            color = SpColor.OnBackgroundTertiary,
+            letterSpacing = SpTypography.LabelSmall.letterSpacing,
+        )
+
+        SpControllerStatusRow(
+            ports = ports,
+            showEmptySlots = true,
+            modifier = Modifier.padding(top = SpSpacing.XSmall),
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerStatusRow.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpControllerStatusRow.kt
@@ -1,0 +1,61 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.spela.player.libretro.PortStatus
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * A row of controller dots with player labels (P1, P2, etc.).
+ *
+ * Content-layer component that composes [SpControllerDot] instances.
+ *
+ * @param ports The list of port statuses to display.
+ * @param showEmptySlots If true, shows all ports (connected + disconnected).
+ *   If false, only shows connected ports.
+ * @param dotSize Size of each dot.
+ */
+@Composable
+fun SpControllerStatusRow(
+    ports: List<PortStatus>,
+    showEmptySlots: Boolean,
+    modifier: Modifier = Modifier,
+    dotSize: Dp = 8.dp,
+    spacing: Dp = SpSpacing.Small,
+) {
+    val visiblePorts = if (showEmptySlots) ports else ports.filter { it.connected }
+
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(spacing),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        visiblePorts.forEach { port ->
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(SpSpacing.XXSmall),
+            ) {
+                SpControllerDot(
+                    connected = port.connected,
+                    active = port.active,
+                    port = port.port,
+                    size = dotSize,
+                )
+                Text(
+                    text = "P${port.port + 1}",
+                    style = SpTypography.LabelSmall,
+                    color = if (port.connected) SpColor.OnBackgroundSecondary else SpColor.OnBackgroundTertiary.copy(alpha = 0.5f),
+                )
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt
@@ -1,5 +1,12 @@
 package com.spela.player.presentation.ui.components
 
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInVertically
+import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.focusable
@@ -31,6 +38,7 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
+import com.spela.player.libretro.ControllerStatusState
 import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
@@ -63,6 +71,8 @@ fun SpNavigationRail(
     activeTab: BottomNavTab,
     onTabSelected: (BottomNavTab) -> Unit,
     showLabels: Boolean,
+    controllerStatus: ControllerStatusState = ControllerStatusState.Empty,
+    onControllerStatusClick: () -> Unit = {},
     modifier: Modifier = Modifier,
 ) {
     val railWidth = if (showLabels) 200.dp else 72.dp
@@ -88,8 +98,48 @@ fun SpNavigationRail(
                 )
             }
 
-            // Push Settings to the bottom
+            // Push Settings + controller indicator to the bottom
             Spacer(Modifier.weight(1f))
+
+            // Controller status indicator (only when 2+ controllers)
+            val animationsEnabled = LocalAnimationsEnabled.current
+            AnimatedVisibility(
+                visible = controllerStatus.isMultiplayer,
+                enter = if (animationsEnabled) fadeIn() + slideInVertically(initialOffsetY = { it }) else EnterTransition.None,
+                exit = if (animationsEnabled) fadeOut() + slideOutVertically(targetOffsetY = { it }) else ExitTransition.None,
+            ) {
+                if (showLabels) {
+                    // Labeled rail: full card
+                    SpControllerStatusCard(
+                        ports = controllerStatus.ports,
+                        onClick = onControllerStatusClick,
+                        modifier = Modifier
+                            .padding(horizontal = SpSpacing.Small)
+                            .padding(bottom = SpSpacing.Small),
+                    )
+                } else {
+                    // Icon-only rail: stacked dots, no labels, no card
+                    Column(
+                        modifier = Modifier
+                            .padding(bottom = SpSpacing.Small)
+                            .clip(RoundedCornerShape(8.dp))
+                            .clickable { onControllerStatusClick() }
+                            .focusable()
+                            .padding(vertical = SpSpacing.Small),
+                        horizontalAlignment = Alignment.CenterHorizontally,
+                        verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                    ) {
+                        controllerStatus.ports.filter { it.connected }.forEach { port ->
+                            SpControllerDot(
+                                connected = port.connected,
+                                active = port.active,
+                                port = port.port,
+                                size = 10.dp,
+                            )
+                        }
+                    }
+                }
+            }
 
             // Settings tab
             RailItem(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNavigationRail.kt
@@ -119,12 +119,20 @@ fun SpNavigationRail(
                     )
                 } else {
                     // Icon-only rail: stacked dots, no labels, no card
+                    val dotInteractionSource = remember { MutableInteractionSource() }
+                    val dotsFocused by dotInteractionSource.collectIsFocusedAsState()
                     Column(
                         modifier = Modifier
                             .padding(bottom = SpSpacing.Small)
-                            .clip(RoundedCornerShape(8.dp))
-                            .clickable { onControllerStatusClick() }
-                            .focusable()
+                            .clip(RoundedCornerShape(SpSpacing.RadiusMedium))
+                            .background(
+                                if (dotsFocused) Color.White.copy(alpha = 0.05f) else Color.Transparent,
+                            )
+                            .clickable(
+                                interactionSource = dotInteractionSource,
+                                indication = null,
+                            ) { onControllerStatusClick() }
+                            .focusable(interactionSource = dotInteractionSource)
                             .padding(vertical = SpSpacing.Small),
                         horizontalAlignment = Alignment.CenterHorizontally,
                         verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpSectionIndicator.kt
@@ -9,9 +9,12 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -23,6 +26,7 @@ import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.graphics.Color
+import com.spela.player.libretro.ControllerStatusState
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 
@@ -30,6 +34,7 @@ import com.spela.player.presentation.ui.theme.SpSpacing
 fun SpSectionIndicator(
     activeTab: BottomNavTab,
     visible: Boolean,
+    controllerStatus: ControllerStatusState = ControllerStatusState.Empty,
     modifier: Modifier = Modifier,
 ) {
     val animationsEnabled = LocalAnimationsEnabled.current
@@ -74,6 +79,24 @@ fun SpSectionIndicator(
                 color = SpColor.OnBackgroundSecondary,
                 fontSize = 12.sp,
             )
+
+            // Controller status dots (only when multiplayer)
+            if (controllerStatus.isMultiplayer) {
+                // Vertical separator
+                Box(
+                    modifier = Modifier
+                        .width(1.dp)
+                        .height(18.dp)
+                        .background(Color.White.copy(alpha = 0.15f)),
+                )
+
+                SpControllerStatusRow(
+                    ports = controllerStatus.ports,
+                    showEmptySlots = false,
+                    dotSize = 8.dp,
+                    spacing = SpSpacing.Small,
+                )
+            }
         }
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/ControllerStatusStateTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/ControllerStatusStateTest.kt
@@ -1,0 +1,84 @@
+package com.spela.player.libretro
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ControllerStatusStateTest {
+
+    @Test
+    fun emptyStateHasNoConnectedPorts() {
+        val state = ControllerStatusState.Empty
+        assertEquals(4, state.ports.size)
+        assertEquals(0, state.connectedCount)
+        assertFalse(state.isMultiplayer)
+        state.ports.forEach { assertFalse(it.connected); assertFalse(it.active) }
+    }
+
+    @Test
+    fun singleControllerIsNotMultiplayer() {
+        val occupied = BooleanArray(8) { it == 0 }
+        val activity = LongArray(8)
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertEquals(1, state.connectedCount)
+        assertFalse(state.isMultiplayer)
+        assertTrue(state.ports[0].connected)
+        assertFalse(state.ports[1].connected)
+    }
+
+    @Test
+    fun twoControllersIsMultiplayer() {
+        val occupied = BooleanArray(8) { it == 0 || it == 1 }
+        val activity = LongArray(8)
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertEquals(2, state.connectedCount)
+        assertTrue(state.isMultiplayer)
+    }
+
+    @Test
+    fun recentActivityMarksPortActive() {
+        val occupied = BooleanArray(8) { it == 0 }
+        val activity = LongArray(8).also { it[0] = 900L }
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertTrue(state.ports[0].active, "Port 0 should be active (100ms ago < 300ms timeout)")
+    }
+
+    @Test
+    fun expiredActivityMarksPortInactive() {
+        val occupied = BooleanArray(8) { it == 0 }
+        val activity = LongArray(8).also { it[0] = 500L }
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertFalse(state.ports[0].active, "Port 0 should be inactive (500ms ago >= 300ms timeout)")
+    }
+
+    @Test
+    fun disconnectedPortIsNeverActive() {
+        val occupied = BooleanArray(8) // all false
+        val activity = LongArray(8).also { it[0] = 999L }
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertFalse(state.ports[0].active, "Disconnected port should not be active even with recent timestamp")
+    }
+
+    @Test
+    fun onlyFirstFourPortsAreIncluded() {
+        val occupied = BooleanArray(8) { true }
+        val activity = LongArray(8)
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertEquals(4, state.ports.size)
+        assertEquals(4, state.connectedCount)
+    }
+
+    @Test
+    fun nonContiguousPortsHandledCorrectly() {
+        val occupied = BooleanArray(8) { it == 0 || it == 2 }
+        val activity = LongArray(8).also { it[2] = 950L }
+        val state = ControllerStatusState.fromPortData(occupied, activity, nowMs = 1000L)
+        assertTrue(state.ports[0].connected)
+        assertFalse(state.ports[0].active)
+        assertFalse(state.ports[1].connected)
+        assertTrue(state.ports[2].connected)
+        assertTrue(state.ports[2].active)
+        assertTrue(state.isMultiplayer)
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
@@ -6,6 +6,7 @@ import kotlinx.coroutines.test.runTest
 import com.spela.player.presentation.viewmodel.LibretroAnalog
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
@@ -297,6 +298,62 @@ class GamepadPortManagerTest {
         val afterSwap = manager.assignments.value
         assertEquals(1, afterSwap.find { it.deviceId == 100 }?.port)
         assertEquals(0, afterSwap.find { it.deviceId == 200 }?.port)
+    }
+
+    @Test
+    fun controllerStatusEmptyByDefault() {
+        val status = manager.controllerStatus.value
+        assertEquals(0, status.connectedCount)
+        assertFalse(status.isMultiplayer)
+        status.ports.forEach { assertFalse(it.connected) }
+    }
+
+    @Test
+    fun controllerStatusUpdatesOnConnect() {
+        manager.connectDevice(100, "Xbox")
+        manager.connectDevice(200, "DualSense")
+        val status = manager.controllerStatus.value
+        assertEquals(2, status.connectedCount)
+        assertTrue(status.isMultiplayer)
+        assertTrue(status.ports[0].connected)
+        assertTrue(status.ports[1].connected)
+        assertFalse(status.ports[2].connected)
+    }
+
+    @Test
+    fun controllerStatusUpdatesOnDisconnect() {
+        manager.connectDevice(100, "Xbox")
+        manager.connectDevice(200, "DualSense")
+        assertTrue(manager.controllerStatus.value.isMultiplayer)
+
+        manager.disconnectDevice(100)
+        val status = manager.controllerStatus.value
+        assertEquals(1, status.connectedCount)
+        assertFalse(status.isMultiplayer)
+        assertFalse(status.ports[0].connected)
+        assertTrue(status.ports[1].connected)
+    }
+
+    @Test
+    fun controllerStatusReflectsActivityAfterReport() {
+        manager.connectDevice(100, "Xbox")
+        manager.connectDevice(200, "DualSense")
+        manager.reportActivity(0)
+        val status = manager.controllerStatus.value
+        assertTrue(status.ports[0].connected)
+        assertTrue(status.ports[1].connected)
+    }
+
+    @Test
+    fun controllerStatusClearsOnClear() {
+        manager.connectDevice(100, "Xbox")
+        manager.connectDevice(200, "DualSense")
+        assertTrue(manager.controllerStatus.value.isMultiplayer)
+
+        manager.clear()
+        val status = manager.controllerStatus.value
+        assertEquals(0, status.connectedCount)
+        assertFalse(status.isMultiplayer)
     }
 
     private class FakeKeyMappingRepo : KeyMappingRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/libretro/GamepadPortManagerTest.kt
@@ -356,6 +356,21 @@ class GamepadPortManagerTest {
         assertFalse(status.isMultiplayer)
     }
 
+    @Test
+    fun controllerStatusUpdatesOnSwap() {
+        manager.connectDevice(100, "Xbox")
+        manager.connectDevice(200, "DualSense")
+        val before = manager.controllerStatus.value
+        assertTrue(before.ports[0].connected)
+        assertTrue(before.ports[1].connected)
+
+        manager.swapPorts(0, 1)
+        val after = manager.controllerStatus.value
+        // Both ports still connected after swap
+        assertTrue(after.ports[0].connected)
+        assertTrue(after.ports[1].connected)
+    }
+
     private class FakeKeyMappingRepo : KeyMappingRepository {
         val effectiveMappings = mutableMapOf<String, Map<Int, Int>>()
 


### PR DESCRIPTION
## Summary

- Adds compact, always-visible controller status indicators that appear when 2+ gamepads are connected
- Three UI variants adapt to the app's responsive navigation layout: rail card (desktop/tablet), section pill extension (gamepad mode), floating mini-pill (phone)
- Each connected controller's dot flashes white on input, letting players physically confirm "this controller in my hands is P2" without navigating to settings
- Clicking the rail card navigates to Settings for full controller management

## Changes

**Data layer:**
- `ControllerStatusState` data model with per-port connection + activity status
- `GamepadPortManager.controllerStatus` StateFlow with 100ms periodic activity refresh

**UI components (Design → Content hierarchy):**
- `SpControllerDot` — single dot with 3 animated states (disconnected/connected/active)
- `SpControllerStatusRow` — row of dots with P# labels, `showEmptySlots` parameter
- `SpControllerStatusCard` — card wrapper for navigation rail with focus handling

**Integration:**
- Labeled rail (>840dp): Card with P1-P4 dots above Settings tab
- Icon-only rail (600-840dp): Stacked dots with focus handling
- Gamepad pill: Dots appended after R1 with vertical separator
- Phone mini-pill: Floating pill at top-center with animated visibility

**Tests:** 8 unit tests (ControllerStatusState) + 6 GamepadPortManager tests + 9 desktop E2E tests

## Design spec

`docs/superpowers/specs/2026-04-07-controller-status-indicators-design.md`

## Test plan

- [ ] Connect 2+ controllers on desktop — rail card appears above Settings
- [ ] Press buttons on each controller — corresponding dot flashes white
- [ ] Click the rail card — navigates to Settings
- [ ] Disconnect one controller (back to 1) — indicator disappears
- [ ] Reconnect controller — reclaims same port slot
- [ ] Verify gamepad mode pill shows dots after R1 with separator