### PR TITLE
chore: log SRAM capture failures instead of swallowing silently

### DIFF
--- a/web/public/emulator.js
+++ b/web/public/emulator.js
@@ -394,8 +394,12 @@
             data: uint8ArrayToBase64(saveFile),
           });
         }
-      } catch (_) {
-        // Ignore SRAM capture errors
+      } catch (err) {
+        // SRAM capture failures could indicate save data corruption — log
+        // to console so a user reporting "my saves aren't working" can
+        // share the error from devtools. Don't post to the parent: a
+        // single failed capture is recoverable, the next tick may succeed.
+        console.warn("[emulator] SRAM capture failed:", err);
       }
     };
 


### PR DESCRIPTION
## Summary
- The SRAM capture path in \`emulator.js\` was \`catch (_) {}\` with comment \"Ignore SRAM capture errors\". A user reporting \"my saves aren't working\" had no diagnostic trail.
- Switch to \`console.warn\` — visible in devtools, doesn't spam the parent.

Audit of the other three silent catches in \`emulator.js\`:
- Audio context resume (line 102, 109): genuinely best-effort, runs on every gesture, not worth logging
- Screenshot canvas-tainted (line 447): expected for cross-origin iframes, not worth logging

Closes #432

## Test plan
- [x] Build clean
- [ ] CI passes