### PR TITLE
feat: auto-fetch RetroAchievements on game detail page

### DIFF
--- a/docs/superpowers/plans/2026-04-15-auto-fetch-ra-achievements.md
+++ b/docs/superpowers/plans/2026-04-15-auto-fetch-ra-achievements.md
@@ -1,0 +1,1138 @@
+# Auto-Fetch RetroAchievements on Game Detail Page — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Automatically fetch RetroAchievements data when a user views a game detail page, using the server's RA API key so achievements are visible to all users.
+
+**Architecture:** Extend the scrape queue with a new `ra_fetch` item type. The `GET /games/{id}/achievements` handler enqueues an `ra_fetch` job when no cache exists, returning `{ status: "pending" }`. The queue worker processes it (hash computation + RA API call), populates the cache, and the frontend polls until data arrives.
+
+**Tech Stack:** Go (Gin, GORM, SQLite), React (TanStack Query), TypeScript
+
+**Spec:** `docs/superpowers/specs/2026-04-15-auto-fetch-ra-achievements-design.md`
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Modify | `server/internal/db/scrape_job.go` | Add `Type` field to `ScrapeQueueItem` |
+| Modify | `server/internal/db/models.go` | Add `RAHashChecked` field to `Game` |
+| Modify | `server/internal/scraper/queue.go` | Add `IsGameQueuedForType` method |
+| Modify | `server/internal/scraper/worker.go` | Dispatch on item type (`scrape` vs `ra_fetch`) |
+| Modify | `server/internal/scraper/scraper_ra.go` | Add `FetchRAAchievements` (single-game) |
+| Modify | `server/internal/api/ra_handler.go` | Add queue/API-key fields, auto-enqueue logic |
+| Modify | `server/internal/api/router.go` | Pass queue + API key to `RAHandler` |
+| Modify | `server/internal/scraper/queue_test.go` | Tests for type-aware queueing |
+| Create | `server/internal/scraper/scraper_ra_fetch_test.go` | Tests for single-game RA fetch |
+| Modify | `server/internal/api/ra_handler_test.go` | Tests for auto-enqueue handler logic |
+| Modify | `web/src/types/api.ts` | Add `status` field to `GameAchievements` |
+| Modify | `web/src/hooks/use-retroachievements.ts` | Poll when status is `"pending"` |
+| Modify | `web/src/hooks/__tests__/use-retroachievements.test.ts` | Tests for pending→data transition |
+
+---
+
+### Task 1: Add `Type` field to `ScrapeQueueItem`
+
+**Files:**
+- Modify: `server/internal/db/scrape_job.go:25-35`
+
+- [ ] **Step 1: Add the Type field to the struct**
+
+In `server/internal/db/scrape_job.go`, add a `Type` field to `ScrapeQueueItem`:
+
+```go
+type ScrapeQueueItem struct {
+	ID           uint       `gorm:"primarykey" json:"id"`
+	CreatedAt    time.Time  `gorm:"index:idx_queue_dequeue,priority:3" json:"createdAt"`
+	JobID        *uint      `gorm:"index" json:"jobId,omitempty"`
+	GameID       uint       `gorm:"not null" json:"gameId"`
+	Type         string     `gorm:"size:32;not null;default:'scrape'" json:"type"` // "scrape" = full metadata scrape, "ra_fetch" = RetroAchievements only
+	Priority     int        `gorm:"not null;default:0;index:idx_queue_dequeue,priority:2,sort:desc" json:"priority"`
+	Status       string     `gorm:"size:32;not null;default:'pending';index:idx_queue_dequeue,priority:1" json:"status"`
+	ErrorMessage string     `gorm:"size:512" json:"errorMessage,omitempty"`
+	CompletedAt  *time.Time `json:"completedAt,omitempty"`
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd server && go build ./...`
+Expected: success (GORM auto-migrates on startup; the new column gets a default value so existing rows are fine)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/internal/db/scrape_job.go
+git commit -m "feat(db): add Type field to ScrapeQueueItem for ra_fetch support (#410)"
+```
+
+---
+
+### Task 2: Add `RAHashChecked` sentinel to Game model
+
+**Files:**
+- Modify: `server/internal/db/models.go:161`
+
+- [ ] **Step 1: Add RAHashChecked field next to RAGameID**
+
+In `server/internal/db/models.go`, find the `RAGameID` field (line 161) and add `RAHashChecked` directly after it:
+
+```go
+	RAGameID            uint           `gorm:"index" json:"-"` // RetroAchievements game ID (cached from hash lookup)
+	// RAHashChecked + RAGameID sentinel logic:
+	//   RAHashChecked=false, RAGameID=0  → Not yet looked up. Compute ROM MD5 and query RA.
+	//   RAHashChecked=true,  RAGameID=0  → Looked up, but RA doesn't have this game. Do NOT retry.
+	//   RAHashChecked=true,  RAGameID>0  → Valid RA game ID cached.
+	// RAHashChecked is ONLY set to true after a successful API response (even if RA returned no match).
+	// Transient errors (network, 403) leave RAHashChecked=false so the next visit retries.
+	RAHashChecked       bool           `gorm:"default:false" json:"-"`
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd server && go build ./...`
+Expected: success
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/internal/db/models.go
+git commit -m "feat(db): add RAHashChecked sentinel to Game model (#410)"
+```
+
+---
+
+### Task 3: Add type-aware queue methods and tests
+
+**Files:**
+- Modify: `server/internal/scraper/queue.go:86-93`
+- Test: `server/internal/scraper/queue_test.go`
+
+- [ ] **Step 1: Write failing tests for type-aware queueing**
+
+Add these tests to `server/internal/scraper/queue_test.go`:
+
+```go
+func TestIsGameQueuedForType(t *testing.T) {
+	database := setupQueueTestDB(t)
+	q := NewScrapeQueue(database)
+
+	// Nothing queued yet
+	queued, err := q.IsGameQueuedForType(42, "ra_fetch")
+	require.NoError(t, err)
+	assert.False(t, queued)
+
+	// Enqueue a scrape item for game 42
+	err = q.EnqueueGame(42, nil, 0)
+	require.NoError(t, err)
+
+	// "scrape" type should be queued (default type), but "ra_fetch" should not
+	queued, err = q.IsGameQueuedForType(42, "scrape")
+	require.NoError(t, err)
+	assert.True(t, queued)
+
+	queued, err = q.IsGameQueuedForType(42, "ra_fetch")
+	require.NoError(t, err)
+	assert.False(t, queued)
+}
+
+func TestEnqueueGameWithType(t *testing.T) {
+	database := setupQueueTestDB(t)
+	q := NewScrapeQueue(database)
+
+	err := q.EnqueueGameWithType(42, nil, 100, "ra_fetch")
+	require.NoError(t, err)
+
+	var item db.ScrapeQueueItem
+	require.NoError(t, database.First(&item).Error)
+	assert.Equal(t, uint(42), item.GameID)
+	assert.Equal(t, 100, item.Priority)
+	assert.Equal(t, "ra_fetch", item.Type)
+	assert.Equal(t, "pending", item.Status)
+	assert.Nil(t, item.JobID)
+}
+
+func TestIsGameQueuedForType_IgnoresCompletedItems(t *testing.T) {
+	database := setupQueueTestDB(t)
+	q := NewScrapeQueue(database)
+
+	err := q.EnqueueGameWithType(42, nil, 100, "ra_fetch")
+	require.NoError(t, err)
+
+	// Dequeue and complete the item
+	item, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	_, err = q.MarkCompleted(item)
+	require.NoError(t, err)
+
+	// Should no longer be queued
+	queued, err := q.IsGameQueuedForType(42, "ra_fetch")
+	require.NoError(t, err)
+	assert.False(t, queued)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && go test ./internal/scraper/ -run "TestIsGameQueuedForType|TestEnqueueGameWithType" -v`
+Expected: FAIL — `IsGameQueuedForType` and `EnqueueGameWithType` not defined
+
+- [ ] **Step 3: Implement `EnqueueGameWithType` and `IsGameQueuedForType`**
+
+Add to `server/internal/scraper/queue.go`:
+
+```go
+// EnqueueGameWithType adds a single game to the queue with a specific type.
+// Type determines what the worker does: "scrape" for full metadata, "ra_fetch" for RA achievements only.
+func (q *ScrapeQueue) EnqueueGameWithType(gameID uint, jobID *uint, priority int, itemType string) error {
+	item := &db.ScrapeQueueItem{
+		JobID:    jobID,
+		GameID:   gameID,
+		Priority: priority,
+		Status:   "pending",
+		Type:     itemType,
+	}
+	if err := q.db.Create(item).Error; err != nil {
+		return fmt.Errorf("enqueuing game %d (type=%s): %w", gameID, itemType, err)
+	}
+	return nil
+}
+
+// IsGameQueuedForType checks whether a game already has a pending or in-progress
+// queue item of the given type. Use this to prevent duplicate enqueuing.
+func (q *ScrapeQueue) IsGameQueuedForType(gameID uint, itemType string) (bool, error) {
+	var count int64
+	err := q.db.Model(&db.ScrapeQueueItem{}).
+		Where("game_id = ? AND type = ? AND status IN ?", gameID, itemType, []string{"pending", "in_progress"}).
+		Count(&count).Error
+	return count > 0, err
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && go test ./internal/scraper/ -run "TestIsGameQueuedForType|TestEnqueueGameWithType" -v`
+Expected: PASS
+
+- [ ] **Step 5: Run full queue test suite for regressions**
+
+Run: `cd server && go test ./internal/scraper/ -run "Test.*Queue\|Test.*Enqueue\|Test.*Dequeue" -v`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add server/internal/scraper/queue.go server/internal/scraper/queue_test.go
+git commit -m "feat(scraper): add type-aware queue methods for ra_fetch (#410)"
+```
+
+---
+
+### Task 4: Add `FetchRAAchievements` (single-game) to scraper
+
+**Files:**
+- Modify: `server/internal/scraper/scraper_ra.go`
+- Create: `server/internal/scraper/scraper_ra_fetch_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `server/internal/scraper/scraper_ra_fetch_test.go`:
+
+```go
+package scraper
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/retroachievements"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var testROMContent = []byte("test rom for ra fetch")
+
+func testROMHash() string {
+	h := md5.Sum(testROMContent)
+	return hex.EncodeToString(h[:])
+}
+
+func setupRAFetchTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(
+		&db.Console{}, &db.Game{}, &db.GameAchievementCache{},
+	))
+	return database
+}
+
+func newTestRAServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	expectedHash := testROMHash()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/dorequest.php":
+			hash := r.URL.Query().Get("m")
+			if hash == expectedHash {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"Success": true,
+					"GameID":  float64(99),
+				})
+			} else {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"Success": true,
+					"GameID":  float64(0),
+				})
+			}
+		case "/API/API_GetGameExtended.php":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"ID":    99,
+				"Title": "Test RA Game",
+				"Achievements": map[string]interface{}{
+					"1001": map[string]interface{}{
+						"ID":          1001,
+						"Title":       "First Step",
+						"Description": "Do the first thing",
+						"Points":      5,
+						"BadgeName":   "badge001",
+						"type":        3,
+					},
+				},
+			})
+		}
+	}))
+}
+
+func TestFetchRAAchievements_PopulatesCache(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+	mockRA := newTestRAServer(t)
+	defer mockRA.Close()
+
+	// Create ROM file
+	tmpDir := t.TempDir()
+	romDir := filepath.Join(tmpDir, "roms")
+	os.MkdirAll(romDir, 0o755)
+	os.WriteFile(filepath.Join(romDir, "game.nes"), testROMContent, 0o644)
+
+	// Create console + game
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Console: console,
+		Title: "Test Game", FileName: "game.nes", FilePath: "roms/game.nes",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	s := &Scraper{
+		DB:       database,
+		RAClient: &retroachievements.RAClient{BaseURL: mockRA.URL, HTTPClient: mockRA.Client()},
+		RAAPIKey: "test-api-key",
+		GameDirs: []string{tmpDir},
+	}
+
+	err := s.FetchRAAchievements(&game)
+	require.NoError(t, err)
+
+	// Verify RAGameID was cached on the game record
+	var updated db.Game
+	require.NoError(t, database.First(&updated, game.ID).Error)
+	assert.Equal(t, uint(99), updated.RAGameID)
+	assert.True(t, updated.RAHashChecked)
+
+	// Verify achievement cache was populated
+	var cache db.GameAchievementCache
+	require.NoError(t, database.Where("ra_game_id = ?", 99).First(&cache).Error)
+	assert.Equal(t, "Test RA Game", cache.Title)
+	assert.Equal(t, 1, cache.TotalCount)
+	assert.Equal(t, game.ID, cache.GameID)
+}
+
+func TestFetchRAAchievements_SkipsWhenCacheFresh(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Console: console,
+		Title: "Test Game", FileName: "game.nes", FilePath: "roms/game.nes",
+		RAGameID: 99, RAHashChecked: true,
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	// Pre-populate cache
+	database.Create(&db.GameAchievementCache{
+		RAGameID: 99, GameID: game.ID, Title: "Cached",
+		AchievementJSON: "[]", TotalCount: 5, TotalPoints: 50,
+	})
+
+	// No RA client needed — should be a no-op
+	s := &Scraper{DB: database}
+
+	err := s.FetchRAAchievements(&game)
+	require.NoError(t, err)
+
+	// Cache should be untouched
+	var cache db.GameAchievementCache
+	database.Where("ra_game_id = ?", 99).First(&cache)
+	assert.Equal(t, "Cached", cache.Title)
+}
+
+func TestFetchRAAchievements_SetsHashCheckedOnNoMatch(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+
+	// Mock RA server that returns GameID=0 for all hashes
+	mockRA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"Success": true,
+			"GameID":  float64(0),
+		})
+	}))
+	defer mockRA.Close()
+
+	tmpDir := t.TempDir()
+	romDir := filepath.Join(tmpDir, "roms")
+	os.MkdirAll(romDir, 0o755)
+	os.WriteFile(filepath.Join(romDir, "unknown.nes"), []byte("unknown rom"), 0o644)
+
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Console: console,
+		Title: "Unknown Game", FileName: "unknown.nes", FilePath: "roms/unknown.nes",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	s := &Scraper{
+		DB:       database,
+		RAClient: &retroachievements.RAClient{BaseURL: mockRA.URL, HTTPClient: mockRA.Client()},
+		RAAPIKey: "test-api-key",
+		GameDirs: []string{tmpDir},
+	}
+
+	err := s.FetchRAAchievements(&game)
+	require.NoError(t, err)
+
+	// RAHashChecked should be true, RAGameID should remain 0
+	var updated db.Game
+	require.NoError(t, database.First(&updated, game.ID).Error)
+	assert.Equal(t, uint(0), updated.RAGameID)
+	assert.True(t, updated.RAHashChecked)
+}
+
+func TestFetchRAAchievements_SkipsWhenHashCheckedAndNoMatch(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Console: console,
+		Title: "No RA Game", FileName: "game.nes", FilePath: "roms/game.nes",
+		RAGameID: 0, RAHashChecked: true, // Already checked, no match
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	// No RA client needed — should skip immediately
+	s := &Scraper{DB: database}
+
+	err := s.FetchRAAchievements(&game)
+	require.NoError(t, err)
+}
+
+func TestFetchRAAchievements_NoRAConfig(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Console: console,
+		Title: "Test Game", FileName: "game.nes", FilePath: "roms/game.nes",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	s := &Scraper{DB: database} // No RAClient or RAAPIKey
+
+	err := s.FetchRAAchievements(&game)
+	assert.Error(t, err)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && go test ./internal/scraper/ -run "TestFetchRAAchievements" -v`
+Expected: FAIL — `FetchRAAchievements` not defined
+
+- [ ] **Step 3: Implement `FetchRAAchievements`**
+
+Add to `server/internal/scraper/scraper_ra.go`:
+
+```go
+// FetchRAAchievements fetches RetroAchievements data for a single game using
+// the server-level API key. This is called by the queue worker for "ra_fetch"
+// items, triggered when a user views a game detail page without cached achievements.
+//
+// The function is idempotent:
+//   - If the GameAchievementCache is already fresh (< 24h), it's a no-op.
+//   - If RAHashChecked=true and RAGameID=0, the game has no RA match — skip.
+//   - If RAGameID > 0, skip the hash lookup and go straight to fetching achievements.
+//
+// See the Game model for the RAHashChecked + RAGameID sentinel documentation.
+func (s *Scraper) FetchRAAchievements(game *db.Game) error {
+	if !s.IsRAConfigured() {
+		return fmt.Errorf("RA client or API key not configured")
+	}
+
+	// If we already know RA doesn't have this game, skip.
+	if game.RAHashChecked && game.RAGameID == 0 {
+		return nil
+	}
+
+	raGameID := game.RAGameID
+
+	// Resolve RAGameID if not cached yet.
+	if raGameID == 0 {
+		var hash string
+		for _, dir := range s.GameDirs {
+			candidate := filepath.Join(dir, game.FilePath)
+			if h, err := retroachievements.ComputeMD5(candidate); err == nil {
+				hash = h
+				break
+			}
+		}
+		if hash == "" {
+			// ROM file not found — mark as checked so we don't retry.
+			s.DB.Model(&db.Game{}).Where("id = ?", game.ID).
+				Updates(map[string]interface{}{"ra_hash_checked": true})
+			slog.Warn("RA fetch: ROM file not found", "game", game.Title, "path", game.FilePath)
+			return nil
+		}
+
+		time.Sleep(500 * time.Millisecond) // RA API rate limit
+		id, err := s.RAClient.GetGameIDFromHash(hash)
+		if err != nil {
+			// Transient error — do NOT set RAHashChecked, allow retry.
+			return fmt.Errorf("RA hash lookup failed for %q: %w", game.Title, err)
+		}
+
+		// Mark hash as checked regardless of whether RA returned a match.
+		updates := map[string]interface{}{"ra_hash_checked": true, "ra_game_id": id}
+		s.DB.Model(&db.Game{}).Where("id = ?", game.ID).Updates(updates)
+
+		if id == 0 {
+			slog.Debug("RA fetch: no RA match for game", "game", game.Title)
+			return nil
+		}
+		raGameID = id
+	}
+
+	// Check if cache is already fresh (< 24h).
+	var cache db.GameAchievementCache
+	cacheHit := s.DB.Where("ra_game_id = ?", raGameID).First(&cache).Error == nil
+	if cacheHit && time.Since(cache.CachedAt) < 24*time.Hour {
+		return nil // Cache is fresh, nothing to do.
+	}
+
+	// Fetch achievements from RA using server API key.
+	time.Sleep(500 * time.Millisecond) // RA API rate limit
+	gameInfo, err := s.RAClient.GetGameExtended(s.RAAPIKey, raGameID)
+	if err != nil {
+		return fmt.Errorf("RA achievement fetch failed for %q (raGameID=%d): %w", game.Title, raGameID, err)
+	}
+
+	achJSON, err := json.Marshal(gameInfo.Achievements)
+	if err != nil {
+		return fmt.Errorf("marshalling achievements for %q: %w", game.Title, err)
+	}
+
+	// Upsert cache entry.
+	if cacheHit {
+		cache.Title = gameInfo.Title
+		cache.AchievementJSON = string(achJSON)
+		cache.TotalCount = gameInfo.TotalCount
+		cache.TotalPoints = gameInfo.TotalPoints
+		cache.CachedAt = time.Now()
+		cache.GameID = game.ID
+		s.DB.Save(&cache)
+	} else {
+		s.DB.Create(&db.GameAchievementCache{
+			RAGameID:        raGameID,
+			GameID:          game.ID,
+			Title:           gameInfo.Title,
+			AchievementJSON: string(achJSON),
+			TotalCount:      gameInfo.TotalCount,
+			TotalPoints:     gameInfo.TotalPoints,
+			CachedAt:        time.Now(),
+		})
+	}
+
+	slog.Info("RA fetch: cached achievements", "game", game.Title, "raGameId", raGameID, "count", gameInfo.TotalCount)
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd server && go test ./internal/scraper/ -run "TestFetchRAAchievements" -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/internal/scraper/scraper_ra.go server/internal/scraper/scraper_ra_fetch_test.go
+git commit -m "feat(scraper): add FetchRAAchievements for single-game RA fetch (#410)"
+```
+
+---
+
+### Task 5: Dispatch `ra_fetch` in queue worker
+
+**Files:**
+- Modify: `server/internal/scraper/worker.go:83-131`
+
+- [ ] **Step 1: Add `ra_fetch` dispatch to `processItem`**
+
+In `server/internal/scraper/worker.go`, modify the `processItem` function. Replace the block starting at "Variant group propagation" through the end of the `if !propagated` block with type-aware dispatch:
+
+Find this code (lines ~94-120):
+```go
+	// Variant group propagation for 'new' mode jobs
+	propagated := false
+	if item.JobID != nil {
+		var job db.ScrapeJob
+		if err := w.db.First(&job, *item.JobID).Error; err == nil {
+			if job.Mode == "new" && game.GroupKey != "" {
+				if w.scraper.propagateGroupMetadata(&game) {
+					propagated = true
+				}
+			}
+		}
+	}
+
+	if !propagated {
+		if err := w.scraper.ScrapeGame(&game); err != nil {
+			slog.Warn("scrape worker: scrape failed", "game", game.Title, "error", err)
+			jobDone, _ := w.queue.MarkFailed(item, err.Error())
+			w.broadcastProgress(item, &game, false, jobDone)
+			w.broadcastScrapeStatus(game.ID, "idle")
+			return
+		}
+
+		// Propagate metadata to unscraped siblings in the same variant group
+		if game.GroupKey != "" {
+			w.scraper.propagateToGroup(&game)
+		}
+	}
+```
+
+Replace with:
+
+```go
+	// Dispatch based on queue item type.
+	// Default to "scrape" for backward compatibility with items created before
+	// the Type field was added (they have Type="" due to GORM zero-value).
+	itemType := item.Type
+	if itemType == "" {
+		itemType = "scrape"
+	}
+
+	switch itemType {
+	case "ra_fetch":
+		if err := w.scraper.FetchRAAchievements(&game); err != nil {
+			slog.Warn("scrape worker: RA fetch failed", "game", game.Title, "error", err)
+			jobDone, _ := w.queue.MarkFailed(item, err.Error())
+			w.broadcastProgress(item, &game, false, jobDone)
+			w.broadcastScrapeStatus(game.ID, "idle")
+			return
+		}
+
+	default: // "scrape" — full metadata scrape
+		// Variant group propagation for 'new' mode jobs
+		propagated := false
+		if item.JobID != nil {
+			var job db.ScrapeJob
+			if err := w.db.First(&job, *item.JobID).Error; err == nil {
+				if job.Mode == "new" && game.GroupKey != "" {
+					if w.scraper.propagateGroupMetadata(&game) {
+						propagated = true
+					}
+				}
+			}
+		}
+
+		if !propagated {
+			if err := w.scraper.ScrapeGame(&game); err != nil {
+				slog.Warn("scrape worker: scrape failed", "game", game.Title, "error", err)
+				jobDone, _ := w.queue.MarkFailed(item, err.Error())
+				w.broadcastProgress(item, &game, false, jobDone)
+				w.broadcastScrapeStatus(game.ID, "idle")
+				return
+			}
+
+			// Propagate metadata to unscraped siblings in the same variant group
+			if game.GroupKey != "" {
+				w.scraper.propagateToGroup(&game)
+			}
+		}
+	}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+Run: `cd server && go build ./...`
+Expected: success
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add server/internal/scraper/worker.go
+git commit -m "feat(scraper): dispatch ra_fetch items in queue worker (#410)"
+```
+
+---
+
+### Task 6: Extend `RAHandler` to auto-enqueue and add handler tests
+
+**Files:**
+- Modify: `server/internal/api/ra_handler.go:22-27` (struct) and `189-326` (handler)
+- Modify: `server/internal/api/router.go:176` (handler construction)
+- Test: `server/internal/api/ra_handler_test.go`
+
+- [ ] **Step 1: Write failing tests for auto-enqueue behavior**
+
+Add to `server/internal/api/ra_handler_test.go`:
+
+```go
+func TestGetGameAchievements_AutoEnqueuesRAFetch(t *testing.T) {
+	mockRA, router, cfg := setupRATestEnv(t)
+	defer mockRA.Close()
+
+	token := registerAndGetToken(t, router)
+	game := createGameWithROM(t, cfg)
+
+	// Set server RA API key so auto-fetch is enabled
+	cfg.DB.Create(&db.ServerSetting{Key: "ra_api_key", Value: "test-server-key"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/achievements", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	// Should return 202 with pending status (no cache, no user RA creds)
+	assert.Equal(t, http.StatusAccepted, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "pending", resp["status"])
+}
+
+func TestGetGameAchievements_ReturnsPendingWhenAlreadyQueued(t *testing.T) {
+	mockRA, router, cfg := setupRATestEnv(t)
+	defer mockRA.Close()
+
+	token := registerAndGetToken(t, router)
+	game := createGameWithROM(t, cfg)
+
+	cfg.DB.Create(&db.ServerSetting{Key: "ra_api_key", Value: "test-server-key"})
+
+	// Manually enqueue an ra_fetch item
+	cfg.Scraper.Queue.EnqueueGameWithType(game.ID, nil, 100, "ra_fetch")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/achievements", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusAccepted, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "pending", resp["status"])
+}
+
+func TestGetGameAchievements_ReturnsCachedData(t *testing.T) {
+	mockRA, router, cfg := setupRATestEnv(t)
+	defer mockRA.Close()
+
+	token := registerAndGetToken(t, router)
+	game := createGameWithROM(t, cfg)
+
+	// Pre-populate the RA game ID and cache
+	cfg.DB.Model(&db.Game{}).Where("id = ?", game.ID).Update("ra_game_id", 42)
+	achJSON, _ := json.Marshal([]map[string]interface{}{
+		{"ID": 501, "Title": "Test Achievement", "Description": "Do thing", "Points": 10, "BadgeName": "badge1", "type": "core"},
+	})
+	cfg.DB.Create(&db.GameAchievementCache{
+		RAGameID: 42, GameID: game.ID, Title: "Test ROM Game",
+		AchievementJSON: string(achJSON), TotalCount: 1, TotalPoints: 10,
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/achievements", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	// Should return 200 with cached data
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(1), resp["totalCount"])
+}
+
+func TestGetGameAchievements_NoAutoFetchWithoutRAKey(t *testing.T) {
+	mockRA, router, cfg := setupRATestEnv(t)
+	defer mockRA.Close()
+
+	token := registerAndGetToken(t, router)
+	game := createGameWithROM(t, cfg)
+
+	// No server RA API key configured, no user RA credentials
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/achievements", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	// Should return 200 with empty response (no auto-fetch without RA key)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	achievements := resp["achievements"].([]interface{})
+	assert.Empty(t, achievements)
+}
+
+func TestGetGameAchievements_SkipsAutoFetchWhenHashCheckedNoMatch(t *testing.T) {
+	mockRA, router, cfg := setupRATestEnv(t)
+	defer mockRA.Close()
+
+	token := registerAndGetToken(t, router)
+	game := createGameWithROM(t, cfg)
+
+	// Mark game as checked but no RA match
+	cfg.DB.Model(&db.Game{}).Where("id = ?", game.ID).
+		Updates(map[string]interface{}{"ra_hash_checked": true, "ra_game_id": 0})
+
+	cfg.DB.Create(&db.ServerSetting{Key: "ra_api_key", Value: "test-server-key"})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/achievements", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	// Should return 200 empty — no enqueue, no pending
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	achievements := resp["achievements"].([]interface{})
+	assert.Empty(t, achievements)
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && go test ./internal/api/ -run "TestGetGameAchievements_Auto|TestGetGameAchievements_Returns|TestGetGameAchievements_No|TestGetGameAchievements_Skips" -v`
+Expected: FAIL — handler doesn't have queue access or auto-enqueue logic yet
+
+- [ ] **Step 3: Add queue and API key fields to RAHandler**
+
+In `server/internal/api/ra_handler.go`, update the struct:
+
+```go
+type RAHandler struct {
+	DB            *gorm.DB
+	RAClient      *retroachievements.RAClient
+	GameDir       string
+	EncryptionKey []byte // AES-256 key for encrypting RA tokens at rest
+	Queue         *scraper.ScrapeQueue // Scrape queue for async RA fetch jobs
+	RAAPIKey      string               // Server-level RA API key; empty = auto-fetch disabled
+}
+```
+
+Add the import for the scraper package at the top of the file:
+
+```go
+import (
+	// ... existing imports ...
+	"github.com/spela/server/internal/scraper"
+)
+```
+
+- [ ] **Step 4: Update RAHandler construction in router.go**
+
+In `server/internal/api/router.go`, line 176, update the handler construction:
+
+```go
+	var raQueue *scraper.ScrapeQueue
+	var raAPIKey string
+	if cfg.Scraper != nil {
+		raQueue = cfg.Scraper.Queue
+		raAPIKey = cfg.Scraper.RAAPIKey
+	}
+	raHandler := &RAHandler{
+		DB: cfg.DB, RAClient: raClient, GameDir: cfg.GameDirs[0],
+		EncryptionKey: encryptionKey, Queue: raQueue, RAAPIKey: raAPIKey,
+	}
+```
+
+- [ ] **Step 5: Modify GetGameAchievements to auto-enqueue**
+
+In `server/internal/api/ra_handler.go`, replace the `GetGameAchievements` function body. The key changes are:
+1. After the cache check, if no fresh cache and no user credentials, try auto-enqueue
+2. If `RAHashChecked=true` and `RAGameID=0`, return empty (no RA match)
+3. Return 202 with `{ status: "pending" }` when enqueuing
+
+Replace the section after the fresh cache return (starting from "Cache is stale or missing — try to refresh using user's RA credentials") with:
+
+```go
+	// Cache is stale or missing — try to refresh using user's RA credentials
+	var cred db.RetroAchievementCredential
+	hasUserCreds := h.DB.Where("user_id = ?", uid).First(&cred).Error == nil
+
+	if hasUserCreds {
+		raToken, err := h.decryptRAToken(&cred)
+		if err != nil {
+			slog.Error("failed to decrypt RA token", "user_id", uid, "error", err)
+			// Fall through to server-key auto-fetch below
+		} else {
+			gameInfo, _, err := h.RAClient.GetGameInfoAndUserProgress(cred.RAUsername, raToken, raGameID)
+			if err != nil {
+				slog.Error("failed to fetch RA game info", "ra_game_id", raGameID, "error", err)
+				// Fall through to server-key auto-fetch below
+			} else {
+				// Success — cache and return
+				achJSON, _ := json.Marshal(gameInfo.Achievements)
+				if cacheHit {
+					cache.Title = gameInfo.Title
+					cache.AchievementJSON = string(achJSON)
+					cache.TotalCount = gameInfo.TotalCount
+					cache.TotalPoints = gameInfo.TotalPoints
+					cache.CachedAt = time.Now()
+					cache.GameID = game.ID
+					h.DB.Save(&cache)
+				} else {
+					h.DB.Create(&db.GameAchievementCache{
+						RAGameID:        raGameID,
+						GameID:          game.ID,
+						Title:           gameInfo.Title,
+						AchievementJSON: string(achJSON),
+						TotalCount:      gameInfo.TotalCount,
+						TotalPoints:     gameInfo.TotalPoints,
+						CachedAt:        time.Now(),
+					})
+				}
+				c.JSON(http.StatusOK, gin.H{
+					"raGameId":     raGameID,
+					"title":        gameInfo.Title,
+					"achievements": gameInfo.Achievements,
+					"totalCount":   gameInfo.TotalCount,
+					"totalPoints":  gameInfo.TotalPoints,
+				})
+				return
+			}
+		}
+	}
+
+	// No user credentials or user fetch failed — try server-level auto-fetch via queue.
+	if h.Queue != nil && h.RAAPIKey != "" {
+		queued, _ := h.Queue.IsGameQueuedForType(game.ID, "ra_fetch")
+		if !queued {
+			if err := h.Queue.EnqueueGameWithType(game.ID, nil, 100, "ra_fetch"); err != nil {
+				slog.Warn("RA auto-fetch: failed to enqueue", "game", game.Title, "error", err)
+			}
+		}
+		c.JSON(http.StatusAccepted, gin.H{"status": "pending"})
+		return
+	}
+
+	// No server RA key configured — return stale cache if available, otherwise empty.
+	if cacheHit {
+		var achievements []retroachievements.Achievement
+		if err := json.Unmarshal([]byte(cache.AchievementJSON), &achievements); err == nil {
+			c.JSON(http.StatusOK, gin.H{
+				"raGameId":     raGameID,
+				"title":        cache.Title,
+				"achievements": achievements,
+				"totalCount":   cache.TotalCount,
+				"totalPoints":  cache.TotalPoints,
+			})
+			return
+		}
+	}
+	c.JSON(http.StatusOK, emptyResponse)
+```
+
+Also modify the top of `GetGameAchievements` to handle the `RAHashChecked` sentinel. After `raGameID := game.RAGameID` and before the `if raGameID == 0` hash lookup block, add:
+
+```go
+	// If we already checked and RA doesn't have this game, return empty.
+	if game.RAHashChecked && raGameID == 0 {
+		c.JSON(http.StatusOK, emptyResponse)
+		return
+	}
+```
+
+And in the existing `if raGameID == 0` block where it does the hash lookup inline, also update the game's `RAHashChecked` field after a successful lookup:
+
+```go
+		// Cache the RA game ID and mark hash as checked on the game record
+		h.DB.Model(&db.Game{}).Where("id = ?", game.ID).
+			Updates(map[string]interface{}{"ra_game_id": raGameID, "ra_hash_checked": true})
+```
+
+**Important:** The inline hash lookup in the handler is still needed for the case where a user WITH RA credentials views a game that hasn't been hashed yet — they get results immediately via their credentials. The auto-enqueue path is for users WITHOUT credentials.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd server && go test ./internal/api/ -run "TestGetGameAchievements" -v`
+Expected: all PASS (both new and existing tests)
+
+- [ ] **Step 7: Run full RA handler test suite**
+
+Run: `cd server && go test ./internal/api/ -run "TestLink|TestUnlink|TestGetGameAchievement|TestGetAchievement|TestRefresh" -v`
+Expected: all PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add server/internal/api/ra_handler.go server/internal/api/router.go server/internal/api/ra_handler_test.go
+git commit -m "feat(api): auto-enqueue ra_fetch when achievements not cached (#410)"
+```
+
+---
+
+### Task 7: Update frontend types and hook for pending status
+
+**Files:**
+- Modify: `web/src/types/api.ts:362-367`
+- Modify: `web/src/hooks/use-retroachievements.ts:56-62`
+- Test: `web/src/hooks/__tests__/use-retroachievements.test.ts`
+
+- [ ] **Step 1: Write failing tests for pending→data transition**
+
+Add to `web/src/hooks/__tests__/use-retroachievements.test.ts`, inside the existing `describe("useGameAchievements", ...)` block:
+
+```typescript
+  it("polls when status is pending and stops when data arrives", async () => {
+    const pendingResponse = { status: "pending" as const };
+    mockApi.get
+      .mockResolvedValueOnce(pendingResponse)
+      .mockResolvedValueOnce(pendingResponse)
+      .mockResolvedValueOnce(mockAchievements);
+
+    const { result } = renderHook(() => useGameAchievements("game-1"), {
+      wrapper: createWrapper(),
+    });
+
+    // First call returns pending
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data?.status).toBe("pending");
+
+    // Should eventually get real data via refetch
+    await waitFor(
+      () => {
+        expect(result.current.data?.achievements).toBeDefined();
+        expect(result.current.data?.achievements?.length).toBeGreaterThan(0);
+      },
+      { timeout: 10000 },
+    );
+
+    expect(result.current.data?.totalCount).toBe(2);
+  });
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd web && npx vitest run src/hooks/__tests__/use-retroachievements.test.ts --reporter=verbose`
+Expected: FAIL — `status` field not on type, no refetch interval logic
+
+- [ ] **Step 3: Add `status` field to `GameAchievements` type**
+
+In `web/src/types/api.ts`, update the interface:
+
+```typescript
+export interface GameAchievements {
+  status?: "pending";
+  raGameId: number;
+  totalCount: number;
+  totalPoints: number;
+  achievements: Achievement[];
+}
+```
+
+- [ ] **Step 4: Update `useGameAchievements` hook to poll when pending**
+
+In `web/src/hooks/use-retroachievements.ts`, replace the `useGameAchievements` function:
+
+```typescript
+export function useGameAchievements(gameId: string | undefined) {
+  return useQuery({
+    queryKey: ["game-achievements", gameId],
+    queryFn: () => api.get<GameAchievements>(`/games/${gameId}/achievements`),
+    enabled: !!gameId,
+    refetchInterval: (query) => {
+      // Poll every 2 seconds while the server is processing an RA fetch.
+      // Stop polling once we have actual achievement data.
+      if (query.state.data?.status === "pending") {
+        return 2000;
+      }
+      return false;
+    },
+  });
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd web && npx vitest run src/hooks/__tests__/use-retroachievements.test.ts --reporter=verbose`
+Expected: all PASS
+
+- [ ] **Step 6: Run full frontend test suite for regressions**
+
+Run: `cd web && npx vitest run --reporter=verbose`
+Expected: all PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add web/src/types/api.ts web/src/hooks/use-retroachievements.ts web/src/hooks/__tests__/use-retroachievements.test.ts
+git commit -m "feat(web): poll for achievements when RA fetch is pending (#410)"
+```
+
+---
+
+### Task 8: Backend integration test and full test run
+
+**Files:**
+- No new files — validation task
+
+- [ ] **Step 1: Run full backend test suite**
+
+Run: `cd server && go test ./... 2>&1 | tail -30`
+Expected: all PASS, no regressions
+
+- [ ] **Step 2: Run full frontend test suite**
+
+Run: `cd web && npx vitest run`
+Expected: all PASS
+
+- [ ] **Step 3: Build both projects**
+
+Run: `cd server && go build ./... && cd ../web && npm run build`
+Expected: both succeed
+
+- [ ] **Step 4: Commit if any fixes were needed**
+
+Only if regressions were found and fixed in previous steps.

--- a/docs/superpowers/specs/2026-04-15-auto-fetch-ra-achievements-design.md
+++ b/docs/superpowers/specs/2026-04-15-auto-fetch-ra-achievements-design.md
@@ -1,0 +1,168 @@
+# Auto-Fetch RetroAchievements on Game Detail Page
+
+**Issue:** #410
+**Date:** 2026-04-15
+
+## Summary
+
+When a user opens a game detail page, automatically fetch RetroAchievements
+data if the game doesn't have cached achievements yet. Uses the server's RA
+API key so achievements are visible to all users — even those who haven't
+linked their personal RA account. This lets achievements serve as an incentive
+for users to register their own credentials and start tracking progress.
+
+## Approach
+
+Extend the scrape queue with a new `ra_fetch` job type. The
+`GET /games/{id}/achievements` endpoint enqueues an `ra_fetch` job when no
+fresh cache exists, returns a `{ status: "pending" }` response, and the
+frontend refetches until data is available. The queue worker handles hash
+computation and RA API calls, avoiding HTTP timeout issues with large ROMs.
+
+## Backend Changes
+
+### 1. New queue item type: `ra_fetch`
+
+Add a `Type string` field to `ScrapeQueueItem` with a default value of
+`"scrape"`. Existing rows with an empty type are treated as `"scrape"` for
+backward compatibility. The worker dispatches based on type:
+
+```go
+switch item.Type {
+case "scrape":     w.scraper.ScrapeGame(&game)
+case "ra_fetch":   w.scraper.FetchRAAchievements(&game)
+}
+```
+
+`FetchRAAchievements` is a new function that:
+1. Checks if `GameAchievementCache` is fresh — if so, no-op
+2. Resolves `RAGameID` (cached on game record, or compute MD5 hash + RA lookup)
+3. Fetches achievements via `GetGameExtended()` using the server's RA API key
+4. Populates `GameAchievementCache`
+
+This is idempotent: if the cache is already fresh, it's a no-op. If a full
+`scrape` also populates RA data in the future (#413), there's no conflict —
+both write to the same cache.
+
+### 2. "No RA match" marker on Game model
+
+Add `RAHashChecked bool` to the Game model to avoid re-hashing large ROMs
+when RA doesn't recognize the game.
+
+```
+# IMPORTANT: RAGameID + RAHashChecked sentinel logic
+#
+# These two fields together determine whether we need to attempt
+# an RA hash lookup for this game:
+#
+#   RAHashChecked=false, RAGameID=0  → Not yet looked up. Compute ROM
+#                                      MD5 hash and query RA API.
+#   RAHashChecked=true,  RAGameID=0  → Looked up, but RA doesn't have
+#                                      this game. Do NOT retry.
+#   RAHashChecked=true,  RAGameID>0  → Valid RA game ID cached.
+#                                      (RAHashChecked is redundant here
+#                                      but kept consistent.)
+#
+# RAHashChecked is ONLY set to true after a SUCCESSFUL lookup attempt
+# (whether RA returned a game ID or not). If the lookup fails due to
+# a transient error (network, 403, timeout), RAHashChecked stays false
+# so the next visit retries.
+```
+
+### 3. Extend `GetGameAchievements` handler
+
+The existing `GET /games/{id}/achievements` handler is extended:
+
+1. Look up game, check console supports RA (existing)
+2. Check `GameAchievementCache` — if fresh, return cached data (existing)
+3. **New:** If no fresh cache AND server RA key is configured:
+   - Check if an `ra_fetch` job is already pending/in-progress for this game
+   - If not, enqueue one at priority 100
+   - Return `{ status: "pending" }` with HTTP 202
+4. If already queued, return `{ status: "pending" }` with HTTP 202
+5. If server RA key not configured, return stale cache or empty response
+6. If console doesn't support RA, return empty response immediately
+
+### 4. Server RA API key access
+
+The handler reads the server-level RA API key from `ServerSetting` (the
+`ra_api_key` key), the same way the scraper does. If not configured, the
+auto-fetch is skipped entirely.
+
+## Frontend Changes
+
+### 1. Update `useGameAchievements` hook
+
+When the endpoint returns `{ status: "pending" }`, enable a short
+`refetchInterval` (e.g., 2 seconds) on the TanStack Query. Once the
+response contains actual achievement data, disable the interval.
+
+This gives the user a natural loading → populated transition. The
+achievements section shows a loading/skeleton state while pending, then
+renders achievements when the data arrives.
+
+### 2. No other frontend changes needed
+
+The existing achievement display components, progress queries, and
+leaderboard all work as-is once the cache is populated.
+
+## Error Handling
+
+### RA API errors (403, timeout, rate limit)
+
+- Worker marks the queue item as failed with the error message
+- Handler returns stale cache if available, or empty response
+- No automatic retry — next page visit enqueues a new `ra_fetch` if cache
+  is still empty
+
+### Hash lookup failures
+
+- **ROM file missing on disk:** Set `RAHashChecked=true`, `RAGameID=0`.
+  Log warning. Don't retry.
+- **RA doesn't recognize hash:** Set `RAHashChecked=true`, `RAGameID=0`.
+  Game doesn't have RA support.
+- **Transient API error during hash lookup:** Don't set `RAHashChecked`.
+  Leave for retry on next visit.
+
+### Server RA key not configured
+
+Return empty response immediately. Achievements section doesn't render.
+
+### Duplicate enqueue prevention
+
+Before enqueuing, check if an `ra_fetch` item is already pending or
+in-progress for this game. If so, return 202 "already queued." Same
+pattern as `scrape-if-needed`.
+
+### Console doesn't support RA
+
+Early return with empty response. No enqueue, no hash computation.
+
+## Testing
+
+### Backend (Go unit tests)
+
+- **Auto-enqueue flow:** No cache → handler enqueues `ra_fetch` → returns
+  pending status
+- **Duplicate prevention:** Second request while job is pending returns
+  "already queued"
+- **`RAHashChecked` sentinel:** After "not found" hash lookup, subsequent
+  requests skip the hash step
+- **`ra_fetch` worker path:** Worker receives `ra_fetch` item, computes
+  hash, calls RA API, populates cache
+- **Error cases:** Missing ROM, RA 403, no server key configured — all
+  return gracefully without crashing
+
+### Frontend (Vitest + Playwright)
+
+- **Unit test (Vitest):** Mock endpoint returning `{ status: "pending" }`
+  then cached data — verify the hook transitions from loading to populated
+  and disables refetch interval
+- **E2E test (Playwright):** On a seeded game, navigate to game detail page,
+  verify achievements section appears
+
+## Out of Scope
+
+- Including RA in the per-game `ScrapeGame()` flow — tracked in #413
+- Decomposing the `scrape` job type into sub-jobs (unwrapping)
+- User-credential-based auto-fetch (existing handler behavior, unchanged)

--- a/server/internal/api/ra_handler.go
+++ b/server/internal/api/ra_handler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spela/server/internal/auth"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/retroachievements"
+	"github.com/spela/server/internal/scraper"
 	"github.com/spela/server/internal/storage"
 	"gorm.io/gorm"
 )
@@ -23,7 +24,9 @@ type RAHandler struct {
 	DB            *gorm.DB
 	RAClient      *retroachievements.RAClient
 	GameDir       string
-	EncryptionKey []byte // AES-256 key for encrypting RA tokens at rest
+	EncryptionKey []byte                // AES-256 key for encrypting RA tokens at rest
+	Queue         *scraper.ScrapeQueue  // Scrape queue for async RA fetch jobs
+	RAAPIKey      string                // Server-level RA API key; empty = auto-fetch disabled
 }
 
 // decryptRAToken decrypts the RA token from a credential record.
@@ -208,6 +211,14 @@ func (h *RAHandler) GetGameAchievements(c *gin.Context) {
 
 	// Determine RA game ID: use cached value if available, otherwise compute hash and look up
 	raGameID := game.RAGameID
+
+	// If we already checked and RA doesn't have this game, return empty.
+	// See Game model for RAHashChecked + RAGameID sentinel documentation.
+	if game.RAHashChecked && raGameID == 0 {
+		c.JSON(http.StatusOK, emptyResponse)
+		return
+	}
+
 	if raGameID == 0 {
 		// No cached RA game ID — compute hash and look up
 		romPath := filepath.Join(h.GameDir, game.FilePath)
@@ -231,8 +242,9 @@ func (h *RAHandler) GetGameAchievements(c *gin.Context) {
 			return
 		}
 
-		// Cache the RA game ID on the game record for future requests
-		h.DB.Model(&db.Game{}).Where("id = ?", game.ID).Update("ra_game_id", raGameID)
+		// Cache the RA game ID and mark hash as checked on the game record
+		h.DB.Model(&db.Game{}).Where("id = ?", game.ID).
+			Updates(map[string]interface{}{"ra_game_id": raGameID, "ra_hash_checked": true})
 	}
 
 	// Check cache (valid for 24 hours) — this is available to ALL authenticated users
@@ -256,73 +268,79 @@ func (h *RAHandler) GetGameAchievements(c *gin.Context) {
 
 	// Cache is stale or missing — try to refresh using user's RA credentials
 	var cred db.RetroAchievementCredential
-	if err := h.DB.Where("user_id = ?", uid).First(&cred).Error; err != nil {
-		// User has no RA credentials. If we have a stale cache, return it anyway.
-		if cacheHit {
-			var achievements []retroachievements.Achievement
-			if err := json.Unmarshal([]byte(cache.AchievementJSON), &achievements); err == nil {
+	hasUserCreds := h.DB.Where("user_id = ?", uid).First(&cred).Error == nil
+
+	if hasUserCreds {
+		raToken, err := h.decryptRAToken(&cred)
+		if err != nil {
+			slog.Error("failed to decrypt RA token", "user_id", uid, "error", err)
+			// Fall through to server-key auto-fetch below
+		} else {
+			gameInfo, _, err := h.RAClient.GetGameInfoAndUserProgress(cred.RAUsername, raToken, raGameID)
+			if err != nil {
+				slog.Error("failed to fetch RA game info", "ra_game_id", raGameID, "error", err)
+				// Fall through to server-key auto-fetch below
+			} else {
+				// Success — cache and return
+				achJSON, _ := json.Marshal(gameInfo.Achievements)
+				if cacheHit {
+					cache.Title = gameInfo.Title
+					cache.AchievementJSON = string(achJSON)
+					cache.TotalCount = gameInfo.TotalCount
+					cache.TotalPoints = gameInfo.TotalPoints
+					cache.CachedAt = time.Now()
+					cache.GameID = game.ID
+					h.DB.Save(&cache)
+				} else {
+					h.DB.Create(&db.GameAchievementCache{
+						RAGameID:        raGameID,
+						GameID:          game.ID,
+						Title:           gameInfo.Title,
+						AchievementJSON: string(achJSON),
+						TotalCount:      gameInfo.TotalCount,
+						TotalPoints:     gameInfo.TotalPoints,
+						CachedAt:        time.Now(),
+					})
+				}
 				c.JSON(http.StatusOK, gin.H{
 					"raGameId":     raGameID,
-					"title":        cache.Title,
-					"achievements": achievements,
-					"totalCount":   cache.TotalCount,
-					"totalPoints":  cache.TotalPoints,
+					"title":        gameInfo.Title,
+					"achievements": gameInfo.Achievements,
+					"totalCount":   gameInfo.TotalCount,
+					"totalPoints":  gameInfo.TotalPoints,
 				})
 				return
 			}
 		}
-		c.JSON(http.StatusOK, emptyResponse)
+	}
+
+	// No user credentials or user fetch failed — try server-level auto-fetch via queue.
+	if h.Queue != nil && h.RAAPIKey != "" {
+		queued, _ := h.Queue.IsGameQueuedForType(game.ID, "ra_fetch")
+		if !queued {
+			if err := h.Queue.EnqueueGameWithType(game.ID, nil, 100, "ra_fetch"); err != nil {
+				slog.Warn("RA auto-fetch: failed to enqueue", "game", game.Title, "error", err)
+			}
+		}
+		c.JSON(http.StatusAccepted, gin.H{"status": "pending"})
 		return
 	}
 
-	// Decrypt RA token for API call
-	raToken, err := h.decryptRAToken(&cred)
-	if err != nil {
-		slog.Error("failed to decrypt RA token", "user_id", uid, "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to access RA credentials"})
-		return
-	}
-
-	// Fetch from RA API
-	gameInfo, _, err := h.RAClient.GetGameInfoAndUserProgress(cred.RAUsername, raToken, raGameID)
-	if err != nil {
-		slog.Error("failed to fetch RA game info", "ra_game_id", raGameID, "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to fetch achievements from RetroAchievements"})
-		return
-	}
-
-	// Cache the result
-	achJSON, err := json.Marshal(gameInfo.Achievements)
-	if err != nil {
-		slog.Warn("failed to marshal achievement data for cache", "ra_game_id", raGameID, "error", err)
-	}
+	// No server RA key configured — return stale cache if available, otherwise empty.
 	if cacheHit {
-		cache.Title = gameInfo.Title
-		cache.AchievementJSON = string(achJSON)
-		cache.TotalCount = gameInfo.TotalCount
-		cache.TotalPoints = gameInfo.TotalPoints
-		cache.CachedAt = time.Now()
-		cache.GameID = game.ID
-		h.DB.Save(&cache)
-	} else {
-		h.DB.Create(&db.GameAchievementCache{
-			RAGameID:        raGameID,
-			GameID:          game.ID,
-			Title:           gameInfo.Title,
-			AchievementJSON: string(achJSON),
-			TotalCount:      gameInfo.TotalCount,
-			TotalPoints:     gameInfo.TotalPoints,
-			CachedAt:        time.Now(),
-		})
+		var achievements []retroachievements.Achievement
+		if err := json.Unmarshal([]byte(cache.AchievementJSON), &achievements); err == nil {
+			c.JSON(http.StatusOK, gin.H{
+				"raGameId":     raGameID,
+				"title":        cache.Title,
+				"achievements": achievements,
+				"totalCount":   cache.TotalCount,
+				"totalPoints":  cache.TotalPoints,
+			})
+			return
+		}
 	}
-
-	c.JSON(http.StatusOK, gin.H{
-		"raGameId":     raGameID,
-		"title":        gameInfo.Title,
-		"achievements": gameInfo.Achievements,
-		"totalCount":   gameInfo.TotalCount,
-		"totalPoints":  gameInfo.TotalPoints,
-	})
+	c.JSON(http.StatusOK, emptyResponse)
 }
 
 // GetAchievementProgress returns the user's achievement progress for a game.

--- a/server/internal/api/ra_handler_test.go
+++ b/server/internal/api/ra_handler_test.go
@@ -1055,3 +1055,141 @@ func TestGetAchievementLeaderboard_MultipleUsers(t *testing.T) {
 	assert.Equal(t, float64(1), second["unlockedCount"])
 	assert.Equal(t, false, second["isComplete"])
 }
+
+func TestGetGameAchievements_AutoEnqueuesRAFetch(t *testing.T) {
+	mockRA, router, cfg := setupRATestEnv(t)
+	defer mockRA.Close()
+
+	token := registerAndGetToken(t, router)
+	game := createGameWithROM(t, cfg)
+
+	// Set server RA API key so auto-fetch is enabled
+	cfg.DB.Create(&db.ServerSetting{Key: "ra_api_key", Value: "test-server-key"})
+	// Configure the scraper's RA API key so it's passed to RAHandler
+	cfg.Scraper.RAAPIKey = "test-server-key"
+	// Rebuild router to pick up the new RA API key
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/achievements", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	// Should return 202 with pending status (no cache, no user RA creds)
+	assert.Equal(t, http.StatusAccepted, w.Code)
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "pending", resp["status"])
+}
+
+func TestGetGameAchievements_ReturnsPendingWhenAlreadyQueued(t *testing.T) {
+	mockRA, router, cfg := setupRATestEnv(t)
+	defer mockRA.Close()
+
+	token := registerAndGetToken(t, router)
+	game := createGameWithROM(t, cfg)
+
+	cfg.Scraper.RAAPIKey = "test-server-key"
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	// Manually enqueue an ra_fetch item
+	cfg.Scraper.Queue.EnqueueGameWithType(game.ID, nil, 100, "ra_fetch")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/achievements", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	assert.Equal(t, http.StatusAccepted, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, "pending", resp["status"])
+}
+
+func TestGetGameAchievements_ReturnsCachedData(t *testing.T) {
+	mockRA, router, cfg := setupRATestEnv(t)
+	defer mockRA.Close()
+
+	token := registerAndGetToken(t, router)
+	game := createGameWithROM(t, cfg)
+
+	// Pre-populate the RA game ID and cache
+	cfg.DB.Model(&db.Game{}).Where("id = ?", game.ID).
+		Updates(map[string]interface{}{"ra_game_id": 42, "ra_hash_checked": true})
+	achJSON, _ := json.Marshal([]map[string]interface{}{
+		{"ID": 501, "Title": "Test Achievement", "Description": "Do thing", "Points": 10, "BadgeName": "badge1", "type": "core"},
+	})
+	cfg.DB.Create(&db.GameAchievementCache{
+		RAGameID: 42, GameID: game.ID, Title: "Test ROM Game",
+		AchievementJSON: string(achJSON), TotalCount: 1, TotalPoints: 10,
+		CachedAt: time.Now(),
+	})
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/achievements", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	// Should return 200 with cached data
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	assert.Equal(t, float64(1), resp["totalCount"])
+}
+
+func TestGetGameAchievements_NoAutoFetchWithoutRAKey(t *testing.T) {
+	mockRA, router, cfg := setupRATestEnv(t)
+	defer mockRA.Close()
+
+	token := registerAndGetToken(t, router)
+	game := createGameWithROM(t, cfg)
+
+	// Pre-set RAGameID so we skip the inline hash lookup (which would call the mock RA server)
+	cfg.DB.Model(&db.Game{}).Where("id = ?", game.ID).
+		Updates(map[string]interface{}{"ra_game_id": 42, "ra_hash_checked": true})
+
+	// No server RA API key configured, no user RA credentials
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/achievements", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	// Should return 200 with empty response (no auto-fetch without RA key)
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	achievements := resp["achievements"].([]interface{})
+	assert.Empty(t, achievements)
+}
+
+func TestGetGameAchievements_SkipsAutoFetchWhenHashCheckedNoMatch(t *testing.T) {
+	mockRA, router, cfg := setupRATestEnv(t)
+	defer mockRA.Close()
+
+	token := registerAndGetToken(t, router)
+	game := createGameWithROM(t, cfg)
+
+	// Mark game as checked but no RA match
+	cfg.DB.Model(&db.Game{}).Where("id = ?", game.ID).
+		Updates(map[string]interface{}{"ra_hash_checked": true, "ra_game_id": 0})
+
+	cfg.Scraper.RAAPIKey = "test-server-key"
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/achievements", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+
+	// Should return 200 empty — no enqueue, no pending
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	achievements := resp["achievements"].([]interface{})
+	assert.Empty(t, achievements)
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -173,7 +173,16 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	playLaterHandler := &PlayLaterHandler{DB: cfg.DB, Hub: cfg.Hub}
 	sharedSessionHandler := &SharedSessionHandler{DB: cfg.DB, Storage: cfg.Storage, Hub: cfg.Hub}
 	netplayHandler := &NetplayHandler{DB: cfg.DB, Hub: cfg.Hub, NetplayHub: cfg.NetplayHub}
-	raHandler := &RAHandler{DB: cfg.DB, RAClient: raClient, GameDir: cfg.GameDirs[0], EncryptionKey: encryptionKey}
+	var raQueue *scraper.ScrapeQueue
+	var raAPIKey string
+	if cfg.Scraper != nil {
+		raQueue = cfg.Scraper.Queue
+		raAPIKey = cfg.Scraper.RAAPIKey
+	}
+	raHandler := &RAHandler{
+		DB: cfg.DB, RAClient: raClient, GameDir: cfg.GameDirs[0],
+		EncryptionKey: encryptionKey, Queue: raQueue, RAAPIKey: raAPIKey,
+	}
 	biosHandler := &BiosHandler{Storage: cfg.Storage, DB: cfg.DB, Hub: cfg.Hub}
 	gameKeyMappingHandler := &GameKeyMappingHandler{DB: cfg.DB}
 	challengeHandler := NewChallengeHandler(cfg.DB, cfg.Storage, cfg.Hub)

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -159,6 +159,13 @@ type Game struct {
 	PartyInfo           string         `gorm:"size:512" json:"partyInfo,omitempty"`                // Demo party and placement, e.g. "Assembly 1993, 1st place"
 	CRC32               string         `gorm:"size:16" json:"-"`
 	RAGameID            uint           `gorm:"index" json:"-"` // RetroAchievements game ID (cached from hash lookup)
+	// RAHashChecked + RAGameID sentinel logic:
+	//   RAHashChecked=false, RAGameID=0  → Not yet looked up. Compute ROM MD5 and query RA.
+	//   RAHashChecked=true,  RAGameID=0  → Looked up, but RA doesn't have this game. Do NOT retry.
+	//   RAHashChecked=true,  RAGameID>0  → Valid RA game ID cached.
+	// RAHashChecked is ONLY set to true after a successful API response (even if RA returned no match).
+	// Transient errors (network, 403) leave RAHashChecked=false so the next visit retries.
+	RAHashChecked       bool           `gorm:"default:false" json:"-"`
 	Screenshots      []GameScreenshot      `gorm:"foreignKey:GameID" json:"-"`
 	ReleaseDates     []GameReleaseDate     `gorm:"foreignKey:GameID" json:"-"`
 	Videos           []GameVideo           `gorm:"foreignKey:GameID" json:"-"`

--- a/server/internal/db/scrape_job.go
+++ b/server/internal/db/scrape_job.go
@@ -28,6 +28,7 @@ type ScrapeQueueItem struct {
 	CreatedAt    time.Time  `gorm:"index:idx_queue_dequeue,priority:3" json:"createdAt"`
 	JobID        *uint      `gorm:"index" json:"jobId,omitempty"`
 	GameID       uint       `gorm:"not null" json:"gameId"`
+	Type         string     `gorm:"size:32;not null;default:'scrape'" json:"type"` // "scrape" = full metadata scrape, "ra_fetch" = RetroAchievements only
 	Priority     int        `gorm:"not null;default:0;index:idx_queue_dequeue,priority:2,sort:desc" json:"priority"` // 0 = bulk, 100 = manual
 	Status       string     `gorm:"size:32;not null;default:'pending';index:idx_queue_dequeue,priority:1" json:"status"` // pending, in_progress, completed, failed, cancelled
 	ErrorMessage string     `gorm:"size:512" json:"errorMessage,omitempty"`

--- a/server/internal/scraper/queue.go
+++ b/server/internal/scraper/queue.go
@@ -92,6 +92,32 @@ func (q *ScrapeQueue) IsGameQueued(gameID uint) (bool, error) {
 	return count > 0, err
 }
 
+// EnqueueGameWithType adds a single game to the queue with a specific type.
+// Type determines what the worker does: "scrape" for full metadata, "ra_fetch" for RA achievements only.
+func (q *ScrapeQueue) EnqueueGameWithType(gameID uint, jobID *uint, priority int, itemType string) error {
+	item := &db.ScrapeQueueItem{
+		JobID:    jobID,
+		GameID:   gameID,
+		Priority: priority,
+		Status:   "pending",
+		Type:     itemType,
+	}
+	if err := q.db.Create(item).Error; err != nil {
+		return fmt.Errorf("enqueuing game %d (type=%s): %w", gameID, itemType, err)
+	}
+	return nil
+}
+
+// IsGameQueuedForType checks whether a game already has a pending or in-progress
+// queue item of the given type. Use this to prevent duplicate enqueuing.
+func (q *ScrapeQueue) IsGameQueuedForType(gameID uint, itemType string) (bool, error) {
+	var count int64
+	err := q.db.Model(&db.ScrapeQueueItem{}).
+		Where("game_id = ? AND type = ? AND status IN ?", gameID, itemType, []string{"pending", "in_progress"}).
+		Count(&count).Error
+	return count > 0, err
+}
+
 // Dequeue returns the next pending item (highest priority first, then oldest)
 // and marks it as in_progress. Returns nil if queue is empty.
 func (q *ScrapeQueue) Dequeue() (*db.ScrapeQueueItem, error) {

--- a/server/internal/scraper/queue_test.go
+++ b/server/internal/scraper/queue_test.go
@@ -279,6 +279,65 @@ func TestIsGameQueued(t *testing.T) {
 	assert.False(t, queued)
 }
 
+func TestEnqueueGameWithType(t *testing.T) {
+	database := setupQueueTestDB(t)
+	q := NewScrapeQueue(database)
+
+	err := q.EnqueueGameWithType(42, nil, 100, "ra_fetch")
+	require.NoError(t, err)
+
+	var item db.ScrapeQueueItem
+	require.NoError(t, database.First(&item).Error)
+	assert.Equal(t, uint(42), item.GameID)
+	assert.Equal(t, 100, item.Priority)
+	assert.Equal(t, "ra_fetch", item.Type)
+	assert.Equal(t, "pending", item.Status)
+	assert.Nil(t, item.JobID)
+}
+
+func TestIsGameQueuedForType(t *testing.T) {
+	database := setupQueueTestDB(t)
+	q := NewScrapeQueue(database)
+
+	// Nothing queued yet
+	queued, err := q.IsGameQueuedForType(42, "ra_fetch")
+	require.NoError(t, err)
+	assert.False(t, queued)
+
+	// Enqueue a scrape item for game 42 (default type via EnqueueGame)
+	err = q.EnqueueGame(42, nil, 0)
+	require.NoError(t, err)
+
+	// "scrape" type should be queued (default type), but "ra_fetch" should not
+	queued, err = q.IsGameQueuedForType(42, "scrape")
+	require.NoError(t, err)
+	assert.True(t, queued)
+
+	queued, err = q.IsGameQueuedForType(42, "ra_fetch")
+	require.NoError(t, err)
+	assert.False(t, queued)
+}
+
+func TestIsGameQueuedForType_IgnoresCompletedItems(t *testing.T) {
+	database := setupQueueTestDB(t)
+	q := NewScrapeQueue(database)
+
+	err := q.EnqueueGameWithType(42, nil, 100, "ra_fetch")
+	require.NoError(t, err)
+
+	// Dequeue and complete the item
+	item, err := q.Dequeue()
+	require.NoError(t, err)
+	require.NotNil(t, item)
+	_, err = q.MarkCompleted(item)
+	require.NoError(t, err)
+
+	// Should no longer be queued
+	queued, err := q.IsGameQueuedForType(42, "ra_fetch")
+	require.NoError(t, err)
+	assert.False(t, queued)
+}
+
 func TestResetInProgressItems(t *testing.T) {
 	database := setupQueueTestDB(t)
 	q := NewScrapeQueue(database)

--- a/server/internal/scraper/scraper_ra.go
+++ b/server/internal/scraper/scraper_ra.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spela/server/internal/db"
@@ -130,4 +131,123 @@ func (s *Scraper) ScrapeRAAchievements(ctx context.Context, onProgress func(curr
 	}
 
 	return successes, total, nil
+}
+
+// FetchRAAchievements fetches RetroAchievements data for a single game using
+// the server-level API key. This is called by the queue worker for "ra_fetch"
+// items, triggered when a user views a game detail page without cached achievements.
+//
+// The function is idempotent:
+//   - If the GameAchievementCache is already fresh (< 24h), it's a no-op.
+//   - If RAHashChecked=true and RAGameID=0, the game has no RA match — skip.
+//   - If RAGameID > 0, skip the hash lookup and go straight to fetching achievements.
+//
+// See the Game model for the RAHashChecked + RAGameID sentinel documentation.
+func (s *Scraper) FetchRAAchievements(game *db.Game) error {
+	// Check sentinel and cache BEFORE requiring RA config — these early
+	// returns don't need the RA client and allow idempotent no-ops.
+	if game.RAHashChecked && game.RAGameID == 0 {
+		return nil // Already checked, RA doesn't have this game.
+	}
+
+	raGameID := game.RAGameID
+
+	// If we already have a RAGameID, check if cache is fresh before requiring RA config.
+	if raGameID > 0 {
+		var cache db.GameAchievementCache
+		cacheHit := s.DB.Where("ra_game_id = ?", raGameID).First(&cache).Error == nil
+		if cacheHit && time.Since(cache.CachedAt) < 24*time.Hour {
+			return nil // Cache is fresh, nothing to do.
+		}
+	}
+
+	// Beyond this point we need the RA client to do actual work.
+	if !s.IsRAConfigured() {
+		return fmt.Errorf("RA client or API key not configured")
+	}
+
+	// Resolve RAGameID if not cached yet.
+	if raGameID == 0 {
+		var hash string
+		for _, dir := range s.GameDirs {
+			candidate := filepath.Join(dir, game.FilePath)
+			if h, err := retroachievements.ComputeMD5(candidate); err == nil {
+				hash = h
+				break
+			}
+		}
+		if hash == "" {
+			// ROM file not found — mark as checked so we don't retry.
+			s.DB.Model(&db.Game{}).Where("id = ?", game.ID).
+				Updates(map[string]interface{}{"ra_hash_checked": true})
+			slog.Warn("RA fetch: ROM file not found", "game", game.Title, "path", game.FilePath)
+			return nil
+		}
+
+		time.Sleep(500 * time.Millisecond) // RA API rate limit
+		id, err := s.RAClient.GetGameIDFromHash(hash)
+		if err != nil {
+			// GetGameIDFromHash returns an error both for transient failures
+			// AND when RA simply doesn't recognize the hash (GameID=0).
+			// Check if this is a "no match" (contains "no RA game found") vs transient.
+			if strings.Contains(err.Error(), "no RA game found") {
+				// RA doesn't have this game — mark checked so we don't rehash.
+				s.DB.Model(&db.Game{}).Where("id = ?", game.ID).
+					Updates(map[string]interface{}{"ra_hash_checked": true})
+				slog.Debug("RA fetch: no RA match for game", "game", game.Title)
+				return nil
+			}
+			// Transient error — do NOT set RAHashChecked, allow retry.
+			return fmt.Errorf("RA hash lookup failed for %q: %w", game.Title, err)
+		}
+
+		// Match found — cache the RA game ID and mark hash as checked.
+		s.DB.Model(&db.Game{}).Where("id = ?", game.ID).
+			Updates(map[string]interface{}{"ra_hash_checked": true, "ra_game_id": id})
+		raGameID = id
+	}
+
+	// Check if cache is already fresh (< 24h). This re-check handles the case
+	// where raGameID was just resolved from a hash lookup.
+	var cache db.GameAchievementCache
+	cacheHit := s.DB.Where("ra_game_id = ?", raGameID).First(&cache).Error == nil
+	if cacheHit && time.Since(cache.CachedAt) < 24*time.Hour {
+		return nil // Cache is fresh, nothing to do.
+	}
+
+	// Fetch achievements from RA using server API key.
+	time.Sleep(500 * time.Millisecond) // RA API rate limit
+	gameInfo, err := s.RAClient.GetGameExtended(s.RAAPIKey, raGameID)
+	if err != nil {
+		return fmt.Errorf("RA achievement fetch failed for %q (raGameID=%d): %w", game.Title, raGameID, err)
+	}
+
+	achJSON, err := json.Marshal(gameInfo.Achievements)
+	if err != nil {
+		return fmt.Errorf("marshalling achievements for %q: %w", game.Title, err)
+	}
+
+	// Upsert cache entry.
+	if cacheHit {
+		cache.Title = gameInfo.Title
+		cache.AchievementJSON = string(achJSON)
+		cache.TotalCount = gameInfo.TotalCount
+		cache.TotalPoints = gameInfo.TotalPoints
+		cache.CachedAt = time.Now()
+		cache.GameID = game.ID
+		s.DB.Save(&cache)
+	} else {
+		s.DB.Create(&db.GameAchievementCache{
+			RAGameID:        raGameID,
+			GameID:          game.ID,
+			Title:           gameInfo.Title,
+			AchievementJSON: string(achJSON),
+			TotalCount:      gameInfo.TotalCount,
+			TotalPoints:     gameInfo.TotalPoints,
+			CachedAt:        time.Now(),
+		})
+	}
+
+	slog.Info("RA fetch: cached achievements", "game", game.Title, "raGameId", raGameID, "count", gameInfo.TotalCount)
+	return nil
 }

--- a/server/internal/scraper/scraper_ra_fetch_test.go
+++ b/server/internal/scraper/scraper_ra_fetch_test.go
@@ -1,0 +1,231 @@
+package scraper
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/retroachievements"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+	"gorm.io/gorm/logger"
+)
+
+var testROMContent = []byte("test rom for ra fetch")
+
+func testROMHash() string {
+	h := md5.Sum(testROMContent)
+	return hex.EncodeToString(h[:])
+}
+
+func setupRAFetchTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	})
+	require.NoError(t, err)
+	require.NoError(t, database.AutoMigrate(
+		&db.Console{}, &db.Game{}, &db.GameAchievementCache{},
+	))
+	return database
+}
+
+func newTestRAServer(t *testing.T) *httptest.Server {
+	t.Helper()
+	expectedHash := testROMHash()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/dorequest.php":
+			hash := r.URL.Query().Get("m")
+			if hash == expectedHash {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"Success": true,
+					"GameID":  float64(99),
+				})
+			} else {
+				json.NewEncoder(w).Encode(map[string]interface{}{
+					"Success": true,
+					"GameID":  float64(0),
+				})
+			}
+		case "/API/API_GetGameExtended.php":
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"ID":    99,
+				"Title": "Test RA Game",
+				"Achievements": map[string]interface{}{
+					"1001": map[string]interface{}{
+						"ID":          1001,
+						"Title":       "First Step",
+						"Description": "Do the first thing",
+						"Points":      5,
+						"BadgeName":   "badge001",
+						"type":        3,
+					},
+				},
+			})
+		}
+	}))
+}
+
+func TestFetchRAAchievements_PopulatesCache(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+	mockRA := newTestRAServer(t)
+	defer mockRA.Close()
+
+	// Create ROM file
+	tmpDir := t.TempDir()
+	romDir := filepath.Join(tmpDir, "roms")
+	os.MkdirAll(romDir, 0o755)
+	os.WriteFile(filepath.Join(romDir, "game.nes"), testROMContent, 0o644)
+
+	// Create console + game
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Console: console,
+		Title: "Test Game", FileName: "game.nes", FilePath: "roms/game.nes",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	s := &Scraper{
+		DB:       database,
+		RAClient: &retroachievements.RAClient{BaseURL: mockRA.URL, HTTPClient: mockRA.Client()},
+		RAAPIKey: "test-api-key",
+		GameDirs: []string{tmpDir},
+	}
+
+	err := s.FetchRAAchievements(&game)
+	require.NoError(t, err)
+
+	// Verify RAGameID was cached on the game record
+	var updated db.Game
+	require.NoError(t, database.First(&updated, game.ID).Error)
+	assert.Equal(t, uint(99), updated.RAGameID)
+	assert.True(t, updated.RAHashChecked)
+
+	// Verify achievement cache was populated
+	var cache db.GameAchievementCache
+	require.NoError(t, database.Where("ra_game_id = ?", 99).First(&cache).Error)
+	assert.Equal(t, "Test RA Game", cache.Title)
+	assert.Equal(t, 1, cache.TotalCount)
+	assert.Equal(t, game.ID, cache.GameID)
+}
+
+func TestFetchRAAchievements_SkipsWhenCacheFresh(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Console: console,
+		Title: "Test Game", FileName: "game.nes", FilePath: "roms/game.nes",
+		RAGameID: 99, RAHashChecked: true,
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	// Pre-populate fresh cache (CachedAt must be recent for the freshness check)
+	database.Create(&db.GameAchievementCache{
+		RAGameID: 99, GameID: game.ID, Title: "Cached",
+		AchievementJSON: "[]", TotalCount: 5, TotalPoints: 50,
+		CachedAt: time.Now(),
+	})
+
+	// No RA client needed — should be a no-op
+	s := &Scraper{DB: database}
+
+	err := s.FetchRAAchievements(&game)
+	require.NoError(t, err)
+
+	// Cache should be untouched
+	var cache db.GameAchievementCache
+	database.Where("ra_game_id = ?", 99).First(&cache)
+	assert.Equal(t, "Cached", cache.Title)
+}
+
+func TestFetchRAAchievements_SetsHashCheckedOnNoMatch(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+
+	// Mock RA server that returns GameID=0 for all hashes
+	mockRA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]interface{}{
+			"Success": true,
+			"GameID":  float64(0),
+		})
+	}))
+	defer mockRA.Close()
+
+	tmpDir := t.TempDir()
+	romDir := filepath.Join(tmpDir, "roms")
+	os.MkdirAll(romDir, 0o755)
+	os.WriteFile(filepath.Join(romDir, "unknown.nes"), []byte("unknown rom"), 0o644)
+
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Console: console,
+		Title: "Unknown Game", FileName: "unknown.nes", FilePath: "roms/unknown.nes",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	s := &Scraper{
+		DB:       database,
+		RAClient: &retroachievements.RAClient{BaseURL: mockRA.URL, HTTPClient: mockRA.Client()},
+		RAAPIKey: "test-api-key",
+		GameDirs: []string{tmpDir},
+	}
+
+	err := s.FetchRAAchievements(&game)
+	require.NoError(t, err)
+
+	// RAHashChecked should be true, RAGameID should remain 0
+	var updated db.Game
+	require.NoError(t, database.First(&updated, game.ID).Error)
+	assert.Equal(t, uint(0), updated.RAGameID)
+	assert.True(t, updated.RAHashChecked)
+}
+
+func TestFetchRAAchievements_SkipsWhenHashCheckedAndNoMatch(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Console: console,
+		Title: "No RA Game", FileName: "game.nes", FilePath: "roms/game.nes",
+		RAGameID: 0, RAHashChecked: true, // Already checked, no match
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	// No RA client needed — should skip immediately
+	s := &Scraper{DB: database}
+
+	err := s.FetchRAAchievements(&game)
+	require.NoError(t, err)
+}
+
+func TestFetchRAAchievements_NoRAConfig(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Console: console,
+		Title: "Test Game", FileName: "game.nes", FilePath: "roms/game.nes",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	s := &Scraper{DB: database} // No RAClient or RAAPIKey
+
+	err := s.FetchRAAchievements(&game)
+	assert.Error(t, err)
+}

--- a/server/internal/scraper/worker.go
+++ b/server/internal/scraper/worker.go
@@ -91,31 +91,51 @@ func (w *ScrapeWorker) processItem(ctx context.Context, item *db.ScrapeQueueItem
 
 	w.broadcastScrapeStatus(game.ID, "scraping")
 
-	// Variant group propagation for 'new' mode jobs
-	propagated := false
-	if item.JobID != nil {
-		var job db.ScrapeJob
-		if err := w.db.First(&job, *item.JobID).Error; err == nil {
-			if job.Mode == "new" && game.GroupKey != "" {
-				if w.scraper.propagateGroupMetadata(&game) {
-					propagated = true
-				}
-			}
-		}
+	// Dispatch based on queue item type.
+	// Default to "scrape" for backward compatibility with items created before
+	// the Type field was added (they have Type="" due to GORM zero-value).
+	itemType := item.Type
+	if itemType == "" {
+		itemType = "scrape"
 	}
 
-	if !propagated {
-		if err := w.scraper.ScrapeGame(&game); err != nil {
-			slog.Warn("scrape worker: scrape failed", "game", game.Title, "error", err)
+	switch itemType {
+	case "ra_fetch":
+		if err := w.scraper.FetchRAAchievements(&game); err != nil {
+			slog.Warn("scrape worker: RA fetch failed", "game", game.Title, "error", err)
 			jobDone, _ := w.queue.MarkFailed(item, err.Error())
 			w.broadcastProgress(item, &game, false, jobDone)
 			w.broadcastScrapeStatus(game.ID, "idle")
 			return
 		}
 
-		// Propagate metadata to unscraped siblings in the same variant group
-		if game.GroupKey != "" {
-			w.scraper.propagateToGroup(&game)
+	default: // "scrape" — full metadata scrape
+		// Variant group propagation for 'new' mode jobs
+		propagated := false
+		if item.JobID != nil {
+			var job db.ScrapeJob
+			if err := w.db.First(&job, *item.JobID).Error; err == nil {
+				if job.Mode == "new" && game.GroupKey != "" {
+					if w.scraper.propagateGroupMetadata(&game) {
+						propagated = true
+					}
+				}
+			}
+		}
+
+		if !propagated {
+			if err := w.scraper.ScrapeGame(&game); err != nil {
+				slog.Warn("scrape worker: scrape failed", "game", game.Title, "error", err)
+				jobDone, _ := w.queue.MarkFailed(item, err.Error())
+				w.broadcastProgress(item, &game, false, jobDone)
+				w.broadcastScrapeStatus(game.ID, "idle")
+				return
+			}
+
+			// Propagate metadata to unscraped siblings in the same variant group
+			if game.GroupKey != "" {
+				w.scraper.propagateToGroup(&game)
+			}
 		}
 	}
 

--- a/web/src/hooks/__tests__/use-retroachievements.test.ts
+++ b/web/src/hooks/__tests__/use-retroachievements.test.ts
@@ -230,6 +230,33 @@ describe("useGameAchievements", () => {
 
     await waitFor(() => expect(result.current.isError).toBe(true));
   });
+
+  it("polls when status is pending and stops when data arrives", async () => {
+    const pendingResponse = { status: "pending" as const };
+    mockApi.get
+      .mockResolvedValueOnce(pendingResponse)
+      .mockResolvedValueOnce(pendingResponse)
+      .mockResolvedValueOnce(mockAchievements);
+
+    const { result } = renderHook(() => useGameAchievements("game-1"), {
+      wrapper: createWrapper(),
+    });
+
+    // First call returns pending
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    expect(result.current.data?.status).toBe("pending");
+
+    // Should eventually get real data via refetch
+    await waitFor(
+      () => {
+        expect(result.current.data?.achievements).toBeDefined();
+        expect(result.current.data?.achievements?.length).toBeGreaterThan(0);
+      },
+      { timeout: 10000 },
+    );
+
+    expect(result.current.data?.totalCount).toBe(2);
+  });
 });
 
 describe("useGameAchievementProgress", () => {

--- a/web/src/hooks/use-retroachievements.ts
+++ b/web/src/hooks/use-retroachievements.ts
@@ -58,6 +58,14 @@ export function useGameAchievements(gameId: string | undefined) {
     queryKey: ["game-achievements", gameId],
     queryFn: () => api.get<GameAchievements>(`/games/${gameId}/achievements`),
     enabled: !!gameId,
+    refetchInterval: (query) => {
+      // Poll every 2 seconds while the server is processing an RA fetch.
+      // Stop polling once we have actual achievement data.
+      if (query.state.data?.status === "pending") {
+        return 2000;
+      }
+      return false;
+    },
   });
 }
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -360,6 +360,7 @@ export interface Achievement {
 }
 
 export interface GameAchievements {
+  status?: "pending";
   raGameId: number;
   totalCount: number;
   totalPoints: number;


### PR DESCRIPTION
## Summary

- Extends the scrape queue with a new `ra_fetch` item type so the queue worker can fetch RetroAchievements for a single game
- When a user views a game detail page without cached achievements, the `GET /games/{id}/achievements` endpoint auto-enqueues an `ra_fetch` job using the server's RA API key, making achievements visible to all users
- Frontend polls every 2s while the fetch is pending, then renders achievements when data arrives
- Adds `RAHashChecked` sentinel on the Game model to avoid re-hashing large ROMs when RA doesn't recognize the game

## Test Plan

- [x] Backend: 5 new `FetchRAAchievements` unit tests (cache fresh, no match, sentinel skip, no config, full flow)
- [x] Backend: 3 new queue tests (`EnqueueGameWithType`, `IsGameQueuedForType`, completed items ignored)
- [x] Backend: 5 new handler tests (auto-enqueue, already queued, cached data, no RA key, hash checked)
- [x] Frontend: 1 new hook test (pending → polling → data transition)
- [x] Full backend suite passes (13 packages)
- [x] Full frontend suite passes (134 files, 1464 tests)

Closes #410