### PR TITLE
refactor: use consoleName in secondary screen labels

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -58,6 +58,7 @@ data class EmulationState(
     val gameId: String = "",
     val gameTitle: String = "",
     val consoleId: String = "",
+    val consoleName: String = "",
     val consoleColorTheme: String? = null,
     val heroUrl: String? = null,
     val gameDescription: String? = null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryArtPage.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryArtPage.kt
@@ -50,6 +50,7 @@ fun SecondaryArtPage(
     gameTitle: String,
     sessionElapsedSeconds: Long,
     consoleId: String,
+    consoleName: String,
     consoleColorTheme: String?,
     gameDescription: String? = null,
     gameDeveloper: String? = null,
@@ -125,7 +126,9 @@ fun SecondaryArtPage(
                 contentAlignment = Alignment.Center,
             ) {
                 Text(
-                    text = consoleId.uppercase(),
+                    text = consoleName.ifEmpty { consoleId.uppercase() },
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                     style = SpTypography.LabelSmall,
                     color = SpColor.OnBackgroundTertiary,
                 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/SecondaryScreenContent.kt
@@ -177,6 +177,7 @@ fun SecondaryScreenContent(
                     gameTitle = state.gameTitle,
                     sessionElapsedSeconds = state.sessionElapsedSeconds,
                     consoleId = state.consoleId,
+                    consoleName = state.consoleName,
                     consoleColorTheme = state.consoleColorTheme,
                 )
 
@@ -194,6 +195,7 @@ fun SecondaryScreenContent(
                                 gameTitle = state.gameTitle,
                                 sessionElapsedSeconds = state.sessionElapsedSeconds,
                                 consoleId = state.consoleId,
+                                consoleName = state.consoleName,
                                 consoleColorTheme = state.consoleColorTheme,
                                 gameDescription = state.gameDescription,
                                 gameDeveloper = state.gameDeveloper,
@@ -376,6 +378,7 @@ private fun CompanionHeader(
     gameTitle: String,
     sessionElapsedSeconds: Long,
     consoleId: String,
+    consoleName: String,
     consoleColorTheme: String?,
 ) {
     val timeText = formatSessionDuration(sessionElapsedSeconds)
@@ -420,12 +423,14 @@ private fun CompanionHeader(
                 style = SpTypography.LabelLarge,
                 color = SpColor.OnBackgroundTertiary,
             )
-            if (consoleId.isNotEmpty()) {
+            if (consoleName.isNotEmpty()) {
                 Spacer(Modifier.width(SpSpacing.Small))
                 Text(
-                    text = consoleId.uppercase(),
+                    text = consoleName,
                     style = SpTypography.LabelSmall,
                     color = SpColor.OnBackgroundTertiary,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
                 )
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -352,6 +352,7 @@ class EmulationViewModel(
                         it.copy(
                             gameTitle = detail.game.title,
                             consoleId = detail.game.consoleId,
+                            consoleName = detail.game.consoleName,
                             heroUrl = detail.game.heroUrl,
                             gameDescription = detail.game.description,
                             gameDeveloper = detail.game.developer,


### PR DESCRIPTION
## Summary
- Add `consoleName` to `EmulationState` and populate it from game detail
- Use `consoleName` instead of `consoleId.uppercase()` in `SecondaryArtPage` and `CompanionHeader`
- Falls back to `consoleId.uppercase()` when `consoleName` is empty
- Both labels use `maxLines=1` with `TextOverflow.Ellipsis` for graceful truncation

Closes #418

## Test plan
- [x] Kotlin compiles (`:shared:compileKotlinDesktop`)
- [ ] CI passes (player unit tests)