### PR TITLE
Show "Not in library" as overlay badge on top-rated cards

### DIFF
--- a/web/src/components/cover-card.tsx
+++ b/web/src/components/cover-card.tsx
@@ -22,6 +22,8 @@ interface CoverCardProps {
   aspectRatio?: string;
   width?: string;
   coverHeight?: number;
+  /** Content rendered over the cover image (badges, tags, etc). */
+  overlay?: ReactNode;
   children?: ReactNode;
 }
 
@@ -34,15 +36,19 @@ export function CoverCard({
   aspectRatio = "3/4",
   width = "w-36",
   coverHeight,
+  overlay,
   children,
 }: CoverCardProps) {
   const content = (
     <div data-comp="CoverCard" className={cn(coverHeight ? "flex-shrink-0" : width, dimmed && "opacity-50")}>
       <div
-        className="w-full border border-surface-800/50"
+        className="relative w-full border border-surface-800/50"
         style={coverHeight ? { height: coverHeight } : { aspectRatio }}
       >
         <CoverImage src={imageUrl} alt={title} className={coverHeight ? "h-full w-auto rounded-xl" : "w-full h-full rounded-xl"} />
+        {overlay && (
+          <div className="absolute bottom-2 left-2 z-10">{overlay}</div>
+        )}
       </div>
       <div className="mt-2 px-0.5">
         <p className="text-sm font-medium text-surface-200 truncate">

--- a/web/src/features/dashboard/components/top-rated-game-card.tsx
+++ b/web/src/features/dashboard/components/top-rated-game-card.tsx
@@ -19,14 +19,12 @@ export function TopRatedGameCard({ game, coverHeight }: { game: TopRatedGame; co
       subtitle={game.consoleName}
       linkTo={isAvailable ? `/games/${game.localGameId}` : undefined}
       coverHeight={coverHeight}
+      overlay={!isAvailable ? <span className="rounded-full bg-black/60 px-3 py-1 text-xs font-medium text-white/90">Not in library</span> : undefined}
     >
       <span className="flex items-center gap-0.5 text-xs text-amber-400">
         <Star className="h-3 w-3 fill-amber-400" />
         {game.igdbCriticsRating.toFixed(0)}
       </span>
-      {!isAvailable && (
-        <span className="text-xs text-surface-500">Not in library</span>
-      )}
     </CoverCard>
   );
 }


### PR DESCRIPTION
## Summary
- Move "Not in library" from text below the card to a semi-transparent pill badge overlaid on the cover art (bottom-left), matching the player app's tag style
- Add generic `overlay` prop to `CoverCard` for positioning content over the cover image

## Test plan
- [ ] Open home page, verify "Not in library" badge appears bottom-left on top-rated cards that aren't in the library
- [ ] Verify cover art is visible through the semi-transparent badge
- [ ] Verify cards that are in the library have no badge