### PR TITLE
fix: rebuild variant groups from scratch on startup

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -281,24 +281,33 @@ func main() {
 	// Start background scrape worker (must start before auto-scan goroutine
 	// so any enqueued items get processed)
 	scrapeWorker := scraper.NewScrapeWorker(database, metaScraper.Queue, metaScraper, hub, func() {
+		if err := scanner.GroupAndElectPrimaries(database); err != nil {
+			slog.Warn("post-scrape regrouping failed", "error", err)
+		}
 		if merged, err := scanner.MergeGroupsByIGDBID(database); err != nil {
-			slog.Warn("IGDB group merge failed", "error", err)
+			slog.Warn("post-scrape IGDB group merge failed", "error", err)
 		} else if merged > 0 {
-			slog.Info("merged groups by IGDB ID", "merged", merged)
+			slog.Info("post-scrape IGDB group merge complete", "merged", merged)
 		}
 	})
 	go scrapeWorker.Run(workerCtx)
 
-	// Merge variant groups by IGDB ID on startup — catches any unmerged
-	// groups from previous sessions (e.g., games scraped before the merge
-	// was re-enabled, or groups that weren't merged because the scrape job
-	// hadn't completed yet).
+	// Rebuild variant groups from scratch on startup. This is idempotent —
+	// the result depends only on filenames and IGDB IDs, not on existing
+	// group state. Fixes any corruption from previous runs.
 	go func() {
+		if err := scanner.RecomputeGroupKeys(database); err != nil {
+			slog.Warn("startup group key recompute failed", "error", err)
+		}
+		if err := scanner.GroupAndElectPrimaries(database); err != nil {
+			slog.Warn("startup regrouping failed", "error", err)
+		}
 		if merged, err := scanner.MergeGroupsByIGDBID(database); err != nil {
 			slog.Warn("startup IGDB group merge failed", "error", err)
 		} else if merged > 0 {
 			slog.Info("startup IGDB group merge complete", "merged", merged)
 		}
+		slog.Info("startup variant grouping complete")
 	}()
 
 	// Auto-scan game library on startup (non-blocking).

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -190,12 +190,15 @@ func (h *AdminHandler) CancelScrape(c *gin.Context) {
 		"jobId": job.ID,
 	}})
 
-	// Merge variant groups for any games scraped before cancellation
+	// Rebuild variant groups after cancellation
 	go func() {
+		if err := scanner.GroupAndElectPrimaries(h.DB); err != nil {
+			slog.Warn("regrouping after cancel failed", "error", err)
+		}
 		if merged, err := scanner.MergeGroupsByIGDBID(h.DB); err != nil {
 			slog.Warn("IGDB group merge after cancel failed", "error", err)
 		} else if merged > 0 {
-			slog.Info("merged groups by IGDB ID after cancel", "merged", merged)
+			slog.Info("IGDB group merge after cancel complete", "merged", merged)
 		}
 	}()
 

--- a/server/internal/scanner/grouping.go
+++ b/server/internal/scanner/grouping.go
@@ -10,6 +10,44 @@ import (
 	"gorm.io/gorm"
 )
 
+// RecomputeGroupKeys recomputes every game's group_key from its filename.
+// This ensures group keys are always derived from source data, not from
+// potentially corrupted state. Safe to run at any time — idempotent.
+func RecomputeGroupKeys(database *gorm.DB) error {
+	const batchSize = 500
+	var offset int
+	updated := 0
+
+	for {
+		var games []db.Game
+		if err := database.Select("id, file_name, group_key").
+			Where("deleted_at IS NULL").
+			Order("id ASC").
+			Limit(batchSize).Offset(offset).
+			Find(&games).Error; err != nil {
+			return fmt.Errorf("loading games for group key recompute: %w", err)
+		}
+		if len(games) == 0 {
+			break
+		}
+
+		for i := range games {
+			newKey := normalizeGroupKey(games[i].FileName)
+			if newKey != games[i].GroupKey {
+				database.Model(&games[i]).Update("group_key", newKey)
+				updated++
+			}
+		}
+
+		offset += batchSize
+	}
+
+	if updated > 0 {
+		slog.Info("recomputed group keys", "updated", updated)
+	}
+	return nil
+}
+
 // GroupAndElectPrimaries groups games by (console_id, group_key) and elects
 // the best variant in each group as primary.
 // Processes one console at a time to bound memory usage for large libraries.

--- a/server/internal/scanner/grouping_test.go
+++ b/server/internal/scanner/grouping_test.go
@@ -559,3 +559,104 @@ func TestReElectPrimaryForGroup(t *testing.T) {
 	require.NoError(t, database.Where("file_path = ?", "nes/Game (Europe).nes").First(&europeGame).Error)
 	assert.True(t, europeGame.IsPrimary, "Europe game should be elected as new primary")
 }
+
+// TestFullRegroupingIsIdempotent verifies that running GroupAndElectPrimaries
+// followed by MergeGroupsByIGDBID produces the correct result regardless of
+// starting state. This is the core "stateless" guarantee.
+func TestFullRegroupingIsIdempotent(t *testing.T) {
+	database := setupTestDB(t)
+
+	var gc db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "GC").First(&gc).Error)
+
+	// Set up: 3 Smash Bros games with different filenames, same IGDB ID,
+	// and one starts in a corrupted catch-all group with unrelated games.
+	smashUSA := db.Game{
+		ConsoleID: gc.ID, Title: "Super Smash Bros. Melee",
+		FileName: "Super Smash Bros. Melee (USA) (En,Ja).rvz",
+		FilePath: "gc/Super Smash Bros. Melee (USA) (En,Ja).rvz",
+		GroupKey: "corrupted group", ScraperID: "igdb:1627",
+	}
+	smashJP := db.Game{
+		ConsoleID: gc.ID, Title: "Super Smash Bros. Melee",
+		FileName: "Dairantou Smash Brothers DX (Japan) (En,Ja).rvz",
+		FilePath: "gc/Dairantou Smash Brothers DX (Japan) (En,Ja).rvz",
+		GroupKey: "corrupted group", ScraperID: "igdb:1627",
+	}
+	smashDemo := db.Game{
+		ConsoleID: gc.ID, Title: "Super Smash Bros. Melee",
+		FileName: "Dairantou Smash Brothers DX (Japan) (Taikenban).rvz",
+		FilePath: "gc/Dairantou Smash Brothers DX (Japan) (Taikenban).rvz",
+		GroupKey: "dairantou smash brothers dx", ScraperID: "igdb:1627",
+	}
+	// Unrelated games in the corrupted group
+	unrelated1 := db.Game{
+		ConsoleID: gc.ID, Title: "Ace Golf",
+		FileName: "Ace Golf (Europe).rvz",
+		FilePath: "gc/Ace Golf (Europe).rvz",
+		GroupKey: "corrupted group", ScraperID: "igdb:9999",
+	}
+	unrelated2 := db.Game{
+		ConsoleID: gc.ID, Title: "Beach Spikers",
+		FileName: "Beach Spikers (USA).rvz",
+		FilePath: "gc/Beach Spikers (USA).rvz",
+		GroupKey: "corrupted group", ScraperID: "igdb:8888",
+	}
+	for _, g := range []*db.Game{&smashUSA, &smashJP, &smashDemo, &unrelated1, &unrelated2} {
+		require.NoError(t, database.Create(g).Error)
+	}
+
+	// Run the full pipeline: recompute keys, regroup, then merge by IGDB ID
+	require.NoError(t, RecomputeGroupKeys(database))
+	require.NoError(t, GroupAndElectPrimaries(database))
+	merged, err := MergeGroupsByIGDBID(database)
+	require.NoError(t, err)
+
+	// Reload all games
+	var postUSA, postJP, postDemo, postAce, postBeach db.Game
+	database.First(&postUSA, smashUSA.ID)
+	database.First(&postJP, smashJP.ID)
+	database.First(&postDemo, smashDemo.ID)
+	database.First(&postAce, unrelated1.ID)
+	database.First(&postBeach, unrelated2.ID)
+
+	// All 3 Smash Bros games should be in the same group
+	assert.Equal(t, postUSA.GroupKey, postJP.GroupKey, "Smash USA and JP should be grouped")
+	assert.Equal(t, postUSA.GroupKey, postDemo.GroupKey, "Smash USA and Demo should be grouped")
+	assert.True(t, merged > 0, "should have merged at least one game")
+
+	// Unrelated games should NOT be in the Smash group
+	assert.NotEqual(t, postUSA.GroupKey, postAce.GroupKey, "Ace Golf should not be in Smash group")
+	assert.NotEqual(t, postUSA.GroupKey, postBeach.GroupKey, "Beach Spikers should not be in Smash group")
+
+	// Ace Golf and Beach Spikers should be in their own groups (ungrouped from each other too)
+	assert.NotEqual(t, postAce.GroupKey, postBeach.GroupKey, "unrelated games should be in separate groups")
+
+	// Exactly one Smash game should be primary
+	smashPrimaries := 0
+	for _, g := range []db.Game{postUSA, postJP, postDemo} {
+		if g.IsPrimary {
+			smashPrimaries++
+		}
+	}
+	assert.Equal(t, 1, smashPrimaries, "exactly one Smash game should be primary")
+
+	// Run the whole thing again — result should be identical (idempotent)
+	require.NoError(t, RecomputeGroupKeys(database))
+	require.NoError(t, GroupAndElectPrimaries(database))
+	_, err = MergeGroupsByIGDBID(database)
+	require.NoError(t, err)
+
+	var postUSA2, postJP2, postDemo2, postAce2, postBeach2 db.Game
+	database.First(&postUSA2, smashUSA.ID)
+	database.First(&postJP2, smashJP.ID)
+	database.First(&postDemo2, smashDemo.ID)
+	database.First(&postAce2, unrelated1.ID)
+	database.First(&postBeach2, unrelated2.ID)
+
+	assert.Equal(t, postUSA.GroupKey, postUSA2.GroupKey, "idempotent: USA group unchanged")
+	assert.Equal(t, postJP.GroupKey, postJP2.GroupKey, "idempotent: JP group unchanged")
+	assert.Equal(t, postDemo.GroupKey, postDemo2.GroupKey, "idempotent: Demo group unchanged")
+	assert.Equal(t, postAce.GroupKey, postAce2.GroupKey, "idempotent: Ace group unchanged")
+	assert.Equal(t, postBeach.GroupKey, postBeach2.GroupKey, "idempotent: Beach group unchanged")
+}


### PR DESCRIPTION
## Summary

Makes grouping idempotent — runs `GroupAndElectPrimaries` (name-based grouping from scratch) followed by `MergeGroupsByIGDBID` (cross-language merge) at every grouping point: startup, scrape completion, and scrape cancel.

The result depends only on filenames and IGDB IDs, not on existing group state. This fixes corrupted catch-all groups like `ace golf` (312 games, 40 different IGDB IDs) that accumulated from previous buggy merge runs.

## Test plan

- [x] `go build ./...` clean
- [ ] Deploy, verify corrupted groups are fixed on startup
- [ ] Verify Smash Bros variants properly grouped