### PR TITLE
feat(player): migrate BIOS status to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -729,7 +729,7 @@ class SpelaApiClient(
 
     // BIOS
 
-    suspend fun getBiosStatus(): BiosStatusResponse {
+    suspend fun getBiosStatus(): com.spela.client.models.BiosListResponse {
         return client.get("$baseUrl/api/bios").body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -544,49 +544,13 @@ data class SharedSessionInvitationCountResponse(
     val count: Int = 0,
 )
 
-// BIOS
-
-@Serializable
-data class BiosFileDto(
-    val name: String,
-    val size: Long,
-    val md5: String? = null,
-    val subDir: String? = null,
-    val consoleId: String? = null,
-    val consoleName: String? = null,
-    val description: String? = null,
-    val required: Boolean = false,
-    val status: String = "present",
-)
-
-@Serializable
-data class BiosConsoleDto(
-    val consoleId: String,
-    val consoleName: String,
-    val biosRequired: Boolean = false,
-    val status: String = "not_required",
-    val requiredPresent: Int = 0,
-    val requiredTotal: Int = 0,
-    val optionalPresent: Int = 0,
-    val optionalTotal: Int = 0,
-    val files: List<BiosConsoleFileDto> = emptyList(),
-)
-
-@Serializable
-data class BiosConsoleFileDto(
-    val fileName: String,
-    val description: String = "",
-    val required: Boolean = false,
-    val md5: String? = null,
-    val status: String = "missing",
-    val subDir: String? = null,
-)
-
-@Serializable
-data class BiosStatusResponse(
-    val files: List<BiosFileDto> = emptyList(),
-    val consoles: List<BiosConsoleDto> = emptyList(),
-)
+// BIOS — BiosFileDto / BiosConsoleDto / BiosConsoleFileDto /
+// BiosStatusResponse replaced by:
+//   com.spela.client.models.BiosFileResponse
+//   com.spela.client.models.ConsoleBiosStatus
+//   com.spela.client.models.ConsoleFileStatus
+//   com.spela.client.models.BiosListResponse
+// (see player/shared-api/).
 
 // Collections
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/BiosRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/BiosRepository.kt
@@ -1,7 +1,7 @@
 package com.spela.player.data.repository
 
+import com.spela.client.models.BiosListResponse
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.data.remote.dto.BiosStatusResponse
 import com.spela.player.domain.model.BiosConsoleStatus
 import com.spela.player.domain.model.BiosMissingFile
 import com.spela.player.util.FileStorage
@@ -10,11 +10,11 @@ open class BiosRepository(
     private val apiClient: SpelaApiClient,
     private val fileStorage: FileStorage,
 ) {
-    private var cachedBiosStatus: BiosStatusResponse? = null
+    private var cachedBiosStatus: BiosListResponse? = null
 
     open suspend fun syncBiosFiles() {
         val serverFiles = try {
-            apiClient.getBiosStatus().files
+            apiClient.getBiosStatus().files.orEmpty()
         } catch (e: Exception) {
             return // Server may not support BIOS yet
         }
@@ -42,7 +42,7 @@ open class BiosRepository(
     /**
      * Fetches enriched BIOS status from the server. Caches the result.
      */
-    open suspend fun fetchBiosStatus(): BiosStatusResponse? {
+    open suspend fun fetchBiosStatus(): BiosListResponse? {
         return try {
             val status = apiClient.getBiosStatus()
             cachedBiosStatus = status
@@ -53,7 +53,7 @@ open class BiosRepository(
         }
     }
 
-    fun getCachedBiosStatus(): BiosStatusResponse? = cachedBiosStatus
+    fun getCachedBiosStatus(): BiosListResponse? = cachedBiosStatus
 
     /**
      * Returns the BIOS status for a given console. Checks which required files
@@ -61,10 +61,10 @@ open class BiosRepository(
      */
     open suspend fun getConsoleStatus(consoleId: String): BiosConsoleStatus? {
         val status = cachedBiosStatus ?: fetchBiosStatus() ?: return null
-        val console = status.consoles.find { it.consoleId == consoleId } ?: return null
+        val console = status.consoles.orEmpty().find { it.consoleId == consoleId } ?: return null
         val biosDir = fileStorage.getBiosDir()
 
-        val missingFiles = console.files
+        val missingFiles = console.files.orEmpty()
             .filter { it.required && it.status == "missing" }
             .map { BiosMissingFile(it.fileName, it.description, it.required, it.subDir) }
 
@@ -129,10 +129,10 @@ open class BiosRepository(
         val localFiles = getLocalBiosFiles()
         val biosDir = fileStorage.getBiosDir()
 
-        return status.consoles
+        return status.consoles.orEmpty()
             .filter { it.biosRequired && it.status == "missing" }
             .mapNotNull { console ->
-                val missingFiles = console.files
+                val missingFiles = console.files.orEmpty()
                     .filter { it.required && it.status == "missing" }
                     .filter { file ->
                         val localPath = if (!file.subDir.isNullOrEmpty()) {


### PR DESCRIPTION
Sixth call-site migration in the #461 series. Swaps four hand-written BIOS DTOs for their generated counterparts — unusually clean because the hand-written names matched the spec names 1:1.

## Change

- `SpelaApiClient.getBiosStatus()` returns `com.spela.client.models.BiosListResponse` (was `BiosStatusResponse`).
- `BiosRepository`:
  - `cachedBiosStatus` typed as `BiosListResponse`
  - `.files` / `.consoles` / inner `.files` all use `.orEmpty()` for the spec's `List<…>?` nullability — no other changes because field names already match (`fileName`, `description`, `required`, `status`, `subDir`, `consoleId`, `consoleName`, `biosRequired`).
- Deleted `BiosFileDto` / `BiosConsoleDto` / `BiosConsoleFileDto` / `BiosStatusResponse` from `Dtos.kt`. Not nested anywhere outside this cluster, clean removal.
- **No mapper needed** — `BiosRepository` consumes response fields directly to build the domain `BiosConsoleStatus` / `BiosMissingFile` without a translation step. Just a type swap.

## Test plan

- [x] `./gradlew :shared:desktopTest` — **467/467 pass** (same as master after #468)
- [x] `./run-desktop-tests.sh` — same
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.