### PR TITLE
fix: update E2E tests for preferences tabs, netplay mock data, and scan page

### DIFF
--- a/web/e2e/admin-scan.spec.ts
+++ b/web/e2e/admin-scan.spec.ts
@@ -50,11 +50,15 @@ test.describe("Admin Scan Page", () => {
     let scrapeURL = "";
     await page.route("**/api/admin/scrape**", (route) => {
       scrapeURL = route.request().url();
-      route.fulfill({ status: 200, json: {} });
+      route.fulfill({ status: 200, json: { total: 0 } });
     });
 
     await page.route("**/api/admin/scrape/status", (route) => {
       route.fulfill({ status: 200, json: { active: false } });
+    });
+
+    await page.route("**/api/admin/scrape/counts", (route) => {
+      route.fulfill({ status: 200, json: { sources: [] } });
     });
 
     await page.goto("/admin/scan");
@@ -70,11 +74,15 @@ test.describe("Admin Scan Page", () => {
     let scrapeURL = "";
     await page.route("**/api/admin/scrape**", (route) => {
       scrapeURL = route.request().url();
-      route.fulfill({ status: 200, json: {} });
+      route.fulfill({ status: 200, json: { total: 0 } });
     });
 
     await page.route("**/api/admin/scrape/status", (route) => {
       route.fulfill({ status: 200, json: { active: false } });
+    });
+
+    await page.route("**/api/admin/scrape/counts", (route) => {
+      route.fulfill({ status: 200, json: { sources: [] } });
     });
 
     await page.goto("/admin/scan");

--- a/web/e2e/netplay.spec.ts
+++ b/web/e2e/netplay.spec.ts
@@ -14,6 +14,8 @@ function mockSession(overrides?: Record<string, unknown>) {
     gameTitle: "Super Mario World",
     gameCoverUrl: "https://example.com/cover.png",
     consoleName: "SNES",
+    consoleId: "snes",
+    coverAspectRatio: 0.75,
     status: "waiting",
     endReason: null,
     inputDelay: 3,

--- a/web/e2e/play-later.spec.ts
+++ b/web/e2e/play-later.spec.ts
@@ -585,8 +585,8 @@ test.describe("Dashboard Play Later Section", () => {
     });
     await expect(playLaterHeading).toBeVisible({ timeout: 10_000 });
 
-    // Assert within the section that contains the Play Later heading
-    const playLaterSection = page.locator("section", {
+    // Assert within the TitledSection div that contains the Play Later heading
+    const playLaterSection = page.locator('[data-comp="TitledSection"]', {
       has: playLaterHeading,
     });
     await expect(

--- a/web/e2e/preferences.spec.ts
+++ b/web/e2e/preferences.spec.ts
@@ -11,6 +11,7 @@ test.describe("Preferences Page", () => {
     await expect(
       page.getByRole("heading", { name: "Preferences" }),
     ).toBeVisible();
+    await page.getByRole("tab", { name: "Emulation" }).click();
     await expect(
       page.getByRole("heading", { name: "Emulation Settings" }),
     ).toBeVisible();
@@ -24,6 +25,7 @@ test.describe("Preferences Page", () => {
     page,
   }) => {
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Video Filters" }).click();
 
     await expect(
       page.getByRole("heading", { name: "Video Filters" }),
@@ -40,6 +42,7 @@ test.describe("Preferences Page", () => {
 
   test("can toggle a preference switch", async ({ page }) => {
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Emulation" }).click();
 
     // Wait for preferences data to be rendered (Auto Save is true after reset,
     // so its switch will be [checked] only once the API response is processed).
@@ -69,6 +72,7 @@ test.describe("Preferences Page", () => {
 
   test("can change global shader selection", async ({ page }) => {
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Video Filters" }).click();
 
     const select = page.locator("select").first();
     await select.selectOption("scanlines");
@@ -77,6 +81,7 @@ test.describe("Preferences Page", () => {
 
   test("displays devices section", async ({ page }) => {
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Devices" }).click();
 
     await expect(
       page.getByRole("heading", { name: "Devices", exact: true }),
@@ -87,6 +92,7 @@ test.describe("Preferences Page", () => {
 test.describe("Shader Preview", () => {
   test("shows preview canvas with 4:3 aspect ratio", async ({ page }) => {
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Video Filters" }).click();
 
     const preview = page.locator("canvas").first();
     await expect(preview).toBeVisible({ timeout: 10_000 });
@@ -100,6 +106,7 @@ test.describe("Shader Preview", () => {
 
   test("preview canvas renders non-empty content", async ({ page }) => {
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Video Filters" }).click();
 
     const preview = page.locator("canvas").first();
     await expect(preview).toBeVisible({ timeout: 10_000 });
@@ -158,6 +165,7 @@ test.describe("Shader Preview", () => {
     });
 
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Video Filters" }).click();
 
     const preview = page.locator("canvas").first();
     await expect(preview).toBeVisible({ timeout: 10_000 });
@@ -172,6 +180,7 @@ test.describe("Shader Preview", () => {
 
   test("opens fullscreen shader preview modal on click", async ({ page }) => {
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Video Filters" }).click();
 
     const preview = page.locator("canvas").first();
     await expect(preview).toBeVisible({ timeout: 10_000 });
@@ -187,6 +196,7 @@ test.describe("Shader Preview", () => {
 
   test("closes fullscreen preview modal on Escape", async ({ page }) => {
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Video Filters" }).click();
 
     const preview = page.locator("canvas").first();
     await expect(preview).toBeVisible({ timeout: 10_000 });
@@ -202,6 +212,7 @@ test.describe("Shader Preview", () => {
 
   test("closes fullscreen preview modal on overlay click", async ({ page }) => {
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Video Filters" }).click();
 
     const preview = page.locator("canvas").first();
     await expect(preview).toBeVisible({ timeout: 10_000 });
@@ -227,6 +238,7 @@ test.describe("Shader Preview", () => {
     });
 
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Video Filters" }).click();
 
     // Wait for the per-console table to render
     const previewButtons = page.locator("table button");
@@ -277,6 +289,7 @@ test.describe("Shader Preview", () => {
     page,
   }) => {
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Video Filters" }).click();
 
     const preview = page.locator("canvas").first();
     await expect(preview).toBeVisible({ timeout: 10_000 });
@@ -340,6 +353,7 @@ test.describe("Shader Preview", () => {
     page,
   }) => {
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Video Filters" }).click();
 
     const preview = page.locator("canvas").first();
     await expect(preview).toBeVisible({ timeout: 10_000 });

--- a/web/e2e/retroachievements.spec.ts
+++ b/web/e2e/retroachievements.spec.ts
@@ -153,6 +153,7 @@ test.describe("RetroAchievements - Preferences Page", () => {
     });
 
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Achievements" }).click();
 
     await expect(
       page.getByRole("heading", { name: "RetroAchievements" }),
@@ -188,6 +189,7 @@ test.describe("RetroAchievements - Preferences Page", () => {
     });
 
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Achievements" }).click();
 
     await page.getByTestId("ra-username-input").fill("testuser");
     await page.getByTestId("ra-password-input").fill("testpass");
@@ -249,6 +251,7 @@ test.describe("RetroAchievements - Preferences Page", () => {
     });
 
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Achievements" }).click();
 
     // Fill in credentials and link
     await page.getByTestId("ra-username-input").fill("RetroUser");
@@ -275,6 +278,7 @@ test.describe("RetroAchievements - Preferences Page", () => {
     });
 
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Achievements" }).click();
 
     // Should show linked account info
     await expect(page.getByText("Linked Account")).toBeVisible();
@@ -315,6 +319,7 @@ test.describe("RetroAchievements - Preferences Page", () => {
     });
 
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Achievements" }).click();
 
     await expect(page.getByTestId("hardcore-toggle")).toBeVisible();
 
@@ -375,6 +380,7 @@ test.describe("RetroAchievements - Preferences Page", () => {
     });
 
     await page.goto("/preferences");
+    await page.getByRole("tab", { name: "Achievements" }).click();
 
     await expect(page.getByTestId("unlink-ra-btn")).toBeVisible();
     await page.getByTestId("unlink-ra-btn").click();


### PR DESCRIPTION
## Summary
- **Preferences/RetroAchievements tests (20 fixes):** Preferences page was refactored to tab-based navigation; tests now click the correct tab before asserting content
- **Netplay session detail tests (6 fixes):** Mock data was missing `consoleId` and `coverAspectRatio` fields, causing `ConsoleBadge` to crash on `undefined.toLowerCase()`
- **Admin scan tests (2 fixes):** Greedy route mock `**/api/admin/scrape**` was catching the new `/scrape/counts` endpoint, returning `{}` which crashed `data.sources.length`
- **Play Later dashboard test (1 fix):** `TitledSection` renders `<div data-comp="TitledSection">`, not `<section>` — updated the locator

## Test plan
- [x] All 28 previously failing tests now pass
- [x] Full E2E suite passes: 196 passed, 0 failed (18 skipped are intentional)
- [ ] CI passes