### PR TITLE
feat: include RetroAchievements in per-game scrape with circuit breaker

### DIFF
--- a/docs/superpowers/specs/2026-04-15-ra-in-scrape-game-design.md
+++ b/docs/superpowers/specs/2026-04-15-ra-in-scrape-game-design.md
@@ -1,0 +1,82 @@
+# Include RetroAchievements in Per-Game Scrape Queue Processing
+
+**Issue:** #413
+**Date:** 2026-04-15
+
+## Summary
+
+Call `FetchRAAchievements()` at the end of `ScrapeGame()` so every game gets
+achievement data during normal scraping. Includes a circuit breaker to stop
+RA requests if the API starts failing mid-scrape.
+
+## Approach
+
+Add a `FetchRAAchievements(game)` call at the end of `ScrapeGame()` and
+`ScrapeGameWithIGDBMatch()`, guarded by `IsRAConfigured()` and a circuit
+breaker. RA failures are logged but never fail the overall scrape.
+
+## Changes
+
+### 1. Call FetchRAAchievements in ScrapeGame()
+
+After the game is saved to DB (after `s.DB.Save(game)`) but before the
+return, add:
+
+```
+if s.IsRAConfigured() && !s.raCircuitOpen {
+    if err := s.FetchRAAchievements(game); err != nil {
+        s.recordRAFailure(game.Title, err)
+    } else {
+        s.raConsecutiveFailures = 0
+    }
+}
+```
+
+Same pattern in `ScrapeGameWithIGDBMatch()`.
+
+### 2. Circuit breaker on Scraper struct
+
+Add two fields to the `Scraper` struct:
+
+- `raCircuitOpen bool` — when true, skip all RA calls
+- `raConsecutiveFailures int` — count of consecutive RA failures
+
+`recordRAFailure()` increments the counter. After 5 consecutive failures,
+sets `raCircuitOpen = true` and logs:
+
+```
+slog.Warn("RA achievements disabled for remainder of scrape",
+    "consecutiveFailures", 5, "lastError", err)
+```
+
+On success, `raConsecutiveFailures` resets to 0.
+
+### 3. Natural reset
+
+Both fields are non-persisted struct state. They reset to zero values on:
+- Server restart
+- Any new Scraper instance
+
+This means the circuit breaker automatically re-closes on the next scrape
+job — no admin action required.
+
+### 4. Error handling
+
+RA fetch errors are logged as warnings but never cause `ScrapeGame()` to
+return an error. A game with good metadata but no achievements is still
+a successful scrape.
+
+## Testing
+
+- `ScrapeGame()` populates achievement cache when RA is configured and
+  the ROM hash is recognized by RA
+- Circuit breaker trips after 5 consecutive failures and skips subsequent
+  games
+- A success after failures resets the counter
+- `ScrapeGame()` still succeeds when RA fetch fails (error is swallowed)
+
+## Out of Scope
+
+- Admin UI notification for circuit breaker trips — tracked in #415
+- Changes to the bulk `ScrapeRAAchievements()` function
+- Frontend changes

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -1,10 +1,12 @@
 package scraper
 
 import (
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
 
+	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/igdb"
 	"github.com/spela/server/internal/pouet"
 	"github.com/spela/server/internal/retroachievements"
@@ -33,6 +35,13 @@ type Scraper struct {
 	enrichMu       sync.Mutex
 	enriching      bool
 	enrichProgress *EnrichProgress
+
+	// RA circuit breaker — trips after consecutive RA API failures during a
+	// scrape to avoid hammering a broken/blocked endpoint for thousands of games.
+	// These are non-persisted struct fields that reset on server restart or new
+	// Scraper instance, so the circuit automatically re-closes on the next scrape.
+	raCircuitOpen          bool
+	raConsecutiveFailures  int
 }
 
 // NewScraper creates a new metadata scraper instance.
@@ -60,6 +69,29 @@ func (s *Scraper) IsIGDBConfigured() bool {
 // IsRAConfigured returns whether the scraper has a configured RA client and API key.
 func (s *Scraper) IsRAConfigured() bool {
 	return s.RAClient != nil && s.RAAPIKey != ""
+}
+
+const raCircuitBreakerThreshold = 5
+
+// tryFetchRAAchievements attempts to fetch RA achievements for a game during
+// a scrape. Respects the circuit breaker and never returns an error — RA
+// failures are logged but don't fail the overall scrape.
+func (s *Scraper) tryFetchRAAchievements(game *db.Game) {
+	if !s.IsRAConfigured() || s.raCircuitOpen {
+		return
+	}
+	if err := s.FetchRAAchievements(game); err != nil {
+		s.raConsecutiveFailures++
+		if s.raConsecutiveFailures >= raCircuitBreakerThreshold {
+			s.raCircuitOpen = true
+			slog.Warn("RA achievements disabled for remainder of scrape",
+				"consecutiveFailures", s.raConsecutiveFailures, "lastError", err)
+		} else {
+			slog.Warn("RA achievement fetch failed", "game", game.Title, "error", err)
+		}
+	} else {
+		s.raConsecutiveFailures = 0
+	}
 }
 
 // TryStartEnrich attempts to acquire the enrichment lock.

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -211,6 +211,10 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 	s.cleanGameImages(game, console.Abbreviation, gameIDStr)
 
 	slog.Info("scraped metadata", "game", game.Title, "scraperId", game.ScraperID, "rating", game.IGDBCriticsRating)
+
+	// Fetch RetroAchievements data (best-effort, never fails the scrape).
+	s.tryFetchRAAchievements(game)
+
 	return nil
 }
 
@@ -665,6 +669,10 @@ func (s *Scraper) ScrapeGameWithIGDBMatch(game *db.Game, igdbID int) error {
 	s.cleanGameImages(game, console.Abbreviation, gameIDStr)
 
 	slog.Info("re-scraped with manual IGDB match", "game", game.Title, "igdbId", igdbID, "scraperId", game.ScraperID)
+
+	// Fetch RetroAchievements data (best-effort, never fails the scrape).
+	s.tryFetchRAAchievements(game)
+
 	return nil
 }
 

--- a/server/internal/scraper/scraper_ra_fetch_test.go
+++ b/server/internal/scraper/scraper_ra_fetch_test.go
@@ -4,6 +4,7 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -228,4 +229,108 @@ func TestFetchRAAchievements_NoRAConfig(t *testing.T) {
 
 	err := s.FetchRAAchievements(&game)
 	assert.Error(t, err)
+}
+
+func TestTryFetchRAAchievements_SkipsWhenNotConfigured(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{ConsoleID: console.ID, Title: "Test", FileName: "t.nes", FilePath: "t.nes"}
+	require.NoError(t, database.Create(&game).Error)
+
+	s := &Scraper{DB: database} // No RA config
+	s.tryFetchRAAchievements(&game)
+	// Should not panic or error — just a no-op
+	assert.False(t, s.raCircuitOpen)
+}
+
+func TestTryFetchRAAchievements_SkipsWhenCircuitOpen(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+	mockRA := newTestRAServer(t)
+	defer mockRA.Close()
+
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{ConsoleID: console.ID, Title: "Test", FileName: "t.nes", FilePath: "t.nes"}
+	require.NoError(t, database.Create(&game).Error)
+
+	s := &Scraper{
+		DB:            database,
+		RAClient:      &retroachievements.RAClient{BaseURL: mockRA.URL, HTTPClient: mockRA.Client()},
+		RAAPIKey:      "test-key",
+		GameDirs:      []string{t.TempDir()},
+		raCircuitOpen: true, // Already tripped
+	}
+
+	s.tryFetchRAAchievements(&game)
+	// Should skip — no RA calls made, no cache populated
+	var count int64
+	database.Model(&db.GameAchievementCache{}).Count(&count)
+	assert.Equal(t, int64(0), count)
+}
+
+func TestTryFetchRAAchievements_CircuitTripsAfterConsecutiveFailures(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+
+	// Mock RA server that always returns 500
+	failingRA := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("internal error"))
+	}))
+	defer failingRA.Close()
+
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+
+	tmpDir := t.TempDir()
+
+	s := &Scraper{
+		DB:       database,
+		RAClient: &retroachievements.RAClient{BaseURL: failingRA.URL, HTTPClient: failingRA.Client()},
+		RAAPIKey: "test-key",
+		GameDirs: []string{tmpDir},
+	}
+
+	// Create 6 games with ROM files (circuit trips at 5)
+	for i := 0; i < 6; i++ {
+		fname := fmt.Sprintf("game%d.nes", i)
+		os.WriteFile(filepath.Join(tmpDir, fname), []byte(fmt.Sprintf("rom%d", i)), 0o644)
+		game := db.Game{ConsoleID: console.ID, Title: fname, FileName: fname, FilePath: fname}
+		require.NoError(t, database.Create(&game).Error)
+		s.tryFetchRAAchievements(&game)
+	}
+
+	assert.True(t, s.raCircuitOpen)
+	assert.Equal(t, 5, s.raConsecutiveFailures) // Stops incrementing after trip
+}
+
+func TestTryFetchRAAchievements_SuccessResetsCounter(t *testing.T) {
+	database := setupRAFetchTestDB(t)
+	mockRA := newTestRAServer(t)
+	defer mockRA.Close()
+
+	tmpDir := t.TempDir()
+	os.MkdirAll(filepath.Join(tmpDir, "roms"), 0o755)
+	os.WriteFile(filepath.Join(tmpDir, "roms/game.nes"), testROMContent, 0o644)
+
+	console := db.Console{Name: "NES", Abbreviation: "nes", Playable: true}
+	require.NoError(t, database.Create(&console).Error)
+	game := db.Game{
+		ConsoleID: console.ID, Console: console,
+		Title: "Test Game", FileName: "game.nes", FilePath: "roms/game.nes",
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	s := &Scraper{
+		DB:                    database,
+		RAClient:              &retroachievements.RAClient{BaseURL: mockRA.URL, HTTPClient: mockRA.Client()},
+		RAAPIKey:              "test-key",
+		GameDirs:              []string{tmpDir},
+		raConsecutiveFailures: 3, // Some prior failures
+	}
+
+	s.tryFetchRAAchievements(&game)
+
+	assert.False(t, s.raCircuitOpen)
+	assert.Equal(t, 0, s.raConsecutiveFailures)
 }


### PR DESCRIPTION
## Summary

- Calls `FetchRAAchievements()` at the end of `ScrapeGame()` and `ScrapeGameWithIGDBMatch()` so every game gets achievement data during normal scraping
- Adds a circuit breaker that trips after 5 consecutive RA API failures, skipping RA for the remainder of the scrape to avoid hammering a blocked/broken endpoint
- RA failures are logged as warnings but never fail the overall scrape — a game with good metadata but no achievements is still a successful scrape
- Circuit breaker resets automatically on server restart or next scrape job

## Test Plan

- [x] 4 new circuit breaker tests: skip when not configured, skip when circuit open, trip after 5 failures, success resets counter
- [x] Full scraper test suite passes
- [x] Go build clean

Closes #413