### PR TITLE
chore: migrate TabRow → SecondaryTabRow in GlobalChallengesScreen

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalChallengesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GlobalChallengesScreen.kt
@@ -13,10 +13,9 @@ import androidx.compose.foundation.lazy.grid.GridCells
 import com.spela.player.presentation.ui.components.SpLazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SecondaryTabRow
 import androidx.compose.material3.Tab
-import androidx.compose.material3.TabRow
 import androidx.compose.material3.TabRowDefaults
-import androidx.compose.material3.TabRowDefaults.tabIndicatorOffset
 import androidx.compose.material3.Text
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
@@ -88,18 +87,16 @@ fun GlobalChallengesScreen(
 
         // Tabs
         val selectedTabIndex = tabs.indexOfFirst { it.first == state.selectedTab }
-        TabRow(
+        SecondaryTabRow(
             selectedTabIndex = selectedTabIndex,
             modifier = Modifier.fillMaxWidth(),
             containerColor = SpColor.Surface,
             contentColor = SpColor.OnSurface,
-            indicator = { tabPositions ->
-                if (selectedTabIndex < tabPositions.size) {
-                    TabRowDefaults.SecondaryIndicator(
-                        modifier = Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
-                        color = SpColor.Link,
-                    )
-                }
+            indicator = {
+                TabRowDefaults.SecondaryIndicator(
+                    modifier = Modifier.tabIndicatorOffset(selectedTabIndex, matchContentSize = false),
+                    color = SpColor.Link,
+                )
             },
         ) {
             tabs.forEachIndexed { index, (tab, title) ->


### PR DESCRIPTION
## Summary

Kills both TabRow-related deprecation warnings from the remaining Group B list in one commit:

- \`TabRow\` → \`SecondaryTabRow\`
- \`TabRowDefaults.tabIndicatorOffset(TabPosition)\` → \`TabIndicatorScope.tabIndicatorOffset(Int, matchContentSize)\`

Leaves only 1 compiler warning still open (\`LocalClipboardManager\` in \`NetplayLobbyScreen\`) — that's PR #2 of 2 in the Group B cleanup and will follow.

## The migration

The old API:

\`\`\`kotlin
TabRow(
    selectedTabIndex,
    indicator = { tabPositions ->   // takes List<TabPosition>
        TabRowDefaults.SecondaryIndicator(
            Modifier.tabIndicatorOffset(tabPositions[selectedTabIndex]),
        )
    },
) { ... }
\`\`\`

The new API reshapes \`indicator\` into a \`TabIndicatorScope.() -> Unit\` so the scope exposes a new \`Modifier.tabIndicatorOffset(selectedTabIndex, matchContentSize)\` extension. Callers no longer resolve the tab position manually from a list, and no longer need to bounds-check \`selectedTabIndex\` against \`tabPositions.size\`:

\`\`\`kotlin
SecondaryTabRow(
    selectedTabIndex,
    indicator = {
        TabRowDefaults.SecondaryIndicator(
            Modifier.tabIndicatorOffset(selectedTabIndex, matchContentSize = false),
        )
    },
) { ... }
\`\`\`

## Decisions

- **\`SecondaryTabRow\`, not \`PrimaryTabRow\`.** This screen already used \`TabRowDefaults.SecondaryIndicator\` with a thin \`SpColor.Link\` underline, not the thicker primary indicator. Picking \`SecondaryTabRow\` preserves the existing visual.
- **\`matchContentSize = false\`.** Preserves the previous behavior where the indicator spans the full tab cell width rather than hugging the label text. Flip to \`true\` if we later decide we want a tighter indicator.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop\` — 1 warning (only \`LocalClipboardManager\` left, PR follows), down from 3
- [x] \`./gradlew :shared:compileDebugKotlinAndroid\` — clean
- [x] \`./gradlew :shared:detektMainDesktop\` — 0 detekt findings
- [x] \`./gradlew :shared:desktopTest\` — 458 tests pass, zero failures
- [ ] **Visual verification pending** — I can't run the app here, so this is a semantically-equivalent edit but reviewer should eyeball the tab indicator on Global Challenges to confirm it still looks right. Same colors, same indicator style, same behavior when \`selectedTabIndex\` is valid (the new API's \`tabIndicatorOffset\` handles out-of-bounds gracefully, which is why the old \`if (selectedTabIndex < tabPositions.size)\` guard could go away).