### PR TITLE
feat: grouping progress on Library Scan page

### DIFF
--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -281,6 +281,9 @@ func main() {
 	// Start background scrape worker (must start before auto-scan goroutine
 	// so any enqueued items get processed)
 	scrapeWorker := scraper.NewScrapeWorker(database, metaScraper.Queue, metaScraper, hub, func() {
+		if err := scanner.RecomputeGroupKeys(database, nil); err != nil {
+			slog.Warn("post-scrape group key recompute failed", "error", err)
+		}
 		if err := scanner.GroupAndElectPrimaries(database); err != nil {
 			slog.Warn("post-scrape regrouping failed", "error", err)
 		}
@@ -296,17 +299,29 @@ func main() {
 	// the result depends only on filenames and IGDB IDs, not on existing
 	// group state. Fixes any corruption from previous runs.
 	go func() {
-		if err := scanner.RecomputeGroupKeys(database); err != nil {
+		broadcastGrouping := func(message string, current, total int) {
+			hub.Broadcast(websocket.Event{Type: "grouping_progress", Payload: map[string]interface{}{
+				"message": message,
+				"current": current,
+				"total":   total,
+			}})
+		}
+
+		broadcastGrouping("Recomputing group keys...", 0, 0)
+		if err := scanner.RecomputeGroupKeys(database, broadcastGrouping); err != nil {
 			slog.Warn("startup group key recompute failed", "error", err)
 		}
+		broadcastGrouping("Electing primary variants...", 0, 0)
 		if err := scanner.GroupAndElectPrimaries(database); err != nil {
 			slog.Warn("startup regrouping failed", "error", err)
 		}
+		broadcastGrouping("Merging cross-language variants...", 0, 0)
 		if merged, err := scanner.MergeGroupsByIGDBID(database); err != nil {
 			slog.Warn("startup IGDB group merge failed", "error", err)
 		} else if merged > 0 {
 			slog.Info("startup IGDB group merge complete", "merged", merged)
 		}
+		hub.Broadcast(websocket.Event{Type: "grouping_complete", Payload: nil})
 		slog.Info("startup variant grouping complete")
 	}()
 

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -192,6 +192,9 @@ func (h *AdminHandler) CancelScrape(c *gin.Context) {
 
 	// Rebuild variant groups after cancellation
 	go func() {
+		if err := scanner.RecomputeGroupKeys(h.DB, nil); err != nil {
+			slog.Warn("group key recompute after cancel failed", "error", err)
+		}
 		if err := scanner.GroupAndElectPrimaries(h.DB); err != nil {
 			slog.Warn("regrouping after cancel failed", "error", err)
 		}

--- a/server/internal/scanner/grouping.go
+++ b/server/internal/scanner/grouping.go
@@ -13,10 +13,19 @@ import (
 // RecomputeGroupKeys recomputes every game's group_key from its filename.
 // This ensures group keys are always derived from source data, not from
 // potentially corrupted state. Safe to run at any time — idempotent.
-func RecomputeGroupKeys(database *gorm.DB) error {
+// GroupingProgress is called during long-running grouping operations
+// to report progress. The message describes the current phase, and
+// current/total indicate progress within that phase (0/0 if unknown).
+type GroupingProgress func(message string, current, total int)
+
+func RecomputeGroupKeys(database *gorm.DB, onProgress GroupingProgress) error {
 	const batchSize = 500
 	var offset int
 	updated := 0
+
+	// Count total games for progress reporting
+	var totalGames int64
+	database.Model(&db.Game{}).Where("deleted_at IS NULL").Count(&totalGames)
 
 	for {
 		var games []db.Game
@@ -49,6 +58,13 @@ func RecomputeGroupKeys(database *gorm.DB) error {
 		}
 
 		offset += batchSize
+		if onProgress != nil {
+			processed := offset
+			if processed > int(totalGames) {
+				processed = int(totalGames)
+			}
+			onProgress("Recomputing group keys...", processed, int(totalGames))
+		}
 	}
 
 	if updated > 0 {

--- a/server/internal/scanner/grouping_test.go
+++ b/server/internal/scanner/grouping_test.go
@@ -607,7 +607,7 @@ func TestFullRegroupingIsIdempotent(t *testing.T) {
 	}
 
 	// Run the full pipeline: recompute keys, regroup, then merge by IGDB ID
-	require.NoError(t, RecomputeGroupKeys(database))
+	require.NoError(t, RecomputeGroupKeys(database, nil))
 	require.NoError(t, GroupAndElectPrimaries(database))
 	merged, err := MergeGroupsByIGDBID(database)
 	require.NoError(t, err)
@@ -642,7 +642,7 @@ func TestFullRegroupingIsIdempotent(t *testing.T) {
 	assert.Equal(t, 1, smashPrimaries, "exactly one Smash game should be primary")
 
 	// Run the whole thing again — result should be identical (idempotent)
-	require.NoError(t, RecomputeGroupKeys(database))
+	require.NoError(t, RecomputeGroupKeys(database, nil))
 	require.NoError(t, GroupAndElectPrimaries(database))
 	_, err = MergeGroupsByIGDBID(database)
 	require.NoError(t, err)

--- a/web/src/hooks/use-grouping-progress.ts
+++ b/web/src/hooks/use-grouping-progress.ts
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { useWebSocketEvent } from "@/hooks/use-websocket";
+
+interface GroupingProgressEvent {
+  message: string;
+  current: number;
+  total: number;
+}
+
+/**
+ * Listens for grouping_progress and grouping_complete WebSocket events.
+ * Returns the current grouping status for display on the Library Scan page.
+ */
+export function useGroupingProgress() {
+  const [active, setActive] = useState(false);
+  const [message, setMessage] = useState("");
+  const [current, setCurrent] = useState(0);
+  const [total, setTotal] = useState(0);
+
+  useWebSocketEvent("grouping_progress", (payload: GroupingProgressEvent) => {
+    setActive(true);
+    setMessage(payload.message || "Grouping variants...");
+    setCurrent(payload.current || 0);
+    setTotal(payload.total || 0);
+  });
+
+  useWebSocketEvent("grouping_complete", () => {
+    setActive(false);
+    setMessage("");
+    setCurrent(0);
+    setTotal(0);
+  });
+
+  return { active, message, current, total };
+}

--- a/web/src/pages/admin/scan-page.tsx
+++ b/web/src/pages/admin/scan-page.tsx
@@ -16,6 +16,7 @@ import { useScanLibrary, useScrapeMetadata, useCancelScrape } from "@/hooks/use-
 import { useToast } from "@/components/ui";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
 import { useScanProgress } from "@/hooks/use-scan-progress";
+import { useGroupingProgress } from "@/hooks/use-grouping-progress";
 import { useConsoles } from "@/hooks/use-consoles";
 import { ScrapeStatusCard } from "@/features/admin/components/scrape-status-card";
 
@@ -455,17 +456,44 @@ function ScrapeCard() {
   );
 }
 
+function GroupingStatus() {
+  const grouping = useGroupingProgress();
+
+  if (!grouping.active) return null;
+
+  return (
+    <Section>
+      <div className="px-5 py-4 space-y-3">
+        <div className="flex items-center gap-2 text-sm">
+          <Loader2 className="h-4 w-4 animate-spin text-brand-400" />
+          <span className="text-surface-200">{grouping.message}</span>
+        </div>
+        {grouping.total > 0 && (
+          <>
+            <ProgressBar value={grouping.current} max={grouping.total} />
+            <p className="text-xs text-surface-400">
+              {grouping.current.toLocaleString()} / {grouping.total.toLocaleString()}
+            </p>
+          </>
+        )}
+      </div>
+    </Section>
+  );
+}
+
 export function AdminScanPage() {
   return (
     <PageLayout title="Library Scan" subtitle="Scan game directories and update metadata.">
       <SectionList className="max-w-3xl">
-      <ScrapeStatusCard />
+        <GroupingStatus />
 
-      <div className="grid gap-5 md:grid-cols-2">
-        <ScanCard />
-        <ScrapeCard />
-      </div>
-    </SectionList>
+        <div className="grid gap-5 md:grid-cols-2">
+          <ScanCard />
+          <ScrapeCard />
+        </div>
+
+        <ScrapeStatusCard />
+      </SectionList>
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary

- Broadcast `grouping_progress` and `grouping_complete` WebSocket events during startup regrouping
- `RecomputeGroupKeys` now reports progress (current/total) via callback
- New `GroupingStatus` component on Library Scan page shows progress bar during regrouping
- Moved `ScrapeStatusCard` below the scan/scrape controls
- Added `RecomputeGroupKeys` to cancel and job-complete handlers (was missing)

## Test plan

- [x] `go build ./...` clean
- [x] `tsc -b` clean
- [x] Scan page tests pass (24/24)
- [x] Grouping tests pass
- [ ] Deploy, verify grouping progress shows on Library Scan page during startup