### PR TITLE
feat(player): migrate getCompletionistMap to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -555,7 +555,7 @@ class SpelaApiClient(
     }
 
     /** Returns the user's completionist map (per-console progress) */
-    suspend fun getCompletionistMap(): CompletionistMapResponseDto {
+    suspend fun getCompletionistMap(): com.spela.client.models.CompletionistMapResponse {
         return client.get("$baseUrl/api/user/completionist-map").body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -1055,19 +1055,19 @@ fun ExplorerBadgeDto.toDomain() = ExplorerBadge(
     target = target,
 )
 
-fun CompletionistConsoleDto.toDomain() = CompletionistConsole(
+fun com.spela.client.models.CompletionistConsole.toDomain() = CompletionistConsole(
     id = id,
     name = name,
-    totalGames = totalGames,
-    playedGames = playedGames,
-    percentage = percentage,
+    totalGames = totalGames.toInt(),
+    playedGames = playedGames.toInt(),
+    percentage = percentage.toInt(),
 )
 
-fun CompletionistMapResponseDto.toDomain() = CompletionistMap(
-    consoles = consoles.map { it.toDomain() },
-    totalGames = totalGames,
-    totalPlayed = totalPlayed,
-    overallPct = overallPct,
+fun com.spela.client.models.CompletionistMapResponse.toDomain() = CompletionistMap(
+    consoles = consoles.orEmpty().map { it.toDomain() },
+    totalGames = totalGames.toInt(),
+    totalPlayed = totalPlayed.toInt(),
+    overallPct = overallPct.toInt(),
 )
 
 // --- Global Search mappers ---

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1715,22 +1715,10 @@ data class ExplorerBadgesResponseDto(
     val badges: List<ExplorerBadgeDto>,
 )
 
-@Serializable
-data class CompletionistConsoleDto(
-    val id: String,
-    val name: String,
-    val totalGames: Int,
-    val playedGames: Int,
-    val percentage: Int,
-)
-
-@Serializable
-data class CompletionistMapResponseDto(
-    val consoles: List<CompletionistConsoleDto>,
-    val totalGames: Int,
-    val totalPlayed: Int,
-    val overallPct: Int,
-)
+// CompletionistConsoleDto and CompletionistMapResponseDto moved to
+// com.spela.client.models.CompletionistConsole and
+// com.spela.client.models.CompletionistMapResponse — see
+// player/shared-api/ (generated from the OpenAPI spec).
 
 // --- Global Search ---
 

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -34,6 +34,53 @@ class GameRepositoryImplTest {
     }
 
     @Test
+    fun completionistMapResponseMapsToDomain() {
+        val response = com.spela.client.models.CompletionistMapResponse(
+            consoles = listOf(
+                com.spela.client.models.CompletionistConsole(
+                    id = "nes",
+                    name = "NES",
+                    percentage = 75L,
+                    playedGames = 15L,
+                    totalGames = 20L,
+                ),
+                com.spela.client.models.CompletionistConsole(
+                    id = "snes",
+                    name = "SNES",
+                    percentage = 50L,
+                    playedGames = 10L,
+                    totalGames = 20L,
+                ),
+            ),
+            overallPct = 62L,
+            totalGames = 40L,
+            totalPlayed = 25L,
+        )
+
+        val domain = response.toDomain()
+
+        assertEquals(2, domain.consoles.size)
+        assertEquals("nes", domain.consoles[0].id)
+        assertEquals(75, domain.consoles[0].percentage) // Long -> Int
+        assertEquals(15, domain.consoles[0].playedGames)
+        assertEquals(40, domain.totalGames)
+        assertEquals(25, domain.totalPlayed)
+        assertEquals(62, domain.overallPct)
+    }
+
+    @Test
+    fun completionistMapResponseHandlesNullConsolesList() {
+        val response = com.spela.client.models.CompletionistMapResponse(
+            consoles = null,
+            overallPct = 0L,
+            totalGames = 0L,
+            totalPlayed = 0L,
+        )
+        val domain = response.toDomain()
+        assertTrue(domain.consoles.isEmpty())
+    }
+
+    @Test
     fun consoleResponseMapsToDomain() {
         val now = kotlin.time.Instant.fromEpochSeconds(0)
         val response = com.spela.client.models.ConsoleResponse(


### PR DESCRIPTION
Second call-site migration in the #461 series. Same pattern as #464 — swap one hand-written Kotlin DTO for the generated `com.spela.client.models.*` type.

**Note:** makers isn't a standalone call in the player (only nested in `ConsoleDto`), so I picked another small self-contained endpoint for this migration.

## Change

- `SpelaApiClient.getCompletionistMap()` returns `com.spela.client.models.CompletionistMapResponse` instead of `CompletionistMapResponseDto`.
- New mappers `CompletionistConsole.toDomain()` and `CompletionistMapResponse.toDomain()` in `DtoMappers.kt`. Fully qualified on the generated type because the domain model shares the name (`com.spela.player.domain.model.CompletionistConsole`). Handles the Long→Int conversion on `percentage` / `totalGames` / `playedGames` / `overallPct` and the nullable generated consoles list via `orEmpty()`.
- Deleted `CompletionistConsoleDto` + `CompletionistMapResponseDto` from `Dtos.kt` — neither was nested in any other hand-written DTO, so they drop cleanly. Breadcrumb comment points to the generated location.
- Two new tests: `completionistMapResponseMapsToDomain` (Long→Int conversion) and `completionistMapResponseHandlesNullConsolesList` (edge case for the spec's `List<…>?` nullability).

## Test plan

- [x] `./gradlew :shared:desktopTest` — **461/461 pass** (up 2 from master)
- [x] `./run-desktop-tests.sh` — same
- [x] Pre-existing `SessionsUiTest` E2E failures unchanged from master
- [ ] CI green

Refs #461.