### PR TITLE
feat(player): migrate taste profile + series + franchise + dev-games

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -167,7 +167,7 @@ class SpelaApiClient(
         hidePreRelease: Boolean = true,
         grouped: Boolean = true,
         region: String? = null,
-    ): GameListResponse {
+    ): com.spela.client.models.PaginatedResponseGameResponse {
         return client.get("$baseUrl/api/games") {
             parameter("consoleId", consoleId)
             page?.let { parameter("page", it) }
@@ -188,7 +188,7 @@ class SpelaApiClient(
         hidePreRelease: Boolean = true,
         grouped: Boolean = true,
         region: String? = null,
-    ): GameListResponse {
+    ): com.spela.client.models.PaginatedResponseGameResponse {
         return client.get("$baseUrl/api/games") {
             consoleId?.let { parameter("consoleId", it) }
             sortBy?.let { parameter("sortBy", it) }
@@ -212,7 +212,7 @@ class SpelaApiClient(
         region: String? = null,
         page: Int? = null,
         pageSize: Int? = null,
-    ): GameListResponse {
+    ): com.spela.client.models.PaginatedResponseGameResponse {
         return client.get("$baseUrl/api/games") {
             parameter("search", query)
             consoleId?.let { parameter("consoleId", it) }
@@ -227,7 +227,7 @@ class SpelaApiClient(
     }
 
     /** Returns a single enriched GameResponse */
-    suspend fun getGameDetail(gameId: String): GameDto {
+    suspend fun getGameDetail(gameId: String): com.spela.client.models.GameResponse {
         return client.get("$baseUrl/api/games/$gameId").body()
     }
 
@@ -246,7 +246,7 @@ class SpelaApiClient(
         client.post("$baseUrl/api/admin/games/$gameId/achievements/refresh")
     }
 
-    suspend fun getRecentlyAddedGames(pageSize: Int = 12): GameListResponse {
+    suspend fun getRecentlyAddedGames(pageSize: Int = 12): com.spela.client.models.PaginatedResponseGameResponse {
         return client.get("$baseUrl/api/games") {
             parameter("sortBy", "created_at")
             parameter("sortOrder", "desc")
@@ -274,7 +274,7 @@ class SpelaApiClient(
         return client.get("$baseUrl/api/games/$gameId/similar").body()
     }
 
-    suspend fun getDeveloperGames(gameId: String): List<DeveloperGameDto> {
+    suspend fun getDeveloperGames(gameId: String): List<com.spela.client.models.DeveloperGameResponse> {
         return client.get("$baseUrl/api/games/$gameId/developer-games").body()
     }
 
@@ -295,7 +295,7 @@ class SpelaApiClient(
     }
 
     /** Returns paginated games for a theme */
-    suspend fun getThemeGames(themeId: String, page: Int = 1, pageSize: Int = 20): GameListResponse {
+    suspend fun getThemeGames(themeId: String, page: Int = 1, pageSize: Int = 20): com.spela.client.models.PaginatedResponseGameResponse {
         return client.get("$baseUrl/api/themes/$themeId/games") {
             parameter("page", page)
             parameter("pageSize", pageSize)
@@ -310,7 +310,7 @@ class SpelaApiClient(
     }
 
     /** Returns paginated games for a keyword */
-    suspend fun getKeywordGames(keywordId: String, page: Int = 1, pageSize: Int = 20): GameListResponse {
+    suspend fun getKeywordGames(keywordId: String, page: Int = 1, pageSize: Int = 20): com.spela.client.models.PaginatedResponseGameResponse {
         return client.get("$baseUrl/api/keywords/$keywordId/games") {
             parameter("page", page)
             parameter("pageSize", pageSize)
@@ -323,22 +323,22 @@ class SpelaApiClient(
     }
 
     /** Returns detail for a specific series */
-    suspend fun getSeriesDetail(id: String): SeriesDetailDto {
+    suspend fun getSeriesDetail(id: String): com.spela.client.models.SeriesDetailResponse {
         return client.get("$baseUrl/api/series/$id").body()
     }
 
     /** Returns detail for a specific franchise */
-    suspend fun getFranchiseDetail(id: String): SeriesDetailDto {
+    suspend fun getFranchiseDetail(id: String): com.spela.client.models.FranchiseDetailResponse {
         return client.get("$baseUrl/api/franchises/$id").body()
     }
 
     /** Returns series links for a game */
-    suspend fun getGameSeries(gameId: String): List<GameSeriesLinkDto> {
+    suspend fun getGameSeries(gameId: String): List<com.spela.client.models.GameSeriesResponse> {
         return client.get("$baseUrl/api/games/$gameId/series").body()
     }
 
     /** Returns franchise links for a game */
-    suspend fun getGameFranchises(gameId: String): List<GameFranchiseLinkDto> {
+    suspend fun getGameFranchises(gameId: String): List<com.spela.client.models.GameFranchiseResponse> {
         return client.get("$baseUrl/api/games/$gameId/franchises").body()
     }
 
@@ -348,12 +348,12 @@ class SpelaApiClient(
     }
 
     /** Returns games matching a mood */
-    suspend fun getMoodGames(mood: String): List<GameDto> {
+    suspend fun getMoodGames(mood: String): List<com.spela.client.models.GameResponse> {
         return client.get("$baseUrl/api/explore/mood/$mood").body()
     }
 
     /** Returns a single random surprise game */
-    suspend fun getSurpriseGame(): GameDto {
+    suspend fun getSurpriseGame(): com.spela.client.models.GameResponse {
         return client.get("$baseUrl/api/explore/surprise").body()
     }
 
@@ -363,7 +363,7 @@ class SpelaApiClient(
     }
 
     /** Returns the user's taste profile (genre/theme/console breakdown) */
-    suspend fun getTasteProfile(): TasteProfileDto {
+    suspend fun getTasteProfile(): com.spela.client.models.TasteProfileResponse {
         return client.get("$baseUrl/api/user/taste-profile").body()
     }
 
@@ -503,7 +503,7 @@ class SpelaApiClient(
         filters: Map<String, String>,
         page: Int? = null,
         pageSize: Int? = null,
-    ): GameListResponse {
+    ): com.spela.client.models.PaginatedResponseGameResponse {
         return client.get("$baseUrl/api/games") {
             filters.forEach { (key, value) ->
                 parameter(key, value)
@@ -567,12 +567,12 @@ class SpelaApiClient(
     }
 
     /** Returns flat GameResponse[] with lastPlayedAt/totalPlayTime enriched */
-    suspend fun getRecentGames(): List<GameDto> {
+    suspend fun getRecentGames(): List<com.spela.client.models.GameResponse> {
         return client.get("$baseUrl/api/user/recent").body()
     }
 
     /** Returns flat GameResponse[] with isFavorite=true */
-    suspend fun getFavoriteGames(): List<GameDto> {
+    suspend fun getFavoriteGames(): List<com.spela.client.models.GameResponse> {
         return client.get("$baseUrl/api/user/favorites").body()
     }
 
@@ -585,7 +585,7 @@ class SpelaApiClient(
     }
 
     /** Returns flat GameResponse[] for user's Play Later queue */
-    suspend fun getPlayLaterGames(): List<GameDto> {
+    suspend fun getPlayLaterGames(): List<com.spela.client.models.GameResponse> {
         return client.get("$baseUrl/api/user/play-later").body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -639,11 +639,14 @@ fun SimilarGameDto.toDomain(): SimilarGame = SimilarGame(
     localGameId = localGameId,
 )
 
-fun DeveloperGameDto.toDomain(): DeveloperGame = DeveloperGame(
-    id = id,
-    title = title,
-    coverUrl = coverUrl,
-    consoleName = consoleName,
+fun com.spela.client.models.DeveloperGameResponse.toDomain(): DeveloperGame = DeveloperGame(
+    // Server sends `localGameId` / `name` / `coverUrl`; the hand-written
+    // DTO used `id` / `title` / `consoleName` which never matched the
+    // server payload. The server never ships `consoleName` for this
+    // endpoint — domain defaults it to "".
+    id = localGameId,
+    title = name,
+    coverUrl = coverUrl.takeIf { it.isNotEmpty() },
 )
 
 fun com.spela.client.models.GameSessionResponse.toDomain(): GameSession = GameSession(
@@ -711,48 +714,64 @@ fun FeaturedSeriesDto.toDomain(): FeaturedSeries = FeaturedSeries(
     heroUrl = heroUrl,
 )
 
-fun SeriesDetailDto.toDomain(): SeriesDetail = SeriesDetail(
+fun com.spela.client.models.SeriesDetailResponse.toDomain(): SeriesDetail = SeriesDetail(
     id = id,
     name = name,
     heroUrl = heroUrl,
     logoUrl = logoUrl,
-    consoles = consoles.map { it.toDomain() },
-    libraryGames = libraryGames,
-    totalGames = totalGames,
-    games = games.map { it.toDomain() },
+    consoles = consoles.orEmpty().map { it.toDomain() },
+    libraryGames = libraryGames.toInt(),
+    totalGames = totalGames.toInt(),
+    games = games.orEmpty().map { it.toDomain() },
 )
 
-fun SeriesConsoleDto.toDomain(): SeriesConsole = SeriesConsole(
+fun com.spela.client.models.FranchiseDetailResponse.toDomain(): SeriesDetail = SeriesDetail(
+    id = id,
+    name = name,
+    heroUrl = heroUrl,
+    logoUrl = logoUrl,
+    consoles = consoles.orEmpty().map { it.toDomain() },
+    libraryGames = libraryGames.toInt(),
+    totalGames = totalGames.toInt(),
+    games = games.orEmpty().map { it.toDomain() },
+)
+
+fun com.spela.client.models.SeriesConsoleInfo.toDomain(): SeriesConsole = SeriesConsole(
     abbreviation = abbreviation,
     name = name,
     color = color,
-    gameCount = gameCount,
+    gameCount = gameCount.toInt(),
 )
 
-fun SeriesGameDto.toDomain(): SeriesGame = SeriesGame(
-    igdbGameId = igdbGameId,
+fun com.spela.client.models.SeriesGameResponse.toDomain(): SeriesGame = SeriesGame(
+    igdbGameId = igdbGameId.toInt(),
     name = name,
     inLibrary = inLibrary,
     localGameId = localGameId,
     coverUrl = coverUrl,
     releaseDate = releaseDate,
-    rating = rating,
+    // Server emits `igdbCriticsRating`; the hand-written DTO used `rating`
+    // which was always 0.0 — the new mapper pulls the real field.
+    rating = igdbCriticsRating,
     consoleAbbreviation = consoleAbbreviation,
     consoleName = consoleName,
     consoleColor = consoleColor,
 )
 
-fun GameSeriesLinkDto.toDomain(): GameSeriesLink = GameSeriesLink(
+fun com.spela.client.models.GameSeriesResponse.toDomain(): GameSeriesLink = GameSeriesLink(
     id = id,
     name = name,
-    totalGames = totalGames,
-    libraryGames = libraryGames,
+    totalGames = totalGames.toInt(),
+    libraryGames = libraryGames.toInt(),
 )
 
-fun GameFranchiseLinkDto.toDomain(): GameFranchiseLink = GameFranchiseLink(
+fun com.spela.client.models.GameFranchiseResponse.toDomain(): GameFranchiseLink = GameFranchiseLink(
     id = id,
     name = name,
-    gameCount = gameCount,
+    // Server sends both totalGames and libraryGames; the hand-written DTO
+    // only had gameCount — we pick totalGames to preserve the UX
+    // ("Part of Foo (N games)"). Domain does not yet split the two.
+    gameCount = totalGames.toInt(),
 )
 
 
@@ -772,25 +791,32 @@ fun ForYouRowDto.toDomain(): ForYouRow = ForYouRow(
     games = games.map { it.toDomain() },
 )
 
-fun TasteBreakdownDto.toDomain(): TasteBreakdown = TasteBreakdown(
+fun com.spela.client.models.TasteProfileGenre.toDomain(): TasteBreakdown = TasteBreakdown(
     name = name,
     percentage = percentage,
     playTime = playTime,
-    gameCount = gameCount,
+    gameCount = gameCount.toInt(),
 )
 
-fun ConsoleBreakdownDto.toDomain(): ConsoleBreakdown = ConsoleBreakdown(
+fun com.spela.client.models.TasteProfileTheme.toDomain(): TasteBreakdown = TasteBreakdown(
+    name = name,
+    percentage = percentage,
+    playTime = playTime,
+    gameCount = gameCount.toInt(),
+)
+
+fun com.spela.client.models.TasteProfileConsole.toDomain(): ConsoleBreakdown = ConsoleBreakdown(
     name = name,
     abbreviation = abbreviation,
     playTime = playTime,
-    gameCount = gameCount,
+    gameCount = gameCount.toInt(),
 )
 
-fun TasteProfileDto.toDomain(): TasteProfile = TasteProfile(
+fun com.spela.client.models.TasteProfileResponse.toDomain(): TasteProfile = TasteProfile(
     totalPlayTime = totalPlayTime,
-    genres = genres.map { it.toDomain() },
-    themes = themes.map { it.toDomain() },
-    topConsoles = topConsoles.map { it.toDomain() },
+    genres = genres.orEmpty().map { it.toDomain() },
+    themes = themes.orEmpty().map { it.toDomain() },
+    topConsoles = topConsoles.orEmpty().map { it.toDomain() },
 )
 
 fun PlayersLikeYouResponseDto.toDomain(): PlayersLikeYouResult = PlayersLikeYouResult(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -458,15 +458,11 @@ data class SimilarGameDto(
     val localGameId: String? = null,
 )
 
-// Developer Games
-
-@Serializable
-data class DeveloperGameDto(
-    val id: String,
-    val title: String,
-    val coverUrl: String? = null,
-    val consoleName: String = "",
-)
+// Developer Games — DeveloperGameDto replaced by
+// com.spela.client.models.DeveloperGameResponse (see player/shared-api/).
+// Noteworthy: hand-written DTO used `id`/`title`/`consoleName` but the
+// server actually emits `localGameId`/`name` (and never emits consoleName
+// on this endpoint). The mapper renames accordingly.
 
 // Save Data (SRAM)
 
@@ -534,55 +530,21 @@ data class FeaturedSeriesDto(
     val heroUrl: String? = null,
 )
 
-@Serializable
-data class SeriesDetailDto(
-    val id: String,
-    val name: String,
-    val heroUrl: String? = null,
-    val logoUrl: String? = null,
-    val consoles: List<SeriesConsoleDto> = emptyList(),
-    val libraryGames: Int = 0,
-    val totalGames: Int = 0,
-    val games: List<SeriesGameDto> = emptyList(),
-)
-
-@Serializable
-data class SeriesConsoleDto(
-    val abbreviation: String,
-    val name: String,
-    val color: String = "#6366f1",
-    val gameCount: Int = 0,
-)
-
-@Serializable
-data class SeriesGameDto(
-    val igdbGameId: Int,
-    val name: String,
-    val inLibrary: Boolean = false,
-    val localGameId: String? = null,
-    val coverUrl: String? = null,
-    val releaseDate: String? = null,
-    val rating: Double = 0.0,
-    val consoleAbbreviation: String? = null,
-    val consoleName: String? = null,
-    val consoleColor: String? = null,
-)
-
-@Serializable
-data class GameSeriesLinkDto(
-    val id: String,
-    val name: String,
-    val totalGames: Int = 0,
-    val libraryGames: Int = 0,
-)
-
-@Serializable
-data class GameFranchiseLinkDto(
-    val id: String,
-    val name: String,
-    val gameCount: Int = 0,
-)
-
+// SeriesDetailDto / SeriesConsoleDto / SeriesGameDto / GameSeriesLinkDto /
+// GameFranchiseLinkDto replaced by generated counterparts:
+//   SeriesDetailDto       -> SeriesDetailResponse (also FranchiseDetailResponse
+//                            for /api/franchises/:id — same shape aside from
+//                            igdbCollectionId vs igdbFranchiseId)
+//   SeriesConsoleDto      -> SeriesConsoleInfo
+//   SeriesGameDto         -> SeriesGameResponse
+//   GameSeriesLinkDto     -> GameSeriesResponse
+//   GameFranchiseLinkDto  -> GameFranchiseResponse (server sends
+//                            totalGames + libraryGames; hand-written DTO
+//                            only had gameCount — mapper picks totalGames)
+//
+// Noteworthy: hand-written SeriesGameDto used `rating` but the server
+// sends `igdbCriticsRating` — the hand-written field was always 0.0.
+// The new mapper pulls the real rating.
 
 @Serializable
 data class MoodDefinitionDto(
@@ -609,29 +571,12 @@ data class ForYouResponseDto(
     val rows: List<ForYouRowDto>,
 )
 
-@Serializable
-data class TasteBreakdownDto(
-    val name: String,
-    val percentage: Double,
-    val playTime: Long,
-    val gameCount: Int,
-)
-
-@Serializable
-data class ConsoleBreakdownDto(
-    val name: String,
-    val abbreviation: String,
-    val playTime: Long,
-    val gameCount: Int,
-)
-
-@Serializable
-data class TasteProfileDto(
-    val totalPlayTime: Long,
-    val genres: List<TasteBreakdownDto>,
-    val themes: List<TasteBreakdownDto>,
-    val topConsoles: List<ConsoleBreakdownDto>,
-)
+// TasteProfileDto / TasteBreakdownDto / ConsoleBreakdownDto replaced by
+// com.spela.client.models.TasteProfileResponse / TasteProfileGenre /
+// TasteProfileTheme / TasteProfileConsole (see player/shared-api/).
+// The generated types use Long for gameCount — the mapper converts to Int
+// for the domain. Generated lists are nullable (Required but nullable in
+// spec), so the mapper applies .orEmpty() when flattening.
 
 @Serializable
 data class PlayersLikeYouResponseDto(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -110,7 +110,7 @@ class ExploreRepositoryImpl(
         dto.toDomain().copy(
             heroUrl = apiClient.resolveUrl(dto.heroUrl),
             logoUrl = apiClient.resolveUrl(dto.logoUrl),
-            games = dto.games.map { gameDto ->
+            games = dto.games.orEmpty().map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 )
@@ -123,7 +123,7 @@ class ExploreRepositoryImpl(
         dto.toDomain().copy(
             heroUrl = apiClient.resolveUrl(dto.heroUrl),
             logoUrl = apiClient.resolveUrl(dto.logoUrl),
-            games = dto.games.map { gameDto ->
+            games = dto.games.orEmpty().map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 )


### PR DESCRIPTION
Twentieth call-site migration in the #461 series. Four domains + a stylistic cleanup across the 13 game-list API methods.

## Clusters migrated

| Domain | Swapped to |
|---|---|
| Taste profile | `TasteProfileResponse` + nested `TasteProfileGenre` / `TasteProfileTheme` / `TasteProfileConsole` |
| Series | `SeriesDetailResponse` + `SeriesConsoleInfo` + `SeriesGameResponse` |
| Franchise | `FranchiseDetailResponse` + `GameFranchiseResponse` |
| Developer games | `DeveloperGameResponse` |

## Type flip

13 game-list methods in `SpelaApiClient` now name `PaginatedResponseGameResponse` / `GameResponse` / `List<GameResponse>` directly instead of via the `GameDto` / `GameListResponse` typealiases. Purely stylistic — typealiases kept because nested hand-written DTOs (`ExploreRowDto`, `ConsoleShowcaseDto`, `ForYouResponseDto`, etc.) still reference them.

## Silent deserialization bugs surfaced and fixed

1. **`DeveloperGameDto` was broken end-to-end** — hand-written had `{id, title, consoleName, coverUrl}` but the server actually sends `{localGameId, name, coverUrl}`. The `@Required` `id`/`title` would've failed kotlinx-serialization outright; the endpoint was apparently rarely hit. New mapper maps `localGameId→id`, `name→title`.
2. **`SeriesGameResponse`** — server sends `igdbCriticsRating`, hand-written had `rating` (always 0.0 via default). Mapper now pulls the real rating into domain `SeriesGame.rating`.
3. **`GameFranchiseResponse`** — server sends both `totalGames` and `libraryGames`; hand-written only had `gameCount`. Mapper picks `totalGames` for the "Part of Foo (N games)" UX.

That's **7 silent deserialization bugs** found by the migration so far: challenges creator avatar / console name (#472), activity event avatar / console (#473), top-rated rating (#475), and now these three.

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop :shared:compileTestKotlinDesktop :desktop:compileKotlinDesktop` — green
- [x] `./run-desktop-tests.sh` — **470/470 pass**
- [x] Pre-existing `SessionsUiTest` E2E failures unchanged
- [ ] CI green

## Skipped (no generated counterpart yet)

`ExploreRowDto` / `ForYouResponseDto` / `FeaturedSeriesDto` / `DeveloperListResponseDto` / `DeveloperDetailResponseDto` / `DeveloperSpotlightResponseDto` / `ConsoleShowcaseDto` / gallery / wizard / trending / cultclassics / etc. — all still on gin-only handlers, no huma migration yet. `SharedSessionDto` family needs a server audit for path/shape drift (flagged earlier). `SaveStateDto` needs a domain-model change.

Refs #461.