### PR TITLE
feat(player): migrate shared-saves to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -772,14 +772,23 @@ class SpelaApiClient(
 
     // Shared Saves
 
-    suspend fun getSharedSaves(gameId: String, page: Int = 1, pageSize: Int = 20): SharedSavesResponse {
+    suspend fun getSharedSaves(
+        gameId: String,
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): com.spela.client.models.PaginatedResponseSharedSaveResponse {
         return client.get("$baseUrl/api/games/$gameId/shared-saves") {
             parameter("page", page)
             parameter("pageSize", pageSize)
         }.body()
     }
 
-    suspend fun shareSave(gameId: String, name: String, description: String, data: ByteArray): SharedSaveStateDto {
+    suspend fun shareSave(
+        gameId: String,
+        name: String,
+        description: String,
+        data: ByteArray,
+    ): com.spela.client.models.SharedSaveResponse {
         return client.submitFormWithBinaryData(
             url = "$baseUrl/api/games/$gameId/shared-saves",
             formData = formData {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -183,17 +183,17 @@ fun UserPreferencesDto.toDomain(): UserPreferences = UserPreferences(
     defaultSecondScreenPage = defaultSecondScreenPage,
 )
 
-fun SharedSaveStateDto.toDomain(): SharedSaveState = SharedSaveState(
+fun com.spela.client.models.SharedSaveResponse.toDomain(): SharedSaveState = SharedSaveState(
     id = id,
     userId = userId,
     username = username,
     userAvatarUrl = avatarUrl,
     gameId = gameId,
     name = name,
-    description = description,
+    description = description.orEmpty(),
     fileSize = fileSize,
-    downloadCount = downloadCount,
-    createdAt = createdAt,
+    downloadCount = downloadCount.toInt(),
+    createdAt = createdAt.toString(),
 )
 
 fun com.spela.client.models.GameRatingResponse.toDomain(): GameRating = GameRating(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -287,28 +287,9 @@ data class UpdateDevicePreferencesRequest(
 
 // Shared Saves
 
-@Serializable
-data class SharedSaveStateDto(
-    val id: String,
-    val userId: String,
-    val username: String,
-    val avatarUrl: String? = null,
-    val gameId: String,
-    val name: String,
-    val description: String = "",
-    val fileSize: Long = 0,
-    val screenshotUrl: String? = null,
-    val downloadCount: Int = 0,
-    val createdAt: String = "",
-)
-
-@Serializable
-data class SharedSavesResponse(
-    val data: List<SharedSaveStateDto> = emptyList(),
-    val total: Long = 0,
-    val page: Int = 1,
-    val pageSize: Int = 20,
-)
+// SharedSaveStateDto / SharedSavesResponse replaced by
+// com.spela.client.models.SharedSaveResponse /
+// PaginatedResponseSharedSaveResponse (see player/shared-api/).
 
 // Ratings
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSaveRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSaveRepositoryImpl.kt
@@ -10,7 +10,7 @@ class SharedSaveRepositoryImpl(
 ) : SharedSaveRepository {
 
     override suspend fun getSharedSaves(gameId: String, page: Int, pageSize: Int): Result<List<SharedSaveState>> = runCatching {
-        apiClient.getSharedSaves(gameId, page = page, pageSize = pageSize).data.map { dto ->
+        apiClient.getSharedSaves(gameId, page = page, pageSize = pageSize).data.orEmpty().map { dto ->
             val save = dto.toDomain()
             save.copy(userAvatarUrl = apiClient.resolveUrl(save.userAvatarUrl))
         }

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -81,6 +81,48 @@ class GameRepositoryImplTest {
     }
 
     @Test
+    fun sharedSaveResponseMapsToDomain() {
+        val now = kotlin.time.Instant.fromEpochSeconds(1_700_000_000)
+        val response = com.spela.client.models.SharedSaveResponse(
+            createdAt = now,
+            downloadCount = 12L,
+            fileSize = 65_536L,
+            gameId = "42",
+            id = "ss1",
+            name = "Boss Fight",
+            userId = "u1",
+            username = "Alice",
+            avatarUrl = "/avatars/alice.png",
+            description = "Before final boss",
+        )
+        val domain = response.toDomain()
+        assertEquals("ss1", domain.id)
+        assertEquals("Alice", domain.username)
+        assertEquals("/avatars/alice.png", domain.userAvatarUrl)
+        assertEquals("Before final boss", domain.description)
+        assertEquals(12, domain.downloadCount) // Long -> Int
+        assertEquals(65_536L, domain.fileSize)
+        assertEquals(now.toString(), domain.createdAt)
+    }
+
+    @Test
+    fun sharedSaveResponseHandlesNullDescription() {
+        val now = kotlin.time.Instant.fromEpochSeconds(0)
+        val response = com.spela.client.models.SharedSaveResponse(
+            createdAt = now,
+            downloadCount = 0L,
+            fileSize = 0L,
+            gameId = "g",
+            id = "s",
+            name = "Untitled",
+            userId = "u",
+            username = "bob",
+            description = null,
+        )
+        assertEquals("", response.toDomain().description)
+    }
+
+    @Test
     fun themeResponseMapsToDomain() {
         val response = com.spela.client.models.ThemeResponse(
             gameCount = 42L,


### PR DESCRIPTION
Eighth call-site migration in the #461 series.

## Change

- `SpelaApiClient.getSharedSaves()` returns `PaginatedResponseSharedSaveResponse`; `shareSave()` returns `SharedSaveResponse`.
- `SharedSaveRepositoryImpl.getSharedSaves()` uses `.data.orEmpty()` for the spec's nullable data list.
- `com.spela.client.models.SharedSaveResponse.toDomain()` mapper: `description` nullable→`orEmpty()`, `downloadCount` Long→Int, `createdAt` Instant→String.
- Deleted `SharedSaveStateDto` and `SharedSavesResponse` from `Dtos.kt` — not nested anywhere, clean removal.
- Two new tests in `GameRepositoryImplTest`: happy-path mapping and null-description edge case.

## Test plan

- [x] `./gradlew :shared:desktopTest` — **469/469 pass** (up 2)
- [x] `./run-desktop-tests.sh` — same
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.