### PR TITLE
feat: pre-push hook — web + server build checks

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# Pre-push hook: verify that web/ and server/ still build before the push
+# hits CI. Runs only the builds whose directories actually contain changes
+# being pushed, so a player-only push is unaffected.
+#
+# Installation (once per clone):
+#   git config core.hooksPath .githooks
+#
+# Bypass for a single push (use sparingly):
+#   git push --no-verify
+#
+# What this catches that `tsc --noEmit` / `go vet` alone don't:
+#   - TS errors that only show up via vite/rollup bundle-time checks
+#     (e.g. path-literal narrowing) — PR #360 round-tripped CI for one.
+#   - Go build-tag / cross-package compile errors that unit tests in a
+#     single package can miss.
+#
+# It does NOT run tests — just the builds. Tests go through CI.
+
+set -euo pipefail
+
+# Colors for terminals that support them.
+if [[ -t 2 ]]; then
+    RED=$'\033[0;31m'
+    GREEN=$'\033[0;32m'
+    YELLOW=$'\033[1;33m'
+    DIM=$'\033[2m'
+    RESET=$'\033[0m'
+else
+    RED=""
+    GREEN=""
+    YELLOW=""
+    DIM=""
+    RESET=""
+fi
+
+log() { printf '%s[pre-push]%s %s\n' "$DIM" "$RESET" "$*" >&2; }
+warn() { printf '%s[pre-push]%s %s\n' "$YELLOW" "$RESET" "$*" >&2; }
+die() { printf '%s[pre-push]%s %s\n' "$RED" "$RESET" "$*" >&2; exit 1; }
+
+# Read all refs being pushed from stdin. Each line is:
+#   <local_ref> <local_sha> <remote_ref> <remote_sha>
+# A zero sha on the remote side means "new branch" — in that case we
+# diff against the upstream merge-base so the hook still only builds
+# what's actually changing on this branch vs. master.
+changed_files=""
+while read -r local_ref local_sha remote_ref remote_sha; do
+    if [[ -z "$local_sha" ]]; then
+        continue
+    fi
+    # Deleted ref (local is zero): nothing to build.
+    if [[ "$local_sha" =~ ^0+$ ]]; then
+        continue
+    fi
+    if [[ "$remote_sha" =~ ^0+$ ]]; then
+        # New branch on remote: diff against the merge-base with master.
+        base=$(git merge-base "$local_sha" origin/master 2>/dev/null || true)
+        if [[ -z "$base" ]]; then
+            # No master reference locally — just scan the full commit range
+            # starting from the root. Uncommon (fresh clone w/ no master
+            # fetch) but handle it gracefully.
+            range="$local_sha"
+        else
+            range="${base}..${local_sha}"
+        fi
+    else
+        range="${remote_sha}..${local_sha}"
+    fi
+    changed_files+=$'\n'$(git diff --name-only "$range" 2>/dev/null || true)
+done
+
+# If no refs came in on stdin at all (e.g. `git push` with nothing to
+# push), skip the hook entirely.
+if [[ -z "${changed_files// /}" ]]; then
+    exit 0
+fi
+
+run_web=false
+run_server=false
+while IFS= read -r f; do
+    [[ -z "$f" ]] && continue
+    case "$f" in
+        web/*) run_web=true ;;
+        server/*) run_server=true ;;
+    esac
+done <<< "$changed_files"
+
+if ! $run_web && ! $run_server; then
+    log "no web/ or server/ changes in this push — skipping builds"
+    exit 0
+fi
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+if $run_web; then
+    log "running ${GREEN}npm run build${RESET} in web/ ..."
+    if ! (cd web && npm run build); then
+        die "web build failed — fix it or push with ${YELLOW}--no-verify${RED} if you know what you're doing"
+    fi
+fi
+
+if $run_server; then
+    log "running ${GREEN}go build ./...${RESET} in server/ ..."
+    if ! (cd server && go build ./...); then
+        die "server build failed — fix it or push with ${YELLOW}--no-verify${RED} if you know what you're doing"
+    fi
+fi
+
+log "${GREEN}builds clean${RESET}"
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,20 @@ Spela is a self-hosted game emulation service with three components:
 2. **Web frontend** (React + TypeScript) - Server administration and game management
 3. **Player app** (Kotlin Multiplatform + Compose Multiplatform) - Native game player
 
+## One-time setup
+
+After cloning the repo, point git at the tracked hooks directory so the
+pre-push hook runs automatically on every push:
+
+```sh
+git config core.hooksPath .githooks
+```
+
+The pre-push hook runs `npm run build` for pushes that touch `web/` and
+`go build ./...` for pushes that touch `server/`. Player-only pushes are
+skipped. Bypass for a single push with `git push --no-verify`. See
+`.githooks/pre-push` for the script.
+
 ## Rules
 1. **No web technology in the player app** - No HTML, CSS, or JavaScript. Must be fully native.
 2. **Web UI uses React + TypeScript** - Vite build, Tailwind CSS, TanStack Query.


### PR DESCRIPTION
## Summary

Adds a tracked pre-push hook that runs \`npm run build\` for pushes touching \`web/\` and \`go build ./...\` for pushes touching \`server/\`. Detection is per-ref: the hook reads the refs git is about to push on stdin, diffs each \`remote_sha..local_sha\` range, and only runs the builds whose directories actually contain changes. Player-only pushes are unaffected.

Closes the IMPROVEMENTS.md entry from 2026-04-11 (line 29 in the current log) — will be struck off in a follow-up to PR #378's doc cleanup.

## Why

PR #360's first CI run caught a TS error that \`tsc --noEmit\` alone missed — the vite/rollup bundle-time type checking differs from the standalone compiler pass for some path-literal narrowing cases, and we round-tripped ~7 minutes of CI waiting for the failure. Catching both bundle-time and \`go build\` errors locally saves that round trip.

## Design

- **Tracked in \`.githooks/pre-push\`** rather than \`.git/hooks/\` so the hook is shared across clones. Activation is one-time per clone:
  \`\`\`sh
  git config core.hooksPath .githooks
  \`\`\`
  Documented in \`CLAUDE.md\` under a new "One-time setup" section.
- **Builds, not tests.** Test runs stay in CI where they get fresh environments and parallelism; the hook is strictly a fast "does it compile end-to-end" sanity check.
- **Per-ref diffing.** For a fresh-branch push (remote sha is all zeros) the hook diffs against the local merge-base with \`origin/master\` instead of the root of history, so pushing a pile of new commits doesn't naively walk the whole repo.
- **Bypass with \`git push --no-verify\`** for unusual situations (WIP branches, recovering from a tooling glitch).
- **Empty stdin is a no-op.** If git had nothing to push, the hook exits 0 cleanly.

## Test plan

- [x] \`bash -n .githooks/pre-push\` — valid syntax
- [x] Piped a simulated new-branch stdin pair at the current HEAD: hook correctly reports \`no web/ or server/ changes in this push — skipping builds\` (only \`.githooks/\` and \`CLAUDE.md\` changed on this branch)
- [x] Piped a historical web-touching commit range (commit \`c9cfb0ca\`): detection logic correctly identifies \`web/*\` files and would trigger the web build
- [x] \`cd server && go build ./...\` — clean on current master, so hook won't spuriously fail existing pushes
- [x] \`cd web && npm run build\` — clean on current master (\`tsc -b && vite build\`, ~1.8s after a warm cache)
- [ ] Hook runs on the actual push to open this PR after I enable \`core.hooksPath\` locally and push (will report back)