### PR TITLE
fix: drain scheduler across multiple passes in restartChallenge test

### DIFF
--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelChallengeTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelChallengeTest.kt
@@ -223,13 +223,17 @@ class EmulationViewModelChallengeTest {
         )
         val vm = builder.build()
         vm.onIntent(EmulationIntent.StartGame("game1", challengeId = "c1"))
-        builder.advanceTimeBy(100)
+        // Drain across multiple passes: ChallengeManager.restartChallenge
+        // launches on dispatchers.io and later hops to dispatchers.main via
+        // withContext(), so a single runCurrent() pass leaves the main-thread
+        // state update unscheduled and the test becomes flaky under CI load.
+        builder.advanceTimeByAndDrain(100)
 
         // First attempt
         assertEquals("attempt-2", vm.state.value.challengeAttemptId)
 
         vm.onIntent(EmulationIntent.RestartChallenge)
-        builder.advanceTimeBy(100)
+        builder.advanceTimeByAndDrain(100)
 
         // Should have abandoned previous attempt and started new one
         assertEquals(1, builder.challengeRepository.abandonAttemptCallCount)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -550,6 +550,29 @@ class EmulationViewModelTestBuilder {
         vmScheduler.runCurrent()
     }
 
+    /**
+     * Advance the VM's virtual clock by [ms] milliseconds and then drain the
+     * scheduler across multiple passes, without blocking on the VM's
+     * long-running background coroutines (e.g. the challenge elapsed-time
+     * loop). Prefer this over plain [advanceTimeBy] for assertions that
+     * depend on a chain of coroutines hopping between dispatchers — a single
+     * pass of `runCurrent()` only drains the first continuation, so a task
+     * that is `launch(dispatchers.io)` then `withContext(dispatchers.main)`
+     * will leave the main-thread step unscheduled on the first pass and
+     * produce a flaky "expected 1, got 0" assertion under load.
+     *
+     * A plain [kotlinx.coroutines.test.TestCoroutineScheduler.advanceUntilIdle]
+     * would also work, but the VM launches background loops (challenge
+     * timer, session heartbeat) that never terminate, so advanceUntilIdle
+     * exhausts memory. This bounded drain is the compromise.
+     */
+    fun advanceTimeByAndDrain(ms: Long, passes: Int = 10) {
+        vmScheduler.advanceTimeBy(ms)
+        repeat(passes) {
+            vmScheduler.runCurrent()
+        }
+    }
+
     fun build(): EmulationViewModel {
         vmScope = CoroutineScope(testDispatcher + Job())
         val apiClient = SpelaApiClient(StubMockEngineFactory, TokenManager())


### PR DESCRIPTION
## Problem
\`restartChallengeReloadsAndStartsNewAttempt\` has been intermittently failing in CI across PRs #355, #356, #357, and now #358 — all of which touch zero player code. It's a pre-existing flake that keeps blocking merges.

## Root cause
\`ChallengeManager.restartChallenge\` launches on \`dispatchers.io\` and later hops to \`dispatchers.main\` via \`withContext()\`. A single pass of \`runCurrent()\` after \`advanceTimeBy(100)\` leaves the main-thread state update unscheduled, and the assertion \`abandonAttemptCallCount == 1\` races the continuation.

A plain \`advanceUntilIdle()\` would also work for the functional chain, but the VM launches background loops (challenge elapsed-time, session heartbeat) that never terminate, so \`advanceUntilIdle\` exhausts memory with \`OutOfMemoryError\` (confirmed locally).

## Fix
Add a bounded \`advanceTimeByAndDrain(ms, passes = 10)\` helper on \`EmulationViewModelTestBuilder\` that advances virtual time once and then runs \`runCurrent()\` repeatedly, draining continuation chains posted between passes without getting stuck in the infinite background loops. Only the flaky test is switched over; other tests still use the simpler \`advanceTimeBy\`.

## Verification
Ran the \`EmulationViewModelChallengeTest\` suite 5 times in a row locally after the change — all green. Previously reproduced the OOM with the naive \`advanceUntilIdle\` approach, then confirmed the bounded drain is stable.

## Test plan
- [x] \`./gradlew :shared:desktopTest --tests EmulationViewModelChallengeTest\` passes 5/5 locally
- [ ] CI passes