### PR TITLE
Carousel card redesign: static height, image-driven width

### DIFF
--- a/docs/superpowers/plans/2026-04-12-carousel-card-redesign.md
+++ b/docs/superpowers/plans/2026-04-12-carousel-card-redesign.md
@@ -1,0 +1,1931 @@
+# Carousel Card Redesign Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make game cards in web carousels use static height with image-driven width (no cropping), matching the player app, and extract a shared ScrollShelf component to eliminate duplicated scroll logic.
+
+**Architecture:** New `ScrollShelf` (Design layer) replaces 6+ duplicated scroll containers. `GameCard` and `CoverCard` (Content layer) get an optional `coverHeight` prop — when set, the card renders at fixed height and lets the image's natural aspect ratio drive its width. All carousel shelf components (Role layer) migrate to use `ScrollShelf` and pass `coverHeight` from centralized constants.
+
+**Tech Stack:** React, TypeScript, Tailwind CSS, Vitest + React Testing Library
+
+**Spec:** `docs/superpowers/specs/2026-04-12-carousel-card-redesign.md`
+
+---
+
+### Task 1: Centralized Carousel Constants
+
+**Files:**
+- Create: `web/src/lib/carousel-constants.ts`
+
+- [ ] **Step 1: Create the constants file**
+
+```ts
+// web/src/lib/carousel-constants.ts
+
+/** Fixed height (px) for game cards in carousel shelves. */
+export const CAROUSEL_CARD_HEIGHT = 240;
+
+/** Default aspect ratio (width/height) for placeholder/skeleton cards. */
+export const CAROUSEL_DEFAULT_ASPECT_RATIO = 3 / 4;
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/lib/carousel-constants.ts
+git commit -m "feat: add centralized carousel card constants"
+```
+
+---
+
+### Task 2: ScrollShelf Component (Design Layer)
+
+Extract the scroll container that is duplicated across `game-shelf.tsx`, `series-shelf.tsx`, `artwork-showcase.tsx`, `developer-spotlight.tsx`, `players-like-you-shelf.tsx`, `for-you-section.tsx`, `temporal-shelves.tsx`, `achievement-shelves.tsx`, and `social-shelves.tsx`.
+
+**Files:**
+- Create: `web/src/components/scroll-shelf.tsx`
+- Create: `web/src/components/__tests__/scroll-shelf.test.tsx`
+
+- [ ] **Step 1: Write the failing tests**
+
+```tsx
+// web/src/components/__tests__/scroll-shelf.test.tsx
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Star } from "lucide-react";
+import { ScrollShelf } from "../scroll-shelf";
+
+describe("ScrollShelf", () => {
+  it("renders title and children", () => {
+    render(
+      <ScrollShelf title="Test Shelf" testId="test-shelf" isLoading={false} isEmpty={false}>
+        <div>Child 1</div>
+        <div>Child 2</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByRole("heading", { name: "Test Shelf", level: 2 })).toBeInTheDocument();
+    expect(screen.getByText("Child 1")).toBeInTheDocument();
+    expect(screen.getByText("Child 2")).toBeInTheDocument();
+  });
+
+  it("renders subtitle when provided", () => {
+    render(
+      <ScrollShelf title="Shelf" subtitle="Some subtitle" testId="s" isLoading={false} isEmpty={false}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByText("Some subtitle")).toBeInTheDocument();
+  });
+
+  it("renders icon when provided", () => {
+    render(
+      <ScrollShelf title="Shelf" icon={Star} testId="s" isLoading={false} isEmpty={false}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    // lucide renders an svg with the Star icon
+    const section = screen.getByTestId("s");
+    expect(section.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders headerRight slot", () => {
+    render(
+      <ScrollShelf title="Shelf" testId="s" isLoading={false} isEmpty={false} headerRight={<span>View all</span>}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByText("View all")).toBeInTheDocument();
+  });
+
+  it("renders scrollable list with title as aria label", () => {
+    render(
+      <ScrollShelf title="My Shelf" testId="s" isLoading={false} isEmpty={false}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByRole("list", { name: "My Shelf" })).toBeInTheDocument();
+  });
+
+  it("returns null when isEmpty is true", () => {
+    const { container } = render(
+      <ScrollShelf title="Shelf" testId="s" isLoading={false} isEmpty={true}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders loading skeleton when isLoading", () => {
+    render(
+      <ScrollShelf title="Shelf" testId="s" isLoading={true} isEmpty={false}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByTestId("s-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders custom loading skeleton when provided", () => {
+    render(
+      <ScrollShelf
+        title="Shelf"
+        testId="s"
+        isLoading={true}
+        isEmpty={false}
+        loadingSkeleton={<div data-testid="custom-skeleton">Loading...</div>}
+      >
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByTestId("custom-skeleton")).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd web && npx vitest run src/components/__tests__/scroll-shelf.test.tsx`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement ScrollShelf**
+
+```tsx
+// web/src/components/scroll-shelf.tsx
+import { useRef, useState, useEffect, useCallback } from "react";
+import type { ReactNode } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { GameCardSkeleton } from "@/components/ui";
+
+interface ScrollShelfProps {
+  title: string;
+  subtitle?: string;
+  icon?: LucideIcon;
+  testId: string;
+  isLoading: boolean;
+  isEmpty: boolean;
+  children: ReactNode;
+  loadingSkeleton?: ReactNode;
+  headerRight?: ReactNode;
+}
+
+export function ScrollShelf({
+  title,
+  subtitle,
+  icon: Icon,
+  testId,
+  isLoading,
+  isEmpty,
+  children,
+  loadingSkeleton,
+  headerRight,
+}: ScrollShelfProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, children]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return (
+      <section data-testid={`${testId}-skeleton`}>
+        <div className="flex items-center gap-2 mb-1">
+          {Icon && <Icon className="h-5 w-5 text-surface-400" />}
+          <div className="h-7 w-60 rounded bg-surface-800 animate-pulse" />
+        </div>
+        {subtitle && <div className="h-4 w-40 rounded bg-surface-800/60 animate-pulse mt-1 mb-5" />}
+        {loadingSkeleton ?? (
+          <div className="flex gap-5 overflow-hidden mt-4">
+            {Array.from({ length: 6 }, (_, i) => (
+              <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+                <GameCardSkeleton />
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    );
+  }
+
+  if (isEmpty) return null;
+
+  return (
+    <section data-testid={testId} data-comp="ScrollShelf" className="group/shelf relative">
+      <div className="flex items-center gap-2 mb-1">
+        {Icon && <Icon className="h-5 w-5 text-brand-400" />}
+        <h2 className="text-xl font-bold text-surface-100">{title}</h2>
+        {headerRight && <div className="ml-auto">{headerRight}</div>}
+      </div>
+      {subtitle && <p className="text-sm text-surface-400 mb-4">{subtitle}</p>}
+
+      <div className="relative">
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+            aria-label={`Scroll ${title} left`}
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+            aria-label={`Scroll ${title} right`}
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        <div
+          ref={scrollRef}
+          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label={title}
+        >
+          {children}
+        </div>
+      </div>
+    </section>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd web && npx vitest run src/components/__tests__/scroll-shelf.test.tsx`
+Expected: All 8 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/components/scroll-shelf.tsx web/src/components/__tests__/scroll-shelf.test.tsx
+git commit -m "feat: add shared ScrollShelf component (Design layer)"
+```
+
+---
+
+### Task 3: GameCard Carousel Mode
+
+Add `coverHeight` prop to `GameCard`. When set, the card uses fixed height with image-driven width.
+
+**Files:**
+- Modify: `web/src/components/game-card.tsx`
+
+- [ ] **Step 1: Add `coverHeight` prop to the interface and update the image container**
+
+In `web/src/components/game-card.tsx`, add `coverHeight?: number` to `GameCardProps`:
+
+```tsx
+interface GameCardProps {
+  game: Game;
+  aspectRatio?: number;
+  coverHeight?: number;
+  showConsoleBadge?: boolean;
+  hideConsoleName?: boolean;
+  subtitle?: string;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+```
+
+Add `coverHeight` to the destructured props:
+
+```tsx
+export function GameCard({
+  game,
+  aspectRatio,
+  coverHeight,
+  showConsoleBadge,
+  hideConsoleName,
+  subtitle,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: GameCardProps) {
+```
+
+- [ ] **Step 2: Update the image rendering for carousel mode**
+
+Replace the image container `<div>` (the one with `className="relative rounded-2xl overflow-hidden..."`) to handle both modes. The key change is the image rendering:
+
+Replace the current image/placeholder block inside the container:
+
+```tsx
+{game.coverUrl ? (
+  <img
+    src={game.coverUrl}
+    alt={game.title}
+    className="w-full transition-transform duration-500 group-hover:scale-105"
+    loading="lazy"
+  />
+) : (
+  <div className="flex items-center justify-center bg-gradient-to-br from-surface-800 to-surface-900" style={{ aspectRatio: game.coverAspectRatio ?? aspectRatio ?? 3 / 4 }}>
+```
+
+With this updated version:
+
+```tsx
+{game.coverUrl ? (
+  <img
+    src={game.coverUrl}
+    alt={game.title}
+    className={
+      coverHeight
+        ? "h-full w-auto transition-transform duration-500 group-hover:scale-105"
+        : "w-full transition-transform duration-500 group-hover:scale-105"
+    }
+    loading="lazy"
+  />
+) : (
+  <div
+    className="flex items-center justify-center bg-gradient-to-br from-surface-800 to-surface-900"
+    style={
+      coverHeight
+        ? { height: coverHeight, aspectRatio: game.coverAspectRatio ?? aspectRatio ?? 3 / 4 }
+        : { aspectRatio: game.coverAspectRatio ?? aspectRatio ?? 3 / 4 }
+    }
+  >
+```
+
+- [ ] **Step 3: Add flex-shrink-0 when in carousel mode**
+
+Update the outermost `<Link>` wrapper to include `flex-shrink-0` when `coverHeight` is set. Change:
+
+```tsx
+<Link ref={ref} to={`/games/${game.id}`} data-comp="GameCard" className="group block space-y-3">
+```
+
+to:
+
+```tsx
+<Link ref={ref} to={`/games/${game.id}`} data-comp="GameCard" className={`group block space-y-3${coverHeight ? " flex-shrink-0" : ""}`}>
+```
+
+- [ ] **Step 4: Set fixed height on the image container when coverHeight is provided**
+
+Update the image container div to apply the fixed height. Change the opening tag of the container:
+
+```tsx
+<div
+  className="relative rounded-2xl overflow-hidden bg-surface-900 border border-surface-800/50 transition-all duration-300 group-hover:border-surface-700/50 group-hover:shadow-xl group-hover:shadow-black/30 group-hover:-translate-y-1"
+>
+```
+
+to:
+
+```tsx
+<div
+  className="relative rounded-2xl overflow-hidden bg-surface-900 border border-surface-800/50 transition-all duration-300 group-hover:border-surface-700/50 group-hover:shadow-xl group-hover:shadow-black/30 group-hover:-translate-y-1"
+  style={coverHeight ? { height: coverHeight } : undefined}
+>
+```
+
+- [ ] **Step 5: Verify the existing game-shelf test still passes**
+
+Run: `cd web && npx vitest run src/features/explore/components/__tests__/game-shelf.test.tsx`
+Expected: All tests PASS (GameCard is used without `coverHeight` here, so behavior is unchanged).
+
+- [ ] **Step 6: Verify type checking passes**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/components/game-card.tsx
+git commit -m "feat: add coverHeight prop to GameCard for carousel mode"
+```
+
+---
+
+### Task 4: CoverCard Carousel Mode
+
+Add `coverHeight` prop to `CoverCard` with the same pattern.
+
+**Files:**
+- Modify: `web/src/components/cover-card.tsx`
+
+- [ ] **Step 1: Add `coverHeight` prop and update sizing logic**
+
+In `web/src/components/cover-card.tsx`, add `coverHeight?: number` to the interface:
+
+```tsx
+interface CoverCardProps {
+  imageUrl?: string | null;
+  title: string;
+  subtitle?: string;
+  linkTo?: string;
+  dimmed?: boolean;
+  aspectRatio?: string;
+  width?: string;
+  coverHeight?: number;
+  children?: ReactNode;
+}
+```
+
+Add `coverHeight` to the destructured props:
+
+```tsx
+export function CoverCard({
+  imageUrl,
+  title,
+  subtitle,
+  linkTo,
+  dimmed = false,
+  aspectRatio = "3/4",
+  width = "w-36",
+  coverHeight,
+  children,
+}: CoverCardProps) {
+```
+
+- [ ] **Step 2: Update the content rendering for carousel mode**
+
+Replace the `content` variable definition. Change the outer container from always using `width` to being flexible when `coverHeight` is set:
+
+```tsx
+  const content = (
+    <div data-comp="CoverCard" className={cn(coverHeight ? "flex-shrink-0" : width, dimmed && "opacity-50")}>
+      <div
+        className="w-full border border-surface-800/50"
+        style={coverHeight ? { height: coverHeight } : { aspectRatio }}
+      >
+        <CoverImage
+          src={imageUrl}
+          alt={title}
+          className={
+            coverHeight
+              ? "h-full w-auto rounded-xl"
+              : "w-full h-full rounded-xl"
+          }
+        />
+      </div>
+      <div className="mt-2 px-0.5">
+        <p className="text-sm font-medium text-surface-200 truncate">
+          {title}
+        </p>
+        {subtitle && (
+          <p className="text-xs text-surface-500 truncate mt-0.5">
+            {subtitle}
+          </p>
+        )}
+        {children && <div className="mt-1">{children}</div>}
+      </div>
+    </div>
+  );
+```
+
+- [ ] **Step 3: Verify type checking passes**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/components/cover-card.tsx
+git commit -m "feat: add coverHeight prop to CoverCard for carousel mode"
+```
+
+---
+
+### Task 5: GameCardSkeleton Carousel Mode
+
+Update `GameCardSkeleton` to support `coverHeight` so loading states match.
+
+**Files:**
+- Modify: `web/src/components/ui/skeleton.tsx`
+
+- [ ] **Step 1: Update GameCardSkeleton to accept coverHeight**
+
+In `web/src/components/ui/skeleton.tsx`, update the `GameCardSkeleton` function. Change:
+
+```tsx
+export function GameCardSkeleton({
+  aspectRatio,
+}: {
+  aspectRatio?: number;
+}) {
+  return (
+    <div className="space-y-3">
+      <Skeleton
+        className="w-full rounded-2xl"
+        style={{ aspectRatio: aspectRatio ?? 3 / 4 }}
+      />
+```
+
+to:
+
+```tsx
+export function GameCardSkeleton({
+  aspectRatio,
+  coverHeight,
+}: {
+  aspectRatio?: number;
+  coverHeight?: number;
+}) {
+  return (
+    <div className={`space-y-3${coverHeight ? " flex-shrink-0" : ""}`}>
+      <Skeleton
+        className="rounded-2xl"
+        style={
+          coverHeight
+            ? { height: coverHeight, aspectRatio: aspectRatio ?? 3 / 4 }
+            : { aspectRatio: aspectRatio ?? 3 / 4, width: "100%" }
+        }
+      />
+```
+
+- [ ] **Step 2: Verify type checking passes**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/components/ui/skeleton.tsx
+git commit -m "feat: add coverHeight support to GameCardSkeleton"
+```
+
+---
+
+### Task 6: Migrate GameShelf
+
+Replace inline scroll logic with `ScrollShelf` and pass `coverHeight` to `GameCard`.
+
+**Files:**
+- Modify: `web/src/features/explore/components/game-shelf.tsx`
+- Modify: `web/src/features/explore/components/__tests__/game-shelf.test.tsx`
+
+- [ ] **Step 1: Rewrite game-shelf.tsx to use ScrollShelf**
+
+Replace the entire file content with:
+
+```tsx
+// web/src/features/explore/components/game-shelf.tsx
+import type { LucideIcon } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
+import type { Game } from "@/types/api";
+
+interface GameShelfProps {
+  title: string;
+  icon?: LucideIcon;
+  games: Game[] | undefined;
+  isLoading: boolean;
+  hideConsoleName?: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+export function GameShelf({
+  title,
+  icon,
+  games,
+  isLoading,
+  hideConsoleName,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: GameShelfProps) {
+  return (
+    <ScrollShelf
+      title={title}
+      icon={icon}
+      testId={`shelf-${title}`}
+      isLoading={isLoading}
+      isEmpty={!games || games.length === 0}
+    >
+      {games?.map((game) => (
+        <div key={game.id} className="flex-shrink-0" role="listitem">
+          <GameCard
+            game={game}
+            coverHeight={CAROUSEL_CARD_HEIGHT}
+            showConsoleBadge={!hideConsoleName}
+            hideConsoleName={hideConsoleName}
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+```
+
+- [ ] **Step 2: Update the test for the new skeleton testId**
+
+The `ScrollShelf` skeleton uses `${testId}-skeleton` which produces `shelf-Top Rated-skeleton`. Update the loading test in `game-shelf.test.tsx`. Change:
+
+```tsx
+  it("renders loading skeleton when loading", () => {
+    renderShelf({ isLoading: true, games: undefined });
+    expect(
+      screen.getByTestId("shelf-skeleton-Top Rated"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "Top Rated", level: 2 }),
+    ).toBeInTheDocument();
+  });
+```
+
+to:
+
+```tsx
+  it("renders loading skeleton when loading", () => {
+    renderShelf({ isLoading: true, games: undefined });
+    expect(
+      screen.getByTestId("shelf-Top Rated-skeleton"),
+    ).toBeInTheDocument();
+  });
+```
+
+Also update the shimmer test — the skeleton structure changed, so update the selector. Change:
+
+```tsx
+  it("renders loading skeleton with shimmer animation", () => {
+    const { container } = renderShelf({ isLoading: true, games: undefined });
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+```
+
+to:
+
+```tsx
+  it("renders loading skeleton with shimmer animation", () => {
+    const { container } = renderShelf({ isLoading: true, games: undefined });
+    const shimmer = container.querySelectorAll("[class*='animate-pulse']");
+    expect(shimmer.length).toBeGreaterThan(0);
+  });
+```
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd web && npx vitest run src/features/explore/components/__tests__/game-shelf.test.tsx`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/features/explore/components/game-shelf.tsx web/src/features/explore/components/__tests__/game-shelf.test.tsx
+git commit -m "refactor: migrate GameShelf to ScrollShelf + coverHeight"
+```
+
+---
+
+### Task 7: Migrate Temporal Shelves
+
+Replace the internal `ScrollShelf` with the shared one and add `coverHeight`.
+
+**Files:**
+- Modify: `web/src/features/explore/components/temporal-shelves.tsx`
+
+- [ ] **Step 1: Replace imports and delete the internal ScrollShelf**
+
+In `temporal-shelves.tsx`, replace the imports at the top:
+
+```tsx
+import { useRef, useState, useEffect, useCallback } from "react";
+import { getReleaseYear } from "@/lib/date-utils";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Calendar,
+  Trophy,
+  Heart,
+  Clock,
+} from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton, Skeleton } from "@/components/ui";
+```
+
+with:
+
+```tsx
+import { getReleaseYear } from "@/lib/date-utils";
+import { Calendar, Trophy, Heart, Clock } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { Skeleton } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
+```
+
+- [ ] **Step 2: Delete the entire internal `ScrollShelf` function**
+
+Remove the `function ScrollShelf(...)` block (the function starting at `// --- Shared scroll shelf wrapper` and ending just before `// --- On This Day Shelf ---`). This is approximately lines 22–140.
+
+- [ ] **Step 3: Update OnThisDayShelf to use shared ScrollShelf + coverHeight**
+
+Replace the `OnThisDayShelf` render. Change the `ScrollShelf` usage and the card wrapper:
+
+```tsx
+export function OnThisDayShelf({
+  data,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: OnThisDayShelfProps) {
+  const dateLabel = data?.date ?? "";
+
+  return (
+    <ScrollShelf
+      title={dateLabel ? `On This Day in Gaming — ${dateLabel}` : "On This Day in Gaming"}
+      subtitle="Games released on this date across the years"
+      icon={Calendar}
+      testId="on-this-day-shelf"
+      isLoading={isLoading}
+      isEmpty={!data?.games || data.games.length === 0}
+    >
+      {data?.games.map((game) => (
+        <div key={game.id} className="flex-shrink-0" role="listitem">
+          <GameCard
+            game={game}
+            coverHeight={CAROUSEL_CARD_HEIGHT}
+            showConsoleBadge
+            subtitle={getReleaseYear(game.releaseDate) ? `Released ${getReleaseYear(game.releaseDate)}` : undefined}
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+```
+
+- [ ] **Step 4: Update AnniversariesShelf**
+
+```tsx
+export function AnniversariesShelf({
+  anniversaries,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: AnniversariesShelfProps) {
+  return (
+    <ScrollShelf
+      title="Your Gaming Anniversaries"
+      subtitle="Milestones from your play history"
+      icon={Heart}
+      testId="anniversaries-shelf"
+      isLoading={isLoading}
+      isEmpty={!anniversaries || anniversaries.length === 0}
+    >
+      {anniversaries?.map((item) => (
+        <div key={`${item.game.id}-${item.yearsAgo}`} className="flex-shrink-0" role="listitem">
+          <GameCard
+            game={item.game}
+            coverHeight={CAROUSEL_CARD_HEIGHT}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+          <p className="text-xs text-amber-400 mt-1.5 font-medium" data-testid="anniversary-label">
+            {item.yearsAgo} year{item.yearsAgo !== 1 ? "s" : ""} ago you played this
+          </p>
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+```
+
+- [ ] **Step 5: Update DecadeSpotlight**
+
+```tsx
+export function DecadeSpotlight({
+  data,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: DecadeSpotlightProps) {
+  return (
+    <ScrollShelf
+      title={data?.label ?? "Decade Spotlight"}
+      subtitle={`The defining games of the ${data?.decade ?? "era"}`}
+      icon={Clock}
+      testId="decade-spotlight"
+      isLoading={isLoading}
+      isEmpty={!data?.games || data.games.length === 0}
+    >
+      {data?.games.map((game) => (
+        <div key={game.id} className="flex-shrink-0" role="listitem">
+          <GameCard
+            game={game}
+            coverHeight={CAROUSEL_CARD_HEIGHT}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+```
+
+Note: `BestOfYearSection` is a grid, NOT a carousel — leave it completely unchanged. Its `Skeleton` import is still needed for the year selector skeleton.
+
+- [ ] **Step 6: Verify type checking and tests pass**
+
+Run: `cd web && npx tsc --noEmit && npx vitest run`
+Expected: No type errors, all tests PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/features/explore/components/temporal-shelves.tsx
+git commit -m "refactor: migrate temporal shelves to shared ScrollShelf + coverHeight"
+```
+
+---
+
+### Task 8: Migrate Achievement Shelves
+
+**Files:**
+- Modify: `web/src/features/explore/components/achievement-shelves.tsx`
+
+- [ ] **Step 1: Replace imports and delete internal ScrollShelf**
+
+Replace the imports:
+
+```tsx
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import {
+  ChevronLeft,
+  ChevronRight,
+  Award,
+  Mountain,
+  Target,
+  Sparkles,
+  Swords,
+} from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton, Skeleton } from "@/components/ui";
+```
+
+with:
+
+```tsx
+import { Link } from "react-router-dom";
+import { Award, Mountain, Target, Sparkles, Swords } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
+```
+
+Delete the internal `ScrollShelf` function (lines 25–142 approximately).
+
+- [ ] **Step 2: Update EasyToCompleteShelf**
+
+```tsx
+export function EasyToCompleteShelf({
+  data,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: EasyToCompleteShelfProps) {
+  return (
+    <ScrollShelf
+      title="Easy to 100%"
+      subtitle="Games with the highest achievement completion rates"
+      icon={Award}
+      testId="easy-to-complete-shelf"
+      isLoading={isLoading}
+      isEmpty={!data?.games || data.games.length === 0}
+    >
+      {data?.games.map((item) => (
+        <div key={item.game.id} className="flex-shrink-0" role="listitem">
+          <GameCard
+            game={item.game}
+            coverHeight={CAROUSEL_CARD_HEIGHT}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+          <p className="text-xs text-surface-400 mt-1.5" data-testid="avg-completion">
+            {item.avgCompletion}% avg completion
+          </p>
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+```
+
+- [ ] **Step 3: Update HardestGamesShelf**
+
+Same pattern — replace `ScrollShelf` usage and card wrapper. Change `className="w-40 sm:w-44 lg:w-48 flex-shrink-0"` to `className="flex-shrink-0"` and add `coverHeight={CAROUSEL_CARD_HEIGHT}` to each `GameCard`.
+
+- [ ] **Step 4: Update AlmostDoneShelf**
+
+Same pattern — replace wrapper class and add `coverHeight`.
+
+- [ ] **Step 5: Update FreshChallengesShelf**
+
+Same pattern.
+
+- [ ] **Step 6: Update ActiveChallengesShelf**
+
+This shelf does NOT use `GameCard` — it uses custom text cards with `w-64`. Keep the `w-64 flex-shrink-0` wrapper. Only change the `ScrollShelf` reference to the shared import:
+
+```tsx
+export function ActiveChallengesShelf({
+  data,
+  isLoading,
+}: ActiveChallengesShelfProps) {
+  return (
+    <ScrollShelf
+      title="Active Challenges"
+      subtitle="Open challenges from the community"
+      icon={Swords}
+      testId="active-challenges-shelf"
+      isLoading={isLoading}
+      isEmpty={!data?.challenges || data.challenges.length === 0}
+    >
+      {data?.challenges.map((ch) => (
+        <div key={ch.id} className="w-64 flex-shrink-0" role="listitem">
+          <Link to={`/challenges/${ch.id}`} className="block">
+            <div className="bg-surface-800 rounded-lg p-4 hover:bg-surface-700 transition-colors">
+              <div className="flex items-center gap-2 mb-2">
+                <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-brand-500/20 text-brand-400">
+                  {ch.type}
+                </span>
+                <span className="text-xs font-medium px-2 py-0.5 rounded-full bg-surface-600 text-surface-300">
+                  {ch.difficulty}
+                </span>
+              </div>
+              <h3 className="text-sm font-semibold text-surface-100 truncate" data-testid="challenge-name">
+                {ch.name}
+              </h3>
+              <p className="text-xs text-surface-400 truncate mt-1">{ch.gameTitle}</p>
+              <div className="flex items-center gap-3 mt-3 text-xs text-surface-400">
+                <span>{ch.attemptCount} attempts</span>
+                <span>{ch.completionCount} completed</span>
+              </div>
+            </div>
+          </Link>
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+```
+
+- [ ] **Step 7: Verify type checking and tests pass**
+
+Run: `cd web && npx tsc --noEmit && npx vitest run`
+Expected: No errors, all tests PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add web/src/features/explore/components/achievement-shelves.tsx
+git commit -m "refactor: migrate achievement shelves to shared ScrollShelf + coverHeight"
+```
+
+---
+
+### Task 9: Migrate Social Shelves
+
+**Files:**
+- Modify: `web/src/features/explore/components/social-shelves.tsx`
+
+- [ ] **Step 1: Replace imports and delete internal ScrollShelf**
+
+Replace the imports:
+
+```tsx
+import { useRef, useState, useEffect, useCallback } from "react";
+import { Link } from "react-router-dom";
+import {
+  ChevronLeft,
+  ChevronRight,
+  TrendingUp,
+  Star,
+  Gem,
+  Radio,
+  MessageSquare,
+  Users,
+  Swords,
+} from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton, Badge, Skeleton } from "@/components/ui";
+```
+
+with:
+
+```tsx
+import { Link } from "react-router-dom";
+import { TrendingUp, Star, Gem, Radio, MessageSquare, Users, Swords } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { Badge } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
+```
+
+Delete the internal `ScrollShelf` function.
+
+- [ ] **Step 2: Update TrendingShelf, CommunityTopShelf, CultClassicsShelf, ActiveNowShelf**
+
+For each of these four shelves:
+- Replace `className="w-40 sm:w-44 lg:w-48 flex-shrink-0"` with `className="flex-shrink-0"`
+- Add `coverHeight={CAROUSEL_CARD_HEIGHT}` to each `GameCard`
+
+- [ ] **Step 3: Update RecentlyReviewedShelf**
+
+This shelf uses a hybrid layout (small cover + review text) with `w-56 sm:w-60` cards. It does NOT use `GameCard` in a standard carousel way. Keep the fixed widths on the wrapper. Only change the `ScrollShelf` reference:
+
+```tsx
+export function RecentlyReviewedShelf({
+  reviews,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: RecentlyReviewedShelfProps) {
+  return (
+    <ScrollShelf
+      title="Recently Reviewed"
+      subtitle="Latest reviews from your community"
+      icon={MessageSquare}
+      testId="recently-reviewed-shelf"
+      isLoading={isLoading}
+      isEmpty={!reviews || reviews.length === 0}
+    >
+      {reviews?.map((item) => (
+        <div key={`${item.game.id}-${item.reviewerName}`} className="w-56 sm:w-60 flex-shrink-0" role="listitem">
+          {/* ... existing hybrid card content unchanged ... */}
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+```
+
+The inner card content (the `<div className="flex gap-3">` block with the small GameCard and review text) stays exactly as-is.
+
+- [ ] **Step 4: Verify type checking and tests pass**
+
+Run: `cd web && npx tsc --noEmit && npx vitest run`
+Expected: No errors, all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/features/explore/components/social-shelves.tsx
+git commit -m "refactor: migrate social shelves to shared ScrollShelf + coverHeight"
+```
+
+---
+
+### Task 10: Migrate PlayersLikeYouShelf
+
+**Files:**
+- Modify: `web/src/features/explore/components/players-like-you-shelf.tsx`
+- Modify: `web/src/features/explore/components/__tests__/players-like-you-shelf.test.tsx`
+
+- [ ] **Step 1: Rewrite to use ScrollShelf**
+
+Replace the entire file with:
+
+```tsx
+// web/src/features/explore/components/players-like-you-shelf.tsx
+import { GameCard } from "@/components/game-card";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
+import type { Game, GameSummary } from "@/types/api";
+
+interface PlayersLikeYouShelfProps {
+  games: GameSummary[] | undefined;
+  isLoading: boolean;
+  similarUsersCount: number;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+export function PlayersLikeYouShelf({
+  games,
+  isLoading,
+  similarUsersCount,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: PlayersLikeYouShelfProps) {
+  const subtitle =
+    similarUsersCount > 0
+      ? `Based on ${similarUsersCount} player${similarUsersCount !== 1 ? "s" : ""} with similar taste`
+      : undefined;
+
+  return (
+    <ScrollShelf
+      title="Players like you also enjoyed"
+      subtitle={subtitle}
+      testId="players-like-you-shelf"
+      isLoading={isLoading}
+      isEmpty={!games || games.length === 0}
+    >
+      {games?.map((game) => (
+        <div key={game.id} className="flex-shrink-0" role="listitem">
+          <GameCard
+            game={game}
+            coverHeight={CAROUSEL_CARD_HEIGHT}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+```
+
+- [ ] **Step 2: Update the test for new skeleton testId**
+
+In `players-like-you-shelf.test.tsx`, the skeleton `data-testid` changes from `players-like-you-skeleton` to `players-like-you-shelf-skeleton` (because `ScrollShelf` uses `${testId}-skeleton`). Update:
+
+```tsx
+  it("shows skeleton when loading", () => {
+    renderComponent({ isLoading: true });
+
+    expect(screen.getByTestId("players-like-you-shelf-skeleton")).toBeInTheDocument();
+    expect(screen.queryByTestId("players-like-you-shelf")).not.toBeInTheDocument();
+  });
+```
+
+Also, the subtitle `data-testid="similar-users-count"` was on the `<p>` tag in the old component. In the new version, `ScrollShelf` renders the subtitle as a plain `<p>` without that testId. Update the subtitle test to search by text instead:
+
+```tsx
+  it("shows similar users count", () => {
+    const games = [makeGame({ id: "p1", title: "Super Metroid" })];
+
+    renderComponent({ games, similarUsersCount: 12 });
+
+    expect(screen.getByText("Based on 12 players with similar taste")).toBeInTheDocument();
+  });
+
+  it("shows singular form for 1 player", () => {
+    const games = [makeGame({ id: "p1", title: "Super Metroid" })];
+
+    renderComponent({ games, similarUsersCount: 1 });
+
+    expect(screen.getByText("Based on 1 player with similar taste")).toBeInTheDocument();
+  });
+```
+
+Remove the `data-testid="similar-users-count"` assertion.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd web && npx vitest run src/features/explore/components/__tests__/players-like-you-shelf.test.tsx`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/features/explore/components/players-like-you-shelf.tsx web/src/features/explore/components/__tests__/players-like-you-shelf.test.tsx
+git commit -m "refactor: migrate PlayersLikeYouShelf to ScrollShelf + coverHeight"
+```
+
+---
+
+### Task 11: Migrate ForYouSection
+
+**Files:**
+- Modify: `web/src/features/explore/components/for-you-section.tsx`
+
+- [ ] **Step 1: Rewrite ForYouShelf to use ScrollShelf**
+
+Replace the imports:
+
+```tsx
+import { useRef, useState, useEffect, useCallback } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton } from "@/components/ui";
+```
+
+with:
+
+```tsx
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
+```
+
+- [ ] **Step 2: Replace the internal ForYouShelf component**
+
+Replace the `ForYouShelf` function with:
+
+```tsx
+function ForYouShelf({
+  row,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: {
+  row: ForYouRow;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}) {
+  if (!row.games || row.games.length === 0) {
+    return null;
+  }
+
+  const testId = `for-you-row-${row.type}`;
+
+  const header = (
+    <div className="flex items-center gap-3 mb-5">
+      {row.type === "because_you_played" && row.sourceGame?.coverUrl && (
+        <img
+          src={row.sourceGame.coverUrl}
+          alt={row.sourceGame.title}
+          className="h-8 w-6 rounded object-cover flex-shrink-0"
+          data-testid="source-game-cover"
+        />
+      )}
+      <div>
+        <h3 className="text-xl font-bold text-surface-100">{row.title}</h3>
+        {row.type === "expand_horizons" && row.genre && (
+          <p className="text-sm text-surface-400 mt-0.5">
+            Try something from <span className="text-brand-400 font-medium">{row.genre}</span>
+          </p>
+        )}
+      </div>
+    </div>
+  );
+
+  return (
+    <section data-testid={testId} className="group/shelf relative">
+      {header}
+      <ScrollShelf
+        title={row.title}
+        testId={`${testId}-scroll`}
+        isLoading={false}
+        isEmpty={false}
+      >
+        {row.games.map((game) => (
+          <div key={game.id} className="flex-shrink-0" role="listitem">
+            <GameCard
+              game={game}
+              coverHeight={CAROUSEL_CARD_HEIGHT}
+              showConsoleBadge
+              onToggleFavorite={onToggleFavorite}
+              onTogglePlayLater={onTogglePlayLater}
+            />
+          </div>
+        ))}
+      </ScrollShelf>
+    </section>
+  );
+}
+```
+
+Note: `ForYouShelf` has a custom header (with source game thumbnail, genre subtitle) that doesn't fit `ScrollShelf`'s title pattern. So we render the header ourselves and use `ScrollShelf` only for the scroll row. The `ScrollShelf` title and heading will be present but we need to handle this — actually, since `ForYouShelf` already has its own header, we should use `ScrollShelf` without rendering its own title. The simplest approach: set `title` to an empty string and omit the icon, so `ScrollShelf` renders its `h2` as empty (effectively invisible). However, the `aria-label` on the scroll list still uses the title, which is good for accessibility.
+
+Actually, a cleaner approach: since `ForYouShelf` has such a custom header, keep the outer `<section>` with custom header and only use the scroll mechanics. The `ScrollShelf` title is used for the `aria-label` so we still pass `row.title`. But the `h2` will be visible. Let me reconsider — `ScrollShelf` always renders a heading. For `ForYouShelf`, we need the scroll container without the heading because we render our own.
+
+The simplest fix: wrap just the scroll part. But `ScrollShelf` is a section-level component. For `ForYouSection`, keep the inline scroll logic for now and just add `coverHeight`. This avoids forcing `ScrollShelf` to have an optional title.
+
+Revised approach — keep the `ForYouShelf` structure but replace the scroll logic with a simpler pattern. Actually, let me just add `coverHeight` and remove the fixed-width wrappers, keeping the existing scroll logic. This component has a custom header that doesn't fit `ScrollShelf`.
+
+Replace the file with:
+
+```tsx
+// web/src/features/explore/components/for-you-section.tsx
+import { useRef, useState, useEffect, useCallback } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { GameCard } from "@/components/game-card";
+import { GameCardSkeleton } from "@/components/ui";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
+import type { ForYouRow, Game } from "@/types/api";
+
+interface ForYouSectionProps {
+  rows: ForYouRow[] | undefined;
+  isLoading: boolean;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}
+
+function ForYouSkeleton() {
+  return (
+    <div data-testid="for-you-skeleton" className="space-y-10">
+      {Array.from({ length: 3 }, (_, i) => (
+        <section key={i}>
+          <div className="h-7 w-64 rounded bg-surface-800 animate-pulse mb-5" />
+          <div className="flex gap-5 overflow-hidden">
+            {Array.from({ length: 6 }, (_, j) => (
+              <GameCardSkeleton key={j} coverHeight={CAROUSEL_CARD_HEIGHT} />
+            ))}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}
+
+function ForYouShelf({
+  row,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: {
+  row: ForYouRow;
+  onToggleFavorite?: (game: Game) => void;
+  onTogglePlayLater?: (game: Game) => void;
+}) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, row.games]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (!row.games || row.games.length === 0) {
+    return null;
+  }
+
+  const testId = `for-you-row-${row.type}`;
+
+  return (
+    <section data-testid={testId} className="group/shelf relative">
+      <div className="flex items-center gap-3 mb-5">
+        {row.type === "because_you_played" && row.sourceGame?.coverUrl && (
+          <img
+            src={row.sourceGame.coverUrl}
+            alt={row.sourceGame.title}
+            className="h-8 w-6 rounded object-cover flex-shrink-0"
+            data-testid="source-game-cover"
+          />
+        )}
+        <div>
+          <h3 className="text-xl font-bold text-surface-100">{row.title}</h3>
+          {row.type === "expand_horizons" && row.genre && (
+            <p className="text-sm text-surface-400 mt-0.5">
+              Try something from <span className="text-brand-400 font-medium">{row.genre}</span>
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="relative">
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label={`Scroll ${row.title} left`}
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
+            aria-label={`Scroll ${row.title} right`}
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        <div
+          ref={scrollRef}
+          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label={row.title}
+        >
+          {row.games.map((game) => (
+            <div key={game.id} className="flex-shrink-0" role="listitem">
+              <GameCard
+                game={game}
+                coverHeight={CAROUSEL_CARD_HEIGHT}
+                showConsoleBadge
+                onToggleFavorite={onToggleFavorite}
+                onTogglePlayLater={onTogglePlayLater}
+              />
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export function ForYouSection({
+  rows,
+  isLoading,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: ForYouSectionProps) {
+  if (isLoading) {
+    return <ForYouSkeleton />;
+  }
+
+  if (!rows || rows.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-testid="for-you-section" className="space-y-10">
+      {rows.map((row, index) => (
+        <ForYouShelf
+          key={`${row.type}-${index}`}
+          row={row}
+          onToggleFavorite={onToggleFavorite}
+          onTogglePlayLater={onTogglePlayLater}
+        />
+      ))}
+    </div>
+  );
+}
+```
+
+The key changes vs the original: removed `w-40 sm:w-44 lg:w-48` from card wrappers, added `coverHeight={CAROUSEL_CARD_HEIGHT}` to `GameCard`, and updated skeleton to use `coverHeight`. The scroll logic stays because `ForYouShelf` has a custom header with a source game thumbnail and genre subtitle that doesn't fit `ScrollShelf`'s title/subtitle/icon props. Same situation as `DeveloperSpotlight` — both have custom headers with the scroll row nested inside.
+
+- [ ] **Step 3: Verify type checking and tests pass**
+
+Run: `cd web && npx tsc --noEmit && npx vitest run`
+Expected: No errors, all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/features/explore/components/for-you-section.tsx
+git commit -m "refactor: add coverHeight to ForYouSection game cards"
+```
+
+---
+
+### Task 12: Migrate DeveloperSpotlight
+
+**Files:**
+- Modify: `web/src/features/explore/components/developer-spotlight.tsx`
+
+- [ ] **Step 1: Add coverHeight import and update card wrappers**
+
+Add the import at the top:
+
+```tsx
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
+```
+
+In the game card mapping, change the wrapper and add `coverHeight`. Replace:
+
+```tsx
+{spotlight.topGames.map((game) => (
+  <div
+    key={game.id}
+    className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+    role="listitem"
+  >
+    <GameCard
+      game={game}
+      showConsoleBadge
+      onToggleFavorite={onToggleFavorite}
+      onTogglePlayLater={onTogglePlayLater}
+    />
+  </div>
+))}
+```
+
+with:
+
+```tsx
+{spotlight.topGames.map((game) => (
+  <div key={game.id} className="flex-shrink-0" role="listitem">
+    <GameCard
+      game={game}
+      coverHeight={CAROUSEL_CARD_HEIGHT}
+      showConsoleBadge
+      onToggleFavorite={onToggleFavorite}
+      onTogglePlayLater={onTogglePlayLater}
+    />
+  </div>
+))}
+```
+
+Note: This component has a custom hero card layout with the scroll row nested inside it. The scroll logic stays inline because the scroll arrows need `group-hover/spotlight` (not `group-hover/shelf`). Only the card sizing changes.
+
+- [ ] **Step 2: Verify type checking passes**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/features/explore/components/developer-spotlight.tsx
+git commit -m "refactor: add coverHeight to DeveloperSpotlight game cards"
+```
+
+---
+
+### Task 13: Migrate SeriesShelf (ScrollShelf only, no coverHeight)
+
+**Files:**
+- Modify: `web/src/features/explore/components/series-shelf.tsx`
+- Modify: `web/src/features/explore/components/__tests__/series-shelf.test.tsx`
+
+- [ ] **Step 1: Rewrite to use ScrollShelf**
+
+Replace the entire file with:
+
+```tsx
+// web/src/features/explore/components/series-shelf.tsx
+import { Link } from "react-router-dom";
+import { Skeleton } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import type { FeaturedSeries } from "@/types/api";
+
+interface SeriesShelfProps {
+  series: FeaturedSeries[] | undefined;
+  isLoading: boolean;
+}
+
+function SeriesSkeletonContent() {
+  return (
+    <div className="flex gap-4 overflow-hidden">
+      {Array.from({ length: 5 }, (_, i) => (
+        <Skeleton key={i} className="w-56 sm:w-60 lg:w-64 h-36 flex-shrink-0 rounded-2xl" />
+      ))}
+    </div>
+  );
+}
+
+export function SeriesShelf({ series, isLoading }: SeriesShelfProps) {
+  return (
+    <ScrollShelf
+      title="Browse by Series"
+      testId="series-shelf"
+      isLoading={isLoading}
+      isEmpty={!series || series.length === 0}
+      loadingSkeleton={<SeriesSkeletonContent />}
+    >
+      {series?.map((s) => (
+        <Link
+          key={s.id}
+          to={`/explore/series/${s.id}`}
+          className="w-56 sm:w-60 lg:w-64 flex-shrink-0 rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950"
+          role="listitem"
+        >
+          <div className="relative h-36 rounded-2xl overflow-hidden border border-white/[0.06] transition-all duration-300 hover:border-white/[0.12] hover:shadow-xl hover:shadow-black/30 hover:-translate-y-1 group/card">
+            {s.heroUrl ? (
+              <img
+                src={s.heroUrl}
+                alt=""
+                className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover/card:scale-105"
+                loading="lazy"
+              />
+            ) : (
+              <div className="absolute inset-0 bg-gradient-to-br from-brand-900/80 via-brand-800/60 to-surface-950/80" />
+            )}
+            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent pointer-events-none" />
+            <div className="relative flex flex-col justify-end h-full p-4">
+              <h3 className="text-base font-bold text-white leading-tight group-hover/card:text-brand-300 transition-colors truncate">
+                {s.name}
+              </h3>
+              <p className="text-xs text-white/70 mt-1">
+                {s.libraryGames}/{s.totalGames} {s.totalGames === 1 ? "game" : "games"}
+                {s.consoleCount > 0 && (
+                  <span className="text-white/50">
+                    {" "}across {s.consoleCount} {s.consoleCount === 1 ? "console" : "consoles"}
+                  </span>
+                )}
+              </p>
+            </div>
+          </div>
+        </Link>
+      ))}
+    </ScrollShelf>
+  );
+}
+```
+
+- [ ] **Step 2: Update the series-shelf test for new skeleton testId**
+
+The old skeleton used `data-testid="series-shelf-skeleton"` which matches the new `${testId}-skeleton` pattern. Check the test file and update if needed. The testId should still be `series-shelf-skeleton` so this should work without changes. Verify by running the test.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd web && npx vitest run src/features/explore/components/__tests__/series-shelf.test.tsx`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/features/explore/components/series-shelf.tsx web/src/features/explore/components/__tests__/series-shelf.test.tsx
+git commit -m "refactor: migrate SeriesShelf to shared ScrollShelf"
+```
+
+---
+
+### Task 14: Migrate ArtworkShowcase (ScrollShelf only, no coverHeight)
+
+**Files:**
+- Modify: `web/src/features/explore/components/artwork-showcase.tsx`
+
+- [ ] **Step 1: Rewrite to use ScrollShelf**
+
+Replace the entire file with:
+
+```tsx
+// web/src/features/explore/components/artwork-showcase.tsx
+import { Link } from "react-router-dom";
+import { Skeleton } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import type { ArtworkItem } from "@/types/api";
+
+interface ArtworkShowcaseProps {
+  artworks: ArtworkItem[] | undefined;
+  isLoading: boolean;
+}
+
+function ArtworkSkeletonContent() {
+  return (
+    <div className="flex gap-5 overflow-hidden">
+      {Array.from({ length: 4 }, (_, i) => (
+        <div key={i} className="w-80 sm:w-96 flex-shrink-0">
+          <Skeleton className="w-full rounded-xl" style={{ aspectRatio: "16/9" }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function ArtworkShowcase({ artworks, isLoading }: ArtworkShowcaseProps) {
+  const displayArtworks = artworks?.slice(0, 10);
+
+  return (
+    <ScrollShelf
+      title="Artwork Showcase"
+      testId="artwork-showcase"
+      isLoading={isLoading}
+      isEmpty={!displayArtworks || displayArtworks.length === 0}
+      loadingSkeleton={<ArtworkSkeletonContent />}
+      headerRight={
+        <div className="flex items-center gap-3 text-sm text-surface-400">
+          <Link to="/explore/gallery" className="hover:text-brand-400 transition-colors" data-testid="browse-screenshots-link">
+            Browse Screenshots
+          </Link>
+          <span className="text-surface-700">|</span>
+          <Link to="/explore/covers" className="hover:text-brand-400 transition-colors" data-testid="browse-covers-link">
+            Browse Cover Art
+          </Link>
+        </div>
+      }
+    >
+      {displayArtworks?.map((artwork, i) => (
+        <Link
+          key={`${artwork.gameId}-${i}`}
+          to={`/games/${artwork.gameId}`}
+          className="w-80 sm:w-96 flex-shrink-0 group/card"
+          role="listitem"
+          data-testid="artwork-card"
+        >
+          <div className="relative rounded-xl overflow-hidden">
+            <div style={{ aspectRatio: "16/9" }}>
+              <img
+                src={artwork.url}
+                alt={`Artwork for ${artwork.gameTitle}`}
+                className="w-full h-full object-cover transition-transform duration-300 group-hover/card:scale-[1.03]"
+                loading="lazy"
+              />
+            </div>
+            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent pointer-events-none" />
+            <div className="absolute bottom-0 left-0 right-0 p-4">
+              <p className="text-sm font-semibold text-white truncate">{artwork.gameTitle}</p>
+              <p className="text-xs text-white/60 mt-0.5">{artwork.consoleName}</p>
+            </div>
+          </div>
+        </Link>
+      ))}
+    </ScrollShelf>
+  );
+}
+```
+
+- [ ] **Step 2: Verify type checking and tests pass**
+
+Run: `cd web && npx tsc --noEmit && npx vitest run`
+Expected: No errors, all tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/features/explore/components/artwork-showcase.tsx
+git commit -m "refactor: migrate ArtworkShowcase to shared ScrollShelf"
+```
+
+---
+
+### Task 15: Migrate TopRatedRow
+
+**Files:**
+- Modify: `web/src/features/dashboard/components/top-rated-row.tsx`
+- Modify: `web/src/features/dashboard/components/top-rated-game-card.tsx`
+
+- [ ] **Step 1: Update TopRatedGameCard to accept and pass coverHeight**
+
+In `top-rated-game-card.tsx`, add a `coverHeight` prop:
+
+```tsx
+import { Star } from "lucide-react";
+import { CoverCard } from "@/components/cover-card";
+import type { TopRatedGame } from "@/types/api";
+
+/**
+ * ROLE component — a top-rated game card with library availability.
+ *
+ * Layer 3 in the component hierarchy (Design → Content → Role).
+ * Maps TopRatedGame domain data to CoverCard. Dimmed when the game
+ * is not available in the local library.
+ */
+export function TopRatedGameCard({ game, coverHeight }: { game: TopRatedGame; coverHeight?: number }) {
+  const isAvailable = game.localGameId != null;
+
+  return (
+    <CoverCard
+      imageUrl={game.coverUrl}
+      title={game.name}
+      subtitle={game.consoleName}
+      linkTo={isAvailable ? `/games/${game.localGameId}` : undefined}
+      coverHeight={coverHeight}
+    >
+      <span className="flex items-center gap-0.5 text-xs text-amber-400">
+        <Star className="h-3 w-3 fill-amber-400" />
+        {game.igdbCriticsRating.toFixed(0)}
+      </span>
+      {!isAvailable && (
+        <span className="text-xs text-surface-500">Not in library</span>
+      )}
+    </CoverCard>
+  );
+}
+```
+
+- [ ] **Step 2: Rewrite TopRatedRow to use ScrollShelf**
+
+Replace the file with:
+
+```tsx
+// web/src/features/dashboard/components/top-rated-row.tsx
+import { Star } from "lucide-react";
+import { Link } from "react-router-dom";
+import { ChevronRight } from "lucide-react";
+import { useTopRatedGlobal } from "@/hooks/use-top-lists";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { GameCardSkeleton } from "@/components/ui";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
+import { TopRatedGameCard } from "./top-rated-game-card";
+
+function TopRatedSkeletonContent() {
+  return (
+    <div className="flex gap-4 overflow-hidden">
+      {Array.from({ length: 6 }, (_, i) => (
+        <GameCardSkeleton key={i} coverHeight={CAROUSEL_CARD_HEIGHT} />
+      ))}
+    </div>
+  );
+}
+
+export function TopRatedRow() {
+  const { data: games, isLoading } = useTopRatedGlobal();
+
+  if (!isLoading && (!games || games.length === 0)) return null;
+
+  return (
+    <ScrollShelf
+      title="Top Rated"
+      icon={Star}
+      testId="top-rated-row"
+      isLoading={isLoading}
+      isEmpty={!games || games.length === 0}
+      loadingSkeleton={<TopRatedSkeletonContent />}
+      headerRight={
+        <Link
+          to="/top-lists"
+          className="flex items-center gap-1 text-sm text-surface-400 hover:text-brand-400 transition-colors"
+        >
+          View all
+          <ChevronRight className="h-4 w-4" />
+        </Link>
+      }
+    >
+      {games?.map((game) => (
+        <div key={`${game.rank}-${game.name}`} className="flex-shrink-0" role="listitem">
+          <TopRatedGameCard game={game} coverHeight={CAROUSEL_CARD_HEIGHT} />
+        </div>
+      ))}
+    </ScrollShelf>
+  );
+}
+```
+
+- [ ] **Step 3: Verify type checking and tests pass**
+
+Run: `cd web && npx tsc --noEmit && npx vitest run`
+Expected: No errors, all tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/features/dashboard/components/top-rated-row.tsx web/src/features/dashboard/components/top-rated-game-card.tsx
+git commit -m "refactor: migrate TopRatedRow to ScrollShelf + coverHeight"
+```
+
+---
+
+### Task 16: Full Build and Test Verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Run the full test suite**
+
+Run: `cd web && npx vitest run`
+Expected: All tests PASS. No regressions.
+
+- [ ] **Step 2: Run the TypeScript compiler**
+
+Run: `cd web && npx tsc --noEmit`
+Expected: No errors.
+
+- [ ] **Step 3: Run the production build**
+
+Run: `cd web && npm run build`
+Expected: Build succeeds with no errors.
+
+- [ ] **Step 4: Start the dev server and visually verify**
+
+Run: `cd web && npm run dev`
+
+Open the browser and verify:
+1. **Explore page**: Game shelves show cards with varying widths based on cover art aspect ratios. Cards have fixed height. No cropping — full box art visible.
+2. **Dashboard**: Top Rated row shows cards with varying widths.
+3. **Scroll arrows**: Hover over a shelf and verify left/right arrows appear and work.
+4. **Loading states**: Refresh the page and observe skeleton cards during loading.
+5. **Empty states**: Shelves with no data don't render.
+6. **Non-game shelves**: Series shelf, Artwork showcase, Active Challenges, Recently Reviewed all still render with their original fixed-width cards.
+
+- [ ] **Step 5: Commit any final fixes if needed**

--- a/docs/superpowers/specs/2026-04-12-carousel-card-redesign.md
+++ b/docs/superpowers/specs/2026-04-12-carousel-card-redesign.md
@@ -1,0 +1,192 @@
+# Carousel Card Redesign: Static Height, Image-Driven Width
+
+## Problem
+
+Game carousels in the web UI use fixed-width cards (`w-40 sm:w-44 lg:w-48`) with
+a forced `3:4` aspect ratio. Cover art with different aspect ratios gets cropped
+via `object-cover`. The player app solved this by making carousel cards
+fixed-height with image-driven width — the full box art is always visible and the
+card expands or contracts to fit. The web UI should match this approach.
+
+## Scope
+
+- **In scope:** All horizontal scroll shelves that contain game cards or cover
+  cards. Also the shared scroll container extraction.
+- **Out of scope:** Grid views (`GameGrid`, `BestOfYearSection`), `HeroCarousel`
+  (opacity transitions, not scrolling), navigation elements (`ConsoleQuickJump`,
+  `KeywordChips`), `GameSummaryCard`.
+
+## Design
+
+### Centralized Constants
+
+A single file for carousel sizing — one place to tweak.
+
+```ts
+// web/src/lib/carousel-constants.ts
+export const CAROUSEL_CARD_HEIGHT = 240;            // px
+export const CAROUSEL_DEFAULT_ASPECT_RATIO = 3 / 4; // fallback for placeholder/skeleton
+```
+
+### ScrollShelf (Design Layer)
+
+A shared horizontal scroll container extracted from the 6+ duplicated copies
+currently spread across `game-shelf.tsx`, `series-shelf.tsx`,
+`artwork-showcase.tsx`, `developer-spotlight.tsx`, `temporal-shelves.tsx`,
+`achievement-shelves.tsx`, and `social-shelves.tsx`.
+
+**File:** `web/src/components/scroll-shelf.tsx`
+
+**Owns:** Horizontal overflow scroll, scroll arrow buttons (appear on hover),
+scroll state tracking (`canScrollLeft`/`canScrollRight`), scrollbar hiding,
+`data-comp="ScrollShelf"`.
+
+**Props:**
+
+| Prop | Type | Description |
+|------|------|-------------|
+| `title` | `string` | Section heading |
+| `subtitle` | `string?` | Secondary text below title |
+| `icon` | `LucideIcon?` | Icon next to title |
+| `testId` | `string` | `data-testid` for the section |
+| `isLoading` | `boolean` | Show skeleton state |
+| `isEmpty` | `boolean` | Return null when true |
+| `children` | `ReactNode` | Scroll row content |
+| `loadingSkeleton` | `ReactNode?` | Custom skeleton (defaults to 6 game card skeletons) |
+| `headerRight` | `ReactNode?` | Extra content in the header row (links, etc.) |
+
+**Does NOT own:** Card sizing, card content, gap between cards. These are
+controlled by the children.
+
+### GameCard Carousel Mode
+
+The existing `GameCard` (Content layer) gets a new optional prop:
+`coverHeight?: number`.
+
+**When `coverHeight` is set (carousel mode):**
+
+- The image container gets a fixed pixel height via
+  `style={{ height: coverHeight }}`.
+- The `<img>` renders with `height: 100%` and `width: auto` — the image's
+  natural aspect ratio drives the card width.
+- No `object-cover`, no cropping — full box art is always visible.
+- The card has `flex-shrink-0` to prevent collapse in flex rows.
+
+**When `coverHeight` is NOT set (grid mode):**
+
+- No change to existing behavior. Card fills parent width, placeholder uses
+  `aspectRatio`.
+
+**Placeholder / missing cover (carousel mode):**
+
+- Uses `game.coverAspectRatio` (from the API, per-console) combined with
+  `coverHeight` to size the placeholder via CSS `aspect-ratio` + fixed height.
+- Falls back to `CAROUSEL_DEFAULT_ASPECT_RATIO` if the API value is missing.
+- Shows the existing gradient + first-letter fallback.
+
+### CoverCard Carousel Mode
+
+Same pattern as `GameCard`. `CoverCard` (Content layer) gets an optional
+`coverHeight?: number` prop with identical behavior: fixed height, image-driven
+width, no crop.
+
+This is used by `TopRatedGameCard` (Role layer) in the `TopRatedRow`.
+
+### GameCardSkeleton
+
+`GameCardSkeleton` also accepts an optional `coverHeight` prop. When set, it
+uses `CAROUSEL_DEFAULT_ASPECT_RATIO` combined with the height to derive skeleton
+dimensions so loading states match the expected card shape.
+
+### Shelf Migration
+
+All shelves migrate to use the shared `ScrollShelf` and pass `coverHeight` to
+their card components.
+
+**Game shelves (ScrollShelf + GameCard with coverHeight):**
+
+| Shelf | File | Notes |
+|-------|------|-------|
+| `GameShelf` | `game-shelf.tsx` | Delete inline scroll logic |
+| `ForYouSection` | `for-you-section.tsx` | Per-row shelves |
+| `PlayersLikeYouShelf` | `players-like-you-shelf.tsx` | |
+| `DeveloperSpotlight` | `developer-spotlight.tsx` | Scroll row is nested inside a hero card. Use `ScrollShelf` with title/icon/subtitle hidden (empty string title, no icon) so it only provides scroll mechanics. The hero card wrapper stays as-is. |
+| `OnThisDayShelf` | `temporal-shelves.tsx` | Delete internal ScrollShelf |
+| `AnniversariesShelf` | `temporal-shelves.tsx` | |
+| `DecadeSpotlight` | `temporal-shelves.tsx` | |
+| `EasyToCompleteShelf` | `achievement-shelves.tsx` | Delete internal ScrollShelf |
+| `HardestGamesShelf` | `achievement-shelves.tsx` | |
+| `AlmostDoneShelf` | `achievement-shelves.tsx` | |
+| `FreshChallengesShelf` | `achievement-shelves.tsx` | |
+| `TrendingShelf` | `social-shelves.tsx` | Delete internal ScrollShelf |
+| `CommunityTopShelf` | `social-shelves.tsx` | |
+| `CultClassicsShelf` | `social-shelves.tsx` | |
+| `ActiveNowShelf` | `social-shelves.tsx` | |
+| `TopRatedRow` | `top-rated-row.tsx` | Switch from TitledSection to ScrollShelf, pass coverHeight through TopRatedGameCard to CoverCard |
+
+Per-card wrapper changes from:
+
+```tsx
+<div className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+  <GameCard game={game} />
+</div>
+```
+
+to:
+
+```tsx
+<div className="flex-shrink-0" role="listitem">
+  <GameCard game={game} coverHeight={CAROUSEL_CARD_HEIGHT} />
+</div>
+```
+
+**Non-game shelves (use ScrollShelf, keep current card sizing):**
+
+| Shelf | File | Card type |
+|-------|------|-----------|
+| `SeriesShelf` | `series-shelf.tsx` | Custom hero cards (`w-56`/`w-60`/`w-64`, `h-36`) |
+| `ArtworkShowcase` | `artwork-showcase.tsx` | Screenshot cards (`w-80`/`w-96`, `16:9`) |
+| `RecentlyReviewedShelf` | `social-shelves.tsx` | Hybrid cover + text (`w-56`/`w-60`) |
+| `ActiveChallengesShelf` | `achievement-shelves.tsx` | Text-only cards (`w-64`) |
+
+These adopt `ScrollShelf` for the scroll container (eliminating duplicated scroll
+logic) but keep their existing fixed-width card sizing since their content isn't
+standard box art.
+
+### What Doesn't Change
+
+- **Grid views** — `GameGrid`, `BestOfYearSection`, any grid layout.
+- **HeroCarousel** — opacity transition slides, not scrolling.
+- **ConsoleQuickJump, KeywordChips** — nav elements.
+- **GameSummaryCard** — horizontal layout card for lists/detail pages.
+- **GameCard without `coverHeight`** — when used outside carousels, behaves
+  exactly as today. This change is purely additive.
+
+## Component Hierarchy Summary
+
+```
+Design layer:
+  ScrollShelf          — shared scroll container with arrows
+  CoverImage           — image with lazy loading + fallback (unchanged)
+
+Content layer:
+  GameCard             — game cover card, now supports coverHeight for carousel mode
+  CoverCard            — generic cover card, now supports coverHeight for carousel mode
+  GameCardSkeleton     — loading placeholder, supports coverHeight
+
+Role layer:
+  GameShelf            — thin wrapper: ScrollShelf + GameCard with coverHeight
+  TopRatedGameCard     — maps TopRatedGame to CoverCard with coverHeight
+  TrendingShelf        — ScrollShelf + GameCard + player count label
+  (... all other shelf components)
+```
+
+## Testing
+
+- Visual: verify carousels render with varying-width cards across consoles with
+  different box art aspect ratios (SNES 7:10, Genesis 28:39, Game Boy 1:1, etc.)
+- Verify placeholder/skeleton sizing matches loaded card dimensions
+- Verify scroll arrows still work
+- Verify grid views are unaffected
+- Verify hover effects (scale, shadow, translate) still work in carousel mode
+- Existing E2E tests for explore page should continue to pass

--- a/web/src/components/__tests__/scroll-shelf.test.tsx
+++ b/web/src/components/__tests__/scroll-shelf.test.tsx
@@ -1,0 +1,88 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { Star } from "lucide-react";
+import { ScrollShelf } from "../scroll-shelf";
+
+describe("ScrollShelf", () => {
+  it("renders title and children", () => {
+    render(
+      <ScrollShelf title="Test Shelf" testId="test-shelf" isLoading={false} isEmpty={false}>
+        <div>Child 1</div>
+        <div>Child 2</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByRole("heading", { name: "Test Shelf", level: 2 })).toBeInTheDocument();
+    expect(screen.getByText("Child 1")).toBeInTheDocument();
+    expect(screen.getByText("Child 2")).toBeInTheDocument();
+  });
+
+  it("renders subtitle when provided", () => {
+    render(
+      <ScrollShelf title="Shelf" subtitle="Some subtitle" testId="s" isLoading={false} isEmpty={false}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByText("Some subtitle")).toBeInTheDocument();
+  });
+
+  it("renders icon when provided", () => {
+    render(
+      <ScrollShelf title="Shelf" icon={Star} testId="s" isLoading={false} isEmpty={false}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    const section = screen.getByTestId("s");
+    expect(section.querySelector("svg")).toBeInTheDocument();
+  });
+
+  it("renders headerRight slot", () => {
+    render(
+      <ScrollShelf title="Shelf" testId="s" isLoading={false} isEmpty={false} headerRight={<span>View all</span>}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByText("View all")).toBeInTheDocument();
+  });
+
+  it("renders scrollable list with title as aria label", () => {
+    render(
+      <ScrollShelf title="My Shelf" testId="s" isLoading={false} isEmpty={false}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByRole("list", { name: "My Shelf" })).toBeInTheDocument();
+  });
+
+  it("returns null when isEmpty is true", () => {
+    const { container } = render(
+      <ScrollShelf title="Shelf" testId="s" isLoading={false} isEmpty={true}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders loading skeleton when isLoading", () => {
+    render(
+      <ScrollShelf title="Shelf" testId="s" isLoading={true} isEmpty={false}>
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByTestId("s-skeleton")).toBeInTheDocument();
+  });
+
+  it("renders custom loading skeleton when provided", () => {
+    render(
+      <ScrollShelf
+        title="Shelf"
+        testId="s"
+        isLoading={true}
+        isEmpty={false}
+        loadingSkeleton={<div data-testid="custom-skeleton">Loading...</div>}
+      >
+        <div>Item</div>
+      </ScrollShelf>,
+    );
+    expect(screen.getByTestId("custom-skeleton")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/cover-card.tsx
+++ b/web/src/components/cover-card.tsx
@@ -21,6 +21,7 @@ interface CoverCardProps {
   dimmed?: boolean;
   aspectRatio?: string;
   width?: string;
+  coverHeight?: number;
   children?: ReactNode;
 }
 
@@ -32,15 +33,16 @@ export function CoverCard({
   dimmed = false,
   aspectRatio = "3/4",
   width = "w-36",
+  coverHeight,
   children,
 }: CoverCardProps) {
   const content = (
-    <div data-comp="CoverCard" className={cn(width, dimmed && "opacity-50")}>
+    <div data-comp="CoverCard" className={cn(coverHeight ? "flex-shrink-0" : width, dimmed && "opacity-50")}>
       <div
         className="w-full border border-surface-800/50"
-        style={{ aspectRatio }}
+        style={coverHeight ? { height: coverHeight } : { aspectRatio }}
       >
-        <CoverImage src={imageUrl} alt={title} className="w-full h-full rounded-xl" />
+        <CoverImage src={imageUrl} alt={title} className={coverHeight ? "h-full w-auto rounded-xl" : "w-full h-full rounded-xl"} />
       </div>
       <div className="mt-2 px-0.5">
         <p className="text-sm font-medium text-surface-200 truncate">

--- a/web/src/components/game-card.tsx
+++ b/web/src/components/game-card.tsx
@@ -10,6 +10,7 @@ import type { Game } from "@/types/api";
 interface GameCardProps {
   game: Game;
   aspectRatio?: number;
+  coverHeight?: number;
   showConsoleBadge?: boolean;
   hideConsoleName?: boolean;
   subtitle?: string;
@@ -20,6 +21,7 @@ interface GameCardProps {
 export function GameCard({
   game,
   aspectRatio,
+  coverHeight,
   showConsoleBadge,
   hideConsoleName,
   subtitle,
@@ -29,19 +31,20 @@ export function GameCard({
   const { ref, isScraping } = useAutoScrape(game);
 
   return (
-    <Link ref={ref} to={`/games/${game.id}`} data-comp="GameCard" className="group block space-y-3">
+    <Link ref={ref} to={`/games/${game.id}`} data-comp="GameCard" className={cn("group block space-y-3", coverHeight && "flex-shrink-0")}>
       <div
         className="relative rounded-2xl overflow-hidden bg-surface-900 border border-surface-800/50 transition-all duration-300 group-hover:border-surface-700/50 group-hover:shadow-xl group-hover:shadow-black/30 group-hover:-translate-y-1"
+        style={coverHeight ? { height: coverHeight } : undefined}
       >
         {game.coverUrl ? (
           <img
             src={game.coverUrl}
             alt={game.title}
-            className="w-full transition-transform duration-500 group-hover:scale-105"
+            className={coverHeight ? "h-full w-auto transition-transform duration-500 group-hover:scale-105" : "w-full transition-transform duration-500 group-hover:scale-105"}
             loading="lazy"
           />
         ) : (
-          <div className="flex items-center justify-center bg-gradient-to-br from-surface-800 to-surface-900" style={{ aspectRatio: game.coverAspectRatio ?? aspectRatio ?? 3 / 4 }}>
+          <div className="flex items-center justify-center bg-gradient-to-br from-surface-800 to-surface-900" style={coverHeight ? { height: coverHeight, aspectRatio: game.coverAspectRatio ?? aspectRatio ?? 3 / 4 } : { aspectRatio: game.coverAspectRatio ?? aspectRatio ?? 3 / 4 }}>
             {isScraping ? (
               <Loader2 className="h-6 w-6 animate-spin text-surface-500" />
             ) : (

--- a/web/src/components/layout/AGENTS.md
+++ b/web/src/components/layout/AGENTS.md
@@ -1,0 +1,35 @@
+# Layout Components
+
+Core layout components for structuring page content. These components provide
+consistent heading alignment, spacing, and optional visual containers across
+all screens.
+
+## Padding Exception
+
+Components in this directory are **allowed to own their own padding and spacing**.
+This is an explicit exception to the general rule that components should not add
+padding outside themselves.
+
+**Why:** `TitledSection` and `SectionList` are the structural backbone of every
+page. Their padding ensures that headings, content, and gaps are visually
+consistent regardless of whether a section has a card background or not. If
+consumers controlled this padding, every page would drift.
+
+## Component Inventory
+
+- **`SectionList`** — Vertical list with standardized gaps between sections.
+  Direct child of the page component. Children should be `TitledSection`.
+
+- **`TitledSection`** — Section with title bar (heading + icon + renderRight).
+  Has `contained` prop: when true, renders a subtle card background
+  (`bg-white/[0.03] rounded-2xl`). Heading position and padding are identical
+  in both modes, so headings always align across a page.
+
+## Rules
+
+1. **Do not override padding** on these components via className. The padding
+   is intentional and ensures alignment.
+2. **Use `contained` for carousels and stats** — any section with a visual
+   grouping that benefits from a subtle background.
+3. **Use non-contained for grids and lists** — content that flows naturally
+   without a card wrapper (e.g., genre breakdowns, theme grids).

--- a/web/src/components/layout/index.ts
+++ b/web/src/components/layout/index.ts
@@ -1,0 +1,2 @@
+export { TitledSection } from "./titled-section";
+export { SectionList } from "./section-list";

--- a/web/src/components/layout/section-list.tsx
+++ b/web/src/components/layout/section-list.tsx
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+interface SectionListProps {
+  children: ReactNode;
+  className?: string;
+}
+
+/**
+ * Core layout component — a vertical list of sections with standardized spacing.
+ *
+ * Use as the top-level container for a page's section layout. Direct children
+ * should be TitledSection components.
+ *
+ * This component is allowed to own its own gap because it is a core layout
+ * component. See AGENTS.md in this directory.
+ */
+export function SectionList({ children, className }: SectionListProps) {
+  return (
+    <div data-comp="SectionList" className={cn("flex flex-col gap-8", className)}>
+      {children}
+    </div>
+  );
+}

--- a/web/src/components/layout/titled-section.tsx
+++ b/web/src/components/layout/titled-section.tsx
@@ -1,0 +1,58 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import type { LucideIcon } from "lucide-react";
+import { cn } from "@/lib/cn";
+
+interface TitledSectionProps extends HTMLAttributes<HTMLDivElement> {
+  title: string;
+  icon?: LucideIcon;
+  /** Optional content rendered on the right side of the title bar (e.g. "View all" link). */
+  renderRight?: ReactNode;
+  /** When true, renders a subtle card background behind the section. */
+  contained?: boolean;
+  children: ReactNode;
+}
+
+/**
+ * Core layout component — a section with a title bar and consistent spacing.
+ *
+ * Always renders the heading at the same horizontal position regardless of
+ * the `contained` prop. When `contained` is true, a subtle card background
+ * wraps the section. This makes headings visually consistent across a page
+ * whether sections have card backgrounds or not.
+ *
+ * This component is allowed to own its own padding (px-5 pt-5 pb-4) because
+ * it is a core layout component. See AGENTS.md in this directory.
+ */
+export function TitledSection({
+  title,
+  icon: Icon,
+  renderRight,
+  contained = false,
+  children,
+  className,
+  id,
+  ...rest
+}: TitledSectionProps) {
+  return (
+    <div
+      data-comp="TitledSection"
+      className={cn(
+        "px-5 pt-5 pb-4",
+        contained && "rounded-2xl bg-white/[0.03]",
+        className,
+      )}
+      {...rest}
+    >
+      <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center gap-2.5">
+          {Icon && <Icon className="h-5 w-5 text-brand-400" />}
+          <h2 id={id} className="text-xl font-bold text-surface-100">
+            {title}
+          </h2>
+        </div>
+        {renderRight}
+      </div>
+      {children}
+    </div>
+  );
+}

--- a/web/src/components/scroll-shelf.tsx
+++ b/web/src/components/scroll-shelf.tsx
@@ -1,0 +1,127 @@
+import { useRef, useState, useEffect, useCallback } from "react";
+import type { ReactNode } from "react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import { GameCardSkeleton } from "@/components/ui";
+
+interface ScrollShelfProps {
+  title: string;
+  subtitle?: string;
+  icon?: LucideIcon;
+  testId: string;
+  isLoading: boolean;
+  isEmpty: boolean;
+  children: ReactNode;
+  loadingSkeleton?: ReactNode;
+  headerRight?: ReactNode;
+}
+
+export function ScrollShelf({
+  title,
+  subtitle,
+  icon: Icon,
+  testId,
+  isLoading,
+  isEmpty,
+  children,
+  loadingSkeleton,
+  headerRight,
+}: ScrollShelfProps) {
+  const scrollRef = useRef<HTMLDivElement>(null);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(false);
+
+  const updateScrollState = useCallback(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    setCanScrollLeft(el.scrollLeft > 0);
+    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
+  }, []);
+
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    updateScrollState();
+    el.addEventListener("scroll", updateScrollState, { passive: true });
+    window.addEventListener("resize", updateScrollState);
+    return () => {
+      el.removeEventListener("scroll", updateScrollState);
+      window.removeEventListener("resize", updateScrollState);
+    };
+  }, [updateScrollState, children]);
+
+  const scroll = useCallback((direction: "left" | "right") => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const scrollAmount = el.clientWidth * 0.7;
+    el.scrollBy({
+      left: direction === "left" ? -scrollAmount : scrollAmount,
+      behavior: "smooth",
+    });
+  }, []);
+
+  if (isLoading) {
+    return (
+      <section data-testid={`${testId}-skeleton`}>
+        <div className="flex items-center gap-2 mb-1">
+          {Icon && <Icon className="h-5 w-5 text-surface-400" />}
+          <div className="h-7 w-60 rounded bg-surface-800 animate-pulse" />
+        </div>
+        {subtitle && <div className="h-4 w-40 rounded bg-surface-800/60 animate-pulse mt-1 mb-5" />}
+        {loadingSkeleton ?? (
+          <div className="flex gap-5 overflow-hidden mt-4">
+            {Array.from({ length: 6 }, (_, i) => (
+              <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
+                <GameCardSkeleton />
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
+    );
+  }
+
+  if (isEmpty) return null;
+
+  return (
+    <section data-testid={testId} data-comp="ScrollShelf" className="group/shelf relative">
+      <div className="flex items-center gap-2 mb-1">
+        {Icon && <Icon className="h-5 w-5 text-brand-400" />}
+        <h2 className="text-xl font-bold text-surface-100">{title}</h2>
+        {headerRight && <div className="ml-auto">{headerRight}</div>}
+      </div>
+      {subtitle && <p className="text-sm text-surface-400 mb-4">{subtitle}</p>}
+
+      <div className="relative">
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+            aria-label={`Scroll ${title} left`}
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+            aria-label={`Scroll ${title} right`}
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        <div
+          ref={scrollRef}
+          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label={title}
+        >
+          {children}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/web/src/components/scroll-shelf.tsx
+++ b/web/src/components/scroll-shelf.tsx
@@ -63,7 +63,7 @@ export function ScrollShelf({
 
   if (isLoading) {
     return (
-      <Section data-testid={`${testId}-skeleton`} className="p-5">
+      <Section data-testid={`${testId}-skeleton`} className="border-0 bg-white/[0.03] p-5">
         <div className="flex items-center gap-2 mb-1">
           {icon && <icon className="h-5 w-5 text-surface-400" />}
           <div className="h-7 w-60 rounded bg-surface-800 animate-pulse" />
@@ -85,7 +85,7 @@ export function ScrollShelf({
   if (isEmpty) return null;
 
   return (
-    <Section data-testid={testId} data-comp="ScrollShelf" className="group/shelf relative p-5">
+    <Section data-testid={testId} data-comp="ScrollShelf" className="group/shelf relative border-0 bg-white/[0.03] p-5">
       <TitledSection title={title} icon={icon} renderRight={headerRight}>
         {subtitle && <p className="text-sm text-surface-400 -mt-3 mb-4">{subtitle}</p>}
 

--- a/web/src/components/scroll-shelf.tsx
+++ b/web/src/components/scroll-shelf.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useEffect, useCallback } from "react";
 import type { ReactNode } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import { Section, TitledSection } from "@/components/ui";
 import { GameCardSkeleton } from "@/components/ui";
 
 interface ScrollShelfProps {
@@ -19,7 +20,7 @@ interface ScrollShelfProps {
 export function ScrollShelf({
   title,
   subtitle,
-  icon: Icon,
+  icon,
   testId,
   isLoading,
   isEmpty,
@@ -62,9 +63,9 @@ export function ScrollShelf({
 
   if (isLoading) {
     return (
-      <section data-testid={`${testId}-skeleton`}>
+      <Section data-testid={`${testId}-skeleton`} className="p-5">
         <div className="flex items-center gap-2 mb-1">
-          {Icon && <Icon className="h-5 w-5 text-surface-400" />}
+          {icon && <icon className="h-5 w-5 text-surface-400" />}
           <div className="h-7 w-60 rounded bg-surface-800 animate-pulse" />
         </div>
         {subtitle && <div className="h-4 w-40 rounded bg-surface-800/60 animate-pulse mt-1 mb-5" />}
@@ -77,51 +78,48 @@ export function ScrollShelf({
             ))}
           </div>
         )}
-      </section>
+      </Section>
     );
   }
 
   if (isEmpty) return null;
 
   return (
-    <section data-testid={testId} data-comp="ScrollShelf" className="group/shelf relative">
-      <div className="flex items-center gap-2 mb-1">
-        {Icon && <Icon className="h-5 w-5 text-brand-400" />}
-        <h2 className="text-xl font-bold text-surface-100">{title}</h2>
-        {headerRight && <div className="ml-auto">{headerRight}</div>}
-      </div>
-      {subtitle && <p className="text-sm text-surface-400 mb-4">{subtitle}</p>}
+    <Section data-testid={testId} data-comp="ScrollShelf" className="group/shelf relative p-5">
+      <TitledSection title={title} icon={icon} renderRight={headerRight}>
+        {subtitle && <p className="text-sm text-surface-400 -mt-3 mb-4">{subtitle}</p>}
 
-      <div className="relative">
-        {canScrollLeft && (
-          <button
-            onClick={() => scroll("left")}
-            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
-            aria-label={`Scroll ${title} left`}
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-        )}
-        {canScrollRight && (
-          <button
-            onClick={() => scroll("right")}
-            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
-            aria-label={`Scroll ${title} right`}
-          >
-            <ChevronRight className="h-5 w-5" />
-          </button>
-        )}
+        <div className="relative">
+          {canScrollLeft && (
+            <button
+              onClick={() => scroll("left")}
+              className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+              aria-label={`Scroll ${title} left`}
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </button>
+          )}
+          {canScrollRight && (
+            <button
+              onClick={() => scroll("right")}
+              className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+              aria-label={`Scroll ${title} right`}
+            >
+              <ChevronRight className="h-5 w-5" />
+            </button>
+          )}
 
-        <div
-          ref={scrollRef}
-          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
-          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-          role="list"
-          aria-label={title}
-        >
-          {children}
+          <div
+            ref={scrollRef}
+            className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+            style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+            role="list"
+            aria-label={title}
+          >
+            {children}
+          </div>
         </div>
-      </div>
-    </section>
+      </TitledSection>
+    </Section>
   );
 }

--- a/web/src/components/scroll-shelf.tsx
+++ b/web/src/components/scroll-shelf.tsx
@@ -2,7 +2,7 @@ import { useRef, useState, useEffect, useCallback } from "react";
 import type { ReactNode } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { Section, TitledSection } from "@/components/ui";
+import { TitledSection } from "@/components/layout";
 import { GameCardSkeleton } from "@/components/ui";
 
 interface ScrollShelfProps {
@@ -63,14 +63,16 @@ export function ScrollShelf({
 
   if (isLoading) {
     return (
-      <Section data-testid={`${testId}-skeleton`} className="border-0 bg-white/[0.03] p-5">
-        <div className="flex items-center gap-2 mb-1">
-          {icon && <icon className="h-5 w-5 text-surface-400" />}
-          <div className="h-7 w-60 rounded bg-surface-800 animate-pulse" />
-        </div>
-        {subtitle && <div className="h-4 w-40 rounded bg-surface-800/60 animate-pulse mt-1 mb-5" />}
+      <TitledSection
+        title={title}
+        icon={icon}
+        contained
+        renderRight={headerRight}
+        className="group/shelf"
+        data-testid={`${testId}-skeleton`}
+      >
         {loadingSkeleton ?? (
-          <div className="flex gap-5 overflow-hidden mt-4">
+          <div className="flex gap-5 overflow-hidden">
             {Array.from({ length: 6 }, (_, i) => (
               <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
                 <GameCardSkeleton />
@@ -78,48 +80,54 @@ export function ScrollShelf({
             ))}
           </div>
         )}
-      </Section>
+      </TitledSection>
     );
   }
 
   if (isEmpty) return null;
 
   return (
-    <Section data-testid={testId} data-comp="ScrollShelf" className="group/shelf relative border-0 bg-white/[0.03] p-5">
-      <TitledSection title={title} icon={icon} renderRight={headerRight}>
-        {subtitle && <p className="text-sm text-surface-400 -mt-3 mb-4">{subtitle}</p>}
+    <TitledSection
+      title={title}
+      icon={icon}
+      contained
+      renderRight={headerRight}
+      className="group/shelf"
+      data-testid={testId}
+      data-comp="ScrollShelf"
+    >
+      {subtitle && <p className="text-sm text-surface-400 -mt-3 mb-4">{subtitle}</p>}
 
-        <div className="relative">
-          {canScrollLeft && (
-            <button
-              onClick={() => scroll("left")}
-              className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
-              aria-label={`Scroll ${title} left`}
-            >
-              <ChevronLeft className="h-5 w-5" />
-            </button>
-          )}
-          {canScrollRight && (
-            <button
-              onClick={() => scroll("right")}
-              className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
-              aria-label={`Scroll ${title} right`}
-            >
-              <ChevronRight className="h-5 w-5" />
-            </button>
-          )}
-
-          <div
-            ref={scrollRef}
-            className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
-            style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-            role="list"
-            aria-label={title}
+      <div className="relative">
+        {canScrollLeft && (
+          <button
+            onClick={() => scroll("left")}
+            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+            aria-label={`Scroll ${title} left`}
           >
-            {children}
-          </div>
+            <ChevronLeft className="h-5 w-5" />
+          </button>
+        )}
+        {canScrollRight && (
+          <button
+            onClick={() => scroll("right")}
+            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
+            aria-label={`Scroll ${title} right`}
+          >
+            <ChevronRight className="h-5 w-5" />
+          </button>
+        )}
+
+        <div
+          ref={scrollRef}
+          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
+          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
+          role="list"
+          aria-label={title}
+        >
+          {children}
         </div>
-      </TitledSection>
-    </Section>
+      </div>
+    </TitledSection>
   );
 }

--- a/web/src/components/ui/section.tsx
+++ b/web/src/components/ui/section.tsx
@@ -1,4 +1,4 @@
-import type { HTMLAttributes, ReactNode } from "react";
+import type { HTMLAttributes } from "react";
 import { cn } from "@/lib/cn";
 
 interface SectionProps extends HTMLAttributes<HTMLDivElement> {

--- a/web/src/components/ui/section.tsx
+++ b/web/src/components/ui/section.tsx
@@ -1,5 +1,4 @@
 import type { HTMLAttributes, ReactNode } from "react";
-import type { LucideIcon } from "lucide-react";
 import { cn } from "@/lib/cn";
 
 interface SectionProps extends HTMLAttributes<HTMLDivElement> {
@@ -10,7 +9,8 @@ interface SectionProps extends HTMLAttributes<HTMLDivElement> {
  * DESIGN component — a container with surface background, border, and rounded corners.
  *
  * Layer 1 in the component hierarchy (Design → Content → Role).
- * Use for grouping related content. For sections with a title, use TitledSection instead.
+ * Use for grouping related content. For sections with a title bar, use
+ * TitledSection from @/components/layout instead.
  */
 export function Section({ className, hover, children, ...props }: SectionProps) {
   return (
@@ -29,62 +29,7 @@ export function Section({ className, hover, children, ...props }: SectionProps) 
   );
 }
 
-interface TitledSectionProps {
-  title: string;
-  icon?: LucideIcon;
-  /** Optional content rendered on the right side of the title bar (e.g. "View all" link). */
-  renderRight?: ReactNode;
-  children: ReactNode;
-  className?: string;
-  id?: string;
-}
-
-/**
- * DESIGN component — a section container with a title bar.
- *
- * Layer 1 in the component hierarchy (Design → Content → Role).
- * Renders a title (with optional icon and right-side content) above
- * the section's children.
- */
-export function TitledSection({
-  title,
-  icon: Icon,
-  renderRight,
-  children,
-  className,
-  id,
-}: TitledSectionProps) {
-  return (
-    <div data-comp="TitledSection" className={className}>
-      <div className="flex items-center justify-between mb-5">
-        <div className="flex items-center gap-2.5">
-          {Icon && <Icon className="h-5 w-5 text-brand-400" />}
-          <h2 id={id} className="text-xl font-bold text-surface-100">
-            {title}
-          </h2>
-        </div>
-        {renderRight}
-      </div>
-      {children}
-    </div>
-  );
-}
-
-interface SectionListProps {
-  children: ReactNode;
-  className?: string;
-}
-
-/**
- * DESIGN component — a vertical list of sections with standardized spacing.
- *
- * Layer 1 in the component hierarchy (Design → Content → Role).
- * Use as the top-level container for a page's section layout.
- */
-export function SectionList({ children, className }: SectionListProps) {
-  return (
-    <div data-comp="SectionList" className={cn("flex flex-col gap-8", className)}>
-      {children}
-    </div>
-  );
-}
+// Re-export layout components for backward compatibility.
+// New code should import from @/components/layout directly.
+export { TitledSection } from "@/components/layout";
+export { SectionList } from "@/components/layout";

--- a/web/src/components/ui/skeleton.tsx
+++ b/web/src/components/ui/skeleton.tsx
@@ -16,14 +16,16 @@ export function Skeleton({ className, style }: SkeletonProps) {
 
 export function GameCardSkeleton({
   aspectRatio,
+  coverHeight,
 }: {
   aspectRatio?: number;
+  coverHeight?: number;
 }) {
   return (
-    <div className="space-y-3">
+    <div className={`space-y-3${coverHeight ? " flex-shrink-0" : ""}`}>
       <Skeleton
-        className="w-full rounded-2xl"
-        style={{ aspectRatio: aspectRatio ?? 3 / 4 }}
+        className="rounded-2xl"
+        style={coverHeight ? { height: coverHeight, aspectRatio: aspectRatio ?? 3 / 4 } : { aspectRatio: aspectRatio ?? 3 / 4, width: "100%" }}
       />
       <div className="space-y-2 px-1">
         <Skeleton className="h-4 w-3/4" />

--- a/web/src/features/dashboard/components/personal-stats-card.tsx
+++ b/web/src/features/dashboard/components/personal-stats-card.tsx
@@ -1,13 +1,13 @@
 import { Link } from "react-router-dom";
 import { Zap, Trophy } from "lucide-react";
-import { Skeleton } from "@/components/ui";
+import { Section, TitledSection, Skeleton } from "@/components/ui";
 import { useUserStats } from "@/hooks/use-stats";
 import { formatPlayTime } from "@/lib/format";
 import { cn } from "@/lib/cn";
 
 function PersonalStatsSkeleton() {
   return (
-    <div className="bg-surface-800/50 rounded-2xl p-5">
+    <Section className="border-0 bg-white/[0.03] p-5">
       <div className="flex items-center gap-2.5 mb-4">
         <Skeleton className="h-5 w-5" />
         <Skeleton className="h-5 w-32" />
@@ -20,7 +20,7 @@ function PersonalStatsSkeleton() {
           </div>
         ))}
       </div>
-    </div>
+    </Section>
   );
 }
 
@@ -38,64 +38,61 @@ export function PersonalStatsCard() {
   const streakHighlight = stats.currentStreak >= 3;
 
   return (
-    <div className="bg-surface-800/50 rounded-2xl p-5">
-      <div className="flex items-center gap-2.5 mb-4">
-        <Trophy className="h-5 w-5 text-brand-400" />
-        <h2 className="text-lg font-bold text-surface-100">Your Stats</h2>
-      </div>
-
-      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-        {/* Total play time */}
-        <div className="bg-surface-800/30 rounded-xl p-4">
-          <p className="text-2xl font-mono font-bold text-brand-400">
-            {formatPlayTime(stats.totalPlayTime)}
-          </p>
-          <p className="text-xs text-surface-500 mt-0.5">Total play time</p>
-        </div>
-
-        {/* Games played */}
-        <div className="bg-surface-800/30 rounded-xl p-4">
-          <p className="text-2xl font-mono font-bold text-surface-100">
-            {stats.gamesPlayed}
-          </p>
-          <p className="text-xs text-surface-500 mt-0.5">Games played</p>
-        </div>
-
-        {/* Current streak */}
-        <div className="bg-surface-800/30 rounded-xl p-4">
-          <p
-            className={cn(
-              "text-2xl font-mono font-bold flex items-center gap-1.5",
-              streakHighlight ? "text-amber-400" : "text-surface-100",
-            )}
-          >
-            {stats.currentStreak}d
-            {streakHighlight && <Zap className="h-5 w-5 text-amber-400" />}
-          </p>
-          <p className="text-xs text-surface-500 mt-0.5">Current streak</p>
-        </div>
-
-        {/* Most played game */}
-        {stats.mostPlayedGame ? (
-          <Link
-            to={`/games/${stats.mostPlayedGame.id}`}
-            className="bg-surface-800/30 rounded-xl p-4 hover:bg-surface-800/50 transition-colors"
-          >
-            <p className="text-sm font-bold text-surface-100 truncate">
-              {stats.mostPlayedGame.title}
-            </p>
-            <p className="text-xs font-mono text-surface-400 mt-0.5">
-              {formatPlayTime(stats.mostPlayedGameTime)}
-            </p>
-            <p className="text-xs text-surface-500 mt-0.5">Most played</p>
-          </Link>
-        ) : (
+    <Section className="border-0 bg-white/[0.03] p-5">
+      <TitledSection title="Your Stats" icon={Trophy}>
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+          {/* Total play time */}
           <div className="bg-surface-800/30 rounded-xl p-4">
-            <p className="text-2xl font-mono font-bold text-surface-100">--</p>
-            <p className="text-xs text-surface-500 mt-0.5">Most played</p>
+            <p className="text-2xl font-mono font-bold text-brand-400">
+              {formatPlayTime(stats.totalPlayTime)}
+            </p>
+            <p className="text-xs text-surface-500 mt-0.5">Total play time</p>
           </div>
-        )}
-      </div>
-    </div>
+
+          {/* Games played */}
+          <div className="bg-surface-800/30 rounded-xl p-4">
+            <p className="text-2xl font-mono font-bold text-surface-100">
+              {stats.gamesPlayed}
+            </p>
+            <p className="text-xs text-surface-500 mt-0.5">Games played</p>
+          </div>
+
+          {/* Current streak */}
+          <div className="bg-surface-800/30 rounded-xl p-4">
+            <p
+              className={cn(
+                "text-2xl font-mono font-bold flex items-center gap-1.5",
+                streakHighlight ? "text-amber-400" : "text-surface-100",
+              )}
+            >
+              {stats.currentStreak}d
+              {streakHighlight && <Zap className="h-5 w-5 text-amber-400" />}
+            </p>
+            <p className="text-xs text-surface-500 mt-0.5">Current streak</p>
+          </div>
+
+          {/* Most played game */}
+          {stats.mostPlayedGame ? (
+            <Link
+              to={`/games/${stats.mostPlayedGame.id}`}
+              className="bg-surface-800/30 rounded-xl p-4 hover:bg-surface-800/50 transition-colors"
+            >
+              <p className="text-sm font-bold text-surface-100 truncate">
+                {stats.mostPlayedGame.title}
+              </p>
+              <p className="text-xs font-mono text-surface-400 mt-0.5">
+                {formatPlayTime(stats.mostPlayedGameTime)}
+              </p>
+              <p className="text-xs text-surface-500 mt-0.5">Most played</p>
+            </Link>
+          ) : (
+            <div className="bg-surface-800/30 rounded-xl p-4">
+              <p className="text-2xl font-mono font-bold text-surface-100">--</p>
+              <p className="text-xs text-surface-500 mt-0.5">Most played</p>
+            </div>
+          )}
+        </div>
+      </TitledSection>
+    </Section>
   );
 }

--- a/web/src/features/dashboard/components/personal-stats-card.tsx
+++ b/web/src/features/dashboard/components/personal-stats-card.tsx
@@ -1,17 +1,14 @@
 import { Link } from "react-router-dom";
 import { Zap, Trophy } from "lucide-react";
-import { Section, TitledSection, Skeleton } from "@/components/ui";
+import { Skeleton } from "@/components/ui";
+import { TitledSection } from "@/components/layout";
 import { useUserStats } from "@/hooks/use-stats";
 import { formatPlayTime } from "@/lib/format";
 import { cn } from "@/lib/cn";
 
 function PersonalStatsSkeleton() {
   return (
-    <Section className="border-0 bg-white/[0.03] p-5">
-      <div className="flex items-center gap-2.5 mb-4">
-        <Skeleton className="h-5 w-5" />
-        <Skeleton className="h-5 w-32" />
-      </div>
+    <TitledSection title="Your Stats" icon={Trophy} contained>
       <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
         {Array.from({ length: 4 }, (_, i) => (
           <div key={i} className="bg-surface-800/30 rounded-xl p-4">
@@ -20,7 +17,7 @@ function PersonalStatsSkeleton() {
           </div>
         ))}
       </div>
-    </Section>
+    </TitledSection>
   );
 }
 
@@ -38,61 +35,59 @@ export function PersonalStatsCard() {
   const streakHighlight = stats.currentStreak >= 3;
 
   return (
-    <Section className="border-0 bg-white/[0.03] p-5">
-      <TitledSection title="Your Stats" icon={Trophy}>
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-          {/* Total play time */}
-          <div className="bg-surface-800/30 rounded-xl p-4">
-            <p className="text-2xl font-mono font-bold text-brand-400">
-              {formatPlayTime(stats.totalPlayTime)}
-            </p>
-            <p className="text-xs text-surface-500 mt-0.5">Total play time</p>
-          </div>
-
-          {/* Games played */}
-          <div className="bg-surface-800/30 rounded-xl p-4">
-            <p className="text-2xl font-mono font-bold text-surface-100">
-              {stats.gamesPlayed}
-            </p>
-            <p className="text-xs text-surface-500 mt-0.5">Games played</p>
-          </div>
-
-          {/* Current streak */}
-          <div className="bg-surface-800/30 rounded-xl p-4">
-            <p
-              className={cn(
-                "text-2xl font-mono font-bold flex items-center gap-1.5",
-                streakHighlight ? "text-amber-400" : "text-surface-100",
-              )}
-            >
-              {stats.currentStreak}d
-              {streakHighlight && <Zap className="h-5 w-5 text-amber-400" />}
-            </p>
-            <p className="text-xs text-surface-500 mt-0.5">Current streak</p>
-          </div>
-
-          {/* Most played game */}
-          {stats.mostPlayedGame ? (
-            <Link
-              to={`/games/${stats.mostPlayedGame.id}`}
-              className="bg-surface-800/30 rounded-xl p-4 hover:bg-surface-800/50 transition-colors"
-            >
-              <p className="text-sm font-bold text-surface-100 truncate">
-                {stats.mostPlayedGame.title}
-              </p>
-              <p className="text-xs font-mono text-surface-400 mt-0.5">
-                {formatPlayTime(stats.mostPlayedGameTime)}
-              </p>
-              <p className="text-xs text-surface-500 mt-0.5">Most played</p>
-            </Link>
-          ) : (
-            <div className="bg-surface-800/30 rounded-xl p-4">
-              <p className="text-2xl font-mono font-bold text-surface-100">--</p>
-              <p className="text-xs text-surface-500 mt-0.5">Most played</p>
-            </div>
-          )}
+    <TitledSection title="Your Stats" icon={Trophy} contained>
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        {/* Total play time */}
+        <div className="bg-surface-800/30 rounded-xl p-4">
+          <p className="text-2xl font-mono font-bold text-brand-400">
+            {formatPlayTime(stats.totalPlayTime)}
+          </p>
+          <p className="text-xs text-surface-500 mt-0.5">Total play time</p>
         </div>
-      </TitledSection>
-    </Section>
+
+        {/* Games played */}
+        <div className="bg-surface-800/30 rounded-xl p-4">
+          <p className="text-2xl font-mono font-bold text-surface-100">
+            {stats.gamesPlayed}
+          </p>
+          <p className="text-xs text-surface-500 mt-0.5">Games played</p>
+        </div>
+
+        {/* Current streak */}
+        <div className="bg-surface-800/30 rounded-xl p-4">
+          <p
+            className={cn(
+              "text-2xl font-mono font-bold flex items-center gap-1.5",
+              streakHighlight ? "text-amber-400" : "text-surface-100",
+            )}
+          >
+            {stats.currentStreak}d
+            {streakHighlight && <Zap className="h-5 w-5 text-amber-400" />}
+          </p>
+          <p className="text-xs text-surface-500 mt-0.5">Current streak</p>
+        </div>
+
+        {/* Most played game */}
+        {stats.mostPlayedGame ? (
+          <Link
+            to={`/games/${stats.mostPlayedGame.id}`}
+            className="bg-surface-800/30 rounded-xl p-4 hover:bg-surface-800/50 transition-colors"
+          >
+            <p className="text-sm font-bold text-surface-100 truncate">
+              {stats.mostPlayedGame.title}
+            </p>
+            <p className="text-xs font-mono text-surface-400 mt-0.5">
+              {formatPlayTime(stats.mostPlayedGameTime)}
+            </p>
+            <p className="text-xs text-surface-500 mt-0.5">Most played</p>
+          </Link>
+        ) : (
+          <div className="bg-surface-800/30 rounded-xl p-4">
+            <p className="text-2xl font-mono font-bold text-surface-100">--</p>
+            <p className="text-xs text-surface-500 mt-0.5">Most played</p>
+          </div>
+        )}
+      </div>
+    </TitledSection>
   );
 }

--- a/web/src/features/dashboard/components/top-rated-game-card.tsx
+++ b/web/src/features/dashboard/components/top-rated-game-card.tsx
@@ -9,7 +9,7 @@ import type { TopRatedGame } from "@/types/api";
  * Maps TopRatedGame domain data to CoverCard. Dimmed when the game
  * is not available in the local library.
  */
-export function TopRatedGameCard({ game }: { game: TopRatedGame }) {
+export function TopRatedGameCard({ game, coverHeight }: { game: TopRatedGame; coverHeight?: number }) {
   const isAvailable = game.localGameId != null;
 
   return (
@@ -18,6 +18,7 @@ export function TopRatedGameCard({ game }: { game: TopRatedGame }) {
       title={game.name}
       subtitle={game.consoleName}
       linkTo={isAvailable ? `/games/${game.localGameId}` : undefined}
+      coverHeight={coverHeight}
     >
       <span className="flex items-center gap-0.5 text-xs text-amber-400">
         <Star className="h-3 w-3 fill-amber-400" />

--- a/web/src/features/dashboard/components/top-rated-row.tsx
+++ b/web/src/features/dashboard/components/top-rated-row.tsx
@@ -1,19 +1,17 @@
 import { Star } from "lucide-react";
-import { Skeleton, TitledSection } from "@/components/ui";
 import { Link } from "react-router-dom";
 import { ChevronRight } from "lucide-react";
 import { useTopRatedGlobal } from "@/hooks/use-top-lists";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { GameCardSkeleton } from "@/components/ui";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
 import { TopRatedGameCard } from "./top-rated-game-card";
 
-function TopRatedSkeleton() {
+function TopRatedSkeletonContent() {
   return (
-    <div className="flex gap-4 overflow-x-auto pb-2">
+    <div className="flex gap-4 overflow-hidden">
       {Array.from({ length: 6 }, (_, i) => (
-        <div key={i} className="flex-shrink-0 w-36 space-y-2">
-          <Skeleton className="aspect-[3/4] w-full rounded-xl" />
-          <Skeleton className="h-4 w-28" />
-          <Skeleton className="h-3 w-20" />
-        </div>
+        <GameCardSkeleton key={i} coverHeight={CAROUSEL_CARD_HEIGHT} />
       ))}
     </div>
   );
@@ -25,10 +23,14 @@ export function TopRatedRow() {
   if (!isLoading && (!games || games.length === 0)) return null;
 
   return (
-    <TitledSection
+    <ScrollShelf
       title="Top Rated"
       icon={Star}
-      renderRight={
+      testId="top-rated-row"
+      isLoading={isLoading}
+      isEmpty={!games || games.length === 0}
+      loadingSkeleton={<TopRatedSkeletonContent />}
+      headerRight={
         <Link
           to="/top-lists"
           className="flex items-center gap-1 text-sm text-surface-400 hover:text-brand-400 transition-colors"
@@ -38,17 +40,11 @@ export function TopRatedRow() {
         </Link>
       }
     >
-      {isLoading ? (
-        <TopRatedSkeleton />
-      ) : (
-        <div className="flex gap-4 overflow-x-auto pb-2">
-          {games?.map((game) => (
-            <div key={`${game.rank}-${game.name}`} className="flex-shrink-0">
-              <TopRatedGameCard game={game} />
-            </div>
-          ))}
+      {games?.map((game) => (
+        <div key={`${game.rank}-${game.name}`} className="flex-shrink-0" role="listitem">
+          <TopRatedGameCard game={game} coverHeight={CAROUSEL_CARD_HEIGHT} />
         </div>
-      )}
-    </TitledSection>
+      ))}
+    </ScrollShelf>
   );
 }

--- a/web/src/features/explore/components/__tests__/artwork-showcase.test.tsx
+++ b/web/src/features/explore/components/__tests__/artwork-showcase.test.tsx
@@ -161,7 +161,7 @@ describe("ArtworkShowcase", () => {
   it("renders the scrollable list with label", () => {
     renderShowcase();
     expect(
-      screen.getByRole("list", { name: "Artwork showcase" }),
+      screen.getByRole("list", { name: "Artwork Showcase" }),
     ).toBeInTheDocument();
   });
 });

--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -402,8 +402,8 @@ describe("ExplorePage", () => {
     });
     renderPage();
     expect(screen.getByTestId("hero-carousel-skeleton")).toBeInTheDocument();
-    expect(screen.getByTestId("shelf-skeleton-Top Rated")).toBeInTheDocument();
-    expect(screen.getByTestId("shelf-skeleton-Recently Added")).toBeInTheDocument();
+    expect(screen.getByTestId("shelf-Top Rated-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("shelf-Recently Added-skeleton")).toBeInTheDocument();
   });
 
   it("renders hero carousel and rows independently when one loads first", () => {
@@ -419,7 +419,7 @@ describe("ExplorePage", () => {
     // Carousel should render
     expect(screen.getByTestId("hero-carousel")).toBeInTheDocument();
     // Rows should show skeleton
-    expect(screen.getByTestId("shelf-skeleton-Top Rated")).toBeInTheDocument();
+    expect(screen.getByTestId("shelf-Top Rated-skeleton")).toBeInTheDocument();
   });
 
   it("does not render carousel when featured games empty but rows exist", () => {
@@ -597,7 +597,7 @@ describe("ExplorePage", () => {
       isLoading: true,
     });
     renderPage();
-    expect(screen.getByTestId("players-like-you-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("players-like-you-shelf-skeleton")).toBeInTheDocument();
   });
 
   it("renders the developer spotlight section", () => {

--- a/web/src/features/explore/components/__tests__/game-shelf.test.tsx
+++ b/web/src/features/explore/components/__tests__/game-shelf.test.tsx
@@ -106,10 +106,7 @@ describe("GameShelf", () => {
   it("renders loading skeleton when loading", () => {
     renderShelf({ isLoading: true, games: undefined });
     expect(
-      screen.getByTestId("shelf-skeleton-Top Rated"),
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { name: "Top Rated", level: 2 }),
+      screen.getByTestId("shelf-Top Rated-skeleton"),
     ).toBeInTheDocument();
   });
 

--- a/web/src/features/explore/components/__tests__/players-like-you-shelf.test.tsx
+++ b/web/src/features/explore/components/__tests__/players-like-you-shelf.test.tsx
@@ -68,7 +68,6 @@ describe("PlayersLikeYouShelf", () => {
 
     renderComponent({ games, similarUsersCount: 12 });
 
-    expect(screen.getByTestId("similar-users-count")).toBeInTheDocument();
     expect(screen.getByText("Based on 12 players with similar taste")).toBeInTheDocument();
   });
 
@@ -83,7 +82,7 @@ describe("PlayersLikeYouShelf", () => {
   it("shows skeleton when loading", () => {
     renderComponent({ isLoading: true });
 
-    expect(screen.getByTestId("players-like-you-skeleton")).toBeInTheDocument();
+    expect(screen.getByTestId("players-like-you-shelf-skeleton")).toBeInTheDocument();
     expect(screen.queryByTestId("players-like-you-shelf")).not.toBeInTheDocument();
   });
 

--- a/web/src/features/explore/components/__tests__/series-shelf.test.tsx
+++ b/web/src/features/explore/components/__tests__/series-shelf.test.tsx
@@ -117,9 +117,6 @@ describe("SeriesShelf", () => {
   it("renders loading skeleton when loading", () => {
     renderShelf({ isLoading: true, series: undefined });
     expect(screen.getByTestId("series-shelf-skeleton")).toBeInTheDocument();
-    expect(
-      screen.getByRole("heading", { name: "Browse by Series", level: 2 }),
-    ).toBeInTheDocument();
   });
 
   it("renders loading skeleton with shimmer animation", () => {

--- a/web/src/features/explore/components/achievement-shelves.tsx
+++ b/web/src/features/explore/components/achievement-shelves.tsx
@@ -1,8 +1,5 @@
-import { useRef, useState, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
 import {
-  ChevronLeft,
-  ChevronRight,
   Award,
   Mountain,
   Target,
@@ -10,7 +7,8 @@ import {
   Swords,
 } from "lucide-react";
 import { GameCard } from "@/components/game-card";
-import { GameCardSkeleton, Skeleton } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
 import type {
   Game,
   EasyToCompleteResponse,
@@ -19,127 +17,6 @@ import type {
   FreshChallengesResponse,
   ActiveChallengesResponse,
 } from "@/types/api";
-
-// --- Shared scroll shelf wrapper (same pattern as social-shelves.tsx) ---
-
-function ScrollShelf({
-  title,
-  subtitle,
-  icon: Icon,
-  testId,
-  isLoading,
-  isEmpty,
-  children,
-}: {
-  title: string;
-  subtitle?: string;
-  icon: React.ElementType;
-  testId: string;
-  isLoading: boolean;
-  isEmpty: boolean;
-  children: React.ReactNode;
-}) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const updateScrollState = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    setCanScrollLeft(el.scrollLeft > 0);
-    setCanScrollRight(
-      el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
-    );
-  }, []);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    updateScrollState();
-    el.addEventListener("scroll", updateScrollState, { passive: true });
-    window.addEventListener("resize", updateScrollState);
-    return () => {
-      el.removeEventListener("scroll", updateScrollState);
-      window.removeEventListener("resize", updateScrollState);
-    };
-  }, [updateScrollState, children]);
-
-  const scroll = useCallback((direction: "left" | "right") => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const scrollAmount = el.clientWidth * 0.7;
-    el.scrollBy({
-      left: direction === "left" ? -scrollAmount : scrollAmount,
-      behavior: "smooth",
-    });
-  }, []);
-
-  if (isLoading) {
-    return (
-      <section data-testid={`${testId}-skeleton`}>
-        <div className="flex items-center gap-2 mb-1">
-          <Icon className="h-5 w-5 text-surface-400" />
-          <Skeleton className="h-7 w-60 rounded" />
-        </div>
-        {subtitle && (
-          <Skeleton className="h-4 w-40 rounded mt-1 mb-5" />
-        )}
-        <div className="flex gap-5 overflow-hidden mt-4">
-          {Array.from({ length: 6 }, (_, i) => (
-            <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
-              <GameCardSkeleton />
-            </div>
-          ))}
-        </div>
-      </section>
-    );
-  }
-
-  if (isEmpty) return null;
-
-  return (
-    <section data-testid={testId} className="group/shelf relative">
-      <div className="flex items-center gap-2 mb-1">
-        <Icon className="h-5 w-5 text-brand-400" />
-        <h2 className="text-xl font-bold text-surface-100">{title}</h2>
-      </div>
-      {subtitle && (
-        <p className="text-sm text-surface-400 mb-4">{subtitle}</p>
-      )}
-
-      <div className="relative">
-        {canScrollLeft && (
-          <button
-            onClick={() => scroll("left")}
-            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
-            aria-label={`Scroll ${title} left`}
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-        )}
-        {canScrollRight && (
-          <button
-            onClick={() => scroll("right")}
-            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
-            aria-label={`Scroll ${title} right`}
-          >
-            <ChevronRight className="h-5 w-5" />
-          </button>
-        )}
-
-        <div
-          ref={scrollRef}
-          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
-          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-          role="list"
-          aria-label={title}
-        >
-          {children}
-        </div>
-      </div>
-    </section>
-  );
-}
 
 // --- Easy to Complete Shelf ---
 
@@ -168,12 +45,13 @@ export function EasyToCompleteShelf({
       {data?.games.map((item) => (
         <div
           key={item.game.id}
-          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          className="flex-shrink-0"
           role="listitem"
         >
           <GameCard
             game={item.game}
             showConsoleBadge
+            coverHeight={CAROUSEL_CARD_HEIGHT}
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
           />
@@ -216,12 +94,13 @@ export function HardestGamesShelf({
       {data?.games.map((item) => (
         <div
           key={item.game.id}
-          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          className="flex-shrink-0"
           role="listitem"
         >
           <GameCard
             game={item.game}
             showConsoleBadge
+            coverHeight={CAROUSEL_CARD_HEIGHT}
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
           />
@@ -264,12 +143,13 @@ export function AlmostDoneShelf({
       {data?.games.map((item) => (
         <div
           key={item.game.id}
-          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          className="flex-shrink-0"
           role="listitem"
         >
           <GameCard
             game={item.game}
             showConsoleBadge
+            coverHeight={CAROUSEL_CARD_HEIGHT}
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
           />
@@ -328,12 +208,13 @@ export function FreshChallengesShelf({
       {data?.games.map((item) => (
         <div
           key={item.game.id}
-          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          className="flex-shrink-0"
           role="listitem"
         >
           <GameCard
             game={item.game}
             showConsoleBadge
+            coverHeight={CAROUSEL_CARD_HEIGHT}
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
           />

--- a/web/src/features/explore/components/artwork-showcase.tsx
+++ b/web/src/features/explore/components/artwork-showcase.tsx
@@ -1,7 +1,6 @@
-import { useRef, useState, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Skeleton } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
 import type { ArtworkItem } from "@/types/api";
 
 interface ArtworkShowcaseProps {
@@ -9,152 +8,65 @@ interface ArtworkShowcaseProps {
   isLoading: boolean;
 }
 
-function ArtworkShowcaseSkeleton() {
+function ArtworkSkeletonContent() {
   return (
-    <section data-testid="artwork-showcase-skeleton">
-      <Skeleton className="w-48 h-7 mb-5" />
-      <div className="flex gap-5 overflow-hidden">
-        {Array.from({ length: 4 }, (_, i) => (
-          <div key={i} className="w-80 sm:w-96 flex-shrink-0">
-            <Skeleton className="w-full rounded-xl" style={{ aspectRatio: "16/9" }} />
-          </div>
-        ))}
-      </div>
-    </section>
+    <div className="flex gap-5 overflow-hidden">
+      {Array.from({ length: 4 }, (_, i) => (
+        <div key={i} className="w-80 sm:w-96 flex-shrink-0">
+          <Skeleton className="w-full rounded-xl" style={{ aspectRatio: "16/9" }} />
+        </div>
+      ))}
+    </div>
   );
 }
 
 export function ArtworkShowcase({ artworks, isLoading }: ArtworkShowcaseProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const updateScrollState = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    setCanScrollLeft(el.scrollLeft > 0);
-    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
-  }, []);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    updateScrollState();
-    el.addEventListener("scroll", updateScrollState, { passive: true });
-    window.addEventListener("resize", updateScrollState);
-    return () => {
-      el.removeEventListener("scroll", updateScrollState);
-      window.removeEventListener("resize", updateScrollState);
-    };
-  }, [updateScrollState, artworks]);
-
-  const scroll = useCallback((direction: "left" | "right") => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const scrollAmount = el.clientWidth * 0.7;
-    el.scrollBy({
-      left: direction === "left" ? -scrollAmount : scrollAmount,
-      behavior: "smooth",
-    });
-  }, []);
-
-  if (isLoading) {
-    return <ArtworkShowcaseSkeleton />;
-  }
-
-  if (!artworks || artworks.length === 0) {
-    return null;
-  }
-
-  // Show up to 10 items
-  const displayArtworks = artworks.slice(0, 10);
+  const displayArtworks = artworks?.slice(0, 10);
 
   return (
-    <section data-testid="artwork-showcase" className="group/artwork">
-      <div className="flex items-center justify-between mb-5">
-        <h2 className="text-xl font-bold text-surface-100">
-          Artwork Showcase
-        </h2>
+    <ScrollShelf
+      title="Artwork Showcase"
+      testId="artwork-showcase"
+      isLoading={isLoading}
+      isEmpty={!displayArtworks || displayArtworks.length === 0}
+      loadingSkeleton={<ArtworkSkeletonContent />}
+      headerRight={
         <div className="flex items-center gap-3 text-sm text-surface-400">
-          <Link
-            to="/explore/gallery"
-            className="hover:text-brand-400 transition-colors"
-            data-testid="browse-screenshots-link"
-          >
+          <Link to="/explore/gallery" className="hover:text-brand-400 transition-colors" data-testid="browse-screenshots-link">
             Browse Screenshots
           </Link>
           <span className="text-surface-700">|</span>
-          <Link
-            to="/explore/covers"
-            className="hover:text-brand-400 transition-colors"
-            data-testid="browse-covers-link"
-          >
+          <Link to="/explore/covers" className="hover:text-brand-400 transition-colors" data-testid="browse-covers-link">
             Browse Cover Art
           </Link>
         </div>
-      </div>
-
-      <div className="relative">
-        {/* Scroll arrows */}
-        {canScrollLeft && (
-          <button
-            onClick={() => scroll("left")}
-            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/artwork:opacity-100 group-focus-within/artwork:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
-            aria-label="Scroll artwork left"
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-        )}
-        {canScrollRight && (
-          <button
-            onClick={() => scroll("right")}
-            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/artwork:opacity-100 group-focus-within/artwork:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
-            aria-label="Scroll artwork right"
-          >
-            <ChevronRight className="h-5 w-5" />
-          </button>
-        )}
-
-        <div
-          ref={scrollRef}
-          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
-          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-          role="list"
-          aria-label="Artwork showcase"
+      }
+    >
+      {displayArtworks?.map((artwork, i) => (
+        <Link
+          key={`${artwork.gameId}-${i}`}
+          to={`/games/${artwork.gameId}`}
+          className="w-80 sm:w-96 flex-shrink-0 group/card"
+          role="listitem"
+          data-testid="artwork-card"
         >
-          {displayArtworks.map((artwork, i) => (
-            <Link
-              key={`${artwork.gameId}-${i}`}
-              to={`/games/${artwork.gameId}`}
-              className="w-80 sm:w-96 flex-shrink-0 group/card"
-              role="listitem"
-              data-testid="artwork-card"
-            >
-              <div className="relative rounded-xl overflow-hidden">
-                <div style={{ aspectRatio: "16/9" }}>
-                  <img
-                    src={artwork.url}
-                    alt={`Artwork for ${artwork.gameTitle}`}
-                    className="w-full h-full object-cover transition-transform duration-300 group-hover/card:scale-[1.03]"
-                    loading="lazy"
-                  />
-                </div>
-                {/* Overlay with game info */}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent pointer-events-none" />
-                <div className="absolute bottom-0 left-0 right-0 p-4">
-                  <p className="text-sm font-semibold text-white truncate">
-                    {artwork.gameTitle}
-                  </p>
-                  <p className="text-xs text-white/60 mt-0.5">
-                    {artwork.consoleName}
-                  </p>
-                </div>
-              </div>
-            </Link>
-          ))}
-        </div>
-      </div>
-    </section>
+          <div className="relative rounded-xl overflow-hidden">
+            <div style={{ aspectRatio: "16/9" }}>
+              <img
+                src={artwork.url}
+                alt={`Artwork for ${artwork.gameTitle}`}
+                className="w-full h-full object-cover transition-transform duration-300 group-hover/card:scale-[1.03]"
+                loading="lazy"
+              />
+            </div>
+            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-transparent pointer-events-none" />
+            <div className="absolute bottom-0 left-0 right-0 p-4">
+              <p className="text-sm font-semibold text-white truncate">{artwork.gameTitle}</p>
+              <p className="text-xs text-white/60 mt-0.5">{artwork.consoleName}</p>
+            </div>
+          </div>
+        </Link>
+      ))}
+    </ScrollShelf>
   );
 }

--- a/web/src/features/explore/components/developer-spotlight.tsx
+++ b/web/src/features/explore/components/developer-spotlight.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import { ChevronLeft, ChevronRight, ArrowRight } from "lucide-react";
 import { Skeleton } from "@/components/ui";
 import { GameCard } from "@/components/game-card";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
 import type { DeveloperSpotlightResponse, Game } from "@/types/api";
 
 interface DeveloperSpotlightProps {
@@ -151,11 +152,12 @@ export function DeveloperSpotlight({
                 {spotlight.topGames.map((game) => (
                   <div
                     key={game.id}
-                    className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+                    className="flex-shrink-0"
                     role="listitem"
                   >
                     <GameCard
                       game={game}
+                      coverHeight={CAROUSEL_CARD_HEIGHT}
                       showConsoleBadge
                       onToggleFavorite={onToggleFavorite}
                       onTogglePlayLater={onTogglePlayLater}

--- a/web/src/features/explore/components/for-you-section.tsx
+++ b/web/src/features/explore/components/for-you-section.tsx
@@ -2,6 +2,7 @@ import { useRef, useState, useEffect, useCallback } from "react";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import { GameCard } from "@/components/game-card";
 import { GameCardSkeleton } from "@/components/ui";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
 import type { ForYouRow, Game } from "@/types/api";
 
 interface ForYouSectionProps {
@@ -19,9 +20,7 @@ function ForYouSkeleton() {
           <div className="h-7 w-64 rounded bg-surface-800 animate-pulse mb-5" />
           <div className="flex gap-5 overflow-hidden">
             {Array.from({ length: 6 }, (_, j) => (
-              <div key={j} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
-                <GameCardSkeleton />
-              </div>
+              <GameCardSkeleton key={j} coverHeight={CAROUSEL_CARD_HEIGHT} />
             ))}
           </div>
         </section>
@@ -135,11 +134,12 @@ function ForYouShelf({
           {row.games.map((game) => (
             <div
               key={game.id}
-              className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+              className="flex-shrink-0"
               role="listitem"
             >
               <GameCard
                 game={game}
+                coverHeight={CAROUSEL_CARD_HEIGHT}
                 showConsoleBadge
                 onToggleFavorite={onToggleFavorite}
                 onTogglePlayLater={onTogglePlayLater}

--- a/web/src/features/explore/components/game-shelf.tsx
+++ b/web/src/features/explore/components/game-shelf.tsx
@@ -1,8 +1,7 @@
-import { useRef, useState, useEffect, useCallback } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { GameCard } from "@/components/game-card";
-import { GameCardSkeleton } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
 import type { Game } from "@/types/api";
 
 interface GameShelfProps {
@@ -15,127 +14,35 @@ interface GameShelfProps {
   onTogglePlayLater?: (game: Game) => void;
 }
 
-function GameShelfSkeleton({ title }: { title: string }) {
-  return (
-    <section data-testid={`shelf-skeleton-${title}`}>
-      <h2 className="text-xl font-bold text-surface-100 mb-5">{title}</h2>
-      <div className="flex gap-5 overflow-hidden">
-        {Array.from({ length: 6 }, (_, i) => (
-          <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
-            <GameCardSkeleton />
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
 export function GameShelf({
   title,
-  icon: Icon,
+  icon,
   games,
   isLoading,
   hideConsoleName,
   onToggleFavorite,
   onTogglePlayLater,
 }: GameShelfProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const updateScrollState = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    setCanScrollLeft(el.scrollLeft > 0);
-    setCanScrollRight(
-      el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
-    );
-  }, []);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    updateScrollState();
-    el.addEventListener("scroll", updateScrollState, { passive: true });
-    window.addEventListener("resize", updateScrollState);
-    return () => {
-      el.removeEventListener("scroll", updateScrollState);
-      window.removeEventListener("resize", updateScrollState);
-    };
-  }, [updateScrollState, games]);
-
-  const scroll = useCallback((direction: "left" | "right") => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const scrollAmount = el.clientWidth * 0.7;
-    el.scrollBy({
-      left: direction === "left" ? -scrollAmount : scrollAmount,
-      behavior: "smooth",
-    });
-  }, []);
-
-  if (isLoading) {
-    return <GameShelfSkeleton title={title} />;
-  }
-
-  if (!games || games.length === 0) {
-    return null;
-  }
-
   return (
-    <section data-testid={`shelf-${title}`} className="group/shelf relative">
-      <div className="flex items-center gap-2.5 mb-5">
-        {Icon && <Icon className="h-5 w-5 text-brand-400" />}
-        <h2 className="text-xl font-bold text-surface-100">{title}</h2>
-      </div>
-
-      <div className="relative">
-        {/* Scroll arrows */}
-        {canScrollLeft && (
-          <button
-            onClick={() => scroll("left")}
-            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
-            aria-label={`Scroll ${title} left`}
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-        )}
-        {canScrollRight && (
-          <button
-            onClick={() => scroll("right")}
-            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
-            aria-label={`Scroll ${title} right`}
-          >
-            <ChevronRight className="h-5 w-5" />
-          </button>
-        )}
-
-        {/* Scrollable row */}
-        <div
-          ref={scrollRef}
-          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
-          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-          role="list"
-          aria-label={title}
-        >
-          {games.map((game) => (
-            <div
-              key={game.id}
-              className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
-              role="listitem"
-            >
-              <GameCard
-                game={game}
-                showConsoleBadge={!hideConsoleName}
-                hideConsoleName={hideConsoleName}
-                onToggleFavorite={onToggleFavorite}
-                onTogglePlayLater={onTogglePlayLater}
-              />
-            </div>
-          ))}
+    <ScrollShelf
+      title={title}
+      icon={icon}
+      testId={`shelf-${title}`}
+      isLoading={isLoading}
+      isEmpty={!games || games.length === 0}
+    >
+      {games?.map((game) => (
+        <div key={game.id} className="flex-shrink-0" role="listitem">
+          <GameCard
+            game={game}
+            coverHeight={CAROUSEL_CARD_HEIGHT}
+            showConsoleBadge={!hideConsoleName}
+            hideConsoleName={hideConsoleName}
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
         </div>
-      </div>
-    </section>
+      ))}
+    </ScrollShelf>
   );
 }

--- a/web/src/features/explore/components/players-like-you-shelf.tsx
+++ b/web/src/features/explore/components/players-like-you-shelf.tsx
@@ -1,7 +1,6 @@
-import { useRef, useState, useEffect, useCallback } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import { GameCard } from "@/components/game-card";
-import { GameCardSkeleton } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
 import type { Game, GameSummary } from "@/types/api";
 
 interface PlayersLikeYouShelfProps {
@@ -12,22 +11,6 @@ interface PlayersLikeYouShelfProps {
   onTogglePlayLater?: (game: Game) => void;
 }
 
-function PlayersLikeYouSkeleton() {
-  return (
-    <section data-testid="players-like-you-skeleton">
-      <div className="h-7 w-80 rounded bg-surface-800 animate-pulse mb-2" />
-      <div className="h-4 w-56 rounded bg-surface-800/60 animate-pulse mb-5" />
-      <div className="flex gap-5 overflow-hidden">
-        {Array.from({ length: 6 }, (_, i) => (
-          <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
-            <GameCardSkeleton />
-          </div>
-        ))}
-      </div>
-    </section>
-  );
-}
-
 export function PlayersLikeYouShelf({
   games,
   isLoading,
@@ -35,106 +18,30 @@ export function PlayersLikeYouShelf({
   onToggleFavorite,
   onTogglePlayLater,
 }: PlayersLikeYouShelfProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const updateScrollState = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    setCanScrollLeft(el.scrollLeft > 0);
-    setCanScrollRight(
-      el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
-    );
-  }, []);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    updateScrollState();
-    el.addEventListener("scroll", updateScrollState, { passive: true });
-    window.addEventListener("resize", updateScrollState);
-    return () => {
-      el.removeEventListener("scroll", updateScrollState);
-      window.removeEventListener("resize", updateScrollState);
-    };
-  }, [updateScrollState, games]);
-
-  const scroll = useCallback((direction: "left" | "right") => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const scrollAmount = el.clientWidth * 0.7;
-    el.scrollBy({
-      left: direction === "left" ? -scrollAmount : scrollAmount,
-      behavior: "smooth",
-    });
-  }, []);
-
-  if (isLoading) {
-    return <PlayersLikeYouSkeleton />;
-  }
-
-  if (!games || games.length === 0) {
-    return null;
-  }
-
-  const title = "Players like you also enjoyed";
+  const subtitle =
+    similarUsersCount > 0
+      ? `Based on ${similarUsersCount} player${similarUsersCount !== 1 ? "s" : ""} with similar taste`
+      : undefined;
 
   return (
-    <section data-testid="players-like-you-shelf" className="group/shelf relative">
-      <h2 className="text-xl font-bold text-surface-100 mb-1">{title}</h2>
-      {similarUsersCount > 0 && (
-        <p className="text-sm text-surface-400 mb-5" data-testid="similar-users-count">
-          Based on {similarUsersCount} player{similarUsersCount !== 1 ? "s" : ""} with similar taste
-        </p>
-      )}
-
-      <div className="relative">
-        {/* Scroll arrows */}
-        {canScrollLeft && (
-          <button
-            onClick={() => scroll("left")}
-            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
-            aria-label={`Scroll ${title} left`}
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-        )}
-        {canScrollRight && (
-          <button
-            onClick={() => scroll("right")}
-            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 transition-all duration-300 shadow-lg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100"
-            aria-label={`Scroll ${title} right`}
-          >
-            <ChevronRight className="h-5 w-5" />
-          </button>
-        )}
-
-        {/* Scrollable row */}
-        <div
-          ref={scrollRef}
-          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
-          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-          role="list"
-          aria-label={title}
-        >
-          {games.map((game) => (
-            <div
-              key={game.id}
-              className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
-              role="listitem"
-            >
-              <GameCard
-                game={game}
-                showConsoleBadge
-                onToggleFavorite={onToggleFavorite}
-                onTogglePlayLater={onTogglePlayLater}
-              />
-            </div>
-          ))}
+    <ScrollShelf
+      title="Players like you also enjoyed"
+      subtitle={subtitle}
+      testId="players-like-you-shelf"
+      isLoading={isLoading}
+      isEmpty={!games || games.length === 0}
+    >
+      {games?.map((game) => (
+        <div key={game.id} className="flex-shrink-0" role="listitem">
+          <GameCard
+            game={game}
+            coverHeight={CAROUSEL_CARD_HEIGHT}
+            showConsoleBadge
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
         </div>
-      </div>
-    </section>
+      ))}
+    </ScrollShelf>
   );
 }

--- a/web/src/features/explore/components/series-shelf.tsx
+++ b/web/src/features/explore/components/series-shelf.tsx
@@ -1,7 +1,6 @@
-import { useRef, useState, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
-import { ChevronLeft, ChevronRight } from "lucide-react";
 import { Skeleton } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
 import type { FeaturedSeries } from "@/types/api";
 
 interface SeriesShelfProps {
@@ -9,146 +8,60 @@ interface SeriesShelfProps {
   isLoading: boolean;
 }
 
-function SeriesShelfSkeleton() {
+function SeriesSkeletonContent() {
   return (
-    <section data-testid="series-shelf-skeleton">
-      <h2 className="text-xl font-bold text-surface-100 mb-5">
-        Browse by Series
-      </h2>
-      <div className="flex gap-4 overflow-hidden">
-        {Array.from({ length: 5 }, (_, i) => (
-          <Skeleton
-            key={i}
-            className="w-56 sm:w-60 lg:w-64 h-36 flex-shrink-0 rounded-2xl"
-          />
-        ))}
-      </div>
-    </section>
+    <div className="flex gap-4 overflow-hidden">
+      {Array.from({ length: 5 }, (_, i) => (
+        <Skeleton key={i} className="w-56 sm:w-60 lg:w-64 h-36 flex-shrink-0 rounded-2xl" />
+      ))}
+    </div>
   );
 }
 
 export function SeriesShelf({ series, isLoading }: SeriesShelfProps) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const updateScrollState = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    setCanScrollLeft(el.scrollLeft > 0);
-    setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 1);
-  }, []);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-
-    updateScrollState();
-    el.addEventListener("scroll", updateScrollState, { passive: true });
-    window.addEventListener("resize", updateScrollState);
-    return () => {
-      el.removeEventListener("scroll", updateScrollState);
-      window.removeEventListener("resize", updateScrollState);
-    };
-  }, [updateScrollState, series]);
-
-  const scroll = useCallback((direction: "left" | "right") => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const scrollAmount = el.clientWidth * 0.7;
-    el.scrollBy({
-      left: direction === "left" ? -scrollAmount : scrollAmount,
-      behavior: "smooth",
-    });
-  }, []);
-
-  if (isLoading) {
-    return <SeriesShelfSkeleton />;
-  }
-
-  if (!series || series.length === 0) {
-    return null;
-  }
-
   return (
-    <section data-testid="series-shelf" className="group/series relative">
-      <h2 className="text-xl font-bold text-surface-100 mb-5">
-        Browse by Series
-      </h2>
-
-      <div className="relative">
-        {/* Scroll arrows */}
-        {canScrollLeft && (
-          <button
-            onClick={() => scroll("left")}
-            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/series:opacity-100 group-focus-within/series:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100 transition-all duration-300 shadow-lg"
-            aria-label="Scroll series left"
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-        )}
-        {canScrollRight && (
-          <button
-            onClick={() => scroll("right")}
-            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/series:opacity-100 group-focus-within/series:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:opacity-100 transition-all duration-300 shadow-lg"
-            aria-label="Scroll series right"
-          >
-            <ChevronRight className="h-5 w-5" />
-          </button>
-        )}
-
-        {/* Scrollable row */}
-        <div
-          ref={scrollRef}
-          className="flex gap-4 overflow-x-auto scrollbar-hide pb-2"
-          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-          role="list"
-          aria-label="Browse by Series"
+    <ScrollShelf
+      title="Browse by Series"
+      testId="series-shelf"
+      isLoading={isLoading}
+      isEmpty={!series || series.length === 0}
+      loadingSkeleton={<SeriesSkeletonContent />}
+    >
+      {series?.map((s) => (
+        <Link
+          key={s.id}
+          to={`/explore/series/${s.id}`}
+          className="w-56 sm:w-60 lg:w-64 flex-shrink-0 rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950"
+          role="listitem"
         >
-          {series.map((s) => (
-            <Link
-              key={s.id}
-              to={`/explore/series/${s.id}`}
-              className="w-56 sm:w-60 lg:w-64 flex-shrink-0 rounded-2xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950"
-              role="listitem"
-            >
-              <div className="relative h-36 rounded-2xl overflow-hidden border border-white/[0.06] transition-all duration-300 hover:border-white/[0.12] hover:shadow-xl hover:shadow-black/30 hover:-translate-y-1 group/card">
-                {/* Background image */}
-                {s.heroUrl ? (
-                  <img
-                    src={s.heroUrl}
-                    alt=""
-                    className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover/card:scale-105"
-                    loading="lazy"
-                  />
-                ) : (
-                  <div className="absolute inset-0 bg-gradient-to-br from-brand-900/80 via-brand-800/60 to-surface-950/80" />
+          <div className="relative h-36 rounded-2xl overflow-hidden border border-white/[0.06] transition-all duration-300 hover:border-white/[0.12] hover:shadow-xl hover:shadow-black/30 hover:-translate-y-1 group/card">
+            {s.heroUrl ? (
+              <img
+                src={s.heroUrl}
+                alt=""
+                className="absolute inset-0 w-full h-full object-cover transition-transform duration-500 group-hover/card:scale-105"
+                loading="lazy"
+              />
+            ) : (
+              <div className="absolute inset-0 bg-gradient-to-br from-brand-900/80 via-brand-800/60 to-surface-950/80" />
+            )}
+            <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent pointer-events-none" />
+            <div className="relative flex flex-col justify-end h-full p-4">
+              <h3 className="text-base font-bold text-white leading-tight group-hover/card:text-brand-300 transition-colors truncate">
+                {s.name}
+              </h3>
+              <p className="text-xs text-white/70 mt-1">
+                {s.libraryGames}/{s.totalGames} {s.totalGames === 1 ? "game" : "games"}
+                {s.consoleCount > 0 && (
+                  <span className="text-white/50">
+                    {" "}across {s.consoleCount} {s.consoleCount === 1 ? "console" : "consoles"}
+                  </span>
                 )}
-
-                {/* Gradient overlay */}
-                <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent pointer-events-none" />
-
-                {/* Content */}
-                <div className="relative flex flex-col justify-end h-full p-4">
-                  <h3 className="text-base font-bold text-white leading-tight group-hover/card:text-brand-300 transition-colors truncate">
-                    {s.name}
-                  </h3>
-                  <p className="text-xs text-white/70 mt-1">
-                    {s.libraryGames}/{s.totalGames} {s.totalGames === 1 ? "game" : "games"}
-                    {s.consoleCount > 0 && (
-                      <span className="text-white/50">
-                        {" "}
-                        across {s.consoleCount}{" "}
-                        {s.consoleCount === 1 ? "console" : "consoles"}
-                      </span>
-                    )}
-                  </p>
-                </div>
-              </div>
-            </Link>
-          ))}
-        </div>
-      </div>
-    </section>
+              </p>
+            </div>
+          </div>
+        </Link>
+      ))}
+    </ScrollShelf>
   );
 }

--- a/web/src/features/explore/components/social-shelves.tsx
+++ b/web/src/features/explore/components/social-shelves.tsx
@@ -1,8 +1,5 @@
-import { useRef, useState, useEffect, useCallback } from "react";
 import { Link } from "react-router-dom";
 import {
-  ChevronLeft,
-  ChevronRight,
   TrendingUp,
   Star,
   Gem,
@@ -12,7 +9,9 @@ import {
   Swords,
 } from "lucide-react";
 import { GameCard } from "@/components/game-card";
-import { GameCardSkeleton, Badge, Skeleton } from "@/components/ui";
+import { Badge } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
 import type {
   Game,
   TrendingGame,
@@ -21,127 +20,6 @@ import type {
   RecentReviewItem,
   ActiveNowItem,
 } from "@/types/api";
-
-// --- Shared scroll shelf wrapper ---
-
-function ScrollShelf({
-  title,
-  subtitle,
-  icon: Icon,
-  testId,
-  isLoading,
-  isEmpty,
-  children,
-}: {
-  title: string;
-  subtitle?: string;
-  icon: React.ElementType;
-  testId: string;
-  isLoading: boolean;
-  isEmpty: boolean;
-  children: React.ReactNode;
-}) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const updateScrollState = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    setCanScrollLeft(el.scrollLeft > 0);
-    setCanScrollRight(
-      el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
-    );
-  }, []);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    updateScrollState();
-    el.addEventListener("scroll", updateScrollState, { passive: true });
-    window.addEventListener("resize", updateScrollState);
-    return () => {
-      el.removeEventListener("scroll", updateScrollState);
-      window.removeEventListener("resize", updateScrollState);
-    };
-  }, [updateScrollState, children]);
-
-  const scroll = useCallback((direction: "left" | "right") => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const scrollAmount = el.clientWidth * 0.7;
-    el.scrollBy({
-      left: direction === "left" ? -scrollAmount : scrollAmount,
-      behavior: "smooth",
-    });
-  }, []);
-
-  if (isLoading) {
-    return (
-      <section data-testid={`${testId}-skeleton`}>
-        <div className="flex items-center gap-2 mb-1">
-          <Icon className="h-5 w-5 text-surface-400" />
-          <Skeleton className="h-7 w-60 rounded" />
-        </div>
-        {subtitle && (
-          <Skeleton className="h-4 w-40 rounded mt-1 mb-5" />
-        )}
-        <div className="flex gap-5 overflow-hidden mt-4">
-          {Array.from({ length: 6 }, (_, i) => (
-            <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
-              <GameCardSkeleton />
-            </div>
-          ))}
-        </div>
-      </section>
-    );
-  }
-
-  if (isEmpty) return null;
-
-  return (
-    <section data-testid={testId} className="group/shelf relative">
-      <div className="flex items-center gap-2 mb-1">
-        <Icon className="h-5 w-5 text-brand-400" />
-        <h2 className="text-xl font-bold text-surface-100">{title}</h2>
-      </div>
-      {subtitle && (
-        <p className="text-sm text-surface-400 mb-4">{subtitle}</p>
-      )}
-
-      <div className="relative">
-        {canScrollLeft && (
-          <button
-            onClick={() => scroll("left")}
-            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
-            aria-label={`Scroll ${title} left`}
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-        )}
-        {canScrollRight && (
-          <button
-            onClick={() => scroll("right")}
-            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
-            aria-label={`Scroll ${title} right`}
-          >
-            <ChevronRight className="h-5 w-5" />
-          </button>
-        )}
-
-        <div
-          ref={scrollRef}
-          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
-          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-          role="list"
-          aria-label={title}
-        >
-          {children}
-        </div>
-      </div>
-    </section>
-  );
-}
 
 // --- Trending Shelf ---
 
@@ -170,12 +48,13 @@ export function TrendingShelf({
       {games?.map((item) => (
         <div
           key={item.game.id}
-          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          className="flex-shrink-0"
           role="listitem"
         >
           <GameCard
             game={item.game}
             showConsoleBadge
+            coverHeight={CAROUSEL_CARD_HEIGHT}
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
           />
@@ -218,12 +97,13 @@ export function CommunityTopShelf({
       {games?.map((item) => (
         <div
           key={item.game.id}
-          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          className="flex-shrink-0"
           role="listitem"
         >
           <GameCard
             game={item.game}
             showConsoleBadge
+            coverHeight={CAROUSEL_CARD_HEIGHT}
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
           />
@@ -269,12 +149,13 @@ export function CultClassicsShelf({
       {games?.map((item) => (
         <div
           key={item.game.id}
-          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          className="flex-shrink-0"
           role="listitem"
         >
           <GameCard
             game={item.game}
             showConsoleBadge
+            coverHeight={CAROUSEL_CARD_HEIGHT}
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
           />
@@ -393,12 +274,13 @@ export function ActiveNowShelf({
       {games?.map((item) => (
         <div
           key={item.game.id}
-          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          className="flex-shrink-0"
           role="listitem"
         >
           <GameCard
             game={item.game}
             showConsoleBadge
+            coverHeight={CAROUSEL_CARD_HEIGHT}
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
           />

--- a/web/src/features/explore/components/temporal-shelves.tsx
+++ b/web/src/features/explore/components/temporal-shelves.tsx
@@ -1,15 +1,9 @@
-import { useRef, useState, useEffect, useCallback } from "react";
 import { getReleaseYear } from "@/lib/date-utils";
-import {
-  ChevronLeft,
-  ChevronRight,
-  Calendar,
-  Trophy,
-  Heart,
-  Clock,
-} from "lucide-react";
+import { Calendar, Trophy, Heart, Clock } from "lucide-react";
 import { GameCard } from "@/components/game-card";
 import { GameCardSkeleton, Skeleton } from "@/components/ui";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
 import type {
   Game,
   OnThisDayResponse,
@@ -17,127 +11,6 @@ import type {
   AnniversaryItem,
   DecadeResponse,
 } from "@/types/api";
-
-// --- Shared scroll shelf wrapper (same pattern as social-shelves.tsx) ---
-
-function ScrollShelf({
-  title,
-  subtitle,
-  icon: Icon,
-  testId,
-  isLoading,
-  isEmpty,
-  children,
-}: {
-  title: string;
-  subtitle?: string;
-  icon: React.ElementType;
-  testId: string;
-  isLoading: boolean;
-  isEmpty: boolean;
-  children: React.ReactNode;
-}) {
-  const scrollRef = useRef<HTMLDivElement>(null);
-  const [canScrollLeft, setCanScrollLeft] = useState(false);
-  const [canScrollRight, setCanScrollRight] = useState(false);
-
-  const updateScrollState = useCallback(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    setCanScrollLeft(el.scrollLeft > 0);
-    setCanScrollRight(
-      el.scrollLeft + el.clientWidth < el.scrollWidth - 1,
-    );
-  }, []);
-
-  useEffect(() => {
-    const el = scrollRef.current;
-    if (!el) return;
-    updateScrollState();
-    el.addEventListener("scroll", updateScrollState, { passive: true });
-    window.addEventListener("resize", updateScrollState);
-    return () => {
-      el.removeEventListener("scroll", updateScrollState);
-      window.removeEventListener("resize", updateScrollState);
-    };
-  }, [updateScrollState, children]);
-
-  const scroll = useCallback((direction: "left" | "right") => {
-    const el = scrollRef.current;
-    if (!el) return;
-    const scrollAmount = el.clientWidth * 0.7;
-    el.scrollBy({
-      left: direction === "left" ? -scrollAmount : scrollAmount,
-      behavior: "smooth",
-    });
-  }, []);
-
-  if (isLoading) {
-    return (
-      <section data-testid={`${testId}-skeleton`}>
-        <div className="flex items-center gap-2 mb-1">
-          <Icon className="h-5 w-5 text-surface-400" />
-          <Skeleton className="h-7 w-60 rounded" />
-        </div>
-        {subtitle && (
-          <Skeleton className="h-4 w-40 rounded mt-1 mb-5" />
-        )}
-        <div className="flex gap-5 overflow-hidden mt-4">
-          {Array.from({ length: 6 }, (_, i) => (
-            <div key={i} className="w-40 sm:w-44 lg:w-48 flex-shrink-0">
-              <GameCardSkeleton />
-            </div>
-          ))}
-        </div>
-      </section>
-    );
-  }
-
-  if (isEmpty) return null;
-
-  return (
-    <section data-testid={testId} className="group/shelf relative">
-      <div className="flex items-center gap-2 mb-1">
-        <Icon className="h-5 w-5 text-brand-400" />
-        <h2 className="text-xl font-bold text-surface-100">{title}</h2>
-      </div>
-      {subtitle && (
-        <p className="text-sm text-surface-400 mb-4">{subtitle}</p>
-      )}
-
-      <div className="relative">
-        {canScrollLeft && (
-          <button
-            onClick={() => scroll("left")}
-            className="absolute -left-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
-            aria-label={`Scroll ${title} left`}
-          >
-            <ChevronLeft className="h-5 w-5" />
-          </button>
-        )}
-        {canScrollRight && (
-          <button
-            onClick={() => scroll("right")}
-            className="absolute -right-2 top-1/2 -translate-y-1/2 z-10 p-2 rounded-full bg-surface-900/90 text-surface-300 hover:text-surface-100 hover:bg-surface-800 opacity-0 group-hover/shelf:opacity-100 group-focus-within/shelf:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 transition-all duration-300 shadow-lg"
-            aria-label={`Scroll ${title} right`}
-          >
-            <ChevronRight className="h-5 w-5" />
-          </button>
-        )}
-
-        <div
-          ref={scrollRef}
-          className="flex gap-5 overflow-x-auto scrollbar-hide pb-2"
-          style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
-          role="list"
-          aria-label={title}
-        >
-          {children}
-        </div>
-      </div>
-    </section>
-  );
-}
 
 // --- On This Day Shelf ---
 
@@ -168,7 +41,7 @@ export function OnThisDayShelf({
       {data?.games.map((game) => (
         <div
           key={game.id}
-          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          className="flex-shrink-0"
           role="listitem"
         >
           <GameCard
@@ -177,6 +50,7 @@ export function OnThisDayShelf({
             subtitle={getReleaseYear(game.releaseDate) ? `Released ${getReleaseYear(game.releaseDate)}` : undefined}
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
+            coverHeight={CAROUSEL_CARD_HEIGHT}
           />
         </div>
       ))}
@@ -307,7 +181,7 @@ export function AnniversariesShelf({
       {anniversaries?.map((item) => (
         <div
           key={`${item.game.id}-${item.yearsAgo}`}
-          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          className="flex-shrink-0"
           role="listitem"
         >
           <GameCard
@@ -315,6 +189,7 @@ export function AnniversariesShelf({
             showConsoleBadge
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
+            coverHeight={CAROUSEL_CARD_HEIGHT}
           />
           <p
             className="text-xs text-amber-400 mt-1.5 font-medium"
@@ -356,7 +231,7 @@ export function DecadeSpotlight({
       {data?.games.map((game) => (
         <div
           key={game.id}
-          className="w-40 sm:w-44 lg:w-48 flex-shrink-0"
+          className="flex-shrink-0"
           role="listitem"
         >
           <GameCard
@@ -364,6 +239,7 @@ export function DecadeSpotlight({
             showConsoleBadge
             onToggleFavorite={onToggleFavorite}
             onTogglePlayLater={onTogglePlayLater}
+            coverHeight={CAROUSEL_CARD_HEIGHT}
           />
         </div>
       ))}

--- a/web/src/lib/carousel-constants.ts
+++ b/web/src/lib/carousel-constants.ts
@@ -1,0 +1,5 @@
+/** Fixed height (px) for game cards in carousel shelves. */
+export const CAROUSEL_CARD_HEIGHT = 240;
+
+/** Default aspect ratio (width/height) for placeholder/skeleton cards. */
+export const CAROUSEL_DEFAULT_ASPECT_RATIO = 3 / 4;

--- a/web/src/pages/dashboard-page.tsx
+++ b/web/src/pages/dashboard-page.tsx
@@ -13,7 +13,7 @@ import { Link } from "react-router-dom";
 import { GameCard } from "@/components/game-card";
 import { ScrollShelf } from "@/components/scroll-shelf";
 import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
-import { Badge, GameCardSkeleton, Skeleton, EmptyState, TitledSection } from "@/components/ui";
+import { Badge, Skeleton, EmptyState, TitledSection } from "@/components/ui";
 import { PersonalStatsCard } from "@/features/dashboard/components/personal-stats-card";
 import {
   useRecentGames,
@@ -34,7 +34,7 @@ import { OnlineUsers } from "@/features/social/components/online-users";
 import { ChallengeCard } from "@/features/challenges/components/challenge-card";
 import { useChallenges } from "@/hooks/use-challenges";
 import { formatRelativeTime } from "@/lib/format";
-import type { Game, RecentAchievement } from "@/types/api";
+import type { RecentAchievement } from "@/types/api";
 
 
 function RecentAchievementsSkeleton() {

--- a/web/src/pages/dashboard-page.tsx
+++ b/web/src/pages/dashboard-page.tsx
@@ -11,7 +11,8 @@ import {
 } from "lucide-react";
 import { Link } from "react-router-dom";
 import { GameCard } from "@/components/game-card";
-import { GameGrid } from "@/components/game-grid";
+import { ScrollShelf } from "@/components/scroll-shelf";
+import { CAROUSEL_CARD_HEIGHT } from "@/lib/carousel-constants";
 import { Badge, GameCardSkeleton, Skeleton, EmptyState, TitledSection } from "@/components/ui";
 import { PersonalStatsCard } from "@/features/dashboard/components/personal-stats-card";
 import {
@@ -35,42 +36,6 @@ import { useChallenges } from "@/hooks/use-challenges";
 import { formatRelativeTime } from "@/lib/format";
 import type { Game, RecentAchievement } from "@/types/api";
 
-function GameRow({
-  games,
-  isLoading,
-  onToggleFavorite,
-  onTogglePlayLater,
-}: {
-  games: Game[] | undefined;
-  isLoading: boolean;
-  onToggleFavorite: (game: Game) => void;
-  onTogglePlayLater?: (game: Game) => void;
-}) {
-  if (isLoading) {
-    return (
-      <GameGrid>
-        {Array.from({ length: 6 }, (_, i) => (
-          <GameCardSkeleton key={i} />
-        ))}
-      </GameGrid>
-    );
-  }
-
-  if (!games || games.length === 0) return null;
-
-  return (
-    <GameGrid>
-      {games.slice(0, 6).map((game) => (
-        <GameCard
-          key={game.id}
-          game={game}
-          onToggleFavorite={onToggleFavorite}
-          onTogglePlayLater={onTogglePlayLater}
-        />
-      ))}
-    </GameGrid>
-  );
-}
 
 function RecentAchievementsSkeleton() {
   return (
@@ -324,98 +289,133 @@ export function DashboardPage() {
       )}
 
       {(recentGames.isLoading || hasRecent) && (
-        <TitledSection
+        <ScrollShelf
           title="Continue Playing"
           icon={Play}
-          renderRight={
+          testId="shelf-continue-playing"
+          isLoading={recentGames.isLoading}
+          isEmpty={!recentGames.data || recentGames.data.length === 0}
+          headerRight={
             <Link to="/games" className="flex items-center gap-1 text-sm text-surface-400 hover:text-brand-400 transition-colors">
               View all<ChevronRight className="h-4 w-4" />
             </Link>
           }
         >
-          <GameRow
-            games={recentGames.data}
-            isLoading={recentGames.isLoading}
-            onToggleFavorite={handleToggleFavorite}
-            onTogglePlayLater={handleTogglePlayLater}
-          />
-        </TitledSection>
+          {recentGames.data?.map((game) => (
+            <div key={game.id} className="flex-shrink-0" role="listitem">
+              <GameCard
+                game={game}
+                coverHeight={CAROUSEL_CARD_HEIGHT}
+                onToggleFavorite={handleToggleFavorite}
+                onTogglePlayLater={handleTogglePlayLater}
+              />
+            </div>
+          ))}
+        </ScrollShelf>
       )}
 
       {(playLaterGames.isLoading || hasPlayLater) && (
-        <TitledSection
+        <ScrollShelf
           title="Play Later"
           icon={Clock}
-          renderRight={
+          testId="shelf-play-later"
+          isLoading={playLaterGames.isLoading}
+          isEmpty={!playLaterGames.data || playLaterGames.data.length === 0}
+          headerRight={
             <Link to="/play-later" className="flex items-center gap-1 text-sm text-surface-400 hover:text-brand-400 transition-colors">
               View all<ChevronRight className="h-4 w-4" />
             </Link>
           }
         >
-          <GameRow
-            games={playLaterGames.data}
-            isLoading={playLaterGames.isLoading}
-            onToggleFavorite={handleToggleFavorite}
-            onTogglePlayLater={handleTogglePlayLater}
-          />
-        </TitledSection>
+          {playLaterGames.data?.map((game) => (
+            <div key={game.id} className="flex-shrink-0" role="listitem">
+              <GameCard
+                game={game}
+                coverHeight={CAROUSEL_CARD_HEIGHT}
+                onToggleFavorite={handleToggleFavorite}
+                onTogglePlayLater={handleTogglePlayLater}
+              />
+            </div>
+          ))}
+        </ScrollShelf>
       )}
 
       {(favoriteGames.isLoading || hasFavorites) && (
-        <TitledSection
+        <ScrollShelf
           title="Favorites"
           icon={Heart}
-          renderRight={
+          testId="shelf-favorites"
+          isLoading={favoriteGames.isLoading}
+          isEmpty={!favoriteGames.data || favoriteGames.data.length === 0}
+          headerRight={
             <Link to="/favorites" className="flex items-center gap-1 text-sm text-surface-400 hover:text-brand-400 transition-colors">
               View all<ChevronRight className="h-4 w-4" />
             </Link>
           }
         >
-          <GameRow
-            games={favoriteGames.data}
-            isLoading={favoriteGames.isLoading}
-            onToggleFavorite={handleToggleFavorite}
-            onTogglePlayLater={handleTogglePlayLater}
-          />
-        </TitledSection>
+          {favoriteGames.data?.map((game) => (
+            <div key={game.id} className="flex-shrink-0" role="listitem">
+              <GameCard
+                game={game}
+                coverHeight={CAROUSEL_CARD_HEIGHT}
+                onToggleFavorite={handleToggleFavorite}
+                onTogglePlayLater={handleTogglePlayLater}
+              />
+            </div>
+          ))}
+        </ScrollShelf>
       )}
 
       {(recentlyAddedGames.isLoading || hasRecentlyAdded) && (
-        <TitledSection
+        <ScrollShelf
           title="Recently Added"
           icon={Sparkles}
-          renderRight={
+          testId="shelf-recently-added"
+          isLoading={recentlyAddedGames.isLoading}
+          isEmpty={!recentlyAddedGames.data?.data || recentlyAddedGames.data.data.length === 0}
+          headerRight={
             <Link to="/games" className="flex items-center gap-1 text-sm text-surface-400 hover:text-brand-400 transition-colors">
               View all<ChevronRight className="h-4 w-4" />
             </Link>
           }
         >
-          <GameRow
-            games={recentlyAddedGames.data?.data}
-            isLoading={recentlyAddedGames.isLoading}
-            onToggleFavorite={handleToggleFavorite}
-            onTogglePlayLater={handleTogglePlayLater}
-          />
-        </TitledSection>
+          {recentlyAddedGames.data?.data?.map((game) => (
+            <div key={game.id} className="flex-shrink-0" role="listitem">
+              <GameCard
+                game={game}
+                coverHeight={CAROUSEL_CARD_HEIGHT}
+                onToggleFavorite={handleToggleFavorite}
+                onTogglePlayLater={handleTogglePlayLater}
+              />
+            </div>
+          ))}
+        </ScrollShelf>
       )}
 
       {!hasRecent && !hasFavorites && (allGames.isLoading || hasGames) && (
-        <TitledSection
+        <ScrollShelf
           title="Discover"
           icon={Gamepad2}
-          renderRight={
+          testId="shelf-discover"
+          isLoading={allGames.isLoading}
+          isEmpty={!allGames.data?.data || allGames.data.data.length === 0}
+          headerRight={
             <Link to="/games" className="flex items-center gap-1 text-sm text-surface-400 hover:text-brand-400 transition-colors">
               View all<ChevronRight className="h-4 w-4" />
             </Link>
           }
         >
-          <GameRow
-            games={allGames.data?.data}
-            isLoading={allGames.isLoading}
-            onToggleFavorite={handleToggleFavorite}
-            onTogglePlayLater={handleTogglePlayLater}
-          />
-        </TitledSection>
+          {allGames.data?.data?.map((game) => (
+            <div key={game.id} className="flex-shrink-0" role="listitem">
+              <GameCard
+                game={game}
+                coverHeight={CAROUSEL_CARD_HEIGHT}
+                onToggleFavorite={handleToggleFavorite}
+                onTogglePlayLater={handleTogglePlayLater}
+              />
+            </div>
+          ))}
+        </ScrollShelf>
       )}
 
       {/* Social widgets */}


### PR DESCRIPTION
## Summary

- Game cards in carousels now use **fixed height with image-driven width** — full box art is always visible, no cropping. Cards expand/contract based on the actual cover art aspect ratio, matching the player app behavior.
- Extracted shared **ScrollShelf** component (Design layer) replacing 6+ duplicated scroll implementations across shelf components (~500 lines removed).
- Introduced **layout module** (`web/src/components/layout/`) with `TitledSection` (supports `contained` prop for optional card background) and `SectionList` for consistent heading alignment and spacing across pages.
- Centralized carousel sizing constants for easy tweaking.
- Migrated all game shelves, dashboard sections, and TopRatedRow to the new system.

## Test plan

- [ ] All 1470 Vitest tests pass (verified)
- [ ] Production build succeeds (verified via pre-push hook)
- [ ] Visual: Explore page carousels show varying-width cards based on cover art aspect ratios
- [ ] Visual: Dashboard sections (Continue Playing, Favorites, etc.) render as horizontal carousels with card backgrounds
- [ ] Visual: Section headings align horizontally across contained and non-contained sections
- [ ] Scroll arrows appear on hover and work correctly
- [ ] Loading skeletons render with correct dimensions
- [ ] Non-game shelves (Series, Artwork, Challenges, Reviews) retain their fixed-width cards
- [ ] Grid views (game lists, Best of Year) are unaffected