### PR TITLE
feat(player): migrate game-stats + most-active-players to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -620,7 +620,7 @@ class SpelaApiClient(
 
     // Game Stats
 
-    suspend fun getGameStats(gameId: String): GameStatsDto {
+    suspend fun getGameStats(gameId: String): com.spela.client.models.GameStatsResponse {
         return client.get("$baseUrl/api/games/$gameId/stats").body()
     }
 
@@ -1100,7 +1100,7 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/stats/most-played").body()
     }
 
-    suspend fun getMostActivePlayers(): MostActivePlayersResponse {
+    suspend fun getMostActivePlayers(): com.spela.client.models.MostActivePlayersResponse {
         return client.get("$baseUrl/api/stats/most-active-players").body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -379,18 +379,18 @@ fun CollectionDetailDto.toDomain(): GameCollectionDetail = GameCollectionDetail(
 
 // Game Stats mappers
 
-fun TopPlayerDto.toDomain(): TopPlayer = TopPlayer(
+fun com.spela.client.models.GameStatsTopPlayer.toDomain(): TopPlayer = TopPlayer(
     userId = userId,
     username = username,
-    avatarUrl = avatarUrl,
+    avatarUrl = avatarUrl.takeIf { it.isNotEmpty() },
     playTime = playTime,
 )
 
-fun GameStatsDto.toDomain(): GameStats = GameStats(
-    totalPlayers = totalPlayers,
+fun com.spela.client.models.GameStatsResponse.toDomain(): GameStats = GameStats(
+    totalPlayers = totalPlayers.toInt(),
     totalPlayTime = totalPlayTime,
     averagePlayTime = averagePlayTime,
-    topPlayers = topPlayers.map { it.toDomain() },
+    topPlayers = topPlayers.orEmpty().map { it.toDomain() },
 )
 
 fun GameAchievementDto.toDomain(): GameAchievement = GameAchievement(
@@ -500,13 +500,13 @@ fun MostPlayedGameDto.toDomain(): MostPlayedGame = MostPlayedGame(
     totalPlayTime = totalPlayTime,
 )
 
-fun ActivePlayerDto.toDomain(): ActivePlayer = ActivePlayer(
+fun com.spela.client.models.ActivePlayerEntry.toDomain(): ActivePlayer = ActivePlayer(
     userId = userId,
     username = username,
-    avatarUrl = avatarUrl,
+    avatarUrl = avatarUrl.takeIf { it.isNotEmpty() },
     totalPlayTime = totalPlayTime,
-    gamesPlayed = gamesPlayed,
-    lastPlayed = lastPlayed,
+    gamesPlayed = gamesPlayed.toInt(),
+    lastPlayed = lastPlayed.toString(),
 )
 
 // Challenge mappers

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -531,20 +531,9 @@ data class MostPlayedResponse(
     val games: List<MostPlayedGameDto> = emptyList(),
 )
 
-@Serializable
-data class ActivePlayerDto(
-    val userId: String,
-    val username: String,
-    val avatarUrl: String? = null,
-    val totalPlayTime: Long = 0,
-    val gamesPlayed: Int = 0,
-    val lastPlayed: String? = null,
-)
-
-@Serializable
-data class MostActivePlayersResponse(
-    val players: List<ActivePlayerDto> = emptyList(),
-)
+// ActivePlayerDto / MostActivePlayersResponse replaced by
+// com.spela.client.models.ActivePlayerEntry and MostActivePlayersResponse
+// (generated; same name).
 
 // Challenges
 
@@ -579,21 +568,8 @@ data class MostActivePlayersResponse(
 
 // Game Stats
 
-@Serializable
-data class TopPlayerDto(
-    val userId: String,
-    val username: String,
-    val avatarUrl: String? = null,
-    val playTime: Long = 0,
-)
-
-@Serializable
-data class GameStatsDto(
-    val totalPlayers: Int = 0,
-    val totalPlayTime: Long = 0,
-    val averagePlayTime: Long = 0,
-    val topPlayers: List<TopPlayerDto> = emptyList(),
-)
+// TopPlayerDto / GameStatsDto replaced by
+// com.spela.client.models.GameStatsTopPlayer and GameStatsResponse.
 
 // Game Achievements (RetroAchievements)
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/StatsRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/StatsRepositoryImpl.kt
@@ -22,7 +22,7 @@ class StatsRepositoryImpl(
     }
 
     override suspend fun getMostActivePlayers(): Result<List<ActivePlayer>> = runCatching {
-        apiClient.getMostActivePlayers().players.map { dto ->
+        apiClient.getMostActivePlayers().players.orEmpty().map { dto ->
             val player = dto.toDomain()
             player.copy(
                 avatarUrl = apiClient.resolveUrl(player.avatarUrl),


### PR DESCRIPTION
Fourteenth call-site migration in the #461 series. Two small stats endpoints.

## Change

- `SpelaApiClient.getGameStats(gameId)` → `GameStatsResponse`
- `SpelaApiClient.getMostActivePlayers()` → `MostActivePlayersResponse` (generated; same name as the old hand-written DTO)
- New mappers: `GameStatsTopPlayer.toDomain()`, `GameStatsResponse.toDomain()`, `ActivePlayerEntry.toDomain()`. `totalPlayers` / `gamesPlayed` Long→Int; `lastPlayed` Instant→String. `avatarUrl` is non-null `String` in the spec (server sends empty string when no avatar) but the domain keeps it nullable — use `takeIf { it.isNotEmpty() }` so empty avatars stay null for the UI layer.
- `StatsRepositoryImpl`: `.players.orEmpty()` for the spec's nullable list.
- Deleted `ActivePlayerDto` / `MostActivePlayersResponse` / `TopPlayerDto` / `GameStatsDto` from `Dtos.kt`.

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop :desktop:compileKotlinDesktop` — green (caught the `:desktop` visibility regression in #476; verified here)
- [x] `./run-desktop-tests.sh` — **470/470 pass** (`FramerateRegressionTest` flaked once on timing, passed on rerun)
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.