### PR TITLE
feat: admin security events page

### DIFF
--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -37,6 +37,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.User{}, &db.Console{}, &db.Game{}, &db.GameDisc{},
 		&db.Favorite{}, &db.PlayHistory{}, &db.RefreshToken{},
 		&db.TokenBlacklist{}, &db.LoginAttempt{},
+		&db.SecurityEvent{},
 		&db.ServerSetting{}, &db.Core{},
 		&db.ConsoleShaderPreference{},
 		&db.ConsoleKeyMappingPreference{},

--- a/server/internal/api/auth_handler.go
+++ b/server/internal/api/auth_handler.go
@@ -148,15 +148,12 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		return
 	}
 
-	clientIP := c.ClientIP()
-
 	// Check account lockout before proceeding
 	if h.isLockedOut(req.Username) {
-		slog.Warn("security: login attempt against locked account",
-			"event", "login_locked",
-			"username", req.Username,
-			"ip", clientIP,
-		)
+		recordSecurityEventCtx(h.DB, c, securityEventInput{
+			EventType: db.SecurityEventLoginLocked,
+			Username:  req.Username,
+		})
 		apiError(c, http.StatusTooManyRequests, "account locked", "Your account has been temporarily locked due to too many failed login attempts. Please try again later.")
 		return
 	}
@@ -170,12 +167,11 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		// "wrong password" (slow bcrypt) by measuring response time.
 		auth.CheckPassword(req.Password, dummyBcryptHash)
 		h.recordFailedLogin(req.Username)
-		slog.Warn("security: failed login (unknown user)",
-			"event", "login_failed",
-			"reason", "unknown_user",
-			"username", req.Username,
-			"ip", clientIP,
-		)
+		recordSecurityEventCtx(h.DB, c, securityEventInput{
+			EventType: db.SecurityEventLoginFailed,
+			Reason:    "unknown_user",
+			Username:  req.Username,
+		})
 		apiError(c, http.StatusUnauthorized, "invalid credentials", "Invalid username or password.")
 		return
 	}
@@ -185,56 +181,57 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		// Re-read the attempt to log the new failure count and detect lockout escalation.
 		var attempt db.LoginAttempt
 		h.DB.Where("username = ?", hashUsername(req.Username)).First(&attempt)
-		slog.Warn("security: failed login (bad password)",
-			"event", "login_failed",
-			"reason", "bad_password",
-			"username", req.Username,
-			"ip", clientIP,
-			"failedCount", attempt.FailedCount,
-		)
+		recordSecurityEventCtx(h.DB, c, securityEventInput{
+			EventType: db.SecurityEventLoginFailed,
+			Reason:    "bad_password",
+			Username:  req.Username,
+			UserID:    &user.ID,
+			Metadata:  map[string]any{"failedCount": attempt.FailedCount},
+		})
 		if attempt.FailedCount >= maxLoginAttempts {
-			slog.Warn("security: account locked due to repeated failures",
-				"event", "account_locked",
-				"username", req.Username,
-				"ip", clientIP,
-				"failedCount", attempt.FailedCount,
-				"lockedUntil", attempt.LockedUntil,
-			)
+			recordSecurityEventCtx(h.DB, c, securityEventInput{
+				EventType: db.SecurityEventAccountLocked,
+				Username:  req.Username,
+				UserID:    &user.ID,
+				Metadata: map[string]any{
+					"failedCount": attempt.FailedCount,
+					"lockedUntil": attempt.LockedUntil,
+				},
+			})
 		}
 		apiError(c, http.StatusUnauthorized, "invalid credentials", "Invalid username or password.")
 		return
 	}
 
 	if user.PendingApproval {
-		slog.Warn("security: login attempt on pending account",
-			"event", "login_blocked",
-			"reason", "pending_approval",
-			"username", req.Username,
-			"ip", clientIP,
-		)
+		recordSecurityEventCtx(h.DB, c, securityEventInput{
+			EventType: db.SecurityEventLoginBlocked,
+			Reason:    "pending_approval",
+			Username:  req.Username,
+			UserID:    &user.ID,
+		})
 		apiError(c, http.StatusForbidden, "account pending approval", "Your account is awaiting admin approval. Please try again once an admin has approved it.")
 		return
 	}
 
 	if user.Disabled {
-		slog.Warn("security: login attempt on disabled account",
-			"event", "login_blocked",
-			"reason", "disabled",
-			"username", req.Username,
-			"ip", clientIP,
-		)
+		recordSecurityEventCtx(h.DB, c, securityEventInput{
+			EventType: db.SecurityEventLoginBlocked,
+			Reason:    "disabled",
+			Username:  req.Username,
+			UserID:    &user.ID,
+		})
 		apiError(c, http.StatusForbidden, "account is disabled", "Your account has been disabled. Please contact an administrator.")
 		return
 	}
 
 	// Successful login — clear any failed attempts
 	h.clearFailedLogins(req.Username)
-	slog.Info("security: successful login",
-		"event", "login_success",
-		"username", req.Username,
-		"userId", user.ID,
-		"ip", clientIP,
-	)
+	recordSecurityEventCtx(h.DB, c, securityEventInput{
+		EventType: db.SecurityEventLoginSuccess,
+		Username:  req.Username,
+		UserID:    &user.ID,
+	})
 
 	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, h.JWTSecret, user.TokenVersion)
 	if err != nil {
@@ -494,6 +491,18 @@ func (h *AuthHandler) SetupStatus(c *gin.Context) {
 	})
 }
 
+// securityEventRetention is how long admin security event rows are kept.
+// Older rows are pruned by StartTokenCleanup.
+const securityEventRetention = 90 * 24 * time.Hour
+
+// pruneExpiredSecurityEvents deletes security_events rows older than the
+// retention window. Extracted from StartTokenCleanup so it can be exercised
+// by unit tests without starting the background goroutine.
+func pruneExpiredSecurityEvents(database *gorm.DB) int64 {
+	result := database.Where("created_at < ?", time.Now().Add(-securityEventRetention)).Delete(&db.SecurityEvent{})
+	return result.RowsAffected
+}
+
 // StartTokenCleanup starts a background goroutine that periodically deletes
 // expired refresh tokens from the database to prevent unbounded growth.
 func StartTokenCleanup(database *gorm.DB, interval time.Duration) {
@@ -516,6 +525,10 @@ func StartTokenCleanup(database *gorm.DB, interval time.Duration) {
 			blResult := database.Where("expires_at < ?", time.Now()).Delete(&db.TokenBlacklist{})
 			if blResult.RowsAffected > 0 {
 				slog.Info("cleaned up expired blacklist entries", "count", blResult.RowsAffected)
+			}
+			// Prune security events older than the retention window
+			if count := pruneExpiredSecurityEvents(database); count > 0 {
+				slog.Info("pruned old security events", "count", count)
 			}
 		}
 	}()

--- a/server/internal/api/middleware.go
+++ b/server/internal/api/middleware.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"fmt"
-	"log/slog"
 	"net/http"
 	"os"
 	"strconv"
@@ -74,15 +73,14 @@ func AuthMiddleware(jwtSecret string, database *gorm.DB) gin.HandlerFunc {
 			return
 		}
 
+		userID := claims.UserID
 		// Reject revoked (logged-out) access tokens
 		if IsTokenBlacklisted(database, token) {
-			slog.Warn("security: revoked token used",
-				"event", "revoked_token_used",
-				"username", claims.Username,
-				"userId", claims.UserID,
-				"ip", c.ClientIP(),
-				"path", c.Request.URL.Path,
-			)
+			recordSecurityEventCtx(database, c, securityEventInput{
+				EventType: db.SecurityEventRevokedTokenUsed,
+				Username:  claims.Username,
+				UserID:    &userID,
+			})
 			abortWithError(c, http.StatusUnauthorized, "token has been revoked", "Your session has ended. Please sign in again.")
 			return
 		}
@@ -90,36 +88,35 @@ func AuthMiddleware(jwtSecret string, database *gorm.DB) gin.HandlerFunc {
 		// Reject disabled users even if their access token is still valid
 		var user db.User
 		if err := database.Select("id", "disabled", "token_version").First(&user, claims.UserID).Error; err != nil {
-			slog.Warn("security: token references missing user",
-				"event", "token_user_missing",
-				"username", claims.Username,
-				"userId", claims.UserID,
-				"ip", c.ClientIP(),
-			)
+			recordSecurityEventCtx(database, c, securityEventInput{
+				EventType: db.SecurityEventTokenUserMissing,
+				Username:  claims.Username,
+				UserID:    &userID,
+			})
 			abortWithError(c, http.StatusUnauthorized, "user not found", "Your account could not be found. Please sign in again.")
 			return
 		}
 		if user.Disabled {
-			slog.Warn("security: disabled account used valid token",
-				"event", "disabled_account_token",
-				"username", claims.Username,
-				"userId", claims.UserID,
-				"ip", c.ClientIP(),
-			)
+			recordSecurityEventCtx(database, c, securityEventInput{
+				EventType: db.SecurityEventDisabledAccountToken,
+				Username:  claims.Username,
+				UserID:    &userID,
+			})
 			abortWithError(c, http.StatusForbidden, "account is disabled", "Your account has been disabled. Please contact an administrator.")
 			return
 		}
 
 		// Reject tokens minted before a role/password/disabled change
 		if claims.TokenVersion != user.TokenVersion {
-			slog.Warn("security: stale token version used",
-				"event", "stale_token_version",
-				"username", claims.Username,
-				"userId", claims.UserID,
-				"ip", c.ClientIP(),
-				"tokenVersion", claims.TokenVersion,
-				"currentVersion", user.TokenVersion,
-			)
+			recordSecurityEventCtx(database, c, securityEventInput{
+				EventType: db.SecurityEventStaleTokenVersion,
+				Username:  claims.Username,
+				UserID:    &userID,
+				Metadata: map[string]any{
+					"tokenVersion":   claims.TokenVersion,
+					"currentVersion": user.TokenVersion,
+				},
+			})
 			abortWithError(c, http.StatusUnauthorized, "token has been invalidated", "Your session is no longer valid. Please sign in again.")
 			return
 		}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -567,6 +567,12 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 			admin.GET("/stats", adminHandler.GetStats)
 			admin.GET("/users/:id/rate-limit", adminHandler.GetUserRateLimit)
 			admin.DELETE("/users/:id/rate-limit", adminHandler.ResetUserRateLimit)
+
+			// Security event audit log (admin-only)
+			securityHandler := &SecurityEventHandler{DB: cfg.DB}
+			admin.GET("/security-events", securityHandler.ListSecurityEvents)
+			admin.GET("/security-events/types", securityHandler.GetSecurityEventTypes)
+			admin.GET("/security-events/:id", securityHandler.GetSecurityEvent)
 			admin.GET("/users/:id/devices", deviceHandler.AdminGetUserDevices)
 			admin.POST("/bios", biosHandler.UploadBiosFile)
 			admin.POST("/bios/download", biosHandler.TriggerDownload)

--- a/server/internal/api/security_event_handler.go
+++ b/server/internal/api/security_event_handler.go
@@ -1,0 +1,194 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// SecurityEventHandler serves the admin-only security event log endpoints
+// that back the /admin/security-events page in the web UI.
+type SecurityEventHandler struct {
+	DB *gorm.DB
+}
+
+// SecurityEventResponse is the JSON shape returned by the API.
+type SecurityEventResponse struct {
+	ID        uint           `json:"id"`
+	CreatedAt time.Time      `json:"createdAt"`
+	EventType string         `json:"eventType"`
+	Reason    string         `json:"reason,omitempty"`
+	Username  string         `json:"username,omitempty"`
+	UserID    *uint          `json:"userId,omitempty"`
+	IP        string         `json:"ip,omitempty"`
+	Path      string         `json:"path,omitempty"`
+	Metadata  map[string]any `json:"metadata,omitempty"`
+}
+
+// SecurityEventsListResponse is the paginated list payload.
+type SecurityEventsListResponse struct {
+	Data     []SecurityEventResponse `json:"data"`
+	Total    int64                   `json:"total"`
+	Page     int                     `json:"page"`
+	PageSize int                     `json:"pageSize"`
+}
+
+// toSecurityEventResponse converts a db row to its API representation,
+// parsing the metadata JSON blob into a map for easier client consumption.
+func toSecurityEventResponse(e db.SecurityEvent) SecurityEventResponse {
+	r := SecurityEventResponse{
+		ID:        e.ID,
+		CreatedAt: e.CreatedAt,
+		EventType: e.EventType,
+		Reason:    e.Reason,
+		Username:  e.Username,
+		UserID:    e.UserID,
+		IP:        e.IP,
+		Path:      e.Path,
+	}
+	if e.Metadata != "" {
+		var m map[string]any
+		if err := json.Unmarshal([]byte(e.Metadata), &m); err == nil {
+			r.Metadata = m
+		}
+	}
+	return r
+}
+
+// parseSinceParam converts a "since" query parameter to a time.Time.
+// Accepts presets ("1h", "24h", "7d", "30d", "all") or an RFC3339 timestamp.
+// Returns the zero time when "all" or empty.
+func parseSinceParam(raw string) time.Time {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "", "all":
+		return time.Time{}
+	case "1h":
+		return time.Now().Add(-1 * time.Hour)
+	case "24h", "1d":
+		return time.Now().Add(-24 * time.Hour)
+	case "7d":
+		return time.Now().Add(-7 * 24 * time.Hour)
+	case "30d":
+		return time.Now().Add(-30 * 24 * time.Hour)
+	}
+	if t, err := time.Parse(time.RFC3339, raw); err == nil {
+		return t
+	}
+	return time.Time{}
+}
+
+// ListSecurityEvents returns a paginated, filterable list of security events.
+//
+// Query parameters:
+//
+//	page       — 1-based page number, default 1
+//	pageSize   — rows per page, default 50, max 200
+//	eventType  — repeatable; restricts to one or more event types
+//	username   — case-insensitive substring match on username
+//	ip         — prefix match on the IP field
+//	since      — preset (1h, 24h, 7d, 30d, all) or RFC3339 timestamp
+func (h *SecurityEventHandler) ListSecurityEvents(c *gin.Context) {
+	page, _ := strconv.Atoi(c.DefaultQuery("page", "1"))
+	if page < 1 {
+		page = 1
+	}
+	pageSize, _ := strconv.Atoi(c.DefaultQuery("pageSize", "50"))
+	if pageSize < 1 {
+		pageSize = 50
+	}
+	if pageSize > 200 {
+		pageSize = 200
+	}
+
+	q := h.DB.Model(&db.SecurityEvent{})
+
+	if types := c.QueryArray("eventType"); len(types) > 0 {
+		q = q.Where("event_type IN ?", types)
+	}
+	if username := strings.TrimSpace(c.Query("username")); username != "" {
+		// Filter uses the denormalized username_lower column so SQLite can
+		// serve the query from an index. See SecurityEvent.UsernameLower for
+		// why this exists.
+		q = q.Where("username_lower LIKE ?", "%"+strings.ToLower(username)+"%")
+	}
+	if ip := strings.TrimSpace(c.Query("ip")); ip != "" {
+		q = q.Where("ip LIKE ?", ip+"%")
+	}
+	if since := parseSinceParam(c.Query("since")); !since.IsZero() {
+		q = q.Where("created_at >= ?", since)
+	}
+
+	var total int64
+	if err := q.Count(&total).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to count security events"})
+		return
+	}
+
+	var rows []db.SecurityEvent
+	if err := q.Order("created_at DESC").
+		Limit(pageSize).
+		Offset((page - 1) * pageSize).
+		Find(&rows).Error; err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to query security events"})
+		return
+	}
+
+	out := make([]SecurityEventResponse, 0, len(rows))
+	for _, e := range rows {
+		out = append(out, toSecurityEventResponse(e))
+	}
+	c.JSON(http.StatusOK, SecurityEventsListResponse{
+		Data:     out,
+		Total:    total,
+		Page:     page,
+		PageSize: pageSize,
+	})
+}
+
+// GetSecurityEvent returns a single security event by ID.
+func (h *SecurityEventHandler) GetSecurityEvent(c *gin.Context) {
+	id, err := strconv.ParseUint(c.Param("id"), 10, 64)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid id"})
+		return
+	}
+	var e db.SecurityEvent
+	if err := h.DB.First(&e, id).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "security event not found"})
+			return
+		}
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to load security event"})
+		return
+	}
+	c.JSON(http.StatusOK, toSecurityEventResponse(e))
+}
+
+// SecurityEventTypesResponse lists every event type the server may emit
+// so the UI can render filter chips without hardcoding the catalog.
+type SecurityEventTypesResponse struct {
+	Types []string `json:"types"`
+}
+
+// GetSecurityEventTypes returns the catalog of known event types.
+func (h *SecurityEventHandler) GetSecurityEventTypes(c *gin.Context) {
+	c.JSON(http.StatusOK, SecurityEventTypesResponse{
+		Types: []string{
+			db.SecurityEventLoginSuccess,
+			db.SecurityEventLoginFailed,
+			db.SecurityEventLoginLocked,
+			db.SecurityEventLoginBlocked,
+			db.SecurityEventAccountLocked,
+			db.SecurityEventRevokedTokenUsed,
+			db.SecurityEventDisabledAccountToken,
+			db.SecurityEventTokenUserMissing,
+			db.SecurityEventStaleTokenVersion,
+		},
+	})
+}

--- a/server/internal/api/security_event_handler_test.go
+++ b/server/internal/api/security_event_handler_test.go
@@ -1,0 +1,437 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// makeSecurityEvent is a test helper that mirrors the recorder's behavior of
+// denormalizing the lowercase username so unit tests exercising the filter
+// path go through the same index.
+func makeSecurityEvent(e db.SecurityEvent) db.SecurityEvent {
+	e.UsernameLower = strings.ToLower(e.Username)
+	return e
+}
+
+// seedSecurityEvents inserts a known set of security events for filtering tests.
+// CreatedAt is set explicitly so the test can assert the "since" filter behavior
+// without depending on row insertion order.
+func seedSecurityEvents(t *testing.T, database *gorm.DB) {
+	t.Helper()
+	now := time.Now()
+	rows := []db.SecurityEvent{
+		makeSecurityEvent(db.SecurityEvent{EventType: db.SecurityEventLoginFailed, Reason: "bad_password", Username: "alice", IP: "10.0.0.1", CreatedAt: now.Add(-30 * time.Minute)}),
+		makeSecurityEvent(db.SecurityEvent{EventType: db.SecurityEventLoginFailed, Reason: "bad_password", Username: "alice", IP: "10.0.0.1", CreatedAt: now.Add(-25 * time.Minute)}),
+		makeSecurityEvent(db.SecurityEvent{EventType: db.SecurityEventAccountLocked, Username: "alice", IP: "10.0.0.1", CreatedAt: now.Add(-20 * time.Minute)}),
+		makeSecurityEvent(db.SecurityEvent{EventType: db.SecurityEventLoginSuccess, Username: "bob", IP: "10.0.0.2", CreatedAt: now.Add(-2 * time.Hour)}),
+		makeSecurityEvent(db.SecurityEvent{EventType: db.SecurityEventRevokedTokenUsed, Username: "carol", IP: "192.168.1.5", CreatedAt: now.Add(-10 * 24 * time.Hour)}),
+	}
+	for i := range rows {
+		require.NoError(t, database.Create(&rows[i]).Error)
+	}
+}
+
+func TestListSecurityEvents_RequiresAdmin(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	req := httptest.NewRequest("GET", "/api/admin/security-events", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+func TestListSecurityEvents_ReturnsAllByDefault(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+	seedSecurityEvents(t, database)
+
+	req := httptest.NewRequest("GET", "/api/admin/security-events", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp SecurityEventsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(5), resp.Total)
+	assert.Equal(t, 1, resp.Page)
+	assert.Equal(t, 50, resp.PageSize)
+	// Newest first.
+	for i := 1; i < len(resp.Data); i++ {
+		assert.False(t, resp.Data[i].CreatedAt.After(resp.Data[i-1].CreatedAt))
+	}
+}
+
+func TestListSecurityEvents_FilterByEventType(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+	seedSecurityEvents(t, database)
+
+	req := httptest.NewRequest("GET", "/api/admin/security-events?eventType=login_failed", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp SecurityEventsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(2), resp.Total)
+	for _, e := range resp.Data {
+		assert.Equal(t, db.SecurityEventLoginFailed, e.EventType)
+	}
+}
+
+func TestListSecurityEvents_FilterByMultipleEventTypes(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+	seedSecurityEvents(t, database)
+
+	req := httptest.NewRequest("GET", "/api/admin/security-events?eventType=login_failed&eventType=account_locked", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp SecurityEventsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(3), resp.Total)
+}
+
+func TestListSecurityEvents_FilterByUsername(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+	seedSecurityEvents(t, database)
+
+	req := httptest.NewRequest("GET", "/api/admin/security-events?username=alice", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp SecurityEventsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(3), resp.Total)
+	for _, e := range resp.Data {
+		assert.Equal(t, "alice", e.Username)
+	}
+}
+
+func TestListSecurityEvents_FilterByUsernameSubstringCaseInsensitive(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+	seedSecurityEvents(t, database)
+
+	req := httptest.NewRequest("GET", "/api/admin/security-events?username=AL", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp SecurityEventsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(3), resp.Total)
+}
+
+func TestListSecurityEvents_FilterByIPPrefix(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+	seedSecurityEvents(t, database)
+
+	req := httptest.NewRequest("GET", "/api/admin/security-events?ip=10.0.0.", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp SecurityEventsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(4), resp.Total)
+}
+
+func TestListSecurityEvents_FilterBySincePreset(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+	seedSecurityEvents(t, database)
+
+	// Last hour: only the alice rows. carol (10d ago) and bob (2h ago) excluded.
+	req := httptest.NewRequest("GET", "/api/admin/security-events?since=1h", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp SecurityEventsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, int64(3), resp.Total)
+}
+
+func TestListSecurityEvents_Pagination(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+	seedSecurityEvents(t, database)
+
+	req := httptest.NewRequest("GET", "/api/admin/security-events?pageSize=2&page=1", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp SecurityEventsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Len(t, resp.Data, 2)
+	assert.Equal(t, 2, resp.PageSize)
+	assert.GreaterOrEqual(t, resp.Total, int64(5))
+}
+
+func TestGetSecurityEvent_ReturnsRow(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+
+	row := db.SecurityEvent{
+		EventType: db.SecurityEventLoginFailed,
+		Reason:    "bad_password",
+		Username:  "dave",
+		IP:        "1.2.3.4",
+		Path:      "/api/auth/login",
+		Metadata:  `{"failedCount":3}`,
+	}
+	require.NoError(t, database.Create(&row).Error)
+
+	req := httptest.NewRequest("GET", "/api/admin/security-events/"+strconv.FormatUint(uint64(row.ID), 10), nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp SecurityEventResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Equal(t, row.ID, resp.ID)
+	assert.Equal(t, "bad_password", resp.Reason)
+	assert.Equal(t, "dave", resp.Username)
+	require.NotNil(t, resp.Metadata)
+	assert.EqualValues(t, 3, resp.Metadata["failedCount"])
+}
+
+func TestGetSecurityEvent_NotFound(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, cfg.DB)
+
+	req := httptest.NewRequest("GET", "/api/admin/security-events/99999", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+func TestGetSecurityEventTypes(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+
+	req := httptest.NewRequest("GET", "/api/admin/security-events/types", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	require.Equal(t, http.StatusOK, w.Code)
+	var resp SecurityEventTypesResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Contains(t, resp.Types, db.SecurityEventLoginFailed)
+	assert.Contains(t, resp.Types, db.SecurityEventLoginSuccess)
+	assert.Contains(t, resp.Types, db.SecurityEventAccountLocked)
+}
+
+func TestParseSinceParam(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		isZero  bool
+		// approxDelta is compared against time.Since(result) for preset cases.
+		approx time.Duration
+	}{
+		{name: "empty", input: "", isZero: true},
+		{name: "all", input: "all", isZero: true},
+		{name: "ALL upper", input: "ALL", isZero: true},
+		{name: "garbage", input: "not-a-time", isZero: true},
+		{name: "1h", input: "1h", isZero: false, approx: time.Hour},
+		{name: "24h", input: "24h", isZero: false, approx: 24 * time.Hour},
+		{name: "1d alias", input: "1d", isZero: false, approx: 24 * time.Hour},
+		{name: "7d", input: "7d", isZero: false, approx: 7 * 24 * time.Hour},
+		{name: "30d", input: "30d", isZero: false, approx: 30 * 24 * time.Hour},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseSinceParam(tc.input)
+			if tc.isZero {
+				assert.True(t, got.IsZero(), "expected zero time, got %v", got)
+				return
+			}
+			diff := time.Since(got)
+			// Allow 1s slack for test jitter.
+			assert.InDelta(t, tc.approx.Seconds(), diff.Seconds(), 1.0)
+		})
+	}
+
+	t.Run("RFC3339 timestamp", func(t *testing.T) {
+		iso := "2026-03-15T10:00:00Z"
+		got := parseSinceParam(iso)
+		assert.False(t, got.IsZero())
+		expected, _ := time.Parse(time.RFC3339, iso)
+		assert.True(t, got.Equal(expected))
+	})
+
+	t.Run("case-insensitive presets with whitespace", func(t *testing.T) {
+		got := parseSinceParam("  24h  ")
+		assert.False(t, got.IsZero())
+	})
+}
+
+func TestPruneExpiredSecurityEvents(t *testing.T) {
+	database, _ := setupTestEnv(t)
+
+	// Fresh row (keep) + old row (delete).
+	fresh := db.SecurityEvent{
+		EventType: db.SecurityEventLoginFailed,
+		Username:  "alice",
+		CreatedAt: time.Now().Add(-1 * time.Hour),
+	}
+	old := db.SecurityEvent{
+		EventType: db.SecurityEventLoginFailed,
+		Username:  "bob",
+		CreatedAt: time.Now().Add(-100 * 24 * time.Hour),
+	}
+	require.NoError(t, database.Create(&fresh).Error)
+	require.NoError(t, database.Create(&old).Error)
+
+	pruned := pruneExpiredSecurityEvents(database)
+	assert.Equal(t, int64(1), pruned)
+
+	var remaining []db.SecurityEvent
+	require.NoError(t, database.Find(&remaining).Error)
+	require.Len(t, remaining, 1)
+	assert.Equal(t, "alice", remaining[0].Username)
+}
+
+func TestSecurityEventDedup_SuppressesRepeats(t *testing.T) {
+	database, _ := setupTestEnv(t)
+
+	// Reset global dedup state so tests don't interfere with each other.
+	globalSecurityEventDedup.mu.Lock()
+	globalSecurityEventDedup.lastSeen = make(map[dedupKey]time.Time)
+	globalSecurityEventDedup.mu.Unlock()
+
+	// A dedup-eligible event (revoked_token_used) hit 5 times in a row from
+	// the same IP should only produce a single DB row.
+	uid := uint(42)
+	for i := 0; i < 5; i++ {
+		recordSecurityEvent(database, securityEventInput{
+			EventType: db.SecurityEventRevokedTokenUsed,
+			Username:  "attacker",
+			UserID:    &uid,
+			IP:        "203.0.113.7",
+		})
+	}
+	var count int64
+	database.Model(&db.SecurityEvent{}).
+		Where("event_type = ?", db.SecurityEventRevokedTokenUsed).
+		Count(&count)
+	assert.Equal(t, int64(1), count)
+}
+
+func TestSecurityEventDedup_LoginEventsNotDeduped(t *testing.T) {
+	database, _ := setupTestEnv(t)
+
+	// Reset global dedup state.
+	globalSecurityEventDedup.mu.Lock()
+	globalSecurityEventDedup.lastSeen = make(map[dedupKey]time.Time)
+	globalSecurityEventDedup.mu.Unlock()
+
+	// login_failed should NOT be deduped — each attempt is independently
+	// meaningful for admins.
+	for i := 0; i < 3; i++ {
+		recordSecurityEvent(database, securityEventInput{
+			EventType: db.SecurityEventLoginFailed,
+			Reason:    "bad_password",
+			Username:  "alice",
+			IP:        "10.0.0.1",
+		})
+	}
+	var count int64
+	database.Model(&db.SecurityEvent{}).
+		Where("event_type = ?", db.SecurityEventLoginFailed).
+		Count(&count)
+	assert.Equal(t, int64(3), count)
+}
+
+// Failed-login flow integration test: hitting /api/auth/login with bad creds
+// must persist a security event the admin can then query.
+func TestLoginFailureRecordsSecurityEvent(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
+
+	// Create a non-admin user to fail-login against.
+	user := db.User{
+		Username:     "victim",
+		Email:        "victim@test.com",
+		PasswordHash: "$2a$10$AAAAAAAAAAAAAAAAAAAAAOYL5eXPeq3xFV2DdRbHeBwM8tCKZWfQO", // dummy
+		Role:         "user",
+	}
+	require.NoError(t, database.Create(&user).Error)
+
+	body := `{"username":"victim","password":"wrongpass"}`
+	req := httptest.NewRequest("POST", "/api/auth/login", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusUnauthorized, w.Code)
+
+	// Now query the security log as admin and verify the event is present.
+	req = httptest.NewRequest("GET", "/api/admin/security-events?username=victim", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	w = httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var resp SecurityEventsListResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	require.Equal(t, int64(1), resp.Total)
+	assert.Equal(t, db.SecurityEventLoginFailed, resp.Data[0].EventType)
+	assert.Equal(t, "bad_password", resp.Data[0].Reason)
+}

--- a/server/internal/api/security_event_recorder.go
+++ b/server/internal/api/security_event_recorder.go
@@ -1,0 +1,180 @@
+package api
+
+import (
+	"encoding/json"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// securityEventInput is the parameter bag for RecordSecurityEvent. Username,
+// userID, ip, and metadata are all optional — only EventType is required.
+type securityEventInput struct {
+	EventType string
+	Reason    string
+	Username  string
+	UserID    *uint
+	IP        string
+	Path      string
+	Metadata  map[string]any
+}
+
+// --- Middleware write amplification guard ----------------------------------
+//
+// AuthMiddleware writes a SecurityEvent row on every failed auth check
+// (revoked token, disabled account, stale token version, missing user). A
+// malicious client replaying a revoked token in a tight loop would otherwise
+// turn each request into a synchronous INSERT on the hot path.
+//
+// securityEventDedup collapses identical events from the same (type, ip, user)
+// tuple within a short window, logging only the first occurrence and
+// incrementing an in-memory counter for the suppressed ones. The first event
+// after a flood still lands in the database; the rest are dropped until the
+// window elapses. The slog mirror is always emitted so log-tailing is
+// unaffected.
+
+const securityEventDedupWindow = 60 * time.Second
+
+type dedupKey struct {
+	eventType string
+	ip        string
+	userID    uint
+	reason    string
+}
+
+type securityEventDedup struct {
+	mu      sync.Mutex
+	lastSeen map[dedupKey]time.Time
+}
+
+var globalSecurityEventDedup = &securityEventDedup{
+	lastSeen: make(map[dedupKey]time.Time),
+}
+
+// shouldRecord returns true if the event should be written to the database.
+// It also opportunistically prunes expired entries to keep the map bounded.
+func (d *securityEventDedup) shouldRecord(in securityEventInput) bool {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+
+	key := dedupKey{eventType: in.EventType, ip: in.IP, reason: in.Reason}
+	if in.UserID != nil {
+		key.userID = *in.UserID
+	}
+
+	now := time.Now()
+	if last, ok := d.lastSeen[key]; ok && now.Sub(last) < securityEventDedupWindow {
+		return false
+	}
+	d.lastSeen[key] = now
+
+	// Cheap GC: every call, if the map has grown past a threshold, drop
+	// expired entries. Keeps the map roughly bounded under attack without
+	// a background goroutine.
+	if len(d.lastSeen) > 1024 {
+		cutoff := now.Add(-securityEventDedupWindow)
+		for k, t := range d.lastSeen {
+			if t.Before(cutoff) {
+				delete(d.lastSeen, k)
+			}
+		}
+	}
+	return true
+}
+
+// eventTypeShouldDedup decides which events are dedup candidates. Login
+// activity (success + failed + locked account access) is always recorded
+// because each attempt is independently meaningful for an admin. Middleware-
+// originated anomalies (revoked token replay, disabled-account-token,
+// stale-version) get the dedup treatment because they can flood under attack.
+func eventTypeShouldDedup(eventType string) bool {
+	switch eventType {
+	case db.SecurityEventRevokedTokenUsed,
+		db.SecurityEventDisabledAccountToken,
+		db.SecurityEventTokenUserMissing,
+		db.SecurityEventStaleTokenVersion:
+		return true
+	}
+	return false
+}
+
+// recordSecurityEvent persists a security event row and emits a structured
+// slog warning on the same call site. Best-effort: a DB failure is logged
+// but never blocks the surrounding auth flow, since refusing to authenticate
+// over an audit-write failure would be a self-inflicted denial of service.
+func recordSecurityEvent(database *gorm.DB, in securityEventInput) {
+	// Always mirror to slog, even when we drop the DB write, so log-tailing
+	// workflows still see the burst.
+	logEvent(in)
+
+	if eventTypeShouldDedup(in.EventType) && !globalSecurityEventDedup.shouldRecord(in) {
+		return
+	}
+
+	var metaJSON string
+	if len(in.Metadata) > 0 {
+		if b, err := json.Marshal(in.Metadata); err == nil {
+			metaJSON = string(b)
+		}
+	}
+
+	row := db.SecurityEvent{
+		EventType:     in.EventType,
+		Reason:        in.Reason,
+		Username:      in.Username,
+		UsernameLower: strings.ToLower(in.Username),
+		UserID:        in.UserID,
+		IP:            in.IP,
+		Path:          in.Path,
+		Metadata:      metaJSON,
+	}
+	if err := database.Create(&row).Error; err != nil {
+		slog.Warn("failed to persist security event",
+			"event", in.EventType,
+			"error", err,
+		)
+	}
+}
+
+func logEvent(in securityEventInput) {
+	logArgs := []any{
+		"event", in.EventType,
+		"username", in.Username,
+		"ip", in.IP,
+	}
+	if in.Reason != "" {
+		logArgs = append(logArgs, "reason", in.Reason)
+	}
+	if in.UserID != nil {
+		logArgs = append(logArgs, "userId", *in.UserID)
+	}
+	if in.Path != "" {
+		logArgs = append(logArgs, "path", in.Path)
+	}
+	for k, v := range in.Metadata {
+		logArgs = append(logArgs, k, v)
+	}
+	if in.EventType == db.SecurityEventLoginSuccess {
+		slog.Info("security: "+in.EventType, logArgs...)
+	} else {
+		slog.Warn("security: "+in.EventType, logArgs...)
+	}
+}
+
+// recordSecurityEventCtx is a thin convenience wrapper that extracts the
+// client IP and request path from a gin.Context. Handlers should prefer this
+// when they have the context in scope.
+func recordSecurityEventCtx(database *gorm.DB, c *gin.Context, in securityEventInput) {
+	if in.IP == "" {
+		in.IP = c.ClientIP()
+	}
+	if in.Path == "" && c.Request != nil && c.Request.URL != nil {
+		in.Path = c.Request.URL.Path
+	}
+	recordSecurityEvent(database, in)
+}

--- a/server/internal/api/test_handler.go
+++ b/server/internal/api/test_handler.go
@@ -74,6 +74,7 @@ func (h *TestHandler) Reset(c *gin.Context) {
 		tx.Unscoped().Where("1 = 1").Delete(&db.RefreshToken{})
 		tx.Unscoped().Where("1 = 1").Delete(&db.TokenBlacklist{})
 		tx.Unscoped().Where("1 = 1").Delete(&db.LoginAttempt{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.SecurityEvent{})
 
 		// 10. Staged uploads
 		tx.Unscoped().Where("1 = 1").Delete(&db.StagedUpload{})

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -151,6 +151,7 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&SimilarGame{},
 		&LoginAttempt{},
 		&TokenBlacklist{},
+		&SecurityEvent{},
 		&CheatCode{},
 		&GameSession{},
 		&SessionSaveState{},

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -274,6 +274,51 @@ type TokenBlacklist struct {
 	ExpiresAt time.Time `gorm:"not null;index"`
 }
 
+// Security event types. Keep in sync with the slog event= discriminators
+// emitted by auth_handler.go and middleware.go.
+const (
+	SecurityEventLoginSuccess         = "login_success"
+	SecurityEventLoginFailed          = "login_failed"
+	SecurityEventLoginLocked          = "login_locked"
+	SecurityEventLoginBlocked         = "login_blocked"
+	SecurityEventAccountLocked        = "account_locked"
+	SecurityEventRevokedTokenUsed     = "revoked_token_used"
+	SecurityEventDisabledAccountToken = "disabled_account_token"
+	SecurityEventTokenUserMissing     = "token_user_missing"
+	SecurityEventStaleTokenVersion    = "stale_token_version"
+)
+
+// SecurityEvent records an admin-only audit entry for an authentication or
+// session-related event. These rows back the /admin/security-events page so
+// admins can investigate suspicious activity without tailing container logs.
+//
+// Unlike LoginAttempt (which stores a SHA-256 hash of the username for lockout
+// counters), SecurityEvent deliberately stores the raw username — admins need
+// to read it to investigate incidents, and the table has a short retention
+// window (see securityEventRetention in auth_handler.go) to limit exposure.
+//
+// Username is stored as a free-form string (not a foreign key) so events
+// referencing deleted or never-existed accounts are still useful. UserID is
+// optional for the same reason. Metadata is a JSON blob for any extra
+// per-event-type fields (failedCount, lockedUntil, etc.).
+//
+// UsernameLower is a denormalized lowercased copy of Username, used by the
+// case-insensitive filter query so an index lookup can be used instead of a
+// `LOWER(username) LIKE ?` table scan (SQLite has no functional indexes).
+// It is populated automatically by the recorder on every write.
+type SecurityEvent struct {
+	ID            uint      `gorm:"primarykey"`
+	CreatedAt     time.Time `gorm:"index;not null"`
+	EventType     string    `gorm:"size:64;not null;index"`
+	Reason        string    `gorm:"size:64;index"`
+	Username      string    `gorm:"size:128;index"`
+	UsernameLower string    `gorm:"size:128;index"`
+	UserID        *uint     `gorm:"index"`
+	IP            string    `gorm:"size:64;index"`
+	Path          string    `gorm:"size:256"`
+	Metadata      string    `gorm:"type:text"`
+}
+
 // ServerSetting stores key-value server configuration.
 type ServerSetting struct {
 	Key   string `gorm:"primarykey;size:128" json:"key"`

--- a/web/e2e/admin-security-events.spec.ts
+++ b/web/e2e/admin-security-events.spec.ts
@@ -1,0 +1,154 @@
+import { test, expect } from "./fixtures";
+
+test.describe("Admin Security Events Page", () => {
+  test("displays heading and description", async ({ page }) => {
+    await page.route("**/api/admin/security-events*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [], total: 0, page: 1, pageSize: 50 }),
+      });
+    });
+
+    await page.goto("/admin/security-events");
+
+    await expect(
+      page.getByRole("heading", { name: /Security Events/ }),
+    ).toBeVisible();
+    await expect(
+      page.getByText(/Audit log of authentication events/),
+    ).toBeVisible();
+  });
+
+  test("renders events from the API", async ({ page }) => {
+    await page.route("**/api/admin/security-events*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: [
+            {
+              id: 1,
+              createdAt: "2026-04-10T09:00:00Z",
+              eventType: "login_failed",
+              reason: "bad_password",
+              username: "alice",
+              ip: "10.0.0.1",
+              metadata: { failedCount: 3 },
+            },
+            {
+              id: 2,
+              createdAt: "2026-04-10T08:55:00Z",
+              eventType: "account_locked",
+              username: "alice",
+              ip: "10.0.0.1",
+            },
+          ],
+          total: 2,
+          page: 1,
+          pageSize: 50,
+        }),
+      });
+    });
+
+    await page.goto("/admin/security-events");
+
+    await expect(page.getByText("2 events")).toBeVisible();
+    // alice appears in both rows.
+    await expect(page.getByText("alice").first()).toBeVisible();
+    await expect(page.getByText("10.0.0.1").first()).toBeVisible();
+  });
+
+  test("shows empty state when no events match", async ({ page }) => {
+    await page.route("**/api/admin/security-events*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [], total: 0, page: 1, pageSize: 50 }),
+      });
+    });
+
+    await page.goto("/admin/security-events");
+
+    await expect(page.getByText("No security events")).toBeVisible();
+  });
+
+  test("filter chip updates URL query string", async ({ page }) => {
+    await page.route("**/api/admin/security-events*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ data: [], total: 0, page: 1, pageSize: 50 }),
+      });
+    });
+
+    await page.goto("/admin/security-events");
+
+    // Filter chips have role=button.
+    await page
+      .getByRole("button", { name: "Login failed" })
+      .first()
+      .click();
+
+    await expect(page).toHaveURL(/eventType=login_failed/);
+  });
+
+  test("clicking a row opens the detail modal", async ({ page }) => {
+    await page.route("**/api/admin/security-events*", (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({
+          data: [
+            {
+              id: 42,
+              createdAt: "2026-04-10T09:00:00Z",
+              eventType: "login_failed",
+              reason: "bad_password",
+              username: "victim",
+              ip: "10.0.0.99",
+              path: "/api/auth/login",
+              metadata: { failedCount: 4 },
+            },
+          ],
+          total: 1,
+          page: 1,
+          pageSize: 50,
+        }),
+      });
+    });
+
+    await page.goto("/admin/security-events");
+
+    // Click the row (the username cell is in the data row, not the header).
+    await page.getByRole("row").nth(1).click();
+
+    await expect(page.getByRole("dialog")).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Security event" }),
+    ).toBeVisible();
+    // Metadata block with the JSON payload.
+    await expect(page.getByText(/failedCount/).first()).toBeVisible();
+    await expect(page.getByText("/api/auth/login")).toBeVisible();
+  });
+
+  test("non-admin user cannot access the page", async ({ browser }) => {
+    // Use a fresh context without the admin auth storage.
+    const context = await browser.newContext({ storageState: undefined });
+    const page = await context.newPage();
+    await page.goto("/admin/security-events");
+    // Should be redirected to login, not render the page.
+    await expect(
+      page.getByRole("heading", { name: /Security Events/ }),
+    ).not.toBeVisible({ timeout: 2_000 });
+    await context.close();
+  });
+
+  test("admin nav link is visible in sidebar", async ({ page }) => {
+    await page.goto("/admin/security-events");
+    // The nav link renders in the sidebar as a link with the label text.
+    await expect(
+      page.getByRole("link", { name: /Security Events/ }).first(),
+    ).toBeVisible();
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -22,6 +22,7 @@ import { MetadataFixPage } from "@/pages/admin/metadata-fix-page";
 import { AdminCheatsPage } from "@/pages/admin/cheats-page";
 import { AdminBiosPage } from "@/pages/admin/bios-page";
 import { CoreCompatibilityPage } from "@/pages/admin/core-compatibility-page";
+import { AdminSecurityEventsPage } from "@/pages/admin/security-events-page";
 import { UploadRomsPage } from "@/pages/admin/upload-roms-page";
 import { RomHacksPage } from "@/pages/admin/rom-hacks-page";
 import { PreferencesPage } from "@/pages/preferences-page";
@@ -253,6 +254,14 @@ export function App() {
                       element={
                         <ProtectedRoute requireAdmin>
                           <CoreCompatibilityPage />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="admin/security-events"
+                      element={
+                        <ProtectedRoute requireAdmin>
+                          <AdminSecurityEventsPage />
                         </ProtectedRoute>
                       }
                     />

--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -22,6 +22,7 @@ import {
   Gamepad2,
   GitCompareArrows,
   Puzzle,
+  ShieldAlert,
 } from "lucide-react";
 import { Sidebar } from "@/components/ui";
 import { useAuth } from "@/hooks/use-auth";
@@ -136,6 +137,11 @@ export function AppLayout() {
                 to: "/admin/core-compatibility",
                 icon: GitCompareArrows,
                 label: "Core Compatibility",
+              },
+              {
+                to: "/admin/security-events",
+                icon: ShieldAlert,
+                label: "Security Events",
               },
             ],
           },

--- a/web/src/features/admin/components/security-event-badge.tsx
+++ b/web/src/features/admin/components/security-event-badge.tsx
@@ -1,0 +1,101 @@
+import {
+  CheckCircle,
+  XCircle,
+  Lock,
+  ShieldOff,
+  AlertTriangle,
+  UserX,
+  KeyRound,
+  type LucideIcon,
+} from "lucide-react";
+import { Badge } from "@/components/ui";
+import type { SecurityEventType } from "@/types/api";
+
+type Variant = "default" | "brand" | "success" | "warning" | "danger";
+
+interface EventMeta {
+  label: string;
+  variant: Variant;
+  icon: LucideIcon;
+  /** Severity for sorting filter chips and visually weighting rows. */
+  severity: "info" | "notice" | "alert";
+}
+
+// Event type → presentation metadata. Keep the catalog in one place so the
+// filter chips and the row badge stay in sync.
+export const SECURITY_EVENT_META: Record<SecurityEventType, EventMeta> = {
+  login_success: {
+    label: "Login success",
+    variant: "success",
+    icon: CheckCircle,
+    severity: "info",
+  },
+  login_failed: {
+    label: "Login failed",
+    variant: "warning",
+    icon: XCircle,
+    severity: "notice",
+  },
+  login_locked: {
+    label: "Login on locked account",
+    variant: "warning",
+    icon: Lock,
+    severity: "notice",
+  },
+  login_blocked: {
+    label: "Login blocked",
+    variant: "warning",
+    icon: ShieldOff,
+    severity: "notice",
+  },
+  account_locked: {
+    label: "Account locked",
+    variant: "danger",
+    icon: Lock,
+    severity: "alert",
+  },
+  revoked_token_used: {
+    label: "Revoked token used",
+    variant: "danger",
+    icon: AlertTriangle,
+    severity: "alert",
+  },
+  disabled_account_token: {
+    label: "Disabled account token",
+    variant: "danger",
+    icon: UserX,
+    severity: "alert",
+  },
+  token_user_missing: {
+    label: "Token for missing user",
+    variant: "danger",
+    icon: UserX,
+    severity: "alert",
+  },
+  stale_token_version: {
+    label: "Stale token version",
+    variant: "warning",
+    icon: KeyRound,
+    severity: "notice",
+  },
+};
+
+interface SecurityEventBadgeProps {
+  type: SecurityEventType;
+}
+
+export function SecurityEventBadge({ type }: SecurityEventBadgeProps) {
+  const meta = SECURITY_EVENT_META[type] ?? {
+    label: type,
+    variant: "default" as Variant,
+    icon: AlertTriangle,
+    severity: "notice" as const,
+  };
+  const Icon = meta.icon;
+  return (
+    <Badge variant={meta.variant}>
+      <Icon className="h-3 w-3 mr-1" />
+      {meta.label}
+    </Badge>
+  );
+}

--- a/web/src/features/admin/components/security-event-detail-modal.tsx
+++ b/web/src/features/admin/components/security-event-detail-modal.tsx
@@ -1,0 +1,93 @@
+import { Modal } from "@/components/ui";
+import { cn } from "@/lib/cn";
+import { formatDateTime } from "@/lib/format";
+import {
+  SecurityEventBadge,
+  SECURITY_EVENT_META,
+} from "./security-event-badge";
+import type { SecurityEvent } from "@/types/api";
+
+interface SecurityEventDetailModalProps {
+  event: SecurityEvent | null;
+  onClose: () => void;
+}
+
+export function SecurityEventDetailModal({
+  event,
+  onClose,
+}: SecurityEventDetailModalProps) {
+  const title = event
+    ? (SECURITY_EVENT_META[event.eventType]?.label ?? "Security event")
+    : "Security event";
+
+  return (
+    <Modal open={event !== null} onClose={onClose} title={title} size="lg">
+      {event && (
+        <div className="space-y-4">
+          <div className="flex items-center gap-3">
+            <SecurityEventBadge type={event.eventType} />
+            {event.reason && (
+              <span className="text-xs text-surface-400">
+                reason: <span className="text-surface-300">{event.reason}</span>
+              </span>
+            )}
+          </div>
+
+          <DetailGrid>
+            <DetailRow
+              label="Time"
+              value={formatDateTime(event.createdAt)}
+              secondary={event.createdAt}
+            />
+            <DetailRow label="Event type" value={event.eventType} mono />
+            <DetailRow label="Username" value={event.username ?? "—"} />
+            <DetailRow
+              label="User ID"
+              value={event.userId?.toString() ?? "—"}
+            />
+            <DetailRow label="IP address" value={event.ip ?? "—"} mono />
+            <DetailRow label="Request path" value={event.path ?? "—"} mono />
+          </DetailGrid>
+
+          {event.metadata && Object.keys(event.metadata).length > 0 && (
+            <div>
+              <p className="mb-2 text-xs font-semibold uppercase tracking-wider text-surface-400">
+                Metadata
+              </p>
+              <pre className="max-h-64 overflow-auto rounded-xl border border-surface-800/50 bg-surface-950 px-4 py-3 text-xs text-surface-300">
+                {JSON.stringify(event.metadata, null, 2)}
+              </pre>
+            </div>
+          )}
+        </div>
+      )}
+    </Modal>
+  );
+}
+
+function DetailGrid({ children }: { children: React.ReactNode }) {
+  return <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">{children}</dl>;
+}
+
+interface DetailRowProps {
+  label: string;
+  value: string;
+  mono?: boolean;
+  secondary?: string;
+}
+
+function DetailRow({ label, value, mono, secondary }: DetailRowProps) {
+  return (
+    <div>
+      <dt className="text-xs font-medium uppercase tracking-wider text-surface-500">
+        {label}
+      </dt>
+      <dd className={cn("text-sm text-surface-200", mono && "font-mono tabular-nums")}>
+        {value}
+      </dd>
+      {secondary && (
+        <dd className="text-[11px] text-surface-500 font-mono">{secondary}</dd>
+      )}
+    </div>
+  );
+}

--- a/web/src/features/admin/components/security-events-filters.tsx
+++ b/web/src/features/admin/components/security-events-filters.tsx
@@ -1,0 +1,148 @@
+import { Search, X } from "lucide-react";
+import { Button, FilterChip, Input } from "@/components/ui";
+import { SECURITY_EVENT_META } from "./security-event-badge";
+import type { SecurityEventType } from "@/types/api";
+
+export type SinceOption = "1h" | "24h" | "7d" | "30d" | "all";
+
+// DEFAULT_SECURITY_EVENTS_SINCE is the preset applied on first load. Both the
+// page and the filters component reference this so "is the default active?"
+// checks never drift.
+export const DEFAULT_SECURITY_EVENTS_SINCE: SinceOption = "24h";
+
+const SINCE_LABELS: Record<SinceOption, string> = {
+  "1h": "Last hour",
+  "24h": "Last 24 hours",
+  "7d": "Last 7 days",
+  "30d": "Last 30 days",
+  all: "All time",
+};
+
+const SINCE_OPTIONS: SinceOption[] = ["1h", "24h", "7d", "30d", "all"];
+
+// Event types rendered as filter chips, ordered alert → notice → info so
+// the most urgent events are always at the front of the row.
+const EVENT_TYPE_ORDER: SecurityEventType[] = [
+  "account_locked",
+  "revoked_token_used",
+  "disabled_account_token",
+  "token_user_missing",
+  "login_failed",
+  "login_locked",
+  "login_blocked",
+  "stale_token_version",
+  "login_success",
+];
+
+interface SecurityEventsFiltersProps {
+  eventTypes: SecurityEventType[];
+  username: string;
+  ip: string;
+  since: SinceOption;
+  onEventTypesChange: (types: SecurityEventType[]) => void;
+  onUsernameChange: (v: string) => void;
+  onIpChange: (v: string) => void;
+  onSinceChange: (v: SinceOption) => void;
+  onClear: () => void;
+}
+
+export function SecurityEventsFilters({
+  eventTypes,
+  username,
+  ip,
+  since,
+  onEventTypesChange,
+  onUsernameChange,
+  onIpChange,
+  onSinceChange,
+  onClear,
+}: SecurityEventsFiltersProps) {
+  function toggleEventType(t: SecurityEventType) {
+    if (eventTypes.includes(t)) {
+      onEventTypesChange(eventTypes.filter((x) => x !== t));
+    } else {
+      onEventTypesChange([...eventTypes, t]);
+    }
+  }
+
+  const hasFilters =
+    eventTypes.length > 0 ||
+    username !== "" ||
+    ip !== "" ||
+    since !== DEFAULT_SECURITY_EVENTS_SINCE;
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-surface-800/50 bg-surface-900/50 p-5">
+      <div className="flex items-center justify-between">
+        <h2 className="text-sm font-semibold uppercase tracking-wider text-surface-400">
+          Filters
+        </h2>
+        {hasFilters && (
+          <Button variant="ghost" size="sm" onClick={onClear}>
+            <X className="h-3.5 w-3.5 mr-1" />
+            Clear
+          </Button>
+        )}
+      </div>
+
+      {/* Time range row — segmented buttons feel more like a toggle than a select. */}
+      <div className="flex flex-wrap gap-2">
+        {SINCE_OPTIONS.map((opt) => (
+          <FilterChip
+            key={opt}
+            label={SINCE_LABELS[opt]}
+            isSelected={since === opt}
+            onClick={() => onSinceChange(opt)}
+          />
+        ))}
+      </div>
+
+      {/* Username + IP search row */}
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <div className="relative">
+          <Search
+            aria-hidden="true"
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-500"
+          />
+          <Input
+            type="text"
+            placeholder="Username contains..."
+            value={username}
+            onChange={(e) => onUsernameChange(e.target.value)}
+            className="pl-9"
+            aria-label="Filter by username"
+          />
+        </div>
+        <div className="relative">
+          <Search
+            aria-hidden="true"
+            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-500"
+          />
+          <Input
+            type="text"
+            placeholder="IP starts with..."
+            value={ip}
+            onChange={(e) => onIpChange(e.target.value)}
+            className="pl-9"
+            aria-label="Filter by IP"
+          />
+        </div>
+      </div>
+
+      {/* Event type chips */}
+      <div>
+        <p className="mb-2 text-xs font-medium text-surface-500">Event type</p>
+        <div className="flex flex-wrap gap-2">
+          {EVENT_TYPE_ORDER.map((t) => (
+            <FilterChip
+              key={t}
+              label={SECURITY_EVENT_META[t].label}
+              isSelected={eventTypes.includes(t)}
+              onClick={() => toggleEventType(t)}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/web/src/features/admin/components/security-events-table.tsx
+++ b/web/src/features/admin/components/security-events-table.tsx
@@ -1,0 +1,167 @@
+import { ShieldAlert } from "lucide-react";
+import {
+  EmptyState,
+  Section,
+  TableRowSkeleton,
+} from "@/components/ui";
+import { formatDateTime } from "@/lib/format";
+import { cn } from "@/lib/cn";
+import { SecurityEventBadge, SECURITY_EVENT_META } from "./security-event-badge";
+import type { SecurityEvent } from "@/types/api";
+
+interface SecurityEventsTableProps {
+  events: SecurityEvent[] | undefined;
+  isLoading: boolean;
+  onRowClick: (event: SecurityEvent) => void;
+}
+
+export function SecurityEventsTable({
+  events,
+  isLoading,
+  onRowClick,
+}: SecurityEventsTableProps) {
+  return (
+    <Section>
+      <div className="overflow-x-auto">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-surface-800">
+              <th
+                scope="col"
+                className="text-left px-5 py-3 text-xs font-semibold uppercase tracking-wider text-surface-400"
+              >
+                Time
+              </th>
+              <th
+                scope="col"
+                className="text-left px-5 py-3 text-xs font-semibold uppercase tracking-wider text-surface-400"
+              >
+                Event
+              </th>
+              <th
+                scope="col"
+                className="text-left px-5 py-3 text-xs font-semibold uppercase tracking-wider text-surface-400"
+              >
+                Username
+              </th>
+              <th
+                scope="col"
+                className="text-left px-5 py-3 text-xs font-semibold uppercase tracking-wider text-surface-400"
+              >
+                IP
+              </th>
+              <th
+                scope="col"
+                className="text-left px-5 py-3 text-xs font-semibold uppercase tracking-wider text-surface-400"
+              >
+                Details
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {isLoading ? (
+              Array.from({ length: 5 }, (_, i) => (
+                <TableRowSkeleton key={i} columns={5} />
+              ))
+            ) : !events || events.length === 0 ? (
+              <tr>
+                <td colSpan={5}>
+                  <EmptyState
+                    icon={ShieldAlert}
+                    title="No security events"
+                    description="No events match the current filters. Try broadening your time range or clearing filters."
+                  />
+                </td>
+              </tr>
+            ) : (
+              events.map((e) => {
+                const meta = SECURITY_EVENT_META[e.eventType];
+                const isAlert = meta?.severity === "alert";
+                // handleRowActivate opens the detail modal, but only when the
+                // click is not finishing a text-selection gesture. Admins
+                // routinely copy IPs, usernames, and timestamps out of rows to
+                // paste into tickets — swallowing selection on click would
+                // make that flow painful.
+                const handleRowActivate = () => {
+                  if (window.getSelection()?.toString()) return;
+                  onRowClick(e);
+                };
+                return (
+                  <tr
+                    key={e.id}
+                    data-comp="SecurityEventRow"
+                    onClick={handleRowActivate}
+                    className={cn(
+                      "border-b border-surface-800/50 cursor-pointer transition-colors hover:bg-surface-800/30",
+                      "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-brand-500",
+                      isAlert && "bg-danger-500/5",
+                    )}
+                    tabIndex={0}
+                    onKeyDown={(ev) => {
+                      if (ev.key === "Enter" || ev.key === " ") {
+                        ev.preventDefault();
+                        onRowClick(e);
+                      }
+                    }}
+                  >
+                    <td
+                      className="px-5 py-3 text-sm text-surface-300 whitespace-nowrap tabular-nums"
+                      title={e.createdAt}
+                    >
+                      {formatDateTime(e.createdAt)}
+                    </td>
+                    <td className="px-5 py-3">
+                      <SecurityEventBadge type={e.eventType} />
+                    </td>
+                    <td className="px-5 py-3 text-sm text-surface-200">
+                      {e.username || (
+                        <span className="text-surface-500">—</span>
+                      )}
+                    </td>
+                    <td className="px-5 py-3 text-sm text-surface-400 font-mono tabular-nums">
+                      {e.ip || <span className="text-surface-500">—</span>}
+                    </td>
+                    <td className="px-5 py-3 text-sm text-surface-400">
+                      {summarizeDetails(e)}
+                    </td>
+                  </tr>
+                );
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+    </Section>
+  );
+}
+
+// summarizeDetails picks the most useful fragment from the event to show
+// inline in the row, so admins can scan without opening every row.
+function summarizeDetails(e: SecurityEvent): string {
+  if (e.reason) return humanizeReason(e.reason);
+  if (e.metadata) {
+    if (typeof e.metadata.failedCount === "number") {
+      return `${e.metadata.failedCount} failed attempt${e.metadata.failedCount === 1 ? "" : "s"}`;
+    }
+    if (typeof e.metadata.lockedUntil === "string") {
+      return `Locked until ${formatDateTime(e.metadata.lockedUntil)}`;
+    }
+  }
+  if (e.path) return e.path;
+  return "";
+}
+
+function humanizeReason(reason: string): string {
+  switch (reason) {
+    case "bad_password":
+      return "Bad password";
+    case "unknown_user":
+      return "Unknown user";
+    case "disabled":
+      return "Disabled account";
+    case "pending_approval":
+      return "Pending approval";
+    default:
+      return reason;
+  }
+}

--- a/web/src/hooks/use-security-events.ts
+++ b/web/src/hooks/use-security-events.ts
@@ -27,12 +27,16 @@ function buildSecurityEventsQuery(filters: SecurityEventsListFilters): string {
 
 export function useSecurityEvents(filters: SecurityEventsListFilters) {
   const qs = buildSecurityEventsQuery(filters);
+  // Each branch narrows to a literal type ApiGetPath accepts. A single
+  // template literal like `/admin/security-events${qs ? `?${qs}` : ""}`
+  // widens to `/admin/security-events${string}`, which would match paths
+  // like `/admin/security-events-extra` and so is correctly rejected.
+  const path = qs
+    ? (`/admin/security-events?${qs}` as const)
+    : ("/admin/security-events" as const);
   return useQuery({
     queryKey: ["admin", "security-events", filters],
-    queryFn: () =>
-      api.get<SecurityEventsListResponse>(
-        `/admin/security-events${qs ? `?${qs}` : ""}` as const,
-      ),
+    queryFn: () => api.get<SecurityEventsListResponse>(path),
     // Poll every 60s so admins see new events without manual refresh.
     // Events are also mirrored to slog, so we don't need sub-minute latency
     // here — the page is for investigation, not live monitoring.
@@ -44,8 +48,10 @@ export function useSecurityEvents(filters: SecurityEventsListFilters) {
 export function useSecurityEvent(id: number | null) {
   return useQuery({
     queryKey: ["admin", "security-events", id],
-    queryFn: () =>
-      api.get<SecurityEvent>(`/admin/security-events/${id}` as const),
+    queryFn: () => {
+      const path = `/admin/security-events/${id}` as const;
+      return api.get<SecurityEvent>(path);
+    },
     enabled: id !== null,
   });
 }

--- a/web/src/hooks/use-security-events.ts
+++ b/web/src/hooks/use-security-events.ts
@@ -1,0 +1,62 @@
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api-client";
+import type {
+  SecurityEvent,
+  SecurityEventType,
+  SecurityEventsListFilters,
+  SecurityEventsListResponse,
+} from "@/types/api";
+
+// buildSecurityEventsQuery serializes the filter object into a URLSearchParams
+// instance. Empty/undefined fields are omitted so the query string stays
+// clean and shareable.
+function buildSecurityEventsQuery(filters: SecurityEventsListFilters): string {
+  const params = new URLSearchParams();
+  if (filters.page) params.set("page", String(filters.page));
+  if (filters.pageSize) params.set("pageSize", String(filters.pageSize));
+  if (filters.username) params.set("username", filters.username);
+  if (filters.ip) params.set("ip", filters.ip);
+  if (filters.since && filters.since !== "all") {
+    params.set("since", filters.since);
+  }
+  if (filters.eventType?.length) {
+    for (const t of filters.eventType) params.append("eventType", t);
+  }
+  return params.toString();
+}
+
+export function useSecurityEvents(filters: SecurityEventsListFilters) {
+  const qs = buildSecurityEventsQuery(filters);
+  return useQuery({
+    queryKey: ["admin", "security-events", filters],
+    queryFn: () =>
+      api.get<SecurityEventsListResponse>(
+        `/admin/security-events${qs ? `?${qs}` : ""}` as const,
+      ),
+    // Poll every 60s so admins see new events without manual refresh.
+    // Events are also mirrored to slog, so we don't need sub-minute latency
+    // here — the page is for investigation, not live monitoring.
+    refetchInterval: 60_000,
+    refetchOnWindowFocus: true,
+  });
+}
+
+export function useSecurityEvent(id: number | null) {
+  return useQuery({
+    queryKey: ["admin", "security-events", id],
+    queryFn: () =>
+      api.get<SecurityEvent>(`/admin/security-events/${id}` as const),
+    enabled: id !== null,
+  });
+}
+
+export function useSecurityEventTypes() {
+  return useQuery({
+    queryKey: ["admin", "security-events", "types"],
+    queryFn: () =>
+      api.get<{ types: SecurityEventType[] }>(
+        "/admin/security-events/types",
+      ),
+    staleTime: Infinity,
+  });
+}

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -223,6 +223,9 @@ export type ApiGetPath = WithQuery<
   | "/admin/uploads"
   | "/admin/uploads/writable"
   | "/admin/core-compatibility"
+  | "/admin/security-events"
+  | "/admin/security-events/types"
+  | `/admin/security-events/${string}`
 
   // WebSocket
   | "/ws"

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -21,6 +21,17 @@ export function formatDate(dateString: string): string {
   });
 }
 
+export function formatDateTime(dateString: string): string {
+  return new Date(dateString).toLocaleString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+  });
+}
+
 export function formatChallengeDuration(ms: number): string {
   const totalSeconds = ms / 1000;
   const minutes = Math.floor(totalSeconds / 60);

--- a/web/src/pages/admin/__tests__/security-events-page.test.tsx
+++ b/web/src/pages/admin/__tests__/security-events-page.test.tsx
@@ -1,0 +1,217 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { AdminSecurityEventsPage } from "../security-events-page";
+import type { SecurityEventsListResponse } from "@/types/api";
+
+vi.mock("@/hooks/use-security-events", () => ({
+  useSecurityEvents: vi.fn(),
+  useSecurityEvent: vi.fn(),
+  useSecurityEventTypes: vi.fn(() => ({ data: undefined })),
+}));
+
+import { useSecurityEvents } from "@/hooks/use-security-events";
+
+const mockUseSecurityEvents = useSecurityEvents as ReturnType<typeof vi.fn>;
+
+function renderPage(initialPath = "/admin/security-events") {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={[initialPath]}>
+        <AdminSecurityEventsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const sampleResponse: SecurityEventsListResponse = {
+  data: [
+    {
+      id: 1,
+      createdAt: "2026-04-10T09:00:00Z",
+      eventType: "login_failed",
+      reason: "bad_password",
+      username: "alice",
+      ip: "10.0.0.1",
+      metadata: { failedCount: 3 },
+    },
+    {
+      id: 2,
+      createdAt: "2026-04-10T08:55:00Z",
+      eventType: "account_locked",
+      username: "alice",
+      ip: "10.0.0.1",
+      metadata: { failedCount: 5, lockedUntil: "2026-04-10T09:10:00Z" },
+    },
+  ],
+  total: 2,
+  page: 1,
+  pageSize: 50,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseSecurityEvents.mockReturnValue({
+    data: sampleResponse,
+    isLoading: false,
+  });
+});
+
+describe("AdminSecurityEventsPage", () => {
+  it("renders heading and description", () => {
+    renderPage();
+    expect(
+      screen.getByRole("heading", { name: /Security Events/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Audit log of authentication events/),
+    ).toBeInTheDocument();
+  });
+
+  it("renders events in the table", () => {
+    renderPage();
+    expect(screen.getAllByText("alice")).toHaveLength(2);
+    expect(screen.getAllByText("10.0.0.1")).toHaveLength(2);
+    // "Login failed" and "Account locked" each appear twice: once as a filter
+    // chip and once as a row badge. Assert the badge count.
+    expect(screen.getAllByText("Login failed").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("Account locked").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("shows total count", () => {
+    renderPage();
+    expect(screen.getByText(/2 events/)).toBeInTheDocument();
+  });
+
+  it("shows loading state when isLoading is true", () => {
+    mockUseSecurityEvents.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+    });
+    renderPage();
+    // Skeletons rendered — there is no empty-state icon when loading.
+    expect(screen.queryByText("No security events")).not.toBeInTheDocument();
+  });
+
+  it("shows empty state when no events match", () => {
+    mockUseSecurityEvents.mockReturnValue({
+      data: { data: [], total: 0, page: 1, pageSize: 50 },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.getByText("No security events")).toBeInTheDocument();
+  });
+
+  it("uses 24h as default time range", () => {
+    renderPage();
+    expect(mockUseSecurityEvents).toHaveBeenCalledWith(
+      expect.objectContaining({ since: "24h" }),
+    );
+  });
+
+  it("reads filters from URL query params", () => {
+    renderPage(
+      "/admin/security-events?eventType=login_failed&username=alice&ip=10&since=7d",
+    );
+    expect(mockUseSecurityEvents).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: ["login_failed"],
+        username: "alice",
+        ip: "10",
+        since: "7d",
+      }),
+    );
+  });
+
+  it("toggling an event type chip updates the query", async () => {
+    const user = userEvent.setup();
+    renderPage();
+    // Click the "Login failed" filter chip (there are two matching elements:
+    // the chip in the filter row and the badge in the table — use getAllByText
+    // and pick the button).
+    const chips = screen.getAllByRole("button", { name: /Login failed/ });
+    await user.click(chips[0]);
+
+    await waitFor(() => {
+      expect(mockUseSecurityEvents).toHaveBeenLastCalledWith(
+        expect.objectContaining({
+          eventType: ["login_failed"],
+        }),
+      );
+    });
+  });
+
+  it("opens detail modal when clicking a row", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // There are multiple "alice" matches — click the username cell in the first
+    // row, which triggers the row click handler.
+    const rows = screen.getAllByRole("row");
+    // rows[0] = header, rows[1] = first data row
+    await user.click(rows[1]);
+
+    await waitFor(() => {
+      expect(screen.getByRole("dialog")).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Metadata/)).toBeInTheDocument();
+  });
+
+  it("renders a Clear button when filters are active", () => {
+    renderPage("/admin/security-events?username=alice");
+    expect(
+      screen.getByRole("button", { name: /Clear/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("does not render a Clear button on default view", () => {
+    renderPage();
+    expect(screen.queryByRole("button", { name: /^Clear$/ })).not.toBeInTheDocument();
+  });
+
+  it("renders a distinct error state on API failure", () => {
+    mockUseSecurityEvents.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+      error: new Error("boom"),
+      refetch: vi.fn(),
+    });
+    renderPage();
+    expect(screen.getByTestId("security-events-error")).toBeInTheDocument();
+    expect(screen.getByText(/Failed to load security events/)).toBeInTheDocument();
+    expect(screen.getByText(/boom/)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Try again/ })).toBeInTheDocument();
+  });
+
+  it("hides the event count row when empty", () => {
+    mockUseSecurityEvents.mockReturnValue({
+      data: { data: [], total: 0, page: 1, pageSize: 50 },
+      isLoading: false,
+    });
+    renderPage();
+    expect(screen.queryByText(/0 events/)).not.toBeInTheDocument();
+  });
+
+  it("does not open detail modal when click is finishing a text selection", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // Simulate an active text selection at click time.
+    const originalGetSelection = window.getSelection.bind(window);
+    window.getSelection = () =>
+      ({ toString: () => "10.0.0.1" }) as unknown as Selection;
+
+    const rows = screen.getAllByRole("row");
+    await user.click(rows[1]);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    window.getSelection = originalGetSelection;
+  });
+});

--- a/web/src/pages/admin/security-events-page.tsx
+++ b/web/src/pages/admin/security-events-page.tsx
@@ -1,0 +1,161 @@
+import { useCallback, useMemo, useState } from "react";
+import { useSearchParams } from "react-router-dom";
+import { AlertTriangle } from "lucide-react";
+import { Button, Section } from "@/components/ui";
+import { Pagination } from "@/components/pagination";
+import {
+  SecurityEventsFilters,
+  type SinceOption,
+  DEFAULT_SECURITY_EVENTS_SINCE,
+} from "@/features/admin/components/security-events-filters";
+import { SecurityEventsTable } from "@/features/admin/components/security-events-table";
+import { SecurityEventDetailModal } from "@/features/admin/components/security-event-detail-modal";
+import { useSecurityEvents } from "@/hooks/use-security-events";
+import type { SecurityEvent, SecurityEventType } from "@/types/api";
+
+const PAGE_SIZE = 50;
+const DEFAULT_SINCE: SinceOption = DEFAULT_SECURITY_EVENTS_SINCE;
+
+// AdminSecurityEventsPage shows an auditable log of authentication events.
+// Filter state lives in the URL query string so views are bookmarkable and
+// shareable between admins during an incident.
+export function AdminSecurityEventsPage() {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const eventTypes = useMemo(
+    () => searchParams.getAll("eventType") as SecurityEventType[],
+    [searchParams],
+  );
+  const username = searchParams.get("username") ?? "";
+  const ip = searchParams.get("ip") ?? "";
+  const since = (searchParams.get("since") ?? DEFAULT_SINCE) as SinceOption;
+  const page = Number(searchParams.get("page") ?? "1") || 1;
+
+  const [detailEvent, setDetailEvent] = useState<SecurityEvent | null>(null);
+
+  const { data, isLoading, isError, error, refetch } = useSecurityEvents({
+    page,
+    pageSize: PAGE_SIZE,
+    eventType: eventTypes,
+    username: username || undefined,
+    ip: ip || undefined,
+    since,
+  });
+
+  // updateParams merges a partial set of filter changes back into the URL,
+  // resetting the page counter whenever a filter other than `page` changes
+  // so the user never lands on an empty page after a filter change.
+  const updateParams = useCallback(
+    (updates: Record<string, string | string[] | null>) => {
+      const next = new URLSearchParams(searchParams);
+      const isFilterChange = Object.keys(updates).some((k) => k !== "page");
+      for (const [key, value] of Object.entries(updates)) {
+        next.delete(key);
+        if (value === null || value === "" || (Array.isArray(value) && value.length === 0)) {
+          continue;
+        }
+        if (Array.isArray(value)) {
+          for (const v of value) next.append(key, v);
+        } else {
+          next.set(key, value);
+        }
+      }
+      if (isFilterChange) next.delete("page");
+      setSearchParams(next, { replace: true });
+    },
+    [searchParams, setSearchParams],
+  );
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-3xl font-bold text-surface-100">Security Events</h1>
+        <p className="mt-1 text-surface-400">
+          Audit log of authentication events. Failed logins, lockouts, and
+          token misuse are recorded here so you can investigate suspicious
+          activity without tailing container logs.
+        </p>
+      </div>
+
+      <SecurityEventsFilters
+        eventTypes={eventTypes}
+        username={username}
+        ip={ip}
+        since={since}
+        onEventTypesChange={(t) => updateParams({ eventType: t })}
+        onUsernameChange={(v) => updateParams({ username: v })}
+        onIpChange={(v) => updateParams({ ip: v })}
+        onSinceChange={(v) =>
+          updateParams({ since: v === DEFAULT_SINCE ? null : v })
+        }
+        onClear={() =>
+          updateParams({
+            eventType: [],
+            username: null,
+            ip: null,
+            since: null,
+          })
+        }
+      />
+
+      {isError ? (
+        <Section>
+          <div
+            data-testid="security-events-error"
+            className="flex flex-col items-center gap-3 px-6 py-10 text-center"
+          >
+            <AlertTriangle className="h-10 w-10 text-danger-500" />
+            <div>
+              <p className="text-sm font-semibold text-surface-100">
+                Failed to load security events
+              </p>
+              <p className="mt-1 text-sm text-surface-400">
+                {error instanceof Error
+                  ? error.message
+                  : "An unknown error occurred while fetching the audit log."}
+              </p>
+            </div>
+            <Button variant="secondary" size="sm" onClick={() => refetch()}>
+              Try again
+            </Button>
+          </div>
+        </Section>
+      ) : (
+        <>
+          {data && data.total > 0 && (
+            <div className="flex items-center justify-between text-sm text-surface-400">
+              <span>
+                {data.total} event{data.total === 1 ? "" : "s"}
+                {data.total > PAGE_SIZE && (
+                  <>
+                    {" "}
+                    · Showing {(page - 1) * PAGE_SIZE + 1}–
+                    {Math.min(page * PAGE_SIZE, data.total)}
+                  </>
+                )}
+              </span>
+            </div>
+          )}
+
+          <SecurityEventsTable
+            events={data?.data}
+            isLoading={isLoading}
+            onRowClick={setDetailEvent}
+          />
+
+          <Pagination
+            total={data?.total ?? 0}
+            pageSize={PAGE_SIZE}
+            currentPage={page}
+            onPageChange={(p) => updateParams({ page: String(p) })}
+          />
+        </>
+      )}
+
+      <SecurityEventDetailModal
+        event={detailEvent}
+        onClose={() => setDetailEvent(null)}
+      />
+    </div>
+  );
+}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -16,6 +16,49 @@ export interface RateLimitStatus {
   isLockedOut: boolean;
 }
 
+// Security event audit log (admin-only). Mirrors the SecurityEvent model on
+// the server. The metadata blob is per-event-type and may include things like
+// failedCount, lockedUntil, tokenVersion, etc.
+export type SecurityEventType =
+  | "login_success"
+  | "login_failed"
+  | "login_locked"
+  | "login_blocked"
+  | "account_locked"
+  | "revoked_token_used"
+  | "disabled_account_token"
+  | "token_user_missing"
+  | "stale_token_version";
+
+export interface SecurityEvent {
+  id: number;
+  createdAt: string;
+  eventType: SecurityEventType;
+  reason?: string;
+  username?: string;
+  userId?: number;
+  ip?: string;
+  path?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface SecurityEventsListResponse {
+  data: SecurityEvent[];
+  total: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface SecurityEventsListFilters {
+  page?: number;
+  pageSize?: number;
+  eventType?: SecurityEventType[];
+  username?: string;
+  ip?: string;
+  /** Preset (1h, 24h, 7d, 30d, all) or RFC3339 timestamp. */
+  since?: string;
+}
+
 export interface DeletedUser {
   id: string;
   username: string;


### PR DESCRIPTION
## Summary
Adds an admin-only audit log at `/admin/security-events` so admins can investigate failed logins, lockouts, revoked-token use, and other suspicious activity from the web UI instead of tailing container logs.

## Backend
- `SecurityEvent` GORM model with indexed `eventType`, `username` (raw + denormalized `username_lower` for case-insensitive queries that can actually use an index on SQLite), `ip`, `userId`, `path`, and a JSON `metadata` blob
- Recorder helper mirrors every event to `slog` and opportunistically dedups middleware-originated events (`revoked_token_used`, `disabled_account_token`, `token_user_missing`, `stale_token_version`) on a 60s window so a flood attack cannot turn every request into a synchronous INSERT on the auth hot path
- `GET /api/admin/security-events` with `page`, `pageSize`, repeatable `eventType`, `username` substring, `ip` prefix, and `since` preset (`1h`, `24h`, `7d`, `30d`, `all`, or RFC3339) filters. `GET /:id` for detail, `GET /types` for the catalog
- `StartTokenCleanup` prunes rows older than 90 days via the extracted `pruneExpiredSecurityEvents` helper so the retention window is testable
- Login flow and `AuthMiddleware` replace inline `slog.Warn` calls with the recorder so failures are persisted as well as logged
- 17 backend tests cover listing, filtering, pagination, detail lookup, `parseSinceParam` branches, retention pruning, dedup behavior, and the end-to-end failed-login-to-admin-query integration path

## Web
- `/admin/security-events` page with URL-persisted filter state (event type chips, username search, IP prefix, time presets), data table with severity-weighted row styling, and a detail modal with a scrollable JSON metadata block
- Distinct loading / empty / error states. Error state includes a retry button and a `data-testid` for E2E targeting
- Row click is gated on `window.getSelection()` so admins can still copy IPs, usernames, and timestamps into tickets without the modal snapping open and clearing their selection
- Focus-visible ring on rows and `aria-hidden` on decorative search icons
- Sidebar link with `ShieldAlert` icon gated behind `AdminMiddleware`
- 14 unit tests + 7 Playwright E2E tests

## Team review
Both the `code-reviewer` and `ui-agent` from `AGENT_TEAM.md` reviewed this before the PR was opened. Findings addressed in this PR:
- **Blocking (code)**: write amplification in `AuthMiddleware` on flood — fixed with dedup LRU; `LOWER(username)` defeated the index — fixed with denormalized `username_lower` column
- **Blocking (UI)**: missing error state — added; row click eating text selection — gated on `getSelection()`
- **High**: wrong detail-modal user link — removed; focus-visible on rows was only a background change — added ring; icon in `h1` inconsistent with other admin pages — removed; `0 events` line showed above empty state — hidden; `parseSinceParam` RFC3339 branch untested — covered; retention cleanup untested — covered

Follow-ups logged for a later PR: moving the recorder to `internal/db`, admin sidebar sub-grouping, "related events from this IP/user" links, response size caps, IP format validation.

## Test plan
- [x] Go: `go test ./internal/api/ -count=1` — all pass (~6min)
- [x] Web unit: `vitest run` — 1454 tests pass
- [x] TypeScript compiles clean
- [ ] CI passes