### PR TITLE
feat: scrape missing RetroAchievements from Library Scan page

### DIFF
--- a/docs/superpowers/specs/2026-04-15-scrape-missing-ra-design.md
+++ b/docs/superpowers/specs/2026-04-15-scrape-missing-ra-design.md
@@ -1,0 +1,63 @@
+# Scrape Missing RetroAchievements from Library Scan Page
+
+**Issue:** #411
+**Date:** 2026-04-15
+
+## Summary
+
+Add a "Scrape Missing Achievements" button on the Library Scan page that
+finds games without cached RA data and enqueues them as `ra_fetch` jobs.
+
+## Backend
+
+### Add `mode=ra` to TriggerScrape
+
+In `admin_handler_scraper.go`, when `mode == "ra"`:
+
+1. Find eligible games on playable consoles where:
+   - `RAHashChecked = false` (never checked against RA), OR
+   - `RAGameID > 0` but no fresh `GameAchievementCache` entry
+2. Apply optional `ConsoleFilter` if `?console=` is provided
+3. Create a `ScrapeJob` with `Mode: "ra"`
+4. Enqueue all as `ra_fetch` type items via `EnqueueGameWithType`
+
+Games with `RAHashChecked=true, RAGameID=0` are excluded — these are
+known non-matches that RA doesn't recognize.
+
+### No other backend changes
+
+- Worker already dispatches `ra_fetch` items to `FetchRAAchievements()`
+- Circuit breaker from #413 protects against RA API failures
+- WebSocket progress events are generic and work for any job type
+
+## Frontend
+
+### Add button in ScrapeCard
+
+Add a "Scrape Missing Achievements" button in the scrape section of the
+Library Scan page, alongside the existing scrape buttons. Same pattern:
+
+```
+scrapeMetadata.mutate({ mode: "ra", console: consoleParam })
+```
+
+Disabled while a job is active, same as the other buttons. Always shown
+regardless of RA configuration — if RA isn't configured, the backend
+simply returns 0 eligible games and the job completes immediately.
+
+### No progress UI changes
+
+The existing progress bar and WebSocket event handling work unchanged.
+
+## Testing
+
+- Backend: `mode=ra` returns correct game count and creates `ra_fetch`
+  queue items
+- Backend: `mode=ra` excludes games with `RAHashChecked=true, RAGameID=0`
+- Frontend: no new tests needed — existing progress UI is generic
+
+## Out of Scope
+
+- Retry logic for previously failed RA fetches
+- Per-source status breakdown for RA on the scan page
+- Admin notification when RA circuit breaker trips (#415)

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -113,10 +113,19 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 		return
 	}
 
-	if err := h.Scraper.Queue.EnqueueGames(job.ID, gameIDs, 0); err != nil {
-		slog.Error("failed to enqueue games", "error", err)
-		c.JSON(http.StatusInternalServerError, gin.H{"error": "enqueuing games"})
-		return
+	// RA mode enqueues as "ra_fetch" items; all other modes enqueue as default "scrape".
+	if mode == "ra" {
+		if err := h.Scraper.Queue.EnqueueGamesWithType(job.ID, gameIDs, 0, "ra_fetch"); err != nil {
+			slog.Error("failed to enqueue RA fetch games", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "enqueuing games"})
+			return
+		}
+	} else {
+		if err := h.Scraper.Queue.EnqueueGames(job.ID, gameIDs, 0); err != nil {
+			slog.Error("failed to enqueue games", "error", err)
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "enqueuing games"})
+			return
+		}
 	}
 
 	h.Hub.Broadcast(ws.Event{Type: "scrape_started", Payload: gin.H{
@@ -157,6 +166,16 @@ func (h *AdminHandler) collectGameIDs(mode string, consoleID uint, source, statu
 			// no filter
 		case "fallback":
 			q = q.Where("scraper_id = 'libretro'")
+		case "ra":
+			// Games on playable consoles that either:
+			//   - Haven't been checked against RA yet (RAHashChecked=false), OR
+			//   - Have a known RA game ID but no fresh achievement cache
+			// Excludes known non-matches (RAHashChecked=true, RAGameID=0).
+			q = q.Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.playable = ?", true).
+				Where(`(games.ra_hash_checked = ? OR (games.ra_game_id > 0 AND games.ra_game_id NOT IN (
+					SELECT ra_game_id FROM game_achievement_caches
+					WHERE ra_game_id = games.ra_game_id AND cached_at > ?
+				)))`, false, time.Now().Add(-24*time.Hour))
 		default:
 			q = q.Where("scraper_id = '' OR scraper_id IS NULL")
 		}

--- a/server/internal/scraper/queue.go
+++ b/server/internal/scraper/queue.go
@@ -69,6 +69,27 @@ func (q *ScrapeQueue) EnqueueGames(jobID uint, gameIDs []uint, priority int) err
 	return nil
 }
 
+// EnqueueGamesWithType inserts multiple queue items with a specific type.
+func (q *ScrapeQueue) EnqueueGamesWithType(jobID uint, gameIDs []uint, priority int, itemType string) error {
+	if len(gameIDs) == 0 {
+		return nil
+	}
+	items := make([]db.ScrapeQueueItem, len(gameIDs))
+	for i, gid := range gameIDs {
+		items[i] = db.ScrapeQueueItem{
+			JobID:    &jobID,
+			GameID:   gid,
+			Priority: priority,
+			Status:   "pending",
+			Type:     itemType,
+		}
+	}
+	if err := q.db.CreateInBatches(items, 500).Error; err != nil {
+		return fmt.Errorf("enqueuing %d games (type=%s): %w", len(gameIDs), itemType, err)
+	}
+	return nil
+}
+
 // EnqueueGame inserts a single queue item. jobID may be nil for standalone scrapes.
 func (q *ScrapeQueue) EnqueueGame(gameID uint, jobID *uint, priority int) error {
 	item := &db.ScrapeQueueItem{

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -103,7 +103,7 @@ export interface ScrapeStartResponse {
   total: number;
 }
 
-export type ScrapeMode = "new" | "all" | "fallback";
+export type ScrapeMode = "new" | "all" | "fallback" | "ra";
 
 export function useScrapeMetadata() {
   const queryClient = useQueryClient();

--- a/web/src/pages/admin/scan-page.tsx
+++ b/web/src/pages/admin/scan-page.tsx
@@ -10,6 +10,7 @@ import {
   RefreshCw,
   RotateCcw,
   Square,
+  Trophy,
 } from "lucide-react";
 import { Button, Section, Select } from "@/components/ui";
 import { useScanLibrary, useScrapeMetadata, useCancelScrape } from "@/hooks/use-admin";
@@ -449,6 +450,36 @@ function ScrapeCard() {
             className="w-full"
           >
             Rescrape All Games
+          </Button>
+          <Button
+            onClick={() =>
+              scrapeMetadata.mutate(
+                { mode: "ra", console: consoleParam },
+                {
+                  onSuccess: (data) => {
+                    const n = data.total;
+                    toast(
+                      n === 0 ? "info" : "success",
+                      n === 0
+                        ? "All games already have achievement data"
+                        : `Fetching achievements for ${n} game${n === 1 ? "" : "s"}...`,
+                    );
+                  },
+                  onError: (err) =>
+                    toast(
+                      "error",
+                      err instanceof Error ? err.message : "Scrape failed",
+                    ),
+                },
+              )
+            }
+            loading={scrapeMetadata.isPending}
+            disabled={isActive}
+            variant="secondary"
+            icon={<Trophy className="h-4 w-4" />}
+            className="w-full"
+          >
+            Scrape Missing Achievements
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Adds `mode=ra` to the existing `POST /admin/scrape` endpoint, which finds games missing RA achievement data and enqueues them as `ra_fetch` queue items
- Adds `EnqueueGamesWithType` to the scrape queue for bulk-enqueuing typed items
- Adds a "Scrape Missing Achievements" button on the Library Scan page alongside existing scrape buttons
- Eligible games: never checked against RA, or have a known RA ID but stale/missing achievement cache
- Excludes known non-matches (RAHashChecked=true, RAGameID=0)

## Test Plan

- [x] Go build clean
- [x] Full backend test suite passes (scraper + api packages)
- [x] Full frontend test suite passes (134 files, 1464 tests)
- [x] Web build clean

Closes #411