### PR TITLE
refactor(api): extract inline and unexported response types into responses.go

### DIFF
--- a/server/internal/api/achievement_showcase_handler.go
+++ b/server/internal/api/achievement_showcase_handler.go
@@ -19,19 +19,6 @@ type AchievementShowcaseHandler struct {
 	DB *gorm.DB
 }
 
-// showcaseResponse is the enriched response for a single showcased achievement.
-type showcaseResponse struct {
-	AchievementRAID uint    `json:"achievementRaId"`
-	RAGameID        uint    `json:"raGameId"`
-	ShowcaseOrder   int     `json:"showcaseOrder"`
-	Title           string  `json:"title,omitempty"`
-	Description     string  `json:"description,omitempty"`
-	Points          int     `json:"points,omitempty"`
-	BadgeURL        string  `json:"badgeUrl,omitempty"`
-	RarityPercent   float64 `json:"rarityPercent,omitempty"`
-	GameTitle       string  `json:"gameTitle,omitempty"`
-}
-
 // GetShowcase returns the current user's showcased achievements.
 func (h *AchievementShowcaseHandler) GetShowcase(c *gin.Context) {
 	uid := getUserID(c)
@@ -115,9 +102,9 @@ func (h *AchievementShowcaseHandler) UpdateShowcase(c *gin.Context) {
 }
 
 // enrichShowcaseEntries loads GameAchievementCache data and enriches showcase entries.
-func (h *AchievementShowcaseHandler) enrichShowcaseEntries(entries []db.UserAchievementShowcase) []showcaseResponse {
+func (h *AchievementShowcaseHandler) enrichShowcaseEntries(entries []db.UserAchievementShowcase) []ShowcaseEntryResponse {
 	if len(entries) == 0 {
-		return []showcaseResponse{}
+		return []ShowcaseEntryResponse{}
 	}
 
 	// Collect unique RA game IDs
@@ -157,9 +144,9 @@ func (h *AchievementShowcaseHandler) enrichShowcaseEntries(entries []db.UserAchi
 	}
 
 	// Build enriched responses
-	results := make([]showcaseResponse, 0, len(entries))
+	results := make([]ShowcaseEntryResponse, 0, len(entries))
 	for _, e := range entries {
-		resp := showcaseResponse{
+		resp := ShowcaseEntryResponse{
 			AchievementRAID: e.AchievementRAID,
 			RAGameID:        e.RAGameID,
 			ShowcaseOrder:   e.ShowcaseOrder,

--- a/server/internal/api/admin_handler_backfill.go
+++ b/server/internal/api/admin_handler_backfill.go
@@ -12,16 +12,6 @@ import (
 	"gorm.io/gorm"
 )
 
-// BackfillImagesResponse is the result of a backfill-images operation.
-type BackfillImagesResponse struct {
-	ArtworkDownloaded  int `json:"artworkDownloaded"`
-	TopRatedDownloaded int `json:"topRatedDownloaded"`
-	SimilarDownloaded  int `json:"similarDownloaded"`
-	GalleryDownloaded  int `json:"galleryDownloaded"`
-	CompanyDownloaded  int `json:"companyDownloaded"`
-	Errors             int `json:"errors"`
-}
-
 // BackfillImages downloads external image URLs (IGDB, SteamGridDB) and
 // replaces them with locally cached copies. This is an admin-only endpoint
 // intended for one-time migration after upgrading.

--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -319,18 +319,8 @@ func (h *AdminHandler) ScrapeStatusCounts(c *gin.Context) {
 		eligible[r.Source][r.Status] = r.Count
 	}
 
-	type sourceResult struct {
-		Source           string `json:"source"`
-		Matched          int64  `json:"matched"`
-		NotFound         int64  `json:"notFound"`
-		NotFoundEligible int64  `json:"notFoundEligible"`
-		Error            int64  `json:"error"`
-		ErrorEligible    int64  `json:"errorEligible"`
-		NotAttempted     int64  `json:"notAttempted"`
-	}
-
 	sources := []string{"igdb", "libretro", "steamgriddb"}
-	results := make([]sourceResult, 0, len(sources))
+	results := make([]ScraperSourceResultResponse, 0, len(sources))
 
 	for _, src := range sources {
 		sc := counts[src]
@@ -339,7 +329,7 @@ func (h *AdminHandler) ScrapeStatusCounts(c *gin.Context) {
 		var attempted int64
 		h.DB.Raw("SELECT COUNT(DISTINCT game_id) FROM game_scrape_results WHERE source = ?", src).Scan(&attempted)
 
-		results = append(results, sourceResult{
+		results = append(results, ScraperSourceResultResponse{
 			Source:           src,
 			Matched:          sc["matched"],
 			NotFound:         sc["not_found"],

--- a/server/internal/api/artwork_handler.go
+++ b/server/internal/api/artwork_handler.go
@@ -13,14 +13,6 @@ type ArtworkHandler struct {
 	DB *gorm.DB
 }
 
-// GameArtworkResponse is the API response for a game's artwork URLs.
-type GameArtworkResponse struct {
-	HeroURL string `json:"heroUrl,omitempty"`
-	GridURL string `json:"gridUrl,omitempty"`
-	LogoURL string `json:"logoUrl,omitempty"`
-	IconURL string `json:"iconUrl,omitempty"`
-}
-
 // GetGameArtwork returns the SteamGridDB artwork for a game.
 // If artwork exists in the DB, return it. If not, return empty (no scrape triggered).
 func (h *ArtworkHandler) GetGameArtwork(c *gin.Context) {

--- a/server/internal/api/auth_handler.go
+++ b/server/internal/api/auth_handler.go
@@ -133,11 +133,6 @@ type refreshRequest struct {
 	RefreshToken string `json:"refreshToken" binding:"required"`
 }
 
-type authResponse struct {
-	AccessToken  string       `json:"accessToken"`
-	RefreshToken string       `json:"refreshToken"`
-	User         UserResponse `json:"user"`
-}
 
 // Login authenticates a user and returns tokens.
 func (h *AuthHandler) Login(c *gin.Context) {
@@ -255,7 +250,7 @@ func (h *AuthHandler) Login(c *gin.Context) {
 	}
 	h.DB.Create(&rt)
 
-	c.JSON(http.StatusOK, authResponse{
+	c.JSON(http.StatusOK, AuthLoginResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		User:         ToUserResponse(user),
@@ -361,7 +356,7 @@ func (h *AuthHandler) Register(c *gin.Context) {
 	}
 	h.DB.Create(&rt)
 
-	c.JSON(http.StatusCreated, authResponse{
+	c.JSON(http.StatusCreated, AuthLoginResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		User:         ToUserResponse(user),
@@ -463,7 +458,7 @@ func (h *AuthHandler) Refresh(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, authResponse{
+	c.JSON(http.StatusOK, AuthLoginResponse{
 		AccessToken:  accessToken,
 		RefreshToken: newRefreshToken,
 		User:         ToUserResponse(user),
@@ -647,7 +642,7 @@ func (h *AuthHandler) Setup(c *gin.Context) {
 	}
 	h.DB.Create(&rt)
 
-	c.JSON(http.StatusCreated, authResponse{
+	c.JSON(http.StatusCreated, AuthLoginResponse{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
 		User:         ToUserResponse(user),

--- a/server/internal/api/bios_handler.go
+++ b/server/internal/api/bios_handler.go
@@ -31,49 +31,6 @@ type BiosHandler struct {
 	downloading bool
 }
 
-// BiosFileResponse represents an individual BIOS file in the response.
-type BiosFileResponse struct {
-	Name        string  `json:"name"`
-	Size        int64   `json:"size"`
-	MD5         string  `json:"md5"`
-	ExpectedMD5 string  `json:"expectedMd5,omitempty"`
-	SubDir      string  `json:"subDir,omitempty"`
-	ConsoleID   *string `json:"consoleId"`
-	ConsoleName *string `json:"consoleName,omitempty"`
-	Description *string `json:"description,omitempty"`
-	Required    bool    `json:"required"`
-	Status      string  `json:"status"` // "valid", "present", "invalid", "missing"
-}
-
-// ConsoleFileStatus represents a single BIOS file within a console summary.
-type ConsoleFileStatus struct {
-	FileName    string `json:"fileName"`
-	Description string `json:"description"`
-	Required    bool   `json:"required"`
-	MD5         string `json:"md5"`
-	Status      string `json:"status"`            // "valid", "present", "invalid", "missing"
-	SubDir      string `json:"subDir,omitempty"`   // subdirectory within system_dir
-}
-
-// ConsoleBiosStatus represents the BIOS status summary for one console.
-type ConsoleBiosStatus struct {
-	ConsoleID       string              `json:"consoleId"`
-	ConsoleName     string              `json:"consoleName"`
-	BiosRequired    bool                `json:"biosRequired"`
-	Status          string              `json:"status"` // "ready", "missing", "invalid", "not_required"
-	RequiredPresent int                 `json:"requiredPresent"`
-	RequiredTotal   int                 `json:"requiredTotal"`
-	OptionalPresent int                 `json:"optionalPresent"`
-	OptionalTotal   int                 `json:"optionalTotal"`
-	Files           []ConsoleFileStatus `json:"files"`
-}
-
-// BiosListResponse is the top-level response for GET /api/bios.
-type BiosListResponse struct {
-	Files    []BiosFileResponse  `json:"files"`
-	Consoles []ConsoleBiosStatus `json:"consoles"`
-}
-
 // consoleNameMap builds a map from lowercase abbreviation to console name.
 func consoleNameMap(database *gorm.DB) map[string]string {
 	names := make(map[string]string)

--- a/server/internal/api/device_handler.go
+++ b/server/internal/api/device_handler.go
@@ -16,12 +16,6 @@ type DeviceHandler struct {
 	DB *gorm.DB
 }
 
-// deviceResponse is the JSON shape returned for a device.
-type deviceResponse struct {
-	db.Device
-	ConsoleShaders map[string]string `json:"consoleShaders"`
-}
-
 // RegisterDevice handles POST /api/user/devices.
 // Upserts a device by (user_id, device_uuid) and returns it with shader preferences.
 func (h *DeviceHandler) RegisterDevice(c *gin.Context) {
@@ -67,7 +61,7 @@ func (h *DeviceHandler) RegisterDevice(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, deviceResponse{
+	c.JSON(http.StatusOK, DeviceResponse{
 		Device:         device,
 		ConsoleShaders: h.buildDeviceShaderMap(device.ID),
 	})
@@ -83,9 +77,9 @@ func (h *DeviceHandler) GetDevices(c *gin.Context) {
 		return
 	}
 
-	resp := make([]deviceResponse, 0, len(devices))
+	resp := make([]DeviceResponse, 0, len(devices))
 	for _, d := range devices {
-		resp = append(resp, deviceResponse{
+		resp = append(resp, DeviceResponse{
 			Device:         d,
 			ConsoleShaders: h.buildDeviceShaderMap(d.ID),
 		})
@@ -234,9 +228,9 @@ func (h *DeviceHandler) AdminGetUserDevices(c *gin.Context) {
 		return
 	}
 
-	resp := make([]deviceResponse, 0, len(devices))
+	resp := make([]DeviceResponse, 0, len(devices))
 	for _, d := range devices {
-		resp = append(resp, deviceResponse{
+		resp = append(resp, DeviceResponse{
 			Device:         d,
 			ConsoleShaders: h.buildDeviceShaderMap(d.ID),
 		})

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -548,23 +548,6 @@ func (h *GameHandler) UpdateMetadata(c *gin.Context) {
 	c.JSON(http.StatusOK, ToGameResponse(game, h.DB, userID))
 }
 
-// scanGameSummary is a lightweight game entry returned in scan results.
-type scanGameSummary struct {
-	ID          string `json:"id"`
-	Title       string `json:"title"`
-	ConsoleName string `json:"consoleName"`
-}
-
-// scanResultResponse extends the scan result with new game details and auto-scrape status.
-type scanResultResponse struct {
-	NewGames     int               `json:"newGames"`
-	UpdatedGames int               `json:"updatedGames"`
-	RemovedGames int               `json:"removedGames"`
-	TotalGames   int               `json:"totalGames"`
-	NewGamesList []scanGameSummary `json:"newGamesList,omitempty"`
-	AutoScraping bool              `json:"autoScraping"`
-}
-
 // ScanGames triggers a library scan in the background.
 // Returns 202 immediately; progress is reported via WebSocket events.
 // Pass ?console=<abbreviation> to scan only games for a specific console.
@@ -607,7 +590,7 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 		}
 
 		// Build response with new game summaries
-		resp := scanResultResponse{
+		resp := GameScanResultResponse{
 			NewGames:     result.NewGames,
 			UpdatedGames: result.UpdatedGames,
 			RemovedGames: result.RemovedGames,
@@ -618,7 +601,7 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 			var newGames []db.Game
 			h.DB.Preload("Console").Where("id IN ?", result.NewGameIDs).Find(&newGames)
 			for _, g := range newGames {
-				resp.NewGamesList = append(resp.NewGamesList, scanGameSummary{
+				resp.NewGamesList = append(resp.NewGamesList, GameScanSummary{
 					ID:          strconv.FormatUint(uint64(g.ID), 10),
 					Title:       g.Title,
 					ConsoleName: g.Console.Name,
@@ -1019,22 +1002,6 @@ func (h *GameHandler) GetRecommendedCore(c *gin.Context) {
 	c.JSON(http.StatusOK, core)
 }
 
-// gameStatsTopPlayer is a player entry in the game stats response.
-type gameStatsTopPlayer struct {
-	UserID   string `json:"userId"`
-	Username string `json:"username"`
-	AvatarURL string `json:"avatarUrl"`
-	PlayTime int64  `json:"playTime"`
-}
-
-// gameStatsResponse is the response for GET /api/games/:id/stats.
-type gameStatsResponse struct {
-	TotalPlayers   int64                `json:"totalPlayers"`
-	TotalPlayTime  int64                `json:"totalPlayTime"`
-	AveragePlayTime int64              `json:"averagePlayTime"`
-	TopPlayers     []gameStatsTopPlayer `json:"topPlayers"`
-}
-
 // GetGameStats returns aggregate community play statistics for a game.
 func (h *GameHandler) GetGameStats(c *gin.Context) {
 	id := c.Param("id")
@@ -1081,9 +1048,9 @@ func (h *GameHandler) GetGameStats(c *gin.Context) {
 		return
 	}
 
-	topPlayers := make([]gameStatsTopPlayer, 0, len(rows))
+	topPlayers := make([]GameStatsTopPlayer, 0, len(rows))
 	for _, r := range rows {
-		topPlayers = append(topPlayers, gameStatsTopPlayer{
+		topPlayers = append(topPlayers, GameStatsTopPlayer{
 			UserID:   strconv.FormatUint(uint64(r.UserID), 10),
 			Username: r.Username,
 			AvatarURL: r.AvatarURL,
@@ -1091,7 +1058,7 @@ func (h *GameHandler) GetGameStats(c *gin.Context) {
 		})
 	}
 
-	c.JSON(http.StatusOK, gameStatsResponse{
+	c.JSON(http.StatusOK, GameStatsResponse{
 		TotalPlayers:    stats.TotalPlayers,
 		TotalPlayTime:   stats.TotalPlayTime,
 		AveragePlayTime: averagePlayTime,
@@ -1112,15 +1079,9 @@ func (h *GameHandler) GetGameCheats(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to fetch cheats"})
 		return
 	}
-	type CheatResponse struct {
-		ID          uint   `json:"id"`
-		Index       int    `json:"index"`
-		Description string `json:"description"`
-		Code        string `json:"code"`
-	}
-	resp := make([]CheatResponse, len(cheats))
+	resp := make([]GameCheatResponse, len(cheats))
 	for i, ch := range cheats {
-		resp[i] = CheatResponse{
+		resp[i] = GameCheatResponse{
 			ID:          ch.ID,
 			Index:       ch.CheatIndex,
 			Description: ch.Description,

--- a/server/internal/api/game_keymapping_handler.go
+++ b/server/internal/api/game_keymapping_handler.go
@@ -15,12 +15,6 @@ type GameKeyMappingHandler struct {
 	DB *gorm.DB
 }
 
-// gameKeyMappingResponse is the JSON shape returned by the key mapping endpoints.
-type gameKeyMappingResponse struct {
-	GameID        uint              `json:"gameId"`
-	CustomMapping map[string]string `json:"customMapping"`
-}
-
 // GetGameKeyMapping returns the user's key mapping for a specific game.
 func (h *GameKeyMappingHandler) GetGameKeyMapping(c *gin.Context) {
 	uid := getUserID(c)
@@ -37,7 +31,7 @@ func (h *GameKeyMappingHandler) GetGameKeyMapping(c *gin.Context) {
 		return
 	}
 
-	c.JSON(http.StatusOK, gameKeyMappingResponse{
+	c.JSON(http.StatusOK, GameKeyMappingResponse{
 		GameID:        pref.GameID,
 		CustomMapping: parseJSONMap(pref.CustomMapping),
 	})
@@ -98,7 +92,7 @@ func (h *GameKeyMappingHandler) UpdateGameKeyMapping(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, gameKeyMappingResponse{
+	c.JSON(http.StatusOK, GameKeyMappingResponse{
 		GameID:        game.ID,
 		CustomMapping: req.CustomMapping,
 	})

--- a/server/internal/api/ra_handler.go
+++ b/server/internal/api/ra_handler.go
@@ -432,13 +432,6 @@ func (h *RAHandler) GetAchievementProgress(c *gin.Context) {
 	}
 
 	// Build enriched progress response with per-achievement playTimeAtUnlock from DB
-	type progressEntry struct {
-		AchievementID    uint   `json:"achievementId"`
-		UnlockedAt       string `json:"unlockedAt"`
-		IsHardcore       bool   `json:"isHardcore"`
-		PlayTimeAtUnlock int64  `json:"playTimeAtUnlock"`
-	}
-
 	// Read back stored values to get per-achievement PlayTimeAtUnlock
 	achIDs := make([]uint, 0, len(userProgress))
 	for _, p := range userProgress {
@@ -451,13 +444,13 @@ func (h *RAHandler) GetAchievementProgress(c *gin.Context) {
 		storedMap[sp.AchievementRAID] = sp
 	}
 
-	enrichedProgress := make([]progressEntry, 0, len(userProgress))
+	enrichedProgress := make([]RAProgressEntry, 0, len(userProgress))
 	for _, p := range userProgress {
 		var ptau int64
 		if sp, ok := storedMap[p.AchievementID]; ok {
 			ptau = sp.PlayTimeAtUnlock
 		}
-		enrichedProgress = append(enrichedProgress, progressEntry{
+		enrichedProgress = append(enrichedProgress, RAProgressEntry{
 			AchievementID:    p.AchievementID,
 			UnlockedAt:       p.UnlockedAt,
 			IsHardcore:       p.IsHardcore,
@@ -534,24 +527,9 @@ func (h *RAHandler) GetRecentAchievements(c *gin.Context) {
 	}
 
 	// Build response
-	type recentAchievement struct {
-		AchievementRAID  uint      `json:"achievementRaId"`
-		Title            string    `json:"title"`
-		Description      string    `json:"description"`
-		Points           int       `json:"points"`
-		BadgeURL         string    `json:"badgeUrl"`
-		UnlockedAt       time.Time `json:"unlockedAt"`
-		IsHardcore       bool      `json:"isHardcore"`
-		PlayTimeAtUnlock int64     `json:"playTimeAtUnlock"`
-		GameID           string    `json:"gameId"`
-		GameTitle        string    `json:"gameTitle"`
-		ConsoleName      string    `json:"consoleName"`
-		CoverURL         string    `json:"coverUrl"`
-	}
-
-	results := make([]recentAchievement, 0, len(progressRows))
+	results := make([]RARecentAchievementResponse, 0, len(progressRows))
 	for _, p := range progressRows {
-		entry := recentAchievement{
+		entry := RARecentAchievementResponse{
 			AchievementRAID:  p.AchievementRAID,
 			UnlockedAt:       p.UnlockedAt,
 			IsHardcore:       p.IsHardcore,
@@ -644,21 +622,9 @@ func (h *RAHandler) GetUnlockedAchievements(c *gin.Context) {
 		gameMap[g.ID] = g
 	}
 
-	type unlockedAchievement struct {
-		AchievementRAID uint    `json:"achievementRaId"`
-		RAGameID        uint    `json:"raGameId"`
-		Title           string  `json:"title"`
-		Description     string  `json:"description"`
-		Points          int     `json:"points"`
-		BadgeURL        string  `json:"badgeUrl"`
-		RarityPercent   float64 `json:"rarityPercent"`
-		GameTitle       string  `json:"gameTitle"`
-		ConsoleName     string  `json:"consoleName"`
-	}
-
-	results := make([]unlockedAchievement, 0, len(progressRows))
+	results := make([]RAUnlockedAchievementResponse, 0, len(progressRows))
 	for _, p := range progressRows {
-		entry := unlockedAchievement{
+		entry := RAUnlockedAchievementResponse{
 			AchievementRAID: p.AchievementRAID,
 			RAGameID:        p.RAGameID,
 		}
@@ -743,21 +709,10 @@ func (h *RAHandler) GetAchievementTimeline(c *gin.Context) {
 	}
 
 	// Build timeline
-	type timelineEntry struct {
-		AchievementRAID  uint      `json:"achievementRaId"`
-		Title            string    `json:"title"`
-		Description      string    `json:"description"`
-		Points           int       `json:"points"`
-		BadgeURL         string    `json:"badgeUrl"`
-		UnlockedAt       time.Time `json:"unlockedAt"`
-		IsHardcore       bool      `json:"isHardcore"`
-		PlayTimeAtUnlock int64     `json:"playTimeAtUnlock"`
-	}
-
-	timeline := make([]timelineEntry, 0, len(progressRows))
+	timeline := make([]RATimelineEntryResponse, 0, len(progressRows))
 	earnedPoints := 0
 	for _, p := range progressRows {
-		entry := timelineEntry{
+		entry := RATimelineEntryResponse{
 			AchievementRAID:  p.AchievementRAID,
 			UnlockedAt:       p.UnlockedAt,
 			IsHardcore:       p.IsHardcore,
@@ -886,21 +841,10 @@ func (h *RAHandler) GetAchievementLeaderboard(c *gin.Context) {
 	}
 
 	// Build response sorted by unlocked count descending
-	type leaderboardEntry struct {
-		UserID          string    `json:"userId"`
-		Username        string    `json:"username"`
-		AvatarURL       string    `json:"avatarUrl"`
-		UnlockedCount   int       `json:"unlockedCount"`
-		EarnedPoints    int       `json:"earnedPoints"`
-		LastUnlockedAt  time.Time `json:"lastUnlockedAt"`
-		FirstUnlockedAt time.Time `json:"firstUnlockedAt"`
-		IsComplete      bool      `json:"isComplete"`
-	}
-
-	entries := make([]leaderboardEntry, 0, len(userStatsMap))
+	entries := make([]RALeaderboardEntryResponse, 0, len(userStatsMap))
 	for uid, stats := range userStatsMap {
 		user := userMap[uid]
-		entries = append(entries, leaderboardEntry{
+		entries = append(entries, RALeaderboardEntryResponse{
 			UserID:          strconv.FormatUint(uint64(uid), 10),
 			Username:        user.Username,
 			AvatarURL:       user.AvatarURL,

--- a/server/internal/api/requests.go
+++ b/server/internal/api/requests.go
@@ -29,7 +29,7 @@ type UpdatePreferencesRequest struct {
 	ConsoleShaders          map[string]string               `json:"consoleShaders"`
 	SelectedKeyMapping      *string                         `json:"selectedKeyMapping"`
 	CustomKeyMapping        map[string]string               `json:"customKeyMapping"`
-	ConsoleKeyMappings      map[string]consoleKeyMappingDTO `json:"consoleKeyMappings"`
+	ConsoleKeyMappings      map[string]ConsoleKeyMappingDTO `json:"consoleKeyMappings"`
 	PreferredRegions        *[]string                       `json:"preferredRegions"`
 }
 

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -1011,3 +1011,326 @@ func parseAspectRatio(aspect string) float64 {
 	}
 	return w / h
 }
+
+// --- Auth ---
+
+// AuthLoginResponse is the response payload for login/register/refresh endpoints.
+type AuthLoginResponse struct {
+	AccessToken  string       `json:"accessToken"`
+	RefreshToken string       `json:"refreshToken"`
+	User         UserResponse `json:"user"`
+}
+
+// --- User ---
+
+// UserPreferencesResponse is the JSON shape for the user preferences endpoints.
+type UserPreferencesResponse struct {
+	ShowPerformanceOverlay  bool                            `json:"showPerformanceOverlay"`
+	AutoSaveEnabled         bool                            `json:"autoSaveEnabled"`
+	AutoLoadSaveEnabled     bool                            `json:"autoLoadSaveEnabled"`
+	SelectedShader          string                          `json:"selectedShader"`
+	SelectedTheme           string                          `json:"selectedTheme"`
+	DefaultSecondScreenPage string                          `json:"defaultSecondScreenPage"`
+	ConsoleShaders          map[string]string               `json:"consoleShaders"`
+	SelectedKeyMapping      string                          `json:"selectedKeyMapping"`
+	CustomKeyMapping        map[string]string               `json:"customKeyMapping"`
+	ConsoleKeyMappings      map[string]ConsoleKeyMappingDTO `json:"consoleKeyMappings"`
+	PreferredRegions        []string                        `json:"preferredRegions"`
+	RALinked                bool                            `json:"raLinked"`
+	RAUsername              string                          `json:"raUsername"`
+	RAHardcoreEnabled       bool                            `json:"raHardcoreEnabled"`
+}
+
+// ConsoleKeyMappingDTO is a per-console key mapping entry in the preferences payload.
+type ConsoleKeyMappingDTO struct {
+	SelectedMapping string            `json:"selectedMapping"`
+	CustomMapping   map[string]string `json:"customMapping,omitempty"`
+}
+
+// UserStatsResponse is the response for GET /api/user/stats.
+type UserStatsResponse struct {
+	TotalPlayTime      int64         `json:"totalPlayTime"`
+	GamesPlayed        int64         `json:"gamesPlayed"`
+	CurrentStreak      int           `json:"currentStreak"`
+	LongestStreak      int           `json:"longestStreak"`
+	MostPlayedGame     *GameResponse `json:"mostPlayedGame"`
+	MostPlayedGameTime int64         `json:"mostPlayedGameTime"`
+	LastPlayedAt       *time.Time    `json:"lastPlayedAt"`
+}
+
+// PlayStatsEntry is a single entry in the play stats (per-game history) response.
+type PlayStatsEntry struct {
+	GameID       uint   `json:"gameId"`
+	PlayTime     int64  `json:"playTime"`
+	LastPlayedAt string `json:"lastPlayedAt"`
+}
+
+// --- Device ---
+
+// DeviceResponse is the API response for a registered device. It embeds the
+// db.Device model (for historical compatibility) and augments it with the
+// device's per-console shader preferences.
+type DeviceResponse struct {
+	db.Device
+	ConsoleShaders map[string]string `json:"consoleShaders"`
+}
+
+// --- Achievement Showcase ---
+
+// ShowcaseEntryResponse is the enriched response for a single showcased achievement.
+type ShowcaseEntryResponse struct {
+	AchievementRAID uint    `json:"achievementRaId"`
+	RAGameID        uint    `json:"raGameId"`
+	ShowcaseOrder   int     `json:"showcaseOrder"`
+	Title           string  `json:"title,omitempty"`
+	Description     string  `json:"description,omitempty"`
+	Points          int     `json:"points,omitempty"`
+	BadgeURL        string  `json:"badgeUrl,omitempty"`
+	RarityPercent   float64 `json:"rarityPercent,omitempty"`
+	GameTitle       string  `json:"gameTitle,omitempty"`
+}
+
+// --- RetroAchievements ---
+
+// RAProgressEntry is a single achievement progress entry returned by GetGameProgress.
+type RAProgressEntry struct {
+	AchievementID    uint   `json:"achievementId"`
+	UnlockedAt       string `json:"unlockedAt"`
+	IsHardcore       bool   `json:"isHardcore"`
+	PlayTimeAtUnlock int64  `json:"playTimeAtUnlock"`
+}
+
+// RARecentAchievementResponse is an enriched recent achievement unlock across games.
+type RARecentAchievementResponse struct {
+	AchievementRAID  uint      `json:"achievementRaId"`
+	Title            string    `json:"title"`
+	Description      string    `json:"description"`
+	Points           int       `json:"points"`
+	BadgeURL         string    `json:"badgeUrl"`
+	UnlockedAt       time.Time `json:"unlockedAt"`
+	IsHardcore       bool      `json:"isHardcore"`
+	PlayTimeAtUnlock int64     `json:"playTimeAtUnlock"`
+	GameID           string    `json:"gameId"`
+	GameTitle        string    `json:"gameTitle"`
+	ConsoleName      string    `json:"consoleName"`
+	CoverURL         string    `json:"coverUrl"`
+}
+
+// RAUnlockedAchievementResponse is a single unlocked achievement in the showcase picker.
+type RAUnlockedAchievementResponse struct {
+	AchievementRAID uint    `json:"achievementRaId"`
+	RAGameID        uint    `json:"raGameId"`
+	Title           string  `json:"title"`
+	Description     string  `json:"description"`
+	Points          int     `json:"points"`
+	BadgeURL        string  `json:"badgeUrl"`
+	RarityPercent   float64 `json:"rarityPercent"`
+	GameTitle       string  `json:"gameTitle"`
+	ConsoleName     string  `json:"consoleName"`
+}
+
+// RATimelineEntryResponse is a single entry in a per-game achievement timeline.
+type RATimelineEntryResponse struct {
+	AchievementRAID  uint      `json:"achievementRaId"`
+	Title            string    `json:"title"`
+	Description      string    `json:"description"`
+	Points           int       `json:"points"`
+	BadgeURL         string    `json:"badgeUrl"`
+	UnlockedAt       time.Time `json:"unlockedAt"`
+	IsHardcore       bool      `json:"isHardcore"`
+	PlayTimeAtUnlock int64     `json:"playTimeAtUnlock"`
+}
+
+// RALeaderboardEntryResponse is a single entry in an achievement leaderboard.
+type RALeaderboardEntryResponse struct {
+	UserID          string    `json:"userId"`
+	Username        string    `json:"username"`
+	AvatarURL       string    `json:"avatarUrl"`
+	UnlockedCount   int       `json:"unlockedCount"`
+	EarnedPoints    int       `json:"earnedPoints"`
+	LastUnlockedAt  time.Time `json:"lastUnlockedAt"`
+	FirstUnlockedAt time.Time `json:"firstUnlockedAt"`
+	IsComplete      bool      `json:"isComplete"`
+}
+
+// --- Game ---
+
+// GameCheatResponse is a single cheat entry in the game cheats response.
+type GameCheatResponse struct {
+	ID          uint   `json:"id"`
+	Index       int    `json:"index"`
+	Description string `json:"description"`
+	Code        string `json:"code"`
+}
+
+// GameScanSummary is a lightweight game entry returned in scan results.
+type GameScanSummary struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	ConsoleName string `json:"consoleName"`
+}
+
+// GameScanResultResponse is the scan result response with new-game summaries and auto-scrape status.
+type GameScanResultResponse struct {
+	NewGames     int               `json:"newGames"`
+	UpdatedGames int               `json:"updatedGames"`
+	RemovedGames int               `json:"removedGames"`
+	TotalGames   int               `json:"totalGames"`
+	NewGamesList []GameScanSummary `json:"newGamesList,omitempty"`
+	AutoScraping bool              `json:"autoScraping"`
+}
+
+// GameStatsTopPlayer is a player entry in the game stats response.
+type GameStatsTopPlayer struct {
+	UserID    string `json:"userId"`
+	Username  string `json:"username"`
+	AvatarURL string `json:"avatarUrl"`
+	PlayTime  int64  `json:"playTime"`
+}
+
+// GameStatsResponse is the response for GET /api/games/:id/stats.
+type GameStatsResponse struct {
+	TotalPlayers    int64                `json:"totalPlayers"`
+	TotalPlayTime   int64                `json:"totalPlayTime"`
+	AveragePlayTime int64                `json:"averagePlayTime"`
+	TopPlayers      []GameStatsTopPlayer `json:"topPlayers"`
+}
+
+// GameKeyMappingResponse is the JSON shape returned by the per-game key mapping endpoints.
+type GameKeyMappingResponse struct {
+	GameID        uint              `json:"gameId"`
+	CustomMapping map[string]string `json:"customMapping"`
+}
+
+// --- Session ---
+
+// SessionStorageConsoleBreakdown is per-console storage usage in the session storage response.
+type SessionStorageConsoleBreakdown struct {
+	ConsoleID   string `json:"consoleId"`
+	ConsoleName string `json:"consoleName"`
+	Bytes       int64  `json:"bytes"`
+	SaveCount   int64  `json:"saveCount"`
+}
+
+// --- System Events ---
+
+// SystemEventCategoryResponse is a single entry in the system event categories response.
+type SystemEventCategoryResponse struct {
+	Code string `json:"code"`
+	Name string `json:"name"`
+}
+
+// --- Stats ---
+
+// MostPlayedEntry is a single entry in the most-played games response.
+type MostPlayedEntry struct {
+	Game          GameResponse `json:"game"`
+	TotalPlayers  int64        `json:"totalPlayers"`
+	TotalPlayTime int64        `json:"totalPlayTime"`
+}
+
+// MostPlayedResponse is the response for GET /api/stats/most-played.
+type MostPlayedResponse struct {
+	Games []MostPlayedEntry `json:"games"`
+}
+
+// ActivePlayerEntry is a single entry in the most-active-players response.
+type ActivePlayerEntry struct {
+	UserID        string    `json:"userId"`
+	Username      string    `json:"username"`
+	AvatarURL     string    `json:"avatarUrl"`
+	TotalPlayTime int64     `json:"totalPlayTime"`
+	GamesPlayed   int64     `json:"gamesPlayed"`
+	LastPlayed    time.Time `json:"lastPlayed"`
+}
+
+// MostActivePlayersResponse is the response for GET /api/stats/most-active-players.
+type MostActivePlayersResponse struct {
+	Players []ActivePlayerEntry `json:"players"`
+}
+
+// HeatmapEntry is a single day's play activity for the heatmap response.
+type HeatmapEntry struct {
+	Date     string `json:"date"`
+	PlayTime int64  `json:"playTime"`
+}
+
+// --- Artwork ---
+
+// GameArtworkResponse is the API response for a game's artwork URLs.
+type GameArtworkResponse struct {
+	HeroURL string `json:"heroUrl,omitempty"`
+	GridURL string `json:"gridUrl,omitempty"`
+	LogoURL string `json:"logoUrl,omitempty"`
+	IconURL string `json:"iconUrl,omitempty"`
+}
+
+// --- BIOS ---
+
+// BiosFileResponse represents an individual BIOS file in the response.
+type BiosFileResponse struct {
+	Name        string  `json:"name"`
+	Size        int64   `json:"size"`
+	MD5         string  `json:"md5"`
+	ExpectedMD5 string  `json:"expectedMd5,omitempty"`
+	SubDir      string  `json:"subDir,omitempty"`
+	ConsoleID   *string `json:"consoleId"`
+	ConsoleName *string `json:"consoleName,omitempty"`
+	Description *string `json:"description,omitempty"`
+	Required    bool    `json:"required"`
+	Status      string  `json:"status"` // "valid", "present", "invalid", "missing"
+}
+
+// ConsoleFileStatus represents a single BIOS file within a console summary.
+type ConsoleFileStatus struct {
+	FileName    string `json:"fileName"`
+	Description string `json:"description"`
+	Required    bool   `json:"required"`
+	MD5         string `json:"md5"`
+	Status      string `json:"status"`           // "valid", "present", "invalid", "missing"
+	SubDir      string `json:"subDir,omitempty"` // subdirectory within system_dir
+}
+
+// ConsoleBiosStatus represents the BIOS status summary for one console.
+type ConsoleBiosStatus struct {
+	ConsoleID       string              `json:"consoleId"`
+	ConsoleName     string              `json:"consoleName"`
+	BiosRequired    bool                `json:"biosRequired"`
+	Status          string              `json:"status"` // "ready", "missing", "invalid", "not_required"
+	RequiredPresent int                 `json:"requiredPresent"`
+	RequiredTotal   int                 `json:"requiredTotal"`
+	OptionalPresent int                 `json:"optionalPresent"`
+	OptionalTotal   int                 `json:"optionalTotal"`
+	Files           []ConsoleFileStatus `json:"files"`
+}
+
+// BiosListResponse is the top-level response for GET /api/bios.
+type BiosListResponse struct {
+	Files    []BiosFileResponse  `json:"files"`
+	Consoles []ConsoleBiosStatus `json:"consoles"`
+}
+
+// --- Admin / Backfill ---
+
+// BackfillImagesResponse is the result of a backfill-images operation.
+type BackfillImagesResponse struct {
+	ArtworkDownloaded  int `json:"artworkDownloaded"`
+	TopRatedDownloaded int `json:"topRatedDownloaded"`
+	SimilarDownloaded  int `json:"similarDownloaded"`
+	GalleryDownloaded  int `json:"galleryDownloaded"`
+	CompanyDownloaded  int `json:"companyDownloaded"`
+	Errors             int `json:"errors"`
+}
+
+// --- Scraper ---
+
+// ScraperSourceResultResponse is a single source's scrape result counts.
+type ScraperSourceResultResponse struct {
+	Source           string `json:"source"`
+	Matched          int64  `json:"matched"`
+	NotFound         int64  `json:"notFound"`
+	NotFoundEligible int64  `json:"notFoundEligible"`
+	Error            int64  `json:"error"`
+	ErrorEligible    int64  `json:"errorEligible"`
+	NotAttempted     int64  `json:"notAttempted"`
+}

--- a/server/internal/api/session_handler.go
+++ b/server/internal/api/session_handler.go
@@ -1120,13 +1120,7 @@ func (h *SessionHandler) GetStorageUsage(c *gin.Context) {
 
 	// Per-console breakdown via JOINs:
 	// session_save_states → game_sessions → games → consoles
-	type consoleRow struct {
-		ConsoleID   string `json:"consoleId"`
-		ConsoleName string `json:"consoleName"`
-		Bytes       int64  `json:"bytes"`
-		SaveCount   int64  `json:"saveCount"`
-	}
-	var rows []consoleRow
+	var rows []SessionStorageConsoleBreakdown
 	h.DB.Model(&db.SessionSaveState{}).
 		Joins("JOIN game_sessions ON game_sessions.id = session_save_states.session_id AND game_sessions.deleted_at IS NULL").
 		Joins("JOIN games ON games.id = game_sessions.game_id AND games.deleted_at IS NULL").
@@ -1138,7 +1132,7 @@ func (h *SessionHandler) GetStorageUsage(c *gin.Context) {
 		Scan(&rows)
 
 	if rows == nil {
-		rows = []consoleRow{}
+		rows = []SessionStorageConsoleBreakdown{}
 	}
 
 	c.JSON(http.StatusOK, gin.H{

--- a/server/internal/api/stats_handler.go
+++ b/server/internal/api/stats_handler.go
@@ -16,18 +16,6 @@ type StatsHandler struct {
 	DB *gorm.DB
 }
 
-// mostPlayedEntry is a single entry in the most-played games response.
-type mostPlayedEntry struct {
-	Game         GameResponse `json:"game"`
-	TotalPlayers int64        `json:"totalPlayers"`
-	TotalPlayTime int64       `json:"totalPlayTime"`
-}
-
-// mostPlayedResponse is the response for GET /api/stats/most-played.
-type mostPlayedResponse struct {
-	Games []mostPlayedEntry `json:"games"`
-}
-
 // MostPlayedGames returns the top 25 most played games across all users.
 func (h *StatsHandler) MostPlayedGames(c *gin.Context) {
 	type row struct {
@@ -47,7 +35,7 @@ func (h *StatsHandler) MostPlayedGames(c *gin.Context) {
 	}
 
 	if len(rows) == 0 {
-		c.JSON(http.StatusOK, mostPlayedResponse{Games: []mostPlayedEntry{}})
+		c.JSON(http.StatusOK, MostPlayedResponse{Games: []MostPlayedEntry{}})
 		return
 	}
 
@@ -67,35 +55,20 @@ func (h *StatsHandler) MostPlayedGames(c *gin.Context) {
 	userID := getUserID(c)
 	data := loadUserGameData(h.DB, userID, gameIDs)
 
-	entries := make([]mostPlayedEntry, 0, len(rows))
+	entries := make([]MostPlayedEntry, 0, len(rows))
 	for _, r := range rows {
 		game, ok := gameMap[r.GameID]
 		if !ok {
 			continue
 		}
-		entries = append(entries, mostPlayedEntry{
+		entries = append(entries, MostPlayedEntry{
 			Game:          toGameResponseWithData(game, &data),
 			TotalPlayers:  r.TotalPlayers,
 			TotalPlayTime: r.TotalPlayTime,
 		})
 	}
 
-	c.JSON(http.StatusOK, mostPlayedResponse{Games: entries})
-}
-
-// activePlayerEntry is a single entry in the most-active players response.
-type activePlayerEntry struct {
-	UserID        string     `json:"userId"`
-	Username      string     `json:"username"`
-	AvatarURL     string     `json:"avatarUrl"`
-	TotalPlayTime int64      `json:"totalPlayTime"`
-	GamesPlayed   int64      `json:"gamesPlayed"`
-	LastPlayed    time.Time  `json:"lastPlayed"`
-}
-
-// mostActivePlayersResponse is the response for GET /api/stats/most-active-players.
-type mostActivePlayersResponse struct {
-	Players []activePlayerEntry `json:"players"`
+	c.JSON(http.StatusOK, MostPlayedResponse{Games: entries})
 }
 
 // MostActivePlayers returns the top 25 most active players.
@@ -120,10 +93,10 @@ func (h *StatsHandler) MostActivePlayers(c *gin.Context) {
 		return
 	}
 
-	players := make([]activePlayerEntry, 0, len(rows))
+	players := make([]ActivePlayerEntry, 0, len(rows))
 	for _, r := range rows {
 		lastPlayed := parseTimeString(r.LastPlayed)
-		players = append(players, activePlayerEntry{
+		players = append(players, ActivePlayerEntry{
 			UserID:        strconv.FormatUint(uint64(r.UserID), 10),
 			Username:      r.Username,
 			AvatarURL:     r.AvatarURL,
@@ -133,7 +106,7 @@ func (h *StatsHandler) MostActivePlayers(c *gin.Context) {
 		})
 	}
 
-	c.JSON(http.StatusOK, mostActivePlayersResponse{Players: players})
+	c.JSON(http.StatusOK, MostActivePlayersResponse{Players: players})
 }
 
 // parseTimeString attempts to parse a time string in common formats returned by
@@ -172,12 +145,6 @@ func RecordDailyPlayActivity(database *gorm.DB, userID uint, seconds int64) {
 	}
 }
 
-// heatmapEntry is a single day's play activity for the heatmap response.
-type heatmapEntry struct {
-	Date     string `json:"date"`
-	PlayTime int64  `json:"playTime"`
-}
-
 // GetPlayHeatmap returns the current user's daily play activity for the past 365 days.
 // GET /api/user/play-heatmap
 func (h *StatsHandler) GetPlayHeatmap(c *gin.Context) {
@@ -212,9 +179,9 @@ func (h *StatsHandler) getHeatmapForUser(c *gin.Context, userID uint) {
 		Order("date ASC").
 		Find(&activities)
 
-	entries := make([]heatmapEntry, 0, len(activities))
+	entries := make([]HeatmapEntry, 0, len(activities))
 	for _, a := range activities {
-		entries = append(entries, heatmapEntry{
+		entries = append(entries, HeatmapEntry{
 			Date:     a.Date.Format("2006-01-02"),
 			PlayTime: a.PlayTime,
 		})

--- a/server/internal/api/stats_handler_test.go
+++ b/server/internal/api/stats_handler_test.go
@@ -341,7 +341,7 @@ func TestHeatmap_Empty(t *testing.T) {
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var entries []heatmapEntry
+	var entries []HeatmapEntry
 	err := json.Unmarshal(w.Body.Bytes(), &entries)
 	require.NoError(t, err)
 	assert.Len(t, entries, 0)
@@ -368,7 +368,7 @@ func TestHeatmap_WithData(t *testing.T) {
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var entries []heatmapEntry
+	var entries []HeatmapEntry
 	err := json.Unmarshal(w.Body.Bytes(), &entries)
 	require.NoError(t, err)
 	assert.Len(t, entries, 2)
@@ -399,7 +399,7 @@ func TestHeatmap_PublicEndpoint(t *testing.T) {
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var entries []heatmapEntry
+	var entries []HeatmapEntry
 	err := json.Unmarshal(w.Body.Bytes(), &entries)
 	require.NoError(t, err)
 	assert.Len(t, entries, 1)
@@ -430,7 +430,7 @@ func TestHeatmap_UserIsolation(t *testing.T) {
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
-	var entries []heatmapEntry
+	var entries []HeatmapEntry
 	err := json.Unmarshal(w.Body.Bytes(), &entries)
 	require.NoError(t, err)
 	assert.Len(t, entries, 1)

--- a/server/internal/api/system_event_handler.go
+++ b/server/internal/api/system_event_handler.go
@@ -269,13 +269,9 @@ func (h *SystemEventHandler) GetSystemEventCategories(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to load categories"})
 		return
 	}
-	type catResponse struct {
-		Code string `json:"code"`
-		Name string `json:"name"`
-	}
-	out := make([]catResponse, 0, len(cats))
+	out := make([]SystemEventCategoryResponse, 0, len(cats))
 	for _, cat := range cats {
-		out = append(out, catResponse{Code: cat.Code, Name: cat.Name})
+		out = append(out, SystemEventCategoryResponse{Code: cat.Code, Name: cat.Name})
 	}
 	c.JSON(http.StatusOK, out)
 }

--- a/server/internal/api/user_handler.go
+++ b/server/internal/api/user_handler.go
@@ -164,29 +164,6 @@ func (h *UserHandler) ChangePassword(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "password changed"})
 }
 
-// preferencesResponse is the JSON shape for the preferences endpoints.
-type preferencesResponse struct {
-	ShowPerformanceOverlay  bool                           `json:"showPerformanceOverlay"`
-	AutoSaveEnabled         bool                           `json:"autoSaveEnabled"`
-	AutoLoadSaveEnabled     bool                           `json:"autoLoadSaveEnabled"`
-	SelectedShader          string                         `json:"selectedShader"`
-	SelectedTheme           string                         `json:"selectedTheme"`
-	DefaultSecondScreenPage string                         `json:"defaultSecondScreenPage"`
-	ConsoleShaders          map[string]string              `json:"consoleShaders"`
-	SelectedKeyMapping      string                         `json:"selectedKeyMapping"`
-	CustomKeyMapping        map[string]string              `json:"customKeyMapping"`
-	ConsoleKeyMappings      map[string]consoleKeyMappingDTO `json:"consoleKeyMappings"`
-	PreferredRegions        []string                       `json:"preferredRegions"`
-	RALinked                bool                           `json:"raLinked"`
-	RAUsername              string                         `json:"raUsername"`
-	RAHardcoreEnabled       bool                           `json:"raHardcoreEnabled"`
-}
-
-type consoleKeyMappingDTO struct {
-	SelectedMapping string            `json:"selectedMapping"`
-	CustomMapping   map[string]string `json:"customMapping,omitempty"`
-}
-
 // GetPreferences returns the current user's emulation preferences.
 func (h *UserHandler) GetPreferences(c *gin.Context) {
 	userID, _ := c.Get("userId")
@@ -221,7 +198,7 @@ func (h *UserHandler) GetPreferences(c *gin.Context) {
 	var raCred db.RetroAchievementCredential
 	raLinked := h.DB.Where("user_id = ?", uid).First(&raCred).Error == nil
 
-	c.JSON(http.StatusOK, preferencesResponse{
+	c.JSON(http.StatusOK, UserPreferencesResponse{
 		ShowPerformanceOverlay:  user.ShowPerfOverlay,
 		AutoSaveEnabled:         user.AutoSaveEnabled,
 		AutoLoadSaveEnabled:     user.AutoLoadSaveEnabled,
@@ -402,7 +379,7 @@ func (h *UserHandler) UpdatePreferences(c *gin.Context) {
 	var raCred db.RetroAchievementCredential
 	raLinked := h.DB.Where("user_id = ?", uid).First(&raCred).Error == nil
 
-	c.JSON(http.StatusOK, preferencesResponse{
+	c.JSON(http.StatusOK, UserPreferencesResponse{
 		ShowPerformanceOverlay:  user.ShowPerfOverlay,
 		AutoSaveEnabled:         user.AutoSaveEnabled,
 		AutoLoadSaveEnabled:     user.AutoLoadSaveEnabled,
@@ -444,7 +421,7 @@ func (h *UserHandler) buildConsoleShaderMap(userID uint) map[string]string {
 
 // buildConsoleKeyMappingMap queries all ConsoleKeyMappingPreference rows for the user
 // and returns a map keyed by console abbreviation (lowercase).
-func (h *UserHandler) buildConsoleKeyMappingMap(userID uint) map[string]consoleKeyMappingDTO {
+func (h *UserHandler) buildConsoleKeyMappingMap(userID uint) map[string]ConsoleKeyMappingDTO {
 	var prefs []db.ConsoleKeyMappingPreference
 	h.DB.Where("user_id = ?", userID).Find(&prefs)
 
@@ -455,10 +432,10 @@ func (h *UserHandler) buildConsoleKeyMappingMap(userID uint) map[string]consoleK
 	}
 	abbrMap := resolveConsoleAbbrs(h.DB, consoleIDs)
 
-	m := make(map[string]consoleKeyMappingDTO, len(prefs))
+	m := make(map[string]ConsoleKeyMappingDTO, len(prefs))
 	for _, p := range prefs {
 		if abbr, ok := abbrMap[p.ConsoleID]; ok {
-			m[abbr] = consoleKeyMappingDTO{
+			m[abbr] = ConsoleKeyMappingDTO{
 				SelectedMapping: p.SelectedMapping,
 				CustomMapping:   parseJSONMap(p.CustomMapping),
 			}
@@ -647,17 +624,6 @@ func (h *UserHandler) RemoveFavorite(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "favorite removed"})
 }
 
-// userStatsResponse is the response for GET /api/user/stats.
-type userStatsResponse struct {
-	TotalPlayTime    int64         `json:"totalPlayTime"`
-	GamesPlayed      int64         `json:"gamesPlayed"`
-	CurrentStreak    int           `json:"currentStreak"`
-	LongestStreak    int           `json:"longestStreak"`
-	MostPlayedGame   *GameResponse `json:"mostPlayedGame"`
-	MostPlayedGameTime int64       `json:"mostPlayedGameTime"`
-	LastPlayedAt     *time.Time    `json:"lastPlayedAt"`
-}
-
 // GetUserStats returns the current user's personal gameplay statistics.
 func (h *UserHandler) GetUserStats(c *gin.Context) {
 	uid := getUserID(c)
@@ -677,7 +643,7 @@ func (h *UserHandler) GetUserStats(c *gin.Context) {
 	}
 
 	if agg.GamesPlayed == 0 {
-		c.JSON(http.StatusOK, userStatsResponse{
+		c.JSON(http.StatusOK, UserStatsResponse{
 			TotalPlayTime:    0,
 			GamesPlayed:      0,
 			CurrentStreak:    0,
@@ -730,7 +696,7 @@ func (h *UserHandler) GetUserStats(c *gin.Context) {
 		}
 	}
 
-	c.JSON(http.StatusOK, userStatsResponse{
+	c.JSON(http.StatusOK, UserStatsResponse{
 		TotalPlayTime:      agg.TotalPlayTime,
 		GamesPlayed:        agg.GamesPlayed,
 		CurrentStreak:      currentStreak,
@@ -801,13 +767,6 @@ func calculateStreaks(playDates []time.Time, today time.Time) (currentStreak, lo
 	}
 
 	return currentStreak, longestStreak
-}
-
-// PlayStatsEntry represents play stats for a single game.
-type PlayStatsEntry struct {
-	GameID       uint   `json:"gameId"`
-	PlayTime     int64  `json:"playTime"`
-	LastPlayedAt string `json:"lastPlayedAt"`
 }
 
 // GetPlayStats returns the current user's play history for all games they've played.


### PR DESCRIPTION
## Summary
Phase 1b of the API type-safety refactor (see #438).

Move 21 response types out of handler bodies (or unexported package-level positions) into named exported types in \`responses.go\`. Two categories:

**9 truly inline** (declared inside handler functions, can't be referenced from OpenAPI):
- RA: \`RAProgressEntry\`, \`RARecentAchievementResponse\`, \`RAUnlockedAchievementResponse\`, \`RATimelineEntryResponse\`, \`RALeaderboardEntryResponse\`
- Game: \`GameCheatResponse\`
- Session: \`SessionStorageConsoleBreakdown\`
- System events: \`SystemEventCategoryResponse\`
- Admin: \`ScraperSourceResultResponse\`

**12 unexported package-level** (lowercase types in handler files):
- \`AuthLoginResponse\`, \`DeviceResponse\`, \`ShowcaseEntryResponse\`, \`UserPreferencesResponse\`, \`ConsoleKeyMappingDTO\`, \`UserStatsResponse\`, \`GameScanSummary\`/\`GameScanResultResponse\`, \`GameStatsTopPlayer\`/\`GameStatsResponse\`, \`GameKeyMappingResponse\`, \`MostPlayedEntry\`/\`MostPlayedResponse\`, \`ActivePlayerEntry\`/\`MostActivePlayersResponse\`, \`HeatmapEntry\`

Plus 4 already-exported types relocated from handler files into \`responses.go\` (BIOS, Artwork, Backfill).

## Wire format
Unchanged. Same JSON shapes, same field names, same tags.

## Out of scope
The audit's count of \"75 inline response types\" included ~116 already-exported response types scattered across explore/enrichment/console handlers. Those are referenceable from OpenAPI annotations as-is (just the package-qualified name) — code organization concern, not type safety. Worth a separate consolidation sweep if the scattered placement causes friction during OpenAPI annotation.

## Naming judgment calls (flagged for review)
1. **\`DeviceResponse\`** still embeds \`db.Device\` plus \`ConsoleShaders\` — preserved exactly. Worth flattening if OpenAPI generators struggle with embedded DB models.
2. **\`GameCheatResponse\`** chosen over \`CheatResponse\` to keep endpoint context clear.
3. **\`RA*\` prefix** on RetroAchievements types to namespace cleanly against the separate challenge leaderboard domain.

Refs #438.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/api/...\` passes locally
- [ ] CI passes