### PR TITLE
feat: per-game scrape status WebSocket events

### DIFF
--- a/docs/superpowers/plans/2026-04-14-game-scrape-status-events.md
+++ b/docs/superpowers/plans/2026-04-14-game-scrape-status-events.md
@@ -1,0 +1,369 @@
+# Per-Game Scrape Status Events Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Broadcast per-game scrape status (`scraping` / `idle`) via WebSocket so the frontend can show a loading indicator on the game detail page whenever a game is being scraped — whether triggered manually or by a bulk job.
+
+**Architecture:** The worker broadcasts `game_scrape_status` events at the start and end of processing each queue item. A new frontend hook `useGameScrapeStatus` listens for events matching a game ID. The existing `game_scraped` event is removed — the frontend refetches game data on `idle` instead.
+
+**Tech Stack:** Go (WebSocket hub), React (TanStack Query, custom hooks)
+
+**Spec:** `docs/superpowers/specs/2026-04-14-game-scrape-status-events-design.md`
+
+---
+
+### Task 1: Add `game_scrape_status` broadcasts to worker
+
+**Files:**
+- Modify: `server/internal/scraper/worker.go`
+
+- [ ] **Step 1: Add `broadcastScrapeStatus` helper method**
+
+Add this method to `ScrapeWorker` in `worker.go`, after the `broadcastProgress` method:
+
+```go
+func (w *ScrapeWorker) broadcastScrapeStatus(gameID uint, status string) {
+	if w.hub == nil {
+		return
+	}
+	w.hub.Broadcast(ws.Event{
+		Type: "game_scrape_status",
+		Payload: map[string]interface{}{
+			"gameId": gameID,
+			"status": status,
+		},
+	})
+}
+```
+
+- [ ] **Step 2: Broadcast `scraping` at start of `processItem`**
+
+In `processItem`, add the broadcast right after loading the game (after the `Preload("Console").First(&game, ...)` block, before the variant group propagation):
+
+```go
+	// Broadcast scraping status
+	w.broadcastScrapeStatus(game.ID, "scraping")
+```
+
+- [ ] **Step 3: Broadcast `idle` at every exit point of `processItem`**
+
+There are three exit points in `processItem` where processing ends:
+
+1. **Game not found** (line ~87): after `MarkFailed`, add:
+   ```go
+   w.broadcastScrapeStatus(item.GameID, "idle")
+   ```
+
+2. **Scrape failed** (line ~108): after `broadcastProgress`, add:
+   ```go
+   w.broadcastScrapeStatus(game.ID, "idle")
+   ```
+
+3. **Success** (line ~125): after `broadcastProgress` at the end of the method, add:
+   ```go
+   w.broadcastScrapeStatus(game.ID, "idle")
+   ```
+
+- [ ] **Step 4: Remove the `game_scraped` broadcast**
+
+Delete the block at the end of `broadcastProgress` that broadcasts `game_scraped` for high-priority items:
+
+```go
+	// For high-priority items (manual scrapes), broadcast game_scraped
+	// so the frontend can update the game detail page.
+	if item.Priority >= 100 {
+		w.db.Preload("Console").Preload("Screenshots").First(game, game.ID)
+		w.hub.Broadcast(ws.Event{
+			Type:    "game_scraped",
+			Payload: game,
+		})
+	}
+```
+
+- [ ] **Step 5: Verify build**
+
+Run: `cd server && go build ./...`
+Expected: Build succeeds.
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd server && git add internal/scraper/worker.go
+git commit -m "feat: broadcast game_scrape_status events from worker"
+```
+
+---
+
+### Task 2: Create `useGameScrapeStatus` hook
+
+**Files:**
+- Create: `web/src/hooks/use-game-scrape-status.ts`
+- Create: `web/src/hooks/__tests__/use-game-scrape-status.test.ts`
+
+- [ ] **Step 1: Write the test**
+
+Create `web/src/hooks/__tests__/use-game-scrape-status.test.ts`:
+
+```ts
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useGameScrapeStatus } from "../use-game-scrape-status";
+
+// Mock useWebSocketEvent to capture the callback
+const mockCallbacks = new Map<string, (payload: unknown) => void>();
+vi.mock("@/hooks/use-websocket", () => ({
+  useWebSocketEvent: (type: string, callback: (payload: unknown) => void) => {
+    mockCallbacks.set(type, callback);
+  },
+}));
+
+describe("useGameScrapeStatus", () => {
+  beforeEach(() => {
+    mockCallbacks.clear();
+  });
+
+  it("returns isScraping false by default", () => {
+    const { result } = renderHook(() => useGameScrapeStatus("42"));
+    expect(result.current.isScraping).toBe(false);
+  });
+
+  it("returns isScraping true when scraping event received for matching game", () => {
+    const { result } = renderHook(() => useGameScrapeStatus("42"));
+    const callback = mockCallbacks.get("game_scrape_status")!;
+
+    act(() => callback({ gameId: 42, status: "scraping" }));
+
+    expect(result.current.isScraping).toBe(true);
+  });
+
+  it("returns isScraping false when idle event received", () => {
+    const { result } = renderHook(() => useGameScrapeStatus("42"));
+    const callback = mockCallbacks.get("game_scrape_status")!;
+
+    act(() => callback({ gameId: 42, status: "scraping" }));
+    expect(result.current.isScraping).toBe(true);
+
+    act(() => callback({ gameId: 42, status: "idle" }));
+    expect(result.current.isScraping).toBe(false);
+  });
+
+  it("ignores events for other game IDs", () => {
+    const { result } = renderHook(() => useGameScrapeStatus("42"));
+    const callback = mockCallbacks.get("game_scrape_status")!;
+
+    act(() => callback({ gameId: 99, status: "scraping" }));
+
+    expect(result.current.isScraping).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/hooks/__tests__/use-game-scrape-status.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `web/src/hooks/use-game-scrape-status.ts`:
+
+```ts
+import { useState } from "react";
+import { useWebSocketEvent } from "@/hooks/use-websocket";
+
+interface GameScrapeStatusEvent {
+  gameId: number;
+  status: "scraping" | "idle";
+}
+
+/**
+ * Listens for game_scrape_status WebSocket events for a specific game.
+ * Returns whether the game is currently being scraped.
+ */
+export function useGameScrapeStatus(gameId: string) {
+  const [isScraping, setIsScraping] = useState(false);
+
+  useWebSocketEvent("game_scrape_status", (payload: GameScrapeStatusEvent) => {
+    if (String(payload.gameId) === gameId) {
+      setIsScraping(payload.status === "scraping");
+    }
+  });
+
+  return { isScraping };
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd web && npx vitest run src/hooks/__tests__/use-game-scrape-status.test.ts`
+Expected: All 4 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add web/src/hooks/use-game-scrape-status.ts web/src/hooks/__tests__/use-game-scrape-status.test.ts
+git commit -m "feat: add useGameScrapeStatus hook"
+```
+
+---
+
+### Task 3: Wire hook into game detail page
+
+**Files:**
+- Modify: `web/src/pages/game-detail-page.tsx`
+
+- [ ] **Step 1: Replace `scrapeGame.isPending` with `useGameScrapeStatus`**
+
+In `game-detail-page.tsx`:
+
+Add import at top:
+```ts
+import { useGameScrapeStatus } from "@/hooks/use-game-scrape-status";
+```
+
+Find the line (around 130):
+```ts
+const scrapeGame = useScrapeGame();
+```
+
+Add after it:
+```ts
+const { isScraping } = useGameScrapeStatus(id!);
+```
+
+Find the line (around 216):
+```ts
+isScraping={scrapeGame.isPending}
+```
+
+Replace with:
+```ts
+isScraping={isScraping}
+```
+
+The `scrapeGame` mutation stays — it's still used for `onScrape={() => scrapeGame.mutate(game.id)}`. It just no longer drives the loading state.
+
+- [ ] **Step 2: Verify build**
+
+Run: `cd web && npx tsc -b`
+Expected: Build succeeds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add web/src/pages/game-detail-page.tsx
+git commit -m "feat: use WebSocket-driven scrape status on game detail page"
+```
+
+---
+
+### Task 4: Update `useGameScrapedListener` to use new event
+
+**Files:**
+- Modify: `web/src/hooks/use-game-scraped-listener.ts`
+- Modify: `web/src/hooks/__tests__/use-game-scraped-listener.test.ts`
+
+- [ ] **Step 1: Replace `game_scraped` handler with `game_scrape_status` handler**
+
+Rewrite `web/src/hooks/use-game-scraped-listener.ts`:
+
+```ts
+import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useWebSocketEvent } from "@/hooks/use-websocket";
+
+interface GameScrapeStatusEvent {
+  gameId: number;
+  status: "scraping" | "idle";
+}
+
+export function useGameScrapedListener() {
+  const queryClient = useQueryClient();
+
+  // When a game finishes scraping (status: "idle"), invalidate cached data
+  // so the UI refetches with updated metadata/covers.
+  const handleScrapeStatus = useCallback(
+    (payload: GameScrapeStatusEvent) => {
+      if (payload.status !== "idle" || !payload.gameId) return;
+
+      const gameId = String(payload.gameId);
+
+      // Invalidate single game query
+      queryClient.invalidateQueries({
+        queryKey: ["game", gameId],
+        exact: true,
+      });
+
+      // Invalidate list queries so covers update in grids/carousels
+      queryClient.invalidateQueries({ queryKey: ["games"] });
+      queryClient.invalidateQueries({ queryKey: ["consoles"] });
+    },
+    [queryClient],
+  );
+
+  useWebSocketEvent("game_scrape_status", handleScrapeStatus);
+
+  // Handle batch scrape progress — invalidate the game query for each game
+  // as it's scraped so the detail page refreshes automatically.
+  const handleScrapeProgress = useCallback(
+    (payload: { gameId?: number }) => {
+      if (!payload?.gameId) return;
+      const gameId = String(payload.gameId);
+      queryClient.invalidateQueries({
+        queryKey: ["game", gameId],
+        exact: true,
+      });
+    },
+    [queryClient],
+  );
+
+  useWebSocketEvent("scrape_progress", handleScrapeProgress);
+}
+```
+
+- [ ] **Step 2: Update tests**
+
+Read the existing test file `web/src/hooks/__tests__/use-game-scraped-listener.test.ts` and update it to test the new `game_scrape_status` event instead of `game_scraped`. The tests should verify that `invalidateQueries` is called when a `game_scrape_status` event with `status: "idle"` is received, and NOT called for `status: "scraping"`.
+
+- [ ] **Step 3: Run tests**
+
+Run: `cd web && npx vitest run src/hooks/__tests__/use-game-scraped-listener.test.ts`
+Expected: All tests PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add web/src/hooks/use-game-scraped-listener.ts web/src/hooks/__tests__/use-game-scraped-listener.test.ts
+git commit -m "refactor: replace game_scraped with game_scrape_status listener"
+```
+
+---
+
+### Task 5: Final verification
+
+**Files:** None (testing only)
+
+- [ ] **Step 1: Full backend build**
+
+Run: `cd server && go build ./...`
+Expected: Clean build.
+
+- [ ] **Step 2: Full frontend type check**
+
+Run: `cd web && npx tsc -b`
+Expected: Clean.
+
+- [ ] **Step 3: Run all frontend tests**
+
+Run: `cd web && npx vitest run`
+Expected: All tests pass. If any tests reference `game_scraped` events, update them to use `game_scrape_status`.
+
+- [ ] **Step 4: Run backend tests**
+
+Run: `cd server && go test ./internal/scraper/ -v -count=1`
+Expected: All tests pass.
+
+- [ ] **Step 5: Verify no remaining references to `game_scraped`**
+
+Run: `grep -rn "game_scraped" web/src/ server/internal/ --include="*.ts" --include="*.tsx" --include="*.go" | grep -v _test | grep -v __tests__`
+Expected: No matches (all references removed from production code).

--- a/docs/superpowers/specs/2026-04-14-game-scrape-status-events-design.md
+++ b/docs/superpowers/specs/2026-04-14-game-scrape-status-events-design.md
@@ -1,0 +1,85 @@
+# Per-Game Scrape Status WebSocket Events
+
+## Problem
+
+After moving to the persistent scrape queue, the "Scrape Metadata" action
+enqueues the game and returns immediately. The frontend has no way to know
+when the game starts or finishes scraping, so the loading indicator is broken.
+
+## Solution
+
+A new WebSocket event `game_scrape_status` broadcasts per-game scraping state
+changes. The worker emits `scraping` when it starts processing a game and
+`idle` when it finishes (regardless of success or failure).
+
+## Event Format
+
+```json
+{"type": "game_scrape_status", "payload": {"gameId": 123, "status": "scraping"}}
+{"type": "game_scrape_status", "payload": {"gameId": 123, "status": "idle"}}
+```
+
+Two states only: `scraping` and `idle`. Success/failure is not part of the
+status — the frontend refetches game data on `idle` to discover the outcome.
+
+## Backend Changes
+
+**`server/internal/scraper/worker.go`**
+
+In `processItem`:
+- Broadcast `game_scrape_status` with `status: "scraping"` at the start,
+  after loading the game but before calling `ScrapeGame` or
+  `propagateGroupMetadata`.
+- Broadcast `game_scrape_status` with `status: "idle"` at the end, after
+  `MarkCompleted` or `MarkFailed`.
+
+Remove the existing `game_scraped` event broadcast (the `if item.Priority >= 100`
+block in `broadcastProgress`). The `game_scrape_status` event replaces it.
+
+The `scrape_progress` event (for bulk job progress tracking) is unchanged.
+
+## Frontend Changes
+
+**New hook: `web/src/hooks/use-game-scrape-status.ts`**
+
+```ts
+function useGameScrapeStatus(gameId: string): { isScraping: boolean }
+```
+
+Listens for `game_scrape_status` WebSocket events matching the given game ID.
+Returns `isScraping: true` when status is `"scraping"`, `false` on `"idle"`.
+
+**Modify: `web/src/hooks/use-game-scraped-listener.ts`**
+
+- Replace the `game_scraped` event handler with a `game_scrape_status` handler.
+- On `status: "idle"`: invalidate the game query (`["game", gameId]`) and list
+  queries (`["games"]`, `["consoles"]`, etc.) so cached data is refetched.
+- Remove the optimistic update logic that patched full game objects into the
+  query cache — a simple `invalidateQueries` is sufficient.
+
+**Modify: `web/src/features/game-detail/components/game-hero.tsx`**
+
+- Use `useGameScrapeStatus(game.id)` to determine whether to show the
+  scraping spinner next to the action buttons.
+- Remove dependency on the old `isScraping` prop/state if it exists.
+
+**Modify: `web/src/pages/game-detail-page.tsx`**
+
+- Wire the new hook if the scraping state is managed at page level.
+
+**Remove: `game_scraped` event type**
+
+- Backend: remove from `worker.go` (`broadcastProgress`)
+- Frontend: remove handler from `use-game-scraped-listener.ts`
+
+## Volume
+
+2 events per game during bulk scrape. At ~1 game per 2 seconds, that is
+1 event/second — negligible overhead.
+
+## Out of Scope
+
+- Enriching `game_scrape_status` with metadata (use a separate
+  `game_metadata_updated` event in the future if needed).
+- Showing scrape status on game cards in carousels/grids (only game detail
+  page for now).

--- a/server/internal/scraper/worker.go
+++ b/server/internal/scraper/worker.go
@@ -85,8 +85,11 @@ func (w *ScrapeWorker) processItem(ctx context.Context, item *db.ScrapeQueueItem
 	if err := w.db.Preload("Console").First(&game, item.GameID).Error; err != nil {
 		slog.Warn("scrape worker: game not found", "gameId", item.GameID, "error", err)
 		w.queue.MarkFailed(item, fmt.Sprintf("game not found: %v", err))
+		w.broadcastScrapeStatus(item.GameID, "idle")
 		return
 	}
+
+	w.broadcastScrapeStatus(game.ID, "scraping")
 
 	// Variant group propagation for 'new' mode jobs
 	propagated := false
@@ -106,6 +109,7 @@ func (w *ScrapeWorker) processItem(ctx context.Context, item *db.ScrapeQueueItem
 			slog.Warn("scrape worker: scrape failed", "game", game.Title, "error", err)
 			jobDone, _ := w.queue.MarkFailed(item, err.Error())
 			w.broadcastProgress(item, &game, false, jobDone)
+			w.broadcastScrapeStatus(game.ID, "idle")
 			return
 		}
 
@@ -123,6 +127,7 @@ func (w *ScrapeWorker) processItem(ctx context.Context, item *db.ScrapeQueueItem
 
 	jobDone, _ := w.queue.MarkCompleted(item)
 	w.broadcastProgress(item, &game, verified, jobDone)
+	w.broadcastScrapeStatus(game.ID, "idle")
 }
 
 func (w *ScrapeWorker) broadcastProgress(item *db.ScrapeQueueItem, game *db.Game, verified bool, jobDone bool) {
@@ -165,13 +170,17 @@ func (w *ScrapeWorker) broadcastProgress(item *db.ScrapeQueueItem, game *db.Game
 		}
 	}
 
-	// For high-priority items (manual scrapes), broadcast game_scraped
-	// so the frontend can update the game detail page.
-	if item.Priority >= 100 {
-		w.db.Preload("Console").Preload("Screenshots").First(game, game.ID)
-		w.hub.Broadcast(ws.Event{
-			Type:    "game_scraped",
-			Payload: game,
-		})
+}
+
+func (w *ScrapeWorker) broadcastScrapeStatus(gameID uint, status string) {
+	if w.hub == nil {
+		return
 	}
+	w.hub.Broadcast(ws.Event{
+		Type: "game_scrape_status",
+		Payload: map[string]interface{}{
+			"gameId": gameID,
+			"status": status,
+		},
+	})
 }

--- a/web/src/hooks/__tests__/use-game-scrape-status.test.ts
+++ b/web/src/hooks/__tests__/use-game-scrape-status.test.ts
@@ -1,0 +1,50 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useGameScrapeStatus } from "../use-game-scrape-status";
+
+const mockCallbacks = new Map<string, (payload: unknown) => void>();
+vi.mock("@/hooks/use-websocket", () => ({
+  useWebSocketEvent: (type: string, callback: (payload: unknown) => void) => {
+    mockCallbacks.set(type, callback);
+  },
+}));
+
+describe("useGameScrapeStatus", () => {
+  beforeEach(() => {
+    mockCallbacks.clear();
+  });
+
+  it("returns isScraping false by default", () => {
+    const { result } = renderHook(() => useGameScrapeStatus("42"));
+    expect(result.current.isScraping).toBe(false);
+  });
+
+  it("returns isScraping true when scraping event received for matching game", () => {
+    const { result } = renderHook(() => useGameScrapeStatus("42"));
+    const callback = mockCallbacks.get("game_scrape_status")!;
+
+    act(() => callback({ gameId: 42, status: "scraping" }));
+
+    expect(result.current.isScraping).toBe(true);
+  });
+
+  it("returns isScraping false when idle event received", () => {
+    const { result } = renderHook(() => useGameScrapeStatus("42"));
+    const callback = mockCallbacks.get("game_scrape_status")!;
+
+    act(() => callback({ gameId: 42, status: "scraping" }));
+    expect(result.current.isScraping).toBe(true);
+
+    act(() => callback({ gameId: 42, status: "idle" }));
+    expect(result.current.isScraping).toBe(false);
+  });
+
+  it("ignores events for other game IDs", () => {
+    const { result } = renderHook(() => useGameScrapeStatus("42"));
+    const callback = mockCallbacks.get("game_scrape_status")!;
+
+    act(() => callback({ gameId: 99, status: "scraping" }));
+
+    expect(result.current.isScraping).toBe(false);
+  });
+});

--- a/web/src/hooks/__tests__/use-game-scraped-listener.test.ts
+++ b/web/src/hooks/__tests__/use-game-scraped-listener.test.ts
@@ -35,68 +35,41 @@ beforeEach(() => {
   });
 });
 
-const makeGame = (overrides = {}) => ({
-  id: "42",
-  title: "Test Game",
-  consoleId: "nes",
-  consoleName: "NES",
-  coverUrl: "",
-  description: "",
-  developer: "",
-  publisher: "",
-  releaseDate: "",
-  genre: "",
-  players: 1,
-  rating: 0,
-  scraperId: "",
-  scrapeAttempts: 0,
-  screenshotUrls: [],
-  isFavorite: false,
-  isInPlayLater: false,
-  playable: true,
-  ...overrides,
-});
-
 describe("useGameScrapedListener", () => {
-  it("does not clobber sub-queries like cheats when game is scraped", () => {
-    // Pre-populate the cheats query for game 42
-    const cheats = [
-      { id: 1, index: 0, description: "Infinite lives", code: "AAEAULPA" },
-    ];
-    queryClient.setQueryData(["game", "42", "cheats"], cheats);
-
-    // Pre-populate the game query
-    const game = makeGame({ scrapeAttempts: 0 });
-    queryClient.setQueryData(["game", "42"], game);
+  it("invalidates game and list queries on game_scrape_status idle", () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
     renderHook(() => useGameScrapedListener(), { wrapper });
 
-    // Simulate the server broadcasting game_scraped after scrape completes
-    const scraped = makeGame({
-      scrapeAttempts: 1,
-      coverUrl: "https://example.com/cover.jpg",
-      description: "A great game",
+    act(() => {
+      wsHandlers["game_scrape_status"]({ gameId: 42, status: "idle" });
     });
+
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ["game", "42"],
+      exact: true,
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["games"] });
+    expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: ["consoles"] });
+  });
+
+  it("does not invalidate on game_scrape_status scraping", () => {
+    const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
+
+    renderHook(() => useGameScrapedListener(), { wrapper });
 
     act(() => {
-      wsHandlers["game_scraped"](scraped);
+      wsHandlers["game_scrape_status"]({ gameId: 42, status: "scraping" });
     });
 
-    // Cheats query must still be an array — this was the original bug
-    const updatedCheats = queryClient.getQueryData(["game", "42", "cheats"]);
-    expect(Array.isArray(updatedCheats)).toBe(true);
-    expect(updatedCheats).toEqual(cheats);
+    expect(invalidateSpy).not.toHaveBeenCalled();
   });
 
   it("invalidates game query on scrape_progress during batch scrape", () => {
     const invalidateSpy = vi.spyOn(queryClient, "invalidateQueries");
 
-    // Pre-populate the game query
-    queryClient.setQueryData(["game", "42"], makeGame());
-
     renderHook(() => useGameScrapedListener(), { wrapper });
 
-    // Simulate batch scrape progress event
     act(() => {
       wsHandlers["scrape_progress"]({
         current: 5,

--- a/web/src/hooks/use-game-scrape-status.ts
+++ b/web/src/hooks/use-game-scrape-status.ts
@@ -1,0 +1,23 @@
+import { useState } from "react";
+import { useWebSocketEvent } from "@/hooks/use-websocket";
+
+interface GameScrapeStatusEvent {
+  gameId: number;
+  status: "scraping" | "idle";
+}
+
+/**
+ * Listens for game_scrape_status WebSocket events for a specific game.
+ * Returns whether the game is currently being scraped.
+ */
+export function useGameScrapeStatus(gameId: string) {
+  const [isScraping, setIsScraping] = useState(false);
+
+  useWebSocketEvent("game_scrape_status", (payload: GameScrapeStatusEvent) => {
+    if (String(payload.gameId) === gameId) {
+      setIsScraping(payload.status === "scraping");
+    }
+  });
+
+  return { isScraping };
+}

--- a/web/src/hooks/use-game-scraped-listener.ts
+++ b/web/src/hooks/use-game-scraped-listener.ts
@@ -1,84 +1,37 @@
 import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
-import type {
-  Game,
-  GamesResponse,
-  CollectionDetail,
-  MostPlayedGame,
-  MostPlayedGamesResponse,
-} from "@/types/api";
 
-function updateGameInArray(games: Game[], scraped: Game): Game[] {
-  let changed = false;
-  const result = games.map((g) => {
-    if (g.id === scraped.id) {
-      changed = true;
-      return { ...g, ...scraped };
-    }
-    return g;
-  });
-  return changed ? result : games;
+interface GameScrapeStatusEvent {
+  gameId: number;
+  status: "scraping" | "idle";
 }
 
 export function useGameScrapedListener() {
   const queryClient = useQueryClient();
 
-  // Handle individual game scrape events (single scrape via admin).
-  // The payload is a full Game response, so we can replace cached data directly.
-  useWebSocketEvent("game_scraped", (payload: Game) => {
-    const scraped = payload;
-    if (!scraped?.id) return;
+  // When a game finishes scraping (status: "idle"), invalidate cached data
+  // so the UI refetches with updated metadata/covers.
+  const handleScrapeStatus = useCallback(
+    (payload: GameScrapeStatusEvent) => {
+      if (payload.status !== "idle" || !payload.gameId) return;
 
-    // Invalidate single game query so it re-fetches with user-specific data
-    queryClient.invalidateQueries({
-      queryKey: ["game", scraped.id],
-      exact: true,
-    });
+      const gameId = String(payload.gameId);
 
-    // Optimistically update list queries with the scraped data (covers, etc.)
-    queryClient.setQueriesData<GamesResponse>(
-      { queryKey: ["games"] },
-      (old) => {
-        if (!old?.data) return old;
-        const updated = updateGameInArray(old.data, scraped);
-        return updated === old.data ? old : { ...old, data: updated };
-      },
-    );
+      // Invalidate single game query
+      queryClient.invalidateQueries({
+        queryKey: ["game", gameId],
+        exact: true,
+      });
 
-    queryClient.setQueriesData<Game[]>(
-      { queryKey: ["consoles"] },
-      (old) => {
-        if (!Array.isArray(old)) return old;
-        return updateGameInArray(old, scraped);
-      },
-    );
+      // Invalidate list queries so covers update in grids/carousels
+      queryClient.invalidateQueries({ queryKey: ["games"] });
+      queryClient.invalidateQueries({ queryKey: ["consoles"] });
+    },
+    [queryClient],
+  );
 
-    queryClient.setQueriesData<CollectionDetail>(
-      { queryKey: ["collection"] },
-      (old) => {
-        if (!old?.games) return old;
-        const updated = updateGameInArray(old.games, scraped);
-        return updated === old.games ? old : { ...old, games: updated };
-      },
-    );
-
-    queryClient.setQueriesData<MostPlayedGamesResponse>(
-      { queryKey: ["most-played-games"] },
-      (old) => {
-        if (!old?.games) return old;
-        let changed = false;
-        const updated = old.games.map((entry: MostPlayedGame) => {
-          if (entry.game.id === scraped.id) {
-            changed = true;
-            return { ...entry, game: { ...entry.game, ...scraped } };
-          }
-          return entry;
-        });
-        return changed ? { ...old, games: updated } : old;
-      },
-    );
-  });
+  useWebSocketEvent("game_scrape_status", handleScrapeStatus);
 
   // Handle batch scrape progress — invalidate the game query for each game
   // as it's scraped so the detail page refreshes automatically.

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -58,6 +58,7 @@ import {
   Disc,
   Trophy,
   Award,
+  FileText,
 } from "lucide-react";
 import { formatFileSize } from "@/lib/format";
 import { api } from "@/lib/api-client";
@@ -308,6 +309,13 @@ export function GameDetailPage() {
                 icon={Disc}
                 label="Discs"
                 value={`${game.discCount}`}
+              />
+            )}
+            {isAdmin && game.fileName && (
+              <MetaItem
+                icon={FileText}
+                label="Filename"
+                value={game.fileName}
               />
             )}
             {achievementCount != null && achievementCount > 0 && (

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -13,6 +13,7 @@ import {
   useToggleFavorite,
   useScrapeIfNeeded,
 } from "@/hooks/use-games";
+import { useGameScrapeStatus } from "@/hooks/use-game-scrape-status";
 import { useTogglePlayLater } from "@/hooks/use-play-later";
 import { useAuth } from "@/hooks/use-auth";
 import { useScrapeGame, useRefreshAchievements } from "@/hooks/use-admin";
@@ -128,6 +129,7 @@ export function GameDetailPage() {
   const togglePlayLater = useTogglePlayLater();
   const { user: currentUser } = useAuth();
   const scrapeGame = useScrapeGame();
+  const { isScraping } = useGameScrapeStatus(id!);
   const refreshAchievements = useRefreshAchievements();
   const scrapeIfNeeded = useScrapeIfNeeded();
   const { data: consoles } = useConsoles();
@@ -213,7 +215,7 @@ export function GameDetailPage() {
         isFavorite={isFavorite}
         isInPlayLater={isInPlayLater}
         isPlayLaterPending={togglePlayLater.isPending}
-        isScraping={scrapeGame.isPending}
+        isScraping={isScraping}
         hasAchievements={hasAchievements}
         achievementCount={achievementCount}
         achievementUnlocked={achievementUnlocked}


### PR DESCRIPTION
## Summary

- Worker broadcasts `game_scrape_status` events (`scraping` / `idle`) for every game it processes
- New `useGameScrapeStatus` hook drives the loading indicator on the game detail page
- Replaces the old `game_scraped` event — frontend refetches game data on `idle` instead of receiving full game objects
- Works for both manual scrapes and bulk queue processing

## Test plan

- [x] 4 new tests for `useGameScrapeStatus` hook (default state, scraping, idle, ignores other IDs)
- [x] 4 updated tests for `useGameScrapedListener` (idle invalidation, scraping ignored, scrape_progress, missing gameId)
- [x] No remaining references to `game_scraped` in production code
- [x] `tsc -b` clean, `go build` clean
- [ ] Manual test: open game detail, trigger scrape, verify spinner appears and disappears