### PR TITLE
chore: hoist horizontal padding out of shared session composables

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sharedsession/SharedSessionDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sharedsession/SharedSessionDetailComponents.kt
@@ -58,11 +58,10 @@ internal fun SharedSessionHeader(
     onTakeTurn: () -> Unit,
     onReleaseTurn: () -> Unit,
     onPlay: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = SpSpacing.ScreenHorizontal),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             SpCoverArt(
@@ -193,11 +192,11 @@ internal fun SharedSessionStatusChip(status: String) {
 internal fun MemberItem(
     member: SharedSessionMember,
     isActive: Boolean,
+    modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
-            .padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.Small)
             .semantics {
                 contentDescription = "${member.username}, ${member.role}" +
                         if (isActive) ", currently playing" else ""
@@ -245,11 +244,10 @@ internal fun InviteSection(
     isInviting: Boolean,
     onInvite: (String) -> Unit,
     onShowInviteSheet: () -> Unit = {},
+    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = SpSpacing.ScreenHorizontal),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Text(
             text = "Invite a friend",
@@ -269,12 +267,11 @@ internal fun SharedSessionSaveItem(
     save: SharedSessionSave,
     isCopying: Boolean = false,
     onCopyToGame: (() -> Unit)? = null,
+    modifier: Modifier = Modifier,
 ) {
     SpCard(
         onGradient = true,
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XSmall),
+        modifier = modifier.fillMaxWidth(),
     ) {
         Row(
             modifier = Modifier

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
@@ -108,6 +108,7 @@ fun SharedSessionDetailScreen(
                                 onTakeTurn = { viewModel.onIntent(SharedSessionDetailIntent.TakeTurn(sharedSessionId)) },
                                 onReleaseTurn = { viewModel.onIntent(SharedSessionDetailIntent.ReleaseTurn(sharedSessionId)) },
                                 onPlay = { onPlay(sharedSession.gameId, sharedSessionId) },
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
                             )
                             Spacer(Modifier.height(SpSpacing.XLarge))
                         }
@@ -127,6 +128,7 @@ fun SharedSessionDetailScreen(
                             MemberItem(
                                 member = member,
                                 isActive = member.userId == sharedSession.activeUserId,
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.Small),
                             )
                         }
 
@@ -141,6 +143,7 @@ fun SharedSessionDetailScreen(
                                 onShowInviteSheet = {
                                     viewModel.onIntent(SharedSessionDetailIntent.ShowInviteSheet)
                                 },
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
                             )
                             Spacer(Modifier.height(SpSpacing.XLarge))
                         }
@@ -175,6 +178,7 @@ fun SharedSessionDetailScreen(
                                             SharedSessionDetailIntent.CopySaveToGame(sharedSessionId, save.id)
                                         )
                                     },
+                                    modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XSmall),
                                 )
                             }
                         }


### PR DESCRIPTION
## Summary

- Follow-up to #364 and #365 — same pattern, now applied to 4 more violators in `SharedSessionDetailComponents.kt`: `SharedSessionHeader`, `MemberItem`, `InviteSection`, `SharedSessionSaveItem`.
- Unique twist: **none of these composables accepted a `modifier` parameter at all**. Each one hardcoded `.padding(horizontal = SpSpacing.ScreenHorizontal)` on its root. Added the param and moved the padding to the `SharedSessionDetailScreen` call sites.
- `MemberItem` and `SharedSessionSaveItem` keep their vertical padding (`Small` and `XSmall` respectively) at the call site — the parent `LazyColumn` has no `Arrangement.spacedBy`, so the 16dp/8dp inter-row gaps have to be preserved per-item.
- `SharedSessionHeader` and `InviteSection` get horizontal-only padding — both are followed by explicit `Spacer`s that already provide vertical rhythm.

## Test plan

- [x] `./gradlew :shared:desktopTest` — BUILD SUCCESSFUL, same suite CI runs
- [x] ui-agent design review — APPROVED; `MemberItem` semantics ordering verified equivalent to the original (padding baked into caller's modifier → `.fillMaxWidth().semantics{...}` produces the same bounding box); pattern verified consistent with `SpSectionHeader` siblings in the same LazyColumn