### PR TITLE
feat(player): migrate global-search to generated SearchResponse

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -492,7 +492,7 @@ class SpelaApiClient(
     /** Returns games filtered by multi-faceted criteria */
     // Global Search
 
-    suspend fun globalSearch(query: String, limit: Int = 5): GlobalSearchResponseDto {
+    suspend fun globalSearch(query: String, limit: Int = 5): com.spela.client.models.SearchResponse {
         return client.get("$baseUrl/api/search") {
             parameter("q", query)
             parameter("limit", limit)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -1113,87 +1113,91 @@ fun com.spela.client.models.CompletionistMapResponse.toDomain() = CompletionistM
 )
 
 // --- Global Search mappers ---
+//
+// Fully qualified on the generated-type side because every one of these
+// clashes name-for-name with a domain model (SearchGameResult etc.).
 
-fun GlobalSearchGameResultDto.toDomain() = SearchGameResult(
+fun com.spela.client.models.SearchGameResult.toDomain() = SearchGameResult(
     id = id,
     title = title,
-    coverUrl = coverUrl,
+    coverUrl = coverUrl.takeIf { it.isNotEmpty() },
     consoleName = consoleName,
     consoleId = consoleId,
-    developer = developer,
-    genre = genre,
+    developer = developer.takeIf { it.isNotEmpty() },
+    genre = genre.takeIf { it.isNotEmpty() },
     coverAspectRatio = coverAspectRatio.toFloat(),
 )
 
-fun GlobalSearchConsoleResultDto.toDomain() = SearchConsoleResult(
+fun com.spela.client.models.SearchConsoleResult.toDomain() = SearchConsoleResult(
     id = id,
     name = name,
     iconUrl = iconUrl,
-    gameCount = gameCount,
+    gameCount = gameCount.toInt(),
     colorTheme = colorTheme,
 )
 
-fun GlobalSearchDeveloperResultDto.toDomain() = SearchDeveloperResult(
+/** The spec uses SearchCompanyResult for both developers and publishers. */
+private fun com.spela.client.models.SearchCompanyResult.toDeveloper() = SearchDeveloperResult(
     name = name,
-    gameCount = gameCount,
+    gameCount = gameCount.toInt(),
     avgRating = avgRating,
 )
 
-fun GlobalSearchPublisherResultDto.toDomain() = SearchPublisherResult(
+private fun com.spela.client.models.SearchCompanyResult.toPublisher() = SearchPublisherResult(
     name = name,
-    gameCount = gameCount,
+    gameCount = gameCount.toInt(),
     avgRating = avgRating,
 )
 
-fun GlobalSearchCollectionResultDto.toDomain() = SearchCollectionResult(
+fun com.spela.client.models.SearchCollectionResult.toDomain() = SearchCollectionResult(
     id = id,
     name = name,
-    gameCount = gameCount,
-    coverUrl = coverUrl,
+    gameCount = gameCount.toInt(),
+    coverUrl = coverUrl.takeIf { it.isNotEmpty() },
     username = username,
 )
 
-fun GlobalSearchSeriesResultDto.toDomain() = SearchSeriesResult(
+fun com.spela.client.models.SearchSeriesResult.toDomain() = SearchSeriesResult(
     id = id,
     name = name,
-    totalGames = totalGames,
-    libraryGames = libraryGames,
+    totalGames = totalGames.toInt(),
+    libraryGames = libraryGames.toInt(),
 )
 
-fun GlobalSearchFranchiseResultDto.toDomain() = SearchFranchiseResult(
+fun com.spela.client.models.SearchFranchiseResult.toDomain() = SearchFranchiseResult(
     id = id,
     name = name,
-    totalGames = totalGames,
-    libraryGames = libraryGames,
+    totalGames = totalGames.toInt(),
+    libraryGames = libraryGames.toInt(),
 )
 
-fun GlobalSearchResponseDto.toDomain() = GlobalSearchResult(
+fun com.spela.client.models.SearchResponse.toDomain() = GlobalSearchResult(
     games = SearchCategory(
-        results = games.results.map { it.toDomain() },
-        total = games.total,
+        results = games.results.orEmpty().map { it.toDomain() },
+        total = games.total.toInt(),
     ),
     consoles = SearchCategory(
-        results = consoles.results.map { it.toDomain() },
-        total = consoles.total,
+        results = consoles.results.orEmpty().map { it.toDomain() },
+        total = consoles.total.toInt(),
     ),
     developers = SearchCategory(
-        results = developers.results.map { it.toDomain() },
-        total = developers.total,
+        results = developers.results.orEmpty().map { it.toDeveloper() },
+        total = developers.total.toInt(),
     ),
     publishers = SearchCategory(
-        results = publishers.results.map { it.toDomain() },
-        total = publishers.total,
+        results = publishers.results.orEmpty().map { it.toPublisher() },
+        total = publishers.total.toInt(),
     ),
     collections = SearchCategory(
-        results = collections.results.map { it.toDomain() },
-        total = collections.total,
+        results = collections.results.orEmpty().map { it.toDomain() },
+        total = collections.total.toInt(),
     ),
     series = SearchCategory(
-        results = series.results.map { it.toDomain() },
-        total = series.total,
+        results = series.results.orEmpty().map { it.toDomain() },
+        total = series.total.toInt(),
     ),
     franchises = SearchCategory(
-        results = franchises.results.map { it.toDomain() },
-        total = franchises.total,
+        results = franchises.results.orEmpty().map { it.toDomain() },
+        total = franchises.total.toInt(),
     ),
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -983,81 +983,8 @@ data class WizardResultsResponseDto(
 // com.spela.client.models.CompletionistMapResponse — see
 // player/shared-api/ (generated from the OpenAPI spec).
 
-// --- Global Search ---
-
-@Serializable
-data class GlobalSearchGameResultDto(
-    val id: String,
-    val title: String,
-    val coverUrl: String? = null,
-    val consoleName: String = "",
-    val consoleId: String = "",
-    val developer: String? = null,
-    val genre: String? = null,
-    val coverAspectRatio: Double = 0.75,
-)
-
-@Serializable
-data class GlobalSearchConsoleResultDto(
-    val id: String,
-    val name: String,
-    val iconUrl: String = "",
-    val gameCount: Int = 0,
-    val colorTheme: String = "#6366f1",
-)
-
-@Serializable
-data class GlobalSearchDeveloperResultDto(
-    val name: String,
-    val gameCount: Int = 0,
-    val avgRating: Double = 0.0,
-)
-
-@Serializable
-data class GlobalSearchPublisherResultDto(
-    val name: String,
-    val gameCount: Int = 0,
-    val avgRating: Double = 0.0,
-)
-
-@Serializable
-data class GlobalSearchCollectionResultDto(
-    val id: String,
-    val name: String,
-    val gameCount: Int = 0,
-    val coverUrl: String? = null,
-    val username: String = "",
-)
-
-@Serializable
-data class GlobalSearchSeriesResultDto(
-    val id: String,
-    val name: String,
-    val totalGames: Int = 0,
-    val libraryGames: Int = 0,
-)
-
-@Serializable
-data class GlobalSearchFranchiseResultDto(
-    val id: String,
-    val name: String,
-    val totalGames: Int = 0,
-    val libraryGames: Int = 0,
-)
-
-@Serializable
-data class GlobalSearchCategoryDto<T>(
-    val results: List<T> = emptyList(),
-    val total: Int = 0,
-)
-
-@Serializable
-data class GlobalSearchResponseDto(
-    val games: GlobalSearchCategoryDto<GlobalSearchGameResultDto> = GlobalSearchCategoryDto(),
-    val consoles: GlobalSearchCategoryDto<GlobalSearchConsoleResultDto> = GlobalSearchCategoryDto(),
-    val developers: GlobalSearchCategoryDto<GlobalSearchDeveloperResultDto> = GlobalSearchCategoryDto(),
-    val publishers: GlobalSearchCategoryDto<GlobalSearchPublisherResultDto> = GlobalSearchCategoryDto(),
-    val collections: GlobalSearchCategoryDto<GlobalSearchCollectionResultDto> = GlobalSearchCategoryDto(),
-    val series: GlobalSearchCategoryDto<GlobalSearchSeriesResultDto> = GlobalSearchCategoryDto(),
-    val franchises: GlobalSearchCategoryDto<GlobalSearchFranchiseResultDto> = GlobalSearchCategoryDto(),
-)
+// Global search DTOs replaced by generated counterparts in
+// com.spela.client.models — GlobalSearchResponseDto -> SearchResponse,
+// GlobalSearchGameResultDto -> SearchGameResult, and so on. The
+// developers/publishers category elements share SearchCompanyResult on
+// the wire; DtoMappers handles the split into the two domain types.


### PR DESCRIPTION
Twenty-first call-site migration in the #461 series. Small cluster — one endpoint, eight hand-written DTOs collapsed.

## Change

- `SpelaApiClient.globalSearch()` now returns `com.spela.client.models.SearchResponse`.
- Seven new mappers in `DtoMappers.kt` on the generated element types (`SearchGameResult`, `SearchConsoleResult`, `SearchCollectionResult`, `SearchSeriesResult`, `SearchFranchiseResult`). Fully qualified on the generated side because every one clashes name-for-name with a domain model.
- `SearchResponse.developers` and `.publishers` both use `SearchCompanyResult` on the wire — split via private `toDeveloper()` / `toPublisher()` helpers so both domain types (`SearchDeveloperResult` / `SearchPublisherResult`) remain populated as before.
- Type conversions: Long→Int on `gameCount` / `total` / `libraryGames` / `totalGames`; empty-string→null via `.takeIf { it.isNotEmpty() }` for `coverUrl` / `developer` / `genre` (`@Required String` in spec, but server sends `""` when missing); `.orEmpty()` for the spec's nullable `results` lists.
- Deleted nine hand-written DTOs from `Dtos.kt`.

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop :shared:compileTestKotlinDesktop :desktop:compileKotlinDesktop` — green
- [x] `./run-desktop-tests.sh` — **470/470 pass** (`FramerateRegressionTest` flaked on timing once, passed on rerun)
- [x] Pre-existing `SessionsUiTest` E2E failures unchanged
- [ ] CI green

Refs #461.