### PR TITLE
refactor(websocket): typed payloads and event constants for hub broadcasts

### DIFF
--- a/server/internal/api/admin_handler_scraper.go
+++ b/server/internal/api/admin_handler_scraper.go
@@ -60,7 +60,7 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 				c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "cancelling active job"})
 				return
 			}
-			h.Hub.Broadcast(ws.Event{Type: "scrape_cancelled", Payload: gin.H{}})
+			h.Hub.Broadcast(ws.Event{Type: ws.EventScrapeCancelled, Payload: ws.ScrapeCancelledPayload{}})
 		case "merge":
 			gameIDs, err := h.collectGameIDs(mode, consoleID, source, status)
 			if err != nil {
@@ -128,10 +128,10 @@ func (h *AdminHandler) TriggerScrape(c *gin.Context) {
 		}
 	}
 
-	h.Hub.Broadcast(ws.Event{Type: "scrape_started", Payload: gin.H{
-		"jobId": job.ID,
-		"total": len(gameIDs),
-		"mode":  mode,
+	h.Hub.Broadcast(ws.Event{Type: ws.EventScrapeStarted, Payload: ws.ScrapeStartedPayload{
+		JobID: job.ID,
+		Total: len(gameIDs),
+		Mode:  mode,
 	}})
 
 	adminID, _ := c.Get("userId")
@@ -205,8 +205,8 @@ func (h *AdminHandler) CancelScrape(c *gin.Context) {
 		return
 	}
 
-	h.Hub.Broadcast(ws.Event{Type: "scrape_cancelled", Payload: gin.H{
-		"jobId": job.ID,
+	h.Hub.Broadcast(ws.Event{Type: ws.EventScrapeCancelled, Payload: ws.ScrapeCancelledPayload{
+		JobID: job.ID,
 	}})
 
 	// Rebuild variant groups after cancellation

--- a/server/internal/api/bios_handler.go
+++ b/server/internal/api/bios_handler.go
@@ -488,7 +488,7 @@ func (h *BiosHandler) TriggerDownload(c *gin.Context) {
 	}
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "bios_download_started", Payload: gin.H{"total": missing}})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventBiosDownloadStarted, Payload: ws.BiosDownloadStartedPayload{Total: missing}})
 	}
 
 	go func() {
@@ -500,7 +500,7 @@ func (h *BiosHandler) TriggerDownload(c *gin.Context) {
 
 		result := bios.DownloadMissing(h.Storage.BiosDir, bios.DefaultRepoBaseURL, func(p bios.DownloadProgress) {
 			if h.Hub != nil {
-				h.Hub.Broadcast(ws.Event{Type: "bios_download_progress", Payload: p})
+				h.Hub.Broadcast(ws.Event{Type: ws.EventBiosDownloadProgress, Payload: p})
 			}
 		})
 
@@ -511,10 +511,10 @@ func (h *BiosHandler) TriggerDownload(c *gin.Context) {
 		)
 
 		if h.Hub != nil {
-			h.Hub.Broadcast(ws.Event{Type: "bios_download_complete", Payload: gin.H{
-				"downloaded": result.Downloaded,
-				"skipped":    result.Skipped,
-				"failed":     result.Failed,
+			h.Hub.Broadcast(ws.Event{Type: ws.EventBiosDownloadComplete, Payload: ws.BiosDownloadCompletePayload{
+				Downloaded: result.Downloaded,
+				Skipped:    result.Skipped,
+				Failed:     result.Failed,
 			}})
 		}
 	}()

--- a/server/internal/api/challenge_handler.go
+++ b/server/internal/api/challenge_handler.go
@@ -639,9 +639,9 @@ func (h *ChallengeHandler) CompleteAttempt(c *gin.Context) {
 	// Broadcast leaderboard update
 	if h.Hub != nil {
 		h.Hub.Broadcast(ws.Event{
-			Type: "challenge_leaderboard_updated",
-			Payload: gin.H{
-				"challengeId": strconv.FormatUint(uint64(attempt.ChallengeID), 10),
+			Type: ws.EventChallengeLeaderboardUpdated,
+			Payload: ws.ChallengeLeaderboardUpdatedPayload{
+				ChallengeID: strconv.FormatUint(uint64(attempt.ChallengeID), 10),
 			},
 		})
 	}

--- a/server/internal/api/enrichment_handler.go
+++ b/server/internal/api/enrichment_handler.go
@@ -881,7 +881,7 @@ func (h *EnrichmentHandler) TriggerEnrichMetadata(c *gin.Context) {
 	}
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "enrich_started", Payload: gin.H{"total": total}})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventEnrichStarted, Payload: ws.EnrichStartedPayload{Total: total}})
 	}
 
 	go func() {
@@ -890,19 +890,19 @@ func (h *EnrichmentHandler) TriggerEnrichMetadata(c *gin.Context) {
 		count, enrichTotal, err := h.Scraper.EnrichAll(mode, func(p scraper.EnrichProgress) {
 			h.Scraper.SetEnrichProgress(&p)
 			if h.Hub != nil {
-				h.Hub.Broadcast(ws.Event{Type: "enrich_progress", Payload: p})
+				h.Hub.Broadcast(ws.Event{Type: ws.EventEnrichProgress, Payload: p})
 			}
 		})
 		if err != nil {
 			slog.Error("metadata enrichment failed", "error", err)
 			if h.Hub != nil {
-				h.Hub.Broadcast(ws.Event{Type: "enrich_error", Payload: ErrorResponse{Error: "enrichment failed"}})
+				h.Hub.Broadcast(ws.Event{Type: ws.EventEnrichError, Payload: ErrorResponse{Error: "enrichment failed"}})
 			}
 			return
 		}
 		slog.Info("metadata enrichment complete", "enriched", count, "total", enrichTotal)
 		if h.Hub != nil {
-			h.Hub.Broadcast(ws.Event{Type: "enrich_complete", Payload: gin.H{"enriched": count, "total": enrichTotal}})
+			h.Hub.Broadcast(ws.Event{Type: ws.EventEnrichComplete, Payload: ws.EnrichCompletePayload{Enriched: count, Total: enrichTotal}})
 		}
 	}()
 

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -569,7 +569,7 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 		return
 	}
 
-	h.Hub.Broadcast(ws.Event{Type: "scan_started", Payload: nil})
+	h.Hub.Broadcast(ws.Event{Type: ws.EventScanStarted, Payload: nil})
 	c.JSON(http.StatusAccepted, gin.H{"message": "scan started in background"})
 
 	go func() {
@@ -581,11 +581,11 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 		}
 		result, err := h.Scanner.Scan(func(p scanner.ScanProgress) {
 			h.Scanner.SetScanProgress(&p)
-			h.Hub.Broadcast(ws.Event{Type: "scan_progress", Payload: p})
+			h.Hub.Broadcast(ws.Event{Type: ws.EventScanProgress, Payload: p})
 		}, scanArgs...)
 		if err != nil {
 			slog.Error("game library scan failed", "error", err)
-			h.Hub.Broadcast(ws.Event{Type: "scan_error", Payload: ErrorResponse{Error: "library scan failed"}})
+			h.Hub.Broadcast(ws.Event{Type: ws.EventScanError, Payload: ErrorResponse{Error: "library scan failed"}})
 			return
 		}
 
@@ -609,7 +609,7 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 			}
 		}
 
-		h.Hub.Broadcast(ws.Event{Type: "scan_complete", Payload: resp})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventScanComplete, Payload: resp})
 
 		// Configure SteamGridDB if API key is set (best-effort artwork during auto-scrape)
 		if apiKey := steamGridDBAPIKey(h.DB); apiKey != "" {
@@ -642,10 +642,10 @@ func (h *GameHandler) ScanGames(c *gin.Context) {
 							slog.Error("failed to enqueue scan auto-scrape games", "error", enqErr)
 						} else {
 							slog.Info("scan auto-scrape job created", "jobId", job.ID, "total", len(gameIDs))
-							h.Hub.Broadcast(ws.Event{Type: "scrape_started", Payload: gin.H{
-								"jobId": job.ID,
-								"total": len(gameIDs),
-								"mode":  "new",
+							h.Hub.Broadcast(ws.Event{Type: ws.EventScrapeStarted, Payload: ws.ScrapeStartedPayload{
+								JobID: job.ID,
+								Total: len(gameIDs),
+								Mode:  "new",
 							}})
 						}
 					}

--- a/server/internal/api/netplay_handler.go
+++ b/server/internal/api/netplay_handler.go
@@ -90,7 +90,7 @@ func (h *NetplayHandler) CreateSession(c *gin.Context) {
 	h.DB.Preload("HostUser").Preload("Game").Preload("Game.Console").First(&session, session.ID)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "netplay_session_created", Payload: h.toSessionResponse(session)})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventNetplaySessionCreated, Payload: h.toSessionResponse(session)})
 	}
 
 	c.JSON(http.StatusCreated, h.toSessionResponse(session))
@@ -228,7 +228,7 @@ func (h *NetplayHandler) JoinByInviteCode(c *gin.Context) {
 	h.expireNetplayInvites(session.ID)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "netplay_player_joined", Payload: h.toSessionResponse(session)})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventNetplayPlayerJoined, Payload: h.toSessionResponse(session)})
 	}
 
 	c.JSON(http.StatusOK, h.toSessionResponse(session))
@@ -272,9 +272,9 @@ func (h *NetplayHandler) LeaveSession(c *gin.Context) {
 	h.expireNetplayInvites(session.ID)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "netplay_session_ended", Payload: gin.H{
-			"sessionId": strconv.FormatUint(uint64(session.ID), 10),
-			"endReason": endReason,
+		h.Hub.Broadcast(ws.Event{Type: ws.EventNetplaySessionEnded, Payload: ws.NetplaySessionEndedPayload{
+			SessionID: strconv.FormatUint(uint64(session.ID), 10),
+			EndReason: endReason,
 		}})
 	}
 
@@ -326,8 +326,8 @@ func (h *NetplayHandler) DeleteSession(c *gin.Context) {
 	h.DB.Delete(&session)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "netplay_session_deleted", Payload: gin.H{
-			"sessionId": strconv.FormatUint(uint64(session.ID), 10),
+		h.Hub.Broadcast(ws.Event{Type: ws.EventNetplaySessionDeleted, Payload: ws.NetplaySessionDeletedPayload{
+			SessionID: strconv.FormatUint(uint64(session.ID), 10),
 		}})
 	}
 
@@ -371,7 +371,7 @@ func (h *NetplayHandler) UpdateSettings(c *gin.Context) {
 	h.DB.Preload("HostUser").Preload("ClientUser").Preload("Game").Preload("Game.Console").First(&session, session.ID)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "netplay_settings_updated", Payload: h.toSessionResponse(session)})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventNetplaySettingsUpdated, Payload: h.toSessionResponse(session)})
 	}
 
 	c.JSON(http.StatusOK, h.toSessionResponse(session))

--- a/server/internal/api/netplay_invite_handler.go
+++ b/server/internal/api/netplay_invite_handler.go
@@ -86,7 +86,7 @@ func (h *NetplayHandler) SendInvite(c *gin.Context) {
 	resp := h.toNetplayInviteResponse(invite)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "netplay_invite_sent", Payload: resp})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventNetplayInviteSent, Payload: resp})
 	}
 
 	c.JSON(http.StatusCreated, resp)
@@ -210,7 +210,7 @@ func (h *NetplayHandler) AcceptNetplayInvite(c *gin.Context) {
 	resp := h.toNetplayInviteResponse(invite)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "netplay_invite_accepted", Payload: resp})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventNetplayInviteAccepted, Payload: resp})
 	}
 
 	c.JSON(http.StatusOK, resp)
@@ -244,9 +244,9 @@ func (h *NetplayHandler) DeclineNetplayInvite(c *gin.Context) {
 	}
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "netplay_invite_declined", Payload: gin.H{
-			"netplaySessionId": strconv.FormatUint(uint64(invite.NetplaySessionID), 10),
-			"inviteeId":        strconv.FormatUint(uint64(uid), 10),
+		h.Hub.Broadcast(ws.Event{Type: ws.EventNetplayInviteDeclined, Payload: ws.NetplayInviteDeclinedPayload{
+			NetplaySessionID: strconv.FormatUint(uint64(invite.NetplaySessionID), 10),
+			InviteeID:        strconv.FormatUint(uint64(uid), 10),
 		}})
 	}
 

--- a/server/internal/api/shared_session_handler.go
+++ b/server/internal/api/shared_session_handler.go
@@ -101,7 +101,7 @@ func (h *SharedSessionHandler) CreateSharedSession(c *gin.Context) {
 	})
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_created", Payload: h.toSharedSessionResponse(ss)})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionCreated, Payload: h.toSharedSessionResponse(ss)})
 	}
 
 	c.JSON(http.StatusCreated, h.toSharedSessionDetailResponse(ss))
@@ -222,7 +222,7 @@ func (h *SharedSessionHandler) UpdateSharedSession(c *gin.Context) {
 	}
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_updated", Payload: h.toSharedSessionResponse(ss)})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionUpdated, Payload: h.toSharedSessionResponse(ss)})
 	}
 
 	c.JSON(http.StatusOK, h.toSharedSessionResponse(ss))
@@ -252,7 +252,7 @@ func (h *SharedSessionHandler) DeleteSharedSession(c *gin.Context) {
 	h.DB.Delete(&ss)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_deleted", Payload: gin.H{"sharedSessionId": strconv.FormatUint(uint64(sharedSessionID), 10)}})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionDeleted, Payload: ws.SharedSessionDeletedPayload{SharedSessionID: strconv.FormatUint(uint64(sharedSessionID), 10)}})
 	}
 
 	c.JSON(http.StatusOK, gin.H{"message": "shared session deleted"})
@@ -318,7 +318,7 @@ func (h *SharedSessionHandler) InviteUser(c *gin.Context) {
 	h.DB.Preload("Inviter").Preload("Invitee").Preload("SharedSession").Preload("SharedSession.Game").First(&invite, invite.ID)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_invite_sent", Payload: h.toSharedSessionInviteResponse(invite)})
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionInviteSent, Payload: h.toSharedSessionInviteResponse(invite)})
 	}
 
 	c.JSON(http.StatusCreated, h.toSharedSessionInviteResponse(invite))
@@ -406,10 +406,10 @@ func (h *SharedSessionHandler) AcceptInvite(c *gin.Context) {
 	if h.Hub != nil {
 		var user db.User
 		h.DB.First(&user, uid)
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_invite_accepted", Payload: gin.H{
-			"sharedSessionId":  strconv.FormatUint(uint64(invite.SharedSessionID), 10),
-			"userId":   strconv.FormatUint(uint64(uid), 10),
-			"username": user.Username,
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionInviteAccepted, Payload: ws.SharedSessionInviteAcceptedPayload{
+			SharedSessionID: strconv.FormatUint(uint64(invite.SharedSessionID), 10),
+			UserID:          strconv.FormatUint(uint64(uid), 10),
+			Username:        user.Username,
 		}})
 	}
 
@@ -444,9 +444,9 @@ func (h *SharedSessionHandler) DeclineInvite(c *gin.Context) {
 	}
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_invite_declined", Payload: gin.H{
-			"sharedSessionId":   strconv.FormatUint(uint64(invite.SharedSessionID), 10),
-			"inviteeId": strconv.FormatUint(uint64(uid), 10),
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionInviteDeclined, Payload: ws.SharedSessionInviteDeclinedPayload{
+			SharedSessionID: strconv.FormatUint(uint64(invite.SharedSessionID), 10),
+			InviteeID:       strconv.FormatUint(uint64(uid), 10),
 		}})
 	}
 
@@ -482,9 +482,9 @@ func (h *SharedSessionHandler) LeaveSharedSession(c *gin.Context) {
 	}
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_member_left", Payload: gin.H{
-			"sharedSessionId": strconv.FormatUint(uint64(ss.ID), 10),
-			"userId":  strconv.FormatUint(uint64(uid), 10),
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionMemberLeft, Payload: ws.SharedSessionMemberLeftPayload{
+			SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
+			UserID:          strconv.FormatUint(uint64(uid), 10),
 		}})
 	}
 
@@ -527,9 +527,9 @@ func (h *SharedSessionHandler) RemoveMember(c *gin.Context) {
 	}
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_member_removed", Payload: gin.H{
-			"sharedSessionId": strconv.FormatUint(uint64(ss.ID), 10),
-			"userId":  strconv.FormatUint(uint64(targetUID), 10),
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionMemberRemoved, Payload: ws.SharedSessionMemberRemovedPayload{
+			SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
+			UserID:          strconv.FormatUint(uint64(targetUID), 10),
 		}})
 	}
 
@@ -601,9 +601,9 @@ func (h *SharedSessionHandler) TakeTurn(c *gin.Context) {
 	}
 
 	if previousUserID != nil && h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_turn_expired", Payload: gin.H{
-			"sharedSessionId":        strconv.FormatUint(uint64(ss.ID), 10),
-			"previousUserId": strconv.FormatUint(uint64(*previousUserID), 10),
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionTurnExpired, Payload: ws.SharedSessionTurnExpiredPayload{
+			SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
+			PreviousUserID:  strconv.FormatUint(uint64(*previousUserID), 10),
 		}})
 	}
 
@@ -611,10 +611,10 @@ func (h *SharedSessionHandler) TakeTurn(c *gin.Context) {
 	h.DB.First(&user, uid)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_turn_acquired", Payload: gin.H{
-			"sharedSessionId":  strconv.FormatUint(uint64(ss.ID), 10),
-			"userId":   strconv.FormatUint(uint64(uid), 10),
-			"username": user.Username,
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionTurnAcquired, Payload: ws.SharedSessionTurnAcquiredPayload{
+			SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
+			UserID:          strconv.FormatUint(uint64(uid), 10),
+			Username:        user.Username,
 		}})
 	}
 
@@ -644,9 +644,9 @@ func (h *SharedSessionHandler) ReleaseTurn(c *gin.Context) {
 	})
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_turn_released", Payload: gin.H{
-			"sharedSessionId": strconv.FormatUint(uint64(ss.ID), 10),
-			"userId":  strconv.FormatUint(uint64(uid), 10),
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionTurnReleased, Payload: ws.SharedSessionTurnReleasedPayload{
+			SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
+			UserID:          strconv.FormatUint(uint64(uid), 10),
 		}})
 	}
 
@@ -771,11 +771,11 @@ func (h *SharedSessionHandler) UploadSave(c *gin.Context) {
 	h.DB.Preload("User").First(&save, save.ID)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_save_uploaded", Payload: gin.H{
-			"sharedSessionId": strconv.FormatUint(uint64(ss.ID), 10),
-			"saveId":  strconv.FormatUint(uint64(save.ID), 10),
-			"userId":  strconv.FormatUint(uint64(uid), 10),
-			"isAuto":  false,
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionSaveUploaded, Payload: ws.SharedSessionSaveUploadedPayload{
+			SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
+			SaveID:          strconv.FormatUint(uint64(save.ID), 10),
+			UserID:          strconv.FormatUint(uint64(uid), 10),
+			IsAuto:          false,
 		}})
 	}
 
@@ -908,11 +908,11 @@ func (h *SharedSessionHandler) UploadAutoSave(c *gin.Context) {
 	h.DB.Preload("User").First(&save, save.ID)
 
 	if h.Hub != nil {
-		h.Hub.Broadcast(ws.Event{Type: "shared_session_save_uploaded", Payload: gin.H{
-			"sharedSessionId": strconv.FormatUint(uint64(ss.ID), 10),
-			"saveId":  strconv.FormatUint(uint64(save.ID), 10),
-			"userId":  strconv.FormatUint(uint64(uid), 10),
-			"isAuto":  true,
+		h.Hub.Broadcast(ws.Event{Type: ws.EventSharedSessionSaveUploaded, Payload: ws.SharedSessionSaveUploadedPayload{
+			SharedSessionID: strconv.FormatUint(uint64(ss.ID), 10),
+			SaveID:          strconv.FormatUint(uint64(save.ID), 10),
+			UserID:          strconv.FormatUint(uint64(uid), 10),
+			IsAuto:          true,
 		}})
 	}
 

--- a/server/internal/api/social_handler.go
+++ b/server/internal/api/social_handler.go
@@ -517,6 +517,6 @@ func CreateActivityEvent(database *gorm.DB, hub *ws.Hub, userID uint, eventType 
 	}
 
 	if hub != nil {
-		hub.Broadcast(ws.Event{Type: "activity_new", Payload: resp})
+		hub.Broadcast(ws.Event{Type: ws.EventActivityNew, Payload: resp})
 	}
 }

--- a/server/internal/scraper/worker.go
+++ b/server/internal/scraper/worker.go
@@ -175,7 +175,7 @@ func (w *ScrapeWorker) broadcastProgress(item *db.ScrapeQueueItem, game *db.Game
 		}
 
 		w.hub.Broadcast(ws.Event{
-			Type: "scrape_progress",
+			Type: ws.EventScrapeProgress,
 			Payload: ScrapeProgress{
 				Current:     job.CompletedItems + job.FailedItems,
 				Total:       job.TotalItems,
@@ -191,10 +191,10 @@ func (w *ScrapeWorker) broadcastProgress(item *db.ScrapeQueueItem, game *db.Game
 
 		if jobDone {
 			w.hub.Broadcast(ws.Event{
-				Type: "scrape_complete",
-				Payload: map[string]interface{}{
-					"scraped": job.CompletedItems,
-					"total":   job.TotalItems,
+				Type: ws.EventScrapeComplete,
+				Payload: ws.ScrapeCompletePayload{
+					Scraped: job.CompletedItems,
+					Total:   job.TotalItems,
 				},
 			})
 			if w.onJobComplete != nil {
@@ -210,10 +210,10 @@ func (w *ScrapeWorker) broadcastScrapeStatus(gameID uint, status string) {
 		return
 	}
 	w.hub.Broadcast(ws.Event{
-		Type: "game_scrape_status",
-		Payload: map[string]interface{}{
-			"gameId": gameID,
-			"status": status,
+		Type: ws.EventGameScrapeStatus,
+		Payload: ws.GameScrapeStatusPayload{
+			GameID: gameID,
+			Status: status,
 		},
 	})
 }

--- a/server/internal/websocket/events.go
+++ b/server/internal/websocket/events.go
@@ -1,0 +1,221 @@
+package websocket
+
+// This file defines the canonical WebSocket event type names (as string
+// constants) and the typed payload structs that accompany them. Producers
+// should always use these constants for the Event.Type field and one of the
+// typed payload structs for the Event.Payload field — never literal strings
+// or ad-hoc maps. This gives the compiler a chance to catch typos and
+// field-shape drift at the point of broadcast.
+//
+// The wire format is unchanged: each event is marshalled as
+// {"type": "...", "payload": {...}}. Typed payload structs carry explicit
+// `json:"..."` tags so the rendered JSON matches the legacy gin.H / map
+// shapes byte-for-byte.
+//
+// Some payloads are typed response structs defined in the api package
+// (NetplaySessionResponse, SharedSessionResponse, ActivityEventResponse,
+// etc.); those are passed directly and only the event-type constant is
+// declared here. The scraper package exposes ScrapeProgress and
+// EnrichProgress similarly.
+
+// --- Event type constants ---
+
+const (
+	// Online presence.
+	EventOnlineStatus = "online_status"
+
+	// Game scanner.
+	EventScanStarted  = "scan_started"
+	EventScanProgress = "scan_progress"
+	EventScanComplete = "scan_complete"
+	EventScanError    = "scan_error"
+
+	// Scraper pipeline.
+	EventScrapeStarted     = "scrape_started"
+	EventScrapeProgress    = "scrape_progress"
+	EventScrapeComplete    = "scrape_complete"
+	EventScrapeCancelled   = "scrape_cancelled"
+	EventGameScrapeStatus  = "game_scrape_status"
+
+	// Metadata enrichment.
+	EventEnrichStarted  = "enrich_started"
+	EventEnrichProgress = "enrich_progress"
+	EventEnrichComplete = "enrich_complete"
+	EventEnrichError    = "enrich_error"
+
+	// BIOS downloads.
+	EventBiosDownloadStarted  = "bios_download_started"
+	EventBiosDownloadProgress = "bios_download_progress"
+	EventBiosDownloadComplete = "bios_download_complete"
+
+	// Activity feed.
+	EventActivityNew = "activity_new"
+
+	// Netplay sessions.
+	EventNetplaySessionCreated  = "netplay_session_created"
+	EventNetplayPlayerJoined    = "netplay_player_joined"
+	EventNetplaySettingsUpdated = "netplay_settings_updated"
+	EventNetplaySessionEnded    = "netplay_session_ended"
+	EventNetplaySessionDeleted  = "netplay_session_deleted"
+
+	// Netplay invites.
+	EventNetplayInviteSent     = "netplay_invite_sent"
+	EventNetplayInviteAccepted = "netplay_invite_accepted"
+	EventNetplayInviteDeclined = "netplay_invite_declined"
+
+	// Shared sessions.
+	EventSharedSessionCreated         = "shared_session_created"
+	EventSharedSessionUpdated         = "shared_session_updated"
+	EventSharedSessionDeleted         = "shared_session_deleted"
+	EventSharedSessionInviteSent      = "shared_session_invite_sent"
+	EventSharedSessionInviteAccepted  = "shared_session_invite_accepted"
+	EventSharedSessionInviteDeclined  = "shared_session_invite_declined"
+	EventSharedSessionMemberLeft      = "shared_session_member_left"
+	EventSharedSessionMemberRemoved   = "shared_session_member_removed"
+	EventSharedSessionTurnAcquired    = "shared_session_turn_acquired"
+	EventSharedSessionTurnReleased    = "shared_session_turn_released"
+	EventSharedSessionTurnExpired     = "shared_session_turn_expired"
+	EventSharedSessionSaveUploaded    = "shared_session_save_uploaded"
+
+	// Challenges.
+	EventChallengeLeaderboardUpdated = "challenge_leaderboard_updated"
+)
+
+// --- Typed payloads ---
+
+// OnlineStatusPayload is the payload for EventOnlineStatus.
+// Status is either "online" or "offline".
+type OnlineStatusPayload struct {
+	UserID uint   `json:"userId"`
+	Status string `json:"status"`
+}
+
+// ScrapeStartedPayload is the payload for EventScrapeStarted.
+type ScrapeStartedPayload struct {
+	JobID uint   `json:"jobId"`
+	Total int    `json:"total"`
+	Mode  string `json:"mode"`
+}
+
+// ScrapeCompletePayload is the payload for EventScrapeComplete.
+type ScrapeCompletePayload struct {
+	Scraped int `json:"scraped"`
+	Total   int `json:"total"`
+}
+
+// ScrapeCancelledPayload is the payload for EventScrapeCancelled.
+// JobID is zero when cancellation is not tied to a specific job
+// (for example, pre-empting a queued job before a new one starts).
+type ScrapeCancelledPayload struct {
+	JobID uint `json:"jobId,omitempty"`
+}
+
+// GameScrapeStatusPayload is the payload for EventGameScrapeStatus.
+// Status is typically "scraping" or "idle".
+type GameScrapeStatusPayload struct {
+	GameID uint   `json:"gameId"`
+	Status string `json:"status"`
+}
+
+// EnrichStartedPayload is the payload for EventEnrichStarted.
+type EnrichStartedPayload struct {
+	Total int64 `json:"total"`
+}
+
+// EnrichCompletePayload is the payload for EventEnrichComplete.
+type EnrichCompletePayload struct {
+	Enriched int `json:"enriched"`
+	Total    int `json:"total"`
+}
+
+// BiosDownloadStartedPayload is the payload for EventBiosDownloadStarted.
+type BiosDownloadStartedPayload struct {
+	Total int `json:"total"`
+}
+
+// BiosDownloadCompletePayload is the payload for EventBiosDownloadComplete.
+type BiosDownloadCompletePayload struct {
+	Downloaded int `json:"downloaded"`
+	Skipped    int `json:"skipped"`
+	Failed     int `json:"failed"`
+}
+
+// NetplaySessionEndedPayload is the payload for EventNetplaySessionEnded.
+type NetplaySessionEndedPayload struct {
+	SessionID string `json:"sessionId"`
+	EndReason string `json:"endReason"`
+}
+
+// NetplaySessionDeletedPayload is the payload for EventNetplaySessionDeleted.
+type NetplaySessionDeletedPayload struct {
+	SessionID string `json:"sessionId"`
+}
+
+// NetplayInviteDeclinedPayload is the payload for EventNetplayInviteDeclined.
+type NetplayInviteDeclinedPayload struct {
+	NetplaySessionID string `json:"netplaySessionId"`
+	InviteeID        string `json:"inviteeId"`
+}
+
+// SharedSessionDeletedPayload is the payload for EventSharedSessionDeleted.
+type SharedSessionDeletedPayload struct {
+	SharedSessionID string `json:"sharedSessionId"`
+}
+
+// SharedSessionInviteAcceptedPayload is the payload for EventSharedSessionInviteAccepted.
+type SharedSessionInviteAcceptedPayload struct {
+	SharedSessionID string `json:"sharedSessionId"`
+	UserID          string `json:"userId"`
+	Username        string `json:"username"`
+}
+
+// SharedSessionInviteDeclinedPayload is the payload for EventSharedSessionInviteDeclined.
+type SharedSessionInviteDeclinedPayload struct {
+	SharedSessionID string `json:"sharedSessionId"`
+	InviteeID       string `json:"inviteeId"`
+}
+
+// SharedSessionMemberLeftPayload is the payload for EventSharedSessionMemberLeft.
+type SharedSessionMemberLeftPayload struct {
+	SharedSessionID string `json:"sharedSessionId"`
+	UserID          string `json:"userId"`
+}
+
+// SharedSessionMemberRemovedPayload is the payload for EventSharedSessionMemberRemoved.
+type SharedSessionMemberRemovedPayload struct {
+	SharedSessionID string `json:"sharedSessionId"`
+	UserID          string `json:"userId"`
+}
+
+// SharedSessionTurnAcquiredPayload is the payload for EventSharedSessionTurnAcquired.
+type SharedSessionTurnAcquiredPayload struct {
+	SharedSessionID string `json:"sharedSessionId"`
+	UserID          string `json:"userId"`
+	Username        string `json:"username"`
+}
+
+// SharedSessionTurnReleasedPayload is the payload for EventSharedSessionTurnReleased.
+type SharedSessionTurnReleasedPayload struct {
+	SharedSessionID string `json:"sharedSessionId"`
+	UserID          string `json:"userId"`
+}
+
+// SharedSessionTurnExpiredPayload is the payload for EventSharedSessionTurnExpired.
+type SharedSessionTurnExpiredPayload struct {
+	SharedSessionID string `json:"sharedSessionId"`
+	PreviousUserID  string `json:"previousUserId"`
+}
+
+// SharedSessionSaveUploadedPayload is the payload for EventSharedSessionSaveUploaded.
+type SharedSessionSaveUploadedPayload struct {
+	SharedSessionID string `json:"sharedSessionId"`
+	SaveID          string `json:"saveId"`
+	UserID          string `json:"userId"`
+	IsAuto          bool   `json:"isAuto"`
+}
+
+// ChallengeLeaderboardUpdatedPayload is the payload for
+// EventChallengeLeaderboardUpdated.
+type ChallengeLeaderboardUpdatedPayload struct {
+	ChallengeID string `json:"challengeId"`
+}

--- a/server/internal/websocket/hub.go
+++ b/server/internal/websocket/hub.go
@@ -126,7 +126,7 @@ func (h *Hub) Run() {
 			userID := client.UserID
 			h.mu.Unlock()
 			slog.Info("websocket client connected", "userId", userID)
-			h.Broadcast(Event{Type: "online_status", Payload: map[string]interface{}{"userId": userID, "status": "online"}})
+			h.Broadcast(Event{Type: EventOnlineStatus, Payload: OnlineStatusPayload{UserID: userID, Status: "online"}})
 
 		case client := <-h.unregister:
 			var broadcastOffline bool
@@ -145,7 +145,7 @@ func (h *Hub) Run() {
 			h.mu.Unlock()
 			slog.Info("websocket client disconnected", "userId", userID)
 			if broadcastOffline {
-				h.Broadcast(Event{Type: "online_status", Payload: map[string]interface{}{"userId": userID, "status": "offline"}})
+				h.Broadcast(Event{Type: EventOnlineStatus, Payload: OnlineStatusPayload{UserID: userID, Status: "offline"}})
 			}
 
 		case event := <-h.broadcast:


### PR DESCRIPTION
## Summary
Phase 3 of the API type-safety refactor (see #440).

Replace untyped \`Event.Payload\` construction sites (\`gin.H{}\`, \`map[string]interface{}{}\`) with typed structs, and replace literal event-type strings with named constants.

## What changed
- **New file** \`server/internal/websocket/events.go\`:
  - **31 EventXxx string constants** grouped by domain (scrape pipeline, activity feed, BIOS, netplay sessions, shared sessions, challenges, presence)
  - **22 typed payload structs** for events whose payloads were previously inline maps
- **Updated 41 broadcast call sites** across 11 files

Events whose payloads were already typed (\`NetplaySessionResponse\`, \`SharedSessionResponse\`, \`ActivityEventResponse\`, \`ScrapeProgress\`, etc.) keep the same payload type — only the event-type literal got swapped for the constant.

## Wire format
Unchanged. \`Event{Type string, Payload interface{}}\` envelope and the JSON shape produced by every broadcast are byte-identical.

## Out of scope
\`netplay_hub.go\` (client-to-client signaling via \`json.RawMessage\`, server is just a broker) — left untouched as instructed.

Refs #440.

## Test plan
- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/websocket/... ./internal/api/... ./internal/scraper/...\` passes locally
- [ ] CI passes