### PR TITLE
feat(player): migrate GameDto + nested types to generated (the big one)

### DIFF
--- a/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/NetplayTestRunner.kt
+++ b/player/desktop/src/desktopMain/kotlin/com/spela/player/desktop/NetplayTestRunner.kt
@@ -134,9 +134,10 @@ private class NetplayTestRunnerImpl(private val config: Config) {
             // Find the game ID for Chip 'n Dale by listing NES games
             log("Finding game on server...")
             val gamesResponse = apiClient.getGamesForConsole("nes", page = 1, pageSize = 100)
-            val game = gamesResponse.data.firstOrNull { it.title.contains("Chip", ignoreCase = true) }
-                ?: gamesResponse.data.firstOrNull { it.title.contains("Rescue", ignoreCase = true) }
-                ?: error("Could not find Chip 'n Dale game on server. Available: ${gamesResponse.data.map { it.title }}")
+            val games = gamesResponse.data.orEmpty()
+            val game = games.firstOrNull { it.title.contains("Chip", ignoreCase = true) }
+                ?: games.firstOrNull { it.title.contains("Rescue", ignoreCase = true) }
+                ?: error("Could not find Chip 'n Dale game on server. Available: ${games.map { it.title }}")
 
             log("Creating netplay session for '${game.title}' (ID: ${game.id})...")
             val session = apiClient.createNetplaySession(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -65,39 +65,45 @@ fun com.spela.client.models.ConsoleResponse.toDomain(): Console = Console(
 )
 
 fun GameDiscDto.toDomain(): GameDisc = GameDisc(
-    discNumber = discNumber,
+    discNumber = discNumber.toInt(),
     fileName = fileName,
     fileSize = fileSize,
 )
 
-/** Maps the enriched GameResponse DTO to domain Game. */
+/** Maps the enriched GameResponse DTO to domain Game.
+ *
+ * The generated GameResponse has several fields server-marked @Required
+ * with `String` type where the hand-written DTO had `String?` — the server
+ * emits empty strings when a field is absent. We convert `""` back to
+ * `null` so the domain layer keeps its existing "missing data" semantics.
+ */
 fun GameDto.toDomain(): Game = Game(
     id = id,
     title = title,
     consoleId = consoleId,
     consoleName = consoleName,
     coverAspectRatio = coverAspectRatio.toFloat(),
-    coverUrl = coverUrl,
-    description = description,
-    developer = developer,
-    publisher = publisher,
-    releaseDate = releaseDate,
-    genre = genre,
+    coverUrl = coverUrl.takeIf { it.isNotEmpty() },
+    description = description.takeIf { it.isNotEmpty() },
+    developer = developer.takeIf { it.isNotEmpty() },
+    publisher = publisher.takeIf { it.isNotEmpty() },
+    releaseDate = releaseDate.takeIf { it.isNotEmpty() },
+    genre = genre.takeIf { it.isNotEmpty() },
     fileSize = fileSize,
     fileName = fileName,
     coreOverride = coreOverride,
-    scrapeAttempts = scrapeAttempts,
-    players = players,
+    scrapeAttempts = scrapeAttempts.toInt(),
+    players = players.toInt(),
     igdbCriticsRating = igdbCriticsRating,
     communityRating = averageRating,
     communityRatingCount = ratingCount,
-    userRating = userRating,
+    userRating = userRating?.toInt(),
     isFavorite = isFavorite,
     isInPlayLater = isInPlayLater,
-    lastPlayedAt = lastPlayedAt,
+    lastPlayedAt = lastPlayedAt?.toString(),
     totalPlayTime = totalPlayTime,
-    discCount = discCount,
-    discs = discs.map { it.toDomain() },
+    discCount = discCount.toInt(),
+    discs = discs.orEmpty().map { it.toDomain() },
     achievementsWarning = achievementsWarning,
     verificationStatus = verificationStatus,
     verificationTag = verificationTag,
@@ -108,18 +114,14 @@ fun GameDto.toDomain(): Game = Game(
     revision = revision,
     tags = tags,
     isPreRelease = isPreRelease,
-    variantCount = variantCount,
+    variantCount = variantCount?.toInt() ?: 0,
     groupKey = groupKey,
-    timeToBeatHastily = timeToBeatHastily,
-    timeToBeatNormally = timeToBeatNormally,
-    timeToBeatCompletely = timeToBeatCompletely,
-    partyInfo = partyInfo,
+    timeToBeatHastily = timeToBeatHastily?.toInt() ?: 0,
+    timeToBeatNormally = timeToBeatNormally?.toInt() ?: 0,
+    timeToBeatCompletely = timeToBeatCompletely?.toInt() ?: 0,
+    partyInfo = partyInfo.orEmpty(),
 )
 
-/**
- * Constructs GameDetail from the enriched GameResponse.
- * screenshotUrls comes directly from the response.
- */
 fun GameVariantDto.toDomain(): GameVariant = GameVariant(
     id = id,
     title = title,
@@ -144,12 +146,13 @@ fun RomHackGameDto.toDomain(): RomHackGame = RomHackGame(
     coverUrl = coverUrl,
 )
 
+/** Constructs GameDetail from the enriched GameResponse. */
 fun GameDto.toGameDetail(): GameDetail = GameDetail(
     game = toDomain(),
-    screenshots = screenshotUrls,
-    variants = variants.map { it.toDomain() },
+    screenshots = screenshotUrls.orEmpty(),
+    variants = variants.orEmpty().map { it.toDomain() },
     parentGame = parentGame?.toDomain(),
-    romHacks = romHacks.map { it.toDomain() },
+    romHacks = romHacks.orEmpty().map { it.toDomain() },
 )
 
 fun SaveStateDto.toDomain(): SaveState = SaveState(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -86,104 +86,22 @@ data class ConsoleDto(
     val updatedAt: String? = null,
 )
 
-@Serializable
-data class GameDiscDto(
-    val discNumber: Int,
-    val fileName: String,
-    val fileSize: Long,
-)
-
-/** Matches GameResponse in responses.go - enriched with consoleName, isFavorite, etc. */
-@Serializable
-data class GameDto(
-    val id: String,
-    val title: String,
-    val consoleId: String,
-    val consoleName: String = "",
-    val coverAspectRatio: Double = 0.75,
-    val fileName: String = "",
-    val fileSize: Long = 0,
-    val coverUrl: String? = null,
-    val screenshotUrls: List<String> = emptyList(),
-    val description: String? = null,
-    val developer: String? = null,
-    val publisher: String? = null,
-    val releaseDate: String? = null,
-    val genre: String? = null,
-    val players: Int = 0,
-    val igdbCriticsRating: Double = 0.0,
-    val averageRating: Double = 0.0,
-    val ratingCount: Long = 0,
-    val userRating: Int? = null,
-    val coreOverride: String? = null,
-    val scraperId: String? = null,
-    val scrapeAttempts: Int = 0,
-    val isFavorite: Boolean = false,
-    val isInPlayLater: Boolean = false,
-    val lastPlayedAt: String? = null,
-    val totalPlayTime: Long = 0,
-    val discCount: Int = 0,
-    val discs: List<GameDiscDto> = emptyList(),
-    val achievementsWarning: String? = null,
-    val verificationStatus: String? = null,
-    val verificationTag: String? = null,
-    val region: String? = null,
-    val playable: Boolean = true,
-    val heroUrl: String? = null,
-    val logoUrl: String? = null,
-    val revision: String? = null,
-    val tags: String? = null,
-    val isPreRelease: Boolean = false,
-    val variantCount: Int = 0,
-    val groupKey: String? = null,
-    val variants: List<GameVariantDto> = emptyList(),
-    val parentGame: ParentGameDto? = null,
-    val romHacks: List<RomHackGameDto> = emptyList(),
-    val timeToBeatHastily: Int = 0,
-    val timeToBeatNormally: Int = 0,
-    val timeToBeatCompletely: Int = 0,
-    val partyInfo: String = "",
-    val createdAt: String? = null,
-    val updatedAt: String? = null,
-)
-
-@Serializable
-data class GameVariantDto(
-    val id: String,
-    val title: String,
-    val fileName: String = "",
-    val region: String? = null,
-    val revision: String? = null,
-    val tags: String? = null,
-    val isPreRelease: Boolean = false,
-    val fileSize: Long = 0,
-    val verificationStatus: String? = null,
-)
-
-/** Minimal reference to a parent game for standalone ROM hacks. */
-@Serializable
-data class ParentGameDto(
-    val id: String,
-    val title: String,
-    val coverUrl: String? = null,
-)
-
-/** Minimal reference to a standalone ROM hack based on a game. */
-@Serializable
-data class RomHackGameDto(
-    val id: String,
-    val title: String,
-    val coverUrl: String? = null,
-)
-
-/** Wrapper for GET /api/games which returns {data, total, page, pageSize} */
-@Serializable
-data class GameListResponse(
-    val data: List<GameDto>,
-    val total: Long,
-    val page: Int,
-    val pageSize: Int,
-)
+// GameDto / GameDiscDto / GameVariantDto / ParentGameDto / RomHackGameDto
+// replaced by generated counterparts in com.spela.client.models — see
+// player/shared-api/. Aliased here so the 39 places that nest these types
+// (other DTOs, paginated wrappers, etc.) keep compiling unchanged.
+//
+// Consumers that read raw fields on the DTO will see the generated types'
+// primary shape (Long / Instant / non-null strings where the server sends
+// empty). Domain translation in DtoMappers.kt handles the conversions
+// (Long->Int, Instant->String, empty-string -> null). New code should
+// prefer the generated names directly.
+typealias GameDto = com.spela.client.models.GameResponse
+typealias GameDiscDto = com.spela.client.models.DiscResponse
+typealias GameVariantDto = com.spela.client.models.VariantResponse
+typealias ParentGameDto = com.spela.client.models.ParentGameResponse
+typealias RomHackGameDto = com.spela.client.models.RomHackGameResponse
+typealias GameListResponse = com.spela.client.models.PaginatedResponseGameResponse
 
 @Serializable
 data class SaveStateDto(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
@@ -61,7 +61,7 @@ class DownloadRepositoryImpl(
         val gameDetail = apiClient.getGameDetail(gameId)
         println("[Download] Game detail: fileName=${gameDetail.fileName} fileSize=${gameDetail.fileSize} discCount=${gameDetail.discCount}")
 
-        val discs = gameDetail.discs
+        val discs = gameDetail.discs.orEmpty()
         if (gameDetail.discCount >= 2) {
             downloadMultiDiscGame(gameId, gameTitle, gameDetail)
         } else if (discs.isNotEmpty() && discs.size == 1) {
@@ -140,7 +140,7 @@ class DownloadRepositoryImpl(
         gameTitle: String,
         game: GameDto,
     ): String {
-        val disc = game.discs.first()
+        val disc = game.discs.orEmpty().first()
         val gameDir = fileStorage.getGamesDir() + "/$gameId"
         if (fileStorage.fileExists(gameDir) && !fileStorage.isDirectory(gameDir)) {
             fileStorage.deleteFile(gameDir)
@@ -150,7 +150,7 @@ class DownloadRepositoryImpl(
         if (disc.fileName.endsWith(".cue", ignoreCase = true) ||
             disc.fileName.endsWith(".gdi", ignoreCase = true)) {
             // Tar archive (cue+bin or gdi+tracks) — stream-extract directly to disk
-            apiClient.downloadDiscAndExtract(gameId, disc.discNumber, fileStorage, gameDir) { downloaded, total ->
+            apiClient.downloadDiscAndExtract(gameId, disc.discNumber.toInt(), fileStorage, gameDir) { downloaded, total ->
                 val reportedTotal = if (disc.fileSize > 0) disc.fileSize else (total ?: -1)
                 downloads.update {
                     it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal))
@@ -159,7 +159,7 @@ class DownloadRepositoryImpl(
         } else {
             // Single file — stream to disk
             val discPath = "$gameDir/${disc.fileName}"
-            apiClient.downloadDiscToFile(gameId, disc.discNumber, fileStorage, discPath) { downloaded, total ->
+            apiClient.downloadDiscToFile(gameId, disc.discNumber.toInt(), fileStorage, discPath) { downloaded, total ->
                 val reportedTotal = if (disc.fileSize > 0) disc.fileSize else (total ?: -1)
                 downloads.update {
                     it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal))
@@ -207,45 +207,45 @@ class DownloadRepositoryImpl(
         fileStorage.createDirectory(gameDir)
 
         val m3uPath = "$gameDir/game.m3u"
-        val totalDiscs = game.discs.size
+        val totalDiscs = game.discs.orEmpty().size
         val totalSize = game.fileSize
         var completedBytes = 0L
 
         // Download each disc FIRST — write M3U only after all discs succeed.
         // Writing M3U early would make getLocalGamePath treat the game as cached
         // even if disc downloads fail or are still in progress.
-        for ((index, disc) in game.discs.sortedBy { it.discNumber }.withIndex()) {
+        for ((index, disc) in game.discs.orEmpty().sortedBy { it.discNumber }.withIndex()) {
             val discOffset = completedBytes
 
             downloads.update {
                 it + (gameId to DownloadProgress(
                     gameId, gameTitle, DownloadState.DOWNLOADING,
                     bytesDownloaded = discOffset, totalBytes = totalSize,
-                    currentDisc = disc.discNumber, totalDiscs = totalDiscs,
+                    currentDisc = disc.discNumber.toInt(), totalDiscs = totalDiscs,
                 ))
             }
 
             if (disc.fileName.endsWith(".cue", ignoreCase = true) ||
                 disc.fileName.endsWith(".gdi", ignoreCase = true)) {
                 // Tar archive (cue+bin or gdi+tracks) - stream-extract directly to disk
-                apiClient.downloadDiscAndExtract(gameId, disc.discNumber, fileStorage, gameDir) { downloaded, total ->
+                apiClient.downloadDiscAndExtract(gameId, disc.discNumber.toInt(), fileStorage, gameDir) { downloaded, total ->
                     downloads.update {
                         it + (gameId to DownloadProgress(
                             gameId, gameTitle, DownloadState.DOWNLOADING,
                             bytesDownloaded = discOffset + downloaded, totalBytes = totalSize,
-                            currentDisc = disc.discNumber, totalDiscs = totalDiscs,
+                            currentDisc = disc.discNumber.toInt(), totalDiscs = totalDiscs,
                         ))
                     }
                 }
             } else {
                 // Single file (ISO/CHD/CSO) - stream to disk
                 val discPath = "$gameDir/${disc.fileName}"
-                apiClient.downloadDiscToFile(gameId, disc.discNumber, fileStorage, discPath) { downloaded, total ->
+                apiClient.downloadDiscToFile(gameId, disc.discNumber.toInt(), fileStorage, discPath) { downloaded, total ->
                     downloads.update {
                         it + (gameId to DownloadProgress(
                             gameId, gameTitle, DownloadState.DOWNLOADING,
                             bytesDownloaded = discOffset + downloaded, totalBytes = totalSize,
-                            currentDisc = disc.discNumber, totalDiscs = totalDiscs,
+                            currentDisc = disc.discNumber.toInt(), totalDiscs = totalDiscs,
                         ))
                     }
                 }
@@ -255,7 +255,7 @@ class DownloadRepositoryImpl(
         }
 
         // Write .m3u with local filenames — only after all discs downloaded
-        val m3uContent = game.discs.sortedBy { it.discNumber }
+        val m3uContent = game.discs.orEmpty().sortedBy { it.discNumber }
             .joinToString("\n") { it.fileName } + "\n"
         fileStorage.writeFile(m3uPath, m3uContent.encodeToByteArray())
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -74,7 +74,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getThemeGames(themeId: String, page: Int, pageSize: Int): Result<List<Game>> = runCatching {
-        apiClient.getThemeGames(themeId, page, pageSize).data.map { gameDto ->
+        apiClient.getThemeGames(themeId, page, pageSize).data.orEmpty().map { gameDto ->
             gameDto.toDomain().copy(
                 coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
@@ -88,7 +88,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getKeywordGames(keywordId: String, page: Int, pageSize: Int): Result<List<Game>> = runCatching {
-        apiClient.getKeywordGames(keywordId, page, pageSize).data.map { gameDto ->
+        apiClient.getKeywordGames(keywordId, page, pageSize).data.orEmpty().map { gameDto ->
             gameDto.toDomain().copy(
                 coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
@@ -389,7 +389,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getFilteredGames(filters: Map<String, String>, page: Int, pageSize: Int): Result<List<Game>> = runCatching {
-        apiClient.getFilteredGames(filters, page, pageSize).data.map { gameDto ->
+        apiClient.getFilteredGames(filters, page, pageSize).data.orEmpty().map { gameDto ->
             gameDto.toDomain().copy(
                 coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 heroUrl = apiClient.resolveUrl(gameDto.heroUrl),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
@@ -36,7 +36,7 @@ class GameRepositoryImpl(
 
     override suspend fun getGamesForConsole(consoleId: String): Result<List<Game>> {
         return runCatching {
-            val games = apiClient.getGamesForConsole(consoleId, pageSize = 200).data
+            val games = apiClient.getGamesForConsole(consoleId, pageSize = 200).data.orEmpty()
                 .map { it.toDomain().resolveImageUrls() }
             cacheGames(games)
             games
@@ -61,20 +61,20 @@ class GameRepositoryImpl(
                 hidePreRelease = hidePreRelease,
                 grouped = grouped,
             )
-            val games = response.data.map { it.toDomain().resolveImageUrls() }
+            val games = response.data.orEmpty().map { it.toDomain().resolveImageUrls() }
             if (page == 1) cacheGames(games)
             PaginatedResult(
                 data = games,
                 total = response.total,
-                page = response.page,
-                pageSize = response.pageSize,
+                page = response.page.toInt(),
+                pageSize = response.pageSize.toInt(),
             )
         }
     }
 
     override suspend fun getAllGames(): Result<List<Game>> {
         return runCatching {
-            val games = apiClient.getAllGames().data.map { it.toDomain().resolveImageUrls() }
+            val games = apiClient.getAllGames().data.orEmpty().map { it.toDomain().resolveImageUrls() }
             cacheGames(games)
             games
         }.recoverCatching {
@@ -96,13 +96,13 @@ class GameRepositoryImpl(
                 hidePreRelease = hidePreRelease,
                 grouped = grouped,
             )
-            val games = response.data.map { it.toDomain().resolveImageUrls() }
+            val games = response.data.orEmpty().map { it.toDomain().resolveImageUrls() }
             if (page == 1) cacheGames(games)
             PaginatedResult(
                 data = games,
                 total = response.total,
-                page = response.page,
-                pageSize = response.pageSize,
+                page = response.page.toInt(),
+                pageSize = response.pageSize.toInt(),
             )
         }
     }
@@ -114,7 +114,7 @@ class GameRepositoryImpl(
         sortOrder: String?,
     ): Result<List<Game>> {
         return runCatching {
-            apiClient.searchGames(query, consoleId, sortBy, sortOrder).data.map { it.toDomain().resolveImageUrls() }
+            apiClient.searchGames(query, consoleId, sortBy, sortOrder).data.orEmpty().map { it.toDomain().resolveImageUrls() }
         }.recoverCatching {
             val cached = searchCachedGames(query)
             if (cached.isNotEmpty()) cached else throw it
@@ -142,12 +142,12 @@ class GameRepositoryImpl(
                 page = page,
                 pageSize = pageSize,
             )
-            val games = response.data.map { it.toDomain().resolveImageUrls() }
+            val games = response.data.orEmpty().map { it.toDomain().resolveImageUrls() }
             PaginatedResult(
                 data = games,
                 total = response.total,
-                page = response.page,
-                pageSize = response.pageSize,
+                page = response.page.toInt(),
+                pageSize = response.pageSize.toInt(),
             )
         }
     }
@@ -215,7 +215,7 @@ class GameRepositoryImpl(
     }
 
     override suspend fun getRecentlyAddedGames(): Result<List<Game>> = runCatching {
-        apiClient.getRecentlyAddedGames().data.map { it.toDomain().resolveImageUrls() }
+        apiClient.getRecentlyAddedGames().data.orEmpty().map { it.toDomain().resolveImageUrls() }
     }
 
     override suspend fun getTopRatedGames(consoleId: String): Result<List<TopRatedGame>> {

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -3,6 +3,59 @@ package com.spela.player.data.repository
 import com.spela.player.data.remote.dto.*
 import kotlin.test.*
 
+private fun testGameResponse(
+    id: String,
+    title: String,
+    consoleId: String,
+    consoleName: String = "",
+    fileName: String = "",
+    fileSize: Long = 0,
+    coverAspectRatio: Double = 0.75,
+    coverUrl: String = "",
+    screenshotUrls: List<String>? = null,
+    description: String = "",
+    developer: String = "",
+    publisher: String = "",
+    releaseDate: String = "",
+    genre: String = "",
+    isFavorite: Boolean = false,
+    isInPlayLater: Boolean = false,
+    lastPlayedAt: kotlin.time.Instant? = null,
+    totalPlayTime: Long = 0,
+): com.spela.client.models.GameResponse {
+    val now = kotlin.time.Instant.fromEpochSeconds(0)
+    return com.spela.client.models.GameResponse(
+        averageRating = 0.0,
+        consoleId = consoleId,
+        consoleName = consoleName,
+        coverAspectRatio = coverAspectRatio,
+        coverUrl = coverUrl,
+        createdAt = now,
+        description = description,
+        developer = developer,
+        discCount = 0L,
+        fileName = fileName,
+        fileSize = fileSize,
+        genre = genre,
+        id = id,
+        igdbCriticsRating = 0.0,
+        isFavorite = isFavorite,
+        isInPlayLater = isInPlayLater,
+        isPreRelease = false,
+        lastPlayedAt = lastPlayedAt,
+        playable = true,
+        players = 0L,
+        publisher = publisher,
+        ratingCount = 0L,
+        releaseDate = releaseDate,
+        scrapeAttempts = 0L,
+        screenshotUrls = screenshotUrls,
+        title = title,
+        totalPlayTime = totalPlayTime,
+        updatedAt = now,
+    )
+}
+
 class GameRepositoryImplTest {
 
     private val sampleConsoles = listOf(
@@ -11,8 +64,8 @@ class GameRepositoryImplTest {
     )
 
     private val sampleGames = listOf(
-        GameDto("1", "Super Mario Bros.", "1", consoleName = "NES", fileName = "smb.nes", fileSize = 40960, releaseDate = "1985-09-13"),
-        GameDto("2", "Zelda", "1", consoleName = "NES", fileName = "zelda.nes", fileSize = 131072, releaseDate = "1986-02-21"),
+        testGameResponse("1", "Super Mario Bros.", "1", consoleName = "NES", fileName = "smb.nes", fileSize = 40960, releaseDate = "1985-09-13"),
+        testGameResponse("2", "Zelda", "1", consoleName = "NES", fileName = "zelda.nes", fileSize = 131072, releaseDate = "1986-02-21"),
     )
 
     @Test
@@ -335,22 +388,23 @@ class GameRepositoryImplTest {
 
     @Test
     fun gameDtoMapsEnrichedFields() {
-        val dto = GameDto(
+        val lastPlayed = kotlin.time.Instant.parse("2024-01-15T10:30:00Z")
+        val dto = testGameResponse(
             "1", "Test", "1",
             isFavorite = true,
-            lastPlayedAt = "2024-01-15T10:30:00Z",
+            lastPlayedAt = lastPlayed,
             totalPlayTime = 3600,
         )
         val domain = dto.toDomain()
 
         assertTrue(domain.isFavorite)
-        assertEquals("2024-01-15T10:30:00Z", domain.lastPlayedAt)
+        assertEquals(lastPlayed.toString(), domain.lastPlayedAt)
         assertEquals(3600, domain.totalPlayTime)
     }
 
     @Test
     fun gameDtoToGameDetailIncludesScreenshots() {
-        val dto = GameDto("1", "Test", "1", screenshotUrls = listOf("https://example.com/ss1.jpg", "https://example.com/ss2.jpg"))
+        val dto = testGameResponse("1", "Test", "1", screenshotUrls = listOf("https://example.com/ss1.jpg", "https://example.com/ss2.jpg"))
         val detail = dto.toGameDetail()
 
         assertEquals("Test", detail.game.title)
@@ -360,7 +414,7 @@ class GameRepositoryImplTest {
 
     @Test
     fun gameDtoToGameDetailWithoutScreenshots() {
-        val dto = GameDto("1", "Test", "1")
+        val dto = testGameResponse("1", "Test", "1")
         val detail = dto.toGameDetail()
 
         assertTrue(detail.screenshots.isEmpty())
@@ -406,23 +460,24 @@ class GameRepositoryImplTest {
 
     @Test
     fun recentGamesAreEnrichedGameResponses() {
-        val dto = GameDto(
+        val lastPlayed = kotlin.time.Instant.parse("2024-01-15T10:30:00Z")
+        val dto = testGameResponse(
             "1", "Super Mario Bros.", "1",
             consoleName = "NES",
             fileName = "smb.nes",
-            lastPlayedAt = "2024-01-15T10:30:00Z",
+            lastPlayedAt = lastPlayed,
             totalPlayTime = 7200,
         )
         val game = dto.toDomain()
 
         assertEquals("Super Mario Bros.", game.title)
-        assertEquals("2024-01-15T10:30:00Z", game.lastPlayedAt)
+        assertEquals(lastPlayed.toString(), game.lastPlayedAt)
         assertEquals(7200, game.totalPlayTime)
     }
 
     @Test
     fun favoriteGamesHaveIsFavoriteTrue() {
-        val dto = GameDto("1", "Zelda", "1", consoleName = "NES", fileName = "zelda.nes", isFavorite = true)
+        val dto = testGameResponse("1", "Zelda", "1", consoleName = "NES", fileName = "zelda.nes", isFavorite = true)
         val game = dto.toDomain()
 
         assertEquals("Zelda", game.title)
@@ -450,14 +505,14 @@ class GameRepositoryImplTest {
     @Test
     fun paginatedResponseUsesDataField() {
         val response = GameListResponse(
-            data = listOf(GameDto("1", "Test", "1")),
-            total = 1,
-            page = 1,
-            pageSize = 50,
+            data = listOf(testGameResponse("1", "Test", "1")),
+            total = 1L,
+            page = 1L,
+            pageSize = 50L,
         )
 
-        assertEquals(1, response.data.size)
-        assertEquals("Test", response.data[0].title)
+        assertEquals(1, response.data.orEmpty().size)
+        assertEquals("Test", response.data.orEmpty()[0].title)
         assertEquals(50, response.pageSize)
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GameRepositoryOfflineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GameRepositoryOfflineTest.kt
@@ -28,6 +28,32 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+/**
+ * Canonical GameResponse JSON for mock HTTP responses. Includes every
+ * @Required field — kotlinx-serialization's strict mode rejects payloads
+ * missing any of them.
+ */
+private fun gameJson(
+    id: String = "10",
+    title: String = "Super Mario Bros",
+    isFavorite: Boolean = false,
+    lastPlayedAt: String? = null,
+    totalPlayTime: Long = 0,
+    screenshotUrls: List<String>? = null,
+): String {
+    val screenshots = screenshotUrls?.joinToString(",", "[", "]") { "\"$it\"" } ?: "null"
+    val lastPlayed = lastPlayedAt?.let { "\"$it\"" } ?: "null"
+    return """{"id":"$id","title":"$title","consoleId":"1","consoleName":"NES",""" +
+        """"averageRating":0,"coverAspectRatio":0.75,"coverUrl":"/covers/smb.png",""" +
+        """"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z",""" +
+        """"description":"A classic platformer","developer":"Nintendo",""" +
+        """"discCount":0,"fileName":"smb.nes","fileSize":40960,"genre":"Platformer",""" +
+        """"igdbCriticsRating":0,"isFavorite":$isFavorite,"isInPlayLater":false,"isPreRelease":false,""" +
+        """"lastPlayedAt":$lastPlayed,"playable":true,"players":1,"publisher":"Nintendo",""" +
+        """"ratingCount":0,"releaseDate":"1985-09-13","scrapeAttempts":0,""" +
+        """"screenshotUrls":$screenshots,"totalPlayTime":$totalPlayTime}"""
+}
+
 @OptIn(ExperimentalCoroutinesApi::class)
 class GameRepositoryOfflineTest {
 
@@ -57,27 +83,27 @@ class GameRepositoryOfflineTest {
                             headersOf(HttpHeaders.ContentType, "application/json"),
                         )
                         path.contains("/api/consoles/") && path.endsWith("/games") -> respond(
-                            """[{"id":"10","title":"Super Mario Bros","consoleId":"1","consoleName":"NES","coverUrl":"/covers/smb.png","description":"A classic platformer","developer":"Nintendo","publisher":"Nintendo","releaseDate":"1985-09-13","genre":"Platformer","fileSize":40960,"fileName":"smb.nes","isFavorite":false,"lastPlayedAt":null,"totalPlayTime":0}]""",
+                            "[${gameJson()}]",
                             HttpStatusCode.OK,
                             headersOf(HttpHeaders.ContentType, "application/json"),
                         )
                         path.endsWith("/api/games") -> respond(
-                            """{"data":[{"id":"10","title":"Super Mario Bros","consoleId":"1","consoleName":"NES","coverUrl":"/covers/smb.png","description":"A classic platformer","developer":"Nintendo","publisher":"Nintendo","releaseDate":"1985-09-13","genre":"Platformer","fileSize":40960,"fileName":"smb.nes"}],"total":1,"page":1,"pageSize":20}""",
+                            """{"data":[${gameJson()}],"total":1,"page":1,"pageSize":20}""",
                             HttpStatusCode.OK,
                             headersOf(HttpHeaders.ContentType, "application/json"),
                         )
                         path.matches(Regex(".*/api/games/\\d+$")) -> respond(
-                            """{"id":"10","title":"Super Mario Bros","consoleId":"1","consoleName":"NES","coverUrl":"/covers/smb.png","screenshotUrls":["/screenshots/smb1.png"],"description":"A classic platformer","developer":"Nintendo","publisher":"Nintendo","releaseDate":"1985-09-13","genre":"Platformer","fileSize":40960,"fileName":"smb.nes"}""",
+                            gameJson(screenshotUrls = listOf("/screenshots/smb1.png")),
                             HttpStatusCode.OK,
                             headersOf(HttpHeaders.ContentType, "application/json"),
                         )
                         path.endsWith("/api/user/recent") -> respond(
-                            """[{"id":"10","title":"Super Mario Bros","consoleId":"1","consoleName":"NES","lastPlayedAt":"2026-02-20T10:00:00Z","totalPlayTime":3600}]""",
+                            "[${gameJson(lastPlayedAt = "2026-02-20T10:00:00Z", totalPlayTime = 3600L)}]",
                             HttpStatusCode.OK,
                             headersOf(HttpHeaders.ContentType, "application/json"),
                         )
                         path.endsWith("/api/user/favorites") -> respond(
-                            """[{"id":"10","title":"Super Mario Bros","consoleId":"1","consoleName":"NES","isFavorite":true}]""",
+                            "[${gameJson(isFavorite = true)}]",
                             HttpStatusCode.OK,
                             headersOf(HttpHeaders.ContentType, "application/json"),
                         )


### PR DESCRIPTION
Sixteenth call-site migration in the #461 series. The keystone one — unlocks every remaining migration blocked by nested `GameDto` references.

## Why typealias (not data-class replacement)

`GameDto` is nested in 39 other hand-written DTOs across `Dtos.kt` — `MostPlayedGameDto`, `UserStatsDto`, `SeriesGameDto`, `CollectionDetailDto`, `ConsoleShowcaseDto`, developer-detail, trending, explore, timeline, and so on. Field-replacing would mean rewriting every one of them in a single commit. **Typealiasing** keeps the nested references valid while flipping the wire format to the generated type. Future PRs can then migrate each of those parent DTOs individually at their own pace, because `GameDto` now resolves to `GameResponse`.

## Change

### Types (in `Dtos.kt`)

Six typealiases to `com.spela.client.models.*`:
- `GameDto` → `GameResponse`
- `GameDiscDto` → `DiscResponse`
- `GameVariantDto` → `VariantResponse`
- `ParentGameDto` → `ParentGameResponse`
- `RomHackGameDto` → `RomHackGameResponse`
- `GameListResponse` → `PaginatedResponseGameResponse`

### Mappers (in `DtoMappers.kt`)

Five `toDomain()` mappers rewritten to handle the type deltas the codegen introduces:

| Delta | Fields | Fix |
|---|---|---|
| `Long` → `Int` | `players`, `scrapeAttempts`, `discCount`, `variantCount`, `userRating`, `timeToBeat{Hastily,Normally,Completely}`, `discNumber` | `.toInt()` |
| `Instant?` → `String?` | `lastPlayedAt` | `.toString()` |
| `@Required String` (server sends `""`) → `String?` | `coverUrl`, `description`, `developer`, `publisher`, `releaseDate`, `genre` | `.takeIf { it.isNotEmpty() }` |
| `List<T>?` → `List<T>` | `discs`, `variants`, `romHacks`, `screenshotUrls` | `.orEmpty()` |

### Call sites

- `GameRepositoryImpl` / `ExploreRepositoryImpl` / `DownloadRepositoryImpl`: `.data.orEmpty()` for the paginated `PaginatedResponseGameResponse.data` field; `.discs.orEmpty()`; `disc.discNumber.toInt()`; `response.page` / `.pageSize` `.toInt()`.
- `NetplayTestRunner` (`:desktop`): `.orEmpty()` on the nullable games list.

### Tests

- `GameRepositoryImplTest`: adds a private `testGameResponse(id, title, consoleId, ...)` helper that matches the old positional `GameDto` constructor signature. Eight `GameDto(...)` call sites switched to it.
- `GameRepositoryOfflineTest`: adds a `gameJson(...)` helper that emits the canonical JSON with **all** `@Required` `GameResponse` fields. The old mock payloads omitted ~10 required fields that kotlinx-serialization's strict mode now rejects — same class of issue we hit in the consoles migration (#464).

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop :shared:compileTestKotlinDesktop :desktop:compileKotlinDesktop :shared:compileDebugKotlinAndroid` — all green
- [x] `./run-desktop-tests.sh` — **470/470 pass** (matches master; pre-existing `SessionsUiTest` E2E failures unchanged)
- [ ] CI green

## What this unlocks

Once this lands, every remaining hand-written DTO that nests a game type becomes migratable: `MostPlayedGameDto`, `UserStatsDto`, `CollectionDetailDto`, `DeveloperDetailDto`, `SearchGameResultDto`, `SeriesGameDto`, `ConsoleShowcaseDto`, `FeaturedGameDto`, developer-spotlight, explore rows, trending, on-this-day, best-of-year, decade, and a dozen others.

Refs #461.