### PR TITLE
chore: migrate LocalClipboardManager → LocalClipboard in netplay lobby

### DIFF
--- a/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/components/PlatformClipboard.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/presentation/ui/components/PlatformClipboard.android.kt
@@ -1,0 +1,7 @@
+package com.spela.player.presentation.ui.components
+
+import android.content.ClipData
+import androidx.compose.ui.platform.ClipEntry
+
+actual fun createTextClipEntry(text: String): ClipEntry =
+    ClipEntry(ClipData.newPlainText("plain text", text))

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/PlatformClipboard.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/PlatformClipboard.kt
@@ -1,0 +1,18 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.ui.platform.ClipEntry
+
+/**
+ * Creates a platform-specific [ClipEntry] from a plain-text string.
+ *
+ * Needed because [ClipEntry] is `expect class`: its constructor takes a
+ * native object (`android.content.ClipData` on Android,
+ * `java.awt.datatransfer.Transferable` on desktop) which can't be
+ * constructed from commonMain code. Compose 1.10 has an internal
+ * `AnnotatedString?.toClipEntry()` helper inside `compose-foundation`
+ * but it's `internal`, so we re-implement the same idea here.
+ *
+ * Use in combination with `androidx.compose.ui.platform.LocalClipboard`
+ * and `Clipboard.setClipEntry(...)`.
+ */
+expect fun createTextClipEntry(text: String): ClipEntry

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/NetplayLobbyScreen.kt
@@ -25,22 +25,23 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalClipboard
 import androidx.compose.ui.semantics.LiveRegionMode
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.liveRegion
 import androidx.compose.ui.semantics.semantics
-import androidx.compose.ui.text.AnnotatedString
 import com.spela.player.domain.model.NetplaySessionStatus
 import com.spela.player.presentation.intent.NetplayLobbyIntent
 import com.spela.player.presentation.ui.feature.netplay.InputDelaySection
 import com.spela.player.presentation.ui.feature.netplay.LobbyHeader
 import com.spela.player.presentation.ui.components.InvitePlayerSheet
 import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.createTextClipEntry
 import com.spela.player.presentation.ui.components.SpSecondaryButton
 import com.spela.player.presentation.ui.components.SpLoadingIndicator
 import com.spela.player.presentation.ui.components.SpNetplayPlayerSlot
@@ -60,6 +61,7 @@ import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.NetplayLobbyViewModel
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 
 data class NetplayStartConfig(
     val gameId: String,
@@ -79,7 +81,8 @@ fun NetplayLobbyScreen(
     onStartGame: (NetplayStartConfig) -> Unit,
 ) {
     val state by viewModel.state.collectAsState()
-    val clipboardManager = LocalClipboardManager.current
+    val clipboard = LocalClipboard.current
+    val clipboardScope = rememberCoroutineScope()
 
     LaunchedEffect(sessionId) {
         viewModel.onIntent(NetplayLobbyIntent.LoadSession(sessionId))
@@ -169,7 +172,9 @@ fun NetplayLobbyScreen(
                                 SpSessionCode(
                                     code = session.inviteCode,
                                     onCopy = {
-                                        clipboardManager.setText(AnnotatedString(session.inviteCode))
+                                        clipboardScope.launch {
+                                            clipboard.setClipEntry(createTextClipEntry(session.inviteCode))
+                                        }
                                     },
                                     modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
                                 )

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/components/PlatformClipboard.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/presentation/ui/components/PlatformClipboard.desktop.kt
@@ -1,0 +1,9 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.platform.ClipEntry
+import java.awt.datatransfer.StringSelection
+
+@OptIn(ExperimentalComposeUiApi::class)
+actual fun createTextClipEntry(text: String): ClipEntry =
+    ClipEntry(StringSelection(text))


### PR DESCRIPTION
## Summary

Kills the final Group B deprecation warning:

\`\`\`
w: NetplayLobbyScreen.kt:82 'val LocalClipboardManager:
   ProvidableCompositionLocal<ClipboardManager>' is deprecated. Use
   LocalClipboard instead which supports suspend functions.
\`\`\`

**Shared desktop compile now emits zero warnings.** 🎉

## The problem

The old API was a synchronous \`ClipboardManager.setText(AnnotatedString)\` that worked from common code directly:

\`\`\`kotlin
val clipboardManager = LocalClipboardManager.current
clipboardManager.setText(AnnotatedString(session.inviteCode))
\`\`\`

The new \`Clipboard\` interface exposes \`suspend fun setClipEntry(ClipEntry?)\`, where \`ClipEntry\` is an \`expect class\` whose constructor takes a platform-specific native object:
- Desktop: \`java.awt.datatransfer.Transferable\` (wrapped in \`ClipEntry\`)
- Android: \`android.content.ClipData\`

There is no common-code helper to construct a \`ClipEntry\` from a plain string. \`compose-foundation\` has an \`internal AnnotatedString?.toClipEntry()\` that does exactly this, but it's scoped \`internal\` and unreachable from application code.

## Fix

Introduced a small project-level platform shim mirroring the existing \`PlatformBackHandler\` / \`PlatformKeyNames\` / \`PlatformDsTouchScreen\` pattern:

- **\`commonMain/.../components/PlatformClipboard.kt\`** — \`expect fun createTextClipEntry(text: String): ClipEntry\`
- **\`desktopMain/.../components/PlatformClipboard.desktop.kt\`** — wraps \`java.awt.datatransfer.StringSelection\`. Needs \`@OptIn(ExperimentalComposeUiApi::class)\` because the desktop \`ClipEntry\` constructor is marked experimental.
- **\`androidMain/.../components/PlatformClipboard.android.kt\`** — wraps \`android.content.ClipData.newPlainText(...)\`.

Updated \`NetplayLobbyScreen\` to:
- use \`LocalClipboard.current\` (returns a \`Clipboard\` instance with suspend setters)
- \`rememberCoroutineScope()\` for launching the set
- call \`clipboard.setClipEntry(createTextClipEntry(session.inviteCode))\` inside the scope

Removed the now-unused \`AnnotatedString\` import from the screen file.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop\` — **0 warnings** (was 1)
- [x] \`./gradlew :shared:compileDebugKotlinAndroid\` — 1 pre-existing warning in \`SecondaryDisplayPresentation.kt:89\` unrelated to this change; clean otherwise
- [x] \`./gradlew :shared:detektMainDesktop\` — 0 findings
- [x] \`./gradlew :shared:desktopTest\` — 458 tests pass, zero failures
- [ ] **Manual test needed**: copy the invite code from a netplay lobby on both platforms and paste somewhere to verify. I can't run the app here, so a reviewer should exercise this flow before merge.

## Follow-up noted

The one remaining warning I see is an Android-target \`w: SecondaryDisplayPresentation.kt:89\` "overrides a deprecated member but is not marked as deprecated itself". It's pre-existing and unrelated to clipboard — belongs in a separate PR.