### PR TITLE
perf: lazy-load page components for code-splitting

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,68 +1,86 @@
+import { lazy, Suspense } from "react";
 import { BrowserRouter, Routes, Route, Navigate } from "react-router-dom";
 import { QueryClientProvider } from "@tanstack/react-query";
 import { AuthProvider } from "@/hooks/use-auth";
 import { ToastProvider } from "@/components/ui";
 import { AppLayout } from "@/components/app-layout";
 import { ProtectedRoute } from "@/components/protected-route";
-import { LoginPage } from "@/pages/login-page";
-import { RegisterPage } from "@/pages/register-page";
-import { DashboardPage } from "@/pages/dashboard-page";
-import { ConsolesPage } from "@/pages/consoles-page";
-import { ConsoleDetailPage } from "@/pages/console-detail-page";
-import { ConsoleGamesPage } from "@/pages/console-games-page";
-import { GamesPage } from "@/pages/games-page";
-import { GameDetailPage } from "@/pages/game-detail-page";
-import { GameAchievementsPage } from "@/pages/game-achievements-page";
-import { FavoritesPage } from "@/pages/favorites-page";
-import { PlayLaterPage } from "@/pages/play-later-page";
-import { AdminUsersPage } from "@/pages/admin/users-page";
-import { AdminSettingsPage } from "@/pages/admin/settings-page";
-import { AdminScanPage } from "@/pages/admin/scan-page";
-import { MetadataFixPage } from "@/pages/admin/metadata-fix-page";
-import { AdminCheatsPage } from "@/pages/admin/cheats-page";
-import { AdminBiosPage } from "@/pages/admin/bios-page";
-import { CoreCompatibilityPage } from "@/pages/admin/core-compatibility-page";
-import { AdminSystemEventsPage } from "@/pages/admin/system-events-page";
-import { UploadRomsPage } from "@/pages/admin/upload-roms-page";
-import { RomHacksPage } from "@/pages/admin/rom-hacks-page";
-import { PreferencesPage } from "@/pages/preferences-page";
-import { PlayPage } from "@/pages/play-page";
-import { StatsPage } from "@/pages/stats-page";
-import { ActivityPage } from "@/pages/activity-page";
-import { CollectionsPage } from "@/pages/collections-page";
-import { CollectionDetailPage } from "@/pages/collection-detail-page";
-import { UserProfilePage } from "@/pages/user-profile-page";
-import { SharedSessionsPage } from "@/pages/shared-sessions-page";
-import { SharedSessionDetailPage } from "@/pages/shared-session-detail-page";
-import { NetplayPage } from "@/pages/netplay-page";
-import { NetplaySessionPage } from "@/pages/netplay-session-page";
-import { LicensesPage } from "@/pages/licenses-page";
-import { ChallengesPage } from "@/pages/challenges-page";
-import { TopListsPage } from "@/pages/top-lists-page";
-import { ExplorePage } from "@/pages/explore-page";
-import { ExploreThemePage } from "@/pages/explore-theme-page";
-import { ExploreKeywordPage } from "@/pages/explore-keyword-page";
-import { ExploreSeriesPage } from "@/pages/explore-series-page";
-import { ExploreFranchisePage } from "@/pages/explore-franchise-page";
-import { DeveloperDetailPage } from "@/pages/developer-detail-page";
-import { PublisherDetailPage } from "@/pages/publisher-detail-page";
-import { ExploreMoodPage } from "@/pages/explore-mood-page";
-import { ExploreWizardPage } from "@/pages/explore-wizard-page";
-import { ScreenshotGalleryPage } from "@/pages/screenshot-gallery-page";
-import { CoverGalleryPage } from "@/pages/cover-gallery-page";
-import { ChallengeDetailPage } from "@/pages/challenge-detail-page";
-import { SessionDetailPage } from "@/pages/session-detail-page";
-import { SetupWizardPage } from "@/pages/setup-wizard-page";
-import { StoragePage } from "@/pages/storage-page";
 import { LibraryLayout } from "@/components/library-layout";
 import { ErrorBoundary } from "@/components/error-boundary";
 import { useTheme } from "@/hooks/use-theme";
+
+// Lazy-loaded pages — one chunk per screen via the router. Each page uses
+// `export default`; tests still use the named export. See feedback memory
+// "Code-split per screen via lazy router imports" for the convention.
+const LoginPage = lazy(() => import("@/pages/login-page"));
+const RegisterPage = lazy(() => import("@/pages/register-page"));
+const DashboardPage = lazy(() => import("@/pages/dashboard-page"));
+const ConsolesPage = lazy(() => import("@/pages/consoles-page"));
+const ConsoleDetailPage = lazy(() => import("@/pages/console-detail-page"));
+const ConsoleGamesPage = lazy(() => import("@/pages/console-games-page"));
+const GamesPage = lazy(() => import("@/pages/games-page"));
+const GameDetailPage = lazy(() => import("@/pages/game-detail-page"));
+const GameAchievementsPage = lazy(() => import("@/pages/game-achievements-page"));
+const FavoritesPage = lazy(() => import("@/pages/favorites-page"));
+const PlayLaterPage = lazy(() => import("@/pages/play-later-page"));
+const AdminUsersPage = lazy(() => import("@/pages/admin/users-page"));
+const AdminSettingsPage = lazy(() => import("@/pages/admin/settings-page"));
+const AdminScanPage = lazy(() => import("@/pages/admin/scan-page"));
+const MetadataFixPage = lazy(() => import("@/pages/admin/metadata-fix-page"));
+const AdminCheatsPage = lazy(() => import("@/pages/admin/cheats-page"));
+const AdminBiosPage = lazy(() => import("@/pages/admin/bios-page"));
+const CoreCompatibilityPage = lazy(() => import("@/pages/admin/core-compatibility-page"));
+const AdminSystemEventsPage = lazy(() => import("@/pages/admin/system-events-page"));
+const UploadRomsPage = lazy(() => import("@/pages/admin/upload-roms-page"));
+const RomHacksPage = lazy(() => import("@/pages/admin/rom-hacks-page"));
+const PreferencesPage = lazy(() => import("@/pages/preferences-page"));
+const PlayPage = lazy(() => import("@/pages/play-page"));
+const StatsPage = lazy(() => import("@/pages/stats-page"));
+const ActivityPage = lazy(() => import("@/pages/activity-page"));
+const CollectionsPage = lazy(() => import("@/pages/collections-page"));
+const CollectionDetailPage = lazy(() => import("@/pages/collection-detail-page"));
+const UserProfilePage = lazy(() => import("@/pages/user-profile-page"));
+const SharedSessionsPage = lazy(() => import("@/pages/shared-sessions-page"));
+const SharedSessionDetailPage = lazy(() => import("@/pages/shared-session-detail-page"));
+const NetplayPage = lazy(() => import("@/pages/netplay-page"));
+const NetplaySessionPage = lazy(() => import("@/pages/netplay-session-page"));
+const LicensesPage = lazy(() => import("@/pages/licenses-page"));
+const ChallengesPage = lazy(() => import("@/pages/challenges-page"));
+const TopListsPage = lazy(() => import("@/pages/top-lists-page"));
+const ExplorePage = lazy(() => import("@/pages/explore-page"));
+const ExploreThemePage = lazy(() => import("@/pages/explore-theme-page"));
+const ExploreKeywordPage = lazy(() => import("@/pages/explore-keyword-page"));
+const ExploreSeriesPage = lazy(() => import("@/pages/explore-series-page"));
+const ExploreFranchisePage = lazy(() => import("@/pages/explore-franchise-page"));
+const DeveloperDetailPage = lazy(() => import("@/pages/developer-detail-page"));
+const PublisherDetailPage = lazy(() => import("@/pages/publisher-detail-page"));
+const ExploreMoodPage = lazy(() => import("@/pages/explore-mood-page"));
+const ExploreWizardPage = lazy(() => import("@/pages/explore-wizard-page"));
+const ScreenshotGalleryPage = lazy(() => import("@/pages/screenshot-gallery-page"));
+const CoverGalleryPage = lazy(() => import("@/pages/cover-gallery-page"));
+const ChallengeDetailPage = lazy(() => import("@/pages/challenge-detail-page"));
+const SessionDetailPage = lazy(() => import("@/pages/session-detail-page"));
+const SetupWizardPage = lazy(() => import("@/pages/setup-wizard-page"));
+const StoragePage = lazy(() => import("@/pages/storage-page"));
 
 import { queryClient } from "@/lib/query-client";
 
 function ThemeApplier({ children }: { children: React.ReactNode }) {
   useTheme();
   return <>{children}</>;
+}
+
+// Minimal full-screen fallback shown while a lazy-loaded route chunk is
+// downloading. Intentionally subtle — most chunks load in <100ms on a warm
+// connection, so a heavy spinner would flash and feel worse than nothing.
+function RouteFallback() {
+  return (
+    <div
+      data-testid="route-fallback"
+      className="min-h-screen bg-surface-950"
+      aria-hidden="true"
+    />
+  );
 }
 
 export function App() {
@@ -73,6 +91,7 @@ export function App() {
           <AuthProvider>
             <ToastProvider>
               <ThemeApplier>
+                <Suspense fallback={<RouteFallback />}>
                 <Routes>
                   {/* Auth routes */}
                   <Route path="/setup" element={<SetupWizardPage />} />
@@ -270,6 +289,7 @@ export function App() {
                   {/* Fallback */}
                   <Route path="*" element={<Navigate to="/" replace />} />
                 </Routes>
+                </Suspense>
               </ThemeApplier>
             </ToastProvider>
           </AuthProvider>

--- a/web/src/features/admin/components/scrape-status-card.tsx
+++ b/web/src/features/admin/components/scrape-status-card.tsx
@@ -4,6 +4,7 @@ import {
   Button,
   Skeleton,
   Divider,
+  useToast,
 } from "@/components/ui";
 import {
   useScrapeStatusCounts,
@@ -11,7 +12,6 @@ import {
   useScrapeStatus,
   type ScrapeSourceCounts,
 } from "@/hooks/use-admin";
-import { useToast } from "@/components/ui";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
 
 const SOURCE_LABELS: Record<string, string> = {

--- a/web/src/pages/activity-page.tsx
+++ b/web/src/pages/activity-page.tsx
@@ -90,3 +90,5 @@ export function ActivityPage() {
     </PageLayout>
   );
 }
+
+export default ActivityPage;

--- a/web/src/pages/admin/bios-page.tsx
+++ b/web/src/pages/admin/bios-page.tsx
@@ -232,3 +232,5 @@ export function AdminBiosPage() {
     </PageLayout>
   );
 }
+
+export default AdminBiosPage;

--- a/web/src/pages/admin/cheats-page.tsx
+++ b/web/src/pages/admin/cheats-page.tsx
@@ -132,3 +132,5 @@ export function AdminCheatsPage() {
     </PageLayout>
   );
 }
+
+export default AdminCheatsPage;

--- a/web/src/pages/admin/core-compatibility-page.tsx
+++ b/web/src/pages/admin/core-compatibility-page.tsx
@@ -118,3 +118,5 @@ export function CoreCompatibilityPage() {
     </PageLayout>
   );
 }
+
+export default CoreCompatibilityPage;

--- a/web/src/pages/admin/metadata-fix-page.tsx
+++ b/web/src/pages/admin/metadata-fix-page.tsx
@@ -179,3 +179,5 @@ export function MetadataFixPage() {
     </PageLayout>
   );
 }
+
+export default MetadataFixPage;

--- a/web/src/pages/admin/rom-hacks-page.tsx
+++ b/web/src/pages/admin/rom-hacks-page.tsx
@@ -219,3 +219,5 @@ export function RomHacksPage() {
     </PageLayout>
   );
 }
+
+export default RomHacksPage;

--- a/web/src/pages/admin/scan-page.tsx
+++ b/web/src/pages/admin/scan-page.tsx
@@ -528,3 +528,5 @@ export function AdminScanPage() {
     </PageLayout>
   );
 }
+
+export default AdminScanPage;

--- a/web/src/pages/admin/settings-page.tsx
+++ b/web/src/pages/admin/settings-page.tsx
@@ -219,3 +219,5 @@ export function AdminSettingsPage() {
     </PageLayout>
   );
 }
+
+export default AdminSettingsPage;

--- a/web/src/pages/admin/system-events-page.tsx
+++ b/web/src/pages/admin/system-events-page.tsx
@@ -193,3 +193,5 @@ export function AdminSystemEventsPage() {
     </PageLayout>
   );
 }
+
+export default AdminSystemEventsPage;

--- a/web/src/pages/admin/upload-roms-page.tsx
+++ b/web/src/pages/admin/upload-roms-page.tsx
@@ -346,3 +346,5 @@ export function UploadRomsPage() {
     </PageLayout>
   );
 }
+
+export default UploadRomsPage;

--- a/web/src/pages/admin/users-page.tsx
+++ b/web/src/pages/admin/users-page.tsx
@@ -117,3 +117,5 @@ export function AdminUsersPage() {
     </PageLayout>
   );
 }
+
+export default AdminUsersPage;

--- a/web/src/pages/challenge-detail-page.tsx
+++ b/web/src/pages/challenge-detail-page.tsx
@@ -259,3 +259,5 @@ export function ChallengeDetailPage() {
     </PageLayout>
   );
 }
+
+export default ChallengeDetailPage;

--- a/web/src/pages/challenges-page.tsx
+++ b/web/src/pages/challenges-page.tsx
@@ -192,3 +192,5 @@ export function ChallengesPage() {
     </PageLayout>
   );
 }
+
+export default ChallengesPage;

--- a/web/src/pages/collection-detail-page.tsx
+++ b/web/src/pages/collection-detail-page.tsx
@@ -368,3 +368,5 @@ export function CollectionDetailPage() {
     </PageLayout>
   );
 }
+
+export default CollectionDetailPage;

--- a/web/src/pages/collections-page.tsx
+++ b/web/src/pages/collections-page.tsx
@@ -284,3 +284,5 @@ export function CollectionsPage() {
     </PageLayout>
   );
 }
+
+export default CollectionsPage;

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -216,3 +216,5 @@ function ScanButton({
     </button>
   );
 }
+
+export default ConsoleDetailPage;

--- a/web/src/pages/console-games-page.tsx
+++ b/web/src/pages/console-games-page.tsx
@@ -292,3 +292,5 @@ export function ConsoleGamesPage() {
     </PageLayout>
   );
 }
+
+export default ConsoleGamesPage;

--- a/web/src/pages/consoles-page.tsx
+++ b/web/src/pages/consoles-page.tsx
@@ -105,3 +105,5 @@ export function ConsolesPage() {
     </PageLayout>
   );
 }
+
+export default ConsolesPage;

--- a/web/src/pages/cover-gallery-page.tsx
+++ b/web/src/pages/cover-gallery-page.tsx
@@ -233,3 +233,5 @@ export function CoverGalleryPage() {
     </PageLayout>
   );
 }
+
+export default CoverGalleryPage;

--- a/web/src/pages/dashboard-page.tsx
+++ b/web/src/pages/dashboard-page.tsx
@@ -429,3 +429,5 @@ export function DashboardPage() {
     </PageLayout>
   );
 }
+
+export default DashboardPage;

--- a/web/src/pages/developer-detail-page.tsx
+++ b/web/src/pages/developer-detail-page.tsx
@@ -393,3 +393,5 @@ export function DeveloperDetailPage() {
     </PageLayout>
   );
 }
+
+export default DeveloperDetailPage;

--- a/web/src/pages/explore-franchise-page.tsx
+++ b/web/src/pages/explore-franchise-page.tsx
@@ -191,3 +191,5 @@ export function ExploreFranchisePage() {
     </PageLayout>
   );
 }
+
+export default ExploreFranchisePage;

--- a/web/src/pages/explore-keyword-page.tsx
+++ b/web/src/pages/explore-keyword-page.tsx
@@ -124,3 +124,5 @@ export function ExploreKeywordPage() {
     </PageLayout>
   );
 }
+
+export default ExploreKeywordPage;

--- a/web/src/pages/explore-mood-page.tsx
+++ b/web/src/pages/explore-mood-page.tsx
@@ -95,3 +95,5 @@ export function ExploreMoodPage() {
     </PageLayout>
   );
 }
+
+export default ExploreMoodPage;

--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -434,3 +434,5 @@ export function ExplorePage() {
     </PageLayout>
   );
 }
+
+export default ExplorePage;

--- a/web/src/pages/explore-series-page.tsx
+++ b/web/src/pages/explore-series-page.tsx
@@ -201,3 +201,5 @@ export function ExploreSeriesPage() {
     </PageLayout>
   );
 }
+
+export default ExploreSeriesPage;

--- a/web/src/pages/explore-theme-page.tsx
+++ b/web/src/pages/explore-theme-page.tsx
@@ -124,3 +124,5 @@ export function ExploreThemePage() {
     </PageLayout>
   );
 }
+
+export default ExploreThemePage;

--- a/web/src/pages/explore-wizard-page.tsx
+++ b/web/src/pages/explore-wizard-page.tsx
@@ -199,3 +199,5 @@ export function ExploreWizardPage() {
     </PageLayout>
   );
 }
+
+export default ExploreWizardPage;

--- a/web/src/pages/favorites-page.tsx
+++ b/web/src/pages/favorites-page.tsx
@@ -42,3 +42,5 @@ export function FavoritesPage() {
     </PageLayout>
   );
 }
+
+export default FavoritesPage;

--- a/web/src/pages/game-achievements-page.tsx
+++ b/web/src/pages/game-achievements-page.tsx
@@ -25,3 +25,5 @@ export function GameAchievementsPage() {
     </PageLayout>
   );
 }
+
+export default GameAchievementsPage;

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -442,3 +442,5 @@ export function GameDetailPage() {
     </PageLayout>
   );
 }
+
+export default GameDetailPage;

--- a/web/src/pages/games-page.tsx
+++ b/web/src/pages/games-page.tsx
@@ -255,3 +255,5 @@ export function GamesPage() {
     </PageLayout>
   );
 }
+
+export default GamesPage;

--- a/web/src/pages/licenses-page.tsx
+++ b/web/src/pages/licenses-page.tsx
@@ -119,3 +119,5 @@ export function LicensesPage() {
     </PageLayout>
   );
 }
+
+export default LicensesPage;

--- a/web/src/pages/login-page.tsx
+++ b/web/src/pages/login-page.tsx
@@ -78,3 +78,5 @@ export function LoginPage() {
     </AuthFormLayout>
   );
 }
+
+export default LoginPage;

--- a/web/src/pages/netplay-page.tsx
+++ b/web/src/pages/netplay-page.tsx
@@ -156,3 +156,5 @@ export function NetplayPage() {
     </PageLayout>
   );
 }
+
+export default NetplayPage;

--- a/web/src/pages/netplay-session-page.tsx
+++ b/web/src/pages/netplay-session-page.tsx
@@ -364,3 +364,5 @@ export function NetplaySessionPage() {
     </PageLayout>
   );
 }
+
+export default NetplaySessionPage;

--- a/web/src/pages/play-later-page.tsx
+++ b/web/src/pages/play-later-page.tsx
@@ -166,3 +166,5 @@ export function PlayLaterPage() {
     </PageLayout>
   );
 }
+
+export default PlayLaterPage;

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -488,3 +488,5 @@ export function PlayPage() {
     </div>
   );
 }
+
+export default PlayPage;

--- a/web/src/pages/preferences-page.tsx
+++ b/web/src/pages/preferences-page.tsx
@@ -239,3 +239,5 @@ export function PreferencesPage() {
     </PageLayout>
   );
 }
+
+export default PreferencesPage;

--- a/web/src/pages/publisher-detail-page.tsx
+++ b/web/src/pages/publisher-detail-page.tsx
@@ -393,3 +393,5 @@ export function PublisherDetailPage() {
     </PageLayout>
   );
 }
+
+export default PublisherDetailPage;

--- a/web/src/pages/register-page.tsx
+++ b/web/src/pages/register-page.tsx
@@ -139,3 +139,5 @@ export function RegisterPage() {
     </AuthFormLayout>
   );
 }
+
+export default RegisterPage;

--- a/web/src/pages/screenshot-gallery-page.tsx
+++ b/web/src/pages/screenshot-gallery-page.tsx
@@ -152,3 +152,5 @@ export function ScreenshotGalleryPage() {
     </PageLayout>
   );
 }
+
+export default ScreenshotGalleryPage;

--- a/web/src/pages/session-detail-page.tsx
+++ b/web/src/pages/session-detail-page.tsx
@@ -426,3 +426,5 @@ export function SessionDetailPage() {
     </PageLayout>
   );
 }
+
+export default SessionDetailPage;

--- a/web/src/pages/setup-page.tsx
+++ b/web/src/pages/setup-page.tsx
@@ -98,3 +98,5 @@ export function SetupPage() {
     </AuthFormLayout>
   );
 }
+
+export default SetupPage;

--- a/web/src/pages/setup-wizard-page.tsx
+++ b/web/src/pages/setup-wizard-page.tsx
@@ -57,3 +57,5 @@ export function SetupWizardPage() {
     </WizardLayout>
   );
 }
+
+export default SetupWizardPage;

--- a/web/src/pages/shared-session-detail-page.tsx
+++ b/web/src/pages/shared-session-detail-page.tsx
@@ -230,3 +230,5 @@ export function SharedSessionDetailPage() {
     </PageLayout>
   );
 }
+
+export default SharedSessionDetailPage;

--- a/web/src/pages/shared-sessions-page.tsx
+++ b/web/src/pages/shared-sessions-page.tsx
@@ -217,3 +217,5 @@ export function SharedSessionsPage() {
     </PageLayout>
   );
 }
+
+export default SharedSessionsPage;

--- a/web/src/pages/stats-page.tsx
+++ b/web/src/pages/stats-page.tsx
@@ -263,3 +263,5 @@ export function StatsPage() {
     </PageLayout>
   );
 }
+
+export default StatsPage;

--- a/web/src/pages/storage-page.tsx
+++ b/web/src/pages/storage-page.tsx
@@ -156,3 +156,5 @@ export function StoragePage() {
     </PageLayout>
   );
 }
+
+export default StoragePage;

--- a/web/src/pages/top-lists-page.tsx
+++ b/web/src/pages/top-lists-page.tsx
@@ -287,3 +287,5 @@ export function TopListsPage() {
     </PageLayout>
   );
 }
+
+export default TopListsPage;

--- a/web/src/pages/user-profile-page.tsx
+++ b/web/src/pages/user-profile-page.tsx
@@ -232,3 +232,5 @@ export function UserProfilePage() {
     </PageLayout>
   );
 }
+
+export default UserProfilePage;


### PR DESCRIPTION
## Summary
- All 50 page components now lazy-load via \`React.lazy(() => import(...))\` in App.tsx
- Each page got an \`export default\` (named export kept for tests)
- \`<Routes>\` wrapped in \`<Suspense>\` with a minimal full-screen fallback

## Bundle impact
- Main \`index.js\`: **949KB → 369KB** (61% smaller initial bundle)
- 50+ separate page chunks (5–75KB each, 1–19KB gzipped)
- Vite chunk size warning resolved

Also bundled in: removed a duplicate \`useToast\` import from \`scrape-status-card.tsx\` (had two separate imports from \`@/components/ui\` — eslint config doesn't include \`no-duplicate-imports\`).

Closes #430

## Test plan
- [x] All 1466 unit tests pass locally
- [x] TypeScript compiles
- [x] Vite build succeeds with the expected chunk split
- [ ] CI passes