### PR TITLE
feat(player): migrate getConsoles() to generated ConsoleResponse

### DIFF
--- a/player/shared/build.gradle.kts
+++ b/player/shared/build.gradle.kts
@@ -49,6 +49,11 @@ kotlin {
                 implementation(libs.ktor.client.logging)
                 implementation(libs.ktor.client.websockets)
 
+                // Generated Kotlin OpenAPI client — models + *Api classes
+                // produced by openapi-generator from the huma spec. See
+                // ../shared-api and scripts/regen-kotlin-api.sh.
+                implementation(project(":shared-api"))
+
                 implementation(libs.sqldelight.coroutines)
 
                 implementation(libs.koin.core)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -155,7 +155,7 @@ class SpelaApiClient(
 
     // Consoles & Games
 
-    suspend fun getConsoles(): List<ConsoleDto> {
+    suspend fun getConsoles(): List<com.spela.client.models.ConsoleResponse> {
         return client.get("$baseUrl/api/consoles").body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -41,6 +41,29 @@ fun ConsoleDto.toDomain(): Console = Console(
     summary = summary,
 )
 
+fun com.spela.client.models.ConsoleResponse.toDomain(): Console = Console(
+    id = id,
+    name = name,
+    abbreviation = abbreviation,
+    gameCount = gameCount.toInt(),
+    code = code,
+    colorTheme = colorTheme,
+    coverAspectRatio = coverAspectRatio,
+    defaultCore = defaultCore,
+    iconUrl = iconUrl,
+    logoUrl = logoPngUrl.ifEmpty { logoUrl },
+    saveStateSupport = saveStateSupport,
+    browserPlayable = browserPlayable,
+    playable = playable,
+    generation = generation.toInt(),
+    makerName = maker.name,
+    makerCode = maker.code,
+    mediaTypeName = mediaType.name,
+    releaseYear = releaseYear?.toInt(),
+    unitsSold = unitsSold,
+    summary = summary,
+)
+
 fun GameDiscDto.toDomain(): GameDisc = GameDisc(
     discNumber = discNumber,
     fileName = fileName,

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -34,6 +34,55 @@ class GameRepositoryImplTest {
     }
 
     @Test
+    fun consoleResponseMapsToDomain() {
+        val now = kotlin.time.Instant.fromEpochSeconds(0)
+        val response = com.spela.client.models.ConsoleResponse(
+            abbreviation = "NES",
+            browserPlayable = false,
+            code = "nintendo-nes",
+            colorTheme = "#e60012",
+            coverAspectRatio = 0.75,
+            createdAt = now,
+            defaultCore = "nestopia",
+            emulatorJsCore = "nes",
+            extensions = listOf("nes"),
+            gameCount = 42L,
+            generation = 3L,
+            iconUrl = "icon",
+            id = "1",
+            logoPngUrl = "logo.png",
+            logoUrl = "logo.svg",
+            maker = com.spela.client.models.HardwareMakerResponse(code = "nintendo", name = "Nintendo"),
+            mediaType = com.spela.client.models.MediaTypeResponse(
+                category = com.spela.client.models.MediaTypeCategoryResponse(code = "cart", name = "Cartridge"),
+                code = "nes-cart",
+                name = "NES Cartridge",
+            ),
+            name = "Nintendo Entertainment System",
+            playable = true,
+            releaseYear = 1983L,
+            saveStateSupport = true,
+            summary = "8-bit classic",
+            unitsSold = 61_900_000L,
+            updatedAt = now,
+        )
+
+        val domain = response.toDomain()
+
+        assertEquals("1", domain.id)
+        assertEquals("Nintendo Entertainment System", domain.name)
+        assertEquals("NES", domain.abbreviation)
+        assertEquals(42, domain.gameCount) // Long -> Int conversion
+        assertEquals(3, domain.generation)
+        assertEquals(1983, domain.releaseYear)
+        assertEquals("Nintendo", domain.makerName)
+        assertEquals("nintendo", domain.makerCode)
+        assertEquals("NES Cartridge", domain.mediaTypeName)
+        assertEquals("logo.png", domain.logoUrl) // logoPngUrl preferred when non-empty
+        assertEquals(61_900_000L, domain.unitsSold)
+    }
+
+    @Test
     fun gameDtoMapsCorrectly() {
         val dto = sampleGames[0]
         val domain = dto.toDomain()

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GameRepositoryOfflineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GameRepositoryOfflineTest.kt
@@ -47,7 +47,12 @@ class GameRepositoryOfflineTest {
                     val path = request.url.encodedPath
                     when {
                         path.endsWith("/api/consoles") -> respond(
-                            """[{"id":"1","name":"NES","abbreviation":"nes","gameCount":5,"colorTheme":"#e74c3c","coverAspectRatio":0.72,"defaultCore":"fceumm","iconUrl":"/images/nes.png","saveStateSupport":true}]""",
+                            // Full ConsoleResponse shape — the generated
+                            // @Required fields are all present; kotlinx-
+                            // serialization's strict mode otherwise rejects
+                            // the payload (unlike the old hand-written
+                            // ConsoleDto, which had defaults everywhere).
+                            """[{"id":"1","name":"NES","abbreviation":"nes","code":"nes","gameCount":5,"colorTheme":"#e74c3c","coverAspectRatio":0.72,"defaultCore":"fceumm","emulatorJsCore":"fceumm","extensions":["nes"],"generation":3,"iconUrl":"/images/nes.png","logoUrl":"/images/nes.svg","logoPngUrl":"/images/nes.png","saveStateSupport":true,"browserPlayable":true,"playable":true,"maker":{"code":"nintendo","name":"Nintendo"},"mediaType":{"code":"cart","name":"Cartridge","category":{"code":"physical","name":"Physical"}},"releaseYear":1983,"summary":"8-bit classic","unitsSold":61900000,"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z"}]""",
                             HttpStatusCode.OK,
                             headersOf(HttpHeaders.ContentType, "application/json"),
                         )


### PR DESCRIPTION
First call-site migration off the hand-written Kotlin DTO layer, stacked on #463 (generated client module). Proves the pattern for subsequent domain migrations in the #461 series.

## Change

`SpelaApiClient.getConsoles()` now returns `List<com.spela.client.models.ConsoleResponse>` (generated from the OpenAPI spec) instead of `List<ConsoleDto>` (hand-written). The ktor call itself is unchanged — only the response type flips.

- `:shared` now depends on `:shared-api` (the generated module added in #463).
- New `ConsoleResponse.toDomain()` mapper in `DtoMappers.kt` handles the Long→Int conversion for `gameCount` / `generation` / `releaseYear` and the now-non-null `maker` / `mediaType` (`@Required` in the OpenAPI spec where the old hand-written `ConsoleDto` had them nullable).
- Old `ConsoleDto` and its mapper stay for now — `ConsoleShowcaseDto.console` still nests `ConsoleDto`, and `/api/explore/consoles/{id}/showcase` hasn't been huma-migrated (no `ConsoleShowcaseResponse` in the spec yet). That's the next showcase-migration PR's job.

## Why this matters

`ConsoleResponse` is derived from Go's `responses.ConsoleResponse`. Any field the server adds, renames, or removes flows through codegen into the Kotlin compiler the moment the spec regenerates — no more silent drift between the server DTO and the hand-rolled Kotlin mirror. Same type-safety story the TypeScript side got in #462.

## Mock JSON update

`GameRepositoryOfflineTest`'s mock `/api/consoles` response had to grow — kotlinx-serialization is strict and the old payload was missing ~half the `@Required` fields the generator emits (`createdAt`, `updatedAt`, `emulatorJsCore`, `generation`, `logoUrl`, `logoPngUrl`, `maker`, `mediaType`, `playable`, `releaseYear`, `summary`, `unitsSold`). The old `ConsoleDto` had defaults that hid this. The new payload matches what the server actually returns.

## Test plan

- [x] `./gradlew :shared:desktopTest` — **459/459 pass** (up 1 from master; adds `consoleResponseMapsToDomain`)
- [x] `./gradlew :shared:compileTestKotlinDesktop` — green
- [x] `./gradlew :shared-api:build` — unchanged, green
- [x] Pre-existing `SessionsUiTest` E2E failures confirmed on master — not caused by this change
- [ ] CI green

Refs #461.