### PR TITLE
feat(player): migrate RA achievements endpoints to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -640,11 +640,15 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/games/$gameId/achievements/progress").body()
     }
 
-    suspend fun getAchievementTimeline(gameId: String): AchievementTimelineResponse {
+    suspend fun getAchievementTimeline(
+        gameId: String,
+    ): com.spela.client.models.AchievementTimelineResponse {
         return client.get("$baseUrl/api/games/$gameId/achievements/timeline").body()
     }
 
-    suspend fun getAchievementLeaderboard(gameId: String): AchievementLeaderboardResponse {
+    suspend fun getAchievementLeaderboard(
+        gameId: String,
+    ): com.spela.client.models.AchievementLeaderboardResponse {
         return client.get("$baseUrl/api/games/$gameId/achievements/leaderboard").body()
     }
 
@@ -654,23 +658,27 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/user/stats").body()
     }
 
-    suspend fun getRecentAchievements(): RecentAchievementsResponse {
+    suspend fun getRecentAchievements(): com.spela.client.models.RecentAchievementsResponse {
         return client.get("$baseUrl/api/user/achievements/recent").body()
     }
 
-    suspend fun getShowcase(): List<ShowcaseAchievementDto> {
+    suspend fun getShowcase(): List<com.spela.client.models.ShowcaseEntryResponse> {
         return client.get("$baseUrl/api/user/achievements/showcase").body()
     }
 
-    suspend fun getPublicShowcase(userId: String): List<ShowcaseAchievementDto> {
+    suspend fun getPublicShowcase(
+        userId: String,
+    ): List<com.spela.client.models.ShowcaseEntryResponse> {
         return client.get("$baseUrl/api/users/$userId/achievements/showcase").body()
     }
 
-    suspend fun getUnlockedAchievements(): UnlockedAchievementsResponse {
+    suspend fun getUnlockedAchievements(): com.spela.client.models.UnlockedAchievementsResponse {
         return client.get("$baseUrl/api/user/achievements/unlocked").body()
     }
 
-    suspend fun updateShowcase(entries: List<ShowcaseUpdateEntry>): List<ShowcaseAchievementDto> {
+    suspend fun updateShowcase(
+        entries: List<com.spela.client.models.ShowcaseEntryInput>,
+    ): List<com.spela.client.models.ShowcaseEntryResponse> {
         return client.put("$baseUrl/api/user/achievements/showcase") {
             contentType(io.ktor.http.ContentType.Application.Json)
             setBody(entries)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -411,36 +411,36 @@ fun AchievementProgressEntryDto.toDomain(): AchievementProgress = AchievementPro
     playTimeAtUnlock = playTimeAtUnlock,
 )
 
-fun AchievementTimelineEntryDto.toDomain(): AchievementTimelineEntry = AchievementTimelineEntry(
+fun com.spela.client.models.RATimelineEntryResponse.toDomain(): AchievementTimelineEntry = AchievementTimelineEntry(
     achievementRaId = achievementRaId,
     title = title,
     description = description,
-    points = points,
+    points = points.toInt(),
     badgeUrl = badgeUrl,
-    unlockedAt = unlockedAt,
+    unlockedAt = unlockedAt.toString(),
     isHardcore = isHardcore,
     playTimeAtUnlock = playTimeAtUnlock,
 )
 
-fun AchievementTimelineResponse.toDomain(): AchievementTimelineData = AchievementTimelineData(
+fun com.spela.client.models.AchievementTimelineResponse.toDomain(): AchievementTimelineData = AchievementTimelineData(
     raGameId = raGameId,
     gameTitle = gameTitle,
     totalPlayTime = totalPlayTime,
-    timeline = timeline.map { it.toDomain() },
-    totalAchievements = totalAchievements,
-    unlockedCount = unlockedCount,
-    totalPoints = totalPoints,
-    earnedPoints = earnedPoints,
+    timeline = timeline.orEmpty().map { it.toDomain() },
+    totalAchievements = totalAchievements.toInt(),
+    unlockedCount = unlockedCount.toInt(),
+    totalPoints = totalPoints.toInt(),
+    earnedPoints = earnedPoints.toInt(),
 )
 
-fun AchievementLeaderboardEntryDto.toDomain(): AchievementPlayerRanking = AchievementPlayerRanking(
+fun com.spela.client.models.RALeaderboardEntryResponse.toDomain(): AchievementPlayerRanking = AchievementPlayerRanking(
     userId = userId,
     username = username,
-    avatarUrl = avatarUrl,
-    unlockedCount = unlockedCount,
-    earnedPoints = earnedPoints,
-    firstUnlockedAt = firstUnlockedAt,
-    lastUnlockedAt = lastUnlockedAt,
+    avatarUrl = avatarUrl.takeIf { it.isNotEmpty() },
+    unlockedCount = unlockedCount.toInt(),
+    earnedPoints = earnedPoints.toInt(),
+    firstUnlockedAt = firstUnlockedAt.toString(),
+    lastUnlockedAt = lastUnlockedAt.toString(),
 )
 
 fun UserStatsDto.toDomain(): UserStats = UserStats(
@@ -453,13 +453,13 @@ fun UserStatsDto.toDomain(): UserStats = UserStats(
     lastPlayedAt = lastPlayedAt,
 )
 
-fun RecentAchievementDto.toDomain(): RecentAchievement = RecentAchievement(
+fun com.spela.client.models.RARecentAchievementResponse.toDomain(): RecentAchievement = RecentAchievement(
     achievementRaId = achievementRaId,
     title = title,
     description = description,
-    points = points,
+    points = points.toInt(),
     badgeUrl = badgeUrl,
-    unlockedAt = unlockedAt,
+    unlockedAt = unlockedAt.toString(),
     isHardcore = isHardcore,
     playTimeAtUnlock = playTimeAtUnlock,
     gameId = gameId,
@@ -468,24 +468,24 @@ fun RecentAchievementDto.toDomain(): RecentAchievement = RecentAchievement(
     coverUrl = coverUrl,
 )
 
-fun ShowcaseAchievementDto.toDomain(): ShowcaseAchievement = ShowcaseAchievement(
+fun com.spela.client.models.ShowcaseEntryResponse.toDomain(): ShowcaseAchievement = ShowcaseAchievement(
     achievementRaId = achievementRaId,
     raGameId = raGameId,
-    showcaseOrder = showcaseOrder,
-    title = title ?: "",
-    description = description ?: "",
-    points = points ?: 0,
+    showcaseOrder = showcaseOrder.toInt(),
+    title = title.orEmpty(),
+    description = description.orEmpty(),
+    points = points?.toInt() ?: 0,
     badgeUrl = badgeUrl,
     rarityPercent = rarityPercent ?: 0.0,
-    gameTitle = gameTitle ?: "",
+    gameTitle = gameTitle.orEmpty(),
 )
 
-fun UnlockedAchievementDto.toDomain(): UnlockedAchievement = UnlockedAchievement(
+fun com.spela.client.models.RAUnlockedAchievementResponse.toDomain(): UnlockedAchievement = UnlockedAchievement(
     achievementRaId = achievementRaId,
     raGameId = raGameId,
     title = title,
     description = description,
-    points = points,
+    points = points.toInt(),
     badgeUrl = badgeUrl,
     rarityPercent = rarityPercent,
     gameTitle = gameTitle,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -610,51 +610,12 @@ data class AchievementProgressResponse(
     val progress: List<AchievementProgressEntryDto> = emptyList(),
 )
 
-// Achievement Timeline
-
-@Serializable
-data class AchievementTimelineEntryDto(
-    val achievementRaId: Long = 0,
-    val title: String = "",
-    val description: String = "",
-    val points: Int = 0,
-    val badgeUrl: String? = null,
-    val unlockedAt: String = "",
-    val isHardcore: Boolean = false,
-    val playTimeAtUnlock: Long? = null,
-)
-
-@Serializable
-data class AchievementTimelineResponse(
-    val raGameId: Long? = null,
-    val gameTitle: String = "",
-    val totalPlayTime: Long = 0,
-    val timeline: List<AchievementTimelineEntryDto> = emptyList(),
-    val totalAchievements: Int = 0,
-    val unlockedCount: Int = 0,
-    val totalPoints: Int = 0,
-    val earnedPoints: Int = 0,
-)
-
-// Achievement Leaderboard
-
-@Serializable
-data class AchievementLeaderboardEntryDto(
-    val userId: String = "",
-    val username: String = "",
-    val avatarUrl: String? = null,
-    val unlockedCount: Int = 0,
-    val earnedPoints: Int = 0,
-    val firstUnlockedAt: String? = null,
-    val lastUnlockedAt: String? = null,
-)
-
-@Serializable
-data class AchievementLeaderboardResponse(
-    val raGameId: Long? = null,
-    val totalAchievements: Int = 0,
-    val leaderboard: List<AchievementLeaderboardEntryDto> = emptyList(),
-)
+// Achievement Timeline + Leaderboard DTOs replaced by generated
+// counterparts in com.spela.client.models:
+//   AchievementTimelineEntryDto      -> RATimelineEntryResponse
+//   AchievementTimelineResponse      -> AchievementTimelineResponse (same name)
+//   AchievementLeaderboardEntryDto   -> RALeaderboardEntryResponse
+//   AchievementLeaderboardResponse   -> AchievementLeaderboardResponse (same name)
 
 // User Stats
 
@@ -669,67 +630,15 @@ data class UserStatsDto(
     val lastPlayedAt: String? = null,
 )
 
-// Recent Achievements
+// Recent + Showcase + Unlocked achievement DTOs replaced by generated
+// counterparts in com.spela.client.models:
+//   RecentAchievementDto           -> RARecentAchievementResponse
+//   RecentAchievementsResponse     -> RecentAchievementsResponse (same name)
+//   ShowcaseAchievementDto         -> ShowcaseEntryResponse
+//   UnlockedAchievementDto         -> RAUnlockedAchievementResponse
+//   UnlockedAchievementsResponse   -> UnlockedAchievementsResponse (same name)
 
-@Serializable
-data class RecentAchievementDto(
-    val achievementRaId: Long = 0,
-    val title: String = "",
-    val description: String = "",
-    val points: Int = 0,
-    val badgeUrl: String? = null,
-    val unlockedAt: String = "",
-    val isHardcore: Boolean = false,
-    val playTimeAtUnlock: Long? = null,
-    val gameId: String = "",
-    val gameTitle: String = "",
-    val consoleName: String = "",
-    val coverUrl: String? = null,
-)
-
-@Serializable
-data class RecentAchievementsResponse(
-    val achievements: List<RecentAchievementDto> = emptyList(),
-)
-
-// Achievement Showcase
-
-@Serializable
-data class ShowcaseAchievementDto(
-    val achievementRaId: Long,
-    val raGameId: Long,
-    val showcaseOrder: Int = 0,
-    val title: String? = null,
-    val description: String? = null,
-    val points: Int? = null,
-    val badgeUrl: String? = null,
-    val rarityPercent: Double? = null,
-    val gameTitle: String? = null,
-)
-
-@Serializable
-data class UnlockedAchievementDto(
-    val achievementRaId: Long,
-    val raGameId: Long,
-    val title: String = "",
-    val description: String = "",
-    val points: Int = 0,
-    val badgeUrl: String? = null,
-    val rarityPercent: Double = 0.0,
-    val gameTitle: String = "",
-    val consoleName: String = "",
-)
-
-@Serializable
-data class UnlockedAchievementsResponse(
-    val achievements: List<UnlockedAchievementDto> = emptyList(),
-)
-
-@Serializable
-data class ShowcaseUpdateEntry(
-    val achievementRaId: Long,
-    val raGameId: Long,
-)
+// ShowcaseUpdateEntry replaced by com.spela.client.models.ShowcaseEntryInput.
 
 // Top Rated
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameStatsRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameStatsRepositoryImpl.kt
@@ -35,7 +35,7 @@ class GameStatsRepositoryImpl(
     }
 
     override suspend fun getAchievementLeaderboard(gameId: String): Result<List<AchievementPlayerRanking>> = runCatching {
-        apiClient.getAchievementLeaderboard(gameId).leaderboard.map { dto ->
+        apiClient.getAchievementLeaderboard(gameId).leaderboard.orEmpty().map { dto ->
             val ranking = dto.toDomain()
             ranking.copy(avatarUrl = apiClient.resolveUrl(ranking.avatarUrl))
         }
@@ -51,7 +51,7 @@ class GameStatsRepositoryImpl(
     }
 
     override suspend fun getRecentAchievements(): Result<List<RecentAchievement>> = runCatching {
-        apiClient.getRecentAchievements().achievements.map { dto ->
+        apiClient.getRecentAchievements().achievements.orEmpty().map { dto ->
             val achievement = dto.toDomain()
             achievement.copy(
                 badgeUrl = apiClient.resolveUrl(achievement.badgeUrl),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
@@ -1,7 +1,7 @@
 package com.spela.player.data.repository
 
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.data.remote.dto.ShowcaseUpdateEntry
+import com.spela.client.models.ShowcaseEntryInput
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.ActivityEvent
 import com.spela.player.domain.model.HeatmapEntry
@@ -63,14 +63,16 @@ class SocialRepositoryImpl(
     }
 
     override suspend fun getUnlockedAchievements(): Result<List<UnlockedAchievement>> = runCatching {
-        apiClient.getUnlockedAchievements().achievements.map { dto ->
+        apiClient.getUnlockedAchievements().achievements.orEmpty().map { dto ->
             val achievement = dto.toDomain()
             achievement.copy(badgeUrl = apiClient.resolveUrl(achievement.badgeUrl))
         }
     }
 
     override suspend fun updateShowcase(achievements: List<ShowcaseAchievement>): Result<List<ShowcaseAchievement>> = runCatching {
-        val entries = achievements.map { ShowcaseUpdateEntry(it.achievementRaId, it.raGameId) }
+        val entries = achievements.map {
+            ShowcaseEntryInput(achievementRaId = it.achievementRaId, raGameId = it.raGameId)
+        }
         apiClient.updateShowcase(entries).map { dto ->
             val achievement = dto.toDomain()
             achievement.copy(badgeUrl = apiClient.resolveUrl(achievement.badgeUrl))


### PR DESCRIPTION
Fifteenth call-site migration in the #461 series. Bundles five RA achievement endpoints — 10 hand-written DTOs swapped.

## Change

- `SpelaApiClient`:
  - `getRecentAchievements()` → `RecentAchievementsResponse`
  - `getShowcase()` / `getPublicShowcase(userId)` → `List<ShowcaseEntryResponse>`
  - `getUnlockedAchievements()` → `UnlockedAchievementsResponse`
  - `getAchievementLeaderboard(gameId)` → `AchievementLeaderboardResponse`
  - `getAchievementTimeline(gameId)` → `AchievementTimelineResponse`
  - `updateShowcase(entries)` takes `List<ShowcaseEntryInput>`
- Five new mappers in `DtoMappers.kt` (`RATimelineEntryResponse`, `AchievementTimelineResponse`, `RALeaderboardEntryResponse`, `RARecentAchievementResponse`, `ShowcaseEntryResponse`, `RAUnlockedAchievementResponse`). Long→Int for `points` / `rank` / `totalAchievements` / `unlockedCount` / `showcaseOrder`; `Instant`→`String` for `unlockedAt` / `firstUnlockedAt` / `lastUnlockedAt`.
- `GameStatsRepositoryImpl` + `SocialRepositoryImpl`: `.orEmpty()` on the spec's nullable list fields; `updateShowcase` constructs `ShowcaseEntryInput` from the generated package.
- Deleted 10 hand-written DTOs from `Dtos.kt`.

## Staying on hand-written (for now)

- `getGameAchievements` / `getAchievementProgress` — server handlers not huma-migrated, no generated types
- `getUserStats` — nests `GameDto` (the big one, saved for later)
- `getMostPlayedGames` — nests `GameDto`

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop :desktop:compileKotlinDesktop` — green
- [x] `./run-desktop-tests.sh` — **470/470 pass**
- [x] Pre-existing `SessionsUiTest` failures unchanged from master
- [ ] CI green

Refs #461.