### PR TITLE
chore: bump GitHub Actions to Node 24 versions

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -43,7 +43,7 @@ jobs:
         run: ./gradlew :android:assembleDebug
 
       - name: Upload APK
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: spela-android-apk
           path: player/android/build/outputs/apk/debug/*.apk

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -76,7 +76,7 @@ jobs:
         run: ./gradlew ${{ matrix.format }}
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.artifact-path }}
@@ -122,7 +122,7 @@ jobs:
         run: bash linux/build-appimage.sh --arch x86_64
 
       - name: Upload AppImage
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: spela-linux-appimage-x86_64
           path: player/desktop/build/appimage/Spela-x86_64.AppImage
@@ -176,7 +176,7 @@ jobs:
         run: bash linux/flatpak/build-flatpak.sh
 
       - name: Upload Flatpak
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: spela-linux-flatpak
           path: player/desktop/build/flatpak/spela.flatpak
@@ -226,13 +226,13 @@ jobs:
         run: bash linux/build-appimage.sh --arch aarch64
 
       - name: Upload DEB
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: spela-linux-arm64-deb
           path: player/desktop/build/compose/binaries/main/deb/*.deb
 
       - name: Upload AppImage
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: spela-linux-appimage-aarch64
           path: player/desktop/build/appimage/Spela-aarch64.AppImage

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -151,7 +151,7 @@ jobs:
           ANDROID_KEY_PASSWORD: ${{ secrets.ANDROID_KEY_PASSWORD }}
         run: ./gradlew :android:assembleRelease -PappVersion=${RELEASE_TAG#v}
       - name: Upload APK
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: spela-android-apk
           path: player/android/build/outputs/apk/release/*.apk
@@ -255,7 +255,7 @@ jobs:
           hdiutil create -volname "Spela" -srcfolder "$APP_DIR" -ov -format UDZO "$DMG_PATH"
           echo "Repackaged $DMG_PATH"
       - name: Upload artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.artifact-name }}
           path: ${{ matrix.artifact-path }}
@@ -296,7 +296,7 @@ jobs:
         working-directory: player
         run: bash linux/build-appimage.sh --arch x86_64
       - name: Upload AppImage
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: spela-linux-appimage-x86_64
           path: player/desktop/build/appimage/Spela-x86_64.AppImage
@@ -345,7 +345,7 @@ jobs:
         working-directory: player
         run: bash linux/flatpak/build-flatpak.sh
       - name: Upload Flatpak
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: spela-linux-flatpak
           path: player/desktop/build/flatpak/spela.flatpak
@@ -392,12 +392,12 @@ jobs:
         working-directory: player
         run: bash linux/build-appimage.sh --arch aarch64
       - name: Upload DEB
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: spela-linux-arm64-deb
           path: player/desktop/build/compose/binaries/main/deb/*.deb
       - name: Upload AppImage
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: spela-linux-appimage-aarch64
           path: player/desktop/build/appimage/Spela-aarch64.AppImage
@@ -419,7 +419,7 @@ jobs:
         with:
           ref: ${{ env.RELEASE_TAG }}
       - name: Download all artifacts
-        uses: actions/download-artifact@v5
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: spela-*
@@ -453,7 +453,7 @@ jobs:
           echo "Release artifacts:"
           ls -lh .
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -75,6 +75,19 @@ valuable — if it's not part of the current task, log it and move on.
 writing, bug investigation, or even casual file reads. If something catches your
 eye and it's not part of the current task, create an issue and move on.
 
+## Issue Tracking for PRs
+
+Every PR must reference at least one GitHub issue in its body via "Closes #N",
+"Fixes #N", or "Refs #N". This keeps the issue → PR → release chain traceable
+for future agents and humans.
+
+If the work fits an existing issue, reference it. If not, file an issue first
+with `gh issue create`, then reference it in the PR. Multiple issues per PR is
+fine when they're naturally bundled.
+
+Drive-by fixes without an issue link are tracking debt — file a one-line issue
+even for small things so the change is discoverable later.
+
 ## PR Review Gate
 
 Before presenting any PR to the user for manual testing or merge approval,


### PR DESCRIPTION
## Summary
- Bump `actions/upload-artifact` v5 → v7 (v6 was the Node 24 upgrade)
- Bump `actions/download-artifact` v5 → v8 (v6 was the Node 24 upgrade)
- Bump `softprops/action-gh-release` v2 → v3 (Node 24 upgrade)

All three bumps are clean Node 24 upgrades with no API changes. Verified by reading each release's changelog.

Also adds an \"Issue Tracking for PRs\" section to AGENTS.md so future agents always reference an issue in PR bodies.

Closes #429

## Test plan
- [ ] CI passes (this PR's own CI proves the actions still work)
- [ ] Next release tag triggers a release build with no Node 20 warnings