### PR TITLE
refactor(api): make PaginatedResponse generic over its element type

### DIFF
--- a/server/internal/api/challenge_handler.go
+++ b/server/internal/api/challenge_handler.go
@@ -305,7 +305,7 @@ func (h *ChallengeHandler) ListChallenges(c *gin.Context) {
 		result = append(result, h.toChallengeResponse(ch))
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[ChallengeResponse]{
 		Data:     result,
 		Total:    total,
 		Page:     page,
@@ -770,7 +770,7 @@ func (h *ChallengeHandler) GetLeaderboard(c *gin.Context) {
 		})
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[ChallengeLeaderboardEntry]{
 		Data:     result,
 		Total:    total,
 		Page:     page,
@@ -815,7 +815,7 @@ func (h *ChallengeHandler) ListGameChallenges(c *gin.Context) {
 		result = append(result, h.toChallengeResponse(ch))
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[ChallengeResponse]{
 		Data:     result,
 		Total:    total,
 		Page:     page,
@@ -855,7 +855,7 @@ func (h *ChallengeHandler) ListMyChallenges(c *gin.Context) {
 		result = append(result, h.toChallengeResponse(ch))
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[ChallengeResponse]{
 		Data:     result,
 		Total:    total,
 		Page:     page,

--- a/server/internal/api/challenge_handler_test.go
+++ b/server/internal/api/challenge_handler_test.go
@@ -297,7 +297,7 @@ func TestListChallenges(t *testing.T) {
 		env.router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var resp PaginatedResponse
+		var resp PaginatedResponse[json.RawMessage]
 		json.Unmarshal(w.Body.Bytes(), &resp)
 		assert.Equal(t, int64(3), resp.Total)
 	})
@@ -309,7 +309,7 @@ func TestListChallenges(t *testing.T) {
 		env.router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var resp PaginatedResponse
+		var resp PaginatedResponse[json.RawMessage]
 		json.Unmarshal(w.Body.Bytes(), &resp)
 		assert.Equal(t, int64(3), resp.Total)
 	})
@@ -321,7 +321,7 @@ func TestListChallenges(t *testing.T) {
 		env.router.ServeHTTP(w, req)
 		assert.Equal(t, http.StatusOK, w.Code)
 
-		var resp PaginatedResponse
+		var resp PaginatedResponse[json.RawMessage]
 		json.Unmarshal(w.Body.Bytes(), &resp)
 		assert.Equal(t, int64(2), resp.Total)
 	})
@@ -709,7 +709,7 @@ func TestLeaderboard(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.Equal(t, int64(2), resp.Total)
 
@@ -775,7 +775,7 @@ func TestLeaderboardBestAttemptOnly(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.Equal(t, int64(1), resp.Total, "leaderboard should show only best attempt per user")
 }
@@ -889,7 +889,7 @@ func TestListGameChallenges(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.Equal(t, int64(2), resp.Total)
 }
@@ -908,7 +908,7 @@ func TestListMyChallenges(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.Equal(t, int64(2), resp.Total)
 }
@@ -1101,7 +1101,7 @@ func TestSurvivalLeaderboard(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.Equal(t, int64(2), resp.Total)
 
@@ -1170,7 +1170,7 @@ func TestSurvivalBestAttempt(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.Equal(t, int64(1), resp.Total, "leaderboard should show only best attempt per user")
 }

--- a/server/internal/api/collection_handler.go
+++ b/server/internal/api/collection_handler.go
@@ -94,7 +94,7 @@ func (h *CollectionHandler) ListMyCollections(c *gin.Context) {
 		result = append(result, h.toCollectionResponse(col, uid))
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[CollectionResponse]{
 		Data:     result,
 		Total:    total,
 		Page:     page,
@@ -148,7 +148,7 @@ func (h *CollectionHandler) ListPublicCollections(c *gin.Context) {
 		result = append(result, h.toCollectionResponse(col, uid))
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[CollectionResponse]{
 		Data:     result,
 		Total:    total,
 		Page:     page,

--- a/server/internal/api/console_handler.go
+++ b/server/internal/api/console_handler.go
@@ -206,7 +206,7 @@ func (h *ConsoleHandler) ListConsoleGames(c *gin.Context) {
 	}
 
 	userID := getUserID(c)
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[GameResponse]{
 		Data:     ToGameResponses(games, h.DB, userID),
 		Total:    total,
 		Page:     page,

--- a/server/internal/api/enrichment_handler.go
+++ b/server/internal/api/enrichment_handler.go
@@ -114,7 +114,7 @@ func (h *EnrichmentHandler) ListThemeGames(c *gin.Context) {
 	}
 
 	userID := getUserID(c)
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[GameResponse]{
 		Data:     ToGameResponses(games, h.DB, userID),
 		Total:    total,
 		Page:     page,
@@ -219,7 +219,7 @@ func (h *EnrichmentHandler) ListKeywordGames(c *gin.Context) {
 	}
 
 	userID := getUserID(c)
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[GameResponse]{
 		Data:     ToGameResponses(games, h.DB, userID),
 		Total:    total,
 		Page:     page,
@@ -534,7 +534,7 @@ func (h *EnrichmentHandler) ListFranchiseGames(c *gin.Context) {
 	}
 
 	userID := getUserID(c)
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[GameResponse]{
 		Data:     ToGameResponses(games, h.DB, userID),
 		Total:    total,
 		Page:     page,

--- a/server/internal/api/enrichment_handler_test.go
+++ b/server/internal/api/enrichment_handler_test.go
@@ -115,7 +115,7 @@ func TestListThemeGames_Success(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, int64(2), resp.Total)
 	assert.Equal(t, 1, resp.Page)
@@ -211,7 +211,7 @@ func TestListKeywordGames_Success(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, int64(1), resp.Total)
 }
@@ -287,7 +287,7 @@ func TestListFranchiseGames_Success(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, int64(2), resp.Total)
 	assert.Equal(t, 1, resp.Page)
@@ -539,7 +539,7 @@ func TestListGames_FilterByTheme(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, int64(1), resp.Total)
 }
@@ -558,7 +558,7 @@ func TestListGames_FilterByKeyword(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, int64(1), resp.Total)
 }
@@ -577,7 +577,7 @@ func TestListGames_FilterByPerspective(t *testing.T) {
 	env.router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, int64(1), resp.Total)
 }

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -61,7 +61,7 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 		}
 		if len(consoleIDs) == 0 {
 			// All abbreviations unknown — return empty list
-			c.JSON(http.StatusOK, PaginatedResponse{
+			c.JSON(http.StatusOK, PaginatedResponse[GameResponse]{
 				Data:     []GameResponse{},
 				Total:    0,
 				Page:     1,
@@ -313,7 +313,7 @@ func (h *GameHandler) ListGames(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[GameResponse]{
 		Data:     ToGameResponses(games, h.DB, userID),
 		Total:    total,
 		Page:     page,

--- a/server/internal/api/netplay_handler.go
+++ b/server/internal/api/netplay_handler.go
@@ -146,7 +146,7 @@ func (h *NetplayHandler) ListSessions(c *gin.Context) {
 		result = append(result, h.toSessionResponse(s))
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[NetplaySessionResponse]{
 		Data:     result,
 		Total:    total,
 		Page:     page,

--- a/server/internal/api/netplay_test.go
+++ b/server/internal/api/netplay_test.go
@@ -327,7 +327,7 @@ func TestNetplay_ListSessions(t *testing.T) {
 	ctx.router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.True(t, resp.Total >= 1)
 	assert.Equal(t, 1, resp.Page)
@@ -340,7 +340,7 @@ func TestNetplay_ListSessions(t *testing.T) {
 	ctx.router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp2 PaginatedResponse
+	var resp2 PaginatedResponse[json.RawMessage]
 	json.Unmarshal(w.Body.Bytes(), &resp2)
 	assert.True(t, resp2.Total >= 1)
 }
@@ -360,16 +360,14 @@ func TestNetplay_ListSessions_Pagination(t *testing.T) {
 	ctx.router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	json.Unmarshal(w.Body.Bytes(), &resp)
 	assert.Equal(t, int64(3), resp.Total)
 	assert.Equal(t, 1, resp.Page)
 	assert.Equal(t, 2, resp.PageSize)
 
 	// The data array should have 2 items
-	dataSlice, ok := resp.Data.([]interface{})
-	require.True(t, ok)
-	assert.Len(t, dataSlice, 2)
+	assert.Len(t, resp.Data, 2)
 }
 
 func TestNetplay_LeaveSession_Host(t *testing.T) {

--- a/server/internal/api/rating_handler.go
+++ b/server/internal/api/rating_handler.go
@@ -107,7 +107,7 @@ func (h *RatingHandler) GetRatings(c *gin.Context) {
 		result = append(result, h.toRatingResponse(r, uid))
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[GameRatingResponse]{
 		Data:     result,
 		Total:    total,
 		Page:     page,

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -189,12 +189,15 @@ type RomHackGameResponse struct {
 	CoverURL string `json:"coverUrl,omitempty"`
 }
 
-// PaginatedResponse wraps a paginated list with standard keys.
-type PaginatedResponse struct {
-	Data     interface{} `json:"data"`
-	Total    int64       `json:"total"`
-	Page     int         `json:"page"`
-	PageSize int         `json:"pageSize"`
+// PaginatedResponse wraps a paginated list with standard keys. The type
+// parameter is the element type of Data so each call site declares exactly
+// what is being paginated (e.g. PaginatedResponse[GameResponse]). Tests that
+// don't care about element shape can use PaginatedResponse[json.RawMessage].
+type PaginatedResponse[T any] struct {
+	Data     []T   `json:"data"`
+	Total    int64 `json:"total"`
+	Page     int   `json:"page"`
+	PageSize int   `json:"pageSize"`
 }
 
 // ToConsoleResponse converts a db.Console to its API response.

--- a/server/internal/api/shared_save_handler.go
+++ b/server/internal/api/shared_save_handler.go
@@ -120,7 +120,7 @@ func (h *SharedSaveHandler) ListSharedSaves(c *gin.Context) {
 		result = append(result, h.toResponse(s, uid))
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[SharedSaveResponse]{
 		Data:     result,
 		Total:    total,
 		Page:     page,

--- a/server/internal/api/social_handler.go
+++ b/server/internal/api/social_handler.go
@@ -242,7 +242,7 @@ func (h *SocialHandler) SearchUsers(c *gin.Context) {
 		})
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[UserSearchResult]{
 		Data:     result,
 		Total:    total,
 		Page:     page,
@@ -445,7 +445,7 @@ func (h *SocialHandler) GetActivityFeed(c *gin.Context) {
 		})
 	}
 
-	c.JSON(http.StatusOK, PaginatedResponse{
+	c.JSON(http.StatusOK, PaginatedResponse[ActivityEventResponse]{
 		Data:     result,
 		Total:    total,
 		Page:     page,

--- a/server/internal/api/social_search_test.go
+++ b/server/internal/api/social_search_test.go
@@ -31,7 +31,7 @@ func TestSearchUsers_EmptyQuery_ReturnsAllUsers(t *testing.T) {
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
 
@@ -78,7 +78,7 @@ func TestSearchUsers_WithQuery_MatchesByPrefix(t *testing.T) {
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), resp.Total) // alice, alex (apitest excluded as self)
@@ -117,7 +117,7 @@ func TestSearchUsers_Pagination(t *testing.T) {
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	assert.Equal(t, int64(5), resp.Total)
@@ -157,7 +157,7 @@ func TestSearchUsers_PageSizeClampedTo50(t *testing.T) {
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	assert.Equal(t, 20, resp.PageSize) // clamped to default 20 since >50
@@ -199,7 +199,7 @@ func TestSearchUsers_ExcludesSelf(t *testing.T) {
 	router.ServeHTTP(w, req)
 	require.Equal(t, http.StatusOK, w.Code)
 
-	var resp PaginatedResponse
+	var resp PaginatedResponse[json.RawMessage]
 	err := json.Unmarshal(w.Body.Bytes(), &resp)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), resp.Total) // self excluded


### PR DESCRIPTION
## Summary
Phase 0b of the API type-safety refactor (see #437).

Replace the loose \`PaginatedResponse{Data interface{}}\` with \`PaginatedResponse[T any]{Data []T}\`. Each handler call site now declares the concrete element type.

Producers (17 call sites) use typed instantiations:
- \`PaginatedResponse[ChallengeResponse]\`
- \`PaginatedResponse[ChallengeLeaderboardEntry]\`
- \`PaginatedResponse[CollectionResponse]\`
- \`PaginatedResponse[GameResponse]\`
- \`PaginatedResponse[GameRatingResponse]\`
- \`PaginatedResponse[NetplaySessionResponse]\`
- \`PaginatedResponse[SharedSaveResponse]\`
- \`PaginatedResponse[UserSearchResult]\`
- \`PaginatedResponse[ActivityEventResponse]\`

Tests use \`PaginatedResponse[json.RawMessage]\` when only inspecting Total/Page/PageSize.

## Wire format
Unchanged: \`{ \"data\": [...], \"total\": ..., \"page\": ..., \"pageSize\": ... }\`. Web TS / Kotlin consumers untouched.

## Why
Without the type parameter, every paginated endpoint would generate \`data: any\` in the OpenAPI schema. This change is what makes accurate codegen possible later.

Refs #437.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./internal/api/...\` clean
- [ ] CI passes