### PR TITLE
feat(player): migrate user-search endpoints to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1148,7 +1148,11 @@ class SpelaApiClient(
 
     // User Search
 
-    suspend fun searchUsers(query: String = "", page: Int = 1, pageSize: Int = 20): UserSearchResponse {
+    suspend fun searchUsers(
+        query: String = "",
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): com.spela.client.models.PaginatedResponseUserSearchResult {
         return client.get("$baseUrl/api/users/search") {
             parameter("q", query)
             parameter("page", page)
@@ -1156,7 +1160,7 @@ class SpelaApiClient(
         }.body()
     }
 
-    suspend fun getRecentPartners(): List<UserSearchResultDto> {
+    suspend fun getRecentPartners(): List<com.spela.client.models.UserSearchResult> {
         return client.get("$baseUrl/api/users/recent-partners").body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -564,7 +564,7 @@ fun com.spela.client.models.ChallengeLeaderboardEntry.toDomain(): ChallengeLeade
 
 // User Search mappers
 
-fun UserSearchResultDto.toDomain(): UserSearchResult = UserSearchResult(
+fun com.spela.client.models.UserSearchResult.toDomain(): UserSearchResult = UserSearchResult(
     id = id,
     username = username,
     avatarUrl = avatarUrl,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -616,20 +616,9 @@ data class SendNetplayInviteRequest(
     val username: String,
 )
 
-@Serializable
-data class UserSearchResultDto(
-    val id: String,
-    val username: String,
-    val avatarUrl: String? = null,
-)
-
-@Serializable
-data class UserSearchResponse(
-    val data: List<UserSearchResultDto>,
-    val total: Long,
-    val page: Int,
-    val pageSize: Int,
-)
+// UserSearchResultDto / UserSearchResponse replaced by
+// com.spela.client.models.UserSearchResult /
+// PaginatedResponseUserSearchResult (see player/shared-api/).
 
 // Game Stats
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/UserRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/UserRepositoryImpl.kt
@@ -17,10 +17,10 @@ class UserRepositoryImpl(
     ): Result<UserSearchPage> = runCatching {
         val response = apiClient.searchUsers(query, page, pageSize)
         UserSearchPage(
-            data = response.data.map { it.toDomain() },
+            data = response.data.orEmpty().map { it.toDomain() },
             total = response.total,
-            page = response.page,
-            pageSize = response.pageSize,
+            page = response.page.toInt(),
+            pageSize = response.pageSize.toInt(),
         )
     }
 


### PR DESCRIPTION
Eleventh call-site migration in the #461 series. Small, self-contained.

## Change

- `SpelaApiClient.searchUsers()` returns `PaginatedResponseUserSearchResult`.
- `SpelaApiClient.getRecentPartners()` returns `List<UserSearchResult>`.
- Mapper `com.spela.client.models.UserSearchResult.toDomain()` replaces the old DTO mapper — fully qualified since domain + generated share the name.
- `UserRepositoryImpl` uses `.data.orEmpty()` for the nullable paginated list; converts `page` / `pageSize` Long→Int to match the domain `UserSearchPage`.
- Deleted `UserSearchResultDto` + `UserSearchResponse` from `Dtos.kt`.

## Test plan

- [x] `./gradlew :shared:desktopTest` — **470/470 pass**
- [x] `./run-desktop-tests.sh` — same
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.