### PR TITLE
feat(player): migrate netplay session endpoints to generated types

### DIFF
--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/NetplayTestRunner.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/NetplayTestRunner.kt
@@ -1,8 +1,8 @@
 package com.spela.player.desktop
 
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.data.remote.dto.CreateNetplaySessionRequest
-import com.spela.player.data.remote.dto.JoinByInviteCodeRequest
+import com.spela.client.models.CreateNetplaySessionRequest
+import com.spela.client.models.JoinByInviteCodeRequest
 import com.spela.player.data.remote.dto.LoginRequest
 import com.spela.player.data.remote.interceptor.TokenManager
 import com.spela.player.libretro.DesktopLibretroController
@@ -140,7 +140,7 @@ private class NetplayTestRunnerImpl(private val config: Config) {
 
             log("Creating netplay session for '${game.title}' (ID: ${game.id})...")
             val session = apiClient.createNetplaySession(
-                CreateNetplaySessionRequest(gameId = game.id, inputDelay = config.inputDelay)
+                CreateNetplaySessionRequest(gameId = game.id, inputDelay = config.inputDelay.toLong())
             )
             sessionId = session.id
             localPort = 0 // Host is always port 0
@@ -152,7 +152,7 @@ private class NetplayTestRunnerImpl(private val config: Config) {
         } else {
             val code = config.inviteCode ?: error("--invite-code required for client role")
             log("Joining session with invite code: $code...")
-            val session = apiClient.joinNetplayByInviteCode(JoinByInviteCodeRequest(code))
+            val session = apiClient.joinNetplayByInviteCode(JoinByInviteCodeRequest(inviteCode = code))
             sessionId = session.id
             localPort = 1 // Client is always port 1
             log("Joined session: ${session.id}")

--- a/player/shared/build.gradle.kts
+++ b/player/shared/build.gradle.kts
@@ -51,8 +51,11 @@ kotlin {
 
                 // Generated Kotlin OpenAPI client — models + *Api classes
                 // produced by openapi-generator from the huma spec. See
-                // ../shared-api and scripts/regen-kotlin-api.sh.
-                implementation(project(":shared-api"))
+                // ../shared-api and scripts/regen-kotlin-api.sh. Exposed
+                // as `api` so downstream consumers (`:desktop`, `:android`)
+                // that call SpelaApiClient can name the generated request/
+                // response types without re-declaring the dep themselves.
+                api(project(":shared-api"))
 
                 implementation(libs.sqldelight.coroutines)
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1106,21 +1106,25 @@ class SpelaApiClient(
 
     // Netplay
 
-    suspend fun createNetplaySession(request: CreateNetplaySessionRequest): NetplaySessionDto {
+    suspend fun createNetplaySession(
+        request: com.spela.client.models.CreateNetplaySessionRequest,
+    ): com.spela.client.models.NetplaySessionResponse {
         return client.post("$baseUrl/api/netplay/sessions") {
             setBody(request)
         }.body()
     }
 
-    suspend fun getNetplaySessions(): NetplaySessionsResponse {
+    suspend fun getNetplaySessions(): com.spela.client.models.PaginatedResponseNetplaySessionResponse {
         return client.get("$baseUrl/api/netplay/sessions").body()
     }
 
-    suspend fun getNetplaySession(sessionId: String): NetplaySessionDto {
+    suspend fun getNetplaySession(sessionId: String): com.spela.client.models.NetplaySessionResponse {
         return client.get("$baseUrl/api/netplay/sessions/$sessionId").body()
     }
 
-    suspend fun joinNetplayByInviteCode(request: JoinByInviteCodeRequest): NetplaySessionDto {
+    suspend fun joinNetplayByInviteCode(
+        request: com.spela.client.models.JoinByInviteCodeRequest,
+    ): com.spela.client.models.NetplaySessionResponse {
         return client.post("$baseUrl/api/netplay/sessions/join") {
             setBody(request)
         }.body()
@@ -1134,13 +1138,19 @@ class SpelaApiClient(
         client.delete("$baseUrl/api/netplay/sessions/$sessionId")
     }
 
-    suspend fun updateNetplaySettings(sessionId: String, request: UpdateNetplaySettingsRequest): NetplaySessionDto {
+    suspend fun updateNetplaySettings(
+        sessionId: String,
+        request: com.spela.client.models.UpdateNetplaySettingsRequest,
+    ): com.spela.client.models.NetplaySessionResponse {
         return client.put("$baseUrl/api/netplay/sessions/$sessionId/settings") {
             setBody(request)
         }.body()
     }
 
-    suspend fun sendNetplayInvite(sessionId: String, request: SendNetplayInviteRequest) {
+    suspend fun sendNetplayInvite(
+        sessionId: String,
+        request: com.spela.client.models.NetplayInviteUserRequest,
+    ) {
         client.post("$baseUrl/api/netplay/sessions/$sessionId/invites") {
             setBody(request)
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -572,13 +572,13 @@ fun com.spela.client.models.UserSearchResult.toDomain(): UserSearchResult = User
 
 // Netplay mappers
 
-fun NetplaySessionDto.toDomain(): NetplaySession = NetplaySession(
+fun com.spela.client.models.NetplaySessionResponse.toDomain(): NetplaySession = NetplaySession(
     id = id,
     gameId = gameId,
     gameTitle = gameTitle,
     gameCoverUrl = gameCoverUrl,
-    gameConsoleName = consoleName,
-    coverAspectRatio = coverAspectRatio,
+    gameConsoleName = consoleName.orEmpty(),
+    coverAspectRatio = coverAspectRatio.toFloat(),
     hostUserId = hostId,
     hostUsername = hostUsername,
     hostAvatarUrl = hostAvatarUrl,
@@ -587,12 +587,12 @@ fun NetplaySessionDto.toDomain(): NetplaySession = NetplaySession(
     clientAvatarUrl = clientAvatarUrl,
     status = NetplaySessionStatus.entries.find { it.name.equals(status, ignoreCase = true) }
         ?: NetplaySessionStatus.WAITING,
-    inputDelay = inputDelay,
+    inputDelay = inputDelay.toInt(),
     inviteCode = inviteCode,
     endReason = endReason,
-    createdAt = createdAt,
-    startedAt = startedAt,
-    endedAt = endedAt,
+    createdAt = createdAt.toString(),
+    startedAt = startedAt?.toString(),
+    endedAt = endedAt?.toString(),
 )
 
 fun com.spela.client.models.TopListGameResponse.toDomain(): TopListGame = TopListGame(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -564,57 +564,14 @@ data class MostActivePlayersResponse(
 
 // Netplay
 
-@Serializable
-data class NetplaySessionDto(
-    val id: String,
-    val gameId: String,
-    val gameTitle: String = "",
-    val gameCoverUrl: String? = null,
-    val consoleName: String = "",
-    val coverAspectRatio: Float = 0.75f,
-    val hostId: String,
-    val hostUsername: String = "",
-    val hostAvatarUrl: String? = null,
-    val clientId: String? = null,
-    val clientUsername: String? = null,
-    val clientAvatarUrl: String? = null,
-    val status: String = "waiting",
-    val inputDelay: Int = 3,
-    val inviteCode: String = "",
-    val endReason: String? = null,
-    val createdAt: String = "",
-    val startedAt: String? = null,
-    val endedAt: String? = null,
-)
-
-@Serializable
-data class NetplaySessionsResponse(
-    val data: List<NetplaySessionDto> = emptyList(),
-    val total: Long = 0,
-    val page: Int = 1,
-    val pageSize: Int = 20,
-)
-
-@Serializable
-data class CreateNetplaySessionRequest(
-    val gameId: String,
-    val inputDelay: Int = 3,
-)
-
-@Serializable
-data class JoinByInviteCodeRequest(
-    val inviteCode: String,
-)
-
-@Serializable
-data class UpdateNetplaySettingsRequest(
-    val inputDelay: Int,
-)
-
-@Serializable
-data class SendNetplayInviteRequest(
-    val username: String,
-)
+// Netplay DTOs replaced by generated counterparts in
+// com.spela.client.models — see player/shared-api/:
+//   NetplaySessionDto             -> NetplaySessionResponse
+//   NetplaySessionsResponse       -> PaginatedResponseNetplaySessionResponse
+//   CreateNetplaySessionRequest   -> CreateNetplaySessionRequest (generated; same name)
+//   JoinByInviteCodeRequest       -> JoinByInviteCodeRequest (generated; same name)
+//   UpdateNetplaySettingsRequest  -> UpdateNetplaySettingsRequest (generated; same name)
+//   SendNetplayInviteRequest      -> NetplayInviteUserRequest
 
 // UserSearchResultDto / UserSearchResponse replaced by
 // com.spela.client.models.UserSearchResult /

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/NetplayRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/NetplayRepositoryImpl.kt
@@ -1,10 +1,10 @@
 package com.spela.player.data.repository
 
+import com.spela.client.models.CreateNetplaySessionRequest
+import com.spela.client.models.JoinByInviteCodeRequest
+import com.spela.client.models.NetplayInviteUserRequest
+import com.spela.client.models.UpdateNetplaySettingsRequest
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.data.remote.dto.CreateNetplaySessionRequest
-import com.spela.player.data.remote.dto.JoinByInviteCodeRequest
-import com.spela.player.data.remote.dto.SendNetplayInviteRequest
-import com.spela.player.data.remote.dto.UpdateNetplaySettingsRequest
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.NetplaySession
 import com.spela.player.domain.repository.NetplayRepository
@@ -18,12 +18,12 @@ class NetplayRepositoryImpl(
         inputDelay: Int,
     ): Result<NetplaySession> = runCatching {
         apiClient.createNetplaySession(
-            CreateNetplaySessionRequest(gameId, inputDelay)
+            CreateNetplaySessionRequest(gameId = gameId, inputDelay = inputDelay.toLong())
         ).toDomain()
     }
 
     override suspend fun getSessions(): Result<List<NetplaySession>> = runCatching {
-        apiClient.getNetplaySessions().data.map { it.toDomain() }
+        apiClient.getNetplaySessions().data.orEmpty().map { it.toDomain() }
     }
 
     override suspend fun getSession(sessionId: String): Result<NetplaySession> = runCatching {
@@ -31,7 +31,7 @@ class NetplayRepositoryImpl(
     }
 
     override suspend fun joinByInviteCode(code: String): Result<NetplaySession> = runCatching {
-        apiClient.joinNetplayByInviteCode(JoinByInviteCodeRequest(code)).toDomain()
+        apiClient.joinNetplayByInviteCode(JoinByInviteCodeRequest(inviteCode = code)).toDomain()
     }
 
     override suspend fun leaveSession(sessionId: String): Result<Unit> = runCatching {
@@ -43,10 +43,13 @@ class NetplayRepositoryImpl(
     }
 
     override suspend fun updateInputDelay(sessionId: String, inputDelay: Int): Result<NetplaySession> = runCatching {
-        apiClient.updateNetplaySettings(sessionId, UpdateNetplaySettingsRequest(inputDelay)).toDomain()
+        apiClient.updateNetplaySettings(
+            sessionId,
+            UpdateNetplaySettingsRequest(inputDelay = inputDelay.toLong()),
+        ).toDomain()
     }
 
     override suspend fun sendNetplayInvite(sessionId: String, username: String): Result<Unit> = runCatching {
-        apiClient.sendNetplayInvite(sessionId, SendNetplayInviteRequest(username))
+        apiClient.sendNetplayInvite(sessionId, NetplayInviteUserRequest(username = username))
     }
 }


### PR DESCRIPTION
Thirteenth call-site migration in the #461 series. Eight netplay methods + six hand-written DTOs.

## Change

- `SpelaApiClient`:
  - `createNetplaySession(CreateNetplaySessionRequest)` → `NetplaySessionResponse`
  - `getNetplaySessions()` → `PaginatedResponseNetplaySessionResponse`
  - `getNetplaySession(id)` / `joinNetplayByInviteCode` / `updateNetplaySettings` → `NetplaySessionResponse`
  - `sendNetplayInvite(sessionId, NetplayInviteUserRequest)` (renamed from `SendNetplayInviteRequest`)
  - `leaveNetplaySession` / `deleteNetplaySession` unchanged (void)
- `NetplayRepositoryImpl`: request builders use named args since the generated request types have nullable fields. `.data.orEmpty()` for the paginated list. `Int`↔`Long` conversions for `inputDelay`.
- `NetplaySessionResponse.toDomain()` mapper: `coverAspectRatio` Double→Float, `inputDelay` Long→Int, `createdAt` / `startedAt` / `endedAt` Instant→String, nullable `consoleName` via `.orEmpty()` (domain has non-null default).
- Deleted six hand-written DTOs from `Dtos.kt`.

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop` — green
- [x] `./run-desktop-tests.sh` — **470/470 pass** (FramerateRegressionTest flaked once on timing, passed on rerun; unrelated)
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.