### PR TITLE
feat: log SystemEvent when EmulatorJS fails to load

### DIFF
--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -543,6 +543,10 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		api.PUT("/user/achievements/showcase", showcaseHandler.UpdateShowcase)
 		api.GET("/users/:id/achievements/showcase", showcaseHandler.GetPublicShowcase)
 
+		// Client error reporting (any authenticated user)
+		emulatorErrorHandler := &SystemEventHandler{DB: cfg.DB}
+		api.POST("/emulator/error", emulatorErrorHandler.ReportEmulatorError)
+
 		// Admin routes
 		admin := api.Group("/admin")
 		admin.Use(AdminMiddleware())

--- a/server/internal/api/system_event_handler.go
+++ b/server/internal/api/system_event_handler.go
@@ -299,3 +299,54 @@ func (h *SystemEventHandler) DismissSystemEvent(c *gin.Context) {
 	}
 	c.JSON(http.StatusOK, gin.H{"dismissed": true})
 }
+
+// ReportEmulatorError accepts a client-side emulator error report from
+// authenticated users and records it as an operational system event. This
+// gives admins visibility into player-facing issues (core download failures,
+// WASM compilation errors, missing ROMs) that otherwise only appear in
+// the user's browser console.
+func (h *SystemEventHandler) ReportEmulatorError(c *gin.Context) {
+	var req struct {
+		Error  string `json:"error" binding:"required"`
+		GameID string `json:"gameId"`
+		Core   string `json:"core"`
+	}
+	if err := c.ShouldBindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request body"})
+		return
+	}
+
+	// Extract user info from the auth context
+	userID, _ := c.Get("userID")
+	username, _ := c.Get("username")
+
+	var uid *uint
+	if id, ok := userID.(uint); ok {
+		uid = &id
+	}
+	var uname string
+	if name, ok := username.(string); ok {
+		uname = name
+	}
+
+	metadata := map[string]any{
+		"error": req.Error,
+	}
+	if req.GameID != "" {
+		metadata["gameId"] = req.GameID
+	}
+	if req.Core != "" {
+		metadata["core"] = req.Core
+	}
+
+	db.RecordOperationalEvent(h.DB, db.SystemEventInput{
+		EventType: db.SystemEventEmulatorJSLoadFailed,
+		Username:  uname,
+		UserID:    uid,
+		IP:        c.ClientIP(),
+		Path:      c.Request.URL.Path,
+		Metadata:  metadata,
+	})
+
+	c.JSON(http.StatusOK, gin.H{"reported": true})
+}

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -315,6 +315,7 @@ const (
 	SystemEventScraperRepeatedErrors   = "scraper_repeated_errors"
 	SystemEventROMFileMissing          = "rom_file_missing"
 	SystemEventAPICredentialsInvalid   = "api_credentials_invalid"
+	SystemEventEmulatorJSLoadFailed    = "emulatorjs_load_failed"
 )
 
 // AllSystemEventTypes is the canonical catalog of system event type strings.
@@ -334,6 +335,7 @@ var AllSystemEventTypes = []string{
 	SystemEventScraperRepeatedErrors,
 	SystemEventROMFileMissing,
 	SystemEventAPICredentialsInvalid,
+	SystemEventEmulatorJSLoadFailed,
 }
 
 // SystemEventTypeCategory maps each event type to its category code. Used by
@@ -353,6 +355,7 @@ var SystemEventTypeCategory = map[string]string{
 	SystemEventScraperRepeatedErrors:   CategoryOperational,
 	SystemEventROMFileMissing:          CategoryOperational,
 	SystemEventAPICredentialsInvalid:   CategoryOperational,
+	SystemEventEmulatorJSLoadFailed:    CategoryOperational,
 }
 
 // SystemEvent records an admin-only audit entry for an authentication,

--- a/web/src/features/admin/components/system-event-badge.tsx
+++ b/web/src/features/admin/components/system-event-badge.tsx
@@ -102,6 +102,12 @@ export const SYSTEM_EVENT_META: Record<SystemEventType, EventMeta> = {
     icon: KeySquare,
     severity: "alert",
   },
+  emulatorjs_load_failed: {
+    label: "Emulator Load Failed",
+    variant: "danger",
+    icon: AlertTriangle,
+    severity: "alert",
+  },
 };
 
 interface SystemEventBadgeProps {

--- a/web/src/lib/api-routes.ts
+++ b/web/src/lib/api-routes.ts
@@ -243,6 +243,9 @@ export type ApiPostPath = WithQuery<
   | "/auth/refresh"
   | "/auth/logout"
 
+  // Emulator
+  | "/emulator/error"
+
   // Games
   | `/games/${string}/scrape-if-needed`
   | `/games/${string}/play-time`

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -150,6 +150,11 @@ export function PlayPage() {
     },
     onError: (err) => {
       toast("error", `Emulator error: ${err}`);
+      api.post("/emulator/error", {
+        error: err,
+        gameId: id ?? "",
+        core: emulatorJsCore ?? "",
+      }).catch(() => {});
     },
     onSramUpdate: (data) => {
       saveManager.enqueueSave(data, true, "sram_autosave");

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -34,7 +34,8 @@ export type OperationalEventType =
   | "ra_circuit_breaker_tripped"
   | "scraper_repeated_errors"
   | "rom_file_missing"
-  | "api_credentials_invalid";
+  | "api_credentials_invalid"
+  | "emulatorjs_load_failed";
 
 export type SystemEventType = SecurityEventType | OperationalEventType;
 


### PR DESCRIPTION
## Summary
- Add `emulatorjs_load_failed` operational event type
- New `POST /api/emulator/error` endpoint (authenticated, non-admin) records the error as a SystemEvent
- Play page calls this endpoint when the emulator iframe reports an error
- Event metadata includes error message, game ID, and core name

Closes #424

## Test plan
- [x] Go builds
- [x] TypeScript compiles
- [x] Pre-push hook passes
- [ ] CI passes