### PR TITLE
feat(server): migrate explore cluster + auth endpoints to huma

### DIFF
--- a/server/internal/api/huma_auth_handlers.go
+++ b/server/internal/api/huma_auth_handlers.go
@@ -1,0 +1,623 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/danielgtaylor/huma/v2/adapters/humagin"
+	"github.com/gin-gonic/gin"
+	"github.com/spela/server/internal/auth"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// --- Request / response shapes -----------------------------------------------
+
+// AuthLoginRequest is the body for POST /api/auth/login.
+type AuthLoginRequest struct {
+	Username string `json:"username" minLength:"1" doc:"Username to sign in as."`
+	Password string `json:"password" minLength:"1" maxLength:"72" doc:"Plain-text password (max 72 bytes — bcrypt limit)."`
+}
+
+// AuthRegisterRequest is the body for POST /api/auth/register and /api/auth/setup.
+// Matches the original gin binding (alphanum, min=3, max=64 for username; valid
+// email; min=8, max=72 for password).
+type AuthRegisterRequest struct {
+	Username string `json:"username" minLength:"3" maxLength:"64" pattern:"^[a-zA-Z0-9]+$" doc:"New account username (3-64 alphanumeric characters)."`
+	Email    string `json:"email" format:"email" doc:"New account email."`
+	Password string `json:"password" minLength:"8" maxLength:"72" doc:"New account password (8-72 characters)."`
+}
+
+// AuthRefreshRequest is the body for POST /api/auth/refresh.
+type AuthRefreshRequest struct {
+	RefreshToken string `json:"refreshToken" minLength:"1" doc:"Raw refresh token previously issued by login/register/refresh."`
+}
+
+// AuthRegisterResponse is the union-style response for POST /api/auth/register.
+// Successful registration returns the AuthLoginResponse fields (accessToken,
+// refreshToken, user) and HTTP 201. A successful registration that requires
+// admin approval returns { "pending": true, "message": "..." } with HTTP 202.
+// Using a single struct with omitempty fields preserves the historical wire
+// format exactly while keeping the OpenAPI spec a single response type.
+type AuthRegisterResponse struct {
+	// Pending-approval fields.
+	Pending bool   `json:"pending,omitempty" doc:"True when the new account is awaiting admin approval. When true, no tokens are returned."`
+	Message string `json:"message,omitempty" doc:"Human-readable status message (only set when pending)."`
+
+	// Normal success fields (omitted when pending).
+	AccessToken  string        `json:"accessToken,omitempty" doc:"Bearer access token."`
+	RefreshToken string        `json:"refreshToken,omitempty" doc:"Refresh token (rotate via /api/auth/refresh)."`
+	User         *UserResponse `json:"user,omitempty" doc:"Registered user profile."`
+}
+
+// SetupStatusResponse is the JSON shape for GET /api/auth/setup-status.
+type SetupStatusResponse struct {
+	NeedsSetup          bool  `json:"needsSetup" doc:"True when no user accounts exist and the server requires first-time setup."`
+	RegistrationEnabled bool  `json:"registrationEnabled" doc:"True when new-account registration is currently allowed."`
+	GameCount           int64 `json:"gameCount" doc:"Total number of games indexed on the server."`
+}
+
+// --- Huma inputs / outputs ---------------------------------------------------
+
+// AuthLoginInput wraps the login body.
+type AuthLoginInput struct {
+	Body AuthLoginRequest
+}
+
+// AuthLoginOutput wraps the login response body.
+type AuthLoginOutput struct {
+	Body AuthLoginResponse
+}
+
+// AuthRegisterInput wraps the register body.
+type AuthRegisterInput struct {
+	Body AuthRegisterRequest
+}
+
+// AuthRegisterOutput uses huma's dynamic-status pattern: 201 Created for a
+// standard registration, 202 Accepted when the account requires admin approval.
+type AuthRegisterOutput struct {
+	Status int
+	Body   AuthRegisterResponse
+}
+
+// AuthRefreshInput wraps the refresh body.
+type AuthRefreshInput struct {
+	Body AuthRefreshRequest
+}
+
+// AuthRefreshOutput wraps the refresh response body.
+type AuthRefreshOutput struct {
+	Body AuthLoginResponse
+}
+
+// AuthSetupInput wraps the setup body (same shape as register).
+type AuthSetupInput struct {
+	Body AuthRegisterRequest
+}
+
+// AuthSetupOutput wraps the setup response body.
+type AuthSetupOutput struct {
+	Body AuthLoginResponse
+}
+
+// SetupStatusInput is the empty input for GET /api/auth/setup-status.
+type SetupStatusInput struct{}
+
+// SetupStatusOutput wraps the setup-status response body.
+type SetupStatusOutput struct {
+	Body SetupStatusResponse
+}
+
+// --- Request-context bridging ------------------------------------------------
+
+// authReqCtxKey is the private context key under which we stash the underlying
+// *gin.Context for auth handlers. This lets us reuse recordSecurityEventCtx —
+// which needs the client IP and request path from gin — inside huma handlers
+// that otherwise only receive a context.Context.
+type authReqCtxKey struct{}
+
+// authRequestContextMiddleware is a huma middleware that attaches the
+// underlying *gin.Context to the huma context so handlers can read the client
+// IP / request path when recording security events. Must run before any handler
+// that calls securityEventCtxFromHuma.
+func authRequestContextMiddleware(ctx huma.Context, next func(huma.Context)) {
+	gctx := humagin.Unwrap(ctx)
+	next(huma.WithValue(ctx, authReqCtxKey{}, gctx))
+}
+
+// ginContextFromCtx returns the *gin.Context stashed in ctx by
+// authRequestContextMiddleware, or nil if the middleware hasn't run (e.g. in
+// a unit test that invokes the handler directly).
+func ginContextFromCtx(ctx context.Context) *gin.Context {
+	if v := ctx.Value(authReqCtxKey{}); v != nil {
+		if g, ok := v.(*gin.Context); ok {
+			return g
+		}
+	}
+	return nil
+}
+
+// recordSecurityEventFromHumaCtx records a security event using the *gin.Context
+// stashed by authRequestContextMiddleware. Falls back to calling
+// db.RecordSecurityEvent directly (without IP/Path) if the middleware wasn't
+// applied — keeps the function usable in tests that bypass routing.
+func recordSecurityEventFromHumaCtx(database *gorm.DB, ctx context.Context, in db.SystemEventInput) {
+	if g := ginContextFromCtx(ctx); g != nil {
+		if in.IP == "" {
+			in.IP = g.ClientIP()
+		}
+		if in.Path == "" && g.Request != nil && g.Request.URL != nil {
+			in.Path = g.Request.URL.Path
+		}
+	}
+	db.RecordSecurityEvent(database, in)
+}
+
+// --- IP rate-limit adapter for huma ------------------------------------------
+
+// IPRateLimitMiddleware wraps a RateLimiter's IP-scoped gin middleware so huma
+// operations can enforce the same per-IP request budget as the raw gin auth
+// endpoints. This is the huma equivalent of UserRateLimitMiddleware for anon
+// routes — login/register/setup/refresh all run under IP-scoped limiters
+// because the caller isn't authenticated yet.
+func IPRateLimitMiddleware(rl *RateLimiter) func(huma.Context, func(huma.Context)) {
+	ginLimiter := rl.RateLimit()
+	return func(ctx huma.Context, next func(huma.Context)) {
+		gctx := humagin.Unwrap(ctx)
+		ginLimiter(gctx)
+		if gctx.IsAborted() {
+			return
+		}
+		next(ctx)
+	}
+}
+
+// --- Route registration ------------------------------------------------------
+
+// RegisterAuthRoutes wires the public authentication endpoints (login, register,
+// refresh, setup, setup-status) into the huma API. Rate limiters mirror the raw
+// gin routes: authLimiter protects login/register/setup, refreshLimiter guards
+// /refresh, and setup-status is unrestricted.
+func RegisterAuthRoutes(api huma.API, h *AuthHandler, authLimiter *RateLimiter, refreshLimiter *RateLimiter) {
+	authRL := IPRateLimitMiddleware(authLimiter)
+	refreshRL := IPRateLimitMiddleware(refreshLimiter)
+	reqCtx := huma.Middlewares{authRequestContextMiddleware}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "authLogin",
+		Method:      http.MethodPost,
+		Path:        "/api/auth/login",
+		Summary:     "Sign in",
+		Description: "Authenticates a user and returns access + refresh tokens. Enforces lockout after repeated failures and performs a dummy bcrypt comparison on unknown usernames to prevent timing-based username enumeration.",
+		Tags:        []string{"auth"},
+		Middlewares: append(reqCtx, authRL),
+	}, h.HumaLogin)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "authRegister",
+		Method:        http.MethodPost,
+		Path:          "/api/auth/register",
+		Summary:       "Register a new account",
+		Description:   "Creates a new user account. The very first user becomes the server owner and is signed in immediately. Subsequent registrations are pending admin approval (HTTP 202) unless registration has been disabled.",
+		DefaultStatus: http.StatusCreated,
+		Tags:          []string{"auth"},
+		Middlewares:   append(reqCtx, authRL),
+	}, h.HumaRegister)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "authRefresh",
+		Method:      http.MethodPost,
+		Path:        "/api/auth/refresh",
+		Summary:     "Rotate refresh token",
+		Description: "Exchanges a refresh token for new access + refresh tokens. Uses token families for replay detection: presenting a consumed token revokes the entire family.",
+		Tags:        []string{"auth"},
+		Middlewares: append(reqCtx, refreshRL),
+	}, h.HumaRefresh)
+
+	huma.Register(api, huma.Operation{
+		OperationID:   "authSetup",
+		Method:        http.MethodPost,
+		Path:          "/api/auth/setup",
+		Summary:       "Perform first-time server setup",
+		Description:   "Creates the initial owner account. Fails with 403 after a user already exists.",
+		DefaultStatus: http.StatusCreated,
+		Tags:          []string{"auth"},
+		Middlewares:   append(reqCtx, authRL),
+	}, h.HumaSetup)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "authSetupStatus",
+		Method:      http.MethodGet,
+		Path:        "/api/auth/setup-status",
+		Summary:     "Get server setup status",
+		Description: "Returns whether the server needs first-time setup, whether new-account registration is enabled, and how many games are indexed.",
+		Tags:        []string{"auth"},
+	}, h.HumaSetupStatus)
+}
+
+// --- Handlers ----------------------------------------------------------------
+
+// HumaLogin is the huma implementation of POST /api/auth/login. Security
+// behaviour (lockout, dummy bcrypt, system events, status codes, user-facing
+// error messages) matches the raw gin Login handler 1:1 so clients cannot
+// distinguish which stack served the request.
+func (h *AuthHandler) HumaLogin(ctx context.Context, in *AuthLoginInput) (*AuthLoginOutput, error) {
+	req := in.Body
+
+	// Check account lockout before proceeding.
+	if h.isLockedOut(req.Username) {
+		recordSecurityEventFromHumaCtx(h.DB, ctx, db.SystemEventInput{
+			EventType: db.SystemEventLoginLocked,
+			Username:  req.Username,
+		})
+		return nil, huma.NewError(http.StatusTooManyRequests, "Your account has been temporarily locked due to too many failed login attempts. Please try again later.")
+	}
+
+	var user db.User
+	userFound := h.DB.Where("username = ?", req.Username).First(&user).Error == nil
+
+	if !userFound {
+		// Run bcrypt against a dummy hash to prevent timing-based username
+		// enumeration (see auth_handler.go comment).
+		auth.CheckPassword(req.Password, dummyBcryptHash)
+		h.recordFailedLogin(req.Username)
+		recordSecurityEventFromHumaCtx(h.DB, ctx, db.SystemEventInput{
+			EventType: db.SystemEventLoginFailed,
+			Reason:    "unknown_user",
+			Username:  req.Username,
+		})
+		return nil, huma.NewError(http.StatusUnauthorized, "Invalid username or password.")
+	}
+
+	if !auth.CheckPassword(req.Password, user.PasswordHash) {
+		h.recordFailedLogin(req.Username)
+		// Re-read the attempt to log the new failure count and detect lockout
+		// escalation.
+		var attempt db.LoginAttempt
+		h.DB.Where("username = ?", hashUsername(req.Username)).First(&attempt)
+		recordSecurityEventFromHumaCtx(h.DB, ctx, db.SystemEventInput{
+			EventType: db.SystemEventLoginFailed,
+			Reason:    "bad_password",
+			Username:  req.Username,
+			UserID:    &user.ID,
+			Metadata:  db.LoginFailedMetadata{FailedCount: attempt.FailedCount},
+		})
+		if attempt.FailedCount >= maxLoginAttempts {
+			recordSecurityEventFromHumaCtx(h.DB, ctx, db.SystemEventInput{
+				EventType: db.SystemEventAccountLocked,
+				Username:  req.Username,
+				UserID:    &user.ID,
+				Metadata: db.AccountLockedMetadata{
+					FailedCount: attempt.FailedCount,
+					LockedUntil: attempt.LockedUntil,
+				},
+			})
+		}
+		return nil, huma.NewError(http.StatusUnauthorized, "Invalid username or password.")
+	}
+
+	if user.PendingApproval {
+		recordSecurityEventFromHumaCtx(h.DB, ctx, db.SystemEventInput{
+			EventType: db.SystemEventLoginBlocked,
+			Reason:    "pending_approval",
+			Username:  req.Username,
+			UserID:    &user.ID,
+		})
+		return nil, huma.NewError(http.StatusForbidden, "Your account is awaiting admin approval. Please try again once an admin has approved it.")
+	}
+
+	if user.Disabled {
+		recordSecurityEventFromHumaCtx(h.DB, ctx, db.SystemEventInput{
+			EventType: db.SystemEventLoginBlocked,
+			Reason:    "disabled",
+			Username:  req.Username,
+			UserID:    &user.ID,
+		})
+		return nil, huma.NewError(http.StatusForbidden, "Your account has been disabled. Please contact an administrator.")
+	}
+
+	// Successful login — clear any failed attempts.
+	h.clearFailedLogins(req.Username)
+	recordSecurityEventFromHumaCtx(h.DB, ctx, db.SystemEventInput{
+		EventType: db.SystemEventLoginSuccess,
+		Username:  req.Username,
+		UserID:    &user.ID,
+	})
+
+	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret, user.TokenVersion)
+	if err != nil {
+		return nil, huma.NewError(http.StatusInternalServerError, "Sign in failed. Please try again.")
+	}
+
+	refreshToken, err := auth.GenerateRefreshToken()
+	if err != nil {
+		return nil, huma.NewError(http.StatusInternalServerError, "Sign in failed. Please try again.")
+	}
+
+	rt := db.RefreshToken{
+		UserID:      user.ID,
+		Token:       auth.HashRefreshToken(refreshToken),
+		ExpiresAt:   time.Now().Add(auth.RefreshTokenDuration),
+		TokenFamily: generateTokenFamily(),
+	}
+	h.DB.Create(&rt)
+
+	return &AuthLoginOutput{Body: AuthLoginResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		User:         ToUserResponse(user),
+	}}, nil
+}
+
+// HumaRegister is the huma implementation of POST /api/auth/register. Returns
+// 201 Created with tokens on success, or 202 Accepted with {pending, message}
+// when the new account is awaiting admin approval — matching the raw gin shape.
+func (h *AuthHandler) HumaRegister(ctx context.Context, in *AuthRegisterInput) (*AuthRegisterOutput, error) {
+	req := in.Body
+
+	hash, err := auth.HashPassword(req.Password)
+	if err != nil {
+		return nil, huma.NewError(http.StatusInternalServerError, "Registration failed. Please try again.")
+	}
+
+	// Use a transaction to atomically check registration eligibility, determine
+	// the role (first user becomes owner), and create the user. This prevents a
+	// TOCTOU race where two simultaneous registrations could both see
+	// userCount=0 and both get the owner role.
+	//
+	// The transaction callback returns a *humaError (via huma.NewError) when it
+	// needs to surface a specific status/message to the client; a generic error
+	// (e.g. db failure) is mapped to a 500 afterwards.
+	var user db.User
+	var txErr error
+	_ = h.DB.Transaction(func(tx *gorm.DB) error {
+		var count int64
+		tx.Model(&db.User{}).Where("username = ? OR email = ?", req.Username, req.Email).Count(&count)
+		if count > 0 {
+			txErr = huma.NewError(http.StatusConflict, "That username or email is already taken.")
+			return fmt.Errorf("duplicate")
+		}
+
+		var totalUsers int64
+		tx.Model(&db.User{}).Count(&totalUsers)
+		if totalUsers > 0 {
+			var setting db.ServerSetting
+			if err := tx.Where("key = ?", "registration_enabled").First(&setting).Error; err == nil {
+				if setting.Value == "false" {
+					txErr = huma.NewError(http.StatusForbidden, "Registration is currently disabled. Please contact an administrator.")
+					return fmt.Errorf("disabled")
+				}
+			}
+		}
+
+		role := db.RoleUser
+		if totalUsers == 0 {
+			role = db.RoleOwner
+		}
+		pendingApproval := role != db.RoleOwner
+
+		user = db.User{
+			Username:        req.Username,
+			Email:           req.Email,
+			PasswordHash:    hash,
+			Role:            role,
+			PendingApproval: pendingApproval,
+		}
+		if err := tx.Create(&user).Error; err != nil {
+			txErr = huma.NewError(http.StatusInternalServerError, "Registration failed. Please try again.")
+			return err
+		}
+		return nil
+	})
+	if txErr != nil {
+		return nil, txErr
+	}
+
+	// Non-owner registrations require admin approval; return 202 Accepted with
+	// {pending: true, message: "..."} and no tokens. Matches the raw gin shape.
+	if user.PendingApproval {
+		return &AuthRegisterOutput{
+			Status: http.StatusAccepted,
+			Body: AuthRegisterResponse{
+				Pending: true,
+				Message: "Your account is pending admin approval.",
+			},
+		}, nil
+	}
+
+	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret)
+	if err != nil {
+		return nil, huma.NewError(http.StatusInternalServerError, "Account created but sign-in failed. Please sign in manually.")
+	}
+
+	refreshToken, err := auth.GenerateRefreshToken()
+	if err != nil {
+		return nil, huma.NewError(http.StatusInternalServerError, "Account created but sign-in failed. Please sign in manually.")
+	}
+
+	rt := db.RefreshToken{
+		UserID:      user.ID,
+		Token:       auth.HashRefreshToken(refreshToken),
+		ExpiresAt:   time.Now().Add(auth.RefreshTokenDuration),
+		TokenFamily: generateTokenFamily(),
+	}
+	h.DB.Create(&rt)
+
+	userResp := ToUserResponse(user)
+	return &AuthRegisterOutput{
+		Status: http.StatusCreated,
+		Body: AuthRegisterResponse{
+			AccessToken:  accessToken,
+			RefreshToken: refreshToken,
+			User:         &userResp,
+		},
+	}, nil
+}
+
+// HumaRefresh is the huma implementation of POST /api/auth/refresh. Preserves
+// replay-detection semantics: presenting a consumed token (or a token that
+// matches a consumed hash) revokes the entire token family.
+func (h *AuthHandler) HumaRefresh(_ context.Context, in *AuthRefreshInput) (*AuthRefreshOutput, error) {
+	req := in.Body
+
+	tokenHash := auth.HashRefreshToken(req.RefreshToken)
+
+	var rt db.RefreshToken
+	if err := h.DB.Where("token = ?", tokenHash).First(&rt).Error; err != nil {
+		// Token not found — check if it was a consumed token (replay detection).
+		var consumed db.RefreshToken
+		if h.DB.Unscoped().Where("token = ? AND consumed = ?", tokenHash, true).First(&consumed).Error == nil {
+			slog.Warn("refresh token replay detected, revoking token family",
+				"user_id", consumed.UserID, "family", consumed.TokenFamily)
+			h.DB.Where("token_family = ? AND user_id = ?", consumed.TokenFamily, consumed.UserID).
+				Delete(&db.RefreshToken{})
+		}
+		return nil, huma.NewError(http.StatusUnauthorized, "Your session has expired. Please sign in again.")
+	}
+
+	if rt.Consumed {
+		slog.Warn("consumed refresh token presented", "user_id", rt.UserID, "family", rt.TokenFamily)
+		h.DB.Where("token_family = ? AND user_id = ?", rt.TokenFamily, rt.UserID).
+			Delete(&db.RefreshToken{})
+		return nil, huma.NewError(http.StatusUnauthorized, "Your session has expired. Please sign in again.")
+	}
+
+	if time.Now().After(rt.ExpiresAt) {
+		h.DB.Delete(&rt)
+		return nil, huma.NewError(http.StatusUnauthorized, "Your session has expired. Please sign in again.")
+	}
+
+	var user db.User
+	if err := h.DB.First(&user, rt.UserID).Error; err != nil {
+		return nil, huma.NewError(http.StatusUnauthorized, "Your account could not be found. Please sign in again.")
+	}
+
+	if user.Disabled {
+		h.DB.Where("token_family = ? AND user_id = ?", rt.TokenFamily, rt.UserID).
+			Delete(&db.RefreshToken{})
+		return nil, huma.NewError(http.StatusForbidden, "Your account has been disabled. Please contact an administrator.")
+	}
+
+	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret, user.TokenVersion)
+	if err != nil {
+		return nil, huma.NewError(http.StatusInternalServerError, "Session refresh failed. Please sign in again.")
+	}
+
+	newRefreshToken, err := auth.GenerateRefreshToken()
+	if err != nil {
+		return nil, huma.NewError(http.StatusInternalServerError, "Session refresh failed. Please sign in again.")
+	}
+
+	family := rt.TokenFamily
+	if family == "" {
+		family = generateTokenFamily()
+	}
+
+	newRT := db.RefreshToken{
+		UserID:      user.ID,
+		Token:       auth.HashRefreshToken(newRefreshToken),
+		ExpiresAt:   time.Now().Add(auth.RefreshTokenDuration),
+		TokenFamily: family,
+	}
+	if err := h.DB.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Model(&rt).Update("consumed", true).Error; err != nil {
+			return err
+		}
+		return tx.Create(&newRT).Error
+	}); err != nil {
+		return nil, huma.NewError(http.StatusInternalServerError, "Session refresh failed. Please sign in again.")
+	}
+
+	return &AuthRefreshOutput{Body: AuthLoginResponse{
+		AccessToken:  accessToken,
+		RefreshToken: newRefreshToken,
+		User:         ToUserResponse(user),
+	}}, nil
+}
+
+// HumaSetup is the huma implementation of POST /api/auth/setup. Creates the
+// initial owner account; fails with 403 if a user already exists.
+func (h *AuthHandler) HumaSetup(_ context.Context, in *AuthSetupInput) (*AuthSetupOutput, error) {
+	req := in.Body
+
+	hash, err := auth.HashPassword(req.Password)
+	if err != nil {
+		return nil, huma.NewError(http.StatusInternalServerError, "Setup failed. Please try again.")
+	}
+
+	var user db.User
+	var txErr error
+	_ = h.DB.Transaction(func(tx *gorm.DB) error {
+		var userCount int64
+		tx.Model(&db.User{}).Count(&userCount)
+		if userCount > 0 {
+			txErr = huma.NewError(http.StatusForbidden, "Setup has already been completed.")
+			return fmt.Errorf("setup already completed")
+		}
+
+		user = db.User{
+			Username:     req.Username,
+			Email:        req.Email,
+			PasswordHash: hash,
+			Role:         db.RoleOwner,
+		}
+		if err := tx.Create(&user).Error; err != nil {
+			txErr = huma.NewError(http.StatusInternalServerError, "Setup failed. Please try again.")
+			return err
+		}
+		return nil
+	})
+	if txErr != nil {
+		return nil, txErr
+	}
+
+	accessToken, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), h.JWTSecret)
+	if err != nil {
+		return nil, huma.NewError(http.StatusInternalServerError, "Setup failed. Please try again.")
+	}
+
+	refreshToken, err := auth.GenerateRefreshToken()
+	if err != nil {
+		return nil, huma.NewError(http.StatusInternalServerError, "Setup failed. Please try again.")
+	}
+
+	rt := db.RefreshToken{
+		UserID:      user.ID,
+		Token:       auth.HashRefreshToken(refreshToken),
+		ExpiresAt:   time.Now().Add(auth.RefreshTokenDuration),
+		TokenFamily: generateTokenFamily(),
+	}
+	h.DB.Create(&rt)
+
+	return &AuthSetupOutput{Body: AuthLoginResponse{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		User:         ToUserResponse(user),
+	}}, nil
+}
+
+// HumaSetupStatus is the huma implementation of GET /api/auth/setup-status.
+func (h *AuthHandler) HumaSetupStatus(_ context.Context, _ *SetupStatusInput) (*SetupStatusOutput, error) {
+	var userCount int64
+	h.DB.Model(&db.User{}).Count(&userCount)
+
+	var gameCount int64
+	h.DB.Model(&db.Game{}).Count(&gameCount)
+
+	registrationEnabled := true
+	var setting db.ServerSetting
+	if err := h.DB.Where("key = ?", "registration_enabled").First(&setting).Error; err == nil {
+		registrationEnabled = setting.Value != "false"
+	}
+
+	return &SetupStatusOutput{Body: SetupStatusResponse{
+		NeedsSetup:          userCount == 0,
+		RegistrationEnabled: registrationEnabled,
+		GameCount:           gameCount,
+	}}, nil
+}

--- a/server/internal/api/huma_explore_challenge.go
+++ b/server/internal/api/huma_explore_challenge.go
@@ -1,0 +1,579 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"net/http"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// --- Inputs / outputs ---
+
+// GetEasyToCompleteInput is the input for GET /api/explore/easy-to-complete.
+type GetEasyToCompleteInput struct{}
+
+// GetEasyToCompleteOutput wraps the easy-to-complete response.
+type GetEasyToCompleteOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         EasyToCompleteResponse
+}
+
+// GetHardestGamesInput is the input for GET /api/explore/hardest-games.
+type GetHardestGamesInput struct{}
+
+// GetHardestGamesOutput wraps the hardest-games response.
+type GetHardestGamesOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         HardestGamesResponse
+}
+
+// GetAlmostDoneInput is the input for GET /api/explore/almost-done.
+type GetAlmostDoneInput struct{}
+
+// GetAlmostDoneOutput wraps the almost-done response.
+type GetAlmostDoneOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         AlmostDoneResponse
+}
+
+// GetFreshChallengesInput is the input for GET /api/explore/fresh-challenges.
+type GetFreshChallengesInput struct{}
+
+// GetFreshChallengesOutput wraps the fresh-challenges response.
+type GetFreshChallengesOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         FreshChallengesResponse
+}
+
+// GetActiveChallengesInput is the input for GET /api/explore/active-challenges.
+type GetActiveChallengesInput struct{}
+
+// GetActiveChallengesOutput wraps the active-challenges response.
+type GetActiveChallengesOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         ActiveChallengesResponse
+}
+
+// RegisterExploreChallengeRoutes wires the achievement / challenge discovery endpoints.
+func RegisterExploreChallengeRoutes(api huma.API, h *ExploreHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
+	requireAuth := RequireAuth(jwtSecret, database)
+	rateLimit := UserRateLimitMiddleware(userLimiter)
+	mw := huma.Middlewares{requireAuth, rateLimit}
+	sec := []map[string][]string{{"bearer": {}}}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getEasyToComplete",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/easy-to-complete",
+		Summary:     "Get games with highest avg achievement completion",
+		Description: "Returns up to 20 games with the highest average achievement completion rate across players.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetEasyToComplete)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getHardestGames",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/hardest-games",
+		Summary:     "Get games with lowest avg achievement completion",
+		Description: "Returns up to 20 games with the lowest average achievement completion rate. Requires at least 2 players attempting.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetHardestGames)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getAlmostDone",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/almost-done",
+		Summary:     "Get games the caller has nearly completed",
+		Description: "Returns games where the caller has completed between 80 and 99 percent of achievements.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetAlmostDone)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getFreshChallenges",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/fresh-challenges",
+		Summary:     "Get games with cached achievements the caller hasn't started",
+		Description: "Returns up to 20 games with cached achievements where the caller has zero unlocks yet.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetFreshChallenges)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getActiveChallenges",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/active-challenges",
+		Summary:     "Get active community challenges",
+		Description: "Returns the 10 most recent active Challenge entities that have not yet expired.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetActiveChallenges)
+}
+
+// --- Handlers ---
+
+// HumaGetEasyToComplete is the huma handler for GET /api/explore/easy-to-complete.
+func (h *ExploreHandler) HumaGetEasyToComplete(ctx context.Context, _ *GetEasyToCompleteInput) (*GetEasyToCompleteOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	type achievementRow struct {
+		GameID           uint
+		RAGameID         uint
+		TotalCount       int
+		PlayersAttempted int
+		AvgUnlocked      float64
+	}
+	var rows []achievementRow
+	if err := h.DB.
+		Table("game_achievement_caches").
+		Select(`game_achievement_caches.game_id,
+			game_achievement_caches.ra_game_id,
+			game_achievement_caches.total_count,
+			COUNT(DISTINCT sub.user_id) as players_attempted,
+			CAST(AVG(sub.unlocked_count) AS REAL) as avg_unlocked`).
+		Joins(`JOIN (
+			SELECT ra_game_id, user_id, COUNT(*) as unlocked_count
+			FROM user_achievement_progresses
+			WHERE deleted_at IS NULL
+			GROUP BY ra_game_id, user_id
+		) sub ON sub.ra_game_id = game_achievement_caches.ra_game_id`).
+		Where("game_achievement_caches.game_id > 0 AND game_achievement_caches.total_count > 0 AND game_achievement_caches.deleted_at IS NULL").
+		Group("game_achievement_caches.game_id, game_achievement_caches.ra_game_id, game_achievement_caches.total_count").
+		Having("players_attempted >= 1").
+		Order("(avg_unlocked / game_achievement_caches.total_count) DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch easy-to-complete games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch easy-to-complete games")
+	}
+
+	if len(rows) == 0 {
+		return &GetEasyToCompleteOutput{
+			CacheControl: "private, max-age=120",
+			Body:         EasyToCompleteResponse{Games: []AchievementGameResponse{}},
+		}, nil
+	}
+
+	gameIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load easy-to-complete games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load games")
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	raGameIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		raGameIDs[i] = r.RAGameID
+	}
+	raTotalMap := make(map[uint]int, len(rows))
+	for _, r := range rows {
+		raTotalMap[r.RAGameID] = r.TotalCount
+	}
+
+	completedMap := make(map[uint]int, len(rows))
+	type userUnlockRow struct {
+		RAGameID uint
+		UserID   uint
+		Unlocked int
+	}
+	var userUnlocks []userUnlockRow
+	if err := h.DB.
+		Table("user_achievement_progresses").
+		Select("ra_game_id, user_id, COUNT(*) as unlocked").
+		Where("ra_game_id IN ? AND deleted_at IS NULL", raGameIDs).
+		Group("ra_game_id, user_id").
+		Scan(&userUnlocks).Error; err == nil {
+		for _, u := range userUnlocks {
+			if total, ok := raTotalMap[u.RAGameID]; ok && u.Unlocked >= total {
+				completedMap[u.RAGameID]++
+			}
+		}
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]AchievementGameResponse, 0, len(rows))
+	for _, r := range rows {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		avgCompletion := 0.0
+		if r.TotalCount > 0 {
+			avgCompletion = math.Round((r.AvgUnlocked/float64(r.TotalCount))*10000) / 100
+		}
+		result = append(result, AchievementGameResponse{
+			Game:              toGameResponseWithData(g, &userData),
+			TotalAchievements: r.TotalCount,
+			AvgCompletion:     avgCompletion,
+			PlayersAttempted:  r.PlayersAttempted,
+			PlayersCompleted:  completedMap[r.RAGameID],
+		})
+	}
+
+	return &GetEasyToCompleteOutput{
+		CacheControl: "private, max-age=120",
+		Body:         EasyToCompleteResponse{Games: result},
+	}, nil
+}
+
+// HumaGetHardestGames is the huma handler for GET /api/explore/hardest-games.
+func (h *ExploreHandler) HumaGetHardestGames(ctx context.Context, _ *GetHardestGamesInput) (*GetHardestGamesOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	type achievementRow struct {
+		GameID           uint
+		RAGameID         uint
+		TotalCount       int
+		PlayersAttempted int
+		AvgUnlocked      float64
+	}
+	var rows []achievementRow
+	if err := h.DB.
+		Table("game_achievement_caches").
+		Select(`game_achievement_caches.game_id,
+			game_achievement_caches.ra_game_id,
+			game_achievement_caches.total_count,
+			COUNT(DISTINCT sub.user_id) as players_attempted,
+			CAST(AVG(sub.unlocked_count) AS REAL) as avg_unlocked`).
+		Joins(`JOIN (
+			SELECT ra_game_id, user_id, COUNT(*) as unlocked_count
+			FROM user_achievement_progresses
+			WHERE deleted_at IS NULL
+			GROUP BY ra_game_id, user_id
+		) sub ON sub.ra_game_id = game_achievement_caches.ra_game_id`).
+		Where("game_achievement_caches.game_id > 0 AND game_achievement_caches.total_count > 0 AND game_achievement_caches.deleted_at IS NULL").
+		Group("game_achievement_caches.game_id, game_achievement_caches.ra_game_id, game_achievement_caches.total_count").
+		Having("players_attempted >= 2").
+		Order("(avg_unlocked / game_achievement_caches.total_count) ASC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch hardest games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch hardest games")
+	}
+
+	if len(rows) == 0 {
+		return &GetHardestGamesOutput{
+			CacheControl: "private, max-age=300",
+			Body:         HardestGamesResponse{Games: []AchievementGameResponse{}},
+		}, nil
+	}
+
+	gameIDs := make([]uint, len(rows))
+	raGameIDs := make([]uint, len(rows))
+	raTotalMap := make(map[uint]int, len(rows))
+	for i, r := range rows {
+		gameIDs[i] = r.GameID
+		raGameIDs[i] = r.RAGameID
+		raTotalMap[r.RAGameID] = r.TotalCount
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load hardest games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load games")
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	completedMap := make(map[uint]int, len(rows))
+	type userUnlockRow struct {
+		RAGameID uint
+		UserID   uint
+		Unlocked int
+	}
+	var userUnlocks []userUnlockRow
+	if err := h.DB.
+		Table("user_achievement_progresses").
+		Select("ra_game_id, user_id, COUNT(*) as unlocked").
+		Where("ra_game_id IN ? AND deleted_at IS NULL", raGameIDs).
+		Group("ra_game_id, user_id").
+		Scan(&userUnlocks).Error; err == nil {
+		for _, u := range userUnlocks {
+			if total, ok := raTotalMap[u.RAGameID]; ok && u.Unlocked >= total {
+				completedMap[u.RAGameID]++
+			}
+		}
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]AchievementGameResponse, 0, len(rows))
+	for _, r := range rows {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		avgCompletion := 0.0
+		if r.TotalCount > 0 {
+			avgCompletion = math.Round((r.AvgUnlocked/float64(r.TotalCount))*10000) / 100
+		}
+		result = append(result, AchievementGameResponse{
+			Game:              toGameResponseWithData(g, &userData),
+			TotalAchievements: r.TotalCount,
+			AvgCompletion:     avgCompletion,
+			PlayersAttempted:  r.PlayersAttempted,
+			PlayersCompleted:  completedMap[r.RAGameID],
+		})
+	}
+
+	return &GetHardestGamesOutput{
+		CacheControl: "private, max-age=300",
+		Body:         HardestGamesResponse{Games: result},
+	}, nil
+}
+
+// HumaGetAlmostDone is the huma handler for GET /api/explore/almost-done.
+func (h *ExploreHandler) HumaGetAlmostDone(ctx context.Context, _ *GetAlmostDoneInput) (*GetAlmostDoneOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	type progressRow struct {
+		GameID        uint
+		RAGameID      uint
+		TotalCount    int
+		UnlockedCount int
+	}
+	var rows []progressRow
+	if err := h.DB.
+		Table("game_achievement_caches").
+		Select(`game_achievement_caches.game_id,
+			game_achievement_caches.ra_game_id,
+			game_achievement_caches.total_count,
+			COUNT(user_achievement_progresses.id) as unlocked_count`).
+		Joins(`JOIN user_achievement_progresses ON user_achievement_progresses.ra_game_id = game_achievement_caches.ra_game_id
+			AND user_achievement_progresses.user_id = ? AND user_achievement_progresses.deleted_at IS NULL`, userID).
+		Where("game_achievement_caches.game_id > 0 AND game_achievement_caches.total_count > 0 AND game_achievement_caches.deleted_at IS NULL").
+		Group("game_achievement_caches.game_id, game_achievement_caches.ra_game_id, game_achievement_caches.total_count").
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch almost-done games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch almost-done games")
+	}
+
+	var filtered []progressRow
+	for _, r := range rows {
+		if r.TotalCount == 0 {
+			continue
+		}
+		pct := float64(r.UnlockedCount) / float64(r.TotalCount) * 100
+		if pct >= 80.0 && pct < 100.0 {
+			filtered = append(filtered, r)
+		}
+	}
+
+	if len(filtered) == 0 {
+		return &GetAlmostDoneOutput{
+			CacheControl: "private, max-age=120",
+			Body:         AlmostDoneResponse{Games: []AlmostDoneGame{}},
+		}, nil
+	}
+
+	sort.Slice(filtered, func(i, j int) bool {
+		pctI := float64(filtered[i].UnlockedCount) / float64(filtered[i].TotalCount)
+		pctJ := float64(filtered[j].UnlockedCount) / float64(filtered[j].TotalCount)
+		return pctI > pctJ
+	})
+
+	gameIDs := make([]uint, len(filtered))
+	for i, r := range filtered {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load almost-done games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load games")
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]AlmostDoneGame, 0, len(filtered))
+	for _, r := range filtered {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		pct := math.Round(float64(r.UnlockedCount)/float64(r.TotalCount)*10000) / 100
+		result = append(result, AlmostDoneGame{
+			Game:              toGameResponseWithData(g, &userData),
+			UnlockedCount:     r.UnlockedCount,
+			TotalCount:        r.TotalCount,
+			CompletionPercent: pct,
+		})
+	}
+
+	return &GetAlmostDoneOutput{
+		CacheControl: "private, max-age=120",
+		Body:         AlmostDoneResponse{Games: result},
+	}, nil
+}
+
+// HumaGetFreshChallenges is the huma handler for GET /api/explore/fresh-challenges.
+func (h *ExploreHandler) HumaGetFreshChallenges(ctx context.Context, _ *GetFreshChallengesInput) (*GetFreshChallengesOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	var startedRAGameIDs []uint
+	if err := h.DB.
+		Table("user_achievement_progresses").
+		Select("DISTINCT ra_game_id").
+		Where("user_id = ? AND deleted_at IS NULL", userID).
+		Scan(&startedRAGameIDs).Error; err != nil {
+		slog.Error("failed to fetch started RA games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch fresh challenges")
+	}
+
+	query := h.DB.
+		Table("game_achievement_caches").
+		Where("game_id > 0 AND total_count > 0 AND deleted_at IS NULL")
+
+	if len(startedRAGameIDs) > 0 {
+		query = query.Where("ra_game_id NOT IN ?", startedRAGameIDs)
+	}
+
+	type cacheRow struct {
+		GameID      uint
+		TotalCount  int
+		TotalPoints int
+	}
+	var rows []cacheRow
+	if err := query.
+		Select("game_id, total_count, total_points").
+		Order("total_count DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch fresh challenges", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch fresh challenges")
+	}
+
+	if len(rows) == 0 {
+		return &GetFreshChallengesOutput{
+			CacheControl: "private, max-age=120",
+			Body:         FreshChallengesResponse{Games: []FreshChallengeGame{}},
+		}, nil
+	}
+
+	gameIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load fresh challenge games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load games")
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]FreshChallengeGame, 0, len(rows))
+	for _, r := range rows {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		result = append(result, FreshChallengeGame{
+			Game:              toGameResponseWithData(g, &userData),
+			TotalAchievements: r.TotalCount,
+			TotalPoints:       r.TotalPoints,
+		})
+	}
+
+	return &GetFreshChallengesOutput{
+		CacheControl: "private, max-age=120",
+		Body:         FreshChallengesResponse{Games: result},
+	}, nil
+}
+
+// HumaGetActiveChallenges is the huma handler for GET /api/explore/active-challenges.
+func (h *ExploreHandler) HumaGetActiveChallenges(_ context.Context, _ *GetActiveChallengesInput) (*GetActiveChallengesOutput, error) {
+	now := time.Now()
+
+	var challenges []db.Challenge
+	if err := h.DB.
+		Preload("Creator").
+		Preload("Game").
+		Preload("Game.Console").
+		Where("status = ? AND deleted_at IS NULL", "active").
+		Where("expires_at IS NULL OR expires_at > ?", now).
+		Order("created_at DESC").
+		Limit(10).
+		Find(&challenges).Error; err != nil {
+		slog.Error("failed to fetch active challenges", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch active challenges")
+	}
+
+	if len(challenges) == 0 {
+		return &GetActiveChallengesOutput{
+			CacheControl: "private, max-age=120",
+			Body:         ActiveChallengesResponse{Challenges: []ExploreChallengeResponse{}},
+		}, nil
+	}
+
+	result := make([]ExploreChallengeResponse, 0, len(challenges))
+	for _, ch := range challenges {
+		coverURL := ""
+		if ch.Game.CoverURL != "" {
+			coverURL = resolveImageURL(ch.Game.CoverURL)
+		}
+		consoleName := ""
+		if ch.Game.Console.Name != "" {
+			consoleName = ch.Game.Console.Name
+		}
+		result = append(result, ExploreChallengeResponse{
+			ID:              strconv.FormatUint(uint64(ch.ID), 10),
+			CreatorUsername: ch.Creator.Username,
+			GameID:          strconv.FormatUint(uint64(ch.GameID), 10),
+			GameTitle:       ch.Game.Title,
+			GameCoverURL:    coverURL,
+			ConsoleName:     consoleName,
+			Name:            ch.Name,
+			Description:     ch.Description,
+			Type:            ch.Type,
+			Difficulty:      ch.Difficulty,
+			AttemptCount:    ch.AttemptCount,
+			CompletionCount: ch.CompletionCount,
+			ExpiresAt:       ch.ExpiresAt,
+			CreatedAt:       ch.CreatedAt,
+		})
+	}
+
+	return &GetActiveChallengesOutput{
+		CacheControl: "private, max-age=120",
+		Body:         ActiveChallengesResponse{Challenges: result},
+	}, nil
+}

--- a/server/internal/api/huma_explore_community.go
+++ b/server/internal/api/huma_explore_community.go
@@ -1,0 +1,510 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// --- Inputs / outputs ---
+
+// GetTrendingInput is the input for GET /api/explore/trending.
+type GetTrendingInput struct{}
+
+// GetTrendingOutput wraps the trending response.
+type GetTrendingOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         TrendingResponse
+}
+
+// GetCommunityTopInput is the input for GET /api/explore/community-top.
+type GetCommunityTopInput struct{}
+
+// GetCommunityTopOutput wraps the community-top response.
+type GetCommunityTopOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         CommunityTopResponse
+}
+
+// GetCultClassicsInput is the input for GET /api/explore/cult-classics.
+type GetCultClassicsInput struct{}
+
+// GetCultClassicsOutput wraps the cult classics response.
+type GetCultClassicsOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         CultClassicsResponse
+}
+
+// GetRecentlyReviewedInput is the input for GET /api/explore/recently-reviewed.
+type GetRecentlyReviewedInput struct{}
+
+// GetRecentlyReviewedOutput wraps the recently-reviewed response.
+type GetRecentlyReviewedOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         RecentlyReviewedResponse
+}
+
+// GetActiveNowInput is the input for GET /api/explore/active-now.
+type GetActiveNowInput struct{}
+
+// GetActiveNowOutput wraps the active-now response.
+type GetActiveNowOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         ActiveNowResponse
+}
+
+// RegisterExploreCommunityRoutes wires the social / community discovery endpoints.
+func RegisterExploreCommunityRoutes(api huma.API, h *ExploreHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
+	requireAuth := RequireAuth(jwtSecret, database)
+	rateLimit := UserRateLimitMiddleware(userLimiter)
+	mw := huma.Middlewares{requireAuth, rateLimit}
+	sec := []map[string][]string{{"bearer": {}}}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getTrending",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/trending",
+		Summary:     "Get trending games",
+		Description: "Returns up to 20 games with the most distinct players in the last 7 days.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetTrending)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getCommunityTop",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/community-top",
+		Summary:     "Get top-rated games by the community",
+		Description: "Returns games with the highest average user ratings on this server (at least 2 ratings).",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetCommunityTop)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getCultClassics",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/cult-classics",
+		Summary:     "Get community cult classics",
+		Description: "Returns games where the community rates higher than critics — avg community rating >= 4.0 with IGDB rating < 75.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetCultClassics)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getRecentlyReviewed",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/recently-reviewed",
+		Summary:     "Get games with recent user reviews",
+		Description: "Returns the 20 most recent user reviews (non-empty review text) with game + reviewer metadata.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetRecentlyReviewed)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getActiveNow",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/active-now",
+		Summary:     "Get games with active shared sessions or challenges",
+		Description: "Returns up to 20 games currently with active shared sessions and/or active challenges, sorted by combined activity.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetActiveNow)
+}
+
+// --- Handlers ---
+
+// HumaGetTrending is the huma handler for GET /api/explore/trending.
+func (h *ExploreHandler) HumaGetTrending(ctx context.Context, _ *GetTrendingInput) (*GetTrendingOutput, error) {
+	userID := UserIDFromContext(ctx)
+	cutoff := time.Now().AddDate(0, 0, -7)
+
+	type trendingRow struct {
+		GameID          uint
+		PlayersThisWeek int
+	}
+	var rows []trendingRow
+	if err := h.DB.
+		Table("play_histories").
+		Select("game_id, COUNT(DISTINCT user_id) as players_this_week").
+		Where("last_played >= ? AND play_time > 0 AND deleted_at IS NULL", cutoff).
+		Group("game_id").
+		Having("players_this_week >= 1").
+		Order("players_this_week DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch trending games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch trending games")
+	}
+
+	if len(rows) == 0 {
+		return &GetTrendingOutput{
+			CacheControl: "private, max-age=30",
+			Body:         TrendingResponse{Games: []TrendingGameResponse{}},
+		}, nil
+	}
+
+	gameIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load trending games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load trending games")
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]TrendingGameResponse, 0, len(rows))
+	for _, r := range rows {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		result = append(result, TrendingGameResponse{
+			Game:            toGameResponseWithData(g, &userData),
+			PlayersThisWeek: r.PlayersThisWeek,
+		})
+	}
+
+	return &GetTrendingOutput{
+		CacheControl: "private, max-age=30",
+		Body:         TrendingResponse{Games: result},
+	}, nil
+}
+
+// HumaGetCommunityTop is the huma handler for GET /api/explore/community-top.
+func (h *ExploreHandler) HumaGetCommunityTop(ctx context.Context, _ *GetCommunityTopInput) (*GetCommunityTopOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	type communityRow struct {
+		GameID      uint
+		AvgRating   float64
+		RatingCount int
+	}
+	var rows []communityRow
+	if err := h.DB.
+		Table("game_ratings").
+		Select("game_ratings.game_id, AVG(game_ratings.rating) as avg_rating, COUNT(*) as rating_count").
+		Joins("JOIN games ON games.id = game_ratings.game_id AND games.deleted_at IS NULL AND games.is_primary = true").
+		Where("game_ratings.deleted_at IS NULL").
+		Group("game_ratings.game_id").
+		Having("rating_count >= 2").
+		Order("avg_rating DESC, rating_count DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch community top", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch community top games")
+	}
+
+	if len(rows) == 0 {
+		return &GetCommunityTopOutput{
+			CacheControl: "private, max-age=120",
+			Body:         CommunityTopResponse{Games: []CommunityTopGame{}},
+		}, nil
+	}
+
+	gameIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load community top games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load community top games")
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]CommunityTopGame, 0, len(rows))
+	for _, r := range rows {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		result = append(result, CommunityTopGame{
+			Game:        toGameResponseWithData(g, &userData),
+			AvgRating:   math.Round(r.AvgRating*100) / 100,
+			RatingCount: r.RatingCount,
+		})
+	}
+
+	return &GetCommunityTopOutput{
+		CacheControl: "private, max-age=120",
+		Body:         CommunityTopResponse{Games: result},
+	}, nil
+}
+
+// HumaGetCultClassics is the huma handler for GET /api/explore/cult-classics.
+func (h *ExploreHandler) HumaGetCultClassics(ctx context.Context, _ *GetCultClassicsInput) (*GetCultClassicsOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	type cultRow struct {
+		GameID          uint
+		CommunityRating float64
+		RatingCount     int
+	}
+	var rows []cultRow
+	if err := h.DB.
+		Table("game_ratings").
+		Select("game_ratings.game_id, AVG(game_ratings.rating) as community_rating, COUNT(*) as rating_count").
+		Joins("JOIN games ON games.id = game_ratings.game_id AND games.deleted_at IS NULL AND games.is_primary = true").
+		Where("game_ratings.deleted_at IS NULL AND games.rating < 75").
+		Group("game_ratings.game_id").
+		Having("rating_count >= 2 AND community_rating >= 4.0").
+		Order("community_rating DESC, rating_count DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch cult classics", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch cult classics")
+	}
+
+	if len(rows) == 0 {
+		return &GetCultClassicsOutput{
+			CacheControl: "private, max-age=300",
+			Body:         CultClassicsResponse{Games: []CultClassicGame{}},
+		}, nil
+	}
+
+	gameIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load cult classic games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load cult classic games")
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]CultClassicGame, 0, len(rows))
+	for _, r := range rows {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		result = append(result, CultClassicGame{
+			Game:              toGameResponseWithData(g, &userData),
+			CommunityRating:   math.Round(r.CommunityRating*100) / 100,
+			IGDBCriticsRating: g.IGDBCriticsRating,
+			RatingCount:       r.RatingCount,
+		})
+	}
+
+	return &GetCultClassicsOutput{
+		CacheControl: "private, max-age=300",
+		Body:         CultClassicsResponse{Games: result},
+	}, nil
+}
+
+// HumaGetRecentlyReviewed is the huma handler for GET /api/explore/recently-reviewed.
+func (h *ExploreHandler) HumaGetRecentlyReviewed(ctx context.Context, _ *GetRecentlyReviewedInput) (*GetRecentlyReviewedOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	type reviewRow struct {
+		GameID       uint
+		Rating       int
+		Review       string
+		ReviewerName string
+		CreatedAt    time.Time
+	}
+	var rows []reviewRow
+	if err := h.DB.
+		Table("game_ratings").
+		Select("game_ratings.game_id, game_ratings.rating, game_ratings.review, users.username as reviewer_name, game_ratings.created_at").
+		Joins("JOIN users ON users.id = game_ratings.user_id AND users.deleted_at IS NULL").
+		Where("game_ratings.deleted_at IS NULL AND game_ratings.review != ''").
+		Order("game_ratings.created_at DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch recently reviewed", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch recently reviewed")
+	}
+
+	if len(rows) == 0 {
+		return &GetRecentlyReviewedOutput{
+			CacheControl: "private, max-age=30",
+			Body:         RecentlyReviewedResponse{Reviews: []RecentReviewItem{}},
+		}, nil
+	}
+
+	gameIDSet := make(map[uint]bool, len(rows))
+	for _, r := range rows {
+		gameIDSet[r.GameID] = true
+	}
+	gameIDs := make([]uint, 0, len(gameIDSet))
+	for id := range gameIDSet {
+		gameIDs = append(gameIDs, id)
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load reviewed games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load reviewed games")
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]RecentReviewItem, 0, len(rows))
+	for _, r := range rows {
+		g, ok := gameMap[r.GameID]
+		if !ok {
+			continue
+		}
+		result = append(result, RecentReviewItem{
+			Game:         toGameResponseWithData(g, &userData),
+			Rating:       r.Rating,
+			Review:       r.Review,
+			ReviewerName: r.ReviewerName,
+			ReviewedAt:   r.CreatedAt,
+		})
+	}
+
+	return &GetRecentlyReviewedOutput{
+		CacheControl: "private, max-age=30",
+		Body:         RecentlyReviewedResponse{Reviews: result},
+	}, nil
+}
+
+// HumaGetActiveNow is the huma handler for GET /api/explore/active-now.
+func (h *ExploreHandler) HumaGetActiveNow(ctx context.Context, _ *GetActiveNowInput) (*GetActiveNowOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	type sessionRow struct {
+		GameID       uint
+		SessionCount int
+	}
+	var sessionRows []sessionRow
+	if err := h.DB.
+		Table("shared_sessions").
+		Select("game_id, COUNT(*) as session_count").
+		Where("status = 'active' AND deleted_at IS NULL").
+		Group("game_id").
+		Scan(&sessionRows).Error; err != nil {
+		slog.Error("failed to fetch active sessions", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch active games")
+	}
+
+	type challengeRow struct {
+		GameID         uint
+		ChallengeCount int
+	}
+	var challengeRows []challengeRow
+	if err := h.DB.
+		Table("challenges").
+		Select("game_id, COUNT(*) as challenge_count").
+		Where("status = 'active' AND deleted_at IS NULL").
+		Group("game_id").
+		Scan(&challengeRows).Error; err != nil {
+		slog.Error("failed to fetch active challenges", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch active games")
+	}
+
+	type activeInfo struct {
+		sessions   int
+		challenges int
+	}
+	activeMap := make(map[uint]*activeInfo)
+	for _, r := range sessionRows {
+		activeMap[r.GameID] = &activeInfo{sessions: r.SessionCount}
+	}
+	for _, r := range challengeRows {
+		if info, ok := activeMap[r.GameID]; ok {
+			info.challenges = r.ChallengeCount
+		} else {
+			activeMap[r.GameID] = &activeInfo{challenges: r.ChallengeCount}
+		}
+	}
+
+	if len(activeMap) == 0 {
+		return &GetActiveNowOutput{
+			CacheControl: "private, max-age=30",
+			Body:         ActiveNowResponse{Games: []ActiveNowItem{}},
+		}, nil
+	}
+
+	gameIDs := make([]uint, 0, len(activeMap))
+	for id := range activeMap {
+		gameIDs = append(gameIDs, id)
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load active games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load active games")
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	type sortItem struct {
+		game  db.Game
+		info  *activeInfo
+		total int
+	}
+	sorted := make([]sortItem, 0, len(games))
+	for _, g := range games {
+		info := activeMap[g.ID]
+		sorted = append(sorted, sortItem{
+			game:  g,
+			info:  info,
+			total: info.sessions + info.challenges,
+		})
+	}
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].total > sorted[j].total
+	})
+
+	if len(sorted) > 20 {
+		sorted = sorted[:20]
+	}
+
+	result := make([]ActiveNowItem, 0, len(sorted))
+	for _, s := range sorted {
+		result = append(result, ActiveNowItem{
+			Game:             toGameResponseWithData(s.game, &userData),
+			ActiveSessions:   s.info.sessions,
+			ActiveChallenges: s.info.challenges,
+		})
+	}
+
+	return &GetActiveNowOutput{
+		CacheControl: "private, max-age=30",
+		Body:         ActiveNowResponse{Games: result},
+	}, nil
+}

--- a/server/internal/api/huma_explore_console.go
+++ b/server/internal/api/huma_explore_console.go
@@ -1,0 +1,281 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// --- Inputs / outputs ---
+
+// GetConsoleShowcaseInput is the input for GET /api/explore/consoles/{id}/showcase.
+type GetConsoleShowcaseInput struct {
+	ID string `path:"id" doc:"Console abbreviation (e.g. 'snes')."`
+}
+
+// GetConsoleShowcaseOutput wraps the console showcase response.
+type GetConsoleShowcaseOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         ConsoleShowcaseResponse
+}
+
+// GetConsoleHighlightsInput is the input for GET /api/explore/console-highlights.
+type GetConsoleHighlightsInput struct{}
+
+// GetConsoleHighlightsOutput wraps the console highlights response.
+type GetConsoleHighlightsOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         ConsoleHighlightsResponse
+}
+
+// RegisterExploreConsoleRoutes wires the console showcase + highlights endpoints.
+func RegisterExploreConsoleRoutes(api huma.API, h *ExploreHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
+	requireAuth := RequireAuth(jwtSecret, database)
+	rateLimit := UserRateLimitMiddleware(userLimiter)
+	mw := huma.Middlewares{requireAuth, rateLimit}
+	sec := []map[string][]string{{"bearer": {}}}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getConsoleShowcase",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/consoles/{id}/showcase",
+		Summary:     "Get console showcase",
+		Description: "Returns aggregated showcase data for a specific console: essentials, hidden gems, genre breakdown, top developers, recently played, recently added.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetConsoleShowcase)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getConsoleHighlights",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/console-highlights",
+		Summary:     "Get console highlights",
+		Description: "Returns a compact list of consoles with game counts and top game for the explore page quick-jump row.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetConsoleHighlights)
+}
+
+// --- Handlers ---
+
+// HumaGetConsoleShowcase is the huma handler for GET /api/explore/consoles/{id}/showcase.
+func (h *ExploreHandler) HumaGetConsoleShowcase(ctx context.Context, in *GetConsoleShowcaseInput) (*GetConsoleShowcaseOutput, error) {
+	userID := UserIDFromContext(ctx)
+	abbr := strings.ToLower(in.ID)
+
+	var console db.Console
+	if err := h.DB.Where("LOWER(abbreviation) = ?", abbr).First(&console).Error; err != nil {
+		return nil, huma.Error404NotFound("console not found")
+	}
+
+	var gameCount int64
+	h.DB.Model(&db.Game{}).Where("console_id = ? AND is_primary = true AND deleted_at IS NULL", console.ID).Count(&gameCount)
+	console.GameCount = int(gameCount)
+
+	var essentials []db.Game
+	if err := h.DB.Preload("Console").
+		Where("console_id = ? AND is_primary = true AND "+effectiveRating+" > 0 AND deleted_at IS NULL", console.ID).
+		Order(effectiveRating + " DESC").
+		Limit(10).
+		Find(&essentials).Error; err != nil {
+		slog.Error("failed to fetch console essentials", "console", abbr, "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch console data")
+	}
+
+	essentialIDs := make([]uint, len(essentials))
+	for i, g := range essentials {
+		essentialIDs[i] = g.ID
+	}
+	hiddenGems := h.buildConsoleHiddenGems(console.ID, essentialIDs)
+	genreBreakdown := h.buildGenreBreakdown(console.ID)
+	topDevelopers := h.buildConsoleTopDevelopers(console.ID, console.Name)
+
+	var recentlyPlayed []db.Game
+	if userID > 0 {
+		var playHistories []db.PlayHistory
+		if err := h.DB.
+			Joins("JOIN games ON games.id = play_histories.game_id").
+			Where("play_histories.user_id = ? AND games.console_id = ? AND games.is_primary = true AND games.deleted_at IS NULL", userID, console.ID).
+			Order("play_histories.last_played DESC").
+			Limit(10).
+			Find(&playHistories).Error; err != nil {
+			slog.Error("failed to fetch recently played", "console", abbr, "error", err)
+		} else {
+			gameIDs := make([]uint, 0, len(playHistories))
+			for _, ph := range playHistories {
+				gameIDs = append(gameIDs, ph.GameID)
+			}
+			if len(gameIDs) > 0 {
+				if err := h.DB.Preload("Console").
+					Where("id IN ? AND is_primary = true AND deleted_at IS NULL", gameIDs).
+					Find(&recentlyPlayed).Error; err != nil {
+					slog.Error("failed to fetch recently played games", "console", abbr, "error", err)
+				}
+				gameMap := make(map[uint]db.Game, len(recentlyPlayed))
+				for _, g := range recentlyPlayed {
+					gameMap[g.ID] = g
+				}
+				ordered := make([]db.Game, 0, len(gameIDs))
+				for _, id := range gameIDs {
+					if g, ok := gameMap[id]; ok {
+						ordered = append(ordered, g)
+					}
+				}
+				recentlyPlayed = ordered
+			}
+		}
+	}
+
+	var recentlyAdded []db.Game
+	if err := h.DB.Preload("Console").
+		Where("console_id = ? AND is_primary = true AND deleted_at IS NULL", console.ID).
+		Order("created_at DESC").
+		Limit(10).
+		Find(&recentlyAdded).Error; err != nil {
+		slog.Error("failed to fetch recently added games", "console", abbr, "error", err)
+	}
+
+	allGames := make([]db.Game, 0, len(essentials)+len(hiddenGems)+len(recentlyPlayed)+len(recentlyAdded))
+	allGames = append(allGames, essentials...)
+	allGames = append(allGames, hiddenGems...)
+	allGames = append(allGames, recentlyPlayed...)
+	allGames = append(allGames, recentlyAdded...)
+	allGameIDs := make([]uint, len(allGames))
+	for i, g := range allGames {
+		allGameIDs[i] = g.ID
+	}
+	userData := loadUserGameData(h.DB, userID, allGameIDs)
+
+	toResponses := func(games []db.Game) []GameResponse {
+		result := make([]GameResponse, len(games))
+		for i, g := range games {
+			result[i] = toGameResponseWithData(g, &userData)
+		}
+		return result
+	}
+
+	return &GetConsoleShowcaseOutput{
+		CacheControl: "private, max-age=300",
+		Body: ConsoleShowcaseResponse{
+			Console:        ToConsoleResponse(console),
+			Essentials:     toResponses(essentials),
+			HiddenGems:     toResponses(hiddenGems),
+			GenreBreakdown: genreBreakdown,
+			TopDevelopers:  topDevelopers,
+			RecentlyPlayed: toResponses(recentlyPlayed),
+			RecentlyAdded:  toResponses(recentlyAdded),
+		},
+	}, nil
+}
+
+// HumaGetConsoleHighlights is the huma handler for GET /api/explore/console-highlights.
+func (h *ExploreHandler) HumaGetConsoleHighlights(ctx context.Context, _ *GetConsoleHighlightsInput) (*GetConsoleHighlightsOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	var consoles []db.Console
+	if err := h.DB.Order("name ASC").Find(&consoles).Error; err != nil {
+		slog.Error("failed to fetch consoles for highlights", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch consoles")
+	}
+
+	type consoleCount struct {
+		ConsoleID uint
+		GameCount int
+	}
+	var counts []consoleCount
+	if err := h.DB.
+		Table("games").
+		Select("console_id, COUNT(*) as game_count").
+		Where("deleted_at IS NULL AND is_primary = true").
+		Group("console_id").
+		Scan(&counts).Error; err != nil {
+		slog.Error("failed to count games per console", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch console data")
+	}
+
+	countMap := make(map[uint]int, len(counts))
+	for _, cc := range counts {
+		countMap[cc.ConsoleID] = cc.GameCount
+	}
+
+	type topGameRow struct {
+		ConsoleID uint
+		GameID    uint
+	}
+	var topGameRows []topGameRow
+	if err := h.DB.Raw(`
+		SELECT console_id, game_id FROM (
+			SELECT games.console_id, games.id as game_id,
+				`+effectiveRatingPrefixed+` as eff_rating,
+				ROW_NUMBER() OVER (PARTITION BY games.console_id ORDER BY `+effectiveRatingPrefixed+` DESC) as rn
+			FROM games
+			JOIN game_artworks ON game_artworks.game_id = games.id AND game_artworks.hero_url != ''
+			WHERE games.deleted_at IS NULL AND games.is_primary = true AND `+effectiveRatingPrefixed+` > 0
+		) ranked WHERE rn = 1
+	`).Scan(&topGameRows).Error; err != nil {
+		slog.Error("failed to fetch top games for console highlights", "error", err)
+	}
+
+	topGameByConsole := make(map[uint]uint, len(topGameRows))
+	for _, row := range topGameRows {
+		topGameByConsole[row.ConsoleID] = row.GameID
+	}
+
+	topGameIDs := make([]uint, 0, len(topGameByConsole))
+	for _, gid := range topGameByConsole {
+		topGameIDs = append(topGameIDs, gid)
+	}
+
+	var topGames []db.Game
+	if len(topGameIDs) > 0 {
+		if err := h.DB.Preload("Console").Where("id IN ?", topGameIDs).Find(&topGames).Error; err != nil {
+			slog.Error("failed to load top games for console highlights", "error", err)
+		}
+	}
+
+	topGameResponses := ToGameResponses(topGames, h.DB, userID)
+	topGameResponseMap := make(map[string]*GameResponse, len(topGameResponses))
+	for i := range topGameResponses {
+		topGameResponseMap[topGameResponses[i].ID] = &topGameResponses[i]
+	}
+
+	highlights := make([]ConsoleHighlight, 0, len(consoles))
+	for _, con := range consoles {
+		gc := countMap[con.ID]
+		if gc == 0 {
+			continue
+		}
+
+		abbr := strings.ToLower(con.Abbreviation)
+		highlight := ConsoleHighlight{
+			ID:         abbr,
+			Name:       con.Name,
+			ColorTheme: con.ColorTheme,
+			IconURL:    "/api/consoles/" + abbr + "/icon",
+			LogoURL:    "/api/consoles/" + abbr + "/logo",
+			GameCount:  gc,
+		}
+
+		if topGameID, ok := topGameByConsole[con.ID]; ok {
+			idStr := strconv.FormatUint(uint64(topGameID), 10)
+			if gr, ok := topGameResponseMap[idStr]; ok {
+				highlight.TopGame = gr
+			}
+		}
+
+		highlights = append(highlights, highlight)
+	}
+
+	return &GetConsoleHighlightsOutput{
+		CacheControl: "private, max-age=300",
+		Body:         ConsoleHighlightsResponse{Consoles: highlights},
+	}, nil
+}

--- a/server/internal/api/huma_explore_developer.go
+++ b/server/internal/api/huma_explore_developer.go
@@ -1,0 +1,397 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// --- Inputs / outputs ---
+
+// GetDevelopersInput is the input for GET /api/explore/developers.
+type GetDevelopersInput struct{}
+
+// GetDevelopersOutput wraps the developer list response.
+type GetDevelopersOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         DeveloperListResponse
+}
+
+// GetDeveloperSpotlightInput is the input for GET /api/explore/developers/spotlight.
+type GetDeveloperSpotlightInput struct{}
+
+// GetDeveloperSpotlightOutput wraps the developer spotlight response.
+type GetDeveloperSpotlightOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         DeveloperSpotlightResponse
+}
+
+// GetDeveloperDetailInput is the input for GET /api/explore/developers/{name}.
+type GetDeveloperDetailInput struct {
+	Name string `path:"name" doc:"Developer name (URL-decoded)."`
+}
+
+// GetDeveloperDetailOutput wraps the developer detail response.
+type GetDeveloperDetailOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         DeveloperDetailResponse
+}
+
+// GetPublisherDetailInput is the input for GET /api/explore/publishers/{name}.
+type GetPublisherDetailInput struct {
+	Name string `path:"name" doc:"Publisher name (URL-decoded)."`
+}
+
+// GetPublisherDetailOutput wraps the publisher detail response.
+type GetPublisherDetailOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         PublisherDetailResponse
+}
+
+// RegisterExploreDeveloperRoutes wires the developer / publisher detail endpoints.
+func RegisterExploreDeveloperRoutes(api huma.API, h *ExploreHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
+	requireAuth := RequireAuth(jwtSecret, database)
+	rateLimit := UserRateLimitMiddleware(userLimiter)
+	mw := huma.Middlewares{requireAuth, rateLimit}
+	sec := []map[string][]string{{"bearer": {}}}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getDevelopers",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/developers",
+		Summary:     "List top developers",
+		Description: "Returns the top 50 developers by game count with average rating and console coverage.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetDevelopers)
+
+	// NOTE: /developers/spotlight must be registered BEFORE /developers/{name} so huma
+	// doesn't treat "spotlight" as a wildcard capture.
+	huma.Register(api, huma.Operation{
+		OperationID: "getDeveloperSpotlight",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/developers/spotlight",
+		Summary:     "Get the weekly featured developer",
+		Description: "Returns a rotating spotlight of a top developer with games that have hero art. Rotates weekly.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetDeveloperSpotlight)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getDeveloperDetail",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/developers/{name}",
+		Summary:     "Get developer detail",
+		Description: "Returns all games by a specific developer along with statistics (rating distribution, genre/platform breakdown, user stats, timeline, related developers).",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetDeveloperDetail)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getPublisherDetail",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/publishers/{name}",
+		Summary:     "Get publisher detail",
+		Description: "Returns all games by a specific publisher along with statistics (rating distribution, genre/platform breakdown, user stats, timeline, related publishers).",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetPublisherDetail)
+}
+
+// --- Handlers ---
+
+// HumaGetDevelopers is the huma handler for GET /api/explore/developers.
+func (h *ExploreHandler) HumaGetDevelopers(_ context.Context, _ *GetDevelopersInput) (*GetDevelopersOutput, error) {
+	type devRow struct {
+		Developer string
+		GameCount int
+		AvgRating float64
+	}
+
+	var rows []devRow
+	if err := h.DB.
+		Table("games").
+		Select("developer, COUNT(*) as game_count, AVG(CASE WHEN rating > 0 THEN rating ELSE NULL END) as avg_rating").
+		Where("games.deleted_at IS NULL AND games.is_primary = true AND developer != ''").
+		Group("developer").
+		Order("game_count DESC").
+		Limit(50).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch developers", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch developers")
+	}
+
+	if len(rows) == 0 {
+		return &GetDevelopersOutput{
+			CacheControl: "private, max-age=300",
+			Body:         DeveloperListResponse{Developers: []DeveloperSummary{}},
+		}, nil
+	}
+
+	devNames := make([]string, len(rows))
+	for i, r := range rows {
+		devNames[i] = r.Developer
+	}
+
+	type devConsoleRow struct {
+		Developer    string
+		Abbreviation string
+	}
+	var consoleRows []devConsoleRow
+	if err := h.DB.
+		Table("games").
+		Select("DISTINCT games.developer, consoles.abbreviation").
+		Joins("JOIN consoles ON consoles.id = games.console_id").
+		Where("games.deleted_at IS NULL AND games.is_primary = true AND games.developer IN ?", devNames).
+		Scan(&consoleRows).Error; err != nil {
+		slog.Error("failed to fetch developer consoles", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch developers")
+	}
+
+	devConsoles := make(map[string][]string)
+	for _, cr := range consoleRows {
+		abbr := strings.ToLower(cr.Abbreviation)
+		devConsoles[cr.Developer] = append(devConsoles[cr.Developer], abbr)
+	}
+
+	developers := make([]DeveloperSummary, len(rows))
+	for i, r := range rows {
+		avgRating := 0.0
+		if r.AvgRating > 0 {
+			avgRating = math.Round(r.AvgRating*10) / 10
+		}
+		consoles := devConsoles[r.Developer]
+		if consoles == nil {
+			consoles = []string{}
+		}
+		developers[i] = DeveloperSummary{
+			Name:      r.Developer,
+			GameCount: r.GameCount,
+			AvgRating: avgRating,
+			Consoles:  consoles,
+		}
+	}
+
+	return &GetDevelopersOutput{
+		CacheControl: "private, max-age=300",
+		Body:         DeveloperListResponse{Developers: developers},
+	}, nil
+}
+
+// HumaGetDeveloperDetail is the huma handler for GET /api/explore/developers/{name}.
+func (h *ExploreHandler) HumaGetDeveloperDetail(ctx context.Context, in *GetDeveloperDetailInput) (*GetDeveloperDetailOutput, error) {
+	userID := UserIDFromContext(ctx)
+	name := in.Name
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("LOWER(games.developer) = LOWER(?) AND games.is_primary = true AND games.deleted_at IS NULL", name).
+		Order("games.rating DESC, games.title ASC").
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch developer games", "developer", name, "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch developer games")
+	}
+
+	avgRating, consoles := calcRatingAndConsoles(games)
+
+	canonicalName := name
+	if len(games) > 0 && games[0].Developer != "" {
+		canonicalName = games[0].Developer
+	}
+
+	gameResponses := ToGameResponses(games, h.DB, userID)
+	heroURL := h.findHeroURL(games)
+	topGames := buildTopGames(gameResponses, 8)
+	genreBreakdown := buildGenreBreakdownFromGames(games)
+	platformBreakdown := buildPlatformBreakdown(games)
+	publishers := buildNameCountBreakdown(games, func(g db.Game) string { return g.Publisher })
+
+	var userStats *EntityUserStats
+	if userID > 0 {
+		userStats = h.buildEntityUserStats(userID, games, gameResponses)
+	}
+
+	companyInfo := h.lookupCompanyInfo(canonicalName)
+	activeYears := buildActiveYears(games)
+	ratingDist := buildRatingDistribution(games)
+	primaryGenre := buildPrimaryGenre(games)
+	timeline := buildTimeline(games)
+	relatedDevelopers := buildRelatedDevelopers(h.DB, canonicalName, publishers)
+
+	return &GetDeveloperDetailOutput{
+		CacheControl: "private, max-age=300",
+		Body: DeveloperDetailResponse{
+			Name:               canonicalName,
+			GameCount:          len(games),
+			AvgRating:          avgRating,
+			Consoles:           consoles,
+			Games:              gameResponses,
+			HeroURL:            heroURL,
+			TopGames:           topGames,
+			GenreBreakdown:     genreBreakdown,
+			PlatformBreakdown:  platformBreakdown,
+			UserStats:          userStats,
+			Publishers:         publishers,
+			CompanyInfo:        companyInfo,
+			ActiveYears:        activeYears,
+			RatingDistribution: ratingDist,
+			PrimaryGenre:       primaryGenre,
+			Timeline:           timeline,
+			RelatedDevelopers:  relatedDevelopers,
+		},
+	}, nil
+}
+
+// HumaGetPublisherDetail is the huma handler for GET /api/explore/publishers/{name}.
+func (h *ExploreHandler) HumaGetPublisherDetail(ctx context.Context, in *GetPublisherDetailInput) (*GetPublisherDetailOutput, error) {
+	userID := UserIDFromContext(ctx)
+	name := in.Name
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("LOWER(games.publisher) = LOWER(?) AND games.is_primary = true AND games.deleted_at IS NULL", name).
+		Order("games.rating DESC, games.title ASC").
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch publisher games", "publisher", name, "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch publisher games")
+	}
+
+	avgRating, consoles := calcRatingAndConsoles(games)
+
+	canonicalName := name
+	if len(games) > 0 && games[0].Publisher != "" {
+		canonicalName = games[0].Publisher
+	}
+
+	gameResponses := ToGameResponses(games, h.DB, userID)
+	heroURL := h.findHeroURL(games)
+	topGames := buildTopGames(gameResponses, 8)
+	genreBreakdown := buildGenreBreakdownFromGames(games)
+	platformBreakdown := buildPlatformBreakdown(games)
+	developers := buildNameCountBreakdown(games, func(g db.Game) string { return g.Developer })
+
+	var userStats *EntityUserStats
+	if userID > 0 {
+		userStats = h.buildEntityUserStats(userID, games, gameResponses)
+	}
+
+	companyInfo := h.lookupCompanyInfo(canonicalName)
+	activeYears := buildActiveYears(games)
+	ratingDist := buildRatingDistribution(games)
+	primaryGenre := buildPrimaryGenre(games)
+	timeline := buildTimeline(games)
+	relatedPublishers := buildRelatedPublishers(h.DB, canonicalName, developers)
+
+	return &GetPublisherDetailOutput{
+		CacheControl: "private, max-age=300",
+		Body: PublisherDetailResponse{
+			Name:               canonicalName,
+			GameCount:          len(games),
+			AvgRating:          avgRating,
+			Consoles:           consoles,
+			Games:              gameResponses,
+			HeroURL:            heroURL,
+			TopGames:           topGames,
+			GenreBreakdown:     genreBreakdown,
+			PlatformBreakdown:  platformBreakdown,
+			UserStats:          userStats,
+			Developers:         developers,
+			CompanyInfo:        companyInfo,
+			ActiveYears:        activeYears,
+			RatingDistribution: ratingDist,
+			PrimaryGenre:       primaryGenre,
+			Timeline:           timeline,
+			RelatedPublishers:  relatedPublishers,
+		},
+	}, nil
+}
+
+// HumaGetDeveloperSpotlight is the huma handler for GET /api/explore/developers/spotlight.
+func (h *ExploreHandler) HumaGetDeveloperSpotlight(ctx context.Context, _ *GetDeveloperSpotlightInput) (*GetDeveloperSpotlightOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	type devRow struct {
+		Developer string
+		GameCount int
+	}
+	var rows []devRow
+	if err := h.DB.
+		Table("games").
+		Select("games.developer, COUNT(DISTINCT games.id) as game_count").
+		Joins("JOIN game_artworks ON game_artworks.game_id = games.id AND game_artworks.hero_url != ''").
+		Where("games.deleted_at IS NULL AND games.is_primary = true AND games.developer != ''").
+		Group("games.developer").
+		Order("game_count DESC").
+		Limit(5).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to fetch developer spotlight candidates", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch developer spotlight")
+	}
+
+	if len(rows) == 0 {
+		return nil, huma.Error404NotFound("no developers with hero art found")
+	}
+
+	_, weekNumber := time.Now().ISOWeek()
+	selectedDev := rows[weekNumber%len(rows)]
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("LOWER(games.developer) = LOWER(?) AND games.is_primary = true AND games.deleted_at IS NULL", selectedDev.Developer).
+		Order("games.rating DESC, games.title ASC").
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch spotlight developer games", "developer", selectedDev.Developer, "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch developer spotlight")
+	}
+
+	avgRating, consoles := calcRatingAndConsoles(games)
+
+	topGames := games
+	if len(topGames) > 8 {
+		topGames = topGames[:8]
+	}
+
+	heroURL := ""
+	if len(games) > 0 {
+		gameIDs := make([]uint, len(games))
+		for i, g := range games {
+			gameIDs[i] = g.ID
+		}
+		var artwork db.GameArtwork
+		if err := h.DB.
+			Joins("JOIN games ON games.id = game_artworks.game_id").
+			Where("game_artworks.game_id IN ? AND game_artworks.hero_url != ''", gameIDs).
+			Order("games.rating DESC").
+			First(&artwork).Error; err == nil {
+			heroURL = resolveImageURL(artwork.HeroURL)
+		}
+	}
+
+	var totalGameCount int64
+	h.DB.Model(&db.Game{}).
+		Where("LOWER(developer) = LOWER(?) AND is_primary = true AND deleted_at IS NULL", selectedDev.Developer).
+		Count(&totalGameCount)
+
+	return &GetDeveloperSpotlightOutput{
+		CacheControl: "private, max-age=300",
+		Body: DeveloperSpotlightResponse{
+			Name:      selectedDev.Developer,
+			GameCount: int(totalGameCount),
+			AvgRating: avgRating,
+			Consoles:  consoles,
+			TopGames:  ToGameResponses(topGames, h.DB, userID),
+			HeroURL:   heroURL,
+		},
+	}, nil
+}

--- a/server/internal/api/huma_explore_featured.go
+++ b/server/internal/api/huma_explore_featured.go
@@ -1,0 +1,491 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// --- Inputs / outputs ---
+
+// GetExploreFeaturedInput is the input for GET /api/explore/featured.
+type GetExploreFeaturedInput struct{}
+
+// GetExploreFeaturedOutput wraps the featured games list for the huma response envelope.
+type GetExploreFeaturedOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         []FeaturedGameResponse
+}
+
+// GetExploreRowsInput is the input for GET /api/explore/rows.
+type GetExploreRowsInput struct{}
+
+// GetExploreRowsOutput wraps the curated shelf rows response.
+type GetExploreRowsOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         ExploreRowsResponse
+}
+
+// GetExploreFeaturedSeriesInput is the input for GET /api/explore/series/featured.
+type GetExploreFeaturedSeriesInput struct{}
+
+// GetExploreFeaturedSeriesOutput wraps the featured series response.
+type GetExploreFeaturedSeriesOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         []FeaturedSeriesResponse
+}
+
+// GetExploreMoodsInput is the input for GET /api/explore/moods.
+type GetExploreMoodsInput struct{}
+
+// GetExploreMoodsOutput wraps the moods response.
+type GetExploreMoodsOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         []MoodResponse
+}
+
+// GetMoodGamesInput is the input for GET /api/explore/mood/{mood}.
+type GetMoodGamesInput struct {
+	Mood string `path:"mood" doc:"Mood identifier, e.g. 'chill', 'challenge'."`
+}
+
+// GetMoodGamesOutput wraps the games list for a mood.
+type GetMoodGamesOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         []GameResponse
+}
+
+// GetSurpriseGameInput is the input for GET /api/explore/surprise.
+type GetSurpriseGameInput struct {
+	Console   string `query:"console" doc:"Console abbreviation filter."`
+	Genre     string `query:"genre" doc:"Genre filter."`
+	MinRating string `query:"minRating" doc:"Minimum IGDB rating (0-100); defaults to 70."`
+}
+
+// GetSurpriseGameOutput wraps a single surprise game response.
+type GetSurpriseGameOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         GameResponse
+}
+
+// --- Registration ---
+
+// RegisterExploreFeaturedRoutes wires the featured / rows / series / moods /
+// surprise explore endpoints into the huma API.
+func RegisterExploreFeaturedRoutes(api huma.API, h *ExploreHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
+	requireAuth := RequireAuth(jwtSecret, database)
+	rateLimit := UserRateLimitMiddleware(userLimiter)
+	mw := huma.Middlewares{requireAuth, rateLimit}
+	sec := []map[string][]string{{"bearer": {}}}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getExploreFeatured",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/featured",
+		Summary:     "Get featured games for the explore hero carousel",
+		Description: "Returns up to 10 featured games selected via weighted random sampling, stable per-day.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetExploreFeatured)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getExploreRows",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/rows",
+		Summary:     "Get curated explore-page shelf rows",
+		Description: "Returns curated shelves (top-rated, recently-added, hidden gems, most-played). Empty rows are omitted.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetExploreRows)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getExploreFeaturedSeries",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/series/featured",
+		Summary:     "Get featured game series",
+		Description: "Returns up to 20 top series with at least 2 library games, sorted by library game count DESC.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetExploreFeaturedSeries)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getExploreMoods",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/moods",
+		Summary:     "List explore mood options",
+		Description: "Returns the static list of moods available in the mood picker.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetExploreMoods)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getMoodGames",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/mood/{mood}",
+		Summary:     "Get games matching a specific mood",
+		Description: "Returns up to 20 games matching the chosen mood (chill, challenge, nostalgia, something-new, quick, together).",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetMoodGames)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getSurpriseGame",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/surprise",
+		Summary:     "Get a random surprise game",
+		Description: "Returns a single random game matching optional console/genre/min-rating filters.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetSurpriseGame)
+}
+
+// --- Handlers ---
+
+// HumaGetExploreFeatured is the huma handler for GET /api/explore/featured.
+func (h *ExploreHandler) HumaGetExploreFeatured(ctx context.Context, _ *GetExploreFeaturedInput) (*GetExploreFeaturedOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	type featuredRow struct {
+		GameID    uint
+		Title     string
+		HeroURL   string
+		LogoURL   string
+		Rating    float64
+		Genre     string
+		ConsoleID uint
+	}
+
+	var allRows []featuredRow
+	err := h.DB.
+		Table("games").
+		Select("games.id AS game_id, games.title, game_artworks.hero_url, game_artworks.logo_url, "+effectiveRatingPrefixed+" AS rating, games.genre, games.console_id").
+		Joins("JOIN game_artworks ON game_artworks.game_id = games.id").
+		Where("games.deleted_at IS NULL").
+		Where("games.is_primary = true").
+		Where("game_artworks.hero_url != '' AND game_artworks.logo_url != ''").
+		Scan(&allRows).Error
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to fetch featured games")
+	}
+
+	rows := weightedSample(allRows, 10, func(r featuredRow) float64 {
+		if r.Rating > 0 {
+			return r.Rating
+		}
+		return 10
+	})
+
+	if len(rows) == 0 {
+		return &GetExploreFeaturedOutput{
+			CacheControl: "private, max-age=300",
+			Body:         []FeaturedGameResponse{},
+		}, nil
+	}
+
+	consoleIDs := make([]uint, 0, len(rows))
+	for _, r := range rows {
+		consoleIDs = append(consoleIDs, r.ConsoleID)
+	}
+	var consoles []db.Console
+	if err := h.DB.Where("id IN ?", consoleIDs).Find(&consoles).Error; err != nil {
+		return nil, huma.Error500InternalServerError("failed to fetch console data")
+	}
+	consoleMap := make(map[uint]db.Console, len(consoles))
+	for _, con := range consoles {
+		consoleMap[con.ID] = con
+	}
+
+	gameIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		gameIDs[i] = r.GameID
+	}
+	favorites := make(map[uint]bool)
+	playLater := make(map[uint]bool)
+	if userID > 0 {
+		var favs []db.Favorite
+		if err := h.DB.Where("user_id = ? AND game_id IN ?", userID, gameIDs).Find(&favs).Error; err != nil {
+			return nil, huma.Error500InternalServerError("failed to fetch favorites")
+		}
+		for _, f := range favs {
+			favorites[f.GameID] = true
+		}
+		var plItems []db.PlayLaterItem
+		if err := h.DB.Where("user_id = ? AND game_id IN ?", userID, gameIDs).Find(&plItems).Error; err != nil {
+			return nil, huma.Error500InternalServerError("failed to fetch play later items")
+		}
+		for _, item := range plItems {
+			playLater[item.GameID] = true
+		}
+	}
+
+	result := make([]FeaturedGameResponse, len(rows))
+	for i, r := range rows {
+		con := consoleMap[r.ConsoleID]
+		abbr := strings.ToLower(con.Abbreviation)
+		result[i] = FeaturedGameResponse{
+			GameID:              strconv.FormatUint(uint64(r.GameID), 10),
+			Title:               r.Title,
+			HeroURL:             resolveImageURL(r.HeroURL),
+			LogoURL:             resolveImageURL(r.LogoURL),
+			ConsoleID:           abbr,
+			ConsoleName:         con.Name,
+			ConsoleAbbreviation: abbr,
+			ConsoleColor:        con.ColorTheme,
+			IGDBCriticsRating:   r.Rating,
+			Genre:               r.Genre,
+			IsFavorite:          favorites[r.GameID],
+			IsPlayLater:         playLater[r.GameID],
+		}
+	}
+
+	return &GetExploreFeaturedOutput{
+		CacheControl: "private, max-age=300",
+		Body:         result,
+	}, nil
+}
+
+// HumaGetExploreRows is the huma handler for GET /api/explore/rows.
+func (h *ExploreHandler) HumaGetExploreRows(ctx context.Context, _ *GetExploreRowsInput) (*GetExploreRowsOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	rows := []ExploreRowResponse{}
+
+	if row, err := h.buildTopRatedRow(userID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to build top-rated row")
+	} else if row != nil {
+		rows = append(rows, *row)
+	}
+
+	if row, err := h.buildRecentlyAddedRow(userID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to build recently-added row")
+	} else if row != nil {
+		rows = append(rows, *row)
+	}
+
+	if row, err := h.buildHiddenGemsRow(userID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to build hidden-gems row")
+	} else if row != nil {
+		rows = append(rows, *row)
+	}
+
+	if row, err := h.buildMostPlayedRow(userID); err != nil {
+		return nil, huma.Error500InternalServerError("failed to build most-played row")
+	} else if row != nil {
+		rows = append(rows, *row)
+	}
+
+	return &GetExploreRowsOutput{
+		CacheControl: "private, max-age=300",
+		Body:         ExploreRowsResponse{Rows: rows},
+	}, nil
+}
+
+// HumaGetExploreFeaturedSeries is the huma handler for GET /api/explore/series/featured.
+func (h *ExploreHandler) HumaGetExploreFeaturedSeries(_ context.Context, _ *GetExploreFeaturedSeriesInput) (*GetExploreFeaturedSeriesOutput, error) {
+	type seriesRow struct {
+		ID           uint
+		Name         string
+		TotalGames   int
+		LibraryGames int
+	}
+
+	var rows []seriesRow
+	if err := h.DB.
+		Table("game_series").
+		Select(`game_series.id, game_series.name,
+			COUNT(game_series_entries.id) as total_games,
+			COUNT(CASE WHEN games.id IS NOT NULL AND games.deleted_at IS NULL THEN 1 END) as library_games`).
+		Joins("JOIN game_series_entries ON game_series_entries.series_id = game_series.id").
+		Joins("LEFT JOIN games ON games.id = game_series_entries.game_id").
+		Group("game_series.id").
+		Having("library_games >= 2").
+		Order("library_games DESC").
+		Limit(20).
+		Scan(&rows).Error; err != nil {
+		return nil, huma.Error500InternalServerError("failed to fetch featured series")
+	}
+
+	if len(rows) == 0 {
+		return &GetExploreFeaturedSeriesOutput{
+			CacheControl: "private, max-age=300",
+			Body:         []FeaturedSeriesResponse{},
+		}, nil
+	}
+
+	seriesIDs := make([]uint, len(rows))
+	for i, r := range rows {
+		seriesIDs[i] = r.ID
+	}
+
+	type entryRow struct {
+		SeriesID  uint
+		GameID    uint
+		ConsoleID uint
+		Rating    float64
+	}
+	var entryRows []entryRow
+	if err := h.DB.Table("game_series_entries").
+		Select("game_series_entries.series_id, games.id as game_id, games.console_id, games.rating").
+		Joins("JOIN games ON games.id = game_series_entries.game_id AND games.deleted_at IS NULL").
+		Where("game_series_entries.series_id IN ?", seriesIDs).
+		Scan(&entryRows).Error; err != nil {
+		slog.Error("failed to batch-load series entries", "error", err)
+	}
+
+	type seriesGameInfo struct {
+		gameID    uint
+		consoleID uint
+		rating    float64
+	}
+	seriesGames := make(map[uint][]seriesGameInfo)
+	for _, e := range entryRows {
+		seriesGames[e.SeriesID] = append(seriesGames[e.SeriesID], seriesGameInfo{
+			gameID:    e.GameID,
+			consoleID: e.ConsoleID,
+			rating:    e.Rating,
+		})
+	}
+
+	allGameIDs := make([]uint, 0)
+	for _, games := range seriesGames {
+		for _, g := range games {
+			allGameIDs = append(allGameIDs, g.gameID)
+		}
+	}
+
+	artworkMap := make(map[uint]string)
+	if len(allGameIDs) > 0 {
+		var artworks []db.GameArtwork
+		h.DB.Where("game_id IN ? AND hero_url != ''", allGameIDs).Find(&artworks)
+		for _, a := range artworks {
+			artworkMap[a.GameID] = resolveImageURL(a.HeroURL)
+		}
+	}
+
+	result := make([]FeaturedSeriesResponse, len(rows))
+	for i, r := range rows {
+		consolesSet := make(map[uint]bool)
+		var bestHeroURL string
+		var bestRating float64 = -1
+		for _, g := range seriesGames[r.ID] {
+			consolesSet[g.consoleID] = true
+			if heroURL, ok := artworkMap[g.gameID]; ok {
+				if g.rating > bestRating {
+					bestRating = g.rating
+					bestHeroURL = heroURL
+				}
+			}
+		}
+
+		result[i] = FeaturedSeriesResponse{
+			ID:           strconv.FormatUint(uint64(r.ID), 10),
+			Name:         r.Name,
+			LibraryGames: r.LibraryGames,
+			TotalGames:   r.TotalGames,
+			ConsoleCount: len(consolesSet),
+			HeroURL:      bestHeroURL,
+		}
+	}
+
+	return &GetExploreFeaturedSeriesOutput{
+		CacheControl: "private, max-age=300",
+		Body:         result,
+	}, nil
+}
+
+// HumaGetExploreMoods is the huma handler for GET /api/explore/moods.
+func (h *ExploreHandler) HumaGetExploreMoods(_ context.Context, _ *GetExploreMoodsInput) (*GetExploreMoodsOutput, error) {
+	return &GetExploreMoodsOutput{
+		CacheControl: "private, max-age=300",
+		Body:         moodDefinitions,
+	}, nil
+}
+
+// HumaGetMoodGames is the huma handler for GET /api/explore/mood/{mood}.
+func (h *ExploreHandler) HumaGetMoodGames(ctx context.Context, in *GetMoodGamesInput) (*GetMoodGamesOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	var games []db.Game
+	var err error
+
+	switch in.Mood {
+	case "chill":
+		games, err = h.getMoodChillGames()
+	case "challenge":
+		games, err = h.getMoodChallengeGames()
+	case "nostalgia":
+		games, err = h.getMoodNostalgiaGames(userID)
+	case "something-new":
+		games, err = h.getMoodSomethingNewGames(userID)
+	case "quick":
+		games, err = h.getMoodQuickGames()
+	case "together":
+		games, err = h.getMoodTogetherGames()
+	default:
+		return nil, huma.Error400BadRequest("invalid mood")
+	}
+
+	if err != nil {
+		slog.Error("failed to fetch mood games", "mood", in.Mood, "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch mood games")
+	}
+
+	return &GetMoodGamesOutput{
+		CacheControl: "private, max-age=120",
+		Body:         ToGameResponses(games, h.DB, userID),
+	}, nil
+}
+
+// HumaGetSurpriseGame is the huma handler for GET /api/explore/surprise.
+func (h *ExploreHandler) HumaGetSurpriseGame(ctx context.Context, in *GetSurpriseGameInput) (*GetSurpriseGameOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	query := h.DB.Preload("Console").Where("cover_url != '' AND is_primary = true")
+
+	if in.Console != "" {
+		var console db.Console
+		if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", in.Console).First(&console).Error; err == nil {
+			query = query.Where("console_id = ?", console.ID)
+		}
+	}
+
+	if in.Genre != "" {
+		query = query.Where("genre = ?", in.Genre)
+	}
+
+	minRating := 70.0
+	if in.MinRating != "" {
+		if r, err := strconv.ParseFloat(in.MinRating, 64); err == nil && r >= 0 && r <= 100 {
+			minRating = r
+		}
+	}
+	if minRating > 0 {
+		query = query.Where("rating >= ?", minRating)
+	}
+
+	var game db.Game
+	if err := query.Order("RANDOM()").Limit(1).First(&game).Error; err != nil {
+		if err.Error() == "record not found" {
+			return nil, huma.Error404NotFound("no eligible games found")
+		}
+		slog.Error("failed to fetch surprise game", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch surprise game")
+	}
+
+	return &GetSurpriseGameOutput{
+		CacheControl: "no-store",
+		Body:         ToGameResponse(game, h.DB, userID),
+	}, nil
+}

--- a/server/internal/api/huma_explore_foryou.go
+++ b/server/internal/api/huma_explore_foryou.go
@@ -1,0 +1,279 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// --- Inputs / outputs ---
+
+// GetForYouInput is the input for GET /api/explore/for-you.
+type GetForYouInput struct{}
+
+// GetForYouOutput wraps the personalized recommendation rows.
+type GetForYouOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         ForYouResponse
+}
+
+// GetPlayersLikeYouInput is the input for GET /api/explore/players-like-you.
+type GetPlayersLikeYouInput struct{}
+
+// GetPlayersLikeYouOutput wraps the collaborative-filter recommendations.
+type GetPlayersLikeYouOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         PlayersLikeYouResponse
+}
+
+// RegisterExploreForYouRoutes wires the personalized recommendation endpoints.
+func RegisterExploreForYouRoutes(api huma.API, h *ExploreHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
+	requireAuth := RequireAuth(jwtSecret, database)
+	rateLimit := UserRateLimitMiddleware(userLimiter)
+	mw := huma.Middlewares{requireAuth, rateLimit}
+	sec := []map[string][]string{{"bearer": {}}}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getForYou",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/for-you",
+		Summary:     "Get personalized recommendation rows",
+		Description: "Returns personalized recommendation shelves derived from the caller's play history.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetForYou)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getPlayersLikeYou",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/players-like-you",
+		Summary:     "Get collaborative-filter game recommendations",
+		Description: "Returns games favourited by users whose favourites overlap with the caller's. Uses Jaccard similarity.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetPlayersLikeYou)
+}
+
+// --- Handlers ---
+
+// HumaGetForYou is the huma handler for GET /api/explore/for-you.
+func (h *ExploreHandler) HumaGetForYou(ctx context.Context, _ *GetForYouInput) (*GetForYouOutput, error) {
+	userID := UserIDFromContext(ctx)
+	if userID == 0 {
+		return nil, huma.Error401Unauthorized("authentication required")
+	}
+
+	rows := []ForYouRowResponse{}
+
+	becauseRows, err := h.buildBecauseYouPlayedRows(userID)
+	if err != nil {
+		slog.Error("failed to build because-you-played rows", "error", err)
+		return nil, huma.Error500InternalServerError("failed to build recommendations")
+	}
+	rows = append(rows, becauseRows...)
+
+	moreGenreRow, err := h.buildMoreGenreRow(userID)
+	if err != nil {
+		slog.Error("failed to build more-genre row", "error", err)
+		return nil, huma.Error500InternalServerError("failed to build recommendations")
+	}
+	if moreGenreRow != nil {
+		rows = append(rows, *moreGenreRow)
+	}
+
+	unfinishedRow, err := h.buildUnfinishedRow(userID)
+	if err != nil {
+		slog.Error("failed to build unfinished row", "error", err)
+		return nil, huma.Error500InternalServerError("failed to build recommendations")
+	}
+	if unfinishedRow != nil {
+		rows = append(rows, *unfinishedRow)
+	}
+
+	expandRow, err := h.buildExpandHorizonsRow(userID)
+	if err != nil {
+		slog.Error("failed to build expand-horizons row", "error", err)
+		return nil, huma.Error500InternalServerError("failed to build recommendations")
+	}
+	if expandRow != nil {
+		rows = append(rows, *expandRow)
+	}
+
+	return &GetForYouOutput{
+		CacheControl: "private, max-age=120",
+		Body:         ForYouResponse{Rows: rows},
+	}, nil
+}
+
+// HumaGetPlayersLikeYou is the huma handler for GET /api/explore/players-like-you.
+func (h *ExploreHandler) HumaGetPlayersLikeYou(ctx context.Context, _ *GetPlayersLikeYouInput) (*GetPlayersLikeYouOutput, error) {
+	userID := UserIDFromContext(ctx)
+	if userID == 0 {
+		return nil, huma.Error401Unauthorized("authentication required")
+	}
+
+	var myFavIDs []uint
+	if err := h.DB.Model(&db.Favorite{}).
+		Select("game_id").
+		Where("user_id = ?", userID).
+		Pluck("game_id", &myFavIDs).Error; err != nil {
+		slog.Error("failed to get user favorites", "error", err)
+		return nil, huma.Error500InternalServerError("failed to get recommendations")
+	}
+
+	if len(myFavIDs) == 0 {
+		return &GetPlayersLikeYouOutput{
+			CacheControl: "private, max-age=120",
+			Body: PlayersLikeYouResponse{
+				Games:             []GameResponse{},
+				SimilarUsersCount: 0,
+			},
+		}, nil
+	}
+
+	type userOverlap struct {
+		UserID       uint
+		OverlapCount int
+	}
+	var overlaps []userOverlap
+	if err := h.DB.Model(&db.Favorite{}).
+		Select("user_id, COUNT(*) as overlap_count").
+		Where("user_id != ? AND game_id IN ?", userID, myFavIDs).
+		Group("user_id").
+		Order("overlap_count DESC").
+		Scan(&overlaps).Error; err != nil {
+		slog.Error("failed to find similar users", "error", err)
+		return nil, huma.Error500InternalServerError("failed to get recommendations")
+	}
+
+	if len(overlaps) == 0 {
+		return &GetPlayersLikeYouOutput{
+			CacheControl: "private, max-age=120",
+			Body: PlayersLikeYouResponse{
+				Games:             []GameResponse{},
+				SimilarUsersCount: 0,
+			},
+		}, nil
+	}
+
+	type similarUser struct {
+		userID     uint
+		similarity float64
+	}
+
+	candidateUserIDs := make([]uint, len(overlaps))
+	overlapMap := make(map[uint]int, len(overlaps))
+	for i, o := range overlaps {
+		candidateUserIDs[i] = o.UserID
+		overlapMap[o.UserID] = o.OverlapCount
+	}
+
+	type favCountRow struct {
+		UserID   uint
+		FavCount int
+	}
+	var favCounts []favCountRow
+	if err := h.DB.Model(&db.Favorite{}).
+		Select("user_id, COUNT(*) as fav_count").
+		Where("user_id IN ?", candidateUserIDs).
+		Group("user_id").
+		Scan(&favCounts).Error; err != nil {
+		slog.Error("failed to get candidate favorite counts", "error", err)
+		return nil, huma.Error500InternalServerError("failed to get recommendations")
+	}
+
+	var similarUsers []similarUser
+	myFavCount := len(myFavIDs)
+	for _, fc := range favCounts {
+		intersection := overlapMap[fc.UserID]
+		union := myFavCount + fc.FavCount - intersection
+		if union == 0 {
+			continue
+		}
+		similarity := float64(intersection) / float64(union)
+		similarUsers = append(similarUsers, similarUser{
+			userID:     fc.UserID,
+			similarity: similarity,
+		})
+	}
+
+	for i := 0; i < len(similarUsers); i++ {
+		for j := i + 1; j < len(similarUsers); j++ {
+			if similarUsers[j].similarity > similarUsers[i].similarity {
+				similarUsers[i], similarUsers[j] = similarUsers[j], similarUsers[i]
+			}
+		}
+	}
+
+	if len(similarUsers) > 5 {
+		similarUsers = similarUsers[:5]
+	}
+
+	topUserIDs := make([]uint, len(similarUsers))
+	for i, su := range similarUsers {
+		topUserIDs[i] = su.userID
+	}
+
+	type recGameRow struct {
+		GameID    uint
+		UserCount int
+	}
+	var recGameRows []recGameRow
+	if err := h.DB.Model(&db.Favorite{}).
+		Select("game_id, COUNT(DISTINCT user_id) as user_count").
+		Where("user_id IN ? AND game_id NOT IN ?", topUserIDs, myFavIDs).
+		Group("game_id").
+		Order("user_count DESC").
+		Limit(20).
+		Scan(&recGameRows).Error; err != nil {
+		slog.Error("failed to get recommended games from similar users", "error", err)
+		return nil, huma.Error500InternalServerError("failed to get recommendations")
+	}
+
+	if len(recGameRows) == 0 {
+		return &GetPlayersLikeYouOutput{
+			CacheControl: "private, max-age=120",
+			Body: PlayersLikeYouResponse{
+				Games:             []GameResponse{},
+				SimilarUsersCount: len(similarUsers),
+			},
+		}, nil
+	}
+
+	gameIDs := make([]uint, len(recGameRows))
+	for i, r := range recGameRows {
+		gameIDs[i] = r.GameID
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ? AND is_primary = true", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load recommended games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to get recommendations")
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+	sorted := make([]db.Game, 0, len(recGameRows))
+	for _, r := range recGameRows {
+		if g, ok := gameMap[r.GameID]; ok {
+			sorted = append(sorted, g)
+		}
+	}
+
+	return &GetPlayersLikeYouOutput{
+		CacheControl: "private, max-age=120",
+		Body: PlayersLikeYouResponse{
+			Games:             ToGameResponses(sorted, h.DB, userID),
+			SimilarUsersCount: len(similarUsers),
+		},
+	}, nil
+}
+

--- a/server/internal/api/huma_explore_gallery.go
+++ b/server/internal/api/huma_explore_gallery.go
@@ -1,0 +1,326 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"net/http"
+	"strconv"
+	"strings"
+
+	"github.com/danielgtaylor/huma/v2"
+	"gorm.io/gorm"
+)
+
+// --- Inputs / outputs ---
+
+// GetScreenshotGalleryInput is the input for GET /api/explore/screenshots.
+type GetScreenshotGalleryInput struct {
+	Page    int    `query:"page" doc:"1-based page number (defaults to 1)."`
+	Limit   int    `query:"limit" doc:"Page size (defaults to 40, max 100)."`
+	Console string `query:"console" doc:"Console abbreviation filter."`
+	Genre   string `query:"genre" doc:"Genre filter."`
+}
+
+// GetScreenshotGalleryOutput wraps the paginated screenshot list.
+type GetScreenshotGalleryOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         ScreenshotGalleryResponse
+}
+
+// GetArtworkGalleryInput is the input for GET /api/explore/artwork.
+type GetArtworkGalleryInput struct {
+	Page  int `query:"page" doc:"1-based page number (defaults to 1)."`
+	Limit int `query:"limit" doc:"Page size (defaults to 40, max 100)."`
+}
+
+// GetArtworkGalleryOutput wraps the paginated artwork list.
+type GetArtworkGalleryOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         ArtworkGalleryResponse
+}
+
+// GetCoverGalleryInput is the input for GET /api/explore/covers.
+type GetCoverGalleryInput struct {
+	Page    int    `query:"page" doc:"1-based page number (defaults to 1)."`
+	Limit   int    `query:"limit" doc:"Page size (defaults to 60, max 200)."`
+	Console string `query:"console" doc:"Console abbreviation filter."`
+}
+
+// GetCoverGalleryOutput wraps the paginated cover list.
+type GetCoverGalleryOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         CoverGalleryResponse
+}
+
+// RegisterExploreGalleryRoutes wires the screenshot / artwork / cover gallery endpoints.
+func RegisterExploreGalleryRoutes(api huma.API, h *ExploreHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
+	requireAuth := RequireAuth(jwtSecret, database)
+	rateLimit := UserRateLimitMiddleware(userLimiter)
+	mw := huma.Middlewares{requireAuth, rateLimit}
+	sec := []map[string][]string{{"bearer": {}}}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getScreenshotGallery",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/screenshots",
+		Summary:     "Get paginated screenshot gallery",
+		Description: "Returns a paginated stream of screenshots with minimal game metadata. Supports console/genre filters.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetScreenshotGallery)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getArtworkGallery",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/artwork",
+		Summary:     "Get paginated IGDB artwork gallery",
+		Description: "Returns a paginated stream of IGDB promotional artwork with game metadata.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetArtworkGallery)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getCoverGallery",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/covers",
+		Summary:     "Get paginated cover gallery",
+		Description: "Returns a paginated dense cover art feed with minimal metadata. Supports console filter.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetCoverGallery)
+}
+
+// clampPagination returns (page, limit, offset) after applying defaults and max
+// limits. The zero-value behaviour matches the gin version's parsePagination
+// helper: page defaults to 1 if <= 0, limit defaults to defaultLimit if <= 0
+// and is capped at maxLimit.
+func clampPagination(page, limit, defaultLimit, maxLimit int) (int, int, int) {
+	if page <= 0 {
+		page = 1
+	}
+	if limit <= 0 {
+		limit = defaultLimit
+	}
+	if limit > maxLimit {
+		limit = maxLimit
+	}
+	return page, limit, (page - 1) * limit
+}
+
+// humaTotalPages mirrors the gin helper totalPages().
+func humaTotalPages(totalCount, limit int) int {
+	if limit <= 0 {
+		return 0
+	}
+	return int(math.Ceil(float64(totalCount) / float64(limit)))
+}
+
+// --- Handlers ---
+
+// HumaGetScreenshotGallery is the huma handler for GET /api/explore/screenshots.
+func (h *ExploreHandler) HumaGetScreenshotGallery(_ context.Context, in *GetScreenshotGalleryInput) (*GetScreenshotGalleryOutput, error) {
+	page, limit, offset := clampPagination(in.Page, in.Limit, 40, 100)
+
+	consoleFilter := strings.TrimSpace(in.Console)
+	genreFilter := strings.TrimSpace(in.Genre)
+
+	baseQuery := h.DB.Table("game_screenshots").
+		Joins("JOIN games ON games.id = game_screenshots.game_id AND games.deleted_at IS NULL AND games.is_primary = true").
+		Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.deleted_at IS NULL").
+		Where("game_screenshots.deleted_at IS NULL")
+
+	if consoleFilter != "" {
+		baseQuery = baseQuery.Where("LOWER(consoles.abbreviation) = LOWER(?)", consoleFilter)
+	}
+	if genreFilter != "" {
+		baseQuery = baseQuery.Where("LOWER(games.genre) = LOWER(?)", genreFilter)
+	}
+
+	var count int64
+	if err := baseQuery.Count(&count).Error; err != nil {
+		slog.Error("failed to count screenshots for gallery", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load screenshot gallery")
+	}
+
+	type screenshotRow struct {
+		URL          string
+		GameID       uint
+		GameTitle    string
+		ConsoleName  string
+		ConsoleAbbr  string
+		ConsoleColor string
+	}
+
+	var rows []screenshotRow
+	if err := baseQuery.
+		Select("game_screenshots.url, games.id as game_id, games.title as game_title, consoles.name as console_name, LOWER(consoles.abbreviation) as console_abbr, consoles.color_theme as console_color").
+		Order("(game_screenshots.id * 2654435761) % 2147483647").
+		Offset(offset).
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to load screenshot gallery", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load screenshot gallery")
+	}
+
+	items := make([]ScreenshotItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, ScreenshotItem{
+			URL:          resolveImageURL(r.URL),
+			GameID:       strconv.FormatUint(uint64(r.GameID), 10),
+			GameTitle:    r.GameTitle,
+			ConsoleName:  r.ConsoleName,
+			ConsoleAbbr:  r.ConsoleAbbr,
+			ConsoleColor: r.ConsoleColor,
+		})
+	}
+
+	return &GetScreenshotGalleryOutput{
+		CacheControl: "private, max-age=300",
+		Body: ScreenshotGalleryResponse{
+			Screenshots: items,
+			Page:        page,
+			TotalPages:  humaTotalPages(int(count), limit),
+			TotalCount:  int(count),
+		},
+	}, nil
+}
+
+// HumaGetArtworkGallery is the huma handler for GET /api/explore/artwork.
+func (h *ExploreHandler) HumaGetArtworkGallery(_ context.Context, in *GetArtworkGalleryInput) (*GetArtworkGalleryOutput, error) {
+	page, limit, offset := clampPagination(in.Page, in.Limit, 40, 100)
+
+	var count int64
+	if err := h.DB.Table("game_artwork_images").
+		Joins("JOIN games ON games.id = game_artwork_images.game_id AND games.deleted_at IS NULL AND games.is_primary = true").
+		Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.deleted_at IS NULL").
+		Count(&count).Error; err != nil {
+		slog.Error("failed to count artwork for gallery", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load artwork gallery")
+	}
+
+	type artworkRow struct {
+		IGDBImageID  string
+		LocalPath    string
+		Width        int
+		Height       int
+		GameID       uint
+		GameTitle    string
+		ConsoleName  string
+		ConsoleAbbr  string
+		ConsoleColor string
+		Rating       float64
+	}
+
+	var rows []artworkRow
+	if err := h.DB.Table("game_artwork_images").
+		Select("game_artwork_images.igdb_image_id, game_artwork_images.local_path, game_artwork_images.width, game_artwork_images.height, games.id as game_id, games.title as game_title, games.rating, consoles.name as console_name, LOWER(consoles.abbreviation) as console_abbr, consoles.color_theme as console_color").
+		Joins("JOIN games ON games.id = game_artwork_images.game_id AND games.deleted_at IS NULL AND games.is_primary = true").
+		Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.deleted_at IS NULL").
+		Order("games.rating DESC").
+		Offset(offset).
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to load artwork gallery", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load artwork gallery")
+	}
+
+	items := make([]ArtworkItem, 0, len(rows))
+	for _, r := range rows {
+		if r.LocalPath == "" {
+			continue
+		}
+		items = append(items, ArtworkItem{
+			URL:          resolveImageURL(r.LocalPath),
+			Width:        r.Width,
+			Height:       r.Height,
+			GameID:       strconv.FormatUint(uint64(r.GameID), 10),
+			GameTitle:    r.GameTitle,
+			ConsoleName:  r.ConsoleName,
+			ConsoleAbbr:  r.ConsoleAbbr,
+			ConsoleColor: r.ConsoleColor,
+		})
+	}
+
+	return &GetArtworkGalleryOutput{
+		CacheControl: "private, max-age=300",
+		Body: ArtworkGalleryResponse{
+			Artworks:   items,
+			Page:       page,
+			TotalPages: humaTotalPages(int(count), limit),
+			TotalCount: int(count),
+		},
+	}, nil
+}
+
+// HumaGetCoverGallery is the huma handler for GET /api/explore/covers.
+func (h *ExploreHandler) HumaGetCoverGallery(_ context.Context, in *GetCoverGalleryInput) (*GetCoverGalleryOutput, error) {
+	page, limit, offset := clampPagination(in.Page, in.Limit, 60, 200)
+
+	consoleFilter := strings.TrimSpace(in.Console)
+
+	baseQuery := h.DB.Table("games").
+		Joins("JOIN consoles ON consoles.id = games.console_id AND consoles.deleted_at IS NULL").
+		Where("games.deleted_at IS NULL").
+		Where("games.is_primary = true").
+		Where("games.cover_url != ''")
+
+	if consoleFilter != "" {
+		baseQuery = baseQuery.Where("LOWER(consoles.abbreviation) = LOWER(?)", consoleFilter)
+	}
+
+	var count int64
+	if err := baseQuery.Count(&count).Error; err != nil {
+		slog.Error("failed to count covers for gallery", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load cover gallery")
+	}
+
+	type coverRow struct {
+		CoverURL     string
+		GameID       uint
+		GameTitle    string
+		ConsoleName  string
+		ConsoleAbbr  string
+		ConsoleColor string
+		Rating       float64
+		CoverAspect  string
+	}
+
+	var rows []coverRow
+	if err := baseQuery.
+		Select("games.cover_url, games.id as game_id, games.title as game_title, games.rating, consoles.name as console_name, LOWER(consoles.abbreviation) as console_abbr, consoles.color_theme as console_color, consoles.cover_aspect").
+		Order("games.rating DESC").
+		Offset(offset).
+		Limit(limit).
+		Scan(&rows).Error; err != nil {
+		slog.Error("failed to load cover gallery", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load cover gallery")
+	}
+
+	items := make([]CoverItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, CoverItem{
+			CoverURL:          resolveImageURL(r.CoverURL),
+			GameID:            strconv.FormatUint(uint64(r.GameID), 10),
+			GameTitle:         r.GameTitle,
+			ConsoleName:       r.ConsoleName,
+			ConsoleAbbr:       r.ConsoleAbbr,
+			ConsoleColor:      r.ConsoleColor,
+			IGDBCriticsRating: r.Rating,
+			CoverAspectRatio:  parseAspectRatio(r.CoverAspect),
+		})
+	}
+
+	return &GetCoverGalleryOutput{
+		CacheControl: "private, max-age=300",
+		Body: CoverGalleryResponse{
+			Covers:     items,
+			Page:       page,
+			TotalPages: humaTotalPages(int(count), limit),
+			TotalCount: int(count),
+		},
+	}, nil
+}

--- a/server/internal/api/huma_explore_temporal.go
+++ b/server/internal/api/huma_explore_temporal.go
@@ -1,0 +1,370 @@
+package api
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// --- Inputs / outputs ---
+
+// GetOnThisDayInput is the input for GET /api/explore/on-this-day.
+type GetOnThisDayInput struct{}
+
+// GetOnThisDayOutput wraps the on-this-day response.
+type GetOnThisDayOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         OnThisDayResponse
+}
+
+// GetBestOfYearInput is the input for GET /api/explore/best-of-year/{year}.
+type GetBestOfYearInput struct {
+	Year string `path:"year" doc:"Release year (1970-2100)."`
+}
+
+// GetBestOfYearOutput wraps the best-of-year response.
+type GetBestOfYearOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         BestOfYearResponse
+}
+
+// GetYourAnniversariesInput is the input for GET /api/explore/your-anniversaries.
+type GetYourAnniversariesInput struct{}
+
+// GetYourAnniversariesOutput wraps the anniversaries response.
+type GetYourAnniversariesOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         AnniversariesResponse
+}
+
+// GetDecadesInput is the input for GET /api/explore/decades/{decade}.
+type GetDecadesInput struct {
+	Decade string `path:"decade" doc:"Decade identifier: '80s', '90s', or '00s'."`
+}
+
+// GetDecadesOutput wraps the decades response.
+type GetDecadesOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         DecadesResponse
+}
+
+// RegisterExploreTemporalRoutes wires the temporal discovery endpoints.
+func RegisterExploreTemporalRoutes(api huma.API, h *ExploreHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
+	requireAuth := RequireAuth(jwtSecret, database)
+	rateLimit := UserRateLimitMiddleware(userLimiter)
+	mw := huma.Middlewares{requireAuth, rateLimit}
+	sec := []map[string][]string{{"bearer": {}}}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getOnThisDay",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/on-this-day",
+		Summary:     "Get games released on today's month/day",
+		Description: "Returns up to 20 games released on today's month/day across all years, sorted oldest first.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetOnThisDay)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getBestOfYear",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/best-of-year/{year}",
+		Summary:     "Get top-rated games from a specific release year",
+		Description: "Returns up to 30 highest-rated games released in the given year.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetBestOfYear)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getYourAnniversaries",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/your-anniversaries",
+		Summary:     "Get personal gameplay anniversaries",
+		Description: "Returns games the caller played roughly 1..10 years ago (within a 3-day window of today's date).",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetYourAnniversaries)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getDecades",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/decades/{decade}",
+		Summary:     "Get best games of a decade",
+		Description: "Returns up to 30 highest-rated games for the given decade (80s, 90s, or 00s).",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetDecades)
+}
+
+// --- Handlers ---
+
+// HumaGetOnThisDay is the huma handler for GET /api/explore/on-this-day.
+func (h *ExploreHandler) HumaGetOnThisDay(ctx context.Context, _ *GetOnThisDayInput) (*GetOnThisDayOutput, error) {
+	userID := UserIDFromContext(ctx)
+	now := time.Now()
+	targetMonth := now.Month()
+	targetDay := now.Day()
+
+	dateLabel := now.Format("January 2")
+
+	var allGames []db.Game
+	if err := h.DB.Preload("Console").
+		Where("release_date != '' AND release_date IS NOT NULL AND is_primary = true AND deleted_at IS NULL").
+		Find(&allGames).Error; err != nil {
+		slog.Error("failed to fetch games for on-this-day", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch games")
+	}
+
+	type matchedGame struct {
+		game db.Game
+		year int
+	}
+	var matched []matchedGame
+	for _, g := range allGames {
+		month, day, ok := parseReleaseDateMonthDay(g.ReleaseDate)
+		if !ok {
+			continue
+		}
+		if month == targetMonth && day == targetDay {
+			year, _ := parseReleaseDateYear(g.ReleaseDate)
+			matched = append(matched, matchedGame{game: g, year: year})
+		}
+	}
+
+	sort.Slice(matched, func(i, j int) bool {
+		return matched[i].year < matched[j].year
+	})
+
+	if len(matched) > 20 {
+		matched = matched[:20]
+	}
+
+	if len(matched) == 0 {
+		return &GetOnThisDayOutput{
+			CacheControl: "private, max-age=300",
+			Body:         OnThisDayResponse{Date: dateLabel, Games: []GameResponse{}},
+		}, nil
+	}
+
+	games := make([]db.Game, len(matched))
+	gameIDs := make([]uint, len(matched))
+	for i, m := range matched {
+		games[i] = m.game
+		gameIDs[i] = m.game.ID
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+	result := make([]GameResponse, len(games))
+	for i, g := range games {
+		result[i] = toGameResponseWithData(g, &userData)
+	}
+
+	return &GetOnThisDayOutput{
+		CacheControl: "private, max-age=300",
+		Body:         OnThisDayResponse{Date: dateLabel, Games: result},
+	}, nil
+}
+
+// HumaGetBestOfYear is the huma handler for GET /api/explore/best-of-year/{year}.
+func (h *ExploreHandler) HumaGetBestOfYear(ctx context.Context, in *GetBestOfYearInput) (*GetBestOfYearOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	year, err := strconv.Atoi(in.Year)
+	if err != nil || year < 1970 || year > 2100 {
+		return nil, huma.Error400BadRequest("invalid year")
+	}
+
+	yearPrefix := fmt.Sprintf("%d", year)
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where("release_date LIKE ? AND is_primary = true AND deleted_at IS NULL", yearPrefix+"%").
+		Where("rating > 0").
+		Order("rating DESC").
+		Limit(30).
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch best-of-year games", "error", err, "year", year)
+		return nil, huma.Error500InternalServerError("failed to fetch games")
+	}
+
+	if len(games) == 0 {
+		return &GetBestOfYearOutput{
+			CacheControl: "private, max-age=300",
+			Body:         BestOfYearResponse{Year: year, Games: []GameResponse{}},
+		}, nil
+	}
+
+	return &GetBestOfYearOutput{
+		CacheControl: "private, max-age=300",
+		Body: BestOfYearResponse{
+			Year:  year,
+			Games: ToGameResponses(games, h.DB, userID),
+		},
+	}, nil
+}
+
+// HumaGetYourAnniversaries is the huma handler for GET /api/explore/your-anniversaries.
+func (h *ExploreHandler) HumaGetYourAnniversaries(ctx context.Context, _ *GetYourAnniversariesInput) (*GetYourAnniversariesOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	now := time.Now()
+
+	var allAnniversaries []AnniversaryItem
+	for yearsAgo := 1; yearsAgo <= 10; yearsAgo++ {
+		anniversary := now.AddDate(-yearsAgo, 0, 0)
+		windowStart := anniversary.AddDate(0, 0, -3)
+		windowEnd := anniversary.AddDate(0, 0, 3)
+
+		var histories []db.PlayHistory
+		if err := h.DB.
+			Where("user_id = ? AND last_played BETWEEN ? AND ? AND deleted_at IS NULL",
+				userID, windowStart, windowEnd).
+			Find(&histories).Error; err != nil {
+			slog.Error("failed to fetch anniversary play histories", "error", err, "yearsAgo", yearsAgo)
+			continue
+		}
+
+		gameMap := make(map[uint]db.PlayHistory)
+		for _, ph := range histories {
+			existing, exists := gameMap[ph.GameID]
+			if !exists {
+				gameMap[ph.GameID] = ph
+			} else {
+				existingDiff := existing.LastPlayed.Sub(anniversary)
+				if existingDiff < 0 {
+					existingDiff = -existingDiff
+				}
+				newDiff := ph.LastPlayed.Sub(anniversary)
+				if newDiff < 0 {
+					newDiff = -newDiff
+				}
+				if newDiff < existingDiff {
+					gameMap[ph.GameID] = ph
+				}
+			}
+		}
+
+		for _, ph := range gameMap {
+			allAnniversaries = append(allAnniversaries, AnniversaryItem{
+				YearsAgo: yearsAgo,
+				PlayedAt: ph.LastPlayed,
+				Game:     GameResponse{ID: strconv.FormatUint(uint64(ph.GameID), 10)},
+			})
+		}
+	}
+
+	if len(allAnniversaries) == 0 {
+		return &GetYourAnniversariesOutput{
+			CacheControl: "private, max-age=120",
+			Body:         AnniversariesResponse{Anniversaries: []AnniversaryItem{}},
+		}, nil
+	}
+
+	gameIDSet := make(map[uint]bool)
+	for _, a := range allAnniversaries {
+		gid, _ := strconv.ParseUint(a.Game.ID, 10, 64)
+		gameIDSet[uint(gid)] = true
+	}
+	gameIDs := make([]uint, 0, len(gameIDSet))
+	for id := range gameIDSet {
+		gameIDs = append(gameIDs, id)
+	}
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").Where("id IN ?", gameIDs).Find(&games).Error; err != nil {
+		slog.Error("failed to load anniversary games", "error", err)
+		return nil, huma.Error500InternalServerError("failed to load games")
+	}
+
+	gameMap := make(map[uint]db.Game, len(games))
+	for _, g := range games {
+		gameMap[g.ID] = g
+	}
+
+	userData := loadUserGameData(h.DB, userID, gameIDs)
+
+	result := make([]AnniversaryItem, 0, len(allAnniversaries))
+	for _, a := range allAnniversaries {
+		gid, _ := strconv.ParseUint(a.Game.ID, 10, 64)
+		g, ok := gameMap[uint(gid)]
+		if !ok {
+			continue
+		}
+		result = append(result, AnniversaryItem{
+			Game:     toGameResponseWithData(g, &userData),
+			YearsAgo: a.YearsAgo,
+			PlayedAt: a.PlayedAt,
+		})
+	}
+
+	sort.Slice(result, func(i, j int) bool {
+		if result[i].YearsAgo != result[j].YearsAgo {
+			return result[i].YearsAgo < result[j].YearsAgo
+		}
+		return result[i].Game.Title < result[j].Game.Title
+	})
+
+	return &GetYourAnniversariesOutput{
+		CacheControl: "private, max-age=120",
+		Body:         AnniversariesResponse{Anniversaries: result},
+	}, nil
+}
+
+// HumaGetDecades is the huma handler for GET /api/explore/decades/{decade}.
+func (h *ExploreHandler) HumaGetDecades(ctx context.Context, in *GetDecadesInput) (*GetDecadesOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	yearRange, ok := decadeRange[in.Decade]
+	if !ok {
+		return nil, huma.Error400BadRequest("invalid decade; valid values: 80s, 90s, 00s")
+	}
+	label := decadeLabel[in.Decade]
+
+	conditions := make([]string, 0, yearRange[1]-yearRange[0]+1)
+	args := make([]interface{}, 0, yearRange[1]-yearRange[0]+1)
+	for y := yearRange[0]; y <= yearRange[1]; y++ {
+		conditions = append(conditions, "release_date LIKE ?")
+		args = append(args, fmt.Sprintf("%d%%", y))
+	}
+	whereClause := "(" + strings.Join(conditions, " OR ") + ")"
+
+	var games []db.Game
+	if err := h.DB.Preload("Console").
+		Where(whereClause, args...).
+		Where("rating > 0 AND is_primary = true AND deleted_at IS NULL").
+		Order("rating DESC").
+		Limit(30).
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch decade games", "error", err, "decade", in.Decade)
+		return nil, huma.Error500InternalServerError("failed to fetch games")
+	}
+
+	if len(games) == 0 {
+		return &GetDecadesOutput{
+			CacheControl: "private, max-age=300",
+			Body:         DecadesResponse{Decade: in.Decade, Label: label, Games: []GameResponse{}},
+		}, nil
+	}
+
+	return &GetDecadesOutput{
+		CacheControl: "private, max-age=300",
+		Body: DecadesResponse{
+			Decade: in.Decade,
+			Label:  label,
+			Games:  ToGameResponses(games, h.DB, userID),
+		},
+	}, nil
+}

--- a/server/internal/api/huma_explore_wizard.go
+++ b/server/internal/api/huma_explore_wizard.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+
+	"github.com/danielgtaylor/huma/v2"
+	"github.com/spela/server/internal/db"
+	"gorm.io/gorm"
+)
+
+// --- Inputs / outputs ---
+
+// GetWizardStepsInput is the input for GET /api/explore/wizard.
+type GetWizardStepsInput struct{}
+
+// GetWizardStepsOutput wraps the wizard steps response.
+type GetWizardStepsOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         WizardResponse
+}
+
+// GetWizardResultsInput is the input for GET /api/explore/wizard/results.
+type GetWizardResultsInput struct {
+	Mood string `query:"mood" doc:"Chosen mood (action|chill|story|challenge|fun)."`
+	Era  string `query:"era" doc:"Chosen era (80s|early90s|late90s|2000s|any)."`
+	Vibe string `query:"vibe" doc:"Chosen vibe (solo|multiplayer|short|long|any)."`
+}
+
+// GetWizardResultsOutput wraps the wizard results response.
+type GetWizardResultsOutput struct {
+	CacheControl string `header:"Cache-Control"`
+	Body         WizardResultsResponse
+}
+
+// RegisterExploreWizardRoutes wires the decision-wizard endpoints.
+func RegisterExploreWizardRoutes(api huma.API, h *ExploreHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
+	requireAuth := RequireAuth(jwtSecret, database)
+	rateLimit := UserRateLimitMiddleware(userLimiter)
+	mw := huma.Middlewares{requireAuth, rateLimit}
+	sec := []map[string][]string{{"bearer": {}}}
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getWizardSteps",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/wizard",
+		Summary:     "Get decision wizard steps",
+		Description: "Returns the static decision wizard configuration (steps + options).",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetWizardSteps)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getWizardResults",
+		Method:      http.MethodGet,
+		Path:        "/api/explore/wizard/results",
+		Summary:     "Get wizard recommendations",
+		Description: "Returns 5 game recommendations based on the wizard's mood/era/vibe selections.",
+		Tags:        []string{"explore"},
+		Middlewares: mw,
+		Security:    sec,
+	}, h.HumaGetWizardResults)
+}
+
+// --- Handlers ---
+
+// HumaGetWizardSteps is the huma handler for GET /api/explore/wizard.
+func (h *ExploreHandler) HumaGetWizardSteps(_ context.Context, _ *GetWizardStepsInput) (*GetWizardStepsOutput, error) {
+	steps := []WizardStep{
+		{
+			Step:  1,
+			Title: "What are you in the mood for?",
+			Type:  "mood",
+			Options: []WizardOption{
+				{ID: "action", Label: "Action & Excitement", Description: "Fast-paced thrills"},
+				{ID: "chill", Label: "Chill & Relaxing", Description: "Laid-back vibes"},
+				{ID: "story", Label: "Deep Story", Description: "Rich narrative experiences"},
+				{ID: "challenge", Label: "A Real Challenge", Description: "Test your skills"},
+				{ID: "fun", Label: "Pure Fun", Description: "Simple pick-up-and-play"},
+			},
+		},
+		{
+			Step:  2,
+			Title: "Pick an era",
+			Type:  "era",
+			Options: []WizardOption{
+				{ID: "80s", Label: "The 80s", Description: "Birth of console gaming"},
+				{ID: "early90s", Label: "Early 90s", Description: "16-bit golden age"},
+				{ID: "late90s", Label: "Late 90s", Description: "3D revolution begins"},
+				{ID: "2000s", Label: "The 2000s", Description: "Handheld renaissance"},
+				{ID: "any", Label: "Any Era", Description: "Surprise me"},
+			},
+		},
+		{
+			Step:  3,
+			Title: "Refine your vibe",
+			Type:  "vibe",
+			Options: []WizardOption{
+				{ID: "solo", Label: "Solo Adventure", Description: "Just me and the game"},
+				{ID: "multiplayer", Label: "Multiplayer", Description: "Games with friends"},
+				{ID: "short", Label: "Quick Session", Description: "Short and sweet"},
+				{ID: "long", Label: "Deep Dive", Description: "Hours of content"},
+				{ID: "any", Label: "Anything Goes", Description: "No preference"},
+			},
+		},
+	}
+
+	return &GetWizardStepsOutput{
+		CacheControl: "private, max-age=300",
+		Body:         WizardResponse{Steps: steps},
+	}, nil
+}
+
+// HumaGetWizardResults is the huma handler for GET /api/explore/wizard/results.
+func (h *ExploreHandler) HumaGetWizardResults(ctx context.Context, in *GetWizardResultsInput) (*GetWizardResultsOutput, error) {
+	userID := UserIDFromContext(ctx)
+
+	query := h.DB.Preload("Console").Where("cover_url != '' AND is_primary = true")
+
+	switch in.Mood {
+	case "action":
+		query = query.Where("genre IN ?", []string{"Action", "Shooter", "Fighting", "Beat 'em up"})
+	case "chill":
+		query = query.Where("genre IN ?", []string{"Puzzle", "Simulation", "Sports"})
+	case "story":
+		query = query.Where("genre IN ?", []string{"RPG", "Adventure"})
+	case "challenge":
+		query = query.Where("genre IN ?", []string{"Action", "Platformer", "Shooter"}).
+			Where("rating >= 75")
+	case "fun":
+		query = query.Where("genre IN ?", []string{"Platformer", "Arcade", "Racing", "Puzzle"})
+	}
+
+	switch in.Era {
+	case "80s":
+		query = query.Where("release_date >= '1980' AND release_date < '1990'")
+	case "early90s":
+		query = query.Where("release_date >= '1990' AND release_date < '1995'")
+	case "late90s":
+		query = query.Where("release_date >= '1995' AND release_date < '2000'")
+	case "2000s":
+		query = query.Where("release_date >= '2000' AND release_date < '2010'")
+	}
+
+	switch in.Vibe {
+	case "solo":
+		query = query.Where("(players IS NULL OR players = 0 OR players = 1)")
+	case "multiplayer":
+		query = query.Where("players > 1")
+	case "short":
+		query = query.Where("genre NOT IN ?", []string{"RPG"})
+	case "long":
+		query = query.Where("genre IN ?", []string{"RPG", "Adventure", "Strategy"})
+	}
+
+	var games []db.Game
+	if err := query.Where("rating > 0").
+		Order("rating DESC, RANDOM()").
+		Limit(5).
+		Find(&games).Error; err != nil {
+		slog.Error("failed to fetch wizard results", "error", err)
+		return nil, huma.Error500InternalServerError("failed to fetch wizard results")
+	}
+
+	if len(games) < 3 {
+		relaxed := h.DB.Preload("Console").Where("cover_url != '' AND is_primary = true")
+		switch in.Mood {
+		case "action":
+			relaxed = relaxed.Where("genre IN ?", []string{"Action", "Shooter", "Fighting", "Beat 'em up", "Platformer"})
+		case "story":
+			relaxed = relaxed.Where("genre IN ?", []string{"RPG", "Adventure"})
+		}
+		relaxed.Order("RANDOM()").Limit(5).Find(&games)
+	}
+
+	title := "Your Perfect Picks"
+	if in.Mood != "" {
+		titles := map[string]string{
+			"action":    "Action-Packed Picks",
+			"chill":     "Chill & Relaxing",
+			"story":     "Story-Driven Adventures",
+			"challenge": "Challenge Accepted",
+			"fun":       "Pure Fun Picks",
+		}
+		if t, ok := titles[in.Mood]; ok {
+			title = t
+		}
+	}
+
+	return &GetWizardResultsOutput{
+		CacheControl: "no-store",
+		Body: WizardResultsResponse{
+			Games: ToGameResponses(games, h.DB, userID),
+			Title: title,
+		},
+	}, nil
+}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -264,6 +264,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterExploreConsoleRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreGalleryRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreCommunityRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterExploreTemporalRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 
 	// Public auth routes — rate limit login/register/setup to prevent brute force,
 	// but leave refresh and setup-status unrestricted (called frequently during normal use).
@@ -335,10 +336,8 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 			// trending / community-top / cult-classics / recently-reviewed /
 			// active-now — migrated to huma (see RegisterExploreCommunityRoutes
 			// above).
-			explore.GET("/on-this-day", exploreHandler.GetOnThisDay)
-			explore.GET("/best-of-year/:year", exploreHandler.GetBestOfYear)
-			explore.GET("/your-anniversaries", exploreHandler.GetYourAnniversaries)
-			explore.GET("/decades/:decade", exploreHandler.GetDecades)
+			// on-this-day / best-of-year / your-anniversaries / decades —
+			// migrated to huma (see RegisterExploreTemporalRoutes above).
 			explore.GET("/easy-to-complete", exploreHandler.GetEasyToComplete)
 			explore.GET("/hardest-games", exploreHandler.GetHardestGames)
 			explore.GET("/almost-done", exploreHandler.GetAlmostDone)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -266,6 +266,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterExploreCommunityRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreTemporalRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreChallengeRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterExploreWizardRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 
 	// Public auth routes — rate limit login/register/setup to prevent brute force,
 	// but leave refresh and setup-status unrestricted (called frequently during normal use).
@@ -321,30 +322,16 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 
 		// Top Lists — migrated to huma as part of RegisterConsoleRoutes above.
 
-		// Explore
-		explore := api.Group("/explore")
-		{
-			// Featured / rows / series / moods / surprise — migrated to huma
-			// (see RegisterExploreFeaturedRoutes above).
-			// for-you / players-like-you — migrated to huma
-			// (see RegisterExploreForYouRoutes above).
-			// developers + developer/publisher detail — migrated to huma
-			// (see RegisterExploreDeveloperRoutes above).
-			// console showcase + highlights — migrated to huma
-			// (see RegisterExploreConsoleRoutes above).
-			// screenshot / artwork / cover galleries — migrated to huma
-			// (see RegisterExploreGalleryRoutes above).
-			// trending / community-top / cult-classics / recently-reviewed /
-			// active-now — migrated to huma (see RegisterExploreCommunityRoutes
-			// above).
-			// on-this-day / best-of-year / your-anniversaries / decades —
-			// migrated to huma (see RegisterExploreTemporalRoutes above).
-			// easy-to-complete / hardest-games / almost-done /
-			// fresh-challenges / active-challenges — migrated to huma
-			// (see RegisterExploreChallengeRoutes above).
-			explore.GET("/wizard", exploreHandler.GetWizardSteps)
-			explore.GET("/wizard/results", exploreHandler.GetWizardResults)
-		}
+		// Explore — all endpoints migrated to huma. See:
+		//   RegisterExploreFeaturedRoutes   (featured/rows/series/moods/surprise)
+		//   RegisterExploreForYouRoutes     (for-you/players-like-you)
+		//   RegisterExploreDeveloperRoutes  (developers/publishers detail + spotlight)
+		//   RegisterExploreConsoleRoutes    (console showcase + highlights)
+		//   RegisterExploreGalleryRoutes    (screenshots/artwork/covers)
+		//   RegisterExploreCommunityRoutes  (trending/community-top/cult-classics/recently-reviewed/active-now)
+		//   RegisterExploreTemporalRoutes   (on-this-day/best-of-year/your-anniversaries/decades)
+		//   RegisterExploreChallengeRoutes  (easy-to-complete/hardest-games/almost-done/fresh-challenges/active-challenges)
+		//   RegisterExploreWizardRoutes     (wizard + wizard/results)
 
 		// Games — most endpoints migrated to huma (see RegisterGameRoutes above).
 		// Download endpoints stay on gin because they use c.File()/tar+zip streaming

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -260,6 +260,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterProfileRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreFeaturedRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreForYouRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterExploreDeveloperRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 
 	// Public auth routes — rate limit login/register/setup to prevent brute force,
 	// but leave refresh and setup-status unrestricted (called frequently during normal use).
@@ -322,10 +323,8 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 			// (see RegisterExploreFeaturedRoutes above).
 			// for-you / players-like-you — migrated to huma
 			// (see RegisterExploreForYouRoutes above).
-			explore.GET("/developers", exploreHandler.GetDevelopers)
-			explore.GET("/developers/spotlight", exploreHandler.GetDeveloperSpotlight)
-			explore.GET("/developers/:name", exploreHandler.GetDeveloperDetail)
-			explore.GET("/publishers/:name", exploreHandler.GetPublisherDetail)
+			// developers + developer/publisher detail — migrated to huma
+			// (see RegisterExploreDeveloperRoutes above).
 			explore.GET("/consoles/:id/showcase", exploreHandler.GetConsoleShowcase)
 			explore.GET("/console-highlights", exploreHandler.GetConsoleHighlights)
 			explore.GET("/screenshots", exploreHandler.GetScreenshotGallery)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -267,17 +267,12 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterExploreTemporalRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreChallengeRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreWizardRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterAuthRoutes(humaAPI, authHandler, authLimiter, refreshLimiter)
 
-	// Public auth routes — rate limit login/register/setup to prevent brute force,
-	// but leave refresh and setup-status unrestricted (called frequently during normal use).
-	authGroup := r.Group("/api/auth")
-	{
-		authGroup.POST("/login", authLimiter.RateLimit(), authHandler.Login)
-		authGroup.POST("/register", authLimiter.RateLimit(), authHandler.Register)
-		authGroup.POST("/setup", authLimiter.RateLimit(), authHandler.Setup)
-		authGroup.POST("/refresh", refreshLimiter.RateLimit(), authHandler.Refresh)
-		authGroup.GET("/setup-status", authHandler.SetupStatus)
-	}
+	// Public auth routes — login/register/setup/refresh/setup-status have been
+	// migrated to huma (see RegisterAuthRoutes above). Rate limiting (per-IP
+	// auth/refresh limiters) is applied via IPRateLimitMiddleware inside the
+	// huma registration.
 
 	// Setup diagnostics (public during first-time setup, admin-only after)
 	r.GET("/api/setup/diagnostics", setupHandler.Diagnostics)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -261,6 +261,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterExploreFeaturedRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreForYouRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreDeveloperRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterExploreConsoleRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 
 	// Public auth routes — rate limit login/register/setup to prevent brute force,
 	// but leave refresh and setup-status unrestricted (called frequently during normal use).
@@ -325,8 +326,8 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 			// (see RegisterExploreForYouRoutes above).
 			// developers + developer/publisher detail — migrated to huma
 			// (see RegisterExploreDeveloperRoutes above).
-			explore.GET("/consoles/:id/showcase", exploreHandler.GetConsoleShowcase)
-			explore.GET("/console-highlights", exploreHandler.GetConsoleHighlights)
+			// console showcase + highlights — migrated to huma
+			// (see RegisterExploreConsoleRoutes above).
 			explore.GET("/screenshots", exploreHandler.GetScreenshotGallery)
 			explore.GET("/artwork", exploreHandler.GetArtworkGallery)
 			explore.GET("/covers", exploreHandler.GetCoverGallery)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -263,6 +263,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterExploreDeveloperRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreConsoleRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreGalleryRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterExploreCommunityRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 
 	// Public auth routes — rate limit login/register/setup to prevent brute force,
 	// but leave refresh and setup-status unrestricted (called frequently during normal use).
@@ -331,11 +332,9 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 			// (see RegisterExploreConsoleRoutes above).
 			// screenshot / artwork / cover galleries — migrated to huma
 			// (see RegisterExploreGalleryRoutes above).
-			explore.GET("/trending", exploreHandler.GetTrending)
-			explore.GET("/community-top", exploreHandler.GetCommunityTop)
-			explore.GET("/cult-classics", exploreHandler.GetCultClassics)
-			explore.GET("/recently-reviewed", exploreHandler.GetRecentlyReviewed)
-			explore.GET("/active-now", exploreHandler.GetActiveNow)
+			// trending / community-top / cult-classics / recently-reviewed /
+			// active-now — migrated to huma (see RegisterExploreCommunityRoutes
+			// above).
 			explore.GET("/on-this-day", exploreHandler.GetOnThisDay)
 			explore.GET("/best-of-year/:year", exploreHandler.GetBestOfYear)
 			explore.GET("/your-anniversaries", exploreHandler.GetYourAnniversaries)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -258,6 +258,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterUploadAdminRoutes(humaAPI, uploadHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterSocialExtraRoutes(humaAPI, socialHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterProfileRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterExploreFeaturedRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 
 	// Public auth routes — rate limit login/register/setup to prevent brute force,
 	// but leave refresh and setup-status unrestricted (called frequently during normal use).
@@ -316,12 +317,8 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		// Explore
 		explore := api.Group("/explore")
 		{
-			explore.GET("/featured", exploreHandler.GetExploreFeatured)
-			explore.GET("/rows", exploreHandler.GetExploreRows)
-			explore.GET("/series/featured", exploreHandler.GetExploreFeaturedSeries)
-			explore.GET("/moods", exploreHandler.GetExploreMoods)
-			explore.GET("/mood/:mood", exploreHandler.GetMoodGames)
-			explore.GET("/surprise", exploreHandler.GetSurpriseGame)
+			// Featured / rows / series / moods / surprise — migrated to huma
+			// (see RegisterExploreFeaturedRoutes above).
 			explore.GET("/for-you", exploreHandler.GetForYou)
 			explore.GET("/players-like-you", exploreHandler.GetPlayersLikeYou)
 			explore.GET("/developers", exploreHandler.GetDevelopers)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -265,6 +265,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterExploreGalleryRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreCommunityRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreTemporalRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterExploreChallengeRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 
 	// Public auth routes — rate limit login/register/setup to prevent brute force,
 	// but leave refresh and setup-status unrestricted (called frequently during normal use).
@@ -338,11 +339,9 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 			// above).
 			// on-this-day / best-of-year / your-anniversaries / decades —
 			// migrated to huma (see RegisterExploreTemporalRoutes above).
-			explore.GET("/easy-to-complete", exploreHandler.GetEasyToComplete)
-			explore.GET("/hardest-games", exploreHandler.GetHardestGames)
-			explore.GET("/almost-done", exploreHandler.GetAlmostDone)
-			explore.GET("/fresh-challenges", exploreHandler.GetFreshChallenges)
-			explore.GET("/active-challenges", exploreHandler.GetActiveChallenges)
+			// easy-to-complete / hardest-games / almost-done /
+			// fresh-challenges / active-challenges — migrated to huma
+			// (see RegisterExploreChallengeRoutes above).
 			explore.GET("/wizard", exploreHandler.GetWizardSteps)
 			explore.GET("/wizard/results", exploreHandler.GetWizardResults)
 		}

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -262,6 +262,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterExploreForYouRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreDeveloperRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreConsoleRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterExploreGalleryRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 
 	// Public auth routes — rate limit login/register/setup to prevent brute force,
 	// but leave refresh and setup-status unrestricted (called frequently during normal use).
@@ -328,9 +329,8 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 			// (see RegisterExploreDeveloperRoutes above).
 			// console showcase + highlights — migrated to huma
 			// (see RegisterExploreConsoleRoutes above).
-			explore.GET("/screenshots", exploreHandler.GetScreenshotGallery)
-			explore.GET("/artwork", exploreHandler.GetArtworkGallery)
-			explore.GET("/covers", exploreHandler.GetCoverGallery)
+			// screenshot / artwork / cover galleries — migrated to huma
+			// (see RegisterExploreGalleryRoutes above).
 			explore.GET("/trending", exploreHandler.GetTrending)
 			explore.GET("/community-top", exploreHandler.GetCommunityTop)
 			explore.GET("/cult-classics", exploreHandler.GetCultClassics)

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -259,6 +259,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterSocialExtraRoutes(humaAPI, socialHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterProfileRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterExploreFeaturedRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
+	RegisterExploreForYouRoutes(humaAPI, exploreHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 
 	// Public auth routes — rate limit login/register/setup to prevent brute force,
 	// but leave refresh and setup-status unrestricted (called frequently during normal use).
@@ -319,8 +320,8 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		{
 			// Featured / rows / series / moods / surprise — migrated to huma
 			// (see RegisterExploreFeaturedRoutes above).
-			explore.GET("/for-you", exploreHandler.GetForYou)
-			explore.GET("/players-like-you", exploreHandler.GetPlayersLikeYou)
+			// for-you / players-like-you — migrated to huma
+			// (see RegisterExploreForYouRoutes above).
 			explore.GET("/developers", exploreHandler.GetDevelopers)
 			explore.GET("/developers/spotlight", exploreHandler.GetDeveloperSpotlight)
 			explore.GET("/developers/:name", exploreHandler.GetDeveloperDetail)

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -1436,6 +1436,666 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/explore/active-challenges": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get active community challenges
+         * @description Returns the 10 most recent active Challenge entities that have not yet expired.
+         */
+        get: operations["getActiveChallenges"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/active-now": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get games with active shared sessions or challenges
+         * @description Returns up to 20 games currently with active shared sessions and/or active challenges, sorted by combined activity.
+         */
+        get: operations["getActiveNow"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/almost-done": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get games the caller has nearly completed
+         * @description Returns games where the caller has completed between 80 and 99 percent of achievements.
+         */
+        get: operations["getAlmostDone"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/artwork": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get paginated IGDB artwork gallery
+         * @description Returns a paginated stream of IGDB promotional artwork with game metadata.
+         */
+        get: operations["getArtworkGallery"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/best-of-year/{year}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get top-rated games from a specific release year
+         * @description Returns up to 30 highest-rated games released in the given year.
+         */
+        get: operations["getBestOfYear"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/community-top": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get top-rated games by the community
+         * @description Returns games with the highest average user ratings on this server (at least 2 ratings).
+         */
+        get: operations["getCommunityTop"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/console-highlights": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get console highlights
+         * @description Returns a compact list of consoles with game counts and top game for the explore page quick-jump row.
+         */
+        get: operations["getConsoleHighlights"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/consoles/{id}/showcase": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get console showcase
+         * @description Returns aggregated showcase data for a specific console: essentials, hidden gems, genre breakdown, top developers, recently played, recently added.
+         */
+        get: operations["getConsoleShowcase"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/covers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get paginated cover gallery
+         * @description Returns a paginated dense cover art feed with minimal metadata. Supports console filter.
+         */
+        get: operations["getCoverGallery"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/cult-classics": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get community cult classics
+         * @description Returns games where the community rates higher than critics — avg community rating >= 4.0 with IGDB rating < 75.
+         */
+        get: operations["getCultClassics"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/decades/{decade}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get best games of a decade
+         * @description Returns up to 30 highest-rated games for the given decade (80s, 90s, or 00s).
+         */
+        get: operations["getDecades"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/developers": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List top developers
+         * @description Returns the top 50 developers by game count with average rating and console coverage.
+         */
+        get: operations["getDevelopers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/developers/spotlight": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get the weekly featured developer
+         * @description Returns a rotating spotlight of a top developer with games that have hero art. Rotates weekly.
+         */
+        get: operations["getDeveloperSpotlight"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/developers/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get developer detail
+         * @description Returns all games by a specific developer along with statistics (rating distribution, genre/platform breakdown, user stats, timeline, related developers).
+         */
+        get: operations["getDeveloperDetail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/easy-to-complete": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get games with highest avg achievement completion
+         * @description Returns up to 20 games with the highest average achievement completion rate across players.
+         */
+        get: operations["getEasyToComplete"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/featured": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get featured games for the explore hero carousel
+         * @description Returns up to 10 featured games selected via weighted random sampling, stable per-day.
+         */
+        get: operations["getExploreFeatured"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/for-you": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get personalized recommendation rows
+         * @description Returns personalized recommendation shelves derived from the caller's play history.
+         */
+        get: operations["getForYou"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/fresh-challenges": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get games with cached achievements the caller hasn't started
+         * @description Returns up to 20 games with cached achievements where the caller has zero unlocks yet.
+         */
+        get: operations["getFreshChallenges"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/hardest-games": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get games with lowest avg achievement completion
+         * @description Returns up to 20 games with the lowest average achievement completion rate. Requires at least 2 players attempting.
+         */
+        get: operations["getHardestGames"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/mood/{mood}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get games matching a specific mood
+         * @description Returns up to 20 games matching the chosen mood (chill, challenge, nostalgia, something-new, quick, together).
+         */
+        get: operations["getMoodGames"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/moods": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * List explore mood options
+         * @description Returns the static list of moods available in the mood picker.
+         */
+        get: operations["getExploreMoods"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/on-this-day": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get games released on today's month/day
+         * @description Returns up to 20 games released on today's month/day across all years, sorted oldest first.
+         */
+        get: operations["getOnThisDay"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/players-like-you": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get collaborative-filter game recommendations
+         * @description Returns games favourited by users whose favourites overlap with the caller's. Uses Jaccard similarity.
+         */
+        get: operations["getPlayersLikeYou"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/publishers/{name}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get publisher detail
+         * @description Returns all games by a specific publisher along with statistics (rating distribution, genre/platform breakdown, user stats, timeline, related publishers).
+         */
+        get: operations["getPublisherDetail"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/recently-reviewed": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get games with recent user reviews
+         * @description Returns the 20 most recent user reviews (non-empty review text) with game + reviewer metadata.
+         */
+        get: operations["getRecentlyReviewed"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/rows": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get curated explore-page shelf rows
+         * @description Returns curated shelves (top-rated, recently-added, hidden gems, most-played). Empty rows are omitted.
+         */
+        get: operations["getExploreRows"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/screenshots": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get paginated screenshot gallery
+         * @description Returns a paginated stream of screenshots with minimal game metadata. Supports console/genre filters.
+         */
+        get: operations["getScreenshotGallery"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/series/featured": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get featured game series
+         * @description Returns up to 20 top series with at least 2 library games, sorted by library game count DESC.
+         */
+        get: operations["getExploreFeaturedSeries"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/surprise": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a random surprise game
+         * @description Returns a single random game matching optional console/genre/min-rating filters.
+         */
+        get: operations["getSurpriseGame"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/trending": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get trending games
+         * @description Returns up to 20 games with the most distinct players in the last 7 days.
+         */
+        get: operations["getTrending"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/wizard": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get decision wizard steps
+         * @description Returns the static decision wizard configuration (steps + options).
+         */
+        get: operations["getWizardSteps"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/wizard/results": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get wizard recommendations
+         * @description Returns 5 game recommendations based on the wizard's mood/era/vibe selections.
+         */
+        get: operations["getWizardResults"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/explore/your-anniversaries": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get personal gameplay anniversaries
+         * @description Returns games the caller played roughly 1..10 years ago (within a 3-day window of today's date).
+         */
+        get: operations["getYourAnniversaries"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/franchises": {
         parameters: {
             query?: never;
@@ -3792,6 +4452,17 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        AchievementGameResponse: {
+            /** Format: double */
+            avgCompletion: number;
+            game: components["schemas"]["GameResponse"];
+            /** Format: int64 */
+            playersAttempted: number;
+            /** Format: int64 */
+            playersCompleted: number;
+            /** Format: int64 */
+            totalAchievements: number;
+        };
         AchievementLeaderboardResponse: {
             /**
              * Format: uri
@@ -3827,6 +4498,31 @@ export interface components {
             /** Format: int64 */
             unlockedCount: number;
         };
+        ActiveChallengesResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/ActiveChallengesResponse.json
+             */
+            readonly $schema?: string;
+            challenges: components["schemas"]["ExploreChallengeResponse"][] | null;
+        };
+        ActiveNowItem: {
+            /** Format: int64 */
+            activeChallenges: number;
+            /** Format: int64 */
+            activeSessions: number;
+            game: components["schemas"]["GameResponse"];
+        };
+        ActiveNowResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/ActiveNowResponse.json
+             */
+            readonly $schema?: string;
+            games: components["schemas"]["ActiveNowItem"][] | null;
+        };
         ActivePlayerEntry: {
             avatarUrl: string;
             /** Format: int64 */
@@ -3837,6 +4533,12 @@ export interface components {
             totalPlayTime: number;
             userId: string;
             username: string;
+        };
+        ActiveYears: {
+            /** Format: int64 */
+            first: number;
+            /** Format: int64 */
+            last: number;
         };
         ActivityEventResponse: {
             avatarUrl?: string;
@@ -3919,6 +4621,40 @@ export interface components {
             category: string;
             rating: string;
         };
+        AlmostDoneGame: {
+            /** Format: double */
+            completionPercent: number;
+            game: components["schemas"]["GameResponse"];
+            /** Format: int64 */
+            totalCount: number;
+            /** Format: int64 */
+            unlockedCount: number;
+        };
+        AlmostDoneResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/AlmostDoneResponse.json
+             */
+            readonly $schema?: string;
+            games: components["schemas"]["AlmostDoneGame"][] | null;
+        };
+        AnniversariesResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/AnniversariesResponse.json
+             */
+            readonly $schema?: string;
+            anniversaries: components["schemas"]["AnniversaryItem"][] | null;
+        };
+        AnniversaryItem: {
+            game: components["schemas"]["GameResponse"];
+            /** Format: date-time */
+            playedAt: string;
+            /** Format: int64 */
+            yearsAgo: number;
+        };
         ApplyIGDBMatchRequest: {
             /**
              * Format: uri
@@ -3928,6 +4664,33 @@ export interface components {
             readonly $schema?: string;
             /** Format: int64 */
             igdbId?: number;
+        };
+        ArtworkGalleryResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/ArtworkGalleryResponse.json
+             */
+            readonly $schema?: string;
+            artworks: components["schemas"]["ArtworkItem"][] | null;
+            /** Format: int64 */
+            page: number;
+            /** Format: int64 */
+            totalCount: number;
+            /** Format: int64 */
+            totalPages: number;
+        };
+        ArtworkItem: {
+            consoleAbbreviation: string;
+            consoleColor: string;
+            consoleName: string;
+            gameId: string;
+            gameTitle: string;
+            /** Format: int64 */
+            height: number;
+            url: string;
+            /** Format: int64 */
+            width: number;
         };
         BackfillImagesResponse: {
             /**
@@ -3948,6 +4711,17 @@ export interface components {
             similarDownloaded: number;
             /** Format: int64 */
             topRatedDownloaded: number;
+        };
+        BestOfYearResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/BestOfYearResponse.json
+             */
+            readonly $schema?: string;
+            games: components["schemas"]["GameResponse"][] | null;
+            /** Format: int64 */
+            year: number;
         };
         BiosDownloadStartedResponse: {
             /**
@@ -4146,6 +4920,22 @@ export interface components {
             userId: string;
             username: string;
         };
+        CommunityTopGame: {
+            /** Format: double */
+            avgRating: number;
+            game: components["schemas"]["GameResponse"];
+            /** Format: int64 */
+            ratingCount: number;
+        };
+        CommunityTopResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/CommunityTopResponse.json
+             */
+            readonly $schema?: string;
+            games: components["schemas"]["CommunityTopGame"][] | null;
+        };
         CompactSavesResponse: {
             /**
              * Format: uri
@@ -4157,6 +4947,15 @@ export interface components {
             deletedCount: number;
             /** Format: int64 */
             freedBytes: number;
+        };
+        CompanyInfo: {
+            country?: string;
+            description?: string;
+            /** Format: int64 */
+            foundedYear?: number;
+            logoUrl?: string;
+            websiteUrl?: string;
+            wikipediaUrl?: string;
         };
         CompletionistConsole: {
             id: string;
@@ -4206,6 +5005,25 @@ export interface components {
             status: string;
             subDir?: string;
         };
+        ConsoleHighlight: {
+            colorTheme: string;
+            /** Format: int64 */
+            gameCount: number;
+            iconUrl: string;
+            id: string;
+            logoUrl: string;
+            name: string;
+            topGame: components["schemas"]["GameResponse"];
+        };
+        ConsoleHighlightsResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/ConsoleHighlightsResponse.json
+             */
+            readonly $schema?: string;
+            consoles: components["schemas"]["ConsoleHighlight"][] | null;
+        };
         ConsoleKeyMappingDTO: {
             customMapping?: {
                 [key: string]: string;
@@ -4245,6 +5063,21 @@ export interface components {
             /** Format: date-time */
             updatedAt: string;
         };
+        ConsoleShowcaseResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/ConsoleShowcaseResponse.json
+             */
+            readonly $schema?: string;
+            console: components["schemas"]["ConsoleResponse"];
+            essentials: components["schemas"]["GameResponse"][] | null;
+            genreBreakdown: components["schemas"]["GenreCount"][] | null;
+            hiddenGems: components["schemas"]["GameResponse"][] | null;
+            recentlyAdded: components["schemas"]["GameResponse"][] | null;
+            recentlyPlayed: components["schemas"]["GameResponse"][] | null;
+            topDevelopers: components["schemas"]["DeveloperSummary"][] | null;
+        };
         Core: {
             /** Format: date-time */
             createdAt: string;
@@ -4274,6 +5107,33 @@ export interface components {
              */
             readonly $schema?: string;
             consoles: components["schemas"]["CoreCompatibilityEntry"][] | null;
+        };
+        CoverGalleryResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/CoverGalleryResponse.json
+             */
+            readonly $schema?: string;
+            covers: components["schemas"]["CoverItem"][] | null;
+            /** Format: int64 */
+            page: number;
+            /** Format: int64 */
+            totalCount: number;
+            /** Format: int64 */
+            totalPages: number;
+        };
+        CoverItem: {
+            consoleAbbreviation: string;
+            consoleColor: string;
+            consoleName: string;
+            /** Format: double */
+            coverAspectRatio: number;
+            coverUrl: string;
+            gameId: string;
+            gameTitle: string;
+            /** Format: double */
+            igdbCriticsRating: number;
         };
         CoverOption: {
             label?: string;
@@ -4334,6 +5194,35 @@ export interface components {
             gameId?: string;
             name?: string;
         };
+        CultClassicGame: {
+            /** Format: double */
+            communityRating: number;
+            game: components["schemas"]["GameResponse"];
+            /** Format: double */
+            igdbCriticsRating: number;
+            /** Format: int64 */
+            ratingCount: number;
+        };
+        CultClassicsResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/CultClassicsResponse.json
+             */
+            readonly $schema?: string;
+            games: components["schemas"]["CultClassicGame"][] | null;
+        };
+        DecadesResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/DecadesResponse.json
+             */
+            readonly $schema?: string;
+            decade: string;
+            games: components["schemas"]["GameResponse"][] | null;
+            label: string;
+        };
         DeletedStatusResponse: {
             /**
              * Format: uri
@@ -4354,9 +5243,69 @@ export interface components {
             role: string;
             username: string;
         };
+        DeveloperDetailResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/DeveloperDetailResponse.json
+             */
+            readonly $schema?: string;
+            activeYears?: components["schemas"]["ActiveYears"];
+            /** Format: double */
+            avgRating: number;
+            companyInfo?: components["schemas"]["CompanyInfo"];
+            consoles: string[] | null;
+            /** Format: int64 */
+            gameCount: number;
+            games: components["schemas"]["GameResponse"][] | null;
+            genreBreakdown: components["schemas"]["GenreCount"][] | null;
+            heroUrl?: string;
+            name: string;
+            platformBreakdown: components["schemas"]["PlatformCount"][] | null;
+            primaryGenre?: string;
+            publishers: components["schemas"]["NameCount"][] | null;
+            ratingDistribution: components["schemas"]["RatingDistribution"];
+            relatedDevelopers?: components["schemas"]["RelatedDeveloper"][] | null;
+            timeline?: components["schemas"]["TimelineEntry"][] | null;
+            topGames: components["schemas"]["GameResponse"][] | null;
+            userStats?: components["schemas"]["EntityUserStats"];
+        };
         DeveloperGameResponse: {
             coverUrl: string;
             localGameId: string;
+            name: string;
+        };
+        DeveloperListResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/DeveloperListResponse.json
+             */
+            readonly $schema?: string;
+            developers: components["schemas"]["DeveloperSummary"][] | null;
+        };
+        DeveloperSpotlightResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/DeveloperSpotlightResponse.json
+             */
+            readonly $schema?: string;
+            /** Format: double */
+            avgRating: number;
+            consoles: string[] | null;
+            /** Format: int64 */
+            gameCount: number;
+            heroUrl: string;
+            name: string;
+            topGames: components["schemas"]["GameResponse"][] | null;
+        };
+        DeveloperSummary: {
+            /** Format: double */
+            avgRating: number;
+            consoles: string[] | null;
+            /** Format: int64 */
+            gameCount: number;
             name: string;
         };
         Device: {
@@ -4440,6 +5389,15 @@ export interface components {
             readonly $schema?: string;
             name?: string;
         };
+        EasyToCompleteResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/EasyToCompleteResponse.json
+             */
+            readonly $schema?: string;
+            games: components["schemas"]["AchievementGameResponse"][] | null;
+        };
         EnrichmentStartedResponse: {
             /**
              * Format: uri
@@ -4469,6 +5427,49 @@ export interface components {
             /** Format: int64 */
             total?: number;
         };
+        EntityUserStats: {
+            /** Format: int64 */
+            favoriteCount: number;
+            /** Format: int64 */
+            gamesPlayed: number;
+            mostPlayedGame: components["schemas"]["GameResponse"];
+            /** Format: int64 */
+            totalPlayTime: number;
+        };
+        ExploreChallengeResponse: {
+            /** Format: int64 */
+            attemptCount: number;
+            /** Format: int64 */
+            completionCount: number;
+            consoleName?: string;
+            /** Format: date-time */
+            createdAt: string;
+            creatorUsername: string;
+            description?: string;
+            difficulty: string;
+            /** Format: date-time */
+            expiresAt?: string;
+            gameCoverUrl?: string;
+            gameId: string;
+            gameTitle: string;
+            id: string;
+            name: string;
+            type: string;
+        };
+        ExploreRowResponse: {
+            games: components["schemas"]["GameResponse"][] | null;
+            id: string;
+            title: string;
+        };
+        ExploreRowsResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/ExploreRowsResponse.json
+             */
+            readonly $schema?: string;
+            rows: components["schemas"]["ExploreRowResponse"][] | null;
+        };
         ExplorerBadge: {
             description: string;
             earned: boolean;
@@ -4488,6 +5489,48 @@ export interface components {
              */
             readonly $schema?: string;
             badges: components["schemas"]["ExplorerBadge"][] | null;
+        };
+        FeaturedGameResponse: {
+            consoleAbbreviation: string;
+            consoleColor: string;
+            consoleId: string;
+            consoleName: string;
+            gameId: string;
+            genre: string;
+            heroUrl: string;
+            /** Format: double */
+            igdbCriticsRating: number;
+            isFavorite: boolean;
+            isPlayLater: boolean;
+            logoUrl: string;
+            title: string;
+        };
+        FeaturedSeriesResponse: {
+            /** Format: int64 */
+            consoleCount: number;
+            heroUrl?: string;
+            id: string;
+            /** Format: int64 */
+            libraryGames: number;
+            name: string;
+            /** Format: int64 */
+            totalGames: number;
+        };
+        ForYouResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/ForYouResponse.json
+             */
+            readonly $schema?: string;
+            rows: components["schemas"]["ForYouRowResponse"][] | null;
+        };
+        ForYouRowResponse: {
+            games: components["schemas"]["GameResponse"][] | null;
+            genre?: string;
+            sourceGame?: components["schemas"]["GameResponse"];
+            title: string;
+            type: string;
         };
         FranchiseDetailResponse: {
             /**
@@ -4514,6 +5557,22 @@ export interface components {
             gameCount: number;
             id: string;
             name: string;
+        };
+        FreshChallengeGame: {
+            game: components["schemas"]["GameResponse"];
+            /** Format: int64 */
+            totalAchievements: number;
+            /** Format: int64 */
+            totalPoints: number;
+        };
+        FreshChallengesResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/FreshChallengesResponse.json
+             */
+            readonly $schema?: string;
+            games: components["schemas"]["FreshChallengeGame"][] | null;
         };
         GameArtworkResponse: {
             /**
@@ -4749,6 +5808,20 @@ export interface components {
             userId: string;
             username: string;
         };
+        GenreCount: {
+            /** Format: int64 */
+            gameCount: number;
+            name: string;
+        };
+        HardestGamesResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/HardestGamesResponse.json
+             */
+            readonly $schema?: string;
+            games: components["schemas"]["AchievementGameResponse"][] | null;
+        };
         HardwareMakerResponse: {
             code: string;
             name: string;
@@ -4949,6 +6022,13 @@ export interface components {
             unscraped: components["schemas"]["GameResponse"][] | null;
             unverified: components["schemas"]["GameResponse"][] | null;
         };
+        MoodResponse: {
+            description: string;
+            gradient: string[] | null;
+            icon: string;
+            id: string;
+            name: string;
+        };
         MostActivePlayersResponse: {
             /**
              * Format: uri
@@ -4973,6 +6053,11 @@ export interface components {
              */
             readonly $schema?: string;
             games: components["schemas"]["MostPlayedEntry"][] | null;
+        };
+        NameCount: {
+            /** Format: int64 */
+            count: number;
+            name: string;
         };
         NetplayInviteResponse: {
             /**
@@ -5042,6 +6127,16 @@ export interface components {
             /** Format: date-time */
             startedAt?: string;
             status: string;
+        };
+        OnThisDayResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/OnThisDayResponse.json
+             */
+            readonly $schema?: string;
+            date: string;
+            games: components["schemas"]["GameResponse"][] | null;
         };
         OnlineUserGameResponse: {
             consoleName: string;
@@ -5214,12 +6309,29 @@ export interface components {
             /** Format: int64 */
             count: number;
         };
+        PlatformCount: {
+            consoleId: string;
+            consoleName: string;
+            /** Format: int64 */
+            count: number;
+        };
         PlayStatsEntry: {
             /** Format: int64 */
             gameId: number;
             lastPlayedAt: string;
             /** Format: int64 */
             playTime: number;
+        };
+        PlayersLikeYouResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/PlayersLikeYouResponse.json
+             */
+            readonly $schema?: string;
+            games: components["schemas"]["GameResponse"][] | null;
+            /** Format: int64 */
+            similarUsersCount: number;
         };
         PossibleConsoleResponse: {
             id: string;
@@ -5254,6 +6366,33 @@ export interface components {
             /** Format: int64 */
             totalPlayTime: number;
             username: string;
+        };
+        PublisherDetailResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/PublisherDetailResponse.json
+             */
+            readonly $schema?: string;
+            activeYears?: components["schemas"]["ActiveYears"];
+            /** Format: double */
+            avgRating: number;
+            companyInfo?: components["schemas"]["CompanyInfo"];
+            consoles: string[] | null;
+            developers: components["schemas"]["NameCount"][] | null;
+            /** Format: int64 */
+            gameCount: number;
+            games: components["schemas"]["GameResponse"][] | null;
+            genreBreakdown: components["schemas"]["GenreCount"][] | null;
+            heroUrl?: string;
+            name: string;
+            platformBreakdown: components["schemas"]["PlatformCount"][] | null;
+            primaryGenre?: string;
+            ratingDistribution: components["schemas"]["RatingDistribution"];
+            relatedPublishers?: components["schemas"]["RelatedPublisher"][] | null;
+            timeline?: components["schemas"]["TimelineEntry"][] | null;
+            topGames: components["schemas"]["GameResponse"][] | null;
+            userStats?: components["schemas"]["EntityUserStats"];
         };
         RALeaderboardEntryResponse: {
             avatarUrl: string;
@@ -5369,6 +6508,18 @@ export interface components {
             /** Format: date-time */
             lockedUntil: string | null;
         };
+        RatingDistribution: {
+            /** Format: int64 */
+            average: number;
+            /** Format: int64 */
+            excellent: number;
+            /** Format: int64 */
+            good: number;
+            /** Format: int64 */
+            poor: number;
+            /** Format: int64 */
+            unrated: number;
+        };
         RatingSummaryResponse: {
             /**
              * Format: uri
@@ -5393,6 +6544,24 @@ export interface components {
             readonly $schema?: string;
             achievements: components["schemas"]["RARecentAchievementResponse"][] | null;
         };
+        RecentReviewItem: {
+            game: components["schemas"]["GameResponse"];
+            /** Format: int64 */
+            rating: number;
+            review: string;
+            /** Format: date-time */
+            reviewedAt: string;
+            reviewerName: string;
+        };
+        RecentlyReviewedResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/RecentlyReviewedResponse.json
+             */
+            readonly $schema?: string;
+            reviews: components["schemas"]["RecentReviewItem"][] | null;
+        };
         RefreshAchievementsResponse: {
             /**
              * Format: uri
@@ -5413,6 +6582,18 @@ export interface components {
             deviceUuid?: string;
             name?: string;
             platform?: string;
+        };
+        RelatedDeveloper: {
+            /** Format: int64 */
+            gameCount: number;
+            name: string;
+            sharedPublishers: string[] | null;
+        };
+        RelatedPublisher: {
+            /** Format: int64 */
+            gameCount: number;
+            name: string;
+            sharedDevelopers: string[] | null;
         };
         ReleaseDateResponse: {
             date: string;
@@ -5584,6 +6765,29 @@ export interface components {
             /** Format: int64 */
             notFoundEligible: number;
             source: string;
+        };
+        ScreenshotGalleryResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/ScreenshotGalleryResponse.json
+             */
+            readonly $schema?: string;
+            /** Format: int64 */
+            page: number;
+            screenshots: components["schemas"]["ScreenshotItem"][] | null;
+            /** Format: int64 */
+            totalCount: number;
+            /** Format: int64 */
+            totalPages: number;
+        };
+        ScreenshotItem: {
+            consoleAbbreviation: string;
+            consoleColor: string;
+            consoleName: string;
+            gameId: string;
+            gameTitle: string;
+            url: string;
         };
         SearchCategoryResultSearchCollectionResult: {
             results: components["schemas"]["SearchCollectionResult"][] | null;
@@ -6180,6 +7384,18 @@ export interface components {
             id: string;
             name: string;
         };
+        TimelineEntry: {
+            games: components["schemas"]["TimelineGame"][] | null;
+            /** Format: int64 */
+            year: number;
+        };
+        TimelineGame: {
+            coverUrl: string;
+            id: string;
+            /** Format: double */
+            igdbCriticsRating: number;
+            title: string;
+        };
         TopListGameResponse: {
             consoleId: string;
             consoleName: string;
@@ -6200,6 +7416,20 @@ export interface components {
             name: string;
             /** Format: int64 */
             rank: number;
+        };
+        TrendingGameResponse: {
+            game: components["schemas"]["GameResponse"];
+            /** Format: int64 */
+            playersThisWeek: number;
+        };
+        TrendingResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/TrendingResponse.json
+             */
+            readonly $schema?: string;
+            games: components["schemas"]["TrendingGameResponse"][] | null;
         };
         UnlockedAchievementsResponse: {
             /**
@@ -6519,6 +7749,38 @@ export interface components {
         VideoResponse: {
             name?: string;
             videoId: string;
+        };
+        WizardOption: {
+            description?: string;
+            id: string;
+            imageUrl?: string;
+            label: string;
+        };
+        WizardResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/WizardResponse.json
+             */
+            readonly $schema?: string;
+            steps: components["schemas"]["WizardStep"][] | null;
+        };
+        WizardResultsResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/WizardResultsResponse.json
+             */
+            readonly $schema?: string;
+            games: components["schemas"]["GameResponse"][] | null;
+            title: string;
+        };
+        WizardStep: {
+            options: components["schemas"]["WizardOption"][] | null;
+            /** Format: int64 */
+            step: number;
+            title: string;
+            type: string;
         };
     };
     responses: never;
@@ -9189,6 +10451,1049 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ReportedResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getActiveChallenges: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActiveChallengesResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getActiveNow: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ActiveNowResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getAlmostDone: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AlmostDoneResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getArtworkGallery: {
+        parameters: {
+            query?: {
+                /** @description 1-based page number (defaults to 1). */
+                page?: number;
+                /** @description Page size (defaults to 40, max 100). */
+                limit?: number;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ArtworkGalleryResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getBestOfYear: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Release year (1970-2100). */
+                year: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["BestOfYearResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getCommunityTop: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CommunityTopResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getConsoleHighlights: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConsoleHighlightsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getConsoleShowcase: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Console abbreviation (e.g. 'snes'). */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ConsoleShowcaseResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getCoverGallery: {
+        parameters: {
+            query?: {
+                /** @description 1-based page number (defaults to 1). */
+                page?: number;
+                /** @description Page size (defaults to 60, max 200). */
+                limit?: number;
+                /** @description Console abbreviation filter. */
+                console?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CoverGalleryResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getCultClassics: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["CultClassicsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getDecades: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Decade identifier: '80s', '90s', or '00s'. */
+                decade: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DecadesResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getDevelopers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeveloperListResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getDeveloperSpotlight: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeveloperSpotlightResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getDeveloperDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Developer name (URL-decoded). */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["DeveloperDetailResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getEasyToComplete: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["EasyToCompleteResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getExploreFeatured: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeaturedGameResponse"][] | null;
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getForYou: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ForYouResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getFreshChallenges: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FreshChallengesResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getHardestGames: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HardestGamesResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getMoodGames: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Mood identifier, e.g. 'chill', 'challenge'. */
+                mood: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GameResponse"][] | null;
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getExploreMoods: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["MoodResponse"][] | null;
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getOnThisDay: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["OnThisDayResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getPlayersLikeYou: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PlayersLikeYouResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getPublisherDetail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Publisher name (URL-decoded). */
+                name: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["PublisherDetailResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getRecentlyReviewed: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RecentlyReviewedResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getExploreRows: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ExploreRowsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getScreenshotGallery: {
+        parameters: {
+            query?: {
+                /** @description 1-based page number (defaults to 1). */
+                page?: number;
+                /** @description Page size (defaults to 40, max 100). */
+                limit?: number;
+                /** @description Console abbreviation filter. */
+                console?: string;
+                /** @description Genre filter. */
+                genre?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["ScreenshotGalleryResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getExploreFeaturedSeries: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["FeaturedSeriesResponse"][] | null;
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getSurpriseGame: {
+        parameters: {
+            query?: {
+                /** @description Console abbreviation filter. */
+                console?: string;
+                /** @description Genre filter. */
+                genre?: string;
+                /** @description Minimum IGDB rating (0-100); defaults to 70. */
+                minRating?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["GameResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getTrending: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrendingResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getWizardSteps: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WizardResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getWizardResults: {
+        parameters: {
+            query?: {
+                /** @description Chosen mood (action|chill|story|challenge|fun). */
+                mood?: string;
+                /** @description Chosen era (80s|early90s|late90s|2000s|any). */
+                era?: string;
+                /** @description Chosen vibe (solo|multiplayer|short|long|any). */
+                vibe?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["WizardResultsResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getYourAnniversaries: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    "Cache-Control"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AnniversariesResponse"];
                 };
             };
             /** @description Error */

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -996,6 +996,106 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Sign in
+         * @description Authenticates a user and returns access + refresh tokens. Enforces lockout after repeated failures and performs a dummy bcrypt comparison on unknown usernames to prevent timing-based username enumeration.
+         */
+        post: operations["authLogin"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Rotate refresh token
+         * @description Exchanges a refresh token for new access + refresh tokens. Uses token families for replay detection: presenting a consumed token revokes the entire family.
+         */
+        post: operations["authRefresh"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Register a new account
+         * @description Creates a new user account. The very first user becomes the server owner and is signed in immediately. Subsequent registrations are pending admin approval (HTTP 202) unless registration has been disabled.
+         */
+        post: operations["authRegister"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/setup": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Perform first-time server setup
+         * @description Creates the initial owner account. Fails with 403 after a user already exists.
+         */
+        post: operations["authSetup"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/auth/setup-status": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get server setup status
+         * @description Returns whether the server needs first-time setup, whether new-account registration is enabled, and how many games are indexed.
+         */
+        get: operations["authSetupStatus"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/bios": {
         parameters: {
             query?: never;
@@ -4692,6 +4792,74 @@ export interface components {
             /** Format: int64 */
             width: number;
         };
+        AuthLoginRequest: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/AuthLoginRequest.json
+             */
+            readonly $schema?: string;
+            /** @description Plain-text password (max 72 bytes — bcrypt limit). */
+            password: string;
+            /** @description Username to sign in as. */
+            username: string;
+        };
+        AuthLoginResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/AuthLoginResponse.json
+             */
+            readonly $schema?: string;
+            accessToken: string;
+            refreshToken: string;
+            user: components["schemas"]["UserResponse"];
+        };
+        AuthRefreshRequest: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/AuthRefreshRequest.json
+             */
+            readonly $schema?: string;
+            /** @description Raw refresh token previously issued by login/register/refresh. */
+            refreshToken: string;
+        };
+        AuthRegisterRequest: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/AuthRegisterRequest.json
+             */
+            readonly $schema?: string;
+            /**
+             * Format: email
+             * @description New account email.
+             */
+            email: string;
+            /** @description New account password (8-72 characters). */
+            password: string;
+            /** @description New account username (3-64 alphanumeric characters). */
+            username: string;
+        };
+        AuthRegisterResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/AuthRegisterResponse.json
+             */
+            readonly $schema?: string;
+            /** @description Bearer access token. */
+            accessToken?: string;
+            /** @description Human-readable status message (only set when pending). */
+            message?: string;
+            /** @description True when the new account is awaiting admin approval. When true, no tokens are returned. */
+            pending?: boolean;
+            /** @description Refresh token (rotate via /api/auth/refresh). */
+            refreshToken?: string;
+            /** @description Registered user profile. */
+            user?: components["schemas"]["UserResponse"];
+        };
         BackfillImagesResponse: {
             /**
              * Format: uri
@@ -7008,6 +7176,23 @@ export interface components {
              */
             readonly $schema?: string;
             consoleId?: string;
+        };
+        SetupStatusResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/SetupStatusResponse.json
+             */
+            readonly $schema?: string;
+            /**
+             * Format: int64
+             * @description Total number of games indexed on the server.
+             */
+            gameCount: number;
+            /** @description True when no user accounts exist and the server requires first-time setup. */
+            needsSetup: boolean;
+            /** @description True when new-account registration is currently allowed. */
+            registrationEnabled: boolean;
         };
         SharedSaveResponse: {
             avatarUrl?: string;
@@ -9560,6 +9745,167 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["MessageResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    authLogin: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthLoginRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthLoginResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    authRefresh: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthRefreshRequest"];
+            };
+        };
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthLoginResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    authRegister: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthRegisterRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthRegisterResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    authSetup: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["AuthRegisterRequest"];
+            };
+        };
+        responses: {
+            /** @description Created */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["AuthLoginResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    authSetupStatus: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["SetupStatusResponse"];
                 };
             };
             /** @description Error */

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -678,6 +678,161 @@
         ],
         "type": "object"
       },
+      "AuthLoginRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/AuthLoginRequest.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "password": {
+            "description": "Plain-text password (max 72 bytes — bcrypt limit).",
+            "maxLength": 72,
+            "minLength": 1,
+            "type": "string"
+          },
+          "username": {
+            "description": "Username to sign in as.",
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "password"
+        ],
+        "type": "object"
+      },
+      "AuthLoginResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/AuthLoginResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "accessToken": {
+            "type": "string"
+          },
+          "refreshToken": {
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/UserResponse"
+          }
+        },
+        "required": [
+          "accessToken",
+          "refreshToken",
+          "user"
+        ],
+        "type": "object"
+      },
+      "AuthRefreshRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/AuthRefreshRequest.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "refreshToken": {
+            "description": "Raw refresh token previously issued by login/register/refresh.",
+            "minLength": 1,
+            "type": "string"
+          }
+        },
+        "required": [
+          "refreshToken"
+        ],
+        "type": "object"
+      },
+      "AuthRegisterRequest": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/AuthRegisterRequest.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "email": {
+            "description": "New account email.",
+            "format": "email",
+            "type": "string"
+          },
+          "password": {
+            "description": "New account password (8-72 characters).",
+            "maxLength": 72,
+            "minLength": 8,
+            "type": "string"
+          },
+          "username": {
+            "description": "New account username (3-64 alphanumeric characters).",
+            "maxLength": 64,
+            "minLength": 3,
+            "pattern": "^[a-zA-Z0-9]+$",
+            "type": "string"
+          }
+        },
+        "required": [
+          "username",
+          "email",
+          "password"
+        ],
+        "type": "object"
+      },
+      "AuthRegisterResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/AuthRegisterResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "accessToken": {
+            "description": "Bearer access token.",
+            "type": "string"
+          },
+          "message": {
+            "description": "Human-readable status message (only set when pending).",
+            "type": "string"
+          },
+          "pending": {
+            "description": "True when the new account is awaiting admin approval. When true, no tokens are returned.",
+            "type": "boolean"
+          },
+          "refreshToken": {
+            "description": "Refresh token (rotate via /api/auth/refresh).",
+            "type": "string"
+          },
+          "user": {
+            "$ref": "#/components/schemas/UserResponse",
+            "description": "Registered user profile."
+          }
+        },
+        "type": "object"
+      },
       "BackfillImagesResponse": {
         "additionalProperties": false,
         "properties": {
@@ -7693,6 +7848,39 @@
         },
         "type": "object"
       },
+      "SetupStatusResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/SetupStatusResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "gameCount": {
+            "description": "Total number of games indexed on the server.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "needsSetup": {
+            "description": "True when no user accounts exist and the server requires first-time setup.",
+            "type": "boolean"
+          },
+          "registrationEnabled": {
+            "description": "True when new-account registration is currently allowed.",
+            "type": "boolean"
+          }
+        },
+        "required": [
+          "needsSetup",
+          "registrationEnabled",
+          "gameCount"
+        ],
+        "type": "object"
+      },
       "SharedSaveResponse": {
         "additionalProperties": false,
         "properties": {
@@ -12568,6 +12756,206 @@
         "summary": "Get a user's login rate-limit status",
         "tags": [
           "admin"
+        ]
+      }
+    },
+    "/api/auth/login": {
+      "post": {
+        "description": "Authenticates a user and returns access + refresh tokens. Enforces lockout after repeated failures and performs a dummy bcrypt comparison on unknown usernames to prevent timing-based username enumeration.",
+        "operationId": "authLogin",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthLoginRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthLoginResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Sign in",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/refresh": {
+      "post": {
+        "description": "Exchanges a refresh token for new access + refresh tokens. Uses token families for replay detection: presenting a consumed token revokes the entire family.",
+        "operationId": "authRefresh",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthRefreshRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthLoginResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Rotate refresh token",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/register": {
+      "post": {
+        "description": "Creates a new user account. The very first user becomes the server owner and is signed in immediately. Subsequent registrations are pending admin approval (HTTP 202) unless registration has been disabled.",
+        "operationId": "authRegister",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthRegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthRegisterResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Register a new account",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/setup": {
+      "post": {
+        "description": "Creates the initial owner account. Fails with 403 after a user already exists.",
+        "operationId": "authSetup",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AuthRegisterRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AuthLoginResponse"
+                }
+              }
+            },
+            "description": "Created"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Perform first-time server setup",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/auth/setup-status": {
+      "get": {
+        "description": "Returns whether the server needs first-time setup, whether new-account registration is enabled, and how many games are indexed.",
+        "operationId": "authSetupStatus",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SetupStatusResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "summary": "Get server setup status",
+        "tags": [
+          "auth"
         ]
       }
     },

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -1,6 +1,38 @@
 {
   "components": {
     "schemas": {
+      "AchievementGameResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "avgCompletion": {
+            "format": "double",
+            "type": "number"
+          },
+          "game": {
+            "$ref": "#/components/schemas/GameResponse"
+          },
+          "playersAttempted": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "playersCompleted": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalAchievements": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "game",
+          "totalAchievements",
+          "avgCompletion",
+          "playersAttempted",
+          "playersCompleted"
+        ],
+        "type": "object"
+      },
       "AchievementLeaderboardResponse": {
         "additionalProperties": false,
         "properties": {
@@ -101,6 +133,82 @@
         ],
         "type": "object"
       },
+      "ActiveChallengesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/ActiveChallengesResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "challenges": {
+            "items": {
+              "$ref": "#/components/schemas/ExploreChallengeResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "challenges"
+        ],
+        "type": "object"
+      },
+      "ActiveNowItem": {
+        "additionalProperties": false,
+        "properties": {
+          "activeChallenges": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "activeSessions": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "game": {
+            "$ref": "#/components/schemas/GameResponse"
+          }
+        },
+        "required": [
+          "game",
+          "activeSessions",
+          "activeChallenges"
+        ],
+        "type": "object"
+      },
+      "ActiveNowResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/ActiveNowResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/ActiveNowItem"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "games"
+        ],
+        "type": "object"
+      },
       "ActivePlayerEntry": {
         "additionalProperties": false,
         "properties": {
@@ -133,6 +241,24 @@
           "totalPlayTime",
           "gamesPlayed",
           "lastPlayed"
+        ],
+        "type": "object"
+      },
+      "ActiveYears": {
+        "additionalProperties": false,
+        "properties": {
+          "first": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "last": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "first",
+          "last"
         ],
         "type": "object"
       },
@@ -346,6 +472,109 @@
         ],
         "type": "object"
       },
+      "AlmostDoneGame": {
+        "additionalProperties": false,
+        "properties": {
+          "completionPercent": {
+            "format": "double",
+            "type": "number"
+          },
+          "game": {
+            "$ref": "#/components/schemas/GameResponse"
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "unlockedCount": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "game",
+          "unlockedCount",
+          "totalCount",
+          "completionPercent"
+        ],
+        "type": "object"
+      },
+      "AlmostDoneResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/AlmostDoneResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/AlmostDoneGame"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "games"
+        ],
+        "type": "object"
+      },
+      "AnniversariesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/AnniversariesResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "anniversaries": {
+            "items": {
+              "$ref": "#/components/schemas/AnniversaryItem"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "anniversaries"
+        ],
+        "type": "object"
+      },
+      "AnniversaryItem": {
+        "additionalProperties": false,
+        "properties": {
+          "game": {
+            "$ref": "#/components/schemas/GameResponse"
+          },
+          "playedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "yearsAgo": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "game",
+          "yearsAgo",
+          "playedAt"
+        ],
+        "type": "object"
+      },
       "ApplyIGDBMatchRequest": {
         "additionalProperties": false,
         "properties": {
@@ -363,6 +592,90 @@
             "type": "integer"
           }
         },
+        "type": "object"
+      },
+      "ArtworkGalleryResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/ArtworkGalleryResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "artworks": {
+            "items": {
+              "$ref": "#/components/schemas/ArtworkItem"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "page": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalPages": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "artworks",
+          "page",
+          "totalPages",
+          "totalCount"
+        ],
+        "type": "object"
+      },
+      "ArtworkItem": {
+        "additionalProperties": false,
+        "properties": {
+          "consoleAbbreviation": {
+            "type": "string"
+          },
+          "consoleColor": {
+            "type": "string"
+          },
+          "consoleName": {
+            "type": "string"
+          },
+          "gameId": {
+            "type": "string"
+          },
+          "gameTitle": {
+            "type": "string"
+          },
+          "height": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "url": {
+            "type": "string"
+          },
+          "width": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "url",
+          "width",
+          "height",
+          "gameId",
+          "gameTitle",
+          "consoleName",
+          "consoleAbbreviation",
+          "consoleColor"
+        ],
         "type": "object"
       },
       "BackfillImagesResponse": {
@@ -409,6 +722,38 @@
           "galleryDownloaded",
           "companyDownloaded",
           "errors"
+        ],
+        "type": "object"
+      },
+      "BestOfYearResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/BestOfYearResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "year": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "year",
+          "games"
         ],
         "type": "object"
       },
@@ -968,6 +1313,55 @@
         ],
         "type": "object"
       },
+      "CommunityTopGame": {
+        "additionalProperties": false,
+        "properties": {
+          "avgRating": {
+            "format": "double",
+            "type": "number"
+          },
+          "game": {
+            "$ref": "#/components/schemas/GameResponse"
+          },
+          "ratingCount": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "game",
+          "avgRating",
+          "ratingCount"
+        ],
+        "type": "object"
+      },
+      "CommunityTopResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/CommunityTopResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/CommunityTopGame"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "games"
+        ],
+        "type": "object"
+      },
       "CompactSavesResponse": {
         "additionalProperties": false,
         "properties": {
@@ -993,6 +1387,31 @@
           "deletedCount",
           "freedBytes"
         ],
+        "type": "object"
+      },
+      "CompanyInfo": {
+        "additionalProperties": false,
+        "properties": {
+          "country": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "foundedYear": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "logoUrl": {
+            "type": "string"
+          },
+          "websiteUrl": {
+            "type": "string"
+          },
+          "wikipediaUrl": {
+            "type": "string"
+          }
+        },
         "type": "object"
       },
       "CompletionistConsole": {
@@ -1153,6 +1572,70 @@
         ],
         "type": "object"
       },
+      "ConsoleHighlight": {
+        "additionalProperties": false,
+        "properties": {
+          "colorTheme": {
+            "type": "string"
+          },
+          "gameCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "iconUrl": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "logoUrl": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "topGame": {
+            "$ref": "#/components/schemas/GameResponse"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "colorTheme",
+          "iconUrl",
+          "logoUrl",
+          "gameCount",
+          "topGame"
+        ],
+        "type": "object"
+      },
+      "ConsoleHighlightsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/ConsoleHighlightsResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "consoles": {
+            "items": {
+              "$ref": "#/components/schemas/ConsoleHighlight"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "consoles"
+        ],
+        "type": "object"
+      },
       "ConsoleKeyMappingDTO": {
         "additionalProperties": false,
         "properties": {
@@ -1297,6 +1780,87 @@
         ],
         "type": "object"
       },
+      "ConsoleShowcaseResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/ConsoleShowcaseResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "console": {
+            "$ref": "#/components/schemas/ConsoleResponse"
+          },
+          "essentials": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "genreBreakdown": {
+            "items": {
+              "$ref": "#/components/schemas/GenreCount"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "hiddenGems": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "recentlyAdded": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "recentlyPlayed": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "topDevelopers": {
+            "items": {
+              "$ref": "#/components/schemas/DeveloperSummary"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "console",
+          "essentials",
+          "hiddenGems",
+          "genreBreakdown",
+          "topDevelopers",
+          "recentlyPlayed",
+          "recentlyAdded"
+        ],
+        "type": "object"
+      },
       "Core": {
         "additionalProperties": false,
         "properties": {
@@ -1394,6 +1958,90 @@
         },
         "required": [
           "consoles"
+        ],
+        "type": "object"
+      },
+      "CoverGalleryResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/CoverGalleryResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "covers": {
+            "items": {
+              "$ref": "#/components/schemas/CoverItem"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "page": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalPages": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "covers",
+          "page",
+          "totalPages",
+          "totalCount"
+        ],
+        "type": "object"
+      },
+      "CoverItem": {
+        "additionalProperties": false,
+        "properties": {
+          "consoleAbbreviation": {
+            "type": "string"
+          },
+          "consoleColor": {
+            "type": "string"
+          },
+          "consoleName": {
+            "type": "string"
+          },
+          "coverAspectRatio": {
+            "format": "double",
+            "type": "number"
+          },
+          "coverUrl": {
+            "type": "string"
+          },
+          "gameId": {
+            "type": "string"
+          },
+          "gameTitle": {
+            "type": "string"
+          },
+          "igdbCriticsRating": {
+            "format": "double",
+            "type": "number"
+          }
+        },
+        "required": [
+          "coverUrl",
+          "gameId",
+          "gameTitle",
+          "consoleName",
+          "consoleAbbreviation",
+          "consoleColor",
+          "igdbCriticsRating",
+          "coverAspectRatio"
         ],
         "type": "object"
       },
@@ -1529,6 +2177,95 @@
         },
         "type": "object"
       },
+      "CultClassicGame": {
+        "additionalProperties": false,
+        "properties": {
+          "communityRating": {
+            "format": "double",
+            "type": "number"
+          },
+          "game": {
+            "$ref": "#/components/schemas/GameResponse"
+          },
+          "igdbCriticsRating": {
+            "format": "double",
+            "type": "number"
+          },
+          "ratingCount": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "game",
+          "communityRating",
+          "igdbCriticsRating",
+          "ratingCount"
+        ],
+        "type": "object"
+      },
+      "CultClassicsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/CultClassicsResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/CultClassicGame"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "games"
+        ],
+        "type": "object"
+      },
+      "DecadesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/DecadesResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "decade": {
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "decade",
+          "label",
+          "games"
+        ],
+        "type": "object"
+      },
       "DeletedStatusResponse": {
         "additionalProperties": false,
         "properties": {
@@ -1588,6 +2325,134 @@
         ],
         "type": "object"
       },
+      "DeveloperDetailResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/DeveloperDetailResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "activeYears": {
+            "$ref": "#/components/schemas/ActiveYears"
+          },
+          "avgRating": {
+            "format": "double",
+            "type": "number"
+          },
+          "companyInfo": {
+            "$ref": "#/components/schemas/CompanyInfo"
+          },
+          "consoles": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "gameCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "genreBreakdown": {
+            "items": {
+              "$ref": "#/components/schemas/GenreCount"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "heroUrl": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "platformBreakdown": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformCount"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "primaryGenre": {
+            "type": "string"
+          },
+          "publishers": {
+            "items": {
+              "$ref": "#/components/schemas/NameCount"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "ratingDistribution": {
+            "$ref": "#/components/schemas/RatingDistribution"
+          },
+          "relatedDevelopers": {
+            "items": {
+              "$ref": "#/components/schemas/RelatedDeveloper"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "timeline": {
+            "items": {
+              "$ref": "#/components/schemas/TimelineEntry"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "topGames": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "userStats": {
+            "$ref": "#/components/schemas/EntityUserStats"
+          }
+        },
+        "required": [
+          "name",
+          "gameCount",
+          "avgRating",
+          "consoles",
+          "games",
+          "topGames",
+          "genreBreakdown",
+          "platformBreakdown",
+          "publishers",
+          "ratingDistribution"
+        ],
+        "type": "object"
+      },
       "DeveloperGameResponse": {
         "additionalProperties": false,
         "properties": {
@@ -1605,6 +2470,120 @@
           "name",
           "coverUrl",
           "localGameId"
+        ],
+        "type": "object"
+      },
+      "DeveloperListResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/DeveloperListResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "developers": {
+            "items": {
+              "$ref": "#/components/schemas/DeveloperSummary"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "developers"
+        ],
+        "type": "object"
+      },
+      "DeveloperSpotlightResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/DeveloperSpotlightResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "avgRating": {
+            "format": "double",
+            "type": "number"
+          },
+          "consoles": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "gameCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "heroUrl": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "topGames": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "gameCount",
+          "avgRating",
+          "consoles",
+          "topGames",
+          "heroUrl"
+        ],
+        "type": "object"
+      },
+      "DeveloperSummary": {
+        "additionalProperties": false,
+        "properties": {
+          "avgRating": {
+            "format": "double",
+            "type": "number"
+          },
+          "consoles": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "gameCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "gameCount",
+          "avgRating",
+          "consoles"
         ],
         "type": "object"
       },
@@ -1812,6 +2791,33 @@
         },
         "type": "object"
       },
+      "EasyToCompleteResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/EasyToCompleteResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/AchievementGameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "games"
+        ],
+        "type": "object"
+      },
       "EnrichmentStartedResponse": {
         "additionalProperties": false,
         "properties": {
@@ -1878,6 +2884,150 @@
         ],
         "type": "object"
       },
+      "EntityUserStats": {
+        "additionalProperties": false,
+        "properties": {
+          "favoriteCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "gamesPlayed": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "mostPlayedGame": {
+            "$ref": "#/components/schemas/GameResponse"
+          },
+          "totalPlayTime": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "totalPlayTime",
+          "gamesPlayed",
+          "favoriteCount",
+          "mostPlayedGame"
+        ],
+        "type": "object"
+      },
+      "ExploreChallengeResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "attemptCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "completionCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "consoleName": {
+            "type": "string"
+          },
+          "createdAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "creatorUsername": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string"
+          },
+          "difficulty": {
+            "type": "string"
+          },
+          "expiresAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "gameCoverUrl": {
+            "type": "string"
+          },
+          "gameId": {
+            "type": "string"
+          },
+          "gameTitle": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "creatorUsername",
+          "gameId",
+          "gameTitle",
+          "name",
+          "type",
+          "difficulty",
+          "attemptCount",
+          "completionCount",
+          "createdAt"
+        ],
+        "type": "object"
+      },
+      "ExploreRowResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "id": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "games"
+        ],
+        "type": "object"
+      },
+      "ExploreRowsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/ExploreRowsResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/ExploreRowResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "rows"
+        ],
+        "type": "object"
+      },
       "ExplorerBadge": {
         "additionalProperties": false,
         "properties": {
@@ -1940,6 +3090,156 @@
         },
         "required": [
           "badges"
+        ],
+        "type": "object"
+      },
+      "FeaturedGameResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "consoleAbbreviation": {
+            "type": "string"
+          },
+          "consoleColor": {
+            "type": "string"
+          },
+          "consoleId": {
+            "type": "string"
+          },
+          "consoleName": {
+            "type": "string"
+          },
+          "gameId": {
+            "type": "string"
+          },
+          "genre": {
+            "type": "string"
+          },
+          "heroUrl": {
+            "type": "string"
+          },
+          "igdbCriticsRating": {
+            "format": "double",
+            "type": "number"
+          },
+          "isFavorite": {
+            "type": "boolean"
+          },
+          "isPlayLater": {
+            "type": "boolean"
+          },
+          "logoUrl": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "gameId",
+          "title",
+          "heroUrl",
+          "logoUrl",
+          "consoleId",
+          "consoleName",
+          "consoleAbbreviation",
+          "consoleColor",
+          "igdbCriticsRating",
+          "genre",
+          "isFavorite",
+          "isPlayLater"
+        ],
+        "type": "object"
+      },
+      "FeaturedSeriesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "consoleCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "heroUrl": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "libraryGames": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "totalGames": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "libraryGames",
+          "totalGames",
+          "consoleCount"
+        ],
+        "type": "object"
+      },
+      "ForYouResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/ForYouResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "rows": {
+            "items": {
+              "$ref": "#/components/schemas/ForYouRowResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "rows"
+        ],
+        "type": "object"
+      },
+      "ForYouRowResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "genre": {
+            "type": "string"
+          },
+          "sourceGame": {
+            "$ref": "#/components/schemas/GameResponse"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "type",
+          "title",
+          "games"
         ],
         "type": "object"
       },
@@ -2027,6 +3327,55 @@
           "id",
           "name",
           "gameCount"
+        ],
+        "type": "object"
+      },
+      "FreshChallengeGame": {
+        "additionalProperties": false,
+        "properties": {
+          "game": {
+            "$ref": "#/components/schemas/GameResponse"
+          },
+          "totalAchievements": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalPoints": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "game",
+          "totalAchievements",
+          "totalPoints"
+        ],
+        "type": "object"
+      },
+      "FreshChallengesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/FreshChallengesResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/FreshChallengeGame"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "games"
         ],
         "type": "object"
       },
@@ -2755,6 +4104,50 @@
         ],
         "type": "object"
       },
+      "GenreCount": {
+        "additionalProperties": false,
+        "properties": {
+          "gameCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "gameCount"
+        ],
+        "type": "object"
+      },
+      "HardestGamesResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/HardestGamesResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/AchievementGameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "games"
+        ],
+        "type": "object"
+      },
       "HardwareMakerResponse": {
         "additionalProperties": false,
         "properties": {
@@ -3314,6 +4707,40 @@
         ],
         "type": "object"
       },
+      "MoodResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "gradient": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "icon": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "description",
+          "icon",
+          "gradient"
+        ],
+        "type": "object"
+      },
       "MostActivePlayersResponse": {
         "additionalProperties": false,
         "properties": {
@@ -3387,6 +4814,23 @@
         },
         "required": [
           "games"
+        ],
+        "type": "object"
+      },
+      "NameCount": {
+        "additionalProperties": false,
+        "properties": {
+          "count": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "name",
+          "count"
         ],
         "type": "object"
       },
@@ -3583,6 +5027,37 @@
           "inputDelay",
           "inviteCode",
           "createdAt"
+        ],
+        "type": "object"
+      },
+      "OnThisDayResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/OnThisDayResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "date": {
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "date",
+          "games"
         ],
         "type": "object"
       },
@@ -4077,6 +5552,27 @@
         ],
         "type": "object"
       },
+      "PlatformCount": {
+        "additionalProperties": false,
+        "properties": {
+          "consoleId": {
+            "type": "string"
+          },
+          "consoleName": {
+            "type": "string"
+          },
+          "count": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "consoleName",
+          "consoleId",
+          "count"
+        ],
+        "type": "object"
+      },
       "PlayStatsEntry": {
         "additionalProperties": false,
         "properties": {
@@ -4097,6 +5593,38 @@
           "gameId",
           "playTime",
           "lastPlayedAt"
+        ],
+        "type": "object"
+      },
+      "PlayersLikeYouResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/PlayersLikeYouResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "similarUsersCount": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "games",
+          "similarUsersCount"
         ],
         "type": "object"
       },
@@ -4220,6 +5748,134 @@
           "favoriteGames",
           "recentGames",
           "topGames"
+        ],
+        "type": "object"
+      },
+      "PublisherDetailResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/PublisherDetailResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "activeYears": {
+            "$ref": "#/components/schemas/ActiveYears"
+          },
+          "avgRating": {
+            "format": "double",
+            "type": "number"
+          },
+          "companyInfo": {
+            "$ref": "#/components/schemas/CompanyInfo"
+          },
+          "consoles": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "developers": {
+            "items": {
+              "$ref": "#/components/schemas/NameCount"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "gameCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "genreBreakdown": {
+            "items": {
+              "$ref": "#/components/schemas/GenreCount"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "heroUrl": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "platformBreakdown": {
+            "items": {
+              "$ref": "#/components/schemas/PlatformCount"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "primaryGenre": {
+            "type": "string"
+          },
+          "ratingDistribution": {
+            "$ref": "#/components/schemas/RatingDistribution"
+          },
+          "relatedPublishers": {
+            "items": {
+              "$ref": "#/components/schemas/RelatedPublisher"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "timeline": {
+            "items": {
+              "$ref": "#/components/schemas/TimelineEntry"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "topGames": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "userStats": {
+            "$ref": "#/components/schemas/EntityUserStats"
+          }
+        },
+        "required": [
+          "name",
+          "gameCount",
+          "avgRating",
+          "consoles",
+          "games",
+          "topGames",
+          "genreBreakdown",
+          "platformBreakdown",
+          "developers",
+          "ratingDistribution"
         ],
         "type": "object"
       },
@@ -4557,6 +6213,39 @@
         ],
         "type": "object"
       },
+      "RatingDistribution": {
+        "additionalProperties": false,
+        "properties": {
+          "average": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "excellent": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "good": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "poor": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "unrated": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "excellent",
+          "good",
+          "average",
+          "poor",
+          "unrated"
+        ],
+        "type": "object"
+      },
       "RatingSummaryResponse": {
         "additionalProperties": false,
         "properties": {
@@ -4619,6 +6308,63 @@
         ],
         "type": "object"
       },
+      "RecentReviewItem": {
+        "additionalProperties": false,
+        "properties": {
+          "game": {
+            "$ref": "#/components/schemas/GameResponse"
+          },
+          "rating": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "review": {
+            "type": "string"
+          },
+          "reviewedAt": {
+            "format": "date-time",
+            "type": "string"
+          },
+          "reviewerName": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "game",
+          "rating",
+          "review",
+          "reviewerName",
+          "reviewedAt"
+        ],
+        "type": "object"
+      },
+      "RecentlyReviewedResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/RecentlyReviewedResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "reviews": {
+            "items": {
+              "$ref": "#/components/schemas/RecentReviewItem"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "reviews"
+        ],
+        "type": "object"
+      },
       "RefreshAchievementsResponse": {
         "additionalProperties": false,
         "properties": {
@@ -4666,6 +6412,60 @@
             "type": "string"
           }
         },
+        "type": "object"
+      },
+      "RelatedDeveloper": {
+        "additionalProperties": false,
+        "properties": {
+          "gameCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sharedPublishers": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "gameCount",
+          "sharedPublishers"
+        ],
+        "type": "object"
+      },
+      "RelatedPublisher": {
+        "additionalProperties": false,
+        "properties": {
+          "gameCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "name": {
+            "type": "string"
+          },
+          "sharedDevelopers": {
+            "items": {
+              "type": "string"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "name",
+          "gameCount",
+          "sharedDevelopers"
+        ],
         "type": "object"
       },
       "ReleaseDateResponse": {
@@ -5092,6 +6892,80 @@
           "error",
           "errorEligible",
           "notAttempted"
+        ],
+        "type": "object"
+      },
+      "ScreenshotGalleryResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/ScreenshotGalleryResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "page": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "screenshots": {
+            "items": {
+              "$ref": "#/components/schemas/ScreenshotItem"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "totalCount": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "totalPages": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "screenshots",
+          "page",
+          "totalPages",
+          "totalCount"
+        ],
+        "type": "object"
+      },
+      "ScreenshotItem": {
+        "additionalProperties": false,
+        "properties": {
+          "consoleAbbreviation": {
+            "type": "string"
+          },
+          "consoleColor": {
+            "type": "string"
+          },
+          "consoleName": {
+            "type": "string"
+          },
+          "gameId": {
+            "type": "string"
+          },
+          "gameTitle": {
+            "type": "string"
+          },
+          "url": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "url",
+          "gameId",
+          "gameTitle",
+          "consoleName",
+          "consoleAbbreviation",
+          "consoleColor"
         ],
         "type": "object"
       },
@@ -6926,6 +8800,54 @@
         ],
         "type": "object"
       },
+      "TimelineEntry": {
+        "additionalProperties": false,
+        "properties": {
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/TimelineGame"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "year": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "year",
+          "games"
+        ],
+        "type": "object"
+      },
+      "TimelineGame": {
+        "additionalProperties": false,
+        "properties": {
+          "coverUrl": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "igdbCriticsRating": {
+            "format": "double",
+            "type": "number"
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "title",
+          "coverUrl",
+          "igdbCriticsRating"
+        ],
+        "type": "object"
+      },
       "TopListGameResponse": {
         "additionalProperties": false,
         "properties": {
@@ -6998,6 +8920,50 @@
           "igdbCriticsRating",
           "localGameId",
           "consoleName"
+        ],
+        "type": "object"
+      },
+      "TrendingGameResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "game": {
+            "$ref": "#/components/schemas/GameResponse"
+          },
+          "playersThisWeek": {
+            "format": "int64",
+            "type": "integer"
+          }
+        },
+        "required": [
+          "game",
+          "playersThisWeek"
+        ],
+        "type": "object"
+      },
+      "TrendingResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/TrendingResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/TrendingGameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "games"
         ],
         "type": "object"
       },
@@ -7789,6 +9755,117 @@
         },
         "required": [
           "videoId"
+        ],
+        "type": "object"
+      },
+      "WizardOption": {
+        "additionalProperties": false,
+        "properties": {
+          "description": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "imageUrl": {
+            "type": "string"
+          },
+          "label": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "label"
+        ],
+        "type": "object"
+      },
+      "WizardResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/WizardResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "steps": {
+            "items": {
+              "$ref": "#/components/schemas/WizardStep"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          }
+        },
+        "required": [
+          "steps"
+        ],
+        "type": "object"
+      },
+      "WizardResultsResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/WizardResultsResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "games": {
+            "items": {
+              "$ref": "#/components/schemas/GameResponse"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "title": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "games",
+          "title"
+        ],
+        "type": "object"
+      },
+      "WizardStep": {
+        "additionalProperties": false,
+        "properties": {
+          "options": {
+            "items": {
+              "$ref": "#/components/schemas/WizardOption"
+            },
+            "type": [
+              "array",
+              "null"
+            ]
+          },
+          "step": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "title": {
+            "type": "string"
+          },
+          "type": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "step",
+          "title",
+          "type",
+          "options"
         ],
         "type": "object"
       }
@@ -12084,6 +14161,1720 @@
         "summary": "Report a client-side emulator error",
         "tags": [
           "system"
+        ]
+      }
+    },
+    "/api/explore/active-challenges": {
+      "get": {
+        "description": "Returns the 10 most recent active Challenge entities that have not yet expired.",
+        "operationId": "getActiveChallenges",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActiveChallengesResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get active community challenges",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/active-now": {
+      "get": {
+        "description": "Returns up to 20 games currently with active shared sessions and/or active challenges, sorted by combined activity.",
+        "operationId": "getActiveNow",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ActiveNowResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get games with active shared sessions or challenges",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/almost-done": {
+      "get": {
+        "description": "Returns games where the caller has completed between 80 and 99 percent of achievements.",
+        "operationId": "getAlmostDone",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AlmostDoneResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get games the caller has nearly completed",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/artwork": {
+      "get": {
+        "description": "Returns a paginated stream of IGDB promotional artwork with game metadata.",
+        "operationId": "getArtworkGallery",
+        "parameters": [
+          {
+            "description": "1-based page number (defaults to 1).",
+            "explode": false,
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "description": "1-based page number (defaults to 1).",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page size (defaults to 40, max 100).",
+            "explode": false,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "description": "Page size (defaults to 40, max 100).",
+              "format": "int64",
+              "type": "integer"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ArtworkGalleryResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get paginated IGDB artwork gallery",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/best-of-year/{year}": {
+      "get": {
+        "description": "Returns up to 30 highest-rated games released in the given year.",
+        "operationId": "getBestOfYear",
+        "parameters": [
+          {
+            "description": "Release year (1970-2100).",
+            "in": "path",
+            "name": "year",
+            "required": true,
+            "schema": {
+              "description": "Release year (1970-2100).",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BestOfYearResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get top-rated games from a specific release year",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/community-top": {
+      "get": {
+        "description": "Returns games with the highest average user ratings on this server (at least 2 ratings).",
+        "operationId": "getCommunityTop",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CommunityTopResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get top-rated games by the community",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/console-highlights": {
+      "get": {
+        "description": "Returns a compact list of consoles with game counts and top game for the explore page quick-jump row.",
+        "operationId": "getConsoleHighlights",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsoleHighlightsResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get console highlights",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/consoles/{id}/showcase": {
+      "get": {
+        "description": "Returns aggregated showcase data for a specific console: essentials, hidden gems, genre breakdown, top developers, recently played, recently added.",
+        "operationId": "getConsoleShowcase",
+        "parameters": [
+          {
+            "description": "Console abbreviation (e.g. 'snes').",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Console abbreviation (e.g. 'snes').",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ConsoleShowcaseResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get console showcase",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/covers": {
+      "get": {
+        "description": "Returns a paginated dense cover art feed with minimal metadata. Supports console filter.",
+        "operationId": "getCoverGallery",
+        "parameters": [
+          {
+            "description": "1-based page number (defaults to 1).",
+            "explode": false,
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "description": "1-based page number (defaults to 1).",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page size (defaults to 60, max 200).",
+            "explode": false,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "description": "Page size (defaults to 60, max 200).",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Console abbreviation filter.",
+            "explode": false,
+            "in": "query",
+            "name": "console",
+            "schema": {
+              "description": "Console abbreviation filter.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CoverGalleryResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get paginated cover gallery",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/cult-classics": {
+      "get": {
+        "description": "Returns games where the community rates higher than critics — avg community rating \u003e= 4.0 with IGDB rating \u003c 75.",
+        "operationId": "getCultClassics",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/CultClassicsResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get community cult classics",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/decades/{decade}": {
+      "get": {
+        "description": "Returns up to 30 highest-rated games for the given decade (80s, 90s, or 00s).",
+        "operationId": "getDecades",
+        "parameters": [
+          {
+            "description": "Decade identifier: '80s', '90s', or '00s'.",
+            "in": "path",
+            "name": "decade",
+            "required": true,
+            "schema": {
+              "description": "Decade identifier: '80s', '90s', or '00s'.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DecadesResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get best games of a decade",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/developers": {
+      "get": {
+        "description": "Returns the top 50 developers by game count with average rating and console coverage.",
+        "operationId": "getDevelopers",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperListResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List top developers",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/developers/spotlight": {
+      "get": {
+        "description": "Returns a rotating spotlight of a top developer with games that have hero art. Rotates weekly.",
+        "operationId": "getDeveloperSpotlight",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperSpotlightResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get the weekly featured developer",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/developers/{name}": {
+      "get": {
+        "description": "Returns all games by a specific developer along with statistics (rating distribution, genre/platform breakdown, user stats, timeline, related developers).",
+        "operationId": "getDeveloperDetail",
+        "parameters": [
+          {
+            "description": "Developer name (URL-decoded).",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "Developer name (URL-decoded).",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DeveloperDetailResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get developer detail",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/easy-to-complete": {
+      "get": {
+        "description": "Returns up to 20 games with the highest average achievement completion rate across players.",
+        "operationId": "getEasyToComplete",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/EasyToCompleteResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get games with highest avg achievement completion",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/featured": {
+      "get": {
+        "description": "Returns up to 10 featured games selected via weighted random sampling, stable per-day.",
+        "operationId": "getExploreFeatured",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FeaturedGameResponse"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get featured games for the explore hero carousel",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/for-you": {
+      "get": {
+        "description": "Returns personalized recommendation shelves derived from the caller's play history.",
+        "operationId": "getForYou",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ForYouResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get personalized recommendation rows",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/fresh-challenges": {
+      "get": {
+        "description": "Returns up to 20 games with cached achievements where the caller has zero unlocks yet.",
+        "operationId": "getFreshChallenges",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FreshChallengesResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get games with cached achievements the caller hasn't started",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/hardest-games": {
+      "get": {
+        "description": "Returns up to 20 games with the lowest average achievement completion rate. Requires at least 2 players attempting.",
+        "operationId": "getHardestGames",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HardestGamesResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get games with lowest avg achievement completion",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/mood/{mood}": {
+      "get": {
+        "description": "Returns up to 20 games matching the chosen mood (chill, challenge, nostalgia, something-new, quick, together).",
+        "operationId": "getMoodGames",
+        "parameters": [
+          {
+            "description": "Mood identifier, e.g. 'chill', 'challenge'.",
+            "in": "path",
+            "name": "mood",
+            "required": true,
+            "schema": {
+              "description": "Mood identifier, e.g. 'chill', 'challenge'.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/GameResponse"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get games matching a specific mood",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/moods": {
+      "get": {
+        "description": "Returns the static list of moods available in the mood picker.",
+        "operationId": "getExploreMoods",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/MoodResponse"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "List explore mood options",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/on-this-day": {
+      "get": {
+        "description": "Returns up to 20 games released on today's month/day across all years, sorted oldest first.",
+        "operationId": "getOnThisDay",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/OnThisDayResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get games released on today's month/day",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/players-like-you": {
+      "get": {
+        "description": "Returns games favourited by users whose favourites overlap with the caller's. Uses Jaccard similarity.",
+        "operationId": "getPlayersLikeYou",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PlayersLikeYouResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get collaborative-filter game recommendations",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/publishers/{name}": {
+      "get": {
+        "description": "Returns all games by a specific publisher along with statistics (rating distribution, genre/platform breakdown, user stats, timeline, related publishers).",
+        "operationId": "getPublisherDetail",
+        "parameters": [
+          {
+            "description": "Publisher name (URL-decoded).",
+            "in": "path",
+            "name": "name",
+            "required": true,
+            "schema": {
+              "description": "Publisher name (URL-decoded).",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublisherDetailResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get publisher detail",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/recently-reviewed": {
+      "get": {
+        "description": "Returns the 20 most recent user reviews (non-empty review text) with game + reviewer metadata.",
+        "operationId": "getRecentlyReviewed",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RecentlyReviewedResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get games with recent user reviews",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/rows": {
+      "get": {
+        "description": "Returns curated shelves (top-rated, recently-added, hidden gems, most-played). Empty rows are omitted.",
+        "operationId": "getExploreRows",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ExploreRowsResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get curated explore-page shelf rows",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/screenshots": {
+      "get": {
+        "description": "Returns a paginated stream of screenshots with minimal game metadata. Supports console/genre filters.",
+        "operationId": "getScreenshotGallery",
+        "parameters": [
+          {
+            "description": "1-based page number (defaults to 1).",
+            "explode": false,
+            "in": "query",
+            "name": "page",
+            "schema": {
+              "description": "1-based page number (defaults to 1).",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Page size (defaults to 40, max 100).",
+            "explode": false,
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "description": "Page size (defaults to 40, max 100).",
+              "format": "int64",
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Console abbreviation filter.",
+            "explode": false,
+            "in": "query",
+            "name": "console",
+            "schema": {
+              "description": "Console abbreviation filter.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Genre filter.",
+            "explode": false,
+            "in": "query",
+            "name": "genre",
+            "schema": {
+              "description": "Genre filter.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ScreenshotGalleryResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get paginated screenshot gallery",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/series/featured": {
+      "get": {
+        "description": "Returns up to 20 top series with at least 2 library games, sorted by library game count DESC.",
+        "operationId": "getExploreFeaturedSeries",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/FeaturedSeriesResponse"
+                  },
+                  "type": [
+                    "array",
+                    "null"
+                  ]
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get featured game series",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/surprise": {
+      "get": {
+        "description": "Returns a single random game matching optional console/genre/min-rating filters.",
+        "operationId": "getSurpriseGame",
+        "parameters": [
+          {
+            "description": "Console abbreviation filter.",
+            "explode": false,
+            "in": "query",
+            "name": "console",
+            "schema": {
+              "description": "Console abbreviation filter.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Genre filter.",
+            "explode": false,
+            "in": "query",
+            "name": "genre",
+            "schema": {
+              "description": "Genre filter.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Minimum IGDB rating (0-100); defaults to 70.",
+            "explode": false,
+            "in": "query",
+            "name": "minRating",
+            "schema": {
+              "description": "Minimum IGDB rating (0-100); defaults to 70.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/GameResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get a random surprise game",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/trending": {
+      "get": {
+        "description": "Returns up to 20 games with the most distinct players in the last 7 days.",
+        "operationId": "getTrending",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrendingResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get trending games",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/wizard": {
+      "get": {
+        "description": "Returns the static decision wizard configuration (steps + options).",
+        "operationId": "getWizardSteps",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WizardResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get decision wizard steps",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/wizard/results": {
+      "get": {
+        "description": "Returns 5 game recommendations based on the wizard's mood/era/vibe selections.",
+        "operationId": "getWizardResults",
+        "parameters": [
+          {
+            "description": "Chosen mood (action|chill|story|challenge|fun).",
+            "explode": false,
+            "in": "query",
+            "name": "mood",
+            "schema": {
+              "description": "Chosen mood (action|chill|story|challenge|fun).",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Chosen era (80s|early90s|late90s|2000s|any).",
+            "explode": false,
+            "in": "query",
+            "name": "era",
+            "schema": {
+              "description": "Chosen era (80s|early90s|late90s|2000s|any).",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Chosen vibe (solo|multiplayer|short|long|any).",
+            "explode": false,
+            "in": "query",
+            "name": "vibe",
+            "schema": {
+              "description": "Chosen vibe (solo|multiplayer|short|long|any).",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/WizardResultsResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get wizard recommendations",
+        "tags": [
+          "explore"
+        ]
+      }
+    },
+    "/api/explore/your-anniversaries": {
+      "get": {
+        "description": "Returns games the caller played roughly 1..10 years ago (within a 3-day window of today's date).",
+        "operationId": "getYourAnniversaries",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/AnniversariesResponse"
+                }
+              }
+            },
+            "description": "OK",
+            "headers": {
+              "Cache-Control": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get personal gameplay anniversaries",
+        "tags": [
+          "explore"
         ]
       }
     },


### PR DESCRIPTION
Closes the gap where ~40 server handlers were still on raw gin. After this lands, every non-binary / non-WebSocket endpoint is on huma and the OpenAPI spec covers the full public surface. Refs #486.

## Scope

**33 explore endpoints** migrated:

| Sub-cluster | Endpoints |
|---|---|
| featured | `/featured`, `/rows`, `/series/featured`, `/moods`, `/mood/{mood}`, `/surprise` |
| foryou | `/for-you`, `/players-like-you` |
| developers | `/developers`, `/developers/spotlight`, `/developers/{name}`, `/publishers/{name}` |
| console | `/consoles/{id}/showcase`, `/console-highlights` |
| gallery | `/screenshots`, `/artwork`, `/covers` |
| community | `/trending`, `/community-top`, `/cult-classics`, `/recently-reviewed`, `/active-now` |
| temporal | `/on-this-day`, `/best-of-year/{year}`, `/your-anniversaries`, `/decades/{decade}` |
| challenge | `/easy-to-complete`, `/hardest-games`, `/almost-done`, `/fresh-challenges`, `/active-challenges` |
| wizard | `/wizard`, `/wizard/results` |

**5 auth endpoints** migrated:
- `POST /auth/login`
- `POST /auth/register`
- `POST /auth/refresh`
- `POST /auth/setup`
- `GET /auth/setup-status`

## Preserved behavior

**Explore:**
- `Cache-Control` headers kept on each response via `\`header:"Cache-Control"\`` field
- Bare-array responses (e.g. `/featured`) stay as top-level JSON arrays
- Auth handling mirrors the gin group: most endpoints tolerate unauthenticated access (zero userID → no personalized data); `/for-you` and `/players-like-you` return 401 when unauthenticated
- Route ordering: `/developers/spotlight` registered before `/developers/{name}` so huma resolves the literal path first

**Auth:**
- Account lockout, dummy-bcrypt timing attack prevention, and all `SystemEvent` recording preserved
- Rate limiters (`authLimiter`, `refreshLimiter`) bridged into huma via new `IPRateLimitMiddleware`
- A request-context middleware stashes the underlying `*gin.Context` in the huma context so security events keep getting `IP` and `Path` populated
- Wire format is byte-identical: login returns `{accessToken, refreshToken, user}`; register returns either the same or `{pending, message}` with 202 when approval is needed; errors use the `humaError` override → `{error, message}`

## Kept alive (for rollback)

Gin handler methods (`AuthHandler.Login/Register/Refresh/Setup/SetupStatus`, `ExploreHandler.GetTrending` etc.) are still defined but no longer routed. They'll be deleted in a follow-up cleanup once CI and prod have run green for a few days.

## Follow-ups this unlocks

- **Kotlin player** can migrate its remaining ~20 hand-written DTOs (`TrendingResponseDto`, `ExploreRowDto`, `DeveloperDetailResponseDto`, `ConsoleShowcaseDto`, `WizardResponseDto`, `ForYouResponseDto`, auth DTOs, etc.) to the generated types now present in the spec
- **Web** can similarly finalize its `api.ts` shim pruning (#489)

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — full suite passes (~7 minutes total; 373s in `internal/api`, covering login/register/refresh/setup plus all the explore handler tests)
- [x] OpenAPI spec regenerated (`web/src/generated/openapi.json` + `api.d.ts`)
- [x] `cd web && npx tsc --noEmit` — clean
- [ ] CI green

## 12 commits on this branch

```
chore(web): regenerate OpenAPI spec after auth migration
feat(server): migrate auth endpoints to huma
chore(web): regenerate OpenAPI spec + TypeScript types
feat(server): migrate explore wizard endpoints to huma
feat(server): migrate explore challenge-driven endpoints to huma
feat(server): migrate explore temporal endpoints to huma
feat(server): migrate explore community discovery endpoints to huma
feat(server): migrate explore screenshot/artwork/cover galleries to huma
feat(server): migrate explore console showcase + highlights to huma
feat(server): migrate explore/developers + spotlight + publishers to huma
feat(server): migrate explore/for-you + players-like-you to huma
feat(server): migrate explore featured/rows/series/moods/surprise to huma
```