### PR TITLE
feat: use game_scrape_status WebSocket events in player app

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/PresenceService.kt
@@ -1,8 +1,6 @@
 package com.spela.player.data.remote
 
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.data.remote.dto.GameDto
-import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.util.DispatcherProvider
 import io.ktor.client.*
 import io.ktor.client.plugins.websocket.*
@@ -13,7 +11,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 
@@ -151,12 +148,10 @@ class PresenceService(
             val payload = event["payload"]?.jsonObject ?: return
 
             when (type) {
-                "game_scraped" -> {
-                    val gameDto = json.decodeFromJsonElement<GameDto>(payload)
-                    val game = gameDto.toDomain().copy(
-                        coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
-                    )
-                    scrapeService?.onGameScraped(game)
+                "game_scrape_status" -> {
+                    val gameId = payload["gameId"]?.jsonPrimitive?.content ?: return
+                    val status = payload["status"]?.jsonPrimitive?.content ?: return
+                    scrapeService?.onScrapeStatusChanged(gameId, status)
                 }
             }
         } catch (_: Exception) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/ScrapeService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/ScrapeService.kt
@@ -1,14 +1,17 @@
 package com.spela.player.data.remote
 
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.domain.model.Game
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 /**
@@ -16,6 +19,8 @@ import kotlinx.coroutines.launch
  *
  * Each game is only scraped once per session. Requests are processed sequentially
  * with a delay between them to avoid overwhelming the server.
+ *
+ * Also tracks per-game scraping status via WebSocket events from the server.
  */
 class ScrapeService(
     private val apiClient: SpelaApiClient,
@@ -25,8 +30,13 @@ class ScrapeService(
     private val requested = mutableSetOf<String>()
     private val queue = Channel<String>(Channel.UNLIMITED)
 
-    private val _scrapedGames = MutableSharedFlow<Game>(extraBufferCapacity = 16)
-    val scrapedGames: SharedFlow<Game> = _scrapedGames.asSharedFlow()
+    /** Games currently being scraped (game IDs). */
+    private val _scrapingGameIds = MutableStateFlow<Set<String>>(emptySet())
+    val scrapingGameIds: StateFlow<Set<String>> = _scrapingGameIds.asStateFlow()
+
+    /** Emitted when a game finishes scraping (status: idle). Observers should refetch game data. */
+    private val _gameScrapeDone = MutableSharedFlow<String>(extraBufferCapacity = 16)
+    val gameScrapeDone: SharedFlow<String> = _gameScrapeDone.asSharedFlow()
 
     companion object {
         private const val THROTTLE_MS = 300L
@@ -55,11 +65,35 @@ class ScrapeService(
         queue.trySend(gameId)
     }
 
+    /** Emitted when a game finishes scraping with updated cover URL. For cover art cards. */
+    private val _scrapedCovers = MutableSharedFlow<Pair<String, String>>(extraBufferCapacity = 16)
+    val scrapedCovers: SharedFlow<Pair<String, String>> = _scrapedCovers.asSharedFlow()
+
     /**
-     * Called by PresenceService when a "game_scraped" WebSocket event arrives.
-     * Emits the updated game to observers.
+     * Called by PresenceService when a "game_scrape_status" WebSocket event arrives.
      */
-    fun onGameScraped(game: Game) {
-        _scrapedGames.tryEmit(game)
+    fun onScrapeStatusChanged(gameId: String, status: String) {
+        when (status) {
+            "scraping" -> _scrapingGameIds.update { it + gameId }
+            "idle" -> {
+                _scrapingGameIds.update { it - gameId }
+                _gameScrapeDone.tryEmit(gameId)
+                // Fetch updated game to get the new cover URL for card updates
+                scope.launch(dispatchers.io) {
+                    try {
+                        val game = apiClient.getGameDetail(gameId)
+                        val resolvedCover = apiClient.resolveUrl(game.coverUrl)
+                        if (!resolvedCover.isNullOrEmpty()) {
+                            _scrapedCovers.tryEmit(gameId to resolvedCover)
+                        }
+                    } catch (_: Exception) {
+                        // Best effort — game detail page handles its own refresh
+                    }
+                }
+            }
+        }
     }
+
+    /** Check if a specific game is currently being scraped. */
+    fun isGameScraping(gameId: String): Boolean = gameId in _scrapingGameIds.value
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -162,6 +162,7 @@ val commonModule = module {
             sharedSessionRepository = get(),
             gameRepository = get(),
             apiClient = get(),
+            scrapeService = get(),
             dispatchers = get(),
             scope = get(),
             biosRepository = get(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -207,8 +207,8 @@ fun SpelaApp(
     ) {
         // Observe scrape completions and update cover art reactively
         LaunchedEffect(scrapeService) {
-            scrapeService?.scrapedGames?.collect { game ->
-                ScrapeUpdates.onGameScraped(game)
+            scrapeService?.scrapedCovers?.collect { (gameId, coverUrl) ->
+                ScrapeUpdates.onCoverUpdated(gameId, coverUrl)
             }
         }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/LocalScrapeService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/LocalScrapeService.kt
@@ -6,7 +6,6 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import com.spela.player.data.remote.ScrapeService
-import com.spela.player.domain.model.Game
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -25,10 +24,8 @@ object ScrapeUpdates {
     private val _updatedCovers = MutableStateFlow<Map<String, String>>(emptyMap())
     val updatedCovers: StateFlow<Map<String, String>> = _updatedCovers.asStateFlow()
 
-    fun onGameScraped(game: Game) {
-        if (!game.coverUrl.isNullOrEmpty()) {
-            _updatedCovers.value = _updatedCovers.value + (game.id to game.coverUrl)
-        }
+    fun onCoverUpdated(gameId: String, coverUrl: String) {
+        _updatedCovers.value = _updatedCovers.value + (gameId to coverUrl)
     }
 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.viewmodel
 
+import com.spela.player.data.remote.ScrapeService
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.repository.BiosRepository
 import com.spela.player.domain.usecase.AddGameToCollectionUseCase
@@ -24,7 +25,6 @@ import com.spela.player.presentation.state.AchievementsViewMode
 import com.spela.player.presentation.state.GameDetailState
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -47,6 +47,7 @@ class GameDetailViewModel(
     private val sharedSessionRepository: SharedSessionRepository,
     private val gameRepository: GameRepository,
     private val apiClient: SpelaApiClient,
+    private val scrapeService: ScrapeService,
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
     private val biosRepository: BiosRepository? = null,
@@ -121,17 +122,13 @@ class GameDetailViewModel(
 
     private fun adminScrapeGame() {
         val gameId = currentGameId ?: return
-        _state.update { it.copy(isAdminActionLoading = true) }
         scope.launch(dispatchers.io) {
             runCatching { apiClient.adminScrapeGame(gameId) }
-                .onSuccess {
-                    // Reload game detail to show updated metadata
-                    loadGame(gameId)
-                    _state.update { it.copy(isAdminActionLoading = false, successMessage = "Metadata scraped") }
-                }
                 .onFailure { error ->
-                    _state.update { it.copy(isAdminActionLoading = false, error = error.message) }
+                    _state.update { it.copy(error = error.message) }
                 }
+            // No need to reload — the WebSocket game_scrape_status event will
+            // set isScraping=true, and on idle the observer reloads the game.
         }
     }
 
@@ -210,6 +207,9 @@ class GameDetailViewModel(
             }
         }
 
+        // Observe WebSocket scrape status for this game
+        observeScrapeStatus(gameId)
+
         // Load community data that applies to all games (playable or not)
         loadGameStats(gameId)
         loadReviews(gameId)
@@ -233,32 +233,37 @@ class GameDetailViewModel(
         }
     }
 
+    private fun observeScrapeStatus(gameId: String) {
+        // Track scraping state from WebSocket events
+        scope.launch(dispatchers.io) {
+            scrapeService.scrapingGameIds.collect { scrapingIds ->
+                _state.update { it.copy(isScraping = gameId in scrapingIds) }
+            }
+        }
+
+        // Reload game data when scraping finishes
+        scope.launch(dispatchers.io) {
+            scrapeService.gameScrapeDone.collect { doneGameId ->
+                if (doneGameId == gameId) {
+                    getGameDetailUseCase(gameId).fold(
+                        onSuccess = { detail ->
+                            _state.update { it.copy(gameDetail = detail) }
+                        },
+                        onFailure = { /* ignore reload failure */ },
+                    )
+                }
+            }
+        }
+    }
+
     private fun scrapeAndRefresh(gameId: String) {
         scope.launch(dispatchers.io) {
             try {
-                _state.update { it.copy(isScraping = true) }
                 apiClient.scrapeIfNeeded(gameId)
-
-                var attempts = 0
-                val maxAttempts = 30
-                while (attempts < maxAttempts) {
-                    delay(1000)
-                    getGameDetailUseCase(gameId).fold(
-                        onSuccess = { refreshed ->
-                            if (refreshed.game.scrapeAttempts > 0) {
-                                _state.update { it.copy(gameDetail = refreshed, isScraping = false) }
-                                return@launch
-                            }
-                        },
-                        onFailure = { /* continue polling */ },
-                    )
-                    attempts++
-                }
-
-                _state.update { it.copy(isScraping = false) }
+                // The WebSocket game_scrape_status events drive isScraping state.
+                // The observer in observeScrapeStatus() handles reload on completion.
             } catch (e: Exception) {
-                println("GameDetailViewModel: scrape failed for game $gameId: ${e.message}")
-                _state.update { it.copy(isScraping = false) }
+                println("GameDetailViewModel: scrape request failed for game $gameId: ${e.message}")
             }
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameListViewModel.kt
@@ -45,15 +45,15 @@ class GameListViewModel(
     private var consoleGamesJob: Job? = null
 
     init {
-        // Observe scrape completions and update games in state
+        // Observe scrape completions and update cover art in game lists
         scope.launch(dispatchers.io) {
-            scrapeService.scrapedGames.collect { scrapedGame ->
+            scrapeService.scrapedCovers.collect { (gameId, coverUrl) ->
                 _state.update { state ->
                     state.copy(
-                        games = updateGameInList(state.games, scrapedGame),
-                        recentGames = updateGameInList(state.recentGames, scrapedGame),
-                        favoriteGames = updateGameInList(state.favoriteGames, scrapedGame),
-                        playLaterGames = updateGameInList(state.playLaterGames, scrapedGame),
+                        games = updateCoverInList(state.games, gameId, coverUrl),
+                        recentGames = updateCoverInList(state.recentGames, gameId, coverUrl),
+                        favoriteGames = updateCoverInList(state.favoriteGames, gameId, coverUrl),
+                        playLaterGames = updateCoverInList(state.playLaterGames, gameId, coverUrl),
                     )
                 }
             }
@@ -69,22 +69,12 @@ class GameListViewModel(
         }
     }
 
-    private fun updateGameInList(games: List<Game>, scraped: Game): List<Game> {
+    private fun updateCoverInList(games: List<Game>, gameId: String, coverUrl: String): List<Game> {
         var changed = false
         val result = games.map { existing ->
-            if (existing.id == scraped.id) {
+            if (existing.id == gameId) {
                 changed = true
-                existing.copy(
-                    coverUrl = scraped.coverUrl,
-                    description = scraped.description,
-                    developer = scraped.developer,
-                    publisher = scraped.publisher,
-                    releaseDate = scraped.releaseDate,
-                    genre = scraped.genre,
-                    players = scraped.players,
-                    igdbCriticsRating = scraped.igdbCriticsRating,
-                    scrapeAttempts = scraped.scrapeAttempts,
-                )
+                existing.copy(coverUrl = coverUrl, scrapeAttempts = existing.scrapeAttempts.coerceAtLeast(1))
             } else {
                 existing
             }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.viewmodel
 
+import com.spela.player.data.remote.ScrapeService
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.interceptor.TokenManager
 import com.spela.player.domain.model.*
@@ -72,6 +73,7 @@ class GameDetailPlayFromSharedSaveTest {
             sharedSessionRepository = PlayFromSharedSaveTestSharedSessionRepository(),
             gameRepository = testGameRepo,
             apiClient = apiClient,
+            scrapeService = ScrapeService(apiClient, testDispatchers, scope),
             dispatchers = testDispatchers,
             scope = scope,
             sessionRepository = fakeSessionRepo,

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.viewmodel
 
+import com.spela.player.data.remote.ScrapeService
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.interceptor.TokenManager
 import com.spela.player.domain.model.*
@@ -77,6 +78,7 @@ class GameDetailRatingTest {
             sharedSessionRepository = StubSharedSessionRepository(),
             gameRepository = fakeGameRepo,
             apiClient = apiClient,
+            scrapeService = ScrapeService(apiClient, testDispatchers, scope),
             dispatchers = testDispatchers,
             scope = scope,
         )

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.viewmodel
 
+import com.spela.player.data.remote.ScrapeService
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.interceptor.TokenManager
 import com.spela.player.domain.model.*
@@ -71,6 +72,7 @@ class GameDetailSharedSaveTest {
             sharedSessionRepository = SharedSaveTestSharedSessionRepository(),
             gameRepository = testGameRepo,
             apiClient = apiClient,
+            scrapeService = ScrapeService(apiClient, testDispatchers, scope),
             dispatchers = testDispatchers,
             scope = scope,
             sessionRepository = StubSessionRepository(),


### PR DESCRIPTION
## Summary

Updates the player app to use the new `game_scrape_status` WebSocket events instead of the removed `game_scraped` event.

- **ScrapeService**: tracks per-game scraping state via `scrapingGameIds` StateFlow, emits `gameScrapeDone` and `scrapedCovers` flows
- **PresenceService**: handles `game_scrape_status` events instead of `game_scraped`
- **GameDetailViewModel**: observes scrape status reactively via WebSocket instead of polling 30x at 1s intervals. Admin scrape no longer needs to reload immediately — WebSocket events drive the UI
- **GameListViewModel**: uses `scrapedCovers` flow to update cover art in game lists
- **ScrapeUpdates/LocalScrapeService**: simplified to use `onCoverUpdated(gameId, coverUrl)` instead of full game objects

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop` — compiles clean
- [x] `./gradlew :shared:desktopTest` — all tests pass
- [ ] Manual test: open game detail, trigger scrape, verify spinner appears/disappears via WebSocket