### PR TITLE
chore: clean up 24 Kotlin compiler warnings in shared module

### DIFF
--- a/player/shared/build.gradle.kts
+++ b/player/shared/build.gradle.kts
@@ -10,6 +10,20 @@ plugins {
 }
 
 kotlin {
+    // Opt into KT-61573: `expect`/`actual` classes are in Beta and emit a
+    // warning on every commonMain expect declaration unless explicitly
+    // acknowledged via this compiler arg. Applied to every target so the
+    // shared module compiles cleanly.
+    targets.configureEach {
+        compilations.configureEach {
+            compileTaskProvider.configure {
+                compilerOptions {
+                    freeCompilerArgs.add("-Xexpect-actual-classes")
+                }
+            }
+        }
+    }
+
     androidTarget {
         compilerOptions {
             jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/ConnectivityMonitor.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/ConnectivityMonitor.kt
@@ -4,6 +4,7 @@ import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.util.DispatcherProvider
 import io.ktor.client.plugins.*
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalForInheritanceCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -25,6 +26,7 @@ class ConnectivityMonitor(
     val connectionState: StateFlow<ConnectionState> = _connectionState.asStateFlow()
 
     /** Backward-compatible derived flow. Repositories using isOnline.value continue working. */
+    @OptIn(ExperimentalForInheritanceCoroutinesApi::class)
     val isOnline: StateFlow<Boolean> = object : StateFlow<Boolean> {
         override val value: Boolean get() = _connectionState.value.isConnected
         override val replayCache: List<Boolean> get() = listOf(value)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -1,7 +1,7 @@
 package com.spela.player.data.remote.dto
 
 import com.spela.player.domain.model.*
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 
 fun AuthResponse.toDomain(): AuthTokens = AuthTokens(
     accessToken = accessToken,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -1,6 +1,6 @@
 package com.spela.player.domain.model
 
-import kotlinx.datetime.Instant
+import kotlin.time.Instant
 import kotlinx.serialization.Serializable
 
 data class PaginatedResult<T>(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/LocalScrapeService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/LocalScrapeService.kt
@@ -27,7 +27,7 @@ object ScrapeUpdates {
 
     fun onGameScraped(game: Game) {
         if (!game.coverUrl.isNullOrEmpty()) {
-            _updatedCovers.value = _updatedCovers.value + (game.id to game.coverUrl!!)
+            _updatedCovers.value = _updatedCovers.value + (game.id to game.coverUrl)
         }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNetplayPlayerSlot.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpNetplayPlayerSlot.kt
@@ -75,7 +75,7 @@ fun SpNetplayPlayerSlot(
             // Avatar
             if (isFilled) {
                 SpAvatar(
-                    username = username!!,
+                    username = username,
                     avatarUrl = avatarUrl,
                     size = 40.dp,
                 )
@@ -100,7 +100,7 @@ fun SpNetplayPlayerSlot(
 
             if (isFilled) {
                 Text(
-                    text = username!!,
+                    text = username,
                     style = SpTypography.TitleMedium,
                     color = SpColor.OnCard,
                     modifier = Modifier.weight(1f),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/HeroCarousel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/HeroCarousel.kt
@@ -268,7 +268,7 @@ private fun HeroSlide(
                 ) {
                     if (game.logoUrl != null) {
                         SpAreaSizedImage(
-                            imageUrl = game.logoUrl!!,
+                            imageUrl = game.logoUrl,
                             contentDescription = "${game.title} logo",
                             targetArea = targetArea,
                             maxHeight = logoMaxH,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/MetadataGrid.kt
@@ -55,11 +55,11 @@ internal fun MetadataGrid(
 ) {
     val items = buildList {
         game.developer?.takeIf { it.isNotBlank() }?.let {
-            add(MetaItem(Icons.Filled.Domain, if (isDemoConsole) "Group" else "Developer", it, onClick = onDeveloperClick?.let { cb -> { cb(game.developer!!) } }))
+            add(MetaItem(Icons.Filled.Domain, if (isDemoConsole) "Group" else "Developer", it, onClick = onDeveloperClick?.let { cb -> { cb(game.developer) } }))
         }
         if (!isDemoConsole) {
             game.publisher?.takeIf { it.isNotBlank() }?.let {
-                add(MetaItem(Icons.Filled.Domain, "Publisher", it, onClick = onPublisherClick?.let { cb -> { cb(game.publisher!!) } }))
+                add(MetaItem(Icons.Filled.Domain, "Publisher", it, onClick = onPublisherClick?.let { cb -> { cb(game.publisher) } }))
             }
         }
         game.releaseDate?.takeIf { it.isNotBlank() }?.let {
@@ -135,8 +135,8 @@ private fun MetadataItem(
         modifier = modifier
             .padding(vertical = SpSpacing.XSmall)
             .then(
-                if (isClickable) Modifier
-                    .clickable(onClick = onClick!!)
+                if (onClick != null) Modifier
+                    .clickable(onClick = onClick)
                     .gamepadFocusable(shape = RoundedCornerShape(SpSpacing.Small))
                 else Modifier
             ),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
@@ -357,7 +357,7 @@ private fun SessionItem(
                                 },
                                 onClick = {
                                     showPlayMenu = false
-                                    onContinueFromTitleScreen?.invoke()
+                                    onContinueFromTitleScreen()
                                 },
                             )
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
@@ -28,8 +28,8 @@ import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.SportsEsports
 import androidx.compose.material.icons.filled.Stop
-import androidx.compose.material.icons.filled.VolumeUp
-import androidx.compose.material.icons.filled.VolumeOff
+import androidx.compose.material.icons.automirrored.filled.VolumeUp
+import androidx.compose.material.icons.automirrored.filled.VolumeOff
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import com.spela.player.presentation.ui.components.SpSlider
@@ -294,7 +294,7 @@ internal fun InGameOverlayPanel(
                         horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
                     ) {
                         Icon(
-                            imageVector = if (state.volume < 0.01f) Icons.Filled.VolumeOff else Icons.Filled.VolumeUp,
+                            imageVector = if (state.volume < 0.01f) Icons.AutoMirrored.Filled.VolumeOff else Icons.AutoMirrored.Filled.VolumeUp,
                             contentDescription = "Volume",
                             tint = SpColor.OnBackgroundSecondary,
                         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondarySaveSlotsPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondarySaveSlotsPage.kt
@@ -208,7 +208,7 @@ private fun SaveSlotCard(
             horizontalAlignment = Alignment.CenterHorizontally,
             verticalArrangement = Arrangement.Center,
         ) {
-            if (isFilled && slotInfo != null && slotInfo.screenshotUrl != null) {
+            if (isFilled && slotInfo.screenshotUrl != null) {
                 // Thumbnail image
                 SubcomposeAsyncImage(
                     model = slotInfo.screenshotUrl,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreKeywordScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreKeywordScreen.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import com.spela.player.presentation.ui.components.SpLazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Label
+import androidx.compose.material.icons.automirrored.filled.Label
 import androidx.compose.material.icons.filled.Star
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
@@ -109,7 +109,7 @@ fun ExploreKeywordScreen(
                         contentAlignment = Alignment.Center,
                     ) {
                         SpEmptyState(
-                            icon = Icons.Filled.Label,
+                            icon = Icons.AutoMirrored.Filled.Label,
                             title = "No games found",
                             message = "No games match this keyword yet.",
                             modifier = Modifier.testTag("keyword_empty_state"),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -1019,7 +1019,7 @@ private fun GameHeroContent(
             // Status indicators (scraping, syncing, downloading)
             val statusText = when {
                 state.isScraping -> "Scraping\u2026"
-                syncState?.isTimedOut == false && syncState != null -> syncState.message
+                syncState != null && !syncState.isTimedOut -> syncState.message
                 state.isDownloading -> {
                     val p = state.downloadProgress
                     if (p != null && p.totalDiscs > 1) "Downloading disc ${p.currentDisc}/${p.totalDiscs}\u2026"

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
@@ -100,7 +100,7 @@ fun NetplayLobbyScreen(
     var autoLaunchCountdown by remember { mutableIntStateOf(0) }
 
     LaunchedEffect(bothConnected, session?.inputDelay) {
-        if (bothConnected && session != null) {
+        if (bothConnected) {
             autoLaunchCountdown = 3
             while (autoLaunchCountdown > 0) {
                 delay(1000)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -297,7 +297,7 @@ class GameDetailViewModel(
                     _state.update {
                         val updatedGame = it.gameDetail?.game?.copy(isFavorite = !currentlyFavorite)
                         it.copy(
-                            gameDetail = updatedGame?.let { g -> it.gameDetail?.copy(game = g) }
+                            gameDetail = updatedGame?.let { g -> it.gameDetail.copy(game = g) }
                         )
                     }
                 },
@@ -314,7 +314,7 @@ class GameDetailViewModel(
         // Optimistic update: flip immediately to prevent double-clicks
         _state.update {
             val updatedGame = it.gameDetail?.game?.copy(isInPlayLater = !currentlyInPlayLater)
-            it.copy(gameDetail = updatedGame?.let { g -> it.gameDetail?.copy(game = g) })
+            it.copy(gameDetail = updatedGame?.let { g -> it.gameDetail.copy(game = g) })
         }
         scope.launch(dispatchers.io) {
             togglePlayLaterUseCase(detail.game.id, currentlyInPlayLater).fold(
@@ -324,7 +324,7 @@ class GameDetailViewModel(
                     _state.update {
                         val revertedGame = it.gameDetail?.game?.copy(isInPlayLater = currentlyInPlayLater)
                         it.copy(
-                            gameDetail = revertedGame?.let { g -> it.gameDetail?.copy(game = g) },
+                            gameDetail = revertedGame?.let { g -> it.gameDetail.copy(game = g) },
                             error = error.message,
                         )
                     }


### PR DESCRIPTION
## Summary

Shared-desktop compile output dropped from **27 warnings to 3**. The 3 remaining are all Group B API migrations (\`TabRow\`→\`PrimaryTabRow\`, \`Modifier.tabIndicatorOffset\`→\`TabIndicatorScope.tabIndicatorOffset\`, \`LocalClipboardManager\`→\`LocalClipboard\`) that need real restructuring and belong in follow-ups.

## Categories

### Deprecated typealias — \`kotlinx.datetime.Instant\` → \`kotlin.time.Instant\` (4 sites, 2 files)
\`DtoMappers.kt\` and \`Models.kt\` import-only change; the type name is the same so no use-site edits needed.

### AutoMirrored icons (3 sites, 2 files)
\`Icons.Filled.VolumeOff\`, \`Icons.Filled.VolumeUp\`, and \`Icons.Filled.Label\` moved to \`Icons.AutoMirrored.Filled.*\` for proper RTL mirroring. Updated \`InGameOverlayPanel.kt\` (volume icons) and \`ExploreKeywordScreen.kt\` (label icon).

### Unnecessary \`!!\` operators (6 sites, 4 files)
Kotlin 2.x smart-casts through \`val\`-encoded null checks and through the branches of \`?.takeIf {}?.let {}\` chains. The compiler knows these receivers are non-null, so \`!!\` was redundant (and misleading).
- \`LocalScrapeService.kt:30\` — after \`isNullOrEmpty()\` guard
- \`SpNetplayPlayerSlot.kt:78,103\` — after \`val isFilled = username != null\`
- \`HeroCarousel.kt:271\` — after \`if (game.logoUrl != null)\`
- \`MetadataGrid.kt:58,62\` — inside \`game.X?.takeIf { it.isNotBlank() }?.let\`
- \`MetadataGrid.kt:139\` — reworked the \`isClickable\` local into a direct \`onClick != null\` check so the smart cast fires

### Unnecessary safe calls \`?.\` (4 sites, 2 files)
- \`SessionsSection.kt:360\` — inside an \`if (showChevron)\` block where \`showChevron = … && onContinueFromTitleScreen != null\`, the callback is smart-cast to non-null, so \`?.invoke()\` becomes a direct call
- \`GameDetailViewModel.kt:300,317,327\` — inside \`updatedGame?.let { g -> … }\` where \`updatedGame = it.gameDetail?.game?.copy(…)\`, \`it.gameDetail\` is already smart-cast to non-null

### "Condition is always 'true'" (3 sites, 3 files)
- \`SecondarySaveSlotsPage.kt:211\` — \`isFilled\` (defined as \`slotInfo?.isFilled == true\`) already implies \`slotInfo != null\`; simplified to \`if (isFilled && slotInfo.screenshotUrl != null)\` with the compiler's smart cast through the val
- \`GameDetailScreen.kt:1022\` — reordered \`syncState?.isTimedOut == false && syncState != null\` to \`syncState != null && !syncState.isTimedOut\` (same logic, explicit null check first, no redundant second check)
- \`NetplayLobbyScreen.kt:103\` — \`bothConnected\` already implies \`session != null\`; removed the redundant second check

### Gradle compiler flag (2 sites, 1 file)
Added \`-Xexpect-actual-classes\` to every Kotlin compilation in \`:shared\`. Suppresses the "expect/actual classes are in Beta" warning from every KMP expect declaration file (KT-61573), as recommended by the compiler message itself. Applied via \`targets.configureEach { compilations.configureEach { … } }\` so new targets inherit it automatically.

### Opt-in annotation (1 site, 1 file)
\`ConnectivityMonitor.kt:28\` defines an anonymous \`StateFlow<Boolean>\` subclass for backward-compat reasons. Inheriting from \`StateFlow\` requires opting into \`ExperimentalForInheritanceCoroutinesApi\`. Annotated the property with \`@OptIn(...)\`.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop\` — **3 warnings** (all Group B API migrations), down from 27
- [x] \`./gradlew :shared:compileDebugKotlinAndroid\` — clean, no new issues on the Android target
- [x] \`./gradlew :shared:detektMainDesktop\` — 0 detekt findings
- [x] \`./gradlew :shared:desktopTest\` — 458 tests pass, zero failures
- [x] Pre-push hook from PR #379 correctly skipped \`npm run build\` and \`go build\` on this push (no \`web/\` or \`server/\` changes)

## Remaining 3 warnings (deferred to follow-up)

1. \`GlobalChallengesScreen.kt:91\` — \`TabRow\` deprecated, replace with \`PrimaryTabRow\` / \`SecondaryTabRow\`
2. \`GlobalChallengesScreen.kt:99\` — \`Modifier.tabIndicatorOffset\` only valid on the deprecated \`TabRow\`; needs the \`TabIndicatorScope\` variant once #1 is done
3. \`NetplayLobbyScreen.kt:82\` — \`LocalClipboardManager\` deprecated, replace with \`LocalClipboard\` (suspend-capable)

These are real API reshapes, not simple replacements, so they belong in a separate PR where they can get proper test coverage.