### PR TITLE
fix: cover art sizing, mobile layout, and dropdown overflow

### DIFF
--- a/web/src/components/cover-card.tsx
+++ b/web/src/components/cover-card.tsx
@@ -40,17 +40,17 @@ export function CoverCard({
   children,
 }: CoverCardProps) {
   const content = (
-    <div data-comp="CoverCard" className={cn(coverHeight ? "flex-shrink-0" : width, dimmed && "opacity-50")}>
+    <div data-comp="CoverCard" className={cn(coverHeight ? "flex-shrink-0 inline-block" : width, dimmed && "opacity-50")}>
       <div
-        className="relative w-full border border-surface-800/50"
-        style={coverHeight ? { height: coverHeight } : { aspectRatio }}
+        className="relative border border-surface-800/50"
+        style={coverHeight ? { height: coverHeight, width: "fit-content" } : { aspectRatio }}
       >
-        <CoverImage src={imageUrl} alt={title} className={coverHeight ? "h-full w-auto rounded-xl" : "w-full h-full rounded-xl"} />
+        <CoverImage src={imageUrl} alt={title} className={coverHeight ? "h-full w-auto rounded-xl" : "w-full h-full rounded-xl"} objectFit={coverHeight ? "contain" : "cover"} />
         {overlay && (
           <div className="absolute bottom-2 left-2 z-10">{overlay}</div>
         )}
       </div>
-      <div className="mt-2 px-0.5">
+      <div className={cn("mt-2 px-0.5", coverHeight && "w-0 min-w-full overflow-hidden")}>
         <p className="text-sm font-medium text-surface-200 truncate">
           {title}
         </p>

--- a/web/src/components/cover-image.tsx
+++ b/web/src/components/cover-image.tsx
@@ -6,6 +6,8 @@ interface CoverImageProps {
   /** Alt text for accessibility. First character used as placeholder. */
   alt: string;
   className?: string;
+  /** How the image fits its container. Default "cover" crops to fill. */
+  objectFit?: "cover" | "contain";
 }
 
 /**
@@ -15,7 +17,7 @@ interface CoverImageProps {
  * Handles image rendering with lazy loading and a character-based
  * placeholder when no image is available. Fills its container.
  */
-export function CoverImage({ src, alt, className }: CoverImageProps) {
+export function CoverImage({ src, alt, className, objectFit = "cover" }: CoverImageProps) {
   return (
     <div
       data-comp="CoverImage"
@@ -28,7 +30,7 @@ export function CoverImage({ src, alt, className }: CoverImageProps) {
         <img
           src={src}
           alt={alt}
-          className="h-full w-full object-cover"
+          className={cn("h-full w-full", objectFit === "cover" ? "object-cover" : "object-contain")}
           loading="lazy"
         />
       ) : (

--- a/web/src/components/game-card.tsx
+++ b/web/src/components/game-card.tsx
@@ -31,10 +31,10 @@ export function GameCard({
   const { ref, isScraping } = useAutoScrape(game);
 
   return (
-    <Link ref={ref} to={`/games/${game.id}`} data-comp="GameCard" className={cn("group block space-y-3", coverHeight && "flex-shrink-0")}>
+    <Link ref={ref} to={`/games/${game.id}`} data-comp="GameCard" className={cn("group block space-y-3", coverHeight && "flex-shrink-0 inline-block")}>
       <div
         className="relative rounded-2xl overflow-hidden bg-surface-900 border border-surface-800/50 transition-all duration-300 group-hover:border-surface-700/50 group-hover:shadow-xl group-hover:shadow-black/30 group-hover:-translate-y-1"
-        style={coverHeight ? { height: coverHeight } : undefined}
+        style={coverHeight ? { height: coverHeight, width: "fit-content" } : undefined}
       >
         {game.coverUrl ? (
           <img
@@ -126,7 +126,7 @@ export function GameCard({
         )}
       </div>
 
-      <div className="px-1 space-y-1">
+      <div className={cn("px-1 space-y-1", coverHeight && "w-0 min-w-full overflow-hidden")}>
         <h3 className="text-sm font-semibold text-surface-100 truncate group-hover:text-brand-400 transition-colors">
           {game.title}
         </h3>

--- a/web/src/components/ui/dropdown-menu.tsx
+++ b/web/src/components/ui/dropdown-menu.tsx
@@ -35,7 +35,7 @@ export function DropdownMenu({
         <div
           role="menu"
           className={cn(
-            "absolute top-full mt-2 z-40 rounded-xl bg-surface-900 border border-surface-800 shadow-2xl py-1 max-h-64 overflow-y-auto",
+            "absolute top-full mt-2 z-40 rounded-xl bg-surface-900 border border-surface-800 shadow-2xl py-1",
             align === "right" ? "right-0" : "left-0",
             className,
           )}

--- a/web/src/features/game-detail/components/cover-art-selector.tsx
+++ b/web/src/features/game-detail/components/cover-art-selector.tsx
@@ -18,14 +18,11 @@ export function CoverArtSelector({
   open,
   onClose,
 }: CoverArtSelectorProps) {
-  const { data, isLoading, isError } = useGameCovers(gameId);
+  const { data, isLoading } = useGameCovers(gameId);
   const setCover = useSetGameCover();
   const { toast } = useToast();
 
-  if (isLoading || isError || !data) return null;
-
-  // Only show if there are multiple cover options
-  if (data.covers.length < 2) return null;
+  const hasCovers = data && data.covers.length >= 2;
 
   function handleSelect(cover: CoverOption) {
     if (cover.source === data!.active && cover.source !== "libretro-regional") {
@@ -52,8 +49,15 @@ export function CoverArtSelector({
 
   return (
     <Modal open={open} onClose={onClose} title="Cover Art Source" size="lg">
+      {isLoading ? (
+        <p className="text-sm text-surface-400 py-4">Loading cover options...</p>
+      ) : !hasCovers ? (
+        <p className="text-sm text-surface-400 py-4">
+          No alternative cover art available. Scrape the game&apos;s metadata to find cover options from different sources.
+        </p>
+      ) : (
       <div className="flex flex-wrap gap-4" data-testid="cover-art-selector">
-        {data.covers.map((cover, index) => {
+        {data!.covers.map((cover, index) => {
           const isActive =
             cover.source === data.active &&
             cover.source !== "libretro-regional";
@@ -105,6 +109,7 @@ export function CoverArtSelector({
           );
         })}
       </div>
+      )}
     </Modal>
   );
 }

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -15,7 +15,7 @@ import {
   Monitor,
   Replace,
 } from "lucide-react";
-import { CoverImage } from "@/components/cover-image";
+import { AreaSizedImage } from "@/components/area-sized-image";
 import { Button, Badge, ActionsMenu } from "@/components/ui";
 import { ConsoleBadge } from "@/components/console-badge";
 import { VerificationBadge } from "./verification-badge";
@@ -83,6 +83,11 @@ export function GameHero({
   const actionsMenuItems = [
     ...(isAdmin
       ? [
+          {
+            label: "Change Cover",
+            icon: <ImageIcon className="h-4 w-4" />,
+            onClick: () => setShowCoverModal(true),
+          },
           {
             label: "Scrape Metadata",
             icon: <RefreshCw className="h-4 w-4" />,
@@ -175,21 +180,23 @@ export function GameHero({
         {/* Content overlay */}
         <div className="relative z-10 flex flex-col items-center md:flex-row md:items-end min-h-[320px] md:min-h-[400px] p-6 md:p-8 gap-6 md:gap-8">
           {/* Cover art */}
-          <div className="flex-shrink-0 w-40 md:w-64 self-center md:self-end">
+          <div className="flex-shrink-0 self-center md:self-end">
             <div className="rounded-xl overflow-hidden bg-surface-900/80 border border-white/10 shadow-2xl backdrop-blur-sm">
-              <CoverImage src={game.coverUrl} alt={game.title} className="w-full h-auto" />
-            </div>
-            <div className="flex justify-center mt-2">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => setShowCoverModal(true)}
-                className="text-white/60 hover:text-white/90 text-xs"
-                data-testid="change-cover-btn"
-              >
-                <ImageIcon className="h-3 w-3" />
-                Change cover
-              </Button>
+              {game.coverUrl ? (
+                <AreaSizedImage
+                  src={game.coverUrl}
+                  alt={game.title}
+                  targetArea={55000}
+                  maxHeight={360}
+                  maxWidth={320}
+                  minHeight={160}
+                  className="rounded-xl"
+                />
+              ) : (
+                <div className="w-48 flex items-center justify-center bg-surface-800" style={{ aspectRatio: "3/4" }}>
+                  <span className="text-3xl font-bold text-surface-600">{game.title.charAt(0).toUpperCase()}</span>
+                </div>
+              )}
             </div>
             <CoverArtSelector
               open={showCoverModal}

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -161,9 +161,9 @@ export function GameHero({
   ];
 
   return (
-    <div className="relative overflow-hidden">
+    <div className="relative">
       {/* Hero banner background */}
-      <div className="relative min-h-[320px] md:min-h-[400px]">
+      <div className="relative min-h-[320px] md:min-h-[400px] overflow-hidden">
         {heroImage ? (
           <img
             src={heroImage}
@@ -176,10 +176,11 @@ export function GameHero({
 
         {/* Subtle bottom gradient — just enough for transition to page background */}
         <div className="absolute inset-0 bg-gradient-to-t from-surface-950 via-transparent to-transparent" />
+      </div>
 
-        {/* Content overlay */}
-        <div className="relative z-10 flex flex-col items-center md:flex-row md:items-end min-h-[320px] md:min-h-[400px] p-6 md:p-8 gap-6 md:gap-8">
-          {/* Cover art */}
+      {/* Content overlay — outside overflow-hidden so dropdowns aren't clipped */}
+      <div className="absolute inset-0 z-10 flex flex-col items-center md:flex-row md:items-end min-h-[320px] md:min-h-[400px] p-6 md:p-8 gap-6 md:gap-8">
+        {/* Cover art */}
           <div className="flex-shrink-0 self-center md:self-end">
             <div className="rounded-xl overflow-hidden bg-surface-900/80 border border-white/10 shadow-2xl backdrop-blur-sm">
               {game.coverUrl ? (
@@ -306,8 +307,6 @@ export function GameHero({
           </div>
         </div>
       </div>
-
-    </div>
   );
 }
 

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -173,9 +173,9 @@ export function GameHero({
         <div className="absolute inset-0 bg-gradient-to-t from-surface-950 via-transparent to-transparent" />
 
         {/* Content overlay */}
-        <div className="relative z-10 flex items-end min-h-[320px] md:min-h-[400px] p-6 md:p-8 gap-6 md:gap-8">
+        <div className="relative z-10 flex flex-col items-center md:flex-row md:items-end min-h-[320px] md:min-h-[400px] p-6 md:p-8 gap-6 md:gap-8">
           {/* Cover art */}
-          <div className="flex-shrink-0 w-36 md:w-48 self-end">
+          <div className="flex-shrink-0 w-40 md:w-64 self-center md:self-end">
             <div className="rounded-xl overflow-hidden bg-surface-900/80 border border-white/10 shadow-2xl backdrop-blur-sm">
               <CoverImage src={game.coverUrl} alt={game.title} className="w-full h-auto" />
             </div>

--- a/web/src/lib/carousel-constants.ts
+++ b/web/src/lib/carousel-constants.ts
@@ -1,5 +1,5 @@
 /** Fixed height (px) for game cards in carousel shelves. */
-export const CAROUSEL_CARD_HEIGHT = 240;
+export const CAROUSEL_CARD_HEIGHT = 200;
 
 /** Default aspect ratio (width/height) for placeholder/skeleton cards. */
 export const CAROUSEL_DEFAULT_ASPECT_RATIO = 3 / 4;


### PR DESCRIPTION
## Summary

- Reduce carousel card height from 240px to 200px for better proportions
- Fix carousel cover cropping by using `object-contain` instead of `object-cover`
- Constrain card width to image width so titles truncate instead of expanding cards
- Use `AreaSizedImage` for game detail hero cover (consistent visual area regardless of aspect ratio)
- Stack cover art above info box on mobile (below `md:` breakpoint), centered
- Move "Change cover" button into the actions menu
- Fix actions menu being clipped by `overflow-hidden` on hero container
- Fix `CoverArtSelector` to show helpful message when no alternative covers exist
- Remove `max-h-64 overflow-y-auto` from `DropdownMenu` to prevent unnecessary scrollbar

## Test plan

- [x] Carousel cards: image-width driven, titles truncate, no grey padding
- [x] Game detail hero: cover art uses area-based sizing
- [x] Mobile: cover stacks above info box (centered)
- [x] Actions menu: not clipped, no scrollbar
- [x] "Change Cover" in actions menu opens modal (with empty state message)
- [x] `tsc -b` clean, `vite build` clean