### PR TITLE
feat(player): migrate user-stats / most-played / saved-searches

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -514,17 +514,24 @@ class SpelaApiClient(
     }
 
     /** Returns user's saved searches */
-    suspend fun getSavedSearches(): List<SavedSearchDto> {
+    suspend fun getSavedSearches(): List<com.spela.client.models.SavedSearchResponse> {
         return client.get("$baseUrl/api/user/saved-searches").body()
     }
 
     /** Creates a new saved search */
-    suspend fun createSavedSearch(name: String, filters: Map<String, String>): SavedSearchDto {
+    suspend fun createSavedSearch(
+        name: String,
+        filters: Map<String, String>,
+    ): com.spela.client.models.SavedSearchResponse {
         return client.post("$baseUrl/api/user/saved-searches") {
-            setBody(CreateSavedSearchRequest(
-                name = name,
-                filters = filters.mapValues { (_, v) -> kotlinx.serialization.json.JsonPrimitive(v) },
-            ))
+            setBody(
+                com.spela.client.models.SavedSearchRequest(
+                    name = name,
+                    filters = kotlinx.serialization.json.JsonObject(
+                        filters.mapValues { (_, v) -> kotlinx.serialization.json.JsonPrimitive(v) },
+                    ),
+                ),
+            )
         }.body()
     }
 
@@ -654,7 +661,7 @@ class SpelaApiClient(
 
     // User Stats & Achievements
 
-    suspend fun getUserStats(): UserStatsDto {
+    suspend fun getUserStats(): com.spela.client.models.UserStatsResponse {
         return client.get("$baseUrl/api/user/stats").body()
     }
 
@@ -1104,7 +1111,7 @@ class SpelaApiClient(
 
     // Stats
 
-    suspend fun getMostPlayedGames(): MostPlayedResponse {
+    suspend fun getMostPlayedGames(): com.spela.client.models.MostPlayedResponse {
         return client.get("$baseUrl/api/stats/most-played").body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -446,14 +446,16 @@ fun com.spela.client.models.RALeaderboardEntryResponse.toDomain(): AchievementPl
     lastUnlockedAt = lastUnlockedAt.toString(),
 )
 
-fun UserStatsDto.toDomain(): UserStats = UserStats(
+fun com.spela.client.models.UserStatsResponse.toDomain(): UserStats = UserStats(
     totalPlayTime = totalPlayTime,
     gamesPlayed = gamesPlayed,
-    currentStreak = currentStreak,
-    longestStreak = longestStreak,
-    mostPlayedGame = mostPlayedGame?.toDomain(),
+    currentStreak = currentStreak.toInt(),
+    longestStreak = longestStreak.toInt(),
+    // Server emits an empty Game placeholder when the user has never
+    // played anything — detect via empty id and pass null through.
+    mostPlayedGame = mostPlayedGame.takeIf { it.id.isNotEmpty() }?.toDomain(),
     mostPlayedGameTime = mostPlayedGameTime,
-    lastPlayedAt = lastPlayedAt,
+    lastPlayedAt = lastPlayedAt?.toString(),
 )
 
 fun com.spela.client.models.RARecentAchievementResponse.toDomain(): RecentAchievement = RecentAchievement(
@@ -497,9 +499,9 @@ fun com.spela.client.models.RAUnlockedAchievementResponse.toDomain(): UnlockedAc
 
 // Stats mappers
 
-fun MostPlayedGameDto.toDomain(): MostPlayedGame = MostPlayedGame(
+fun com.spela.client.models.MostPlayedEntry.toDomain(): MostPlayedGame = MostPlayedGame(
     game = game.toDomain(),
-    totalPlayers = totalPlayers,
+    totalPlayers = totalPlayers.toInt(),
     totalPlayTime = totalPlayTime,
 )
 
@@ -1027,11 +1029,16 @@ fun ExploreChallengeDto.toDomain() = ExploreChallenge(
 
 // --- Phase 13: Advanced Search & Saved Searches ---
 
-fun SavedSearchDto.toDomain() = SavedSearch(
+fun com.spela.client.models.SavedSearchResponse.toDomain() = SavedSearch(
     id = id,
     name = name,
-    filters = filters.mapValues { (_, v) -> v.content },
-    createdAt = createdAt,
+    // The generated filters field is a JsonElement? (JsonObject at runtime).
+    // Flatten to the domain Map<String, String>. Non-object / null gives
+    // an empty map.
+    filters = (filters as? kotlinx.serialization.json.JsonObject)
+        ?.mapValues { (_, v) -> (v as? kotlinx.serialization.json.JsonPrimitive)?.content.orEmpty() }
+        ?: emptyMap(),
+    createdAt = createdAt.toString(),
 )
 
 // --- Phase 14: Wild Features ---

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1,7 +1,6 @@
 package com.spela.player.data.remote.dto
 
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.JsonPrimitive
 
 @Serializable
 data class LoginRequest(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -437,17 +437,9 @@ data class AddGameToCollectionRequest(val gameId: Int)
 
 // Stats
 
-@Serializable
-data class MostPlayedGameDto(
-    val game: GameDto,
-    val totalPlayers: Int = 0,
-    val totalPlayTime: Long = 0,
-)
-
-@Serializable
-data class MostPlayedResponse(
-    val games: List<MostPlayedGameDto> = emptyList(),
-)
+// MostPlayedGameDto / MostPlayedResponse replaced by
+// com.spela.client.models.MostPlayedEntry and MostPlayedResponse
+// (generated; same name).
 
 // ActivePlayerDto / MostActivePlayersResponse replaced by
 // com.spela.client.models.ActivePlayerEntry and MostActivePlayersResponse
@@ -537,16 +529,7 @@ data class AchievementProgressResponse(
 
 // User Stats
 
-@Serializable
-data class UserStatsDto(
-    val totalPlayTime: Long = 0,
-    val gamesPlayed: Long = 0,
-    val currentStreak: Int = 0,
-    val longestStreak: Int = 0,
-    val mostPlayedGame: GameDto? = null,
-    val mostPlayedGameTime: Long = 0,
-    val lastPlayedAt: String? = null,
-)
+// UserStatsDto replaced by com.spela.client.models.UserStatsResponse.
 
 // Recent + Showcase + Unlocked achievement DTOs replaced by generated
 // counterparts in com.spela.client.models:
@@ -1154,19 +1137,8 @@ data class ActiveChallengesResponseDto(
 
 // --- Phase 13: Advanced Search & Saved Searches ---
 
-@Serializable
-data class SavedSearchDto(
-    val id: String,
-    val name: String,
-    val filters: Map<String, JsonPrimitive> = emptyMap(),
-    val createdAt: String = "",
-)
-
-@Serializable
-data class CreateSavedSearchRequest(
-    val name: String,
-    val filters: Map<String, JsonPrimitive>,
-)
+// SavedSearchDto / CreateSavedSearchRequest replaced by
+// com.spela.client.models.SavedSearchResponse / SavedSearchRequest.
 
 // --- Phase 14: Wild Features — Wizard, Badges, Completionist Map ---
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/StatsRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/StatsRepositoryImpl.kt
@@ -11,7 +11,7 @@ class StatsRepositoryImpl(
 ) : StatsRepository {
 
     override suspend fun getMostPlayedGames(): Result<List<MostPlayedGame>> = runCatching {
-        apiClient.getMostPlayedGames().games.map { dto ->
+        apiClient.getMostPlayedGames().games.orEmpty().map { dto ->
             val mostPlayed = dto.toDomain()
             mostPlayed.copy(
                 game = mostPlayed.game.copy(


### PR DESCRIPTION
Seventeenth call-site migration in the #461 series. Four endpoints, six hand-written DTOs. First batch after the GameDto unlock in #479 — the nested `GameDto` references now flow through the typealias transparently.

## Change

- `SpelaApiClient`:
  - `getUserStats()` → `UserStatsResponse`
  - `getMostPlayedGames()` → `MostPlayedResponse` (generated; same name as the deleted hand-written one)
  - `getSavedSearches()` → `List<SavedSearchResponse>`
  - `createSavedSearch(name, filters)` now builds `SavedSearchRequest` and wraps filters as a `kotlinx.serialization.json.JsonObject` of `JsonPrimitive`s
- Three new mappers in `DtoMappers.kt`:
  - `UserStatsResponse.toDomain()` — `currentStreak` / `longestStreak` Long→Int; `lastPlayedAt` Instant→String. `mostPlayedGame` is `@Required` non-null in the spec — detect "no game" via empty id and pass `null` through so domain keeps the nullable semantics.
  - `MostPlayedEntry.toDomain()` — `totalPlayers` Long→Int.
  - `SavedSearchResponse.toDomain()` — `filters` is a `JsonElement?` (`JsonObject` at runtime); flatten to `Map<String, String>`. `createdAt` Instant→String.
- `StatsRepositoryImpl`: `.games.orEmpty()` for the spec's nullable list.
- Deleted `MostPlayedGameDto` / `MostPlayedResponse` / `UserStatsDto` / `SavedSearchDto` / `CreateSavedSearchRequest` from `Dtos.kt`.

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop :shared:compileTestKotlinDesktop :desktop:compileKotlinDesktop` — all green
- [x] `./run-desktop-tests.sh` — **470/470 pass** (matches master)
- [x] Pre-existing `SessionsUiTest` failures unchanged
- [ ] CI green

Refs #461.