### PR TITLE
feat(player): migrate session saves to generated SessionSaveResponse (with domain change)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionDetailUiTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionDetailUiTest.kt
@@ -78,12 +78,12 @@ class SessionDetailUiTest {
         )
         harness.sessionRepo.preAddSessionSave(
             sessionId = "s1",
-            saveId = 1,
+            saveId = "1",
             name = "Boss Fight Save",
         )
         harness.sessionRepo.preAddSessionSave(
             sessionId = "s1",
-            saveId = 2,
+            saveId = "2",
             name = "After Tutorial",
         )
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1284,8 +1284,7 @@ class FakeSessionRepository : SessionRepository {
 
     override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<SaveState> {
         val save = SaveState(
-            id = (sessionSaves[sessionId]?.size?.toLong() ?: 0L) + 1,
-            gameId = 0,
+            id = ((sessionSaves[sessionId]?.size ?: 0) + 1).toString(),
             name = name,
             isAuto = false,
         )
@@ -1309,8 +1308,7 @@ class FakeSessionRepository : SessionRepository {
         val key = "$sessionId:$slot"
         slotSaves[key] = data
         val save = SaveState(
-            id = (sessionSaves[sessionId]?.size?.toLong() ?: 0L) + 1,
-            gameId = 0,
+            id = ((sessionSaves[sessionId]?.size ?: 0) + 1).toString(),
             name = "Slot $slot",
             isAuto = false,
             slot = slot,
@@ -1393,13 +1391,12 @@ class FakeSessionRepository : SessionRepository {
 
     fun preAddSessionSave(
         sessionId: String,
-        saveId: Long = 1,
+        saveId: String = "1",
         name: String = "Save 1",
         isAuto: Boolean = false,
     ) {
         val save = SaveState(
             id = saveId,
-            gameId = 0,
             name = name,
             isAuto = isAuto,
         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1553,11 +1553,11 @@ class SpelaApiClient(
         }.body()
     }
 
-    suspend fun getSessionSaves(sessionId: String): List<SaveStateDto> {
+    suspend fun getSessionSaves(sessionId: String): List<com.spela.client.models.SessionSaveResponse> {
         return client.get("$baseUrl/api/sessions/$sessionId/saves").body()
     }
 
-    suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): SaveStateDto {
+    suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): com.spela.client.models.SessionSaveResponse {
         return client.submitFormWithBinaryData(
             url = "$baseUrl/api/sessions/$sessionId/saves",
             formData = formData {
@@ -1616,7 +1616,7 @@ class SpelaApiClient(
         return response.body()
     }
 
-    suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): SaveStateDto {
+    suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): com.spela.client.models.SessionSaveResponse {
         return client.submitFormWithBinaryData(
             url = "$baseUrl/api/sessions/$sessionId/saves/slot/$slot",
             formData = formData {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -1,7 +1,6 @@
 package com.spela.player.data.remote.dto
 
 import com.spela.player.domain.model.*
-import kotlin.time.Instant
 
 fun AuthResponse.toDomain(): AuthTokens = AuthTokens(
     accessToken = accessToken,
@@ -155,17 +154,16 @@ fun GameDto.toGameDetail(): GameDetail = GameDetail(
     romHacks = romHacks.orEmpty().map { it.toDomain() },
 )
 
-fun SaveStateDto.toDomain(): SaveState = SaveState(
+fun com.spela.client.models.SessionSaveResponse.toDomain(): SaveState = SaveState(
     id = id,
-    gameId = gameId,
     name = name,
-    createdAt = createdAt?.let { runCatching { Instant.parse(it) }.getOrNull() },
+    createdAt = createdAt,
     fileSize = fileSize,
     isAuto = isAuto,
     coreName = coreName,
     notes = notes,
     screenshotUrl = screenshotUrl,
-    slot = slot,
+    slot = slot?.toInt(),
     isSynced = true,
 )
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -99,21 +99,10 @@ typealias ParentGameDto = com.spela.client.models.ParentGameResponse
 typealias RomHackGameDto = com.spela.client.models.RomHackGameResponse
 typealias GameListResponse = com.spela.client.models.PaginatedResponseGameResponse
 
-@Serializable
-data class SaveStateDto(
-    val id: Long,
-    val userId: Long = 0,
-    val gameId: Long = 0,
-    val name: String,
-    val fileSize: Long = 0,
-    val isAuto: Boolean = false,
-    val coreName: String? = null,
-    val notes: String? = null,
-    val screenshotUrl: String? = null,
-    val slot: Int? = null,
-    val createdAt: String? = null,
-    val updatedAt: String? = null,
-)
+// SaveStateDto replaced by com.spela.client.models.SessionSaveResponse
+// (see player/shared-api/). The generated type has `id: String`, no
+// `gameId` field (derivable from session context), `createdAt: Instant`
+// (no String parsing needed), and `slot: Long?` (mapper converts to Int?).
 
 // LibretroCoreDto replaced by com.spela.client.models.Core (see
 // player/shared-api/). Generated Core has @Required createdAt/updatedAt

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -146,8 +146,7 @@ data class GameDetail(
 
 @Serializable
 data class SaveState(
-    val id: Long,
-    val gameId: Long,
+    val id: String,
     val name: String,
     val createdAt: Instant? = null,
     val fileSize: Long = 0,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/CreateChallengeDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/CreateChallengeDialog.kt
@@ -222,7 +222,7 @@ internal fun CreateChallengeDialog(
                         val save = selectedSaveState
                         if (name.isNotBlank() && save != null) {
                             onSubmit(
-                                save.id.toString(),
+                                save.id,
                                 name,
                                 description,
                                 selectedType.apiId,

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -422,18 +422,22 @@ class GameRepositoryImplTest {
 
     @Test
     fun saveStateDtoMapsCorrectly() {
-        val dto = SaveStateDto(
-            id = 1,
-            gameId = 1,
+        val now = kotlin.time.Instant.parse("2024-01-15T10:30:00Z")
+        val dto = com.spela.client.models.SessionSaveResponse(
+            id = "save-1",
+            sessionId = "session-1",
+            userId = "user-1",
+            username = "alice",
             name = "Slot 1",
             fileSize = 65536,
             isAuto = false,
-            createdAt = "2024-01-15T10:30:00Z",
+            isCurrent = false,
+            createdAt = now,
+            updatedAt = now,
         )
         val domain = dto.toDomain()
 
-        assertEquals(1L, domain.id)
-        assertEquals(1L, domain.gameId)
+        assertEquals("save-1", domain.id)
         assertEquals("Slot 1", domain.name)
         assertEquals(65536, domain.fileSize)
         assertFalse(domain.isAuto)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -174,12 +174,12 @@ private class FakePlayFromSharedSaveSessionRepository : SessionRepository {
     override suspend fun deleteSession(sessionId: String) = Result.success(Unit)
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
     override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String) =
-        Result.success(SaveState(id = 1, gameId = 1, name = name))
+        Result.success(SaveState(id = "1", name = name))
     override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
     override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String) = Result.success(Unit)
     override suspend fun downloadSessionAutoSave(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String) =
-        Result.success(SaveState(id = 1, gameId = 1, name = "Slot $slot"))
+        Result.success(SaveState(id = "1", name = "Slot $slot"))
     override suspend fun downloadSlotSave(sessionId: String, slot: Int) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String) = Result.success(Unit)
     override suspend fun downloadSessionSram(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -368,7 +368,7 @@ class StubSessionRepository : SessionRepository {
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
     override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<SaveState> {
         uploadSessionSaveCallCount++
-        return Result.success(SaveState(id = 1, gameId = 1, name = name))
+        return Result.success(SaveState(id = "1", name = name))
     }
     override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
     override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<Unit> {
@@ -388,7 +388,7 @@ class StubSessionRepository : SessionRepository {
         return downloadSessionSramResult
     }
     override suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String) =
-        Result.success(SaveState(id = 1, gameId = 1, name = "Slot $slot"))
+        Result.success(SaveState(id = "1", name = "Slot $slot"))
     override suspend fun downloadSlotSave(sessionId: String, slot: Int) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun createSessionFromSharedSave(gameId: String, saveId: String) =
         Result.success(GameSession(id = "shared-session-1", gameId = gameId, name = "From shared save $saveId"))


### PR DESCRIPTION
Twenty-second call-site migration in the #461 series. Last Kotlin migration that has a clean generated counterpart — required the domain-model change that earlier batches deferred.

## Domain change

- `SaveState.id: Long` → `SaveState.id: String` — the hand-written `SaveStateDto` had a Long database id; generated `SessionSaveResponse` uses a String (UUID-like) per the huma spec. Call sites that stringified the old Long (e.g. `CreateChallengeDialog`) just drop the `.toString()`.
- `SaveState.gameId: Long` **dropped** — verified no production code ever reads it (only test fixtures set it to 0). Saves belong to a session, which belongs to a game — `gameId` is accessible via session context wherever it matters.

## API + mapper

- `SpelaApiClient.getSessionSaves` / `uploadSessionSave` / `uploadSlotSave` return `SessionSaveResponse` / `List<SessionSaveResponse>`.
- Mapper simplified: `createdAt` is already `Instant` in the generated type (no more lazy `Instant.parse` roundtrip), `slot` Long?→Int? via `?.toInt()`, other fields pass through.
- Deleted `SaveStateDto` from `Dtos.kt`.

## Test fixtures

- 7 `SaveState` constructors in tests (`GameDetailPlayFromSharedSaveTest`, `EmulationTestStubs`, `TestFakes`) flipped from `Long id/gameId` to `String id`, `gameId` dropped.
- `GameRepositoryImplTest.saveStateDtoMapsCorrectly` rewritten to build a full `SessionSaveResponse` with all `@Required` fields (`sessionId`, `userId`, `username`, `isCurrent`, `updatedAt` — not used by mapper but needed for kotlinx-serialization strict mode).
- `SessionDetailUiTest`: `preAddSessionSave`'s `saveId: Long` parameter becomes `String`.

## Schema notes

- `SessionSaveResponse` has `@Required` `sessionId` / `userId` / `username` / `isCurrent` / `updatedAt` that the domain `SaveState` doesn't surface. Mapper ignores them.
- `createdAt` is now always present (`@Required Instant`). Domain keeps nullable for backward-compat with SQLite-backed offline saves, but the server path never produces null.

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop :shared:compileTestKotlinDesktop :desktop:compileKotlinDesktop` — all green
- [x] `./run-desktop-tests.sh` — **470/470 pass**
- [x] Pre-existing `SessionsUiTest` E2E failures unchanged
- [ ] CI green

## What's left after this

**Shared sessions** — flagged earlier with URL-path drift and shape drift. Needs server-side audit (check which paths are live) before Kotlin can migrate safely. **All other remaining hand-written DTOs** are endpoints that haven't been huma-migrated server-side — no generated counterparts exist, so they'll migrate automatically as the server continues moving handlers to huma. **Auth** stays hand-written until auth endpoints get huma-migrated too.

Refs #461.