### PR TITLE
chore: split admin sidebar into Content and System sub-sections

### DIFF
--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -106,11 +106,41 @@ export function AppLayout() {
         { to: "/storage", icon: HardDrive, label: "Storage" },
       ],
     },
+    // Admin nav is split into two sub-sections so the 10-item flat list
+    // doesn't feel like one dense block. "Content" manages the game
+    // library; "System" manages users and server health. The "Admin · "
+    // prefix is intentionally dropped — the section header chrome
+    // already communicates grouping, and the links are admin-gated + all
+    // live under /admin/, so "ADMIN" would be redundant in the label.
     ...(isAdmin
       ? [
           {
-            section: "Admin",
+            section: "Content",
             items: [
+              // Ordered by frequency of daily use.
+              { to: "/admin/scan", icon: ScanSearch, label: "Library Scan" },
+              { to: "/admin/upload", icon: Upload, label: "Upload ROMs" },
+              { to: "/admin/rom-hacks", icon: Puzzle, label: "ROM Hacks" },
+              {
+                to: "/admin/metadata",
+                icon: FileSearch,
+                label: "Metadata Fix",
+              },
+              { to: "/admin/cheats", icon: Gamepad2, label: "Cheats" },
+              {
+                to: "/admin/bios",
+                icon: Cpu,
+                label: "BIOS Files",
+                warning: hasMissingBios,
+              },
+            ],
+          },
+          {
+            section: "System",
+            items: [
+              // Ordered by frequency of use. Security Events is last
+              // because it's an incident-response surface — rarely
+              // visited, but critical when needed.
               { to: "/admin/users", icon: Users, label: "Users" },
               {
                 to: "/admin/settings",
@@ -118,21 +148,6 @@ export function AppLayout() {
                 label: "Settings",
                 warning: igdbNotConfigured,
               },
-              {
-                to: "/admin/bios",
-                icon: Cpu,
-                label: "BIOS Files",
-                warning: hasMissingBios,
-              },
-              { to: "/admin/upload", icon: Upload, label: "Upload ROMs" },
-              { to: "/admin/rom-hacks", icon: Puzzle, label: "ROM Hacks" },
-              { to: "/admin/scan", icon: ScanSearch, label: "Library Scan" },
-              {
-                to: "/admin/metadata",
-                icon: FileSearch,
-                label: "Metadata Fix",
-              },
-              { to: "/admin/cheats", icon: Gamepad2, label: "Cheats" },
               {
                 to: "/admin/core-compatibility",
                 icon: GitCompareArrows,


### PR DESCRIPTION
The admin nav grew to 10 items after adding Security Events in PR #357. A single "Admin" block that long starts feeling dense and makes it harder to scan for the item you want.

## Changes

Split into two sibling sections:

- **Content** — things that manage the game library: Library Scan, Upload ROMs, ROM Hacks, Metadata Fix, Cheats, BIOS Files
- **System** — users and server health: Users, Settings, Core Compatibility, Security Events

Each section is ordered by frequency of daily use. Within System, Security Events is last because it's an incident-response surface — rarely visited, but critical when needed.

The "Admin · " prefix on the section labels is intentionally dropped: the section header chrome already communicates grouping, the links are admin-gated, and all routes live under `/admin/`, so prefixing every label with "ADMIN" would be redundant.

## Team review
Spawned `ui-agent` in `plan` mode before opening. Addressed all findings:
- **H1**: Dropped "Admin · " prefix (section header already groups visually)
- **M4**: Moved Security Events to the end of System (incident-response surface, not third-most important)
- **M3**: Kept BIOS under Content (`hasMissingBios` warning is a library-content signal)
- **N6**: Sibling sections over collapsible parent (correct — collapsible infra doesn't exist in sidebar.tsx and building it for this would be over-engineering)

Pure navigation refactor, no code-reviewer needed.

## Test plan
- [x] `vitest run` — 1462 tests pass, sidebar tests unchanged
- [x] TypeScript compiles clean
- [ ] CI passes