### PR TITLE
fix: show full box art on game detail page

### DIFF
--- a/web/src/features/game-detail/components/cover-art-selector.tsx
+++ b/web/src/features/game-detail/components/cover-art-selector.tsx
@@ -9,14 +9,12 @@ import { cn } from "@/lib/cn";
 
 interface CoverArtSelectorProps {
   gameId: string;
-  aspectRatio?: number;
   open: boolean;
   onClose: () => void;
 }
 
 export function CoverArtSelector({
   gameId,
-  aspectRatio,
   open,
   onClose,
 }: CoverArtSelectorProps) {
@@ -78,14 +76,11 @@ export function CoverArtSelector({
                 setCover.isPending && "opacity-50 cursor-not-allowed",
               )}
             >
-              <div
-                className="w-24 md:w-32"
-                style={{ aspectRatio: aspectRatio ?? 3 / 4 }}
-              >
+              <div className="w-24 md:w-32">
                 <img
                   src={cover.url}
                   alt={`${label} cover`}
-                  className="h-full w-full object-cover"
+                  className="w-full h-auto"
                   loading="lazy"
                 />
               </div>

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -37,7 +37,6 @@ import type { Game } from "@/types/api";
 
 interface GameHeroProps {
   game: Game;
-  aspectRatio?: number;
   canPlayInBrowser: boolean;
   isAdmin: boolean;
   isFavorite: boolean;
@@ -63,7 +62,6 @@ interface GameHeroProps {
 
 export function GameHero({
   game,
-  aspectRatio,
   canPlayInBrowser,
   isAdmin,
   isFavorite,
@@ -190,9 +188,7 @@ export function GameHero({
           {/* Cover art */}
           <div className="flex-shrink-0 w-36 md:w-48 self-end">
             <div className="rounded-xl overflow-hidden bg-surface-900/80 border border-white/10 shadow-2xl backdrop-blur-sm">
-              <div style={{ aspectRatio: aspectRatio ?? 3 / 4 }}>
-                <CoverImage src={game.coverUrl} alt={game.title} className="w-full h-full" />
-              </div>
+              <CoverImage src={game.coverUrl} alt={game.title} className="w-full h-auto" />
             </div>
             <div className="flex justify-center mt-2">
               <Button
@@ -210,7 +206,6 @@ export function GameHero({
               open={showCoverModal}
               onClose={() => setShowCoverModal(false)}
               gameId={game.id}
-              aspectRatio={aspectRatio}
             />
           </div>
 

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -203,7 +203,6 @@ export function GameDetailPage() {
 
       <GameHero
         game={game}
-        aspectRatio={consoleInfo?.coverAspectRatio}
         canPlayInBrowser={canPlayInBrowser}
         isAdmin={isAdmin}
         isFavorite={isFavorite}


### PR DESCRIPTION
## Summary

- Game detail hero cover art now uses fixed width with image-driven height instead of a forced aspect ratio from the platform config
- Cover art selector modal uses the same approach
- Full box art is always visible — no more cropping
- Removed the now-unused `aspectRatio` prop from `GameHero` and `CoverArtSelector`

## Test plan

- [ ] All 1470 tests pass (verified)
- [ ] Visual: Game detail page shows full uncropped box art for games across different consoles (SNES, Genesis, Game Boy, etc.)
- [ ] Visual: "Change cover" modal shows all cover options at their natural aspect ratios
- [ ] Cover art still has rounded corners and border styling