### PR TITLE
refactor(db,api): introduce typed UserRole enum

### DIFF
--- a/server/internal/api/admin_cover_test.go
+++ b/server/internal/api/admin_cover_test.go
@@ -24,7 +24,7 @@ func createAdminUser(t *testing.T, database *gorm.DB) (db.User, string) {
 		Role:         "owner",
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 	return user, token
 }
@@ -242,7 +242,7 @@ func TestGetGameCovers_NonAdmin_Returns403(t *testing.T) {
 		Role:         "user",
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	game := createTestGame(t, database)

--- a/server/internal/api/admin_deleted_users_test.go
+++ b/server/internal/api/admin_deleted_users_test.go
@@ -92,7 +92,7 @@ func TestListDeletedUsers_NonAdmin_Returns403(t *testing.T) {
 		Role:         "user",
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest("GET", "/api/admin/users/deleted", nil)
@@ -184,7 +184,7 @@ func TestHardDeleteUser_RejectsOwner(t *testing.T) {
 		Role:         "admin",
 	}
 	require.NoError(t, database.Create(&admin).Error)
-	adminToken, err := auth.GenerateAccessToken(admin.ID, admin.Username, admin.Role, testJWTSecret)
+	adminToken, err := auth.GenerateAccessToken(admin.ID, admin.Username, string(admin.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	// Soft-delete the owner (shouldn't happen normally, but test the guard)
@@ -225,7 +225,7 @@ func TestHardDeleteUser_NonAdmin_Returns403(t *testing.T) {
 		Role:         "user",
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	deleted := softDeleteUser(t, database, "deleted-user", "deleted@test.com")

--- a/server/internal/api/admin_handler_romhacks_test.go
+++ b/server/internal/api/admin_handler_romhacks_test.go
@@ -41,7 +41,7 @@ func setupRomHackTestEnv(t *testing.T) *romHackTestEnv {
 		Role:         "owner",
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	// Find a console
@@ -410,7 +410,7 @@ func TestCreateRomHack_NonAdminDenied(t *testing.T) {
 		Role:         "user",
 	}
 	require.NoError(t, env.db.Create(&user).Error)
-	userToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	userToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	patch := buildTestIPSPatch(0, []byte("X"))

--- a/server/internal/api/admin_handler_users.go
+++ b/server/internal/api/admin_handler_users.go
@@ -28,10 +28,10 @@ func (h *AdminHandler) ListUsers(c *gin.Context) {
 // CreateUser creates a new user account (admin only).
 func (h *AdminHandler) CreateUser(c *gin.Context) {
 	var req struct {
-		Username string `json:"username" binding:"required,min=3,max=64"`
-		Email    string `json:"email" binding:"required,email"`
-		Password string `json:"password" binding:"required,min=8,max=72"`
-		Role     string `json:"role"`
+		Username string       `json:"username" binding:"required,min=3,max=64"`
+		Email    string       `json:"email" binding:"required,email"`
+		Password string       `json:"password" binding:"required,min=8,max=72"`
+		Role     db.UserRole  `json:"role"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
@@ -40,9 +40,9 @@ func (h *AdminHandler) CreateUser(c *gin.Context) {
 	}
 
 	if req.Role == "" {
-		req.Role = "user"
+		req.Role = db.RoleUser
 	}
-	if req.Role != "admin" && req.Role != "user" {
+	if req.Role != db.RoleAdmin && req.Role != db.RoleUser {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "role must be 'admin' or 'user'"})
 		return
 	}
@@ -92,11 +92,11 @@ func (h *AdminHandler) UpdateUser(c *gin.Context) {
 	}
 
 	var req struct {
-		Role            string `json:"role"`
-		Email           string `json:"email"`
-		Password        string `json:"password"`
-		Disabled        *bool  `json:"disabled"`
-		PendingApproval *bool  `json:"pendingApproval"`
+		Role            db.UserRole `json:"role"`
+		Email           string      `json:"email"`
+		Password        string      `json:"password"`
+		Disabled        *bool       `json:"disabled"`
+		PendingApproval *bool       `json:"pendingApproval"`
 	}
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)

--- a/server/internal/api/admin_igdb_match_test.go
+++ b/server/internal/api/admin_igdb_match_test.go
@@ -91,7 +91,7 @@ func createIGDBMatchTestUser(t *testing.T, database *gorm.DB) string {
 		Role:         "admin",
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, igdbMatchTestSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), igdbMatchTestSecret)
 	require.NoError(t, err)
 	return token
 }

--- a/server/internal/api/admin_igdb_test.go
+++ b/server/internal/api/admin_igdb_test.go
@@ -63,16 +63,16 @@ func setupIGDBTestEnv(t *testing.T, twitchServer *httptest.Server) (*gorm.DB, *g
 	return database, router
 }
 
-func createIGDBTestUser(t *testing.T, database *gorm.DB, role string) string {
+func createIGDBTestUser(t *testing.T, database *gorm.DB, role db.UserRole) string {
 	t.Helper()
 	user := db.User{
-		Username:     "igdb-test-" + role,
-		Email:        "igdb-test-" + role + "@test.com",
+		Username:     "igdb-test-" + string(role),
+		Email:        "igdb-test-" + string(role) + "@test.com",
 		PasswordHash: "unused",
 		Role:         role,
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, igdbTestJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), igdbTestJWTSecret)
 	require.NoError(t, err)
 	return token
 }

--- a/server/internal/api/admin_rate_limit_test.go
+++ b/server/internal/api/admin_rate_limit_test.go
@@ -178,7 +178,7 @@ func TestGetUserRateLimit_NonAdmin_Returns403(t *testing.T) {
 		Role:         "user",
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest("GET", "/api/admin/users/"+strconv.Itoa(int(user.ID))+"/rate-limit", nil)
@@ -261,7 +261,7 @@ func TestResetUserRateLimit_NonAdmin_Returns403(t *testing.T) {
 		Role:         "user",
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	req := httptest.NewRequest("DELETE", "/api/admin/users/"+strconv.Itoa(int(user.ID))+"/rate-limit", nil)

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -468,7 +468,7 @@ func TestAdminEndpoint_NonAdmin(t *testing.T) {
 	// Verify user is not admin
 	var user db.User
 	database.Where("username = ?", "regularuser").First(&user)
-	assert.Equal(t, "user", user.Role)
+	assert.Equal(t, db.RoleUser, user.Role)
 
 	// Try admin endpoint
 	w := httptest.NewRecorder()
@@ -2491,7 +2491,7 @@ func TestScrapeStatus_NonAdmin(t *testing.T) {
 	// Verify user is not admin
 	var user db.User
 	database.Where("username = ?", "regularuser2").First(&user)
-	assert.Equal(t, "user", user.Role)
+	assert.Equal(t, db.RoleUser, user.Role)
 
 	// Non-admin should be rejected
 	w := httptest.NewRecorder()

--- a/server/internal/api/auth_handler.go
+++ b/server/internal/api/auth_handler.go
@@ -233,7 +233,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 		UserID:    &user.ID,
 	})
 
-	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, h.JWTSecret, user.TokenVersion)
+	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret, user.TokenVersion)
 	if err != nil {
 		apiError(c, http.StatusInternalServerError, "failed to generate token", "Sign in failed. Please try again.")
 		return
@@ -341,7 +341,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 		return
 	}
 
-	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, h.JWTSecret)
+	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret)
 	if err != nil {
 		apiError(c, http.StatusInternalServerError, "failed to generate token", "Account created but sign-in failed. Please sign in manually.")
 		return
@@ -427,7 +427,7 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 		return
 	}
 
-	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, h.JWTSecret, user.TokenVersion)
+	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret, user.TokenVersion)
 	if err != nil {
 		apiError(c, http.StatusInternalServerError, "failed to generate token", "Session refresh failed. Please sign in again.")
 		return
@@ -627,7 +627,7 @@ func (h *AuthHandler) Setup(c *gin.Context) {
 		return
 	}
 
-	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, h.JWTSecret)
+	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret)
 	if err != nil {
 		apiError(c, http.StatusInternalServerError, "failed to generate token", "Setup failed. Please try again.")
 		return

--- a/server/internal/api/bios_handler_test.go
+++ b/server/internal/api/bios_handler_test.go
@@ -72,7 +72,7 @@ func setupBiosTestEnv(t *testing.T) (*storage.Storage, *gorm.DB, *gin.Engine) {
 }
 
 // createBiosTestUser creates a user and returns a JWT token.
-func createBiosTestUser(t *testing.T, database *gorm.DB, role string) string {
+func createBiosTestUser(t *testing.T, database *gorm.DB, role db.UserRole) string {
 	t.Helper()
 	user := db.User{
 		Username:     fmt.Sprintf("user-%s-%d", role, database.RowsAffected),
@@ -81,7 +81,7 @@ func createBiosTestUser(t *testing.T, database *gorm.DB, role string) string {
 		Role:         role,
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, biosTestJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), biosTestJWTSecret)
 	require.NoError(t, err)
 	return token
 }

--- a/server/internal/api/challenge_handler.go
+++ b/server/internal/api/challenge_handler.go
@@ -341,7 +341,7 @@ func (h *ChallengeHandler) UpdateChallenge(c *gin.Context) {
 	}
 
 	role, _ := c.Get("role")
-	if challenge.CreatorID != uid && !db.IsAdminOrOwner(role.(string)) {
+	if challenge.CreatorID != uid && !db.IsAdminOrOwner(role.(db.UserRole)) {
 		c.JSON(http.StatusForbidden, ErrorResponse{Error: "not authorized to update this challenge"})
 		return
 	}
@@ -405,7 +405,7 @@ func (h *ChallengeHandler) DeleteChallenge(c *gin.Context) {
 	}
 
 	role, _ := c.Get("role")
-	if challenge.CreatorID != uid && !db.IsAdminOrOwner(role.(string)) {
+	if challenge.CreatorID != uid && !db.IsAdminOrOwner(role.(db.UserRole)) {
 		c.JSON(http.StatusForbidden, ErrorResponse{Error: "not authorized to delete this challenge"})
 		return
 	}

--- a/server/internal/api/challenge_handler_test.go
+++ b/server/internal/api/challenge_handler_test.go
@@ -79,7 +79,7 @@ func setupChallengeTestWithRateLimit(t *testing.T, rateLimitSec int) *challengeT
 		Role:         "admin",
 	}
 	database.Create(&adminUser)
-	adminToken, _ := auth.GenerateAccessToken(adminUser.ID, adminUser.Username, adminUser.Role, testJWTSecret)
+	adminToken, _ := auth.GenerateAccessToken(adminUser.ID, adminUser.Username, string(adminUser.Role), testJWTSecret)
 
 	// Create a game with a console
 	var console db.Console

--- a/server/internal/api/game_handler_replace_test.go
+++ b/server/internal/api/game_handler_replace_test.go
@@ -43,7 +43,7 @@ func setupReplaceROMTestEnv(t *testing.T) *replaceROMTestEnv {
 		Role:         "owner",
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	router, cleanup := NewRouter(*cfg)
@@ -337,7 +337,7 @@ func TestReplaceROM_RequiresAdmin(t *testing.T) {
 		Role:         "user",
 	}
 	require.NoError(t, env.db.Create(&user).Error)
-	userToken, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	userToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	// Try to replace ROM as non-admin

--- a/server/internal/api/middleware.go
+++ b/server/internal/api/middleware.go
@@ -123,7 +123,7 @@ func AuthMiddleware(jwtSecret string, database *gorm.DB) gin.HandlerFunc {
 
 		c.Set("userId", claims.UserID)
 		c.Set("username", claims.Username)
-		c.Set("role", claims.Role)
+		c.Set("role", db.UserRole(claims.Role))
 		c.Next()
 	}
 }
@@ -132,7 +132,8 @@ func AuthMiddleware(jwtSecret string, database *gorm.DB) gin.HandlerFunc {
 func AdminMiddleware() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		role, _ := c.Get("role")
-		if role != "admin" && role != "owner" {
+		userRole, _ := role.(db.UserRole)
+		if !db.IsAdminOrOwner(userRole) {
 			abortWithError(c, http.StatusForbidden, "admin access required", "You don't have permission to access this resource.")
 			return
 		}

--- a/server/internal/api/netplay_handler.go
+++ b/server/internal/api/netplay_handler.go
@@ -295,8 +295,8 @@ func (h *NetplayHandler) LeaveSession(c *gin.Context) {
 func (h *NetplayHandler) DeleteSession(c *gin.Context) {
 	uid := getUserID(c)
 	role, _ := c.Get("role")
-	roleStr, _ := role.(string)
-	isAdmin := db.IsAdminOrOwner(roleStr)
+	userRole, _ := role.(db.UserRole)
+	isAdmin := db.IsAdminOrOwner(userRole)
 
 	session, ok := h.loadSession(c)
 	if !ok {

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -603,10 +603,10 @@ func ToGameResponses(games []db.Game, database *gorm.DB, userID uint) []GameResp
 
 // UserResponse is the API response for a user, with string ID for consistency.
 type UserResponse struct {
-	ID              string    `json:"id"`
-	Username        string    `json:"username"`
-	Email           string    `json:"email"`
-	Role            string    `json:"role"`
+	ID              string      `json:"id"`
+	Username        string      `json:"username"`
+	Email           string      `json:"email"`
+	Role            db.UserRole `json:"role"`
 	AvatarURL       string    `json:"avatarUrl,omitempty"`
 	Disabled        bool      `json:"disabled"`
 	PendingApproval bool      `json:"pendingApproval"`
@@ -631,11 +631,11 @@ func ToUserResponse(u db.User) UserResponse {
 
 // DeletedUserResponse is the API response for a soft-deleted user.
 type DeletedUserResponse struct {
-	ID              string    `json:"id"`
-	Username        string    `json:"username"`
-	Email           string    `json:"email"`
-	Role            string    `json:"role"`
-	Disabled        bool      `json:"disabled"`
+	ID              string      `json:"id"`
+	Username        string      `json:"username"`
+	Email           string      `json:"email"`
+	Role            db.UserRole `json:"role"`
+	Disabled        bool        `json:"disabled"`
 	CreatedAt       time.Time `json:"createdAt"`
 	DeletedAt       time.Time `json:"deletedAt"`
 }

--- a/server/internal/api/setup_handler_test.go
+++ b/server/internal/api/setup_handler_test.go
@@ -13,16 +13,16 @@ import (
 	"gorm.io/gorm"
 )
 
-func createSetupTestUser(t *testing.T, database *gorm.DB, role string) string {
+func createSetupTestUser(t *testing.T, database *gorm.DB, role db.UserRole) string {
 	t.Helper()
 	user := db.User{
-		Username:     "setup-test-" + role,
-		Email:        "setup-test-" + role + "@test.com",
+		Username:     "setup-test-" + string(role),
+		Email:        "setup-test-" + string(role) + "@test.com",
 		PasswordHash: "unused",
 		Role:         role,
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 	return token
 }
@@ -109,7 +109,7 @@ func TestDiagnostics_RegularUserForbidden(t *testing.T) {
 		Role:         "user",
 	}
 	require.NoError(t, database.Create(&regularUser).Error)
-	regularToken, err := auth.GenerateAccessToken(regularUser.ID, regularUser.Username, regularUser.Role, testJWTSecret)
+	regularToken, err := auth.GenerateAccessToken(regularUser.ID, regularUser.Username, string(regularUser.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	w := httptest.NewRecorder()

--- a/server/internal/api/shared_save_handler.go
+++ b/server/internal/api/shared_save_handler.go
@@ -164,7 +164,7 @@ func (h *SharedSaveHandler) DeleteSharedSave(c *gin.Context) {
 
 	// Check ownership or admin
 	role, _ := c.Get("role")
-	if save.UserID != uid && !db.IsAdminOrOwner(role.(string)) {
+	if save.UserID != uid && !db.IsAdminOrOwner(role.(db.UserRole)) {
 		c.JSON(http.StatusForbidden, ErrorResponse{Error: "not authorized to delete this shared save"})
 		return
 	}

--- a/server/internal/api/test_handler_test.go
+++ b/server/internal/api/test_handler_test.go
@@ -78,11 +78,11 @@ func TestResetEndpoint_DeletesExtraUsers(t *testing.T) {
 	// Verify admin and player still exist
 	var admin db.User
 	require.NoError(t, database.Where("username = ?", "admin").First(&admin).Error)
-	assert.Equal(t, "owner", admin.Role)
+	assert.Equal(t, db.RoleOwner, admin.Role)
 
 	var player db.User
 	require.NoError(t, database.Where("username = ?", "player").First(&player).Error)
-	assert.Equal(t, "user", player.Role)
+	assert.Equal(t, db.RoleUser, player.Role)
 }
 
 func TestResetEndpoint_ResetsUserPreferences(t *testing.T) {

--- a/server/internal/api/upload_handler_test.go
+++ b/server/internal/api/upload_handler_test.go
@@ -41,7 +41,7 @@ func setupUploadTestEnv(t *testing.T) *uploadTestEnv {
 		Role:         "owner",
 	}
 	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, user.Role, testJWTSecret)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	return &uploadTestEnv{
@@ -592,7 +592,7 @@ func TestUploadROMs_NonAdmin_Forbidden(t *testing.T) {
 		Role:         "user",
 	}
 	require.NoError(t, env.db.Create(&regularUser).Error)
-	userToken, err := auth.GenerateAccessToken(regularUser.ID, regularUser.Username, regularUser.Role, testJWTSecret)
+	userToken, err := auth.GenerateAccessToken(regularUser.ID, regularUser.Username, string(regularUser.Role), testJWTSecret)
 	require.NoError(t, err)
 
 	files := map[string][]byte{

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -6,15 +6,25 @@ import (
 	"gorm.io/gorm"
 )
 
+// UserRole is the typed user role enumeration. The wire format remains a
+// plain string ("owner" / "admin" / "user") since UserRole's underlying type
+// is string. The named type lets handlers and OpenAPI annotations express
+// the bounded set of valid values precisely.
+type UserRole string
+
 // Role constants for the role hierarchy: owner > admin > user.
 const (
-	RoleOwner = "owner"
-	RoleAdmin = "admin"
-	RoleUser  = "user"
+	RoleOwner UserRole = "owner"
+	RoleAdmin UserRole = "admin"
+	RoleUser  UserRole = "user"
 )
 
+// AllUserRoles is the canonical list of valid user roles. Used by the
+// OpenAPI generator and any handler that needs to enumerate valid roles.
+var AllUserRoles = []UserRole{RoleOwner, RoleAdmin, RoleUser}
+
 // IsAdminOrOwner returns true if the role is admin or owner.
-func IsAdminOrOwner(role string) bool {
+func IsAdminOrOwner(role UserRole) bool {
 	return role == RoleAdmin || role == RoleOwner
 }
 
@@ -27,7 +37,7 @@ type User struct {
 	Username     string         `gorm:"uniqueIndex;size:64;not null" json:"username"`
 	Email        string         `gorm:"uniqueIndex;size:255;not null" json:"email"`
 	PasswordHash string         `gorm:"not null" json:"-"`
-	Role         string         `gorm:"size:16;default:user" json:"role"` // "owner", "admin", or "user"
+	Role         UserRole       `gorm:"size:16;default:user" json:"role"`
 	AvatarURL    string         `gorm:"size:512" json:"avatarUrl,omitempty"`
 	TokenVersion        int            `gorm:"default:0" json:"-"`
 	Disabled            bool           `gorm:"default:false" json:"disabled"`


### PR DESCRIPTION
## Summary
Phase 0c of the API type-safety refactor (see #437).

Promote bare \`string\` user roles to a typed \`db.UserRole\` so producers, consumers, and the future OpenAPI spec all express the bounded enum precisely.

- Define \`type UserRole string\` with typed \`RoleOwner\`/\`RoleAdmin\`/\`RoleUser\` constants
- Add \`AllUserRoles\` slice for enumeration
- Change \`User.Role\` field type and \`IsAdminOrOwner\` parameter type
- Update \`UserResponse.Role\` and \`DeletedUserResponse.Role\`
- Middleware sets typed value in gin context; handlers read it as \`db.UserRole\`
- \`AdminMiddleware\` uses \`IsAdminOrOwner\` instead of inline string compare
- Cast \`string(user.Role)\` at \`auth.GenerateAccessToken\` (auth package stays role-agnostic)
- Update 3 test helpers to take \`db.UserRole\`

## Out of scope
\`SharedSessionMember.Role\` (owner/member) is a different enum — will be typed in Phase 1 (#438) when sweeping shared session types.

## Wire format
Unchanged. Still emits \`\"owner\"\` / \`\"admin\"\` / \`\"user\"\` strings.

Refs #437.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [ ] CI passes