### PR TITLE
ci: skip tests on doc-only pushes and PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,18 @@ name: CI
 on:
   push:
     branches: [master]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.plans/**'
+      - 'design-proposals/**'
   pull_request:
     branches: [master]
+    paths-ignore:
+      - '**.md'
+      - 'LICENSE'
+      - '.plans/**'
+      - 'design-proposals/**'
 
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true


### PR DESCRIPTION
## Summary

Adds \`paths-ignore\` to both the \`push\` and \`pull_request\` triggers in \`.github/workflows/ci.yml\` so doc-only changes don't burn ~7 min of Go tests + 4 min of Player tests + 2 min of Web tests for no signal.

Motivated by PR #384 (docs-only AGENTS.md migration) burning ~7 min of Go tests that had nothing to validate.

## Filtered paths

- \`**.md\` — catches every markdown file anywhere in the tree (IMPROVEMENTS.md, CLAUDE.md, README.md, per-package AGENTS.md, \`docs/\`, \`design-proposals/*.md\`, etc.)
- \`LICENSE\` — never affects any build
- \`.plans/**\` — transient planning directory (mostly untracked today, defensive in case it gets committed)
- \`design-proposals/**\` — design proposal drafts (same story)

## Semantics

GitHub skips the workflow when a push/PR changes **only** files matching the ignore list. A mixed push (docs + code) still runs everything. That's why workflow-level filters are enough as a first step — per-job path filters (e.g. \`go-test\` skips if no \`server/**\` changes) would need to untangle the \`needs:\` graph, which is fiddlier than the savings justify right now.

## Not filtered (intentional)

- \`.github/workflows/*.yml\` — workflow edits still run CI to validate themselves
- \`.gitignore\` — can affect what subsequent jobs see
- Everything else

## Test plan

- [x] YAML syntax valid (visual review; \`paths-ignore\` is standard GitHub Actions schema)
- [ ] **Self-test**: this PR itself only changes \`.github/workflows/ci.yml\`, which is NOT in the ignore list, so CI should still run. That's the proof that workflow edits aren't skipped.
- [ ] Next doc-only PR after this lands should show zero job runs on GitHub Actions → confirms the ignore works.