### PR TITLE
fix: speed up token blacklist lookup and log security events

### DIFF
--- a/server/internal/api/auth_handler.go
+++ b/server/internal/api/auth_handler.go
@@ -148,8 +148,15 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
+	clientIP := c.ClientIP()
+
 	// Check account lockout before proceeding
 	if h.isLockedOut(req.Username) {
+		slog.Warn("security: login attempt against locked account",
+			"event", "login_locked",
+			"username", req.Username,
+			"ip", clientIP,
+		)
 		apiError(c, http.StatusTooManyRequests, "account locked", "Your account has been temporarily locked due to too many failed login attempts. Please try again later.")
 		return
 	}
@@ -163,28 +170,71 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		// "wrong password" (slow bcrypt) by measuring response time.
 		auth.CheckPassword(req.Password, dummyBcryptHash)
 		h.recordFailedLogin(req.Username)
+		slog.Warn("security: failed login (unknown user)",
+			"event", "login_failed",
+			"reason", "unknown_user",
+			"username", req.Username,
+			"ip", clientIP,
+		)
 		apiError(c, http.StatusUnauthorized, "invalid credentials", "Invalid username or password.")
 		return
 	}
 
 	if !auth.CheckPassword(req.Password, user.PasswordHash) {
 		h.recordFailedLogin(req.Username)
+		// Re-read the attempt to log the new failure count and detect lockout escalation.
+		var attempt db.LoginAttempt
+		h.DB.Where("username = ?", hashUsername(req.Username)).First(&attempt)
+		slog.Warn("security: failed login (bad password)",
+			"event", "login_failed",
+			"reason", "bad_password",
+			"username", req.Username,
+			"ip", clientIP,
+			"failedCount", attempt.FailedCount,
+		)
+		if attempt.FailedCount >= maxLoginAttempts {
+			slog.Warn("security: account locked due to repeated failures",
+				"event", "account_locked",
+				"username", req.Username,
+				"ip", clientIP,
+				"failedCount", attempt.FailedCount,
+				"lockedUntil", attempt.LockedUntil,
+			)
+		}
 		apiError(c, http.StatusUnauthorized, "invalid credentials", "Invalid username or password.")
 		return
 	}
 
 	if user.PendingApproval {
+		slog.Warn("security: login attempt on pending account",
+			"event", "login_blocked",
+			"reason", "pending_approval",
+			"username", req.Username,
+			"ip", clientIP,
+		)
 		apiError(c, http.StatusForbidden, "account pending approval", "Your account is awaiting admin approval. Please try again once an admin has approved it.")
 		return
 	}
 
 	if user.Disabled {
+		slog.Warn("security: login attempt on disabled account",
+			"event", "login_blocked",
+			"reason", "disabled",
+			"username", req.Username,
+			"ip", clientIP,
+		)
 		apiError(c, http.StatusForbidden, "account is disabled", "Your account has been disabled. Please contact an administrator.")
 		return
 	}
 
 	// Successful login — clear any failed attempts
 	h.clearFailedLogins(req.Username)
+	slog.Info("security: successful login",
+		"event", "login_success",
+		"username", req.Username,
+		"userId", user.ID,
+		"ip", clientIP,
+	)
 
 	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, h.JWTSecret, user.TokenVersion)
 	if err != nil {
@@ -509,11 +559,19 @@ func (h *AuthHandler) Logout(c *gin.Context) {
 }
 
 // IsTokenBlacklisted checks if a JWT access token has been revoked.
+//
+// Uses an existence-style query (SELECT id ... LIMIT 1) instead of COUNT(*),
+// because COUNT scans all matching rows even when only existence is needed.
+// On the indexed token_hash column the query short-circuits at the first
+// match, keeping middleware overhead minimal even on large blacklist tables.
 func IsTokenBlacklisted(database *gorm.DB, token string) bool {
 	hash := sha256.Sum256([]byte(token))
-	var count int64
-	database.Model(&db.TokenBlacklist{}).Where("token_hash = ?", hex.EncodeToString(hash[:])).Count(&count)
-	return count > 0
+	var bl db.TokenBlacklist
+	err := database.Select("id").
+		Where("token_hash = ?", hex.EncodeToString(hash[:])).
+		Limit(1).
+		Take(&bl).Error
+	return err == nil
 }
 
 // Setup creates the initial owner account. Only works when no users exist.

--- a/server/internal/api/middleware.go
+++ b/server/internal/api/middleware.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"fmt"
+	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -75,6 +76,13 @@ func AuthMiddleware(jwtSecret string, database *gorm.DB) gin.HandlerFunc {
 
 		// Reject revoked (logged-out) access tokens
 		if IsTokenBlacklisted(database, token) {
+			slog.Warn("security: revoked token used",
+				"event", "revoked_token_used",
+				"username", claims.Username,
+				"userId", claims.UserID,
+				"ip", c.ClientIP(),
+				"path", c.Request.URL.Path,
+			)
 			abortWithError(c, http.StatusUnauthorized, "token has been revoked", "Your session has ended. Please sign in again.")
 			return
 		}
@@ -82,16 +90,36 @@ func AuthMiddleware(jwtSecret string, database *gorm.DB) gin.HandlerFunc {
 		// Reject disabled users even if their access token is still valid
 		var user db.User
 		if err := database.Select("id", "disabled", "token_version").First(&user, claims.UserID).Error; err != nil {
+			slog.Warn("security: token references missing user",
+				"event", "token_user_missing",
+				"username", claims.Username,
+				"userId", claims.UserID,
+				"ip", c.ClientIP(),
+			)
 			abortWithError(c, http.StatusUnauthorized, "user not found", "Your account could not be found. Please sign in again.")
 			return
 		}
 		if user.Disabled {
+			slog.Warn("security: disabled account used valid token",
+				"event", "disabled_account_token",
+				"username", claims.Username,
+				"userId", claims.UserID,
+				"ip", c.ClientIP(),
+			)
 			abortWithError(c, http.StatusForbidden, "account is disabled", "Your account has been disabled. Please contact an administrator.")
 			return
 		}
 
 		// Reject tokens minted before a role/password/disabled change
 		if claims.TokenVersion != user.TokenVersion {
+			slog.Warn("security: stale token version used",
+				"event", "stale_token_version",
+				"username", claims.Username,
+				"userId", claims.UserID,
+				"ip", c.ClientIP(),
+				"tokenVersion", claims.TokenVersion,
+				"currentVersion", user.TokenVersion,
+			)
 			abortWithError(c, http.StatusUnauthorized, "token has been invalidated", "Your session is no longer valid. Please sign in again.")
 			return
 		}

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -187,6 +187,17 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		return nil, fmt.Errorf("running migrations: %w", err)
 	}
 
+	// Defensive: ensure the token_blacklist token_hash index exists.
+	// AutoMigrate creates indexes for new tables, but databases that predate
+	// the uniqueIndex annotation can end up without it, causing the auth
+	// middleware's lookup to fall back to a table scan on every request.
+	if err := db.Exec("CREATE UNIQUE INDEX IF NOT EXISTS idx_token_blacklists_token_hash ON token_blacklists(token_hash)").Error; err != nil {
+		slog.Warn("failed to ensure token_blacklists token_hash index", "error", err)
+	}
+	if err := db.Exec("CREATE INDEX IF NOT EXISTS idx_token_blacklists_expires_at ON token_blacklists(expires_at)").Error; err != nil {
+		slog.Warn("failed to ensure token_blacklists expires_at index", "error", err)
+	}
+
 	// Promote the first user to owner if no owner exists (handles upgrades).
 	var ownerCount int64
 	db.Model(&User{}).Where("role = ?", RoleOwner).Count(&ownerCount)


### PR DESCRIPTION
## Problem
Auth middleware was calling \`database.Count(*)\` against \`token_blacklists\` on every authenticated request. A 2.6s query was observed in production — either the unique index was missing on databases that predated the \`uniqueIndex\` annotation, or \`Count\` was scanning matching rows instead of short-circuiting. Either way, the query was hammering the disk on every API call.

## Fix

**Performance**
- \`IsTokenBlacklisted\` now uses \`SELECT id ... LIMIT 1\` (\`Take\`) instead of \`Count(*)\` — short-circuits at the first match
- After \`AutoMigrate\`, defensively run \`CREATE UNIQUE INDEX IF NOT EXISTS\` for \`token_hash\` and \`CREATE INDEX IF NOT EXISTS\` for \`expires_at\`, so older databases get the indexes the model declares

**Security event logging** (\`slog.Warn\` with \`event=\` discriminator + IP + username)
- \`login_failed\` (unknown_user, bad_password) — includes failed counter
- \`account_locked\` — when threshold is reached
- \`login_locked\` — login attempt against an already-locked account
- \`login_blocked\` (disabled, pending_approval) — login on blocked account
- \`revoked_token_used\` — middleware sees a blacklisted token
- \`disabled_account_token\` — disabled user presents valid token
- \`token_user_missing\` — token claims a user that no longer exists
- \`stale_token_version\` — token from before role/password change
- \`login_success\` (info level) — for audit trail

## Test plan
- [x] \`go test ./internal/api/ -count=1\` passes (357s)
- [x] Build clean
- [ ] CI passes