### PR TITLE
fix: IGDB exact search now checks alt names + separator variants

### DIFF
--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -102,6 +102,59 @@ func formatPlatformList(platformIDs []int) string {
 	return "(" + strings.Join(parts, ", ") + ")"
 }
 
+// SearchNameVariants returns a deduplicated list of search-name candidates
+// derived from the cleaned ROM title. It handles the common mismatch between
+// No-Intro ROM naming ("Title - Subtitle") and IGDB naming ("Title: Subtitle")
+// by generating both separator styles. Callers pass the list to the IGDB
+// exact-match query which ORs over all variants in a single round trip.
+//
+// The input is always included verbatim; the variants are additional forms.
+// Order is stable so tests can pin expectations.
+func SearchNameVariants(name string) []string {
+	out := []string{name}
+	seen := map[string]bool{name: true}
+	add := func(s string) {
+		if s != "" && !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	// " - " ↔ ": " — No-Intro vs IGDB. Applied to the FIRST occurrence only;
+	// multi-dash names ("Tom Clancy's Rainbow Six - Rogue Spear - Black Thorn")
+	// fan out combinatorially otherwise and most real cases only have one
+	// title/subtitle boundary.
+	if strings.Contains(name, " - ") {
+		add(strings.Replace(name, " - ", ": ", 1))
+	}
+	if strings.Contains(name, ": ") {
+		add(strings.Replace(name, ": ", " - ", 1))
+	}
+	return out
+}
+
+// buildExactMatchWhereClause returns the IGDB `where` subclause that matches
+// any of the given name variants against EITHER the primary `name` field
+// or the `alternative_names.name` field. Alternative names are how IGDB
+// stores regional/localized titles (e.g. "Broken Sword: The Shadow of the
+// Templars" is an alternative_name for game id 616 "Circle of Blood"), so
+// searching only `name` misses a lot of region-mismatched ROM lookups.
+//
+// Example output for ["Broken Sword - …", "Broken Sword: …"]:
+//
+//	(name ~ "Broken Sword - …" | name ~ "Broken Sword: …" |
+//	 alternative_names.name ~ "Broken Sword - …" |
+//	 alternative_names.name ~ "Broken Sword: …")
+func buildExactMatchWhereClause(nameVariants []string) string {
+	parts := make([]string, 0, len(nameVariants)*2)
+	for _, v := range nameVariants {
+		parts = append(parts, fmt.Sprintf(`name ~ "%s"`, escapeQuery(v)))
+	}
+	for _, v := range nameVariants {
+		parts = append(parts, fmt.Sprintf(`alternative_names.name ~ "%s"`, escapeQuery(v)))
+	}
+	return "(" + strings.Join(parts, " | ") + ")"
+}
+
 // oauthToken holds a Twitch OAuth token with its expiration.
 type oauthToken struct {
 	AccessToken string
@@ -389,10 +442,11 @@ func (c *Client) SearchGame(name string, platformIDs []int) ([]Game, error) {
 }
 
 // SearchGameExact queries IGDB for a game by exact name match, accepting one
-// or more platform IDs. Uses a "where name" clause instead of the "search"
-// keyword to avoid text-search relevance ranking which can omit the exact
-// game (e.g. "Super Mario 64" text search returns the unreleased sequel but
-// not the original).
+// or more platform IDs. Uses a "where" clause over both the primary `name`
+// field and `alternative_names.name` (regional/localized titles), with
+// separator-style variants (" - " vs ": ") auto-expanded so No-Intro ROM
+// filenames match IGDB's colon-separated titles. A single query ORs all
+// combinations so the whole lookup is one round trip.
 func (c *Client) SearchGameExact(name string, platformIDs []int) ([]Game, error) {
 	if err := c.authenticate(); err != nil {
 		return nil, fmt.Errorf("IGDB authentication: %w", err)
@@ -404,13 +458,16 @@ func (c *Client) SearchGameExact(name string, platformIDs []int) ([]Game, error)
 	// Wait for rate limiter
 	<-c.rateLimiter
 
-	// Case-insensitive exact match using ~ operator
+	variants := SearchNameVariants(name)
+	whereNames := buildExactMatchWhereClause(variants)
+
+	// Case-insensitive exact match using ~ operator over name + alt names.
 	query := fmt.Sprintf(
-		`fields name,summary,storyline,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.company.logo.image_id,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,total_rating,total_rating_count,rating,rating_count,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where name ~ "%s" & platforms = %s; limit 5;`,
-		escapeQuery(name), formatPlatformList(platformIDs),
+		`fields name,summary,storyline,cover.image_id,screenshots.image_id,genres.name,involved_companies.company.name,involved_companies.company.logo.image_id,involved_companies.developer,involved_companies.publisher,first_release_date,aggregated_rating,total_rating,total_rating_count,rating,rating_count,game_modes.name,release_dates.date,release_dates.region,release_dates.platform.name,release_dates.human; where %s & platforms = %s; limit 5;`,
+		whereNames, formatPlatformList(platformIDs),
 	)
 
-	slog.Info("IGDB exact search request", "name", name, "platformIDs", platformIDs, "query", query)
+	slog.Info("IGDB exact search request", "name", name, "variants", variants, "platformIDs", platformIDs, "query", query)
 
 	c.mu.Lock()
 	token := c.token.AccessToken

--- a/server/internal/scraper/scraper_igdb_test.go
+++ b/server/internal/scraper/scraper_igdb_test.go
@@ -1367,3 +1367,130 @@ func TestScrapeGame_SNESJapanOnlyGame_SearchesSuperFamicomPlatform(t *testing.T)
 	assert.Equal(t, "igdb:3651", game.ScraperID)
 }
 
+// TestScrapeGame_AlternativeNameAndSeparatorVariant verifies that the IGDB
+// scraper finds games whose primary IGDB name differs from the ROM filename
+// AND where the separator style (` - ` vs ` : `) doesn't match.
+//
+// Real example: "Broken Sword - The Shadow of the Templars (USA).bin" on PSX.
+// IGDB stores this game at id 616 with primary name "Circle of Blood" (the
+// original US release title) and ships "Broken Sword: The Shadow of the
+// Templars" as an entry in `alternative_names`. Two things have to work for
+// a match:
+//
+//  1. Query must check `alternative_names.name`, not just `name` — the
+//     primary name "Circle of Blood" bears no resemblance to the ROM
+//     filename so the current `name ~ "X"` clause returns zero.
+//  2. Query must normalize ` - ` ↔ ` : ` separators — No-Intro ROM names
+//     use dashes, IGDB uses colons, and the `~` operator is literal
+//     (no punctuation fuzzing).
+//
+// The mock IGDB server here returns the game stub only when the query body
+// contains both the `alternative_names.name ~` literal AND the colon
+// variant of the title — mimicking the real API's requirements.
+func TestScrapeGame_AlternativeNameAndSeparatorVariant(t *testing.T) {
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"access_token": "test-token",
+			"expires_in":   3600,
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	var capturedQueries []string
+	igdbServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/games") {
+			json.NewEncoder(w).Encode([]map[string]any{})
+			return
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		query := string(body)
+		capturedQueries = append(capturedQueries, query)
+
+		// Only return the game if the query both:
+		//   (a) references alternative_names.name, and
+		//   (b) contains the colon-separator variant of the title.
+		hasAltName := strings.Contains(query, "alternative_names.name")
+		hasColonVariant := strings.Contains(query, "Broken Sword: The Shadow of the Templars")
+		if !hasAltName || !hasColonVariant {
+			json.NewEncoder(w).Encode([]igdb.Game{})
+			return
+		}
+
+		json.NewEncoder(w).Encode([]igdb.Game{
+			{
+				ID:               616,
+				Name:             "Circle of Blood",
+				Summary:          "A point-and-click adventure game.",
+				AggregatedRating: 82.5,
+				TotalRating:      82.5,
+				TotalRatingCount: 35,
+			},
+		})
+	}))
+	defer igdbServer.Close()
+
+	origTokenURL := igdb.TwitchTokenURLForTest()
+	origAPIBase := igdb.IGDBAPIBaseForTest()
+	igdb.SetTwitchTokenURLForTest(tokenServer.URL)
+	igdb.SetIGDBAPIBaseForTest(igdbServer.URL + "/v4")
+	defer func() {
+		igdb.SetTwitchTokenURLForTest(origTokenURL)
+		igdb.SetIGDBAPIBaseForTest(origAPIBase)
+	}()
+
+	database := setupTestDB(t)
+	store := setupTestStorage(t)
+
+	console := db.Console{Abbreviation: "PSX", Name: "Sony PlayStation"}
+	require.NoError(t, database.Create(&console).Error)
+
+	game := db.Game{
+		ConsoleID: console.ID,
+		Console:   console,
+		Title:     "Broken Sword - The Shadow of the Templars (USA)",
+		FileName:  "Broken Sword - The Shadow of the Templars (USA).bin",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	igdbClient := igdb.NewClient("test-id", "test-secret")
+	igdbClient.HTTPClient = &http.Client{Timeout: 5 * time.Second}
+
+	s := &Scraper{
+		DB:         database,
+		Storage:    store,
+		HTTPClient: &http.Client{Timeout: 5 * time.Second},
+		IGDBClient: igdbClient,
+		DATCache:   NewDATCache(t.TempDir(), &http.Client{Timeout: 5 * time.Second}),
+		cache:      &nameCache{entries: make(map[string][]nameEntry)},
+	}
+
+	err := s.ScrapeGame(&game)
+	require.NoError(t, err)
+
+	foundAlt := false
+	foundColon := false
+	for _, q := range capturedQueries {
+		if strings.Contains(q, "alternative_names.name") {
+			foundAlt = true
+		}
+		if strings.Contains(q, "Broken Sword: The Shadow of the Templars") {
+			foundColon = true
+		}
+	}
+	assert.True(t, foundAlt,
+		"scraper did not issue any IGDB /games query that filters on alternative_names.name; captured: %v",
+		capturedQueries)
+	assert.True(t, foundColon,
+		"scraper did not include the colon-separator variant of the title in any query; captured: %v",
+		capturedQueries)
+
+	assert.NotEmpty(t, game.Description,
+		"description should be populated from the Broken Sword response — "+
+			"empty means neither the alt-name filter nor the separator variant hit")
+	assert.Greater(t, game.IGDBCriticsRating, 0.0,
+		"IGDB rating should be populated from the Broken Sword response")
+	assert.Equal(t, "igdb:616", game.ScraperID)
+}
+


### PR DESCRIPTION
## Bug reproduction

You reported that "Broken Sword - The Shadow of the Templars (USA)" on PSX never got a description or rating from IGDB, even though [igdb.com/games/circle-of-blood](https://www.igdb.com/games/circle-of-blood) has the full metadata. You noted IGDB has it filed under the **primary name "Circle of Blood"** (the original US release title) and lists "Broken Sword: The Shadow of the Templars" among its **alternative names**.

## Root cause — two tangled issues

Verified both against the real IGDB API.

### 1. \`where name ~\` ignores \`alternative_names\`

IGDB stores regional, localized, and alternate titles in a separate \`alternative_names\` table (Les Chevaliers de Baphomet, Baphomets Fluch, Broken Sword 1, Chinese/Italian/Spanish titles, and the US-vs-EU split). The exact-match filter \`where name ~ "X"\` is literal against the **primary** title only. Any game whose IGDB primary name differs from its ROM filename is unreachable.

\`\`\`
where name ~ "Broken Sword - The Shadow of the Templars" & platforms = (7)
→ []   (primary name is "Circle of Blood")

where alternative_names.name ~ "Broken Sword: The Shadow of the Templars" & platforms = (7)
→ id 616, "Circle of Blood"   (matches alt_name id 186246)
\`\`\`

### 2. Separator mismatch between No-Intro and IGDB

No-Intro ROM filenames use \` - \` for title/subtitle boundaries. IGDB uses \` : \`. The \`~\` operator is case-insensitive literal match — no punctuation fuzzing. So even searching alternative_names with the dash variant returns nothing.

\`\`\`
where alternative_names.name ~ "Broken Sword - The Shadow of the Templars" → []
where alternative_names.name ~ "Broken Sword: The Shadow of the Templars" → id 616
\`\`\`

Both fixes have to land together or the bug is still reachable.

## Fix

Two new helpers in \`server/internal/igdb/client.go\`:

### \`SearchNameVariants(name string) []string\`

Expands separator styles so one lookup catches both No-Intro and IGDB formats. Input is always preserved; variants are additive.
- If name contains \` - \`, adds the \` : \` variant
- If name contains \` : \`, adds the \` - \` variant
- Multi-dash names (\`A - B - C\`) only get the first boundary swapped to avoid combinatorial fan-out

### \`buildExactMatchWhereClause(variants []string) string\`

Renders the IGDB \`where\` subclause that ORs over \`name ~\` **and** \`alternative_names.name ~\` for every variant. Example for \`["Broken Sword - The Shadow of the Templars", "Broken Sword: The Shadow of the Templars"]\`:

\`\`\`
(name ~ "Broken Sword - The Shadow of the Templars"
 | name ~ "Broken Sword: The Shadow of the Templars"
 | alternative_names.name ~ "Broken Sword - The Shadow of the Templars"
 | alternative_names.name ~ "Broken Sword: The Shadow of the Templars")
\`\`\`

\`SearchGameExact\` uses these to build the exact-match query. **Still a single round trip** — the compound \`where\` clause handles all four checks in one request.

## Tests (TDD)

Added \`TestScrapeGame_AlternativeNameAndSeparatorVariant\` in \`scraper_igdb_test.go\`. The mock IGDB server returns the Broken Sword stub **only** when the query contains both:
1. An \`alternative_names.name\` filter
2. The colon-separator variant of the title

### BEFORE the fix
\`\`\`
--- FAIL: TestScrapeGame_AlternativeNameAndSeparatorVariant (1.10s)
Scraper queries: where name ~ "Broken Sword - ..."; where platforms = (7)
Error: scraper did not include the colon-separator variant of the title
Error: scraper did not issue any query that filters on alternative_names.name
Error: description empty, rating 0, ScraperID "libretro"
\`\`\`

### AFTER the fix
\`\`\`
=== RUN   TestScrapeGame_AlternativeNameAndSeparatorVariant
  IGDB exact search request name="Broken Sword - The Shadow of the Templars"
  variants="[Broken Sword - ... Broken Sword: ...]"
  query="... where (name ~ \"Broken Sword - ...\" | name ~ \"Broken Sword: ...\"
               | alternative_names.name ~ \"Broken Sword - ...\"
               | alternative_names.name ~ \"Broken Sword: ...\")
          & platforms = (7); limit 5;"
  IGDB exact search response resultCount=1 results="[Circle of Blood (id:616)]"
  scraped metadata game="Circle of Blood" scraperId=igdb:616 rating=82.5
--- PASS: TestScrapeGame_AlternativeNameAndSeparatorVariant (1.15s)
\`\`\`

## Test sweeps

- \`go test ./internal/scraper/\` ✅
- \`go test ./internal/igdb/\` ✅
- \`go test ./...\` ✅ (all 14 server packages)
- Pre-push hook ran \`go build ./...\` ✅ clean

## Will I need to re-scrape?

**Yes** — existing games where IGDB's primary name differs from the ROM title, or where the separator style differs, need a force re-scrape to pick up metadata. New imports after this lands are handled automatically.

## Second-order benefits

This fix is more general than just Broken Sword. Any game with a regional/localized primary name on IGDB benefits — games released under different titles in Japan vs the West (complements PR #387's SNES/Super Famicom platform fix), US-vs-EU title splits (Resident Evil / Biohazard and similar pairs), and any title where the ROM uses one subtitle separator and IGDB uses the other.