### PR TITLE
refactor(api,db): typed metadata structs for SystemEvent and ActivityEvent

### DIFF
--- a/server/internal/api/activity_event_metadata.go
+++ b/server/internal/api/activity_event_metadata.go
@@ -1,0 +1,65 @@
+package api
+
+// Activity event metadata variants. The wire format for each is a flat JSON
+// object — these structs exist to make producers type-safe at the call site.
+// Each struct's JSON tags match the historical map[string]interface{} keys
+// exactly so the on-the-wire shape (consumed by web and player clients) is
+// unchanged.
+
+// StartedPlayingMetadata is the metadata shape for the "started_playing"
+// activity event. Seconds is the user's reported play-time increment for
+// this session.
+type StartedPlayingMetadata struct {
+	Seconds int64 `json:"seconds"`
+}
+
+// RatedGameMetadata is the metadata shape for the "rated_game" activity event.
+type RatedGameMetadata struct {
+	Rating int `json:"rating"`
+}
+
+// SharedSaveMetadata is the metadata shape for the "shared_save" activity event.
+type SharedSaveMetadata struct {
+	SaveName string `json:"saveName"`
+}
+
+// CreatedCollectionMetadata is the metadata shape for the
+// "created_collection" activity event.
+type CreatedCollectionMetadata struct {
+	CollectionName string `json:"collectionName"`
+}
+
+// CreatedSharedSessionMetadata is the metadata shape for the
+// "created_shared_session" activity event.
+type CreatedSharedSessionMetadata struct {
+	SharedSessionName string `json:"sharedSessionName"`
+}
+
+// JoinedSharedSessionMetadata is the metadata shape for the
+// "joined_shared_session" activity event.
+type JoinedSharedSessionMetadata struct {
+	SharedSessionName string `json:"sharedSessionName"`
+}
+
+// ChallengeCreatedMetadata is the metadata shape for the "challenge_created"
+// activity event.
+type ChallengeCreatedMetadata struct {
+	ChallengeID   uint   `json:"challengeId"`
+	ChallengeName string `json:"challengeName"`
+}
+
+// ChallengeCompletedMetadata is the metadata shape for the
+// "challenge_completed" activity event.
+type ChallengeCompletedMetadata struct {
+	ChallengeID   uint   `json:"challengeId"`
+	ChallengeName string `json:"challengeName"`
+	DurationMs    int64  `json:"durationMs"`
+}
+
+// ChallengeRecordMetadata is the metadata shape for the "challenge_record"
+// activity event (fired when an attempt becomes the new #1 leaderboard entry).
+type ChallengeRecordMetadata struct {
+	ChallengeID   uint   `json:"challengeId"`
+	ChallengeName string `json:"challengeName"`
+	DurationMs    int64  `json:"durationMs"`
+}

--- a/server/internal/api/auth_handler.go
+++ b/server/internal/api/auth_handler.go
@@ -181,16 +181,16 @@ func (h *AuthHandler) Login(c *gin.Context) {
 			Reason:    "bad_password",
 			Username:  req.Username,
 			UserID:    &user.ID,
-			Metadata:  map[string]any{"failedCount": attempt.FailedCount},
+			Metadata:  db.LoginFailedMetadata{FailedCount: attempt.FailedCount},
 		})
 		if attempt.FailedCount >= maxLoginAttempts {
 			recordSecurityEventCtx(h.DB, c, db.SystemEventInput{
 				EventType: db.SystemEventAccountLocked,
 				Username:  req.Username,
 				UserID:    &user.ID,
-				Metadata: map[string]any{
-					"failedCount": attempt.FailedCount,
-					"lockedUntil": attempt.LockedUntil,
+				Metadata: db.AccountLockedMetadata{
+					FailedCount: attempt.FailedCount,
+					LockedUntil: attempt.LockedUntil,
 				},
 			})
 		}

--- a/server/internal/api/challenge_handler.go
+++ b/server/internal/api/challenge_handler.go
@@ -226,9 +226,9 @@ func (h *ChallengeHandler) CreateChallenge(c *gin.Context) {
 	// Reload with associations
 	h.DB.Preload("Creator").Preload("Game").Preload("Game.Console").First(&challenge, challenge.ID)
 
-	CreateActivityEvent(h.DB, h.Hub, uid, "challenge_created", challenge.GameID, map[string]interface{}{
-		"challengeId":   challenge.ID,
-		"challengeName": challenge.Name,
+	CreateActivityEvent(h.DB, h.Hub, uid, "challenge_created", challenge.GameID, ChallengeCreatedMetadata{
+		ChallengeID:   challenge.ID,
+		ChallengeName: challenge.Name,
 	})
 
 	c.JSON(http.StatusCreated, h.toChallengeResponse(challenge))
@@ -609,10 +609,10 @@ func (h *ChallengeHandler) CompleteAttempt(c *gin.Context) {
 	var challenge db.Challenge
 	h.DB.First(&challenge, attempt.ChallengeID)
 
-	CreateActivityEvent(h.DB, h.Hub, uid, "challenge_completed", challenge.GameID, map[string]interface{}{
-		"challengeId":   challenge.ID,
-		"challengeName": challenge.Name,
-		"durationMs":    durationMs,
+	CreateActivityEvent(h.DB, h.Hub, uid, "challenge_completed", challenge.GameID, ChallengeCompletedMetadata{
+		ChallengeID:   challenge.ID,
+		ChallengeName: challenge.Name,
+		DurationMs:    durationMs,
 	})
 
 	// Check if this is an overall record (rank 1)
@@ -628,10 +628,10 @@ func (h *ChallengeHandler) CompleteAttempt(c *gin.Context) {
 			Count(&betterCount)
 
 		if betterCount == 0 {
-			CreateActivityEvent(h.DB, h.Hub, uid, "challenge_record", challenge.GameID, map[string]interface{}{
-				"challengeId":   challenge.ID,
-				"challengeName": challenge.Name,
-				"durationMs":    durationMs,
+			CreateActivityEvent(h.DB, h.Hub, uid, "challenge_record", challenge.GameID, ChallengeRecordMetadata{
+				ChallengeID:   challenge.ID,
+				ChallengeName: challenge.Name,
+				DurationMs:    durationMs,
 			})
 		}
 	}

--- a/server/internal/api/collection_handler.go
+++ b/server/internal/api/collection_handler.go
@@ -37,8 +37,8 @@ func (h *CollectionHandler) CreateCollection(c *gin.Context) {
 		return
 	}
 
-	CreateActivityEvent(h.DB, h.Hub, uid, "created_collection", 0, map[string]interface{}{
-		"collectionName": req.Name,
+	CreateActivityEvent(h.DB, h.Hub, uid, "created_collection", 0, CreatedCollectionMetadata{
+		CollectionName: req.Name,
 	})
 
 	c.JSON(http.StatusCreated, h.toCollectionResponse(collection, uid))

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -407,10 +407,10 @@ func (h *GameHandler) DownloadGame(c *gin.Context) {
 	if err != nil {
 		db.RecordOperationalEvent(h.DB, db.SystemEventInput{
 			EventType: db.SystemEventROMFileMissing,
-			Metadata: map[string]any{
-				"gameId":       game.ID,
-				"gameTitle":    game.Title,
-				"expectedPath": game.FilePath,
+			Metadata: db.ROMFileMissingMetadata{
+				GameID:       game.ID,
+				GameTitle:    game.Title,
+				ExpectedPath: game.FilePath,
 			},
 		})
 		c.JSON(http.StatusNotFound, ErrorResponse{Error: "game file not found"})
@@ -785,8 +785,8 @@ func (h *GameHandler) UpdatePlayTime(c *gin.Context) {
 	}
 
 	// Emit activity event for started playing
-	CreateActivityEvent(h.DB, h.Hub, uid, "started_playing", uint(gid), map[string]interface{}{
-		"seconds": req.Seconds,
+	CreateActivityEvent(h.DB, h.Hub, uid, "started_playing", uint(gid), StartedPlayingMetadata{
+		Seconds: req.Seconds,
 	})
 
 	c.JSON(http.StatusOK, gin.H{

--- a/server/internal/api/middleware.go
+++ b/server/internal/api/middleware.go
@@ -112,9 +112,9 @@ func AuthMiddleware(jwtSecret string, database *gorm.DB) gin.HandlerFunc {
 				EventType: db.SystemEventStaleTokenVersion,
 				Username:  claims.Username,
 				UserID:    &userID,
-				Metadata: map[string]any{
-					"tokenVersion":   claims.TokenVersion,
-					"currentVersion": user.TokenVersion,
+				Metadata: db.StaleTokenVersionMetadata{
+					TokenVersion:   claims.TokenVersion,
+					CurrentVersion: user.TokenVersion,
 				},
 			})
 			abortWithError(c, http.StatusUnauthorized, "token has been invalidated", "Your session is no longer valid. Please sign in again.")

--- a/server/internal/api/rating_handler.go
+++ b/server/internal/api/rating_handler.go
@@ -55,8 +55,8 @@ func (h *RatingHandler) CreateOrUpdateRating(c *gin.Context) {
 			return
 		}
 
-		CreateActivityEvent(h.DB, h.Hub, uid, "rated_game", uint(gid), map[string]interface{}{
-			"rating": req.Rating,
+		CreateActivityEvent(h.DB, h.Hub, uid, "rated_game", uint(gid), RatedGameMetadata{
+			Rating: req.Rating,
 		})
 
 		c.JSON(http.StatusCreated, h.toRatingResponse(rating, uid))

--- a/server/internal/api/shared_save_handler.go
+++ b/server/internal/api/shared_save_handler.go
@@ -80,8 +80,8 @@ func (h *SharedSaveHandler) ShareSave(c *gin.Context) {
 		return
 	}
 
-	CreateActivityEvent(h.DB, h.Hub, uid, "shared_save", uint(gid), map[string]interface{}{
-		"saveName": name,
+	CreateActivityEvent(h.DB, h.Hub, uid, "shared_save", uint(gid), SharedSaveMetadata{
+		SaveName: name,
 	})
 
 	c.JSON(http.StatusCreated, h.toResponse(shared, uid))

--- a/server/internal/api/shared_session_handler.go
+++ b/server/internal/api/shared_session_handler.go
@@ -96,8 +96,8 @@ func (h *SharedSessionHandler) CreateSharedSession(c *gin.Context) {
 	// Reload with associations
 	h.DB.Preload("Members").Preload("Members.User").Preload("Game").Preload("Game.Console").Preload("Owner").First(&ss, ss.ID)
 
-	CreateActivityEvent(h.DB, h.Hub, uid, "created_shared_session", uint(gid), map[string]interface{}{
-		"sharedSessionName": req.Name,
+	CreateActivityEvent(h.DB, h.Hub, uid, "created_shared_session", uint(gid), CreatedSharedSessionMetadata{
+		SharedSessionName: req.Name,
 	})
 
 	if h.Hub != nil {
@@ -399,8 +399,8 @@ func (h *SharedSessionHandler) AcceptInvite(c *gin.Context) {
 		return
 	}
 
-	CreateActivityEvent(h.DB, h.Hub, uid, "joined_shared_session", invite.SharedSession.GameID, map[string]interface{}{
-		"sharedSessionName": invite.SharedSession.Name,
+	CreateActivityEvent(h.DB, h.Hub, uid, "joined_shared_session", invite.SharedSession.GameID, JoinedSharedSessionMetadata{
+		SharedSessionName: invite.SharedSession.Name,
 	})
 
 	if h.Hub != nil {

--- a/server/internal/api/social_handler.go
+++ b/server/internal/api/social_handler.go
@@ -454,12 +454,23 @@ func (h *SocialHandler) GetActivityFeed(c *gin.Context) {
 }
 
 // CreateActivityEvent creates a new activity event and broadcasts it via WebSocket.
-func CreateActivityEvent(database *gorm.DB, hub *ws.Hub, userID uint, eventType string, gameID uint, metadata map[string]interface{}) {
+// metadata should be one of the typed *Metadata structs defined in
+// activity_event_metadata.go (e.g. StartedPlayingMetadata, RatedGameMetadata)
+// so the call site is compile-checked against the expected shape. Pass nil
+// for events that carry no metadata. The wire format is the JSON-encoded
+// struct — unchanged from the prior map[string]interface{} representation.
+func CreateActivityEvent(database *gorm.DB, hub *ws.Hub, userID uint, eventType string, gameID uint, metadata any) {
 	metadataJSON := ""
+	// metadataMap is the broadcast-response shape (matches the persisted JSON
+	// after round-tripping through the DB). We marshal once for the DB blob,
+	// then unmarshal back into a map so the in-memory WebSocket broadcast
+	// mirrors what subsequent GETs will return.
+	var metadataMap map[string]interface{}
 	if metadata != nil {
 		b, err := json.Marshal(metadata)
 		if err == nil {
 			metadataJSON = string(b)
+			_ = json.Unmarshal(b, &metadataMap)
 		}
 	}
 
@@ -502,7 +513,7 @@ func CreateActivityEvent(database *gorm.DB, hub *ws.Hub, userID uint, eventType 
 		GameTitle:    game.Title,
 		GameCoverURL: coverURL,
 		ConsoleName:  consoleName,
-		Metadata:     metadata,
+		Metadata:     metadataMap,
 	}
 
 	if hub != nil {

--- a/server/internal/api/system_event_handler.go
+++ b/server/internal/api/system_event_handler.go
@@ -321,14 +321,10 @@ func (h *SystemEventHandler) ReportEmulatorError(c *gin.Context) {
 		uname = name
 	}
 
-	metadata := map[string]any{
-		"error": req.Error,
-	}
-	if req.GameID != "" {
-		metadata["gameId"] = req.GameID
-	}
-	if req.Core != "" {
-		metadata["core"] = req.Core
+	metadata := db.EmulatorJSLoadFailedMetadata{
+		Error:  req.Error,
+		GameID: req.GameID,
+		Core:   req.Core,
 	}
 
 	db.RecordOperationalEvent(h.DB, db.SystemEventInput{

--- a/server/internal/db/system_event_metadata.go
+++ b/server/internal/db/system_event_metadata.go
@@ -1,0 +1,64 @@
+package db
+
+import "time"
+
+// System event metadata variants. The wire format for each is a flat JSON
+// object — these structs exist to make producers type-safe at the call site.
+// Each struct's JSON tags match the historical map[string]any keys exactly
+// so the on-the-wire shape is unchanged.
+
+// LoginFailedMetadata is the metadata shape for the SystemEventLoginFailed event.
+type LoginFailedMetadata struct {
+	FailedCount int `json:"failedCount"`
+}
+
+// AccountLockedMetadata is the metadata shape for the SystemEventAccountLocked event.
+type AccountLockedMetadata struct {
+	FailedCount int       `json:"failedCount"`
+	LockedUntil time.Time `json:"lockedUntil"`
+}
+
+// StaleTokenVersionMetadata is the metadata shape for the SystemEventStaleTokenVersion event.
+type StaleTokenVersionMetadata struct {
+	TokenVersion   int `json:"tokenVersion"`
+	CurrentVersion int `json:"currentVersion"`
+}
+
+// RACircuitBreakerTrippedMetadata is the metadata shape for the
+// SystemEventRACircuitBreakerTripped event.
+type RACircuitBreakerTrippedMetadata struct {
+	ConsecutiveFailures int    `json:"consecutiveFailures"`
+	LastError           string `json:"lastError"`
+}
+
+// ScraperRepeatedErrorsMetadata is the metadata shape for the
+// SystemEventScraperRepeatedErrors event.
+type ScraperRepeatedErrorsMetadata struct {
+	ConsecutiveFailures int    `json:"consecutiveFailures"`
+	Error               string `json:"error"`
+	GameTitle           string `json:"gameTitle"`
+}
+
+// ROMFileMissingMetadata is the metadata shape for the SystemEventROMFileMissing event.
+type ROMFileMissingMetadata struct {
+	GameID       uint   `json:"gameId"`
+	GameTitle    string `json:"gameTitle"`
+	ExpectedPath string `json:"expectedPath"`
+}
+
+// APICredentialsInvalidMetadata is the metadata shape for the
+// SystemEventAPICredentialsInvalid event.
+type APICredentialsInvalidMetadata struct {
+	Service string `json:"service"`
+	Error   string `json:"error"`
+}
+
+// EmulatorJSLoadFailedMetadata is the metadata shape for the
+// SystemEventEmulatorJSLoadFailed event. GameID and Core are optional and
+// omitted from the serialized payload when empty to preserve the historical
+// "only include set fields" behavior.
+type EmulatorJSLoadFailedMetadata struct {
+	Error  string `json:"error"`
+	GameID string `json:"gameId,omitempty"`
+	Core   string `json:"core,omitempty"`
+}

--- a/server/internal/db/system_event_recorder.go
+++ b/server/internal/db/system_event_recorder.go
@@ -21,7 +21,14 @@ type SystemEventInput struct {
 	UserID    *uint
 	IP        string
 	Path      string
-	Metadata  map[string]any
+	// Metadata is the typed per-event-type metadata struct. Producers should
+	// pass one of the *Metadata structs defined in system_event_metadata.go
+	// (e.g. LoginFailedMetadata, AccountLockedMetadata) so the call site is
+	// compile-checked against the expected shape. Leave nil for events that
+	// carry no metadata. The recorder serializes this as a flat JSON object
+	// using the struct's json tags — the on-the-wire shape is unchanged from
+	// the prior map[string]any representation.
+	Metadata any
 }
 
 // --- Middleware write amplification guard ----------------------------------
@@ -156,9 +163,14 @@ func recordSystemEvent(database *gorm.DB, in SystemEventInput) {
 	}
 
 	var metaJSON string
-	if len(in.Metadata) > 0 {
+	if in.Metadata != nil {
 		if b, err := json.Marshal(in.Metadata); err == nil {
-			metaJSON = string(b)
+			s := string(b)
+			// Treat empty JSON object / null as "no metadata" to match the
+			// prior len(map) > 0 behavior and keep the column empty.
+			if s != "" && s != "{}" && s != "null" {
+				metaJSON = s
+			}
 		}
 	}
 
@@ -210,8 +222,18 @@ func logSystemEvent(in SystemEventInput) {
 	if in.Path != "" {
 		logArgs = append(logArgs, "path", in.Path)
 	}
-	for k, v := range in.Metadata {
-		logArgs = append(logArgs, k, v)
+	if in.Metadata != nil {
+		// Marshal the typed metadata struct and re-parse into a map so slog
+		// attrs use the exact JSON key names (matches historical behavior
+		// when Metadata was map[string]any).
+		if b, err := json.Marshal(in.Metadata); err == nil {
+			var m map[string]any
+			if json.Unmarshal(b, &m) == nil {
+				for k, v := range m {
+					logArgs = append(logArgs, k, v)
+				}
+			}
+		}
 	}
 	if in.EventType == SystemEventLoginSuccess {
 		slog.Info("system-event: "+in.EventType, logArgs...)

--- a/server/internal/scraper/scraper.go
+++ b/server/internal/scraper/scraper.go
@@ -87,9 +87,9 @@ func (s *Scraper) tryFetchRAAchievements(game *db.Game) {
 		if strings.Contains(errStr, "status 401") || strings.Contains(errStr, "status 403") {
 			db.RecordOperationalEvent(s.DB, db.SystemEventInput{
 				EventType: db.SystemEventAPICredentialsInvalid,
-				Metadata: map[string]any{
-					"service": "retroachievements",
-					"error":   errStr,
+				Metadata: db.APICredentialsInvalidMetadata{
+					Service: "retroachievements",
+					Error:   errStr,
 				},
 			})
 		}
@@ -100,9 +100,9 @@ func (s *Scraper) tryFetchRAAchievements(game *db.Game) {
 				"consecutiveFailures", s.raConsecutiveFailures, "lastError", err)
 			db.RecordOperationalEvent(s.DB, db.SystemEventInput{
 				EventType: db.SystemEventRACircuitBreakerTripped,
-				Metadata: map[string]any{
-					"consecutiveFailures": s.raConsecutiveFailures,
-					"lastError":           errStr,
+				Metadata: db.RACircuitBreakerTrippedMetadata{
+					ConsecutiveFailures: s.raConsecutiveFailures,
+					LastError:           errStr,
 				},
 			})
 		} else {

--- a/server/internal/scraper/worker.go
+++ b/server/internal/scraper/worker.go
@@ -131,10 +131,10 @@ func (w *ScrapeWorker) processItem(ctx context.Context, item *db.ScrapeQueueItem
 				if w.scraperConsecutiveFailures >= 5 {
 					db.RecordOperationalEvent(w.db, db.SystemEventInput{
 						EventType: db.SystemEventScraperRepeatedErrors,
-						Metadata: map[string]any{
-							"consecutiveFailures": w.scraperConsecutiveFailures,
-							"error":               err.Error(),
-							"gameTitle":            game.Title,
+						Metadata: db.ScraperRepeatedErrorsMetadata{
+							ConsecutiveFailures: w.scraperConsecutiveFailures,
+							Error:               err.Error(),
+							GameTitle:           game.Title,
 						},
 					})
 				}


### PR DESCRIPTION
## Summary
Phase 2 of the API type-safety refactor (see #439).

Replace untyped \`map[string]any\` metadata blobs with typed Go structs at every producer call site. Wire format unchanged — JSON keys preserved exactly.

## What changed
- **New file** \`db/system_event_metadata.go\` with 8 typed metadata structs (one per SystemEvent type with metadata)
- **New file** \`api/activity_event_metadata.go\` with 9 typed metadata structs (one per ActivityEvent type with metadata)
- \`SystemEventInput.Metadata\` and \`CreateActivityEvent\`'s metadata parameter loosened from \`map[string]any\` to \`any\` — accepts typed structs at the producer side and unchanged maps in tests
- Recorder logs via marshal-then-unmarshal-to-map so slog attribute output stays identical
- **17 producer sites converted** (8 SystemEvent, 9 ActivityEvent)

## Out of scope
- \`SystemEventResponse.Metadata\` / \`ActivityEventResponse.Metadata\` stay \`map[string]any\` on the read path. Making them true OpenAPI \`oneOf\` discriminated unions is a separate, bigger change that requires matching TypeScript/Kotlin consumer updates. **This PR's win is producer-side compile-time safety** — typos like \`failedCunt\` are now compile errors.

Refs #439.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/db/... ./internal/api/... ./internal/scraper/...\` passes locally
- [ ] CI passes