### PR TITLE
feat(player): migrate collections to generated types

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1065,31 +1065,42 @@ class SpelaApiClient(
 
     // Collections
 
-    suspend fun getMyCollections(page: Int = 1, pageSize: Int = 20): CollectionsResponse {
+    suspend fun getMyCollections(
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): com.spela.client.models.PaginatedResponseCollectionResponse {
         return client.get("$baseUrl/api/collections") {
             parameter("page", page)
             parameter("pageSize", pageSize)
         }.body()
     }
 
-    suspend fun getPublicCollections(page: Int = 1, pageSize: Int = 20): CollectionsResponse {
+    suspend fun getPublicCollections(
+        page: Int = 1,
+        pageSize: Int = 20,
+    ): com.spela.client.models.PaginatedResponseCollectionResponse {
         return client.get("$baseUrl/api/collections/public") {
             parameter("page", page)
             parameter("pageSize", pageSize)
         }.body()
     }
 
-    suspend fun getCollection(id: String): CollectionDetailDto {
+    suspend fun getCollection(id: String): com.spela.client.models.CollectionDetailResponse {
         return client.get("$baseUrl/api/collections/$id").body()
     }
 
-    suspend fun createCollection(request: CreateCollectionRequest): CollectionDto {
+    suspend fun createCollection(
+        request: com.spela.client.models.CreateCollectionRequest,
+    ): com.spela.client.models.CollectionResponse {
         return client.post("$baseUrl/api/collections") {
             setBody(request)
         }.body()
     }
 
-    suspend fun updateCollection(id: String, request: UpdateCollectionRequest): CollectionDto {
+    suspend fun updateCollection(
+        id: String,
+        request: com.spela.client.models.UpdateCollectionRequest,
+    ): com.spela.client.models.CollectionResponse {
         return client.put("$baseUrl/api/collections/$id") {
             setBody(request)
         }.body()
@@ -1101,7 +1112,7 @@ class SpelaApiClient(
 
     suspend fun addGameToCollection(collectionId: String, gameId: String) {
         client.post("$baseUrl/api/collections/$collectionId/games") {
-            setBody(AddGameToCollectionRequest(gameId = gameId.toInt()))
+            setBody(com.spela.client.models.AddGameToCollectionRequest(gameId = gameId.toLong()))
         }
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -355,7 +355,7 @@ fun SharedSessionSaveDto.toDomain(): SharedSessionSave = SharedSessionSave(
 
 // Collection mappers
 
-fun CollectionDto.toDomain(): GameCollection = GameCollection(
+fun com.spela.client.models.CollectionResponse.toDomain(): GameCollection = GameCollection(
     id = id,
     userId = userId,
     username = username,
@@ -364,10 +364,10 @@ fun CollectionDto.toDomain(): GameCollection = GameCollection(
     description = description,
     isPublic = isPublic,
     coverUrl = coverUrl,
-    gameCount = gameCount,
+    gameCount = gameCount.toInt(),
 )
 
-fun CollectionDetailDto.toDomain(): GameCollectionDetail = GameCollectionDetail(
+fun com.spela.client.models.CollectionDetailResponse.toDomain(): GameCollectionDetail = GameCollectionDetail(
     id = id,
     userId = userId,
     username = username,
@@ -376,8 +376,8 @@ fun CollectionDetailDto.toDomain(): GameCollectionDetail = GameCollectionDetail(
     description = description,
     isPublic = isPublic,
     coverUrl = coverUrl,
-    gameCount = gameCount,
-    games = games.map { it.toDomain() },
+    gameCount = gameCount.toInt(),
+    games = games.orEmpty().map { it.toDomain() },
 )
 
 // Game Stats mappers

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -378,61 +378,14 @@ data class SharedSessionInvitationCountResponse(
 
 // Collections
 
-@Serializable
-data class CollectionDto(
-    val id: String,
-    val userId: String,
-    val username: String,
-    val avatarUrl: String? = null,
-    val name: String,
-    val description: String? = null,
-    val isPublic: Boolean = false,
-    val coverUrl: String? = null,
-    val gameCount: Int = 0,
-    val createdAt: String? = null,
-    val updatedAt: String? = null,
-)
-
-@Serializable
-data class CollectionDetailDto(
-    val id: String,
-    val userId: String,
-    val username: String,
-    val avatarUrl: String? = null,
-    val name: String,
-    val description: String? = null,
-    val isPublic: Boolean = false,
-    val coverUrl: String? = null,
-    val gameCount: Int = 0,
-    val games: List<GameDto> = emptyList(),
-    val createdAt: String? = null,
-    val updatedAt: String? = null,
-)
-
-@Serializable
-data class CollectionsResponse(
-    val data: List<CollectionDto> = emptyList(),
-    val total: Int = 0,
-    val page: Int = 1,
-    val pageSize: Int = 20,
-)
-
-@Serializable
-data class CreateCollectionRequest(
-    val name: String,
-    val description: String? = null,
-    val isPublic: Boolean = false,
-)
-
-@Serializable
-data class UpdateCollectionRequest(
-    val name: String? = null,
-    val description: String? = null,
-    val isPublic: Boolean? = null,
-)
-
-@Serializable
-data class AddGameToCollectionRequest(val gameId: Int)
+// Collection DTOs replaced by generated counterparts:
+//   CollectionDto                  -> CollectionResponse
+//   CollectionDetailDto            -> CollectionDetailResponse
+//   CollectionsResponse            -> PaginatedResponseCollectionResponse
+//   CreateCollectionRequest        -> CreateCollectionRequest (same name, generated)
+//   UpdateCollectionRequest        -> UpdateCollectionRequest (same name, generated)
+//   AddGameToCollectionRequest     -> AddGameToCollectionRequest (same name, generated; gameId is Long? in spec)
+// (all in com.spela.client.models)
 
 // Stats
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CollectionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CollectionRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package com.spela.player.data.repository
 
+import com.spela.client.models.CreateCollectionRequest
+import com.spela.client.models.UpdateCollectionRequest
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.data.remote.dto.CreateCollectionRequest
-import com.spela.player.data.remote.dto.UpdateCollectionRequest
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.GameCollection
 import com.spela.player.domain.model.GameCollectionDetail
@@ -13,13 +13,13 @@ class CollectionRepositoryImpl(
 ) : CollectionRepository {
 
     override suspend fun getMyCollections(page: Int, pageSize: Int): Result<List<GameCollection>> = runCatching {
-        apiClient.getMyCollections(page = page, pageSize = pageSize).data.map { dto ->
+        apiClient.getMyCollections(page = page, pageSize = pageSize).data.orEmpty().map { dto ->
             dto.toDomain().resolveImageUrls()
         }
     }
 
     override suspend fun getPublicCollections(page: Int, pageSize: Int): Result<List<GameCollection>> = runCatching {
-        apiClient.getPublicCollections(page = page, pageSize = pageSize).data.map { dto ->
+        apiClient.getPublicCollections(page = page, pageSize = pageSize).data.orEmpty().map { dto ->
             dto.toDomain().resolveImageUrls()
         }
     }


### PR DESCRIPTION
Eighteenth call-site migration in the #461 series. Seven endpoints, six hand-written DTOs swapped. Unlocked by the #479 GameDto typealias — `CollectionDetailResponse.games: List<GameResponse>?` maps through the existing `GameResponse.toDomain()`.

## Change

- `SpelaApiClient`:
  - `getMyCollections` / `getPublicCollections` → `PaginatedResponseCollectionResponse`
  - `getCollection(id)` → `CollectionDetailResponse`
  - `createCollection(CreateCollectionRequest)` → `CollectionResponse`
  - `updateCollection(id, UpdateCollectionRequest)` → `CollectionResponse`
  - `addGameToCollection` builds `com.spela.client.models.AddGameToCollectionRequest`; `gameId` is `Long?` in the spec so `.toLong()` replaces the old `.toInt()`
- Two new mappers in `DtoMappers.kt`: `CollectionResponse.toDomain()` / `CollectionDetailResponse.toDomain()`. `gameCount` Long→Int; `games` nullable → `.orEmpty()`; nested `GameResponse` mapping cascades through the `GameResponse.toDomain()` mapper from #479.
- `CollectionRepositoryImpl`: `.data.orEmpty()` for paginated list access; imports switched from `player.data.remote.dto` to `client.models`.
- Deleted six hand-written DTOs from `Dtos.kt`.

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop :shared:compileTestKotlinDesktop :desktop:compileKotlinDesktop` — all green
- [x] `./run-desktop-tests.sh` — **470/470 pass**
- [x] Pre-existing `SessionsUiTest` failures unchanged
- [ ] CI green

Refs #461.