### PR TITLE
feat(player): migrate 8 clusters to generated types (big batch)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/device/DeviceManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/device/DeviceManager.kt
@@ -2,7 +2,7 @@ package com.spela.player.data.device
 
 import com.spela.player.data.local.SpelaDatabase
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.data.remote.dto.RegisterDeviceRequest
+import com.spela.client.models.RegisterDeviceRequest
 import com.spela.player.util.currentPlatform
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -149,7 +149,7 @@ class SpelaApiClient(
         }.body()
     }
 
-    suspend fun getCurrentUser(): UserDto {
+    suspend fun getCurrentUser(): com.spela.client.models.UserResponse {
         return client.get("$baseUrl/api/user/profile").body()
     }
 
@@ -599,11 +599,13 @@ class SpelaApiClient(
 
     // User Preferences
 
-    suspend fun getPreferences(): UserPreferencesDto {
+    suspend fun getPreferences(): com.spela.client.models.UserPreferencesResponse {
         return client.get("$baseUrl/api/user/preferences").body()
     }
 
-    suspend fun updatePreferences(request: UpdatePreferencesRequest): UserPreferencesDto {
+    suspend fun updatePreferences(
+        request: com.spela.client.models.UpdatePreferencesRequest,
+    ): com.spela.client.models.UserPreferencesResponse {
         return client.put("$baseUrl/api/user/preferences") {
             setBody(request)
         }.body()
@@ -611,11 +613,14 @@ class SpelaApiClient(
 
     // Game Key Mapping
 
-    suspend fun getGameKeyMapping(gameId: String): GameKeyMappingDto {
+    suspend fun getGameKeyMapping(gameId: String): com.spela.client.models.GameKeyMappingResponse {
         return client.get("$baseUrl/api/user/games/$gameId/keymapping").body()
     }
 
-    suspend fun updateGameKeyMapping(gameId: String, request: UpdateGameKeyMappingRequest): GameKeyMappingDto {
+    suspend fun updateGameKeyMapping(
+        gameId: String,
+        request: com.spela.client.models.UpdateGameKeyMappingRequest,
+    ): com.spela.client.models.GameKeyMappingResponse {
         return client.put("$baseUrl/api/user/games/$gameId/keymapping") {
             setBody(request)
         }.body()
@@ -633,7 +638,7 @@ class SpelaApiClient(
 
     // Game Cheats
 
-    suspend fun getGameCheats(gameId: String): List<CheatDto> {
+    suspend fun getGameCheats(gameId: String): List<com.spela.client.models.GameCheatResponse> {
         return client.get("$baseUrl/api/games/$gameId/cheats").body()
     }
 
@@ -698,23 +703,28 @@ class SpelaApiClient(
         client.delete("$baseUrl/api/user/devices/$deviceId")
     }
 
-    suspend fun registerDevice(request: RegisterDeviceRequest): DeviceDto {
+    suspend fun registerDevice(
+        request: com.spela.client.models.RegisterDeviceRequest,
+    ): com.spela.client.models.DeviceResponse {
         return client.post("$baseUrl/api/user/devices") {
             setBody(request)
         }.body()
     }
 
-    suspend fun getDevices(): List<DeviceDto> {
+    suspend fun getDevices(): List<com.spela.client.models.DeviceResponse> {
         return client.get("$baseUrl/api/user/devices").body()
     }
 
-    suspend fun updateDevice(deviceId: Long, name: String): DeviceDto {
+    suspend fun updateDevice(deviceId: Long, name: String): com.spela.client.models.DeviceResponse {
         return client.put("$baseUrl/api/user/devices/$deviceId") {
             setBody(mapOf("name" to name))
         }.body()
     }
 
-    suspend fun updateDevicePreferences(deviceId: Long, request: UpdateDevicePreferencesRequest): DeviceDto {
+    suspend fun updateDevicePreferences(
+        deviceId: Long,
+        request: com.spela.client.models.UpdateDevicePreferencesRequest,
+    ): com.spela.client.models.DeviceResponse {
         return client.put("$baseUrl/api/user/devices/$deviceId/preferences") {
             setBody(request)
         }.body()
@@ -754,21 +764,23 @@ class SpelaApiClient(
 
     // Cores
 
-    suspend fun getAvailableCores(): List<LibretroCoreDto> {
+    suspend fun getAvailableCores(): List<com.spela.client.models.Core> {
         return client.get("$baseUrl/api/cores").body()
     }
 
-    /** May return either a full Core object or just {coreName: "..."} */
-    suspend fun getRecommendedCore(gameId: String): LibretroCoreDto {
+    /** May return either a full Core object or just {coreName: "..."}. The
+     *  lightweight fallback shape can't satisfy [com.spela.client.models.Core]'s
+     *  @Required timestamps, so this method returns the domain type directly. */
+    suspend fun getRecommendedCore(gameId: String): com.spela.player.domain.model.LibretroCore {
         val text: String = client.get("$baseUrl/api/games/$gameId/core").body()
         return try {
-            json.decodeFromString<LibretroCoreDto>(text)
+            json.decodeFromString<com.spela.client.models.Core>(text).toDomain()
         } catch (_: Exception) {
             // Server returns just {coreName: "..."} when core isn't in DB
             val obj = json.parseToJsonElement(text).jsonObject
             val coreName = obj["coreName"]?.jsonPrimitive?.content
                 ?: throw IllegalStateException("No core name in response: $text")
-            LibretroCoreDto(id = 0, name = coreName)
+            com.spela.player.domain.model.LibretroCore(id = 0, name = coreName)
         }
     }
 
@@ -1495,27 +1507,34 @@ class SpelaApiClient(
 
     // ── Game Sessions ──
 
-    suspend fun getSessionsForGame(gameId: String): List<GameSessionDto> {
+    suspend fun getSessionsForGame(gameId: String): List<com.spela.client.models.GameSessionResponse> {
         return client.get("$baseUrl/api/games/$gameId/sessions").body()
     }
 
-    suspend fun createSessionFromSharedSave(gameId: String, saveId: String): GameSessionDto {
+    suspend fun createSessionFromSharedSave(
+        gameId: String,
+        saveId: String,
+    ): com.spela.client.models.GameSessionResponse {
         return client.post("$baseUrl/api/games/$gameId/sessions/from-shared-save/$saveId").body()
     }
 
-    suspend fun createSession(gameId: String, name: String): GameSessionDto {
+    suspend fun createSession(gameId: String, name: String): com.spela.client.models.GameSessionResponse {
         return client.post("$baseUrl/api/games/$gameId/sessions") {
-            setBody(CreateSessionRequest(name = name))
+            setBody(com.spela.client.models.CreateSessionRequest(name = name))
         }.body()
     }
 
-    suspend fun getSession(sessionId: String): GameSessionDto {
+    suspend fun getSession(sessionId: String): com.spela.client.models.GameSessionResponse {
         return client.get("$baseUrl/api/sessions/$sessionId").body()
     }
 
-    suspend fun updateSession(sessionId: String, name: String? = null, coreName: String? = null): GameSessionDto {
+    suspend fun updateSession(
+        sessionId: String,
+        name: String? = null,
+        coreName: String? = null,
+    ): com.spela.client.models.GameSessionResponse {
         return client.put("$baseUrl/api/sessions/$sessionId") {
-            setBody(UpdateSessionRequest(name = name, coreName = coreName))
+            setBody(com.spela.client.models.UpdateSessionRequest(name = name, coreName = coreName))
         }.body()
     }
 
@@ -1523,10 +1542,13 @@ class SpelaApiClient(
         client.delete("$baseUrl/api/sessions/$sessionId")
     }
 
-    suspend fun duplicateSession(sessionId: String, name: String? = null): GameSessionDto {
+    suspend fun duplicateSession(
+        sessionId: String,
+        name: String? = null,
+    ): com.spela.client.models.GameSessionResponse {
         return client.post("$baseUrl/api/sessions/$sessionId/duplicate") {
             if (name != null) {
-                setBody(mapOf("name" to name))
+                setBody(com.spela.client.models.DuplicateSessionRequest(name = name))
             }
         }.body()
     }
@@ -1648,13 +1670,22 @@ class SpelaApiClient(
         return response.body()
     }
 
-    suspend fun getSessionCheats(sessionId: String): SessionCheatConfigDto {
+    suspend fun getSessionCheats(sessionId: String): com.spela.client.models.SessionCheatsResponse {
         return client.get("$baseUrl/api/sessions/$sessionId/cheats").body()
     }
 
-    suspend fun updateSessionCheats(sessionId: String, cheatsEnabled: Boolean, enabledIndices: List<Int>): SessionCheatConfigDto {
+    suspend fun updateSessionCheats(
+        sessionId: String,
+        cheatsEnabled: Boolean,
+        enabledIndices: List<Int>,
+    ): com.spela.client.models.SessionCheatsResponse {
         return client.put("$baseUrl/api/sessions/$sessionId/cheats") {
-            setBody(UpdateSessionCheatsRequest(cheatsEnabled = cheatsEnabled, enabledIndices = enabledIndices))
+            setBody(
+                com.spela.client.models.UpdateSessionCheatsRequest(
+                    cheatsEnabled = cheatsEnabled,
+                    enabledIndices = enabledIndices.map { it.toLong() },
+                )
+            )
         }.body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -169,7 +169,7 @@ fun SaveStateDto.toDomain(): SaveState = SaveState(
     isSynced = true,
 )
 
-fun UserPreferencesDto.toDomain(): UserPreferences = UserPreferences(
+fun com.spela.client.models.UserPreferencesResponse.toDomain(): UserPreferences = UserPreferences(
     showPerformanceOverlay = showPerformanceOverlay,
     autoSaveEnabled = autoSaveEnabled,
     autoLoadSaveEnabled = autoLoadSaveEnabled,
@@ -180,7 +180,7 @@ fun UserPreferencesDto.toDomain(): UserPreferences = UserPreferences(
     consoleKeyMappings = consoleKeyMappings.mapValues {
         ConsoleKeyMappingPref(
             selectedMapping = it.value.selectedMapping,
-            customMapping = it.value.customMapping,
+            customMapping = it.value.customMapping.orEmpty(),
         )
     },
     defaultSecondScreenPage = defaultSecondScreenPage,
@@ -245,7 +245,7 @@ fun com.spela.client.models.ActivityEventResponse.toDomain(): ActivityEvent = Ac
     createdAt = createdAt.toString(),
 )
 
-fun LibretroCoreDto.toDomain(): LibretroCore = LibretroCore(
+fun com.spela.client.models.Core.toDomain(): LibretroCore = LibretroCore(
     id = id,
     name = name,
     displayName = displayName,
@@ -646,11 +646,11 @@ fun DeveloperGameDto.toDomain(): DeveloperGame = DeveloperGame(
     consoleName = consoleName,
 )
 
-fun GameSessionDto.toDomain(): GameSession = GameSession(
+fun com.spela.client.models.GameSessionResponse.toDomain(): GameSession = GameSession(
     id = id,
     gameId = gameId,
     name = name,
-    lastPlayedAt = lastPlayedAt,
+    lastPlayedAt = lastPlayedAt?.toString(),
     lastPlayedByUsername = lastPlayedByUsername,
     totalPlayTime = totalPlayTime,
     screenshotUrl = screenshotUrl,
@@ -658,14 +658,14 @@ fun GameSessionDto.toDomain(): GameSession = GameSession(
     cheatsEnabled = cheatsEnabled,
     isSharedSession = isSharedSession,
     sharedSessionId = sharedSessionId,
-    memberCount = memberCount,
-    memberUsernames = memberUsernames,
-    memberAvatars = memberAvatars,
+    memberCount = memberCount.toInt(),
+    memberUsernames = memberUsernames.orEmpty(),
+    memberAvatars = memberAvatars.orEmpty(),
 )
 
-fun SessionCheatConfigDto.toDomain() = SessionCheatConfig(
+fun com.spela.client.models.SessionCheatsResponse.toDomain() = SessionCheatConfig(
     cheatsEnabled = cheatsEnabled,
-    enabledIndices = enabledIndices,
+    enabledIndices = enabledIndices.orEmpty().map { it.toInt() },
 )
 
 // Explore mappers

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -27,16 +27,13 @@ data class RefreshRequest(
     val refreshToken: String,
 )
 
-@Serializable
-data class UserDto(
-    val id: String,
-    val username: String,
-    val email: String = "",
-    val role: String,
-    val avatarUrl: String? = null,
-    val createdAt: String? = null,
-    val updatedAt: String? = null,
-)
+// UserDto replaced by com.spela.client.models.UserResponse (see
+// player/shared-api/). Aliased here so AuthResponse.user — which lives
+// in the hand-written auth DTO block — keeps compiling unchanged. The
+// generated UserResponse adds @Required createdAt/updatedAt Instants
+// and @Required disabled/pendingApproval booleans the domain model
+// ignores.
+typealias UserDto = com.spela.client.models.UserResponse
 
 @Serializable
 data class HardwareMakerDto(
@@ -118,89 +115,35 @@ data class SaveStateDto(
     val updatedAt: String? = null,
 )
 
-@Serializable
-data class LibretroCoreDto(
-    val id: Long,
-    val name: String,
-    val displayName: String = "",
-    val description: String? = null,
-    val version: String? = null,
-    val platforms: String = "",
-    val downloadUrl: String? = null,
-    val createdAt: String? = null,
-    val updatedAt: String? = null,
-)
+// LibretroCoreDto replaced by com.spela.client.models.Core (see
+// player/shared-api/). Generated Core has @Required createdAt/updatedAt
+// Instants that the {coreName: "..."} fallback in getRecommendedCore
+// can't satisfy — that method returns the domain type directly.
 
-@Serializable
-data class ConsoleKeyMappingDto(
-    val selectedMapping: String = "",
-    val customMapping: Map<String, String> = emptyMap(),
-)
+// ConsoleKeyMappingDto replaced by com.spela.client.models.ConsoleKeyMappingDTO
+// (generator uses "DTO" uppercase). The generated type has
+// customMapping: Map<String,String>? — the mapper applies .orEmpty() when
+// converting to the domain ConsoleKeyMappingPref.
 
-@Serializable
-data class GameKeyMappingDto(
-    val customMapping: Map<String, String> = emptyMap(),
-)
+// GameKeyMappingDto / UpdateGameKeyMappingRequest replaced by
+// com.spela.client.models.GameKeyMappingResponse and
+// com.spela.client.models.UpdateGameKeyMappingRequest
+// (see player/shared-api/).
 
-@Serializable
-data class UpdateGameKeyMappingRequest(
-    val customMapping: Map<String, String>,
-)
+// UserPreferencesDto / UpdatePreferencesRequest replaced by
+// com.spela.client.models.UserPreferencesResponse and
+// com.spela.client.models.UpdatePreferencesRequest (see player/shared-api/).
+// Repository builds the update payload with named args since every field on
+// the generated request is nullable.
 
-@Serializable
-data class UserPreferencesDto(
-    val showPerformanceOverlay: Boolean = false,
-    val autoSaveEnabled: Boolean = true,
-    val autoLoadSaveEnabled: Boolean = true,
-    val selectedShader: String = "none",
-    val selectedTheme: String = "default-dark",
-    val consoleShaders: Map<String, String> = emptyMap(),
-    val raLinked: Boolean = false,
-    val raUsername: String = "",
-    val raHardcoreEnabled: Boolean = false,
-    val selectedKeyMapping: String = "default",
-    val customKeyMapping: Map<String, String> = emptyMap(),
-    val consoleKeyMappings: Map<String, ConsoleKeyMappingDto> = emptyMap(),
-    val defaultSecondScreenPage: String = "art",
-)
-
-@Serializable
-data class UpdatePreferencesRequest(
-    val showPerformanceOverlay: Boolean? = null,
-    val autoSaveEnabled: Boolean? = null,
-    val autoLoadSaveEnabled: Boolean? = null,
-    val selectedShader: String? = null,
-    val selectedTheme: String? = null,
-    val consoleShaders: Map<String, String>? = null,
-    val selectedKeyMapping: String? = null,
-    val customKeyMapping: Map<String, String>? = null,
-    val consoleKeyMappings: Map<String, ConsoleKeyMappingDto>? = null,
-    val defaultSecondScreenPage: String? = null,
-)
-
-// Devices
-
-@Serializable
-data class RegisterDeviceRequest(
-    val deviceUuid: String,
-    val name: String,
-    val platform: String,
-)
-
-@Serializable
-data class DeviceDto(
-    val id: Long,
-    val deviceUuid: String,
-    val name: String,
-    val platform: String,
-    val lastSeenAt: String = "",
-    val consoleShaders: Map<String, String> = emptyMap(),
-)
-
-@Serializable
-data class UpdateDevicePreferencesRequest(
-    val consoleShaders: Map<String, String>,
-)
+// Devices — DeviceDto / RegisterDeviceRequest / UpdateDevicePreferencesRequest
+// replaced by com.spela.client.models.DeviceResponse /
+// RegisterDeviceRequest / UpdateDevicePreferencesRequest (see
+// player/shared-api/). DeviceDto is typealiased because the settings UI
+// references it directly; the generated DeviceResponse has `lastSeenAt`
+// typed as Instant rather than the hand-written String, so consumers
+// must format via `.toString()`.
+typealias DeviceDto = com.spela.client.models.DeviceResponse
 
 // Shared Saves
 
@@ -527,60 +470,24 @@ data class DeveloperGameDto(
 
 // Save Data (SRAM)
 
-// Game Sessions
+// Game Sessions — GameSessionDto / CreateSessionRequest / UpdateSessionRequest
+// replaced by com.spela.client.models.GameSessionResponse /
+// CreateSessionRequest / UpdateSessionRequest (see player/shared-api/).
+// The generated response models memberCount as Long (mapper converts to
+// Int), lastPlayedAt as Instant? (mapper converts to String via
+// .toString()), and memberUsernames / memberAvatars as List<String>?
+// (mapper applies .orEmpty()). DuplicateSessionRequest is used in-place
+// for the duplicate-session call.
 
-@Serializable
-data class GameSessionDto(
-    val id: String,
-    val gameId: String,
-    val name: String,
-    val lastPlayedAt: String? = null,
-    val lastPlayedByUsername: String? = null,
-    val totalPlayTime: Long = 0,
-    val screenshotUrl: String? = null,
-    val coreName: String? = null,
-    val cheatsEnabled: Boolean = false,
-    val isSharedSession: Boolean = false,
-    val sharedSessionId: String? = null,
-    val memberCount: Int = 1,
-    val memberUsernames: List<String> = emptyList(),
-    val memberAvatars: List<String> = emptyList(),
-)
+// Session Cheats — SessionCheatConfigDto / UpdateSessionCheatsRequest
+// replaced by com.spela.client.models.SessionCheatsResponse /
+// UpdateSessionCheatsRequest. The server spec models enabledIndices as
+// List<Long>? — the API client converts Int⇄Long at the boundary and
+// the mapper converts to List<Int> for the domain.
 
-@Serializable
-data class CreateSessionRequest(
-    val name: String,
-)
-
-@Serializable
-data class UpdateSessionRequest(
-    val name: String? = null,
-    val coreName: String? = null,
-)
-
-// Session Cheats
-
-@Serializable
-data class SessionCheatConfigDto(
-    val cheatsEnabled: Boolean = false,
-    val enabledIndices: List<Int> = emptyList(),
-)
-
-@Serializable
-data class UpdateSessionCheatsRequest(
-    val cheatsEnabled: Boolean,
-    val enabledIndices: List<Int>,
-)
-
-// Cheats
-
-@Serializable
-data class CheatDto(
-    val id: Int = 0,
-    val index: Int = 0,
-    val description: String = "",
-    val code: String = "",
-)
+// Cheats — CheatDto replaced by com.spela.client.models.GameCheatResponse
+// (see player/shared-api/). Server sends id/index as Long; the repository
+// stores them directly without domain conversion.
 
 // Explore
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CheatRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CheatRepositoryImpl.kt
@@ -31,7 +31,7 @@ class CheatRepositoryImpl(
                 queries.upsertCheat(
                     id = cheatId,
                     game_id = gameId,
-                    cheat_index = dto.index.toLong(),
+                    cheat_index = dto.index,
                     description = dto.description,
                     code = dto.code,
                     enabled = if (wasEnabled) 1L else 0L,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreRepositoryImpl.kt
@@ -27,7 +27,7 @@ class CoreRepositoryImpl(
     }
 
     override suspend fun getRecommendedCore(gameId: String): Result<LibretroCore> = runCatching {
-        apiClient.getRecommendedCore(gameId).toDomain()
+        apiClient.getRecommendedCore(gameId)
     }
 
     override suspend fun downloadCore(coreName: String, downloadUrl: String?, onProgress: (Float) -> Unit): Result<String> = runCatching {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/PreferencesRepositoryImpl.kt
@@ -3,10 +3,10 @@ package com.spela.player.data.repository
 import com.spela.player.data.local.SpelaDatabase
 import com.spela.player.data.device.DeviceManager
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.data.remote.dto.ConsoleKeyMappingDto
-import com.spela.player.data.remote.dto.UpdateDevicePreferencesRequest
-import com.spela.player.data.remote.dto.UpdatePreferencesRequest
-import com.spela.player.data.remote.dto.UserPreferencesDto
+import com.spela.client.models.ConsoleKeyMappingDTO
+import com.spela.client.models.UpdateDevicePreferencesRequest
+import com.spela.client.models.UpdatePreferencesRequest
+import com.spela.client.models.UserPreferencesResponse
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.DEFAULT_CONSOLE_ID
 import com.spela.player.domain.model.ShaderPreset
@@ -37,7 +37,7 @@ class PreferencesRepositoryImpl(
         }
     }
 
-    private fun cachePreferences(dto: UserPreferencesDto) {
+    private fun cachePreferences(dto: UserPreferencesResponse) {
         val jsonString = json.encodeToString(dto)
         database.spelaDatabaseQueries.upsertCachedPreferences(
             json_data = jsonString,
@@ -49,7 +49,7 @@ class PreferencesRepositoryImpl(
         val cached = database.spelaDatabaseQueries.getCachedPreferences().executeAsOneOrNull()
             ?: return null
         return runCatching {
-            json.decodeFromString<UserPreferencesDto>(cached.json_data).toDomain()
+            json.decodeFromString<UserPreferencesResponse>(cached.json_data).toDomain()
         }.getOrNull()
     }
 
@@ -177,7 +177,7 @@ class PreferencesRepositoryImpl(
 
             // Import per-console mappings from server
             for ((consoleId, mapping) in prefs.consoleKeyMappings) {
-                for ((retroButtonStr, keyCodeStr) in mapping.customMapping) {
+                for ((retroButtonStr, keyCodeStr) in mapping.customMapping.orEmpty()) {
                     val retroButton = retroButtonStr.toIntOrNull() ?: continue
                     val keyCode = keyCodeStr.toIntOrNull() ?: continue
                     database.spelaDatabaseQueries.insertKeyMapping(
@@ -226,7 +226,7 @@ class PreferencesRepositoryImpl(
                 .groupBy { it.console_id }
 
             val consoleMappings = consoleGroups.mapValues { (_, entities) ->
-                ConsoleKeyMappingDto(
+                ConsoleKeyMappingDTO(
                     selectedMapping = "",
                     customMapping = entities.associate {
                         it.libretro_button_id.toString() to it.platform_key_code.toString()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/settings/DeviceManagementSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/settings/DeviceManagementSection.kt
@@ -120,13 +120,11 @@ private fun DeviceRow(
                 style = SpTypography.BodySmall,
                 color = SpColor.OnBackgroundTertiary,
             )
-            if (device.lastSeenAt.isNotEmpty()) {
-                Text(
-                    text = "Last seen: ${device.lastSeenAt}",
-                    style = SpTypography.BodySmall,
-                    color = SpColor.OnBackgroundTertiary,
-                )
-            }
+            Text(
+                text = "Last seen: ${device.lastSeenAt}",
+                style = SpTypography.BodySmall,
+                color = SpColor.OnBackgroundTertiary,
+            )
         }
         Spacer(Modifier.width(SpSpacing.Small))
         SpIconButton(

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -442,10 +442,20 @@ class GameRepositoryImplTest {
 
     @Test
     fun authResponseMapsCorrectly() {
+        val now = kotlin.time.Instant.fromEpochSeconds(0)
         val dto = AuthResponse(
             accessToken = "access123",
             refreshToken = "refresh456",
-            user = UserDto("1", "testuser", "test@example.com", "user"),
+            user = UserDto(
+                createdAt = now,
+                disabled = false,
+                email = "test@example.com",
+                id = "1",
+                pendingApproval = false,
+                role = "user",
+                updatedAt = now,
+                username = "testuser",
+            ),
         )
         val tokens = dto.toDomain()
 
@@ -486,12 +496,15 @@ class GameRepositoryImplTest {
 
     @Test
     fun coreResponseMapsCorrectly() {
-        val dto = LibretroCoreDto(
+        val now = kotlin.time.Instant.fromEpochSeconds(0)
+        val dto = com.spela.client.models.Core(
+            createdAt = now,
+            displayName = "Nestopia UE",
             id = 1,
             name = "nestopia",
-            displayName = "Nestopia UE",
-            version = "1.52.0",
             platforms = "windows,linux,macos,android",
+            updatedAt = now,
+            version = "1.52.0",
         )
         val domain = dto.toDomain()
 


### PR DESCRIPTION
Nineteenth call-site migration in the #461 series. **Eight domains in one PR** to cut CI overhead now that the migration pattern is well-established. Unlocked by the #479 GameDto typealias; nested types resolve via the chain.

## Clusters migrated

| # | Domain | Key changes |
|---|---|---|
| 1 | User profile | `UserDto` → typealias `UserResponse` (hand-written `AuthResponse.user` still points at the alias — auth endpoints not huma-migrated) |
| 2 | Preferences | `UserPreferencesDto` / `UpdatePreferencesRequest` / `ConsoleKeyMappingDto` → generated. Note: generated name is `ConsoleKeyMappingDTO` (uppercase) |
| 3 | Devices | `DeviceDto` → typealias `DeviceResponse` (used in presentation); `RegisterDeviceRequest` / `UpdateDevicePreferencesRequest` deleted. Removed vestigial `.isNotEmpty()` branch on `lastSeenAt` (now non-null `Instant`) |
| 4 | Game sessions | `GameSessionDto` / `CreateSessionRequest` / `UpdateSessionRequest` deleted. `DuplicateSessionRequest` from generated. `memberCount` Long→Int, `lastPlayedAt` Instant→String |
| 5 | Session cheats | `SessionCheatConfigDto` / `UpdateSessionCheatsRequest` deleted. `enabledIndices` is `List<Long>?` in spec (huma quirk); `.orEmpty().map { it.toInt() }` |
| 6 | Game cheats | `CheatDto` deleted. Drop `.toLong()` on now-Long `dto.index` |
| 7 | Cores | `LibretroCoreDto` deleted; mapper on `Core`. `getRecommendedCore` returns domain `LibretroCore` directly — the `{coreName:"..."}` fallback can't satisfy `Core`'s `@Required createdAt/updatedAt` Instants |
| 8 | Key mappings | `GameKeyMappingDto` / `UpdateGameKeyMappingRequest` deleted; unused outside data layer |

## Skipped: Session saves

`SaveStateDto` → `SessionSaveResponse` needs a domain-model change: `SaveState.id: Long, gameId: Long` but generated has `id: String` and no `gameId` field. Requires coordinated updates across tests / UI / repository — saved for a follow-up PR.

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop :shared:compileTestKotlinDesktop :desktop:compileKotlinDesktop` — all green
- [x] `./run-desktop-tests.sh` — **470/470 pass** (matches master)
- [x] Pre-existing `SessionsUiTest` E2E failures unchanged
- [ ] CI green

Refs #461.