### PR TITLE
refactor: extract shared Divider component

### DIFF
--- a/web/src/components/ui/divider.tsx
+++ b/web/src/components/ui/divider.tsx
@@ -1,0 +1,14 @@
+import { cn } from "@/lib/cn";
+
+interface DividerProps {
+  className?: string;
+}
+
+export function Divider({ className }: DividerProps) {
+  return (
+    <div
+      data-comp="Divider"
+      className={cn("border-t border-surface-800/50", className)}
+    />
+  );
+}

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -28,3 +28,4 @@ export { LeaderboardSkeleton } from "./leaderboard-skeleton";
 export { ConfirmDeleteModal } from "./confirm-delete-modal";
 export { LeaderboardRow } from "./leaderboard-row";
 export { FilterChip } from "./filter-chip";
+export { Divider } from "./divider";

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -1,6 +1,7 @@
 import { type ReactNode, useEffect, useRef } from "react";
 import { NavLink, useLocation } from "react-router-dom";
 import { cn } from "@/lib/cn";
+import { Divider } from "./divider";
 import { Gamepad2, LogOut, Search } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
@@ -119,7 +120,9 @@ function SidebarContent({ links, user, onLogout, version, onSearchClick }: Sideb
       </nav>
 
       {user && (
-        <div className="border-t border-surface-800/50 px-3 py-4">
+        <>
+        <Divider />
+        <div className="px-3 py-4">
           <div className="flex items-center gap-3">
             <div className="h-9 w-9 flex-shrink-0 rounded-full bg-gradient-to-br from-brand-500 to-brand-700 flex items-center justify-center text-sm font-bold text-white">
               {user.username.charAt(0).toUpperCase()}
@@ -142,6 +145,7 @@ function SidebarContent({ links, user, onLogout, version, onSearchClick }: Sideb
             )}
           </div>
         </div>
+        </>
       )}
 
       {version && (

--- a/web/src/features/admin/components/scrape-status-card.tsx
+++ b/web/src/features/admin/components/scrape-status-card.tsx
@@ -3,6 +3,7 @@ import {
   Section,
   Button,
   Skeleton,
+  Divider,
 } from "@/components/ui";
 import {
   useScrapeStatusCounts,
@@ -166,7 +167,7 @@ export function ScrapeStatusCard() {
           data.sources.map((counts, i) => (
             <div key={counts.source}>
               {i > 0 && (
-                <div className="border-t border-surface-800/50 mb-5" />
+                <Divider className="mb-5" />
               )}
               <SourceSection
                 counts={counts}

--- a/web/src/features/admin/components/system-event-detail-modal.tsx
+++ b/web/src/features/admin/components/system-event-detail-modal.tsx
@@ -1,5 +1,5 @@
 import { Filter } from "lucide-react";
-import { Button, Modal } from "@/components/ui";
+import { Button, Divider, Modal } from "@/components/ui";
 import { cn } from "@/lib/cn";
 import { formatDateTime } from "@/lib/format";
 import {
@@ -56,9 +56,11 @@ export function SystemEventDetailModal({
           </DetailGrid>
 
           {(event.username || event.ip) && (
+            <>
+            <Divider />
             <div
               data-testid="system-event-pivot-actions"
-              className="flex flex-wrap gap-2 border-t border-surface-800/50 pt-4"
+              className="flex flex-wrap gap-2"
             >
               {event.username && onPivotToUsername && (
                 <Button
@@ -89,6 +91,7 @@ export function SystemEventDetailModal({
                 </Button>
               )}
             </div>
+            </>
           )}
 
           {event.metadata && Object.keys(event.metadata).length > 0 && (

--- a/web/src/features/bios/components/bios-console-card.tsx
+++ b/web/src/features/bios/components/bios-console-card.tsx
@@ -7,7 +7,7 @@ import {
   ChevronRight,
   Trash2,
 } from "lucide-react";
-import { Section, Badge, Button } from "@/components/ui";
+import { Section, Badge, Button, Divider } from "@/components/ui";
 import type { BiosConsole, BiosConsoleFile } from "@/types/api";
 
 function statusBadge(status: BiosConsole["status"]) {
@@ -81,7 +81,9 @@ export function BiosConsoleCard({
       </button>
 
       {expanded && (
-        <div className="px-5 pb-4 space-y-2 border-t border-surface-800/50 pt-3">
+        <>
+        <Divider />
+        <div className="px-5 pb-4 space-y-2 pt-3">
           {biosConsole.files.map((file) => (
             <div
               key={file.fileName}
@@ -126,6 +128,7 @@ export function BiosConsoleCard({
             </div>
           ))}
         </div>
+        </>
       )}
     </Section>
   );


### PR DESCRIPTION
## Summary
- New `<Divider>` component in `web/src/components/ui/divider.tsx`
- Replaces inline `border-t border-surface-800/50` in 4 files: scrape-status-card, system-event-detail-modal, bios-console-card, sidebar
- Accepts optional `className` prop for additional spacing (e.g. `<Divider className="mb-5" />`)

Closes #419

## Test plan
- [x] TypeScript compiles
- [ ] CI passes