### PR TITLE
feat(player): migrate ratings endpoints to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -803,24 +803,33 @@ class SpelaApiClient(
 
     // Ratings
 
-    suspend fun rateGame(gameId: String, request: RateGameRequest): GameRatingDto {
+    suspend fun rateGame(
+        gameId: String,
+        request: com.spela.client.models.CreateOrUpdateRatingRequest,
+    ): com.spela.client.models.GameRatingResponse {
         return client.post("$baseUrl/api/games/$gameId/ratings") {
             setBody(request)
         }.body()
     }
 
-    suspend fun getGameRatings(gameId: String, page: Int = 1, pageSize: Int = 20): GameRatingsResponse {
+    suspend fun getGameRatings(
+        gameId: String,
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): com.spela.client.models.PaginatedResponseGameRatingResponse {
         return client.get("$baseUrl/api/games/$gameId/ratings") {
             parameter("page", page)
             parameter("pageSize", pageSize)
         }.body()
     }
 
-    suspend fun getGameRatingSummary(gameId: String): RatingSummaryDto {
+    suspend fun getGameRatingSummary(
+        gameId: String,
+    ): com.spela.client.models.RatingSummaryResponse {
         return client.get("$baseUrl/api/games/$gameId/ratings/summary").body()
     }
 
-    suspend fun getMyRating(gameId: String): GameRatingDto {
+    suspend fun getMyRating(gameId: String): com.spela.client.models.GameRatingResponse {
         return client.get("$baseUrl/api/games/$gameId/ratings/mine").body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -196,21 +196,23 @@ fun SharedSaveStateDto.toDomain(): SharedSaveState = SharedSaveState(
     createdAt = createdAt,
 )
 
-fun GameRatingDto.toDomain(): GameRating = GameRating(
+fun com.spela.client.models.GameRatingResponse.toDomain(): GameRating = GameRating(
     id = id,
     userId = userId,
     username = username,
     avatarUrl = avatarUrl,
     gameId = gameId,
-    rating = rating,
-    review = review,
-    createdAt = createdAt,
+    rating = rating.toInt(),
+    review = review.orEmpty(),
+    createdAt = createdAt.toString(),
 )
 
-fun RatingSummaryDto.toDomain(): RatingSummary = RatingSummary(
+fun com.spela.client.models.RatingSummaryResponse.toDomain(): RatingSummary = RatingSummary(
     averageRating = averageRating,
     totalRatings = totalRatings,
-    distribution = distribution.mapKeys { it.key.toIntOrNull() ?: 0 },
+    distribution = distribution.entries.associate {
+        (it.key.toIntOrNull() ?: 0) to it.value.toInt()
+    },
 )
 
 fun OnlineUserGameDto.toDomain(): OnlineUserGame = OnlineUserGame(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -312,39 +312,10 @@ data class SharedSavesResponse(
 
 // Ratings
 
-@Serializable
-data class RateGameRequest(
-    val rating: Int,
-    val review: String = "",
-)
-
-@Serializable
-data class GameRatingDto(
-    val id: String,
-    val userId: String,
-    val username: String,
-    val avatarUrl: String? = null,
-    val gameId: String,
-    val rating: Int,
-    val review: String = "",
-    val createdAt: String = "",
-    val updatedAt: String = "",
-)
-
-@Serializable
-data class GameRatingsResponse(
-    val data: List<GameRatingDto> = emptyList(),
-    val total: Long = 0,
-    val page: Int = 1,
-    val pageSize: Int = 20,
-)
-
-@Serializable
-data class RatingSummaryDto(
-    val averageRating: Double = 0.0,
-    val totalRatings: Long = 0,
-    val distribution: Map<String, Int> = emptyMap(),
-)
+// RateGameRequest / GameRatingDto / GameRatingsResponse / RatingSummaryDto
+// replaced by CreateOrUpdateRatingRequest / GameRatingResponse /
+// PaginatedResponseGameRatingResponse / RatingSummaryResponse in
+// com.spela.client.models (see player/shared-api/).
 
 // Social
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/RatingRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/RatingRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.spela.player.data.repository
 
+import com.spela.client.models.CreateOrUpdateRatingRequest
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.data.remote.dto.RateGameRequest
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.GameRating
 import com.spela.player.domain.model.RatingSummary
@@ -12,13 +12,13 @@ class RatingRepositoryImpl(
 ) : RatingRepository {
 
     override suspend fun rateGame(gameId: String, rating: Int, review: String): Result<GameRating> = runCatching {
-        val request = RateGameRequest(rating = rating, review = review)
+        val request = CreateOrUpdateRatingRequest(rating = rating.toLong(), review = review)
         val dto = apiClient.rateGame(gameId, request)
         dto.toDomain().resolveUrls()
     }
 
     override suspend fun getGameRatings(gameId: String, page: Int, pageSize: Int): Result<List<GameRating>> = runCatching {
-        apiClient.getGameRatings(gameId, page = page, pageSize = pageSize).data.map {
+        apiClient.getGameRatings(gameId, page = page, pageSize = pageSize).data.orEmpty().map {
             it.toDomain().resolveUrls()
         }
     }

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -81,6 +81,65 @@ class GameRepositoryImplTest {
     }
 
     @Test
+    fun gameRatingResponseMapsToDomain() {
+        val createdAt = kotlin.time.Instant.fromEpochSeconds(1_700_000_000)
+        val response = com.spela.client.models.GameRatingResponse(
+            createdAt = createdAt,
+            gameId = "42",
+            id = "r1",
+            rating = 4L,
+            updatedAt = createdAt,
+            userId = "u1",
+            username = "mattias",
+            avatarUrl = "/avatars/mattias.png",
+            review = "Great game",
+        )
+
+        val domain = response.toDomain()
+
+        assertEquals("r1", domain.id)
+        assertEquals("u1", domain.userId)
+        assertEquals("42", domain.gameId)
+        assertEquals(4, domain.rating) // Long -> Int
+        assertEquals("Great game", domain.review)
+        assertEquals("/avatars/mattias.png", domain.avatarUrl)
+        assertEquals(createdAt.toString(), domain.createdAt)
+    }
+
+    @Test
+    fun gameRatingResponseHandlesNullReview() {
+        val now = kotlin.time.Instant.fromEpochSeconds(0)
+        val response = com.spela.client.models.GameRatingResponse(
+            createdAt = now,
+            gameId = "42",
+            id = "r1",
+            rating = 3L,
+            updatedAt = now,
+            userId = "u1",
+            username = "mattias",
+            review = null,
+        )
+        assertEquals("", response.toDomain().review)
+    }
+
+    @Test
+    fun ratingSummaryResponseMapsToDomain() {
+        val response = com.spela.client.models.RatingSummaryResponse(
+            averageRating = 4.25,
+            distribution = mapOf("1" to 1L, "2" to 2L, "3" to 5L, "4" to 10L, "5" to 20L),
+            totalRatings = 38L,
+        )
+
+        val domain = response.toDomain()
+
+        assertEquals(4.25, domain.averageRating)
+        assertEquals(38L, domain.totalRatings)
+        assertEquals(5, domain.distribution.size)
+        assertEquals(20, domain.distribution[5]) // String "5" -> Int 5 key, Long 20 -> Int 20 value
+        assertEquals(1, domain.distribution[1])
+    }
+
+    @Test
     fun consoleResponseMapsToDomain() {
         val now = kotlin.time.Instant.fromEpochSeconds(0)
         val response = com.spela.client.models.ConsoleResponse(


### PR DESCRIPTION
Third call-site migration in the #461 series. Covers the full ratings surface — four API methods and five hand-written DTOs replaced in one PR because they only talk to each other and nothing outside.

## Change

- `SpelaApiClient.rateGame()` → takes `CreateOrUpdateRatingRequest`, returns `GameRatingResponse`
- `SpelaApiClient.getGameRatings()` → returns `PaginatedResponseGameRatingResponse`
- `SpelaApiClient.getGameRatingSummary()` → returns `RatingSummaryResponse`
- `SpelaApiClient.getMyRating()` → returns `GameRatingResponse`
- `RatingRepositoryImpl` updated for the generated request type (`rating` is `Long?` in the spec, so repo does `rating.toLong()`) and the nullable paginated `data` list (`.orEmpty()`)
- New mappers `GameRatingResponse.toDomain()` and `RatingSummaryResponse.toDomain()` — handle Long→Int rating, nullable review via `orEmpty()`, `Instant`→String for `createdAt`, and `Map<String, Long>`→`Map<Int, Int>` for the distribution
- Deleted `RateGameRequest`, `GameRatingDto`, `GameRatingsResponse`, `RatingSummaryDto` from `Dtos.kt` — not nested anywhere, clean removal

## Test plan

- [x] `./gradlew :shared:desktopTest` — **464/464 pass** (up 3 from master: rating mapper tests + null-review edge case + distribution conversion)
- [x] `./run-desktop-tests.sh` — same
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.