### PR TITLE
feat(player): migrate themes + keywords to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -290,7 +290,7 @@ class SpelaApiClient(
     }
 
     /** Returns all themes with game counts, sorted by count DESC */
-    suspend fun getThemes(): List<ThemeDto> {
+    suspend fun getThemes(): List<com.spela.client.models.ThemeResponse> {
         return client.get("$baseUrl/api/themes").body()
     }
 
@@ -303,7 +303,7 @@ class SpelaApiClient(
     }
 
     /** Returns top keywords by game count */
-    suspend fun getKeywords(limit: Int = 50): List<KeywordDto> {
+    suspend fun getKeywords(limit: Int = 50): List<com.spela.client.models.KeywordResponse> {
         return client.get("$baseUrl/api/keywords") {
             parameter("limit", limit)
         }.body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -681,16 +681,16 @@ fun ExploreRowDto.toDomain(): ExploreRow = ExploreRow(
     games = games.map { it.toDomain() },
 )
 
-fun ThemeDto.toDomain(): Theme = Theme(
+fun com.spela.client.models.ThemeResponse.toDomain(): Theme = Theme(
     id = id,
     name = name,
-    gameCount = gameCount,
+    gameCount = gameCount.toInt(),
 )
 
-fun KeywordDto.toDomain(): Keyword = Keyword(
+fun com.spela.client.models.KeywordResponse.toDomain(): Keyword = Keyword(
     id = id,
     name = name,
-    gameCount = gameCount,
+    gameCount = gameCount.toInt(),
 )
 
 fun FeaturedSeriesDto.toDomain(): FeaturedSeries = FeaturedSeries(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1137,21 +1137,9 @@ data class ExploreRowsResponseDto(
     val rows: List<ExploreRowDto>,
 )
 
-// Themes & Keywords
-
-@Serializable
-data class ThemeDto(
-    val id: String,
-    val name: String,
-    val gameCount: Int = 0,
-)
-
-@Serializable
-data class KeywordDto(
-    val id: String,
-    val name: String,
-    val gameCount: Int = 0,
-)
+// Themes & Keywords — ThemeDto / KeywordDto replaced by
+// com.spela.client.models.ThemeResponse / KeywordResponse
+// (see player/shared-api/).
 
 // Series & Franchise
 

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -81,6 +81,32 @@ class GameRepositoryImplTest {
     }
 
     @Test
+    fun themeResponseMapsToDomain() {
+        val response = com.spela.client.models.ThemeResponse(
+            gameCount = 42L,
+            id = "action",
+            name = "Action",
+        )
+        val domain = response.toDomain()
+        assertEquals("action", domain.id)
+        assertEquals("Action", domain.name)
+        assertEquals(42, domain.gameCount) // Long -> Int
+    }
+
+    @Test
+    fun keywordResponseMapsToDomain() {
+        val response = com.spela.client.models.KeywordResponse(
+            gameCount = 7L,
+            id = "time-travel",
+            name = "Time Travel",
+        )
+        val domain = response.toDomain()
+        assertEquals("time-travel", domain.id)
+        assertEquals("Time Travel", domain.name)
+        assertEquals(7, domain.gameCount)
+    }
+
+    @Test
     fun explorerBadgeMapsToDomain() {
         val generated = com.spela.client.models.ExplorerBadge(
             description = "Played 100 games",


### PR DESCRIPTION
Fifth call-site migration in the #461 series. Bundles two small public-read endpoints (themes + keywords) because they share the exact same shape — `(id, name, gameCount)` — and the mappers are nearly identical.

## Change

- `SpelaApiClient.getThemes()` returns `List<com.spela.client.models.ThemeResponse>` (was `List<ThemeDto>`)
- `SpelaApiClient.getKeywords(limit)` returns `List<com.spela.client.models.KeywordResponse>` (was `List<KeywordDto>`)
- Replaced `ThemeDto.toDomain()` / `KeywordDto.toDomain()` with extensions on the generated types. Long→Int for `gameCount`.
- Deleted `ThemeDto` and `KeywordDto` — not nested in any other hand-written DTO, clean removal.
- Two new tests in `GameRepositoryImplTest` covering each mapper.

## Test plan

- [x] `./gradlew :shared:desktopTest` — **467/467 pass** (up 2 from master)
- [x] `./run-desktop-tests.sh` — same
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.