### PR TITLE
feat(player): migrate top-rated / top-list / longest to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -254,19 +254,19 @@ class SpelaApiClient(
         }.body()
     }
 
-    suspend fun getTopRatedGames(consoleId: String): List<TopRatedGameDto> {
+    suspend fun getTopRatedGames(consoleId: String): List<com.spela.client.models.TopRatedGameResponse> {
         return client.get("$baseUrl/api/consoles/$consoleId/top-rated").body()
     }
 
-    suspend fun getTopRatedGamesGlobal(): List<TopRatedGameDto> {
+    suspend fun getTopRatedGamesGlobal(): List<com.spela.client.models.TopRatedGameResponse> {
         return client.get("$baseUrl/api/top-rated").body()
     }
 
-    suspend fun getTopRatedAvailable(): List<TopListGameDto> {
+    suspend fun getTopRatedAvailable(): List<com.spela.client.models.TopListGameResponse> {
         return client.get("$baseUrl/api/top-lists/top-rated").body()
     }
 
-    suspend fun getLongestGames(): List<LongestGameDto> {
+    suspend fun getLongestGames(): List<com.spela.client.models.LongestGameResponse> {
         return client.get("$baseUrl/api/top-lists/longest").body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -595,35 +595,35 @@ fun NetplaySessionDto.toDomain(): NetplaySession = NetplaySession(
     endedAt = endedAt,
 )
 
-fun TopListGameDto.toDomain(): TopListGame = TopListGame(
-    rank = rank,
+fun com.spela.client.models.TopListGameResponse.toDomain(): TopListGame = TopListGame(
+    rank = rank.toInt(),
     gameId = gameId,
     name = name,
     coverUrl = coverUrl,
     consoleName = consoleName,
     consoleId = consoleId,
-    rating = rating,
+    rating = igdbCriticsRating, // server sends igdbCriticsRating, not rating
 )
 
-fun TopRatedGameDto.toDomain(): TopRatedGame = TopRatedGame(
-    rank = rank,
+fun com.spela.client.models.TopRatedGameResponse.toDomain(): TopRatedGame = TopRatedGame(
+    rank = rank.toInt(),
     name = name,
     coverUrl = coverUrl,
-    rating = rating,
+    rating = igdbCriticsRating, // server sends igdbCriticsRating, not rating
     localGameId = localGameId,
     consoleName = consoleName,
 )
 
-fun LongestGameDto.toDomain(): LongestGame = LongestGame(
-    rank = rank,
+fun com.spela.client.models.LongestGameResponse.toDomain(): LongestGame = LongestGame(
+    rank = rank.toInt(),
     gameId = gameId,
     name = name,
     coverUrl = coverUrl,
     consoleName = consoleName,
     consoleId = consoleId,
-    timeToBeatNormally = timeToBeatNormally,
-    timeToBeatHastily = timeToBeatHastily,
-    timeToBeatCompletely = timeToBeatCompletely,
+    timeToBeatNormally = timeToBeatNormally.toInt(),
+    timeToBeatHastily = timeToBeatHastily.toInt(),
+    timeToBeatCompletely = timeToBeatCompletely.toInt(),
 )
 
 fun SimilarGameDto.toDomain(): SimilarGame = SimilarGame(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -800,43 +800,14 @@ data class ShowcaseUpdateEntry(
 
 // Top Rated
 
-@Serializable
-data class TopRatedGameDto(
-    val rank: Int,
-    val name: String,
-    val coverUrl: String? = null,
-    val rating: Double = 0.0,
-    val localGameId: String? = null,
-    val consoleName: String = "",
-)
-
-// Top Lists
-
-@Serializable
-data class TopListGameDto(
-    val rank: Int,
-    val gameId: String,
-    val name: String,
-    val coverUrl: String? = null,
-    val consoleName: String = "",
-    val consoleId: String = "",
-    val rating: Double = 0.0,
-)
-
-// Longest Games
-
-@Serializable
-data class LongestGameDto(
-    val rank: Int,
-    val gameId: String,
-    val name: String,
-    val coverUrl: String? = null,
-    val consoleName: String = "",
-    val consoleId: String = "",
-    val timeToBeatNormally: Int = 0,
-    val timeToBeatHastily: Int = 0,
-    val timeToBeatCompletely: Int = 0,
-)
+// TopRatedGameDto / TopListGameDto / LongestGameDto replaced by
+// com.spela.client.models.TopRatedGameResponse / TopListGameResponse /
+// LongestGameResponse (see player/shared-api/).
+//
+// Noteworthy: the hand-written TopRatedGameDto and TopListGameDto used
+// `rating` but the server actually sends `igdbCriticsRating` — the
+// hand-written field was always 0.0. The new mapper pulls the real
+// rating.
 
 // Similar Games
 


### PR DESCRIPTION
Twelfth call-site migration in the #461 series. Four endpoints + three related hand-written DTOs.

## Change

- `SpelaApiClient`:
  - `getTopRatedGames(consoleId)` / `getTopRatedGamesGlobal()` → `List<TopRatedGameResponse>`
  - `getTopRatedAvailable()` → `List<TopListGameResponse>`
  - `getLongestGames()` → `List<LongestGameResponse>`
- Three new mappers in `DtoMappers.kt`. `rank` Long→Int; `timeToBeatNormally` / `timeToBeatHastily` / `timeToBeatCompletely` Long→Int.
- Deleted `TopRatedGameDto` / `TopListGameDto` / `LongestGameDto` from `Dtos.kt`.

## Bug fix surfaced by the migration

Hand-written `TopRatedGameDto` and `TopListGameDto` expected `rating: Double`, but the server actually sends `igdbCriticsRating`. The hand-written field name was dead — kotlinx-serialization silently fell back to `0.0`. Top-Rated cards and the global top-rated list have been showing 0.0 ratings all along. The new mapper reads `igdbCriticsRating` and maps it to the domain `rating`.

This is the **fourth** silent deserialization bug the migration has surfaced (earlier: #472 challenges' `creatorAvatar`/`consoleName`, #473 activity events' `avatarUrl`/`consoleName`, plus web types in #462 where rename drift gets compile-time checked).

## Test plan

- [x] `./gradlew :shared:desktopTest` — **470/470 pass**
- [x] `./run-desktop-tests.sh` — same
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.