### PR TITLE
fix: positional padding bugs in four skeleton and hero-content layouts

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
@@ -108,7 +108,7 @@ fun ExploreGroupDetailContent(
                     Column(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(SpSpacing.ScreenHorizontal)
+                            .padding(horizontal = SpSpacing.ScreenHorizontal)
                             .testTag("${groupLabel}_detail_loading"),
                     ) {
                         Spacer(Modifier.height(SpSpacing.Large))

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ChallengeDetailScreen.kt
@@ -138,7 +138,7 @@ fun ChallengeDetailScreen(
                 }
 
                 Column(
-                    modifier = Modifier.padding(SpSpacing.ScreenHorizontal),
+                    modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
                 ) {
                     Spacer(Modifier.height(SpSpacing.Large))
 
@@ -377,7 +377,7 @@ private fun ChallengeDetailSkeleton() {
             modifier = Modifier.fillMaxWidth().aspectRatio(16f / 10f),
         )
 
-        Column(modifier = Modifier.padding(SpSpacing.ScreenHorizontal)) {
+        Column(modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal)) {
             Spacer(Modifier.height(SpSpacing.Large))
             SpShimmer(width = 220.dp, height = 28.dp) // Title
             Spacer(Modifier.height(SpSpacing.Small))

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreMoodScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreMoodScreen.kt
@@ -94,7 +94,7 @@ fun ExploreMoodScreen(
                     Column(
                         modifier = Modifier
                             .fillMaxSize()
-                            .padding(SpSpacing.ScreenHorizontal)
+                            .padding(horizontal = SpSpacing.ScreenHorizontal)
                             .testTag("mood_detail_loading"),
                     ) {
                         Spacer(Modifier.height(SpSpacing.Large))


### PR DESCRIPTION
## Summary

Four sites used the positional \`Modifier.padding(SpSpacing.ScreenHorizontal)\` form, which resolves to \`padding(all = 20.dp)\` — it applies ScreenHorizontal on *all four sides*, not just left/right. In each case the Column is immediately followed by a \`Spacer(Modifier.height(SpSpacing.Large))\`, which is the established pattern for content that sets its own top inset explicitly. The extra 20dp from the positional padding was adding an unintended top gap between the preceding hero/section and the first child element.

## Sites fixed

- \`ChallengeDetailScreen.kt:141\` — challenge title Column below the screenshot hero
- \`ChallengeDetailScreen.kt:380\` — matching \`ChallengeDetailSkeleton\` Column (keeps skeleton visually consistent with real content)
- \`ExploreMoodScreen.kt:97\` — mood detail loading skeleton Column
- \`ExploreGroupDetailContent.kt:111\` — series/franchise detail loading skeleton Column

All four now use \`padding(horizontal = SpSpacing.ScreenHorizontal)\` so the top gap between the hero/previous element and the first Text/Shimmer is exactly \`SpSpacing.Large\` (24dp) as the spacer intends, rather than 20+24 = 44dp.

## Why these weren't caught by detekt

These Columns are nested inside screen-body lambdas (\`when {}\`/\`else {}\` branches of the screen composable), so they aren't root layouts of a \`@Composable fun\`. The \`ComponentOuterSpacingRule\` (extended in PR #373 to catch positional forms) correctly doesn't flag them — the "components must not control their own outer spacing" rule applies to reusable components, not to screen-local layout code. These are regular positional-arg bugs, not rule violations.

## Test plan

- [x] \`./gradlew :shared:detekt\` — 0 findings
- [x] \`./gradlew :shared:desktopTest\` — 458 tests pass
- [ ] CI green