### PR TITLE
chore: make SessionCheatsSection padding-agnostic

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sessiondetail/SessionCheatsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sessiondetail/SessionCheatsSection.kt
@@ -48,17 +48,13 @@ internal fun SessionCheatsSection(
     val cheatsUnavailable = cheatsLoadAttempted && !isLoadingCheats && availableCheats.isEmpty()
 
     Column(modifier = modifier) {
-        SpSectionHeader(
-            title = "Cheats",
-            modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
-        )
+        SpSectionHeader(title = "Cheats")
         Spacer(Modifier.height(SpSpacing.Small))
 
         // Master toggle
         SpInnerCard(
             modifier = Modifier
                 .fillMaxWidth()
-                .padding(horizontal = SpSpacing.ScreenHorizontal)
                 .testTag("session_cheats_section"),
         ) {
             Column(
@@ -124,25 +120,19 @@ internal fun SessionCheatsSection(
                     text = "Loading cheats\u2026",
                     style = SpTypography.BodyMedium,
                     color = SpColor.OnBackgroundSecondary,
-                    modifier = Modifier
-                        .padding(horizontal = SpSpacing.ScreenHorizontal)
-                        .testTag("session_cheats_loading"),
+                    modifier = Modifier.testTag("session_cheats_loading"),
                 )
             } else if (availableCheats.isEmpty()) {
                 Text(
                     text = "No cheats available for this game",
                     style = SpTypography.BodyMedium,
                     color = SpColor.OnBackgroundSecondary,
-                    modifier = Modifier
-                        .padding(horizontal = SpSpacing.ScreenHorizontal)
-                        .testTag("session_cheats_empty"),
+                    modifier = Modifier.testTag("session_cheats_empty"),
                 )
             } else {
                 // Select All / Deselect All actions
                 Row(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = SpSpacing.ScreenHorizontal),
+                    modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.End,
                 ) {
                     TextButton(
@@ -167,7 +157,6 @@ internal fun SessionCheatsSection(
                         label = "Search cheats",
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(horizontal = SpSpacing.ScreenHorizontal)
                             .testTag("session_cheats_search"),
                     )
                     Spacer(Modifier.height(SpSpacing.Small))
@@ -195,10 +184,7 @@ internal fun SessionCheatsSection(
                             onToggle = { onToggleCheatAtIndex(cheat.index) },
                             modifier = Modifier
                                 .fillMaxWidth()
-                                .padding(
-                                    horizontal = SpSpacing.ScreenHorizontal,
-                                    vertical = SpSpacing.XXSmall,
-                                ),
+                                .padding(vertical = SpSpacing.XXSmall),
                         )
                     }
                 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
@@ -244,6 +244,7 @@ fun SessionDetailScreen(
                                         SessionDetailIntent.DeselectAllCheats(sessionId)
                                     )
                                 },
+                                modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
                             )
                         }
 


### PR DESCRIPTION
## Summary

- Follow-up to #364/#365/#366/#367. SessionCheatsSection was baking `.padding(horizontal = ScreenHorizontal)` into seven of its sub-elements (header, master toggle card, loading text, empty text, select/deselect row, search field, cheat items) — your ui-agent audit on PR #364 called this out as a "whole-section class of violator."
- Made the section **padding-agnostic**: stripped every internal horizontal padding and moved a single `Modifier.padding(horizontal = ScreenHorizontal)` to the `SessionDetailScreen` call site. This matches the pattern every other `item { }` in that LazyColumn already uses.
- Vertical `XXSmall` spacing on the `SessionCheatItem` iteration is preserved — it's legit call-site spacing (the section is the caller of the item) and the forEach has no `Arrangement.spacedBy` to rely on.

## Test plan

- [x] `./gradlew :shared:desktopTest` — BUILD SUCCESSFUL
- [x] ui-agent review — APPROVED, visual result identical, decision to go padding-agnostic is the right call since every other LazyColumn sibling in the same screen uses call-site padding