### PR TITLE
chore: hoist horizontal padding out of GameLibraryControls

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameLibraryControls.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/library/GameLibraryControls.kt
@@ -74,8 +74,7 @@ internal fun GameLibraryControls(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .horizontalScroll(rememberScrollState())
-                .padding(horizontal = SpSpacing.ScreenHorizontal),
+                .horizontalScroll(rememberScrollState()),
             horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
         ) {
             FilterChip(
@@ -94,9 +93,7 @@ internal fun GameLibraryControls(
 
         // Sort controls + hide betas + view mode toggle
         Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = SpSpacing.ScreenHorizontal),
+            modifier = Modifier.fillMaxWidth(),
             verticalAlignment = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
         ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/AllGamesScreen.kt
@@ -85,7 +85,7 @@ fun AllGamesScreen(
             onSortOrderChanged = { viewModel.onIntent(GameListIntent.SetSortOrder(it)) },
             onToggleViewMode = { viewModel.onIntent(GameListIntent.ToggleViewMode) },
             onToggleHideBetas = { viewModel.onIntent(GameListIntent.ToggleHideBetas) },
-            modifier = Modifier.padding(vertical = SpSpacing.Small),
+            modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.Small),
         )
 
         Spacer(Modifier.height(SpSpacing.Small))


### PR DESCRIPTION
## Summary

- Follow-up in the design-system padding audit. `GameLibraryControls`'s root Column correctly accepted the caller's modifier, but the two inner Rows (filter chips with `horizontalScroll`, sort/view-mode Row) both baked `.padding(horizontal = ScreenHorizontal)` internally.
- Stripped both internal paddings and added `horizontal = ScreenHorizontal` to the existing `vertical = Small` caller modifier at `AllGamesScreen.kt:88`. Visual behavior identical — the horizontalScroll chips still scroll correctly within the padded bounds.

## Test plan

- [x] `./gradlew :shared:desktopTest` — BUILD SUCCESSFUL