### PR TITLE
feat(player): migrate RA account endpoints to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -883,11 +883,13 @@ class SpelaApiClient(
 
     // RetroAchievements
 
-    suspend fun getRAStatus(): RAStatusDto {
+    suspend fun getRAStatus(): com.spela.client.models.RAStatusResponse {
         return client.get("$baseUrl/api/user/ra/status").body()
     }
 
-    suspend fun linkRA(request: RALinkRequestDto): RAStatusDto {
+    suspend fun linkRA(
+        request: com.spela.client.models.LinkRAAccountRequest,
+    ): com.spela.client.models.RAStatusResponse {
         return client.post("$baseUrl/api/user/ra/link") {
             setBody(request)
         }.body()
@@ -897,11 +899,13 @@ class SpelaApiClient(
         client.delete("$baseUrl/api/user/ra/link")
     }
 
-    suspend fun getRAToken(): RATokenResponseDto {
+    suspend fun getRAToken(): com.spela.client.models.RATokenResponse {
         return client.get("$baseUrl/api/user/ra/token").body()
     }
 
-    suspend fun updateRASettings(request: RASettingsRequestDto): RAStatusDto {
+    suspend fun updateRASettings(
+        request: com.spela.client.models.UpdateRASettingsRequest,
+    ): com.spela.client.models.RAStatusResponse {
         return client.put("$baseUrl/api/user/ra/settings") {
             setBody(request)
         }.body()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -371,29 +371,12 @@ data class CoreNameResponse(
 
 // RetroAchievements
 
-@Serializable
-data class RAStatusDto(
-    val linked: Boolean = false,
-    val username: String = "",
-    val hardcoreEnabled: Boolean = false,
-)
-
-@Serializable
-data class RALinkRequestDto(
-    val username: String,
-    val password: String,
-)
-
-@Serializable
-data class RATokenResponseDto(
-    val username: String,
-    val token: String,
-)
-
-@Serializable
-data class RASettingsRequestDto(
-    val hardcoreEnabled: Boolean,
-)
+// RA DTOs replaced by generated counterparts in
+// com.spela.client.models — see player/shared-api/:
+//   RAStatusDto           -> RAStatusResponse
+//   RALinkRequestDto      -> LinkRAAccountRequest
+//   RATokenResponseDto    -> RATokenResponse
+//   RASettingsRequestDto  -> UpdateRASettingsRequest
 
 // Public Profile
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/AchievementsRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/AchievementsRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package com.spela.player.data.repository
 
+import com.spela.client.models.LinkRAAccountRequest
+import com.spela.client.models.UpdateRASettingsRequest
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.data.remote.dto.RALinkRequestDto
-import com.spela.player.data.remote.dto.RASettingsRequestDto
 import com.spela.player.domain.model.RACredentials
 import com.spela.player.domain.model.RAStatus
 import com.spela.player.domain.repository.AchievementsRepository
@@ -16,7 +16,7 @@ class AchievementsRepositoryImpl(
     }
 
     override suspend fun linkRA(username: String, password: String): Result<RAStatus> = runCatching {
-        val dto = apiClient.linkRA(RALinkRequestDto(username, password))
+        val dto = apiClient.linkRA(LinkRAAccountRequest(username = username, password = password))
         RAStatus(linked = dto.linked, username = dto.username, hardcoreEnabled = dto.hardcoreEnabled)
     }
 
@@ -30,7 +30,7 @@ class AchievementsRepositoryImpl(
     }
 
     override suspend fun updateRASettings(hardcoreEnabled: Boolean): Result<RAStatus> = runCatching {
-        val dto = apiClient.updateRASettings(RASettingsRequestDto(hardcoreEnabled))
+        val dto = apiClient.updateRASettings(UpdateRASettingsRequest(hardcoreEnabled = hardcoreEnabled))
         RAStatus(linked = dto.linked, username = dto.username, hardcoreEnabled = dto.hardcoreEnabled)
     }
 }


### PR DESCRIPTION
Seventh call-site migration in the #461 series. Covers the RetroAchievements account-management surface — status, link, unlink, token, settings.

## Change

- `SpelaApiClient`: five RA methods now use generated types:
  - `getRAStatus()` → `RAStatusResponse`
  - `linkRA(LinkRAAccountRequest)` → `RAStatusResponse`
  - `getRAToken()` → `RATokenResponse`
  - `updateRASettings(UpdateRASettingsRequest)` → `RAStatusResponse`
  - `unlinkRA()` unchanged (void)
- `AchievementsRepositoryImpl` constructs `LinkRAAccountRequest` and `UpdateRASettingsRequest` with named args — both have nullable fields in the spec (spec marks `username`, `password`, `hardcoreEnabled` as optional even though huma treats them as required on the server side). The repository already reads fields directly to construct domain `RAStatus`, so no mapper layer needed.
- Deleted `RAStatusDto` / `RALinkRequestDto` / `RATokenResponseDto` / `RASettingsRequestDto` from `Dtos.kt`. Not nested anywhere, clean removal.

## Test plan

- [x] `./gradlew :shared:desktopTest` — **467/467 pass**
- [x] `./run-desktop-tests.sh` — same
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.