### PR TITLE
fix: run MergeGroupsByIGDBID on server startup

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -246,6 +246,18 @@ func main() {
 	})
 	go scrapeWorker.Run(workerCtx)
 
+	// Merge variant groups by IGDB ID on startup — catches any unmerged
+	// groups from previous sessions (e.g., games scraped before the merge
+	// was re-enabled, or groups that weren't merged because the scrape job
+	// hadn't completed yet).
+	go func() {
+		if merged, err := scanner.MergeGroupsByIGDBID(database); err != nil {
+			slog.Warn("startup IGDB group merge failed", "error", err)
+		} else if merged > 0 {
+			slog.Info("startup IGDB group merge complete", "merged", merged)
+		}
+	}()
+
 	// Auto-scan game library on startup (non-blocking).
 	// Uses the same scan flow as the manual "Scan library" button so progress
 	// is visible in the web UI via WebSocket events.

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/igdb"
+	"github.com/spela/server/internal/scanner"
 	ws "github.com/spela/server/internal/websocket"
 	"gorm.io/gorm"
 )
@@ -188,6 +189,15 @@ func (h *AdminHandler) CancelScrape(c *gin.Context) {
 	h.Hub.Broadcast(ws.Event{Type: "scrape_cancelled", Payload: gin.H{
 		"jobId": job.ID,
 	}})
+
+	// Merge variant groups for any games scraped before cancellation
+	go func() {
+		if merged, err := scanner.MergeGroupsByIGDBID(h.DB); err != nil {
+			slog.Warn("IGDB group merge after cancel failed", "error", err)
+		} else if merged > 0 {
+			slog.Info("merged groups by IGDB ID after cancel", "merged", merged)
+		}
+	}()
 
 	adminID, _ := c.Get("userId")
 	slog.Info("audit: admin cancelled scrape", "admin_id", adminID, "jobId", job.ID)


### PR DESCRIPTION
## Summary

The IGDB group merge only ran after a scrape job completed (`onJobComplete`). For a 40k game scrape taking 24+ hours, that's too long to wait. Now it also runs on startup to catch any unmerged groups from previous sessions immediately.

## Test plan

- [x] `go build ./...` clean
- [ ] Deploy, verify Smash Bros variants are grouped on startup