### PR TITLE
feat(player): migrate getExplorerBadges to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -550,7 +550,7 @@ class SpelaApiClient(
     }
 
     /** Returns the user's explorer badges */
-    suspend fun getExplorerBadges(): ExplorerBadgesResponseDto {
+    suspend fun getExplorerBadges(): com.spela.client.models.ExplorerBadgesResponse {
         return client.get("$baseUrl/api/user/explorer-badges").body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -1047,14 +1047,14 @@ fun WizardResultsResponseDto.toDomain() = WizardResults(
     title = title,
 )
 
-fun ExplorerBadgeDto.toDomain() = ExplorerBadge(
+fun com.spela.client.models.ExplorerBadge.toDomain() = ExplorerBadge(
     id = id,
     name = name,
     description = description,
     icon = icon,
     earned = earned,
-    progress = progress,
-    target = target,
+    progress = progress.toInt(),
+    target = target.toInt(),
 )
 
 fun com.spela.client.models.CompletionistConsole.toDomain() = CompletionistConsole(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1670,21 +1670,10 @@ data class WizardResultsResponseDto(
     val title: String,
 )
 
-@Serializable
-data class ExplorerBadgeDto(
-    val id: String,
-    val name: String,
-    val description: String,
-    val icon: String,
-    val earned: Boolean,
-    val progress: Int,
-    val target: Int,
-)
-
-@Serializable
-data class ExplorerBadgesResponseDto(
-    val badges: List<ExplorerBadgeDto>,
-)
+// ExplorerBadgeDto and ExplorerBadgesResponseDto replaced by
+// com.spela.client.models.ExplorerBadge and
+// com.spela.client.models.ExplorerBadgesResponse
+// (see player/shared-api/).
 
 // CompletionistConsoleDto and CompletionistMapResponseDto moved to
 // com.spela.client.models.CompletionistConsole and

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -426,7 +426,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getExplorerBadges(): Result<List<ExplorerBadge>> = runCatching {
-        apiClient.getExplorerBadges().badges.map { it.toDomain() }
+        apiClient.getExplorerBadges().badges.orEmpty().map { it.toDomain() }
     }
 
     override suspend fun getCompletionistMap(): Result<CompletionistMap> = runCatching {

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -81,6 +81,28 @@ class GameRepositoryImplTest {
     }
 
     @Test
+    fun explorerBadgeMapsToDomain() {
+        val generated = com.spela.client.models.ExplorerBadge(
+            description = "Played 100 games",
+            earned = true,
+            icon = "trophy",
+            id = "centurion",
+            name = "Centurion",
+            progress = 100L,
+            target = 100L,
+        )
+
+        val domain = generated.toDomain()
+
+        assertEquals("centurion", domain.id)
+        assertEquals("Centurion", domain.name)
+        assertEquals("Played 100 games", domain.description)
+        assertTrue(domain.earned)
+        assertEquals(100, domain.progress) // Long -> Int
+        assertEquals(100, domain.target)
+    }
+
+    @Test
     fun gameRatingResponseMapsToDomain() {
         val createdAt = kotlin.time.Instant.fromEpochSeconds(1_700_000_000)
         val response = com.spela.client.models.GameRatingResponse(


### PR DESCRIPTION
Fourth call-site migration in the #461 series. (Branch name is a legacy from scouting — this PR is explorer-badges, not favorites.)

## Change

- `SpelaApiClient.getExplorerBadges()` returns `com.spela.client.models.ExplorerBadgesResponse` instead of `ExplorerBadgesResponseDto`.
- `ExploreRepositoryImpl.getExplorerBadges()` handles the nullable `badges` list via `.orEmpty()` (spec says `List<ExplorerBadge>?`).
- `com.spela.client.models.ExplorerBadge.toDomain()` replaces the old DTO mapper. Fully qualified because the domain model shares the name. Long→Int for `progress` / `target`.
- Deleted `ExplorerBadgeDto` and `ExplorerBadgesResponseDto` — not nested in any other hand-written DTO, clean removal.
- `explorerBadgeMapsToDomain` test in `GameRepositoryImplTest` covers the Long→Int conversion.

## Test plan

- [x] `./gradlew :shared:desktopTest` — **465/465 pass** (up 1 from master)
- [x] `./run-desktop-tests.sh` — same
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.