### PR TITLE
fix: IGDB scraper misses Japan-only SNES releases (Alcahest etc.)

### DIFF
--- a/server/internal/api/admin_handler_igdb.go
+++ b/server/internal/api/admin_handler_igdb.go
@@ -42,13 +42,13 @@ func (h *AdminHandler) SearchIGDB(c *gin.Context) {
 		return
 	}
 
-	platformID, ok := igdb.AbbreviationToIGDBPlatform[game.Console.Abbreviation]
+	platformIDs, ok := igdb.AbbreviationToIGDBPlatform[game.Console.Abbreviation]
 	if !ok {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "no IGDB platform mapping for this console"})
 		return
 	}
 
-	games, err := h.Scraper.IGDBClient.SearchGame(query, platformID)
+	games, err := h.Scraper.IGDBClient.SearchGame(query, platformIDs)
 	if err != nil {
 		slog.Warn("IGDB search failed", "query", query, "error", err)
 		c.JSON(http.StatusBadGateway, gin.H{"error": "IGDB search failed"})

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -462,12 +462,12 @@ func (h *AdminHandler) refreshTopRatedForAllConsoles() {
 
 	for _, console := range consoles {
 		abbr := console.Abbreviation
-		platformID, ok := igdb.AbbreviationToIGDBPlatform[abbr]
+		platformIDs, ok := igdb.AbbreviationToIGDBPlatform[abbr]
 		if !ok {
 			continue
 		}
 
-		topGames, err := h.Scraper.IGDBClient.GetTopGames(platformID, 100)
+		topGames, err := h.Scraper.IGDBClient.GetTopGames(platformIDs, 100)
 		if err != nil {
 			slog.Warn("failed to fetch top-rated games", "console", abbr, "error", err)
 			continue

--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -432,7 +432,7 @@ func (h *ConsoleHandler) GetTopRated(c *gin.Context) {
 	}
 
 	abbr := strings.ToUpper(console.Abbreviation)
-	igdbPlatformID, ok := igdb.AbbreviationToIGDBPlatform[abbr]
+	igdbPlatformIDs, ok := igdb.AbbreviationToIGDBPlatform[abbr]
 	if !ok {
 		c.JSON(http.StatusOK, []TopRatedGameResponse{})
 		return
@@ -456,7 +456,7 @@ func (h *ConsoleHandler) GetTopRated(c *gin.Context) {
 		// Fetch a larger pool from IGDB, then apply Bayesian weighting to match
 		// the IGDB website's ranking (which favors well-known, highly-rated games
 		// over obscure titles with few but high ratings).
-		topGames, err := h.Scraper.IGDBClient.GetTopGames(igdbPlatformID, 100)
+		topGames, err := h.Scraper.IGDBClient.GetTopGames(igdbPlatformIDs, 100)
 		if err != nil {
 			slog.Warn("failed to fetch top-rated games from IGDB", "console", abbr, "error", err)
 			// Fall through to serve stale data if available

--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -19,68 +19,87 @@ var (
 	igdbImageBase  = "https://images.igdb.com/igdb/image/upload"
 )
 
-// AbbreviationToIGDBPlatform maps Spela console abbreviations to IGDB platform IDs.
-var AbbreviationToIGDBPlatform = map[string]int{
-	"NES":    18,
-	"SNES":   19,
-	"GB":     33,
-	"GBC":    22,
-	"GBA":    24,
-	"N64":    4,
-	"NDS":    20,
-	"SMS":    64,
-	"GEN":    29,
-	"SAT":    32,
-	"PSX":    7,
-	"PSP":    38,
-	"NEOGEO": 80,
-	"NEOCD":  136, // Neo Geo CD
-	"PCE":    86,
-	"PCECD":  150, // TurboGrafx-CD / PC Engine CD
-	"A26":    59,
-	"GG":     35,
-	"SCD":    78,
-	"32X":    30,
-	"DC":     23,
-	"VB":     87,
-	"3DS":    37,
-	"GC":     21,
-	"PS2":    8,
-	"C64":    15,
-	"AMIGA":  16,
-	"ACD32":  114,
+// AbbreviationToIGDBPlatform maps Spela console abbreviations to one or more
+// IGDB platform IDs. Most consoles have a single ID because IGDB merged the
+// regional variants under one hardware-family entry (NES covers Famicom,
+// Mega Drive/Genesis is id 29, Master System/Mark III is id 64, TG16/PC Engine
+// is id 86, etc.). The SNES is the one exception: IGDB filed the Japanese
+// Super Famicom under a separate platform id (58), so Japan-only releases
+// like Alcahest (IGDB id 3651) are NOT reachable through SNES id 19 alone.
+// Mapping SNES to both [19, 58] causes the search query to include the
+// Japanese variant as well.
+var AbbreviationToIGDBPlatform = map[string][]int{
+	"NES":    {18},
+	"SNES":   {19, 58}, // SNES + Super Famicom (Japan); see package doc above
+	"GB":     {33},
+	"GBC":    {22},
+	"GBA":    {24},
+	"N64":    {4},
+	"NDS":    {20},
+	"SMS":    {64},
+	"GEN":    {29},
+	"SAT":    {32},
+	"PSX":    {7},
+	"PSP":    {38},
+	"NEOGEO": {80},
+	"NEOCD":  {136}, // Neo Geo CD
+	"PCE":    {86},
+	"PCECD":  {150}, // TurboGrafx-CD / PC Engine CD
+	"A26":    {59},
+	"GG":     {35},
+	"SCD":    {78},
+	"32X":    {30},
+	"DC":     {23},
+	"VB":     {87},
+	"3DS":    {37},
+	"GC":     {21},
+	"PS2":    {8},
+	"C64":    {15},
+	"AMIGA":  {16},
+	"ACD32":  {114},
 	// ADEMO (Amiga Demos) intentionally omitted — demoscene productions
 	// don't exist in IGDB and would match against commercial games.
-	"DOS": 13,
+	"DOS": {13},
 	// DDEMO (DOS Demos) intentionally omitted — same reason as ADEMO.
-	"A52":    66,
-	"A78":    60,
-	"LYNX":   61,
-	"JAG":    62,
-	"NGP":    120,
-	"WS":     57,
-	"CV":     68,
-	"PCFX":   274,
-	"PKMN":   166,
-	"MSX1":   27,
-	"MSX2":   53,
-	"ARCADE": 52,
-	"PS3":    9,
-	"PS4":    48,
-	"PS5":    167,
-	"XBOX":   11,
-	"X360":   12,
-	"XONE":   49,
-	"XSX":    169,
-	"3DO":    50,
-	"CDI":    117,
-	"WII":    5,
-	"WIIU":   41,
-	"NSW":    130,
-	"C128":   15, // shares IGDB platform with C64
-	"PET":    90,
-	"PLUS4":  94,
-	"VIC20":  71,
+	"A52":    {66},
+	"A78":    {60},
+	"LYNX":   {61},
+	"JAG":    {62},
+	"NGP":    {120},
+	"WS":     {57},
+	"CV":     {68},
+	"PCFX":   {274},
+	"PKMN":   {166},
+	"MSX1":   {27},
+	"MSX2":   {53},
+	"ARCADE": {52},
+	"PS3":    {9},
+	"PS4":    {48},
+	"PS5":    {167},
+	"XBOX":   {11},
+	"X360":   {12},
+	"XONE":   {49},
+	"XSX":    {169},
+	"3DO":    {50},
+	"CDI":    {117},
+	"WII":    {5},
+	"WIIU":   {41},
+	"NSW":    {130},
+	"C128":   {15}, // shares IGDB platform with C64
+	"PET":    {90},
+	"PLUS4":  {94},
+	"VIC20":  {71},
+}
+
+// formatPlatformList renders a list of platform IDs as an IGDB query tuple:
+// [19, 58] → "(19, 58)". This matches IGDB's syntax for matching a game
+// where any of the listed platforms is present.
+func formatPlatformList(platformIDs []int) string {
+	parts := make([]string, len(platformIDs))
+	for i, id := range platformIDs {
+		parts[i] = fmt.Sprintf("%d", id)
+	}
+	return "(" + strings.Join(parts, ", ") + ")"
 }
 
 // oauthToken holds a Twitch OAuth token with its expiration.
@@ -311,21 +330,27 @@ func ImageURL(imageID, size string) string {
 	return fmt.Sprintf("%s/t_%s/%s.jpg", igdbImageBase, size, imageID)
 }
 
-// SearchGame searches IGDB for a game by name and platform.
-func (c *Client) SearchGame(name string, platformID int) ([]Game, error) {
+// SearchGame searches IGDB for a game by name, accepting one or more platform
+// IDs. The platform filter is expressed as `platforms = (id1, id2, ...)` so
+// games that match ANY of the listed platforms are returned. Callers that
+// only have a single id can pass a single-element slice.
+func (c *Client) SearchGame(name string, platformIDs []int) ([]Game, error) {
 	if err := c.authenticate(); err != nil {
 		return nil, fmt.Errorf("IGDB authentication: %w", err)
+	}
+	if len(platformIDs) == 0 {
+		return nil, fmt.Errorf("IGDB search: no platform IDs supplied")
 	}
 
 	// Wait for rate limiter
 	<-c.rateLimiter
 
 	query := fmt.Sprintf(
-		`search "%s"; fields name,summary,storyline,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.company.logo.image_id,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,total_rating,total_rating_count,rating,rating_count,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where platforms = (%d); limit 5;`,
-		escapeQuery(name), platformID,
+		`search "%s"; fields name,summary,storyline,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.company.logo.image_id,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,total_rating,total_rating_count,rating,rating_count,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where platforms = %s; limit 5;`,
+		escapeQuery(name), formatPlatformList(platformIDs),
 	)
 
-	slog.Info("IGDB search request", "name", name, "platformID", platformID, "query", query)
+	slog.Info("IGDB search request", "name", name, "platformIDs", platformIDs, "query", query)
 
 	c.mu.Lock()
 	token := c.token.AccessToken
@@ -363,13 +388,17 @@ func (c *Client) SearchGame(name string, platformID int) ([]Game, error) {
 	return games, nil
 }
 
-// SearchGameExact queries IGDB for a game by exact name match and platform.
-// Uses a "where name" clause instead of the "search" keyword to avoid text-search
-// relevance ranking which can omit the exact game (e.g. "Super Mario 64" text search
-// returns the unreleased sequel but not the original).
-func (c *Client) SearchGameExact(name string, platformID int) ([]Game, error) {
+// SearchGameExact queries IGDB for a game by exact name match, accepting one
+// or more platform IDs. Uses a "where name" clause instead of the "search"
+// keyword to avoid text-search relevance ranking which can omit the exact
+// game (e.g. "Super Mario 64" text search returns the unreleased sequel but
+// not the original).
+func (c *Client) SearchGameExact(name string, platformIDs []int) ([]Game, error) {
 	if err := c.authenticate(); err != nil {
 		return nil, fmt.Errorf("IGDB authentication: %w", err)
+	}
+	if len(platformIDs) == 0 {
+		return nil, fmt.Errorf("IGDB exact search: no platform IDs supplied")
 	}
 
 	// Wait for rate limiter
@@ -377,11 +406,11 @@ func (c *Client) SearchGameExact(name string, platformID int) ([]Game, error) {
 
 	// Case-insensitive exact match using ~ operator
 	query := fmt.Sprintf(
-		`fields name,summary,storyline,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.company.logo.image_id,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,total_rating,total_rating_count,rating,rating_count,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where name ~ "%s" & platforms = (%d); limit 5;`,
-		escapeQuery(name), platformID,
+		`fields name,summary,storyline,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.company.logo.image_id,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,total_rating,total_rating_count,rating,rating_count,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where name ~ "%s" & platforms = %s; limit 5;`,
+		escapeQuery(name), formatPlatformList(platformIDs),
 	)
 
-	slog.Info("IGDB exact search request", "name", name, "platformID", platformID, "query", query)
+	slog.Info("IGDB exact search request", "name", name, "platformIDs", platformIDs, "query", query)
 
 	c.mu.Lock()
 	token := c.token.AccessToken
@@ -540,24 +569,29 @@ type TopGame struct {
 	CriticRatingCount     int     `json:"aggregated_rating_count"`
 }
 
-// GetTopGames fetches the top-rated games for a given IGDB platform.
+// GetTopGames fetches the top-rated games for the given IGDB platform(s).
 // Only includes games that have both user ratings (rating_count > 5) AND
 // at least one critic/aggregated rating, to filter out games with inflated
-// user-only scores.
-func (c *Client) GetTopGames(platformID int, limit int) ([]TopGame, error) {
+// user-only scores. Accepts multiple platform IDs so the SNES top list
+// includes Japan-only releases living under Super Famicom (58) alongside
+// the international SNES (19).
+func (c *Client) GetTopGames(platformIDs []int, limit int) ([]TopGame, error) {
 	if err := c.authenticate(); err != nil {
 		return nil, fmt.Errorf("IGDB authentication: %w", err)
+	}
+	if len(platformIDs) == 0 {
+		return nil, fmt.Errorf("IGDB top games: no platform IDs supplied")
 	}
 
 	// Wait for rate limiter
 	<-c.rateLimiter
 
 	query := fmt.Sprintf(
-		`fields name, cover.image_id, total_rating, total_rating_count, rating, rating_count, aggregated_rating, aggregated_rating_count; where platforms = (%d) & total_rating != null & total_rating_count > 5 & aggregated_rating != null; sort total_rating desc; limit %d;`,
-		platformID, limit,
+		`fields name, cover.image_id, total_rating, total_rating_count, rating, rating_count, aggregated_rating, aggregated_rating_count; where platforms = %s & total_rating != null & total_rating_count > 5 & aggregated_rating != null; sort total_rating desc; limit %d;`,
+		formatPlatformList(platformIDs), limit,
 	)
 
-	slog.Info("IGDB top games request", "platformID", platformID, "limit", limit)
+	slog.Info("IGDB top games request", "platformIDs", platformIDs, "limit", limit)
 
 	c.mu.Lock()
 	token := c.token.AccessToken
@@ -586,7 +620,7 @@ func (c *Client) GetTopGames(platformID int, limit int) ([]TopGame, error) {
 		return nil, fmt.Errorf("decoding IGDB response: %w", err)
 	}
 
-	slog.Info("IGDB top games response", "platformID", platformID, "resultCount", len(games))
+	slog.Info("IGDB top games response", "platformIDs", platformIDs, "resultCount", len(games))
 
 	return games, nil
 }

--- a/server/internal/igdb/client_test.go
+++ b/server/internal/igdb/client_test.go
@@ -232,7 +232,7 @@ func TestSearchGame_Success(t *testing.T) {
 		rateLimiter:  time.Tick(time.Millisecond),
 	}
 
-	games, err := c.SearchGame("Super Mario Bros", 18)
+	games, err := c.SearchGame("Super Mario Bros", []int{18})
 	require.NoError(t, err)
 	require.Len(t, games, 1)
 
@@ -287,7 +287,7 @@ func TestSearchGame_APIError(t *testing.T) {
 		rateLimiter:  time.Tick(time.Millisecond),
 	}
 
-	_, err := c.SearchGame("test", 18)
+	_, err := c.SearchGame("test", []int{18})
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "429")
 }
@@ -323,7 +323,7 @@ func TestSearchGame_NoResults(t *testing.T) {
 		rateLimiter:  time.Tick(time.Millisecond),
 	}
 
-	games, err := c.SearchGame("nonexistent-game-xyz", 18)
+	games, err := c.SearchGame("nonexistent-game-xyz", []int{18})
 	require.NoError(t, err)
 	assert.Empty(t, games)
 }
@@ -461,7 +461,7 @@ func TestRateLimiting(t *testing.T) {
 
 	start := time.Now()
 	for i := 0; i < 3; i++ {
-		_, err := c.SearchGame("test", 18)
+		_, err := c.SearchGame("test", []int{18})
 		require.NoError(t, err)
 	}
 	elapsed := time.Since(start)
@@ -888,11 +888,17 @@ func TestGetTimeToBeat_APIError(t *testing.T) {
 
 func TestPlatformMapping(t *testing.T) {
 	// Verify key platform mappings exist
-	assert.Equal(t, 18, AbbreviationToIGDBPlatform["NES"])
-	assert.Equal(t, 19, AbbreviationToIGDBPlatform["SNES"])
-	assert.Equal(t, 7, AbbreviationToIGDBPlatform["PSX"])
-	assert.Equal(t, 29, AbbreviationToIGDBPlatform["GEN"])
-	assert.Equal(t, 4, AbbreviationToIGDBPlatform["N64"])
+	assert.Equal(t, []int{18}, AbbreviationToIGDBPlatform["NES"])
+	// SNES maps to both the international SNES id (19) AND the Japanese
+	// Super Famicom id (58). Japan-only releases like Alcahest (IGDB id
+	// 3651) are filed under Super Famicom on IGDB and would not be found
+	// by a single-id search filter. See scraper_igdb_test.go /
+	// TestScrapeGame_SNESJapanOnlyGame_SearchesSuperFamicomPlatform for
+	// the full regression test.
+	assert.Equal(t, []int{19, 58}, AbbreviationToIGDBPlatform["SNES"])
+	assert.Equal(t, []int{7}, AbbreviationToIGDBPlatform["PSX"])
+	assert.Equal(t, []int{29}, AbbreviationToIGDBPlatform["GEN"])
+	assert.Equal(t, []int{4}, AbbreviationToIGDBPlatform["N64"])
 
 	// Unknown platform returns zero value
 	_, exists := AbbreviationToIGDBPlatform["UNKNOWN"]

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -216,7 +216,7 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 
 // scrapeIGDB searches IGDB for game metadata and downloads images.
 func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string) error {
-	platformID, ok := igdb.AbbreviationToIGDBPlatform[console.Abbreviation]
+	platformIDs, ok := igdb.AbbreviationToIGDBPlatform[console.Abbreviation]
 	if !ok {
 		return fmt.Errorf("no IGDB platform ID for console %s", console.Abbreviation)
 	}
@@ -301,14 +301,14 @@ func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string
 	// not the original).
 	var games []igdb.Game
 	var err error
-	games, err = s.IGDBClient.SearchGameExact(searchName, platformID)
+	games, err = s.IGDBClient.SearchGameExact(searchName, platformIDs)
 	if err != nil {
 		slog.Warn("IGDB exact search failed, falling back to text search", "game", searchName, "error", err)
 	}
 
 	// Fall back to text search if exact match found nothing
 	if len(games) == 0 {
-		games, err = s.IGDBClient.SearchGame(searchName, platformID)
+		games, err = s.IGDBClient.SearchGame(searchName, platformIDs)
 		if err != nil {
 			return fmt.Errorf("IGDB search: %w", err)
 		}
@@ -396,8 +396,8 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 	// Use platform-specific release date when available (e.g. SNES release of
 	// a game that originally launched on another platform), falling back to
 	// the global first release date.
-	platformID, _ := igdb.AbbreviationToIGDBPlatform[console.Abbreviation]
-	if rd := earliestPlatformReleaseDate(match.ReleaseDates, platformID); rd > 0 {
+	platformIDs := igdb.AbbreviationToIGDBPlatform[console.Abbreviation]
+	if rd := earliestPlatformReleaseDate(match.ReleaseDates, platformIDs); rd > 0 {
 		t := time.Unix(rd, 0)
 		game.ReleaseDate = t.Format("2006-01-02")
 	} else if match.FirstReleaseDate > 0 {
@@ -694,15 +694,21 @@ func (s *Scraper) cleanGameImages(game *db.Game, consoleAbbr, gameIDStr string) 
 }
 
 // earliestPlatformReleaseDate returns the earliest release date (unix timestamp)
-// from the given release dates that matches the specified IGDB platform ID.
-// Returns 0 if no matching platform release date is found.
-func earliestPlatformReleaseDate(dates []igdb.ReleaseDate, platformID int) int64 {
+// from the given release dates that matches any of the supplied IGDB platform
+// IDs. For multi-region consoles like SNES (which maps to both 19 and 58 to
+// pick up Japan-only releases), this returns the earliest date across all
+// regional variants. Returns 0 if no matching platform release date is found.
+func earliestPlatformReleaseDate(dates []igdb.ReleaseDate, platformIDs []int) int64 {
+	match := make(map[int]bool, len(platformIDs))
+	for _, id := range platformIDs {
+		match[id] = true
+	}
 	var earliest int64
 	for _, rd := range dates {
 		if rd.Platform == nil || rd.Date == 0 {
 			continue
 		}
-		if rd.Platform.ID == platformID {
+		if match[rd.Platform.ID] {
 			if earliest == 0 || rd.Date < earliest {
 				earliest = rd.Date
 			}

--- a/server/internal/scraper/scraper_igdb_test.go
+++ b/server/internal/scraper/scraper_igdb_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/crc32"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1101,22 +1102,22 @@ func TestEarliestPlatformReleaseDate(t *testing.T) {
 	tests := []struct {
 		name       string
 		dates      []igdb.ReleaseDate
-		platformID int
-		want       int64
+		platformIDs []int
+		want        int64
 	}{
 		{
 			name:       "no dates",
 			dates:      nil,
-			platformID: 19,
-			want:       0,
+			platformIDs: []int{19},
+			want:        0,
 		},
 		{
 			name: "no matching platform",
 			dates: []igdb.ReleaseDate{
 				{Date: 500000000, Platform: &igdb.ReleasePlatform{ID: 18, Name: "NES"}},
 			},
-			platformID: 19,
-			want:       0,
+			platformIDs: []int{19},
+			want:        0,
 		},
 		{
 			name: "single matching platform",
@@ -1124,8 +1125,8 @@ func TestEarliestPlatformReleaseDate(t *testing.T) {
 				{Date: 500000000, Platform: &igdb.ReleasePlatform{ID: 18, Name: "NES"}},
 				{Date: 700000000, Platform: &igdb.ReleasePlatform{ID: 19, Name: "SNES"}},
 			},
-			platformID: 19,
-			want:       700000000,
+			platformIDs: []int{19},
+			want:        700000000,
 		},
 		{
 			name: "multiple regions same platform picks earliest",
@@ -1134,8 +1135,8 @@ func TestEarliestPlatformReleaseDate(t *testing.T) {
 				{Date: 720000000, Platform: &igdb.ReleasePlatform{ID: 19, Name: "SNES"}, Region: 2}, // NA
 				{Date: 710000000, Platform: &igdb.ReleasePlatform{ID: 19, Name: "SNES"}, Region: 1}, // Europe
 			},
-			platformID: 19,
-			want:       700000000,
+			platformIDs: []int{19},
+			want:        700000000,
 		},
 		{
 			name: "skips entries with nil platform",
@@ -1143,8 +1144,8 @@ func TestEarliestPlatformReleaseDate(t *testing.T) {
 				{Date: 600000000, Platform: nil},
 				{Date: 700000000, Platform: &igdb.ReleasePlatform{ID: 19, Name: "SNES"}},
 			},
-			platformID: 19,
-			want:       700000000,
+			platformIDs: []int{19},
+			want:        700000000,
 		},
 		{
 			name: "skips entries with zero date",
@@ -1152,14 +1153,14 @@ func TestEarliestPlatformReleaseDate(t *testing.T) {
 				{Date: 0, Platform: &igdb.ReleasePlatform{ID: 19, Name: "SNES"}},
 				{Date: 700000000, Platform: &igdb.ReleasePlatform{ID: 19, Name: "SNES"}},
 			},
-			platformID: 19,
-			want:       700000000,
+			platformIDs: []int{19},
+			want:        700000000,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := earliestPlatformReleaseDate(tt.dates, tt.platformID)
+			got := earliestPlatformReleaseDate(tt.dates, tt.platformIDs)
 			assert.Equal(t, tt.want, got)
 		})
 	}
@@ -1244,3 +1245,125 @@ func TestScrapeGame_UsesPlatformSpecificReleaseDate(t *testing.T) {
 	// Should use SNES release date (1992), NOT the global first release (1987)
 	assert.Equal(t, "1992-01-01", game.ReleaseDate, "should use platform-specific release date, not global FirstReleaseDate")
 }
+
+// TestScrapeGame_SNESJapanOnlyGame_SearchesSuperFamicomPlatform verifies that
+// when scraping a Japanese-only SNES game, the IGDB search query includes
+// both the SNES (19) AND Super Famicom (58) platform IDs. IGDB is the only
+// console in Spela's mapping where the international and Japanese SKUs live
+// under separate platform IDs — Japan-only releases like "Alcahest (Japan)"
+// (IGDB id 3651) are filed under Super Famicom (58) only, so a query that
+// filters by SNES (19) alone returns zero results and the scraper records
+// the game as not_found.
+//
+// The mock IGDB server here intentionally returns results only when the
+// query body contains the literal "58" (Super Famicom platform ID),
+// mimicking IGDB's real behaviour for Alcahest. The test passes iff the
+// scraper populates the game's description and rating from the mock
+// response — proving the query included the Japanese platform ID.
+func TestScrapeGame_SNESJapanOnlyGame_SearchesSuperFamicomPlatform(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	var capturedQueries []string
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The /games endpoint gets hit twice (exact search then text search
+		// fallback) plus enrichment endpoints. Only the /games requests
+		// carry a query body we care about.
+		if !strings.HasSuffix(r.URL.Path, "/games") {
+			json.NewEncoder(w).Encode([]map[string]any{})
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		query := string(body)
+		capturedQueries = append(capturedQueries, query)
+
+		// Return the Alcahest data ONLY if the query names Super Famicom
+		// (platform id 58). This is the behaviour the real IGDB API exhibits
+		// for Japan-only SNES releases — the game isn't reachable through
+		// platform 19 alone.
+		if !strings.Contains(query, "58") {
+			json.NewEncoder(w).Encode([]igdb.Game{})
+			return
+		}
+
+		json.NewEncoder(w).Encode([]igdb.Game{
+			{
+				ID:               3651,
+				Name:             "Alcahest",
+				Summary:          "Alcahest is an action role-playing game with a top-down perspective that plays similar to The Legend of Zelda.",
+				AggregatedRating: 79.9,
+				TotalRating:      79.9,
+				TotalRatingCount: 42,
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := igdb.TwitchTokenURLForTest()
+	origAPIBase := igdb.IGDBAPIBaseForTest()
+	igdb.SetTwitchTokenURLForTest(tokenServer.URL)
+	igdb.SetIGDBAPIBaseForTest(igdbServer.URL + "/v4")
+	defer func() {
+		igdb.SetTwitchTokenURLForTest(origTokenURL)
+		igdb.SetIGDBAPIBaseForTest(origAPIBase)
+	}()
+
+	database := setupTestDB(t)
+	store := setupTestStorage(t)
+
+	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo Entertainment System"}
+	require.NoError(t, database.Create(&console).Error)
+
+	game := db.Game{
+		ConsoleID: console.ID,
+		Console:   console,
+		Title:     "Alcahest (Japan)",
+		FileName:  "Alcahest (Japan).sfc",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	igdbClient := igdb.NewClient("test-id", "test-secret")
+	igdbClient.HTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+	s := &Scraper{
+		DB:         database,
+		Storage:    store,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		IGDBClient: igdbClient,
+		DATCache:   NewDATCache(t.TempDir(), &http.Client{Timeout: 5 * time.Second}),
+		cache:      &nameCache{entries: make(map[string][]nameEntry)},
+	}
+
+	err := s.ScrapeGame(&game)
+	require.NoError(t, err)
+
+	// At least one /games query must have included the Super Famicom platform id.
+	foundSFC := false
+	for _, q := range capturedQueries {
+		if strings.Contains(q, "58") {
+			foundSFC = true
+			break
+		}
+	}
+	assert.True(t, foundSFC,
+		"scraper did not include Super Famicom (58) in any IGDB /games query; captured queries: %v",
+		capturedQueries)
+
+	// The scraper should have matched and populated metadata.
+	assert.Equal(t, "Alcahest", game.Title)
+	assert.NotEmpty(t, game.Description,
+		"game description should be populated from IGDB Alcahest response — "+
+			"if this is empty, the scraper's search returned nothing, which means "+
+			"the query did not include the Super Famicom platform")
+	assert.Greater(t, game.IGDBCriticsRating, 0.0,
+		"IGDB rating should be populated from the Alcahest response")
+	assert.Equal(t, "igdb:3651", game.ScraperID)
+}
+


### PR DESCRIPTION
## Bug reproduction

You reported that \`Alcahest (Japan).sfc\` on SNES never got a description or rating after scraping, even though IGDB has both. I reproduced it with the testdata file and confirmed the root cause.

## Root cause

IGDB's platform catalog has **two** entries for the Super Nintendo:

- platform **19** — "Super Nintendo Entertainment System" (international)
- platform **58** — "Super Famicom" (Japan)

Japan-only releases — Alcahest (IGDB id 3651), Ganbare Goemon, the original title of Mother 2, and hundreds of others — are filed **only** under platform 58. The Spela mapping had \`"SNES": 19\` (a single \`int\`), so the scraper always sent \`where name ~ "Alcahest" & platforms = (19)\` which returns nothing, and quietly marked the game as \`not_found\`.

The exact search and the fulltext-fallback search both filter by the same platform id, so neither path can rescue a Japan-only title. It's invisible to Spela.

I queried IGDB directly to verify:

\`\`\`
$ curl .../v4/games -d 'fields name,platforms.name; where name ~ "Alcahest" & platforms = (19); limit 5;'
[]
$ curl .../v4/games -d 'fields name,platforms.name; where name ~ "Alcahest" & platforms = (58); limit 5;'
[{"id":3651,"name":"Alcahest","platforms":[{"id":58,"name":"Super Famicom"}]}]
\`\`\`

## Is this just a SNES problem?

Yes. **SNES is the only console in Spela's mapping where IGDB split the international and Japanese SKUs into separate platform ids.** I verified by querying IGDB's \`/platforms\` endpoint for every *Famicom*/*Mark III*/*Mega Drive*/*Genesis*/*TurboGrafx*/*PC Engine* name — only "Super Famicom" comes back as a distinct platform. Everything else was merged under one hardware-family id:

| Family | IGDB id | Notes |
|---|---|---|
| NES / Famicom | 18 | Merged. Famicom games match through platform 18. |
| SMS / Mark III | 64 | Merged. Name is "Sega Master System/Mark III". |
| Mega Drive / Genesis | 29 | Merged. Name is "Sega Mega Drive/Genesis". |
| TG16 / PC Engine | 86 | Merged. Name is "TurboGrafx-16/PC Engine". |
| **SNES / Super Famicom** | **19 / 58** | **Split** — this PR. |

## The fix

\`AbbreviationToIGDBPlatform\` is now \`map[string][]int\`. SNES maps to \`{19, 58}\`; everything else is a single-element slice. \`SearchGame\`, \`SearchGameExact\`, and \`GetTopGames\` now take \`platformIDs []int\` and render the filter as \`platforms = (19, 58)\` (tuple syntax with OR semantics — empirically verified against the real IGDB API: \`platforms = (19, 58)\` returns Alcahest, while \`platforms = [19, 58]\` with subset semantics returns nothing because Alcahest has only 58).

New helper \`formatPlatformList([]int) string\` renders the tuple. \`earliestPlatformReleaseDate\` also takes \`[]int\` so the platform-specific release-date selection considers all mapped ids.

All 4 call sites updated:
- \`scraper/scraper_igdb.go\`: scrape path + release date selection
- \`api/admin_handler_igdb.go\`: admin IGDB search endpoint
- \`api/admin_handler_scraper.go\`: top-rated refresh
- \`api/console_handler.go\`: \`GetTopRated\`

## Tests (TDD flow, per your request)

Added \`TestScrapeGame_SNESJapanOnlyGame_SearchesSuperFamicomPlatform\` in \`scraper_igdb_test.go\`:

1. Mock IGDB server inspects every \`/games\` POST body
2. Returns the Alcahest stub **only** when the query contains the literal \`"58"\` — mimicking the real API's behaviour
3. Runs the scraper with console=SNES, filename=\`"Alcahest (Japan).sfc"\`
4. Asserts the scrape matched, populated description and rating, and set \`ScraperID\` to \`"igdb:3651"\`

### BEFORE the mapping change (tests fail):
\`\`\`
--- FAIL: TestScrapeGame_SNESJapanOnlyGame_SearchesSuperFamicomPlatform (0.56s)
    scraper did not include Super Famicom (58) in any IGDB /games query;
    captured queries: [... where platforms = (19); ... where platforms = (19); ...]
    Error:  Should NOT be empty, but was [game.Description]
    Error:  "0" is not greater than "0" [game.IGDBCriticsRating]
    Error:  expected "igdb:3651", actual "libretro" [game.ScraperID]
\`\`\`

### AFTER (tests pass):
\`\`\`
=== RUN   TestScrapeGame_SNESJapanOnlyGame_SearchesSuperFamicomPlatform
    IGDB exact search request name=Alcahest platformIDs="[19 58]"
      query="... where name ~ "Alcahest" & platforms = (19, 58); limit 5;"
    IGDB exact search response name=Alcahest resultCount=1 results="[Alcahest (id:3651)]"
    scraped metadata game=Alcahest scraperId=igdb:3651 rating=79.9
--- PASS: TestScrapeGame_SNESJapanOnlyGame_SearchesSuperFamicomPlatform (0.80s)
\`\`\`

Updated the existing tests to match the new signatures:
- \`TestEarliestPlatformReleaseDate\` table entries now use \`platformIDs []int\`
- \`TestPlatformMapping\` asserts against slices and explicitly pins SNES to \`{19, 58}\` with a comment pointing at the regression test
- The \`SearchGame(name, 18)\` calls in \`client_test.go\` become \`SearchGame(name, []int{18})\`

## Test sweeps

- \`go test ./internal/scraper/\` — ✅ all pass
- \`go test ./internal/igdb/\` — ✅ all pass
- \`go test ./internal/api/\` — ✅ all pass
- \`go test ./...\` — ✅ all 14 server packages pass
- Pre-push hook ran \`go build ./...\` — ✅ clean

## Will you need to re-scrape existing games?

Yes — Alcahest and any other Japan-only SNES releases you already have in your library need a \`force\` re-scrape to pick up the metadata. Existing international SNES games aren't affected (their match still goes through platform 19, which is still in the slice).