### PR TITLE
chore: hoist horizontal padding out of stats feature composables

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/stats/PersonalStatsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/stats/PersonalStatsSection.kt
@@ -37,9 +37,7 @@ internal fun PersonalStatsSection(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(horizontal = SpSpacing.ScreenHorizontal),
+        modifier = modifier.fillMaxWidth(),
     ) {
         SpSectionHeader(title = "Your Stats")
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/stats/StatsComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/stats/StatsComponents.kt
@@ -72,7 +72,6 @@ internal fun MostPlayedGameItem(
         onGradient = true,
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XSmall)
             .semantics {
                 contentDescription = "Rank $rank: ${item.game.title}, ${formatPlayTime(item.totalPlayTime)} play time"
                 role = Role.Button
@@ -136,7 +135,6 @@ internal fun ActivePlayerItem(
         onGradient = true,
         modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XSmall)
             .semantics {
                 contentDescription = "Rank $rank: ${item.username}, ${formatPlayTime(item.totalPlayTime)} play time"
                 role = Role.Button

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/StatsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/StatsScreen.kt
@@ -113,7 +113,10 @@ fun StatsScreen(
                             // Personal Stats section
                             if (state.personalStats != null) {
                                 item {
-                                    PersonalStatsSection(stats = state.personalStats!!)
+                                    PersonalStatsSection(
+                                        stats = state.personalStats!!,
+                                        modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
+                                    )
                                     Spacer(Modifier.height(SpSpacing.XXLarge))
                                 }
                             }
@@ -137,7 +140,8 @@ fun StatsScreen(
                                         item = item,
                                         onClick = { onGameSelected(item.game.id) },
                                         modifier = (if (index == 0) Modifier.autoFocus() else Modifier)
-                                            .rememberFocus("game_${item.game.id}"),
+                                            .rememberFocus("game_${item.game.id}")
+                                            .padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XSmall),
                                     )
                                 }
 
@@ -164,7 +168,8 @@ fun StatsScreen(
                                         rank = index + 1,
                                         item = item,
                                         onClick = { onUserSelected(item.userId) },
-                                        modifier = Modifier.rememberFocus("player_${item.userId}"),
+                                        modifier = Modifier.rememberFocus("player_${item.userId}")
+                                            .padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XSmall),
                                     )
                                 }
                             }


### PR DESCRIPTION
## Summary

- Follow-up to #364 — same exact refactor pattern, now applied to 3 more violators in the stats feature: `PersonalStatsSection`, `MostPlayedGameItem`, `ActivePlayerItem`.
- All three were accepting a caller-supplied `modifier` parameter but then chaining their own `.padding(horizontal = SpSpacing.ScreenHorizontal[, vertical = XSmall])` on top, violating the "components never control their own outer spacing" rule.
- Padding is hoisted to the StatsScreen call sites. `PersonalStatsSection` gets horizontal-only padding (it's followed by an explicit `Spacer(XXLarge)`). `MostPlayedGameItem` and `ActivePlayerItem` keep `vertical = XSmall` at the call site because the parent `LazyColumn` has no `Arrangement.spacedBy`, so that 8dp inter-row gap can't be dropped without a visual regression.

## Test plan

- [x] `./gradlew :shared:desktopTest` — BUILD SUCCESSFUL, same suite CI runs
- [x] ui-agent design review — APPROVED, modifier order verified correct (focus modifiers before padding so the focusable region encompasses the full row), decision to keep per-item vertical padding over `spacedBy` validated for this screen's heterogeneous LazyColumn