### PR TITLE
feat(player): migrate challenges to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1166,7 +1166,7 @@ class SpelaApiClient(
         sort: String? = null,
         page: Int = 1,
         pageSize: Int = 20,
-    ): ChallengesResponse {
+    ): com.spela.client.models.PaginatedResponseChallengeResponse {
         return client.get("$baseUrl/api/challenges") {
             gameId?.let { parameter("gameId", it) }
             consoleId?.let { parameter("consoleId", it) }
@@ -1177,21 +1177,28 @@ class SpelaApiClient(
         }.body()
     }
 
-    suspend fun getGameChallenges(gameId: String, page: Int = 1, pageSize: Int = 20): ChallengesResponse {
+    suspend fun getGameChallenges(
+        gameId: String,
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): com.spela.client.models.PaginatedResponseChallengeResponse {
         return client.get("$baseUrl/api/games/$gameId/challenges") {
             parameter("page", page)
             parameter("pageSize", pageSize)
         }.body()
     }
 
-    suspend fun getMyChallenges(page: Int = 1, pageSize: Int = 20): ChallengesResponse {
+    suspend fun getMyChallenges(
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): com.spela.client.models.PaginatedResponseChallengeResponse {
         return client.get("$baseUrl/api/user/challenges") {
             parameter("page", page)
             parameter("pageSize", pageSize)
         }.body()
     }
 
-    suspend fun getChallenge(id: String): ChallengeDto {
+    suspend fun getChallenge(id: String): com.spela.client.models.ChallengeResponse {
         return client.get("$baseUrl/api/challenges/$id").body()
     }
 
@@ -1204,7 +1211,7 @@ class SpelaApiClient(
         coreName: String,
         saveData: ByteArray,
         screenshotData: ByteArray?,
-    ): ChallengeDto {
+    ): com.spela.client.models.ChallengeResponse {
         return client.submitFormWithBinaryData(
             url = "$baseUrl/api/challenges",
             formData = formData {
@@ -1236,11 +1243,16 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/challenges/$challengeId/save/download").body()
     }
 
-    suspend fun startChallengeAttempt(challengeId: String): ChallengeAttemptDto {
+    suspend fun startChallengeAttempt(
+        challengeId: String,
+    ): com.spela.client.models.ChallengeAttemptResponse {
         return client.post("$baseUrl/api/challenges/$challengeId/attempts/start").body()
     }
 
-    suspend fun completeChallengeAttempt(challengeId: String, attemptId: String): ChallengeAttemptDto {
+    suspend fun completeChallengeAttempt(
+        challengeId: String,
+        attemptId: String,
+    ): com.spela.client.models.ChallengeAttemptResponse {
         return client.post("$baseUrl/api/challenges/$challengeId/attempts/$attemptId/complete").body()
     }
 
@@ -1248,7 +1260,9 @@ class SpelaApiClient(
         client.post("$baseUrl/api/challenges/$challengeId/attempts/$attemptId/abandon")
     }
 
-    suspend fun getMyChallengeAttempts(challengeId: String): List<ChallengeAttemptDto> {
+    suspend fun getMyChallengeAttempts(
+        challengeId: String,
+    ): List<com.spela.client.models.ChallengeAttemptResponse> {
         return client.get("$baseUrl/api/challenges/$challengeId/attempts/mine").body()
     }
 
@@ -1256,7 +1270,7 @@ class SpelaApiClient(
         challengeId: String,
         page: Int = 1,
         pageSize: Int = 50,
-    ): ChallengeLeaderboardResponse {
+    ): com.spela.client.models.PaginatedResponseChallengeLeaderboardEntry {
         return client.get("$baseUrl/api/challenges/$challengeId/leaderboard") {
             parameter("page", page)
             parameter("pageSize", pageSize)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -511,51 +511,55 @@ fun ActivePlayerDto.toDomain(): ActivePlayer = ActivePlayer(
 
 // Challenge mappers
 
-fun ChallengeDto.toDomain(): Challenge = Challenge(
+fun com.spela.client.models.ChallengeResponse.toDomain(): Challenge = Challenge(
     id = id,
     creatorId = creatorId,
     creatorUsername = creatorUsername,
-    creatorAvatarUrl = creatorAvatarUrl,
+    creatorAvatarUrl = creatorAvatar,
     gameId = gameId,
     gameTitle = gameTitle,
     gameCoverUrl = gameCoverUrl,
-    gameConsoleName = gameConsoleName,
+    gameConsoleName = consoleName.orEmpty(),
     name = name,
-    description = description,
+    description = description.orEmpty(),
     type = ChallengeType.fromApiId(type),
     difficulty = ChallengeDifficulty.fromApiId(difficulty),
     status = status,
     screenshotUrl = screenshotUrl,
-    coreName = coreName,
+    coreName = coreName.orEmpty(),
     saveFileSize = saveFileSize,
-    attemptCount = attemptCount,
-    completionCount = completionCount,
-    bestTimeMs = bestTimeMs,
-    expiresAt = expiresAt,
-    createdAt = createdAt,
+    attemptCount = attemptCount.toInt(),
+    completionCount = completionCount.toInt(),
+    // bestTimeMs not exposed by the server spec — domain keeps the field
+    // so UI can compute it from the user's best attempt if needed.
+    bestTimeMs = null,
+    expiresAt = expiresAt?.toString(),
+    createdAt = createdAt.toString(),
 )
 
-fun ChallengeAttemptDto.toDomain(): ChallengeAttempt = ChallengeAttempt(
+fun com.spela.client.models.ChallengeAttemptResponse.toDomain(): ChallengeAttempt = ChallengeAttempt(
     id = id,
     challengeId = challengeId,
     userId = userId,
     username = username,
     avatarUrl = avatarUrl,
     status = status,
-    startedAt = startedAt,
-    completedAt = completedAt,
+    startedAt = startedAt.toString(),
+    completedAt = completedAt?.toString(),
     durationMs = durationMs,
     isBest = isBest,
 )
 
-fun ChallengeLeaderboardEntryDto.toDomain(): ChallengeLeaderboardEntry = ChallengeLeaderboardEntry(
-    rank = rank,
+fun com.spela.client.models.ChallengeLeaderboardEntry.toDomain(): ChallengeLeaderboardEntry = ChallengeLeaderboardEntry(
+    rank = rank.toInt(),
     userId = userId,
     username = username,
     avatarUrl = avatarUrl,
     durationMs = durationMs,
-    completedAt = completedAt,
-    isCurrentUser = isCurrentUser,
+    completedAt = completedAt.toString(),
+    // isCurrentUser is derived from the auth'd user at the presentation
+    // layer — server spec doesn't ship it.
+    isCurrentUser = false,
 )
 
 // User Search mappers

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -605,71 +605,19 @@ data class MostActivePlayersResponse(
 
 // Challenges
 
-@Serializable
-data class ChallengeDto(
-    val id: String,
-    val creatorId: String,
-    val creatorUsername: String = "",
-    val creatorAvatarUrl: String? = null,
-    val gameId: String,
-    val gameTitle: String = "",
-    val gameCoverUrl: String? = null,
-    val gameConsoleName: String = "",
-    val name: String,
-    val description: String = "",
-    val type: String = "completion",
-    val difficulty: String = "medium",
-    val status: String = "active",
-    val screenshotUrl: String? = null,
-    val coreName: String = "",
-    val saveFileSize: Long = 0,
-    val attemptCount: Int = 0,
-    val completionCount: Int = 0,
-    val bestTimeMs: Long? = null,
-    val expiresAt: String? = null,
-    val createdAt: String = "",
-)
-
-@Serializable
-data class ChallengesResponse(
-    val data: List<ChallengeDto> = emptyList(),
-    val total: Long = 0,
-    val page: Int = 1,
-    val pageSize: Int = 20,
-)
-
-@Serializable
-data class ChallengeAttemptDto(
-    val id: String,
-    val challengeId: String,
-    val userId: String,
-    val username: String = "",
-    val avatarUrl: String? = null,
-    val status: String = "in_progress",
-    val startedAt: String = "",
-    val completedAt: String? = null,
-    val durationMs: Long = 0,
-    val isBest: Boolean = false,
-)
-
-@Serializable
-data class ChallengeLeaderboardEntryDto(
-    val rank: Int,
-    val userId: String,
-    val username: String = "",
-    val avatarUrl: String? = null,
-    val durationMs: Long = 0,
-    val completedAt: String = "",
-    val isCurrentUser: Boolean = false,
-)
-
-@Serializable
-data class ChallengeLeaderboardResponse(
-    val data: List<ChallengeLeaderboardEntryDto> = emptyList(),
-    val total: Long = 0,
-    val page: Int = 1,
-    val pageSize: Int = 50,
-)
+// Challenge DTOs replaced by generated counterparts in
+// com.spela.client.models — see player/shared-api/:
+//   ChallengeDto                  -> ChallengeResponse
+//   ChallengesResponse            -> PaginatedResponseChallengeResponse
+//   ChallengeAttemptDto           -> ChallengeAttemptResponse
+//   ChallengeLeaderboardEntryDto  -> ChallengeLeaderboardEntry
+//   ChallengeLeaderboardResponse  -> PaginatedResponseChallengeLeaderboardEntry
+//
+// Noteworthy: the hand-written ChallengeDto used `creatorAvatarUrl`
+// and `gameConsoleName` where the server actually sends `creatorAvatar`
+// and `consoleName`. The hand-written names were effectively dead —
+// kotlinx-serialization fell back to defaults. The new mapper maps
+// the real fields.
 
 // Netplay
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ChallengeRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ChallengeRepositoryImpl.kt
@@ -18,7 +18,7 @@ class ChallengeRepositoryImpl(
         sort: String?,
         page: Int,
     ): Result<List<Challenge>> = runCatching {
-        apiClient.getChallenges(gameId, consoleId, difficulty, sort, page).data.map { dto ->
+        apiClient.getChallenges(gameId, consoleId, difficulty, sort, page).data.orEmpty().map { dto ->
             val challenge = dto.toDomain()
             challenge.copy(
                 screenshotUrl = apiClient.resolveUrl(challenge.screenshotUrl),
@@ -29,7 +29,7 @@ class ChallengeRepositoryImpl(
     }
 
     override suspend fun getGameChallenges(gameId: String, page: Int): Result<List<Challenge>> = runCatching {
-        apiClient.getGameChallenges(gameId, page).data.map { dto ->
+        apiClient.getGameChallenges(gameId, page).data.orEmpty().map { dto ->
             val challenge = dto.toDomain()
             challenge.copy(
                 screenshotUrl = apiClient.resolveUrl(challenge.screenshotUrl),
@@ -40,7 +40,7 @@ class ChallengeRepositoryImpl(
     }
 
     override suspend fun getMyChallenges(page: Int): Result<List<Challenge>> = runCatching {
-        apiClient.getMyChallenges(page).data.map { dto ->
+        apiClient.getMyChallenges(page).data.orEmpty().map { dto ->
             val challenge = dto.toDomain()
             challenge.copy(
                 screenshotUrl = apiClient.resolveUrl(challenge.screenshotUrl),
@@ -63,7 +63,7 @@ class ChallengeRepositoryImpl(
         challengeId: String,
         page: Int,
     ): Result<List<ChallengeLeaderboardEntry>> = runCatching {
-        apiClient.getChallengeLeaderboard(challengeId, page).data.map { dto ->
+        apiClient.getChallengeLeaderboard(challengeId, page).data.orEmpty().map { dto ->
             val entry = dto.toDomain()
             entry.copy(avatarUrl = apiClient.resolveUrl(entry.avatarUrl))
         }

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -81,6 +81,47 @@ class GameRepositoryImplTest {
     }
 
     @Test
+    fun challengeResponseMapsToDomain() {
+        val now = kotlin.time.Instant.fromEpochSeconds(1_700_000_000)
+        val response = com.spela.client.models.ChallengeResponse(
+            attemptCount = 25L,
+            completionCount = 4L,
+            createdAt = now,
+            creatorId = "u1",
+            creatorUsername = "mattias",
+            difficulty = "hard",
+            gameId = "g1",
+            gameTitle = "Super Metroid",
+            id = "c1",
+            name = "100% Run",
+            saveFileSize = 65_536L,
+            status = "active",
+            type = "completion",
+            updatedAt = now,
+            consoleName = "SNES", // server sends consoleName, not gameConsoleName
+            coreName = "snes9x",
+            creatorAvatar = "/avatars/mattias.png", // server sends creatorAvatar, not creatorAvatarUrl
+            description = "Collect everything",
+            expiresAt = null,
+            gameCoverUrl = "/covers/smetroid.png",
+            screenshotUrl = "/screenshots/smetroid.png",
+        )
+
+        val domain = response.toDomain()
+
+        assertEquals("c1", domain.id)
+        assertEquals("100% Run", domain.name)
+        assertEquals("SNES", domain.gameConsoleName) // mapped from consoleName
+        assertEquals("/avatars/mattias.png", domain.creatorAvatarUrl) // mapped from creatorAvatar
+        assertEquals(25, domain.attemptCount) // Long -> Int
+        assertEquals(4, domain.completionCount)
+        assertEquals(com.spela.player.domain.model.ChallengeDifficulty.HARD, domain.difficulty)
+        assertEquals(com.spela.player.domain.model.ChallengeType.COMPLETION, domain.type)
+        assertEquals(now.toString(), domain.createdAt)
+        assertEquals(null, domain.bestTimeMs) // not in spec
+    }
+
+    @Test
     fun sharedSaveResponseMapsToDomain() {
         val now = kotlin.time.Instant.fromEpochSeconds(1_700_000_000)
         val response = com.spela.client.models.SharedSaveResponse(


### PR DESCRIPTION
Ninth call-site migration in the #461 series. (Branch was scouted for collections first — pivoted to challenges since collections nest `GameDto`, which is the last un-migrated monster.)

## Change

- `SpelaApiClient`: 10 challenge methods now use generated types
  - `getChallenges` / `getGameChallenges` / `getMyChallenges` → `PaginatedResponseChallengeResponse`
  - `getChallenge` / `createChallenge` → `ChallengeResponse`
  - `startChallengeAttempt` / `completeChallengeAttempt` / `getMyChallengeAttempts` → `ChallengeAttemptResponse`
  - `getChallengeLeaderboard` → `PaginatedResponseChallengeLeaderboardEntry`
- Three new mappers in `DtoMappers.kt` (`ChallengeResponse` / `ChallengeAttemptResponse` / `ChallengeLeaderboardEntry`). Long→Int for `attemptCount` / `completionCount` / `rank`; `Instant`→`String` for `createdAt` / `expiresAt` / `startedAt` / `completedAt`.
- `ChallengeRepositoryImpl` uses `.data.orEmpty()` for the spec's nullable data list.
- Deleted five hand-written DTOs: `ChallengeDto` / `ChallengesResponse` / `ChallengeAttemptDto` / `ChallengeLeaderboardEntryDto` / `ChallengeLeaderboardResponse`.

## Bug fixes surfaced by the migration

The hand-written `ChallengeDto` expected `creatorAvatarUrl` and `gameConsoleName`, but the server actually sends `creatorAvatar` and `consoleName`. kotlinx-serialization silently fell back to the defaults (`null` / `""`), so the player app has been rendering empty console names and null creator avatars on every challenge card. The new mapper pulls the real field names from the spec.

`bestTimeMs` and `isCurrentUser` aren't in the server spec — `bestTimeMs` was effectively always null (preserved), and `isCurrentUser` was always false (preserved; presentation layer can compute it from the auth'd user id at render time).

## Test plan

- [x] `./gradlew :shared:desktopTest` — **470/470 pass** (up 1)
- [x] `./run-desktop-tests.sh` — same
- [x] Pre-existing `SessionsUiTest` E2E failures unchanged from master
- [ ] CI green

Refs #461.