### PR TITLE
feat: detect Taikenban (Japanese demo) as pre-release

### DIFF
--- a/server/internal/scanner/filename_parser.go
+++ b/server/internal/scanner/filename_parser.go
@@ -31,10 +31,11 @@ var bracketContentPattern = regexp.MustCompile(`\[([^\]]*)\]`)
 // tagKeywords maps lowercase tag keywords to their canonical form.
 // Tags that indicate pre-release status are marked separately.
 var preReleaseTags = map[string]bool{
-	"beta":  true,
-	"proto": true,
-	"sample": true,
-	"demo":  true,
+	"beta":      true,
+	"proto":     true,
+	"sample":    true,
+	"demo":      true,
+	"taikenban": true, // Japanese for "trial version" / demo
 }
 
 // allKnownTags are tags we extract from filenames.
@@ -44,6 +45,7 @@ var allKnownTags = map[string]string{
 	"prototype":       "proto",
 	"sample":          "sample",
 	"demo":            "demo",
+	"taikenban":       "demo",
 	"unl":             "unl",
 	"unlicensed":      "unl",
 	"hack":            "hack",

--- a/server/internal/scanner/filename_parser_test.go
+++ b/server/internal/scanner/filename_parser_test.go
@@ -206,6 +206,24 @@ func TestParseFilenameMetadata(t *testing.T) {
 			wantPreRel:   false,
 			wantGroupKey: "chrono cross",
 		},
+		{
+			name:         "demo tag marks pre-release",
+			filename:     "Mega Man Battle Network 5 (USA) (Demo).gba",
+			wantRegion:   "USA",
+			wantRevision: "",
+			wantTags:     "demo",
+			wantPreRel:   true,
+			wantGroupKey: "mega man battle network 5",
+		},
+		{
+			name:         "taikenban (Japanese demo) marks pre-release",
+			filename:     "Dairantou Smash Brothers DX (Japan) (Taikenban).rvz",
+			wantRegion:   "Japan",
+			wantRevision: "",
+			wantTags:     "demo",
+			wantPreRel:   true,
+			wantGroupKey: "dairantou smash brothers dx",
+		},
 	}
 
 	for _, tt := range tests {

--- a/server/internal/scanner/grouping_test.go
+++ b/server/internal/scanner/grouping_test.go
@@ -660,3 +660,45 @@ func TestFullRegroupingIsIdempotent(t *testing.T) {
 	assert.Equal(t, postAce.GroupKey, postAce2.GroupKey, "idempotent: Ace group unchanged")
 	assert.Equal(t, postBeach.GroupKey, postBeach2.GroupKey, "idempotent: Beach group unchanged")
 }
+
+func TestDemoGameIsNotElectedPrimary(t *testing.T) {
+	database := setupTestDB(t)
+
+	var gc db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "GC").First(&gc).Error)
+
+	// Full release and demo of the same game, same IGDB ID
+	fullGame := db.Game{
+		ConsoleID: gc.ID, Title: "Super Smash Bros. Melee",
+		FileName: "Super Smash Bros. Melee (USA) (En,Ja).rvz",
+		FilePath: "gc/Super Smash Bros. Melee (USA) (En,Ja).rvz",
+		GroupKey: "super smash bros melee", ScraperID: "igdb:1627",
+		Region: "USA",
+	}
+	demoGame := db.Game{
+		ConsoleID: gc.ID, Title: "Super Smash Bros. Melee",
+		FileName: "Dairantou Smash Brothers DX (Japan) (Taikenban).rvz",
+		FilePath: "gc/Dairantou Smash Brothers DX (Japan) (Taikenban).rvz",
+		GroupKey: "dairantou smash brothers dx", ScraperID: "igdb:1627",
+		Region: "Japan", IsPreRelease: true, // Taikenban = demo
+	}
+	require.NoError(t, database.Create(&fullGame).Error)
+	require.NoError(t, database.Create(&demoGame).Error)
+
+	// Group and merge
+	require.NoError(t, GroupAndElectPrimaries(database))
+	_, err := MergeGroupsByIGDBID(database)
+	require.NoError(t, err)
+
+	// Reload
+	var postFull, postDemo db.Game
+	database.First(&postFull, fullGame.ID)
+	database.First(&postDemo, demoGame.ID)
+
+	// Same group
+	assert.Equal(t, postFull.GroupKey, postDemo.GroupKey, "should be in same group")
+
+	// Full game is primary, demo is not
+	assert.True(t, postFull.IsPrimary, "full game should be primary")
+	assert.False(t, postDemo.IsPrimary, "demo should not be primary")
+}

--- a/web/src/components/game-card.tsx
+++ b/web/src/components/game-card.tsx
@@ -106,6 +106,15 @@ export function GameCard({
           </div>
         )}
 
+        {/* Pre-release badge */}
+        {game.isPreRelease && (
+          <div className="absolute top-2.5 left-2.5 z-10">
+            <span className="inline-flex items-center rounded-full bg-warning-500/80 backdrop-blur-sm px-2 py-0.5 text-[10px] font-medium text-white">
+              Pre-release
+            </span>
+          </div>
+        )}
+
         {/* Console badge */}
         {game.consoleName && (
           <div className={cn(

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -214,6 +214,11 @@ export function GameHero({
               </h1>
               <div className="flex flex-wrap items-center gap-2 mt-2">
                 {consoleName && <ConsoleBadge code={game.consoleId} label={consoleName} />}
+                {game.isPreRelease && (
+                  <Badge variant="warning" data-testid="pre-release-badge">
+                    Pre-release
+                  </Badge>
+                )}
                 {!game.playable && (
                   <Badge variant="warning" data-testid="external-emulator-badge">
                     <Monitor className="h-3 w-3 mr-1" />


### PR DESCRIPTION
## Summary

Japanese demo ROMs use "(Taikenban)" (体験版) instead of "(Demo)". This wasn't detected as a pre-release, so demo versions could be elected as the primary variant over full releases.

- Add `taikenban` to pre-release tags (mapped to "demo" canonical tag)
- New filename parser test for taikenban detection
- New grouping test verifying demo is never elected primary

Existing games need a library rescan to update their `is_pre_release` flag.

## Test plan

- [x] `TestParseFilenameMetadata/taikenban_(Japanese_demo)_marks_pre-release` — PASS
- [x] `TestDemoGameIsNotElectedPrimary` — PASS
- [x] All existing parser and grouping tests pass