### PR TITLE
fix: address code review issues in scrape queue

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -237,7 +237,13 @@ func main() {
 
 	// Start background scrape worker (must start before auto-scan goroutine
 	// so any enqueued items get processed)
-	scrapeWorker := scraper.NewScrapeWorker(database, metaScraper.Queue, metaScraper, hub, nil)
+	scrapeWorker := scraper.NewScrapeWorker(database, metaScraper.Queue, metaScraper, hub, func() {
+		if merged, err := scanner.MergeGroupsByIGDBID(database); err != nil {
+			slog.Warn("IGDB group merge failed", "error", err)
+		} else if merged > 0 {
+			slog.Info("merged groups by IGDB ID", "merged", merged)
+		}
+	})
 	go scrapeWorker.Run(workerCtx)
 
 	// Auto-scan game library on startup (non-blocking).

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -330,6 +330,12 @@ func (h *AdminHandler) ScrapeGame(c *gin.Context) {
 	h.tryConfigureIGDB()
 	h.tryConfigureSteamGridDB()
 
+	// Skip if already queued
+	if queued, _ := h.Scraper.Queue.IsGameQueued(game.ID); queued {
+		c.JSON(http.StatusAccepted, gin.H{"status": "already_queued", "gameId": game.ID})
+		return
+	}
+
 	// Attach to active job if one exists
 	activeJob, _ := h.Scraper.Queue.GetActiveJob()
 	var jobID *uint

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -715,6 +715,12 @@ func (h *GameHandler) ScrapeIfNeeded(c *gin.Context) {
 		h.Scraper.ConfigureSteamGridDB(apiKey)
 	}
 
+	// Skip if already queued
+	if queued, _ := h.Scraper.Queue.IsGameQueued(game.ID); queued {
+		c.JSON(http.StatusAccepted, gin.H{"status": "already_queued"})
+		return
+	}
+
 	// Attach to active job if one exists
 	activeJob, _ := h.Scraper.Queue.GetActiveJob()
 	var jobID *uint

--- a/server/internal/scraper/queue.go
+++ b/server/internal/scraper/queue.go
@@ -83,6 +83,15 @@ func (q *ScrapeQueue) EnqueueGame(gameID uint, jobID *uint, priority int) error 
 	return nil
 }
 
+// IsGameQueued returns true if the game already has a pending or in_progress queue item.
+func (q *ScrapeQueue) IsGameQueued(gameID uint) (bool, error) {
+	var count int64
+	err := q.db.Model(&db.ScrapeQueueItem{}).
+		Where("game_id = ? AND status IN ?", gameID, []string{"pending", "in_progress"}).
+		Count(&count).Error
+	return count > 0, err
+}
+
 // Dequeue returns the next pending item (highest priority first, then oldest)
 // and marks it as in_progress. Returns nil if queue is empty.
 func (q *ScrapeQueue) Dequeue() (*db.ScrapeQueueItem, error) {
@@ -149,7 +158,7 @@ func (q *ScrapeQueue) finishItem(item *db.ScrapeQueueItem, status, errMsg string
 		if err := tx.First(&job, *item.JobID).Error; err != nil {
 			return err
 		}
-		if job.CompletedItems+job.FailedItems >= job.TotalItems {
+		if job.Status == "running" && job.CompletedItems+job.FailedItems >= job.TotalItems {
 			now := time.Now()
 			if err := tx.Model(&job).Updates(map[string]interface{}{
 				"status":       "completed",

--- a/server/internal/scraper/queue_test.go
+++ b/server/internal/scraper/queue_test.go
@@ -221,6 +221,64 @@ func TestCancelJob(t *testing.T) {
 	assert.Equal(t, int64(1), completedCount)
 }
 
+func TestCancelledJobNotOverwrittenByCompletion(t *testing.T) {
+	database := setupQueueTestDB(t)
+	q := NewScrapeQueue(database)
+
+	job, _ := q.CreateJob("all", "", "", "", 2)
+	require.NoError(t, q.EnqueueGames(job.ID, []uint{1, 2}, 0))
+
+	// Dequeue both items
+	item1, _ := q.Dequeue()
+	item2, _ := q.Dequeue()
+
+	// Complete the first
+	q.MarkCompleted(item1)
+
+	// Cancel the job while item2 is in_progress
+	require.NoError(t, q.CancelJob(job.ID))
+
+	// Complete the second item (simulates worker finishing current game)
+	jobDone, err := q.MarkCompleted(item2)
+	require.NoError(t, err)
+	assert.False(t, jobDone) // should NOT report done — job was cancelled
+
+	// Job should still be cancelled, not completed
+	var updatedJob db.ScrapeJob
+	database.First(&updatedJob, job.ID)
+	assert.Equal(t, "cancelled", updatedJob.Status)
+}
+
+func TestIsGameQueued(t *testing.T) {
+	database := setupQueueTestDB(t)
+	q := NewScrapeQueue(database)
+
+	// Not queued
+	queued, err := q.IsGameQueued(42)
+	require.NoError(t, err)
+	assert.False(t, queued)
+
+	// Enqueue it
+	require.NoError(t, q.EnqueueGame(42, nil, 0))
+	queued, err = q.IsGameQueued(42)
+	require.NoError(t, err)
+	assert.True(t, queued)
+
+	// Dequeue (in_progress) — still considered queued
+	q.Dequeue()
+	queued, err = q.IsGameQueued(42)
+	require.NoError(t, err)
+	assert.True(t, queued)
+
+	// Complete — no longer queued
+	var item db.ScrapeQueueItem
+	database.First(&item)
+	q.MarkCompleted(&item)
+	queued, err = q.IsGameQueued(42)
+	require.NoError(t, err)
+	assert.False(t, queued)
+}
+
 func TestResetInProgressItems(t *testing.T) {
 	database := setupQueueTestDB(t)
 	q := NewScrapeQueue(database)


### PR DESCRIPTION
## Summary

Follow-up to #395 — fixes 3 issues identified during code review:

- **Cancelled job overwrite**: `finishItem` could mark a cancelled job as "completed" when the last in-progress item finished. Added `job.Status == "running"` guard.
- **Duplicate enqueue**: `ScrapeGame` and `ScrapeIfNeeded` could enqueue the same game multiple times, inflating `total_items` and preventing job completion. Added `IsGameQueued` check.
- **Missing post-scrape step**: `MergeGroupsByIGDBID` (merges variant groups sharing the same IGDB ID) was lost when `ScrapeAll` was removed. Wired it into the `onJobComplete` callback.

## Test plan

- [x] New test: `TestCancelledJobNotOverwrittenByCompletion` — verifies cancelled job stays cancelled after in-progress item completes
- [x] New test: `TestIsGameQueued` — verifies deduplication across pending, in_progress, and completed states
- [x] All 17 queue tests pass
- [x] `go build ./...` clean