### PR TITLE
feat(player): migrate social endpoints to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -848,22 +848,25 @@ class SpelaApiClient(
 
     // Social
 
-    suspend fun getOnlineUsers(): OnlineUsersResponse {
+    suspend fun getOnlineUsers(): com.spela.client.models.OnlineUsersResponse {
         return client.get("$baseUrl/api/social/online").body()
     }
 
-    suspend fun getActivityFeed(page: Int = 1, pageSize: Int = 20): ActivityFeedResponse {
+    suspend fun getActivityFeed(
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): com.spela.client.models.PaginatedResponseActivityEventResponse {
         return client.get("$baseUrl/api/social/activity") {
             parameter("page", page)
             parameter("pageSize", pageSize)
         }.body()
     }
 
-    suspend fun getPublicProfile(userId: String): PublicProfileDto {
+    suspend fun getPublicProfile(userId: String): com.spela.client.models.PublicProfileResponse {
         return client.get("$baseUrl/api/users/$userId/profile").body()
     }
 
-    suspend fun getPublicPlayHeatmap(userId: String): List<HeatmapEntryDto> {
+    suspend fun getPublicPlayHeatmap(userId: String): List<com.spela.client.models.HeatmapEntry> {
         return client.get("$baseUrl/api/users/$userId/play-heatmap").body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -215,31 +215,31 @@ fun com.spela.client.models.RatingSummaryResponse.toDomain(): RatingSummary = Ra
     },
 )
 
-fun OnlineUserGameDto.toDomain(): OnlineUserGame = OnlineUserGame(
+fun com.spela.client.models.OnlineUserGameResponse.toDomain(): OnlineUserGame = OnlineUserGame(
     id = id,
     title = title,
     coverUrl = coverUrl,
     consoleName = consoleName,
 )
 
-fun OnlineUserDto.toDomain(): OnlineUser = OnlineUser(
+fun com.spela.client.models.OnlineUserResponse.toDomain(): OnlineUser = OnlineUser(
     id = id,
     username = username,
     avatarUrl = avatarUrl,
     currentGame = currentGame?.toDomain(),
 )
 
-fun ActivityEventDto.toDomain(): ActivityEvent = ActivityEvent(
+fun com.spela.client.models.ActivityEventResponse.toDomain(): ActivityEvent = ActivityEvent(
     id = id,
     userId = userId,
     username = username,
-    userAvatarUrl = userAvatarUrl,
+    userAvatarUrl = avatarUrl, // server sends `avatarUrl`
     eventType = eventType,
     gameId = gameId,
     gameTitle = gameTitle,
     gameCoverUrl = gameCoverUrl,
-    gameConsoleName = gameConsoleName,
-    createdAt = createdAt,
+    gameConsoleName = consoleName, // server sends `consoleName`
+    createdAt = createdAt.toString(),
 )
 
 fun LibretroCoreDto.toDomain(): LibretroCore = LibretroCore(
@@ -251,31 +251,31 @@ fun LibretroCoreDto.toDomain(): LibretroCore = LibretroCore(
     downloadUrl = downloadUrl,
 )
 
-fun HeatmapEntryDto.toDomain(): HeatmapEntry = HeatmapEntry(
+fun com.spela.client.models.HeatmapEntry.toDomain(): HeatmapEntry = HeatmapEntry(
     date = date,
     playTime = playTime,
 )
 
-fun PublicProfileGameDto.toDomain(): PublicProfileGame = PublicProfileGame(
+fun com.spela.client.models.PublicProfileGame.toDomain(): PublicProfileGame = PublicProfileGame(
     id = id,
     title = title,
     coverUrl = coverUrl,
     consoleName = consoleName,
-    playTime = playTime,
+    playTime = playTime ?: 0L,
 )
 
-fun PublicProfileDto.toDomain(): PublicProfile = PublicProfile(
+fun com.spela.client.models.PublicProfileResponse.toDomain(): PublicProfile = PublicProfile(
     id = id,
     username = username,
     avatarUrl = avatarUrl,
-    memberSince = memberSince,
+    memberSince = memberSince.toString(),
     isOnline = isOnline,
     currentGame = currentGame?.toDomain(),
     totalPlayTime = totalPlayTime,
     gamesPlayed = gamesPlayed,
-    favoriteGames = favoriteGames.map { it.toDomain() },
-    recentGames = recentGames.map { it.toDomain() },
-    topGames = topGames.map { it.toDomain() },
+    favoriteGames = favoriteGames.orEmpty().map { it.toDomain() },
+    recentGames = recentGames.orEmpty().map { it.toDomain() },
+    topGames = topGames.orEmpty().map { it.toDomain() },
 )
 
 // Shared Session mappers

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -300,49 +300,16 @@ data class UpdateDevicePreferencesRequest(
 
 // Social
 
-@Serializable
-data class OnlineUserGameDto(
-    val id: String,
-    val title: String,
-    val coverUrl: String? = null,
-    val consoleName: String = "",
-)
-
-@Serializable
-data class OnlineUserDto(
-    val id: String,
-    val username: String,
-    val avatarUrl: String? = null,
-    val currentGame: OnlineUserGameDto? = null,
-)
-
-@Serializable
-data class OnlineUsersResponse(
-    val users: List<OnlineUserDto> = emptyList(),
-)
-
-@Serializable
-data class ActivityEventDto(
-    val id: String,
-    val userId: String,
-    val username: String,
-    val userAvatarUrl: String? = null,
-    val eventType: String,
-    val gameId: String? = null,
-    val gameTitle: String? = null,
-    val gameCoverUrl: String? = null,
-    val gameConsoleName: String? = null,
-    val metadata: String? = null,
-    val createdAt: String = "",
-)
-
-@Serializable
-data class ActivityFeedResponse(
-    val data: List<ActivityEventDto> = emptyList(),
-    val total: Long = 0,
-    val page: Int = 1,
-    val pageSize: Int = 20,
-)
+// Social DTOs replaced by generated counterparts:
+//   OnlineUserGameDto     -> OnlineUserGameResponse
+//   OnlineUserDto         -> OnlineUserResponse
+//   OnlineUsersResponse   -> OnlineUsersResponse (generated; same name)
+//   ActivityEventDto      -> ActivityEventResponse
+//   ActivityFeedResponse  -> PaginatedResponseActivityEventResponse
+// Noteworthy: hand-written ActivityEventDto used `userAvatarUrl` and
+// `gameConsoleName` where the server sends `avatarUrl` and
+// `consoleName`. The hand-written names were dead; new mapper reads
+// the real fields.
 
 /** Wrapper for GET /api/games/:id/core when core is not in DB */
 @Serializable
@@ -361,35 +328,11 @@ data class CoreNameResponse(
 
 // Public Profile
 
-@Serializable
-data class PublicProfileGameDto(
-    val id: String,
-    val title: String,
-    val coverUrl: String? = null,
-    val consoleName: String = "",
-    val playTime: Long = 0,
-)
-
-@Serializable
-data class PublicProfileDto(
-    val id: String,
-    val username: String,
-    val avatarUrl: String? = null,
-    val memberSince: String = "",
-    val isOnline: Boolean = false,
-    val currentGame: OnlineUserGameDto? = null,
-    val totalPlayTime: Long = 0,
-    val gamesPlayed: Long = 0,
-    val favoriteGames: List<PublicProfileGameDto> = emptyList(),
-    val recentGames: List<PublicProfileGameDto> = emptyList(),
-    val topGames: List<PublicProfileGameDto> = emptyList(),
-)
-
-@Serializable
-data class HeatmapEntryDto(
-    val date: String,
-    val playTime: Long = 0,
-)
+// Public profile + heatmap DTOs replaced:
+//   PublicProfileGameDto  -> PublicProfileGame
+//   PublicProfileDto      -> PublicProfileResponse
+//   HeatmapEntryDto       -> HeatmapEntry
+// (all in com.spela.client.models)
 
 // Shared Session
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
@@ -16,7 +16,7 @@ class SocialRepositoryImpl(
 ) : SocialRepository {
 
     override suspend fun getOnlineUsers(): Result<List<OnlineUser>> = runCatching {
-        apiClient.getOnlineUsers().users.map { dto ->
+        apiClient.getOnlineUsers().users.orEmpty().map { dto ->
             val user = dto.toDomain()
             user.copy(
                 avatarUrl = apiClient.resolveUrl(user.avatarUrl),
@@ -28,7 +28,7 @@ class SocialRepositoryImpl(
     }
 
     override suspend fun getActivityFeed(page: Int, pageSize: Int): Result<List<ActivityEvent>> = runCatching {
-        apiClient.getActivityFeed(page = page, pageSize = pageSize).data.map { dto ->
+        apiClient.getActivityFeed(page = page, pageSize = pageSize).data.orEmpty().map { dto ->
             val event = dto.toDomain()
             event.copy(
                 userAvatarUrl = apiClient.resolveUrl(event.userAvatarUrl),


### PR DESCRIPTION
Tenth call-site migration in the #461 series. Covers the full social surface — online users, activity feed, public profile, public play heatmap. Eight hand-written DTOs replaced in one PR.

## Change

- `SpelaApiClient`:
  - `getOnlineUsers()` → `OnlineUsersResponse`
  - `getActivityFeed()` → `PaginatedResponseActivityEventResponse`
  - `getPublicProfile()` → `PublicProfileResponse`
  - `getPublicPlayHeatmap()` → `List<HeatmapEntry>`
- Six new mappers in `DtoMappers.kt` (`OnlineUserGameResponse`, `OnlineUserResponse`, `ActivityEventResponse`, `HeatmapEntry`, `PublicProfileGame`, `PublicProfileResponse`). Handle nullable `playTime` via `?: 0L`, nullable paginated lists via `.orEmpty()`, `Instant`→`String` for `memberSince` / `createdAt`.
- `SocialRepositoryImpl`: `.users.orEmpty()` + `.data.orEmpty()` for the spec's nullable paginated lists.
- Deleted eight hand-written DTOs: `OnlineUserGameDto` / `OnlineUserDto` / `OnlineUsersResponse` / `ActivityEventDto` / `ActivityFeedResponse` / `PublicProfileGameDto` / `PublicProfileDto` / `HeatmapEntryDto`.

## Bug fix surfaced by the migration

Hand-written `ActivityEventDto` expected `userAvatarUrl` and `gameConsoleName`, but the server actually sends `avatarUrl` and `consoleName`. Like the challenge bug in #472, the hand-written names were dead — kotlinx-serialization silently fell back to `null` / `""`. Activity events in the feed have been rendering with null user avatars and empty console names this whole time. The new mapper reads the real fields.

## Test plan

- [x] `./gradlew :shared:desktopTest` — **470/470 pass** (same as master after #472)
- [x] `./run-desktop-tests.sh` — same
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.