### PR TITLE
refactor(api): extract 38 anonymous request structs into named types

### DIFF
--- a/server/internal/api/achievement_showcase_handler.go
+++ b/server/internal/api/achievement_showcase_handler.go
@@ -70,10 +70,7 @@ func (h *AchievementShowcaseHandler) GetPublicShowcase(c *gin.Context) {
 func (h *AchievementShowcaseHandler) UpdateShowcase(c *gin.Context) {
 	uid := getUserID(c)
 
-	var req []struct {
-		AchievementRAID uint `json:"achievementRaId" binding:"required"`
-		RAGameID        uint `json:"raGameId" binding:"required"`
-	}
+	var req []ShowcaseEntryInput
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})
 		return

--- a/server/internal/api/admin_handler_covers.go
+++ b/server/internal/api/admin_handler_covers.go
@@ -101,10 +101,7 @@ func (h *AdminHandler) SetGameCover(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Source      string `json:"source" binding:"required"`
-		LibRetroName string `json:"libretroName,omitempty"`
-	}
+	var req SetGameCoverRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})

--- a/server/internal/api/admin_handler_heroes.go
+++ b/server/internal/api/admin_handler_heroes.go
@@ -78,9 +78,7 @@ func (h *AdminHandler) SetGameHero(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		URL string `json:"url" binding:"required"`
-	}
+	var req SetGameHeroRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})
 		return

--- a/server/internal/api/admin_handler_igdb.go
+++ b/server/internal/api/admin_handler_igdb.go
@@ -90,9 +90,7 @@ func (h *AdminHandler) ApplyIGDBMatch(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		IGDBID int `json:"igdbId" binding:"required,min=1"`
-	}
+	var req ApplyIGDBMatchRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "igdbId is required and must be a positive integer"})

--- a/server/internal/api/admin_handler_users.go
+++ b/server/internal/api/admin_handler_users.go
@@ -27,12 +27,7 @@ func (h *AdminHandler) ListUsers(c *gin.Context) {
 
 // CreateUser creates a new user account (admin only).
 func (h *AdminHandler) CreateUser(c *gin.Context) {
-	var req struct {
-		Username string       `json:"username" binding:"required,min=3,max=64"`
-		Email    string       `json:"email" binding:"required,email"`
-		Password string       `json:"password" binding:"required,min=8,max=72"`
-		Role     db.UserRole  `json:"role"`
-	}
+	var req AdminCreateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})
@@ -91,13 +86,7 @@ func (h *AdminHandler) UpdateUser(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Role            db.UserRole `json:"role"`
-		Email           string      `json:"email"`
-		Password        string      `json:"password"`
-		Disabled        *bool       `json:"disabled"`
-		PendingApproval *bool       `json:"pendingApproval"`
-	}
+	var req AdminUpdateUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})

--- a/server/internal/api/admin_igdb_handler.go
+++ b/server/internal/api/admin_igdb_handler.go
@@ -16,10 +16,7 @@ type IGDBHandler struct {
 
 // TestIGDB validates IGDB credentials by attempting a Twitch OAuth token exchange.
 func (h *IGDBHandler) TestIGDB(c *gin.Context) {
-	var req struct {
-		ClientID     string `json:"clientId"`
-		ClientSecret string `json:"clientSecret"`
-	}
+	var req TestIGDBRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "clientId and clientSecret are required"})
 		return

--- a/server/internal/api/challenge_handler.go
+++ b/server/internal/api/challenge_handler.go
@@ -346,11 +346,7 @@ func (h *ChallengeHandler) UpdateChallenge(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Name        *string `json:"name"`
-		Description *string `json:"description"`
-		Status      *string `json:"status"`
-	}
+	var req UpdateChallengeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})
 		return

--- a/server/internal/api/collection_handler.go
+++ b/server/internal/api/collection_handler.go
@@ -20,11 +20,7 @@ type CollectionHandler struct {
 func (h *CollectionHandler) CreateCollection(c *gin.Context) {
 	uid := getUserID(c)
 
-	var req struct {
-		Name        string `json:"name" binding:"required,max=255"`
-		Description string `json:"description" binding:"max=2048"`
-		IsPublic    bool   `json:"isPublic"`
-	}
+	var req CreateCollectionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request: name is required"})
 		return
@@ -220,11 +216,7 @@ func (h *CollectionHandler) UpdateCollection(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Name        *string `json:"name"`
-		Description *string `json:"description"`
-		IsPublic    *bool   `json:"isPublic"`
-	}
+	var req UpdateCollectionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request"})
 		return
@@ -308,9 +300,7 @@ func (h *CollectionHandler) AddGame(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		GameID uint `json:"gameId" binding:"required"`
-	}
+	var req AddGameToCollectionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request: gameId is required"})
 		return

--- a/server/internal/api/device_handler.go
+++ b/server/internal/api/device_handler.go
@@ -27,11 +27,7 @@ type deviceResponse struct {
 func (h *DeviceHandler) RegisterDevice(c *gin.Context) {
 	uid := getUserID(c)
 
-	var req struct {
-		DeviceUUID string `json:"deviceUuid" binding:"required"`
-		Name       string `json:"name" binding:"required"`
-		Platform   string `json:"platform" binding:"required"`
-	}
+	var req RegisterDeviceRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})
@@ -113,9 +109,7 @@ func (h *DeviceHandler) UpdateDevice(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Name string `json:"name" binding:"required"`
-	}
+	var req UpdateDeviceRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})
@@ -189,9 +183,7 @@ func (h *DeviceHandler) UpdateDevicePreferences(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		ConsoleShaders map[string]string `json:"consoleShaders"`
-	}
+	var req UpdateDevicePreferencesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -494,20 +494,7 @@ func (h *GameHandler) UpdateMetadata(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Title         string  `json:"title"`
-		Description   string  `json:"description"`
-		CoverURL      string  `json:"coverUrl"`
-		ScreenshotURL string  `json:"screenshotUrl"`
-		Developer     string  `json:"developer"`
-		Publisher     string  `json:"publisher"`
-		ReleaseDate   string  `json:"releaseDate"`
-		Genre         string  `json:"genre"`
-		Players       int     `json:"players"`
-		IGDBCriticsRating float64 `json:"igdbCriticsRating"`
-		CoreOverride  string  `json:"coreOverride"`
-		PartyInfo     string  `json:"partyInfo"`
-	}
+	var req UpdateGameMetadataRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})
@@ -774,9 +761,7 @@ func (h *GameHandler) UpdatePlayTime(c *gin.Context) {
 	// maxPlayTimeSeconds caps total play time at ~100 years to prevent overflow.
 	const maxPlayTimeSeconds int64 = 100 * 365 * 24 * 3600
 
-	var req struct {
-		Seconds int64 `json:"seconds" binding:"min=0,max=86400"`
-	}
+	var req UpdateGamePlayTimeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request: seconds must be between 0 and 86400"})
 		return
@@ -995,9 +980,7 @@ func (h *GameHandler) UpdateVerificationTag(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Tag string `json:"tag"`
-	}
+	var req UpdateVerificationTagRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request"})
 		return

--- a/server/internal/api/game_keymapping_handler.go
+++ b/server/internal/api/game_keymapping_handler.go
@@ -48,9 +48,7 @@ func (h *GameKeyMappingHandler) UpdateGameKeyMapping(c *gin.Context) {
 	uid := getUserID(c)
 	gameID := c.Param("gameId")
 
-	var req struct {
-		CustomMapping map[string]string `json:"customMapping"`
-	}
+	var req UpdateGameKeyMappingRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})

--- a/server/internal/api/netplay_handler.go
+++ b/server/internal/api/netplay_handler.go
@@ -31,11 +31,7 @@ type NetplayHandler struct {
 func (h *NetplayHandler) CreateSession(c *gin.Context) {
 	uid := getUserID(c)
 
-	var req struct {
-		GameID     string `json:"gameId" binding:"required"`
-		InputDelay *int   `json:"inputDelay"`
-		CoreName   string `json:"coreName"`
-	}
+	var req CreateNetplaySessionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request: gameId is required"})
 		return
@@ -168,9 +164,7 @@ func (h *NetplayHandler) GetSession(c *gin.Context) {
 func (h *NetplayHandler) JoinByInviteCode(c *gin.Context) {
 	uid := getUserID(c)
 
-	var req struct {
-		InviteCode string `json:"inviteCode" binding:"required"`
-	}
+	var req JoinByInviteCodeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invite code is required"})
 		return
@@ -359,9 +353,7 @@ func (h *NetplayHandler) UpdateSettings(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		InputDelay *int `json:"inputDelay"`
-	}
+	var req UpdateNetplaySettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request"})
 		return

--- a/server/internal/api/netplay_invite_handler.go
+++ b/server/internal/api/netplay_invite_handler.go
@@ -32,9 +32,7 @@ func (h *NetplayHandler) SendInvite(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Username string `json:"username" binding:"required"`
-	}
+	var req NetplayInviteUserRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request: username is required"})
 		return

--- a/server/internal/api/play_later_handler.go
+++ b/server/internal/api/play_later_handler.go
@@ -120,9 +120,7 @@ func (h *PlayLaterHandler) RemoveFromPlayLater(c *gin.Context) {
 func (h *PlayLaterHandler) ReorderPlayLater(c *gin.Context) {
 	uid := getUserID(c)
 
-	var req struct {
-		GameIDs []string `json:"gameIds"`
-	}
+	var req ReorderPlayLaterRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request"})
 		return

--- a/server/internal/api/ra_handler.go
+++ b/server/internal/api/ra_handler.go
@@ -39,10 +39,7 @@ func (h *RAHandler) decryptRAToken(cred *db.RetroAchievementCredential) (string,
 func (h *RAHandler) LinkAccount(c *gin.Context) {
 	uid := getUserID(c)
 
-	var req struct {
-		Username string `json:"username" binding:"required"`
-		Password string `json:"password" binding:"required"`
-	}
+	var req LinkRAAccountRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "username and password are required"})
 		return
@@ -126,9 +123,7 @@ func (h *RAHandler) GetStatus(c *gin.Context) {
 func (h *RAHandler) UpdateSettings(c *gin.Context) {
 	uid := getUserID(c)
 
-	var req struct {
-		HardcoreEnabled *bool `json:"hardcoreEnabled"`
-	}
+	var req UpdateRASettingsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})

--- a/server/internal/api/rating_handler.go
+++ b/server/internal/api/rating_handler.go
@@ -35,10 +35,7 @@ func (h *RatingHandler) CreateOrUpdateRating(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Rating int    `json:"rating" binding:"required,min=1,max=5"`
-		Review string `json:"review"`
-	}
+	var req CreateOrUpdateRatingRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request: rating must be between 1 and 5"})
 		return

--- a/server/internal/api/requests.go
+++ b/server/internal/api/requests.go
@@ -1,0 +1,291 @@
+package api
+
+// This file holds all named request body types accepted by the api handlers.
+// Naming each request shape (instead of declaring inline `var req struct { ... }`
+// in the handler body) lets the future OpenAPI spec reference these types
+// by name and gives callers a single place to find request schemas.
+
+import (
+	"github.com/spela/server/internal/db"
+)
+
+// --- User ---
+
+// UpdateProfileRequest is the body for PUT /api/user/profile.
+type UpdateProfileRequest struct {
+	Email           string `json:"email"`
+	AvatarURL       string `json:"avatarUrl"`
+	CurrentPassword string `json:"currentPassword"`
+}
+
+// UpdatePreferencesRequest is the body for PUT /api/user/preferences.
+type UpdatePreferencesRequest struct {
+	ShowPerformanceOverlay  *bool                           `json:"showPerformanceOverlay"`
+	AutoSaveEnabled         *bool                           `json:"autoSaveEnabled"`
+	AutoLoadSaveEnabled     *bool                           `json:"autoLoadSaveEnabled"`
+	SelectedShader          *string                         `json:"selectedShader"`
+	SelectedTheme           *string                         `json:"selectedTheme"`
+	DefaultSecondScreenPage *string                         `json:"defaultSecondScreenPage"`
+	ConsoleShaders          map[string]string               `json:"consoleShaders"`
+	SelectedKeyMapping      *string                         `json:"selectedKeyMapping"`
+	CustomKeyMapping        map[string]string               `json:"customKeyMapping"`
+	ConsoleKeyMappings      map[string]consoleKeyMappingDTO `json:"consoleKeyMappings"`
+	PreferredRegions        *[]string                       `json:"preferredRegions"`
+}
+
+// UpdateGameKeyMappingRequest is the body for PUT /api/user/games/:gameId/keymapping.
+type UpdateGameKeyMappingRequest struct {
+	CustomMapping map[string]string `json:"customMapping"`
+}
+
+// --- Admin user management ---
+
+// AdminCreateUserRequest is the body for POST /api/admin/users.
+type AdminCreateUserRequest struct {
+	Username string      `json:"username" binding:"required,min=3,max=64"`
+	Email    string      `json:"email" binding:"required,email"`
+	Password string      `json:"password" binding:"required,min=8,max=72"`
+	Role     db.UserRole `json:"role"`
+}
+
+// AdminUpdateUserRequest is the body for PUT /api/admin/users/:id.
+type AdminUpdateUserRequest struct {
+	Role            db.UserRole `json:"role"`
+	Email           string      `json:"email"`
+	Password        string      `json:"password"`
+	Disabled        *bool       `json:"disabled"`
+	PendingApproval *bool       `json:"pendingApproval"`
+}
+
+// --- Games (admin metadata + play time) ---
+
+// UpdateGameMetadataRequest is the body for PUT /api/admin/games/:id/metadata.
+type UpdateGameMetadataRequest struct {
+	Title             string  `json:"title"`
+	Description       string  `json:"description"`
+	CoverURL          string  `json:"coverUrl"`
+	ScreenshotURL     string  `json:"screenshotUrl"`
+	Developer         string  `json:"developer"`
+	Publisher         string  `json:"publisher"`
+	ReleaseDate       string  `json:"releaseDate"`
+	Genre             string  `json:"genre"`
+	Players           int     `json:"players"`
+	IGDBCriticsRating float64 `json:"igdbCriticsRating"`
+	CoreOverride      string  `json:"coreOverride"`
+	PartyInfo         string  `json:"partyInfo"`
+}
+
+// UpdateGamePlayTimeRequest is the body for POST /api/games/:id/play-time.
+type UpdateGamePlayTimeRequest struct {
+	Seconds int64 `json:"seconds" binding:"min=0,max=86400"`
+}
+
+// UpdateVerificationTagRequest is the body for PUT /api/admin/games/:id/verification-tag.
+type UpdateVerificationTagRequest struct {
+	Tag string `json:"tag"`
+}
+
+// SetGameCoverRequest is the body for POST /api/admin/games/:id/cover.
+type SetGameCoverRequest struct {
+	Source       string `json:"source" binding:"required"`
+	LibRetroName string `json:"libretroName,omitempty"`
+}
+
+// SetGameHeroRequest is the body for POST /api/admin/games/:id/hero.
+type SetGameHeroRequest struct {
+	URL string `json:"url" binding:"required"`
+}
+
+// ApplyIGDBMatchRequest is the body for POST /api/admin/games/:id/igdb-match.
+type ApplyIGDBMatchRequest struct {
+	IGDBID int `json:"igdbId" binding:"required,min=1"`
+}
+
+// --- Sessions ---
+
+// CreateSessionRequest is the body for POST /api/games/:id/sessions.
+type CreateSessionRequest struct {
+	Name string `json:"name" binding:"required,max=255"`
+}
+
+// UpdateSessionRequest is the body for PUT /api/sessions/:id.
+type UpdateSessionRequest struct {
+	Name          *string `json:"name"`
+	CheatsEnabled *bool   `json:"cheatsEnabled"`
+	CoreName      *string `json:"coreName"`
+}
+
+// DuplicateSessionRequest is the body for POST /api/sessions/:id/duplicate.
+type DuplicateSessionRequest struct {
+	Name string `json:"name"`
+}
+
+// UpdateSessionSaveRequest is the body for PUT /api/sessions/:id/saves/:saveId.
+type UpdateSessionSaveRequest struct {
+	Name  *string `json:"name"`
+	Notes *string `json:"notes"`
+}
+
+// UpdateSessionPlayTimeRequest is the body for POST /api/sessions/:id/play-time.
+type UpdateSessionPlayTimeRequest struct {
+	Seconds int64 `json:"seconds" binding:"required"`
+}
+
+// UpdateSessionCheatsRequest is the body for PUT /api/sessions/:id/cheats.
+type UpdateSessionCheatsRequest struct {
+	CheatsEnabled  bool  `json:"cheatsEnabled"`
+	EnabledIndices []int `json:"enabledIndices"`
+}
+
+// --- Shared sessions ---
+
+// CreateSharedSessionRequest is the body for POST /api/shared-sessions.
+type CreateSharedSessionRequest struct {
+	GameID string `json:"gameId" binding:"required"`
+	Name   string `json:"name" binding:"required,max=255"`
+}
+
+// UpdateSharedSessionRequest is the body for PUT /api/shared-sessions/:id.
+type UpdateSharedSessionRequest struct {
+	Name   *string `json:"name"`
+	Status *string `json:"status"`
+}
+
+// InviteToSharedSessionRequest is the body for POST /api/shared-sessions/:id/invites.
+type InviteToSharedSessionRequest struct {
+	Username string `json:"username" binding:"required"`
+}
+
+// --- Netplay ---
+
+// CreateNetplaySessionRequest is the body for POST /api/netplay/sessions.
+type CreateNetplaySessionRequest struct {
+	GameID     string `json:"gameId" binding:"required"`
+	InputDelay *int   `json:"inputDelay"`
+	CoreName   string `json:"coreName"`
+}
+
+// JoinByInviteCodeRequest is the body for POST /api/netplay/sessions/join.
+type JoinByInviteCodeRequest struct {
+	InviteCode string `json:"inviteCode" binding:"required"`
+}
+
+// UpdateNetplaySettingsRequest is the body for PUT /api/netplay/sessions/:id/settings.
+type UpdateNetplaySettingsRequest struct {
+	InputDelay *int `json:"inputDelay"`
+}
+
+// NetplayInviteUserRequest is the body for POST /api/netplay/sessions/:id/invites.
+type NetplayInviteUserRequest struct {
+	Username string `json:"username" binding:"required"`
+}
+
+// --- Collections ---
+
+// CreateCollectionRequest is the body for POST /api/collections.
+type CreateCollectionRequest struct {
+	Name        string `json:"name" binding:"required,max=255"`
+	Description string `json:"description" binding:"max=2048"`
+	IsPublic    bool   `json:"isPublic"`
+}
+
+// UpdateCollectionRequest is the body for PUT /api/collections/:id.
+type UpdateCollectionRequest struct {
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
+	IsPublic    *bool   `json:"isPublic"`
+}
+
+// AddGameToCollectionRequest is the body for POST /api/collections/:id/games.
+type AddGameToCollectionRequest struct {
+	GameID uint `json:"gameId" binding:"required"`
+}
+
+// --- Ratings ---
+
+// CreateOrUpdateRatingRequest is the body for PUT /api/games/:id/rating.
+type CreateOrUpdateRatingRequest struct {
+	Rating int    `json:"rating" binding:"required,min=1,max=5"`
+	Review string `json:"review"`
+}
+
+// --- Challenges ---
+
+// UpdateChallengeRequest is the body for PUT /api/challenges/:id.
+type UpdateChallengeRequest struct {
+	Name        *string `json:"name"`
+	Description *string `json:"description"`
+	Status      *string `json:"status"`
+}
+
+// --- Devices ---
+
+// RegisterDeviceRequest is the body for POST /api/user/devices.
+type RegisterDeviceRequest struct {
+	DeviceUUID string `json:"deviceUuid" binding:"required"`
+	Name       string `json:"name" binding:"required"`
+	Platform   string `json:"platform" binding:"required"`
+}
+
+// UpdateDeviceRequest is the body for PUT /api/user/devices/:id.
+type UpdateDeviceRequest struct {
+	Name string `json:"name" binding:"required"`
+}
+
+// UpdateDevicePreferencesRequest is the body for PUT /api/user/devices/:id/preferences.
+type UpdateDevicePreferencesRequest struct {
+	ConsoleShaders map[string]string `json:"consoleShaders"`
+}
+
+// --- System events ---
+
+// ReportEmulatorErrorRequest is the body for POST /api/system-events/emulator-error.
+type ReportEmulatorErrorRequest struct {
+	Error  string `json:"error" binding:"required"`
+	GameID string `json:"gameId"`
+	Core   string `json:"core"`
+}
+
+// --- Play later ---
+
+// ReorderPlayLaterRequest is the body for PUT /api/user/play-later/reorder.
+type ReorderPlayLaterRequest struct {
+	GameIDs []string `json:"gameIds"`
+}
+
+// --- Upload (admin) ---
+
+// SetUploadConsoleRequest is the body for POST /api/admin/uploads/:id/console.
+type SetUploadConsoleRequest struct {
+	ConsoleID string `json:"consoleId" binding:"required"`
+}
+
+// --- RetroAchievements ---
+
+// LinkRAAccountRequest is the body for POST /api/user/ra/link.
+type LinkRAAccountRequest struct {
+	Username string `json:"username" binding:"required"`
+	Password string `json:"password" binding:"required"`
+}
+
+// UpdateRASettingsRequest is the body for PUT /api/user/ra/settings.
+type UpdateRASettingsRequest struct {
+	HardcoreEnabled *bool `json:"hardcoreEnabled"`
+}
+
+// --- IGDB (admin) ---
+
+// TestIGDBRequest is the body for POST /api/admin/igdb/test.
+type TestIGDBRequest struct {
+	ClientID     string `json:"clientId"`
+	ClientSecret string `json:"clientSecret"`
+}
+
+// --- Achievements ---
+
+// ShowcaseEntryInput is one entry in the body for PUT /api/user/achievements/showcase.
+// The full request body is a JSON array of these.
+type ShowcaseEntryInput struct {
+	AchievementRAID uint `json:"achievementRaId" binding:"required"`
+	RAGameID        uint `json:"raGameId" binding:"required"`
+}

--- a/server/internal/api/session_handler.go
+++ b/server/internal/api/session_handler.go
@@ -39,9 +39,7 @@ func (h *SessionHandler) CreateSession(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Name string `json:"name" binding:"required,max=255"`
-	}
+	var req CreateSessionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "name is required and must be 255 characters or fewer"})
 		return
@@ -272,11 +270,7 @@ func (h *SessionHandler) UpdateSession(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Name          *string `json:"name"`
-		CheatsEnabled *bool   `json:"cheatsEnabled"`
-		CoreName      *string `json:"coreName"`
-	}
+	var req UpdateSessionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request"})
 		return
@@ -374,9 +368,7 @@ func (h *SessionHandler) DuplicateSession(c *gin.Context) {
 		}
 	}
 
-	var req struct {
-		Name string `json:"name"`
-	}
+	var req DuplicateSessionRequest
 	_ = c.ShouldBindJSON(&req)
 	if strings.TrimSpace(req.Name) == "" {
 		req.Name = session.Name + " (Copy)"
@@ -641,10 +633,7 @@ func (h *SessionHandler) UpdateSessionSave(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Name  *string `json:"name"`
-		Notes *string `json:"notes"`
-	}
+	var req UpdateSessionSaveRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request"})
 		return
@@ -1017,9 +1006,7 @@ func (h *SessionHandler) UpdatePlayTime(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Seconds int64 `json:"seconds" binding:"required"`
-	}
+	var req UpdateSessionPlayTimeRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "seconds is required"})
 		return
@@ -1090,10 +1077,7 @@ func (h *SessionHandler) UpdateSessionCheats(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		CheatsEnabled  bool  `json:"cheatsEnabled"`
-		EnabledIndices []int `json:"enabledIndices"`
-	}
+	var req UpdateSessionCheatsRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request"})
 		return

--- a/server/internal/api/shared_session_handler.go
+++ b/server/internal/api/shared_session_handler.go
@@ -31,10 +31,7 @@ type SharedSessionHandler struct {
 func (h *SharedSessionHandler) CreateSharedSession(c *gin.Context) {
 	uid := getUserID(c)
 
-	var req struct {
-		GameID string `json:"gameId" binding:"required"`
-		Name   string `json:"name" binding:"required,max=255"`
-	}
+	var req CreateSharedSessionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request: gameId and name are required"})
 		return
@@ -197,10 +194,7 @@ func (h *SharedSessionHandler) UpdateSharedSession(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Name   *string `json:"name"`
-		Status *string `json:"status"`
-	}
+	var req UpdateSharedSessionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request"})
 		return
@@ -272,9 +266,7 @@ func (h *SharedSessionHandler) InviteUser(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Username string `json:"username" binding:"required"`
-	}
+	var req InviteToSharedSessionRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request: username is required"})
 		return

--- a/server/internal/api/system_event_handler.go
+++ b/server/internal/api/system_event_handler.go
@@ -306,11 +306,7 @@ func (h *SystemEventHandler) DismissSystemEvent(c *gin.Context) {
 // WASM compilation errors, missing ROMs) that otherwise only appear in
 // the user's browser console.
 func (h *SystemEventHandler) ReportEmulatorError(c *gin.Context) {
-	var req struct {
-		Error  string `json:"error" binding:"required"`
-		GameID string `json:"gameId"`
-		Core   string `json:"core"`
-	}
+	var req ReportEmulatorErrorRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})
 		return

--- a/server/internal/api/upload_handler.go
+++ b/server/internal/api/upload_handler.go
@@ -518,9 +518,7 @@ func (h *UploadHandler) SetConsole(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		ConsoleID string `json:"consoleId" binding:"required"`
-	}
+	var req SetUploadConsoleRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "consoleId required"})
 		return

--- a/server/internal/api/user_handler.go
+++ b/server/internal/api/user_handler.go
@@ -46,11 +46,7 @@ func (h *UserHandler) UpdateProfile(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		Email           string `json:"email"`
-		AvatarURL       string `json:"avatarUrl"`
-		CurrentPassword string `json:"currentPassword"`
-	}
+	var req UpdateProfileRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})
@@ -271,19 +267,7 @@ func (h *UserHandler) UpdatePreferences(c *gin.Context) {
 		return
 	}
 
-	var req struct {
-		ShowPerformanceOverlay  *bool                            `json:"showPerformanceOverlay"`
-		AutoSaveEnabled         *bool                            `json:"autoSaveEnabled"`
-		AutoLoadSaveEnabled     *bool                            `json:"autoLoadSaveEnabled"`
-		SelectedShader          *string                          `json:"selectedShader"`
-		SelectedTheme           *string                          `json:"selectedTheme"`
-		DefaultSecondScreenPage *string                          `json:"defaultSecondScreenPage"`
-		ConsoleShaders          map[string]string                `json:"consoleShaders"`
-		SelectedKeyMapping      *string                          `json:"selectedKeyMapping"`
-		CustomKeyMapping        map[string]string                `json:"customKeyMapping"`
-		ConsoleKeyMappings      map[string]consoleKeyMappingDTO  `json:"consoleKeyMappings"`
-		PreferredRegions        *[]string                        `json:"preferredRegions"`
-	}
+	var req UpdatePreferencesRequest
 	if err := c.ShouldBindJSON(&req); err != nil {
 		slog.Debug("request binding failed", "error", err)
 		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid request body"})


### PR DESCRIPTION
## Summary
Phase 1a of the API type-safety refactor (see #438).

Move every inline \`var req struct { ... }\` declaration in \`server/internal/api/\` into a named type in a new \`requests.go\` file. Anonymous types can't be referenced by name in OpenAPI annotations — naming them is the prerequisite for annotating endpoints in a later phase.

- **New file**: \`server/internal/api/requests.go\` with **39 named types** (38 \`*Request\` + 1 \`ShowcaseEntryInput\`) grouped by domain
- Updated **21 handler files** to use the named types

## Wire format
Unchanged. Same JSON shapes, same \`binding:\` tags, same validation. Pure rename / extraction.

## Naming convention
\`<Verb><Object>Request\` — e.g. \`CreateChallengeRequest\`, \`UpdateGameMetadataRequest\`, \`JoinByInviteCodeRequest\`. Admin-only operations get the \`Admin\` prefix to distinguish from public counterparts (\`AdminCreateUserRequest\` vs the not-yet-extracted public \`registerRequest\`).

## Observations worth follow-up issues (will file separately)
1. **Pre-existing unexported request types** in auth/user/saved_search handlers don't follow the new exported convention — should normalize when those touch OpenAPI annotation
2. **Inconsistent validation** — some handlers rely on \`binding:\` tags, others re-validate in handler body. Could be unified.
3. **\`UpdateGameMetadataRequest\`** uses non-empty string semantics, can't clear fields — others use \`*string\` pointer semantics. Consistency choice for future.

Refs #438.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [ ] CI passes