### PR TITLE
fix(player): correct shared-session URL drift + migrate DTOs to generated

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -966,11 +966,11 @@ class SpelaApiClient(
     }
 
     suspend fun getSharedSessionInvitations(): SharedSessionInvitationsResponse {
-        return client.get("$baseUrl/api/shared-sessions/invitations").body()
+        return client.get("$baseUrl/api/user/shared-session-invites").body()
     }
 
     suspend fun getPendingInvitationCount(): SharedSessionInvitationCountResponse {
-        return client.get("$baseUrl/api/shared-sessions/invitations/count").body()
+        return client.get("$baseUrl/api/user/shared-session-invites/count").body()
     }
 
     suspend fun createSharedSession(request: CreateSharedSessionRequest): SharedSessionDetailDto {
@@ -984,21 +984,23 @@ class SpelaApiClient(
     }
 
     suspend fun inviteToSharedSession(sharedSessionId: String, request: InviteToSharedSessionRequest) {
-        client.post("$baseUrl/api/shared-sessions/$sharedSessionId/invitations") {
+        client.post("$baseUrl/api/shared-sessions/$sharedSessionId/invites") {
             setBody(request)
         }
     }
 
     suspend fun acceptSharedSessionInvitation(invitationId: String) {
-        client.post("$baseUrl/api/shared-sessions/invitations/$invitationId/accept")
+        client.post("$baseUrl/api/user/shared-session-invites/$invitationId/accept")
     }
 
     suspend fun rejectSharedSessionInvitation(invitationId: String) {
-        client.post("$baseUrl/api/shared-sessions/invitations/$invitationId/reject")
+        // Server calls this "decline" — kept as rejectSharedSessionInvitation here
+        // so the repository-level public name is stable.
+        client.post("$baseUrl/api/user/shared-session-invites/$invitationId/decline")
     }
 
     suspend fun leaveSharedSession(sharedSessionId: String) {
-        client.delete("$baseUrl/api/shared-sessions/$sharedSessionId/members/me")
+        client.post("$baseUrl/api/shared-sessions/$sharedSessionId/leave")
     }
 
     suspend fun removeSharedSessionMember(sharedSessionId: String, userId: String) {
@@ -1018,11 +1020,11 @@ class SpelaApiClient(
     }
 
     suspend fun takeTurn(sharedSessionId: String): TakeTurnResponse {
-        return client.post("$baseUrl/api/shared-sessions/$sharedSessionId/turn/take").body()
+        return client.post("$baseUrl/api/shared-sessions/$sharedSessionId/take-turn").body()
     }
 
     suspend fun releaseTurn(sharedSessionId: String) {
-        client.post("$baseUrl/api/shared-sessions/$sharedSessionId/turn/release")
+        client.post("$baseUrl/api/shared-sessions/$sharedSessionId/release-turn")
     }
 
     suspend fun sharedSessionHeartbeat(sharedSessionId: String) {
@@ -1057,6 +1059,11 @@ class SpelaApiClient(
     }
 
     suspend fun copySharedSessionSaveToGame(sharedSessionId: String, saveId: Long) {
+        // NOTE: This endpoint is not currently registered on the server — it is
+        // missing from both the huma handlers and the remaining gin routes
+        // (see server/internal/api/huma_shared.go and server/internal/api/router.go).
+        // The path is kept at its original (pre-huma) location so that if the
+        // server adds it back at the same path, the player will continue to work.
         client.post("$baseUrl/api/shared-sessions/$sharedSessionId/saves/$saveId/copy-to-game")
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -954,19 +954,20 @@ class SpelaApiClient(
 
     // Shared Sessions
 
-    suspend fun getMySharedSessions(page: Int = 1, pageSize: Int = 20): SharedSessionsResponse {
-        return client.get("$baseUrl/api/shared-sessions") {
-            parameter("page", page)
-            parameter("pageSize", pageSize)
-        }.body()
+    suspend fun getMySharedSessions(@Suppress("UNUSED_PARAMETER") page: Int = 1, @Suppress("UNUSED_PARAMETER") pageSize: Int = 20): List<SharedSessionDto> {
+        // Server returns a bare array (not a paginated wrapper). page/pageSize
+        // are kept on the signature so the repository caller does not need to
+        // change, but they are ignored because the server does not paginate.
+        return client.get("$baseUrl/api/shared-sessions").body<List<SharedSessionDto>?>() ?: emptyList()
     }
 
     suspend fun getSharedSession(sharedSessionId: String): SharedSessionDetailDto {
         return client.get("$baseUrl/api/shared-sessions/$sharedSessionId").body()
     }
 
-    suspend fun getSharedSessionInvitations(): SharedSessionInvitationsResponse {
-        return client.get("$baseUrl/api/user/shared-session-invites").body()
+    suspend fun getSharedSessionInvitations(): List<SharedSessionInvitationDto> {
+        // Server returns a bare array (nullable on the wire when empty).
+        return client.get("$baseUrl/api/user/shared-session-invites").body<List<SharedSessionInvitationDto>?>() ?: emptyList()
     }
 
     suspend fun getPendingInvitationCount(): SharedSessionInvitationCountResponse {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -300,75 +300,82 @@ fun com.spela.client.models.PublicProfileResponse.toDomain(): PublicProfile = Pu
 )
 
 // Shared Session mappers
+//
+// The generated types use kotlinx.datetime.Instant for timestamps and
+// kotlin.Long for counts; the domain models keep String timestamps and Int
+// counts to stay consistent with the rest of the player. The mappers handle
+// the conversion.
+//
+// Fields not present on the server (description, lastActivityAt,
+// gameConsoleName on invites, lastPlayedAt, isOnline, inviterAvatarUrl) get
+// their Kotlin defaults from the domain model constructors.
 
-fun SharedSessionDto.toDomain(): SharedSession = SharedSession(
+fun com.spela.client.models.SharedSessionResponse.toDomain(): SharedSession = SharedSession(
     id = id,
     name = name,
-    ownerId = ownerId,
-    ownerUsername = ownerUsername,
     gameId = gameId,
     gameTitle = gameTitle,
     gameCoverUrl = gameCoverUrl,
-    gameConsoleName = gameConsoleName,
-    status = status,
-    memberCount = memberCount,
-    activeUserId = activeUserId,
-    lastActivityAt = lastActivityAt,
-    createdAt = createdAt,
-    updatedAt = updatedAt,
-)
-
-fun SharedSessionDetailDto.toDomain(): SharedSessionDetail = SharedSessionDetail(
-    id = id,
-    name = name,
+    gameConsoleName = consoleName.orEmpty(),
     ownerId = ownerId,
     ownerUsername = ownerUsername,
+    status = status,
+    memberCount = memberCount.toInt(),
+    activeUserId = activeUserId,
+    lastActivityAt = updatedAt.toString(),
+    createdAt = createdAt.toString(),
+    updatedAt = updatedAt.toString(),
+)
+
+fun com.spela.client.models.SharedSessionDetailResponse.toDomain(): SharedSessionDetail = SharedSessionDetail(
+    id = id,
+    name = name,
     gameId = gameId,
     gameTitle = gameTitle,
     gameCoverUrl = gameCoverUrl,
-    gameConsoleName = gameConsoleName,
+    gameConsoleName = consoleName.orEmpty(),
+    ownerId = ownerId,
+    ownerUsername = ownerUsername,
     status = status,
-    memberCount = memberCount,
+    memberCount = memberCount.toInt(),
     activeUserId = activeUserId,
-    members = members.map { it.toDomain() },
-    lastActivityAt = lastActivityAt,
-    createdAt = createdAt,
-    updatedAt = updatedAt,
+    members = members.orEmpty().map { it.toDomain() },
+    lastActivityAt = updatedAt.toString(),
+    createdAt = createdAt.toString(),
+    updatedAt = updatedAt.toString(),
 )
 
-fun SharedSessionMemberDto.toDomain(): SharedSessionMember = SharedSessionMember(
+fun com.spela.client.models.SharedSessionMemberResponse.toDomain(): SharedSessionMember = SharedSessionMember(
     userId = userId,
     username = username,
     avatarUrl = avatarUrl,
     role = role,
-    joinedAt = joinedAt,
-    lastPlayedAt = lastPlayedAt,
-    isOnline = isOnline,
+    joinedAt = joinedAt.toString(),
+    // lastPlayedAt / isOnline are not sent by the server — domain defaults apply.
 )
 
-fun SharedSessionInvitationDto.toDomain(): SharedSessionInvitation = SharedSessionInvitation(
+fun com.spela.client.models.SharedSessionInviteResponse.toDomain(): SharedSessionInvitation = SharedSessionInvitation(
     id = id,
     sharedSessionId = sharedSessionId,
     sharedSessionName = sharedSessionName,
-    gameId = gameId,
     gameTitle = gameTitle,
-    gameCoverUrl = gameCoverUrl,
-    gameConsoleName = gameConsoleName,
+    // gameId / gameCoverUrl / gameConsoleName / inviterAvatarUrl are not sent —
+    // domain defaults apply.
     inviterUsername = inviterUsername,
-    inviterAvatarUrl = inviterAvatarUrl,
-    createdAt = createdAt,
+    createdAt = createdAt.toString(),
 )
 
-fun SharedSessionSaveDto.toDomain(): SharedSessionSave = SharedSessionSave(
-    id = id,
+fun com.spela.client.models.SharedSessionSaveResponse.toDomain(): SharedSessionSave = SharedSessionSave(
+    // Server sends id as String; domain keeps Long. The backing column is a
+    // 64-bit integer so toLong() is safe.
+    id = id.toLong(),
     sharedSessionId = sharedSessionId,
     username = username,
-    avatarUrl = avatarUrl,
     name = name,
     fileSize = fileSize,
     isAuto = isAuto,
-    createdAt = createdAt,
-    updatedAt = updatedAt,
+    createdAt = createdAt.toString(),
+    updatedAt = updatedAt.toString(),
 )
 
 // Collection mappers

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -165,112 +165,37 @@ data class CoreNameResponse(
 //   HeatmapEntryDto       -> HeatmapEntry
 // (all in com.spela.client.models)
 
-// Shared Session
+// Shared Session — hand-written DTOs replaced by generated counterparts in
+// com.spela.client.models. Aliased below so existing call sites keep working.
+//
+// Silent-bug field renames vs. the old hand-written DTOs (these were never
+// actually delivered by the server, so the DTO fields were always their
+// Kotlin defaults — empty string / null / false):
+//   SharedSessionDto.description             -> not sent (always "")
+//   SharedSessionDto.gameConsoleName         -> server sends `consoleName`
+//   SharedSessionDto.lastActivityAt          -> not sent; mapper uses updatedAt
+//   SharedSessionDetailDto.description       -> not sent
+//   SharedSessionDetailDto.gameConsoleName   -> server sends `consoleName`
+//   SharedSessionDetailDto.lastActivityAt    -> not sent; mapper uses updatedAt
+//   SharedSessionMemberDto.lastPlayedAt      -> not sent
+//   SharedSessionMemberDto.isOnline          -> not sent; mapper defaults false
+//   SharedSessionInvitationDto.gameId        -> not sent
+//   SharedSessionInvitationDto.gameCoverUrl  -> not sent
+//   SharedSessionInvitationDto.gameConsoleName -> not sent
+//   SharedSessionInvitationDto.inviterAvatarUrl -> not sent
+//   SharedSessionSaveDto.gameId / .userId / .avatarUrl -> not sent
+//
+// CreateSharedSessionRequest.description was also never read by the server.
 
-@Serializable
-data class SharedSessionDto(
-    val id: String,
-    val name: String,
-    val description: String = "",
-    val gameId: String,
-    val gameTitle: String = "",
-    val gameCoverUrl: String? = null,
-    val gameConsoleName: String = "",
-    val ownerId: String,
-    val ownerUsername: String = "",
-    val status: String = "active",
-    val memberCount: Int = 0,
-    val activeUserId: String? = null,
-    val lastActivityAt: String = "",
-    val createdAt: String = "",
-    val updatedAt: String = "",
-)
-
-@Serializable
-data class SharedSessionDetailDto(
-    val id: String,
-    val name: String,
-    val description: String = "",
-    val gameId: String,
-    val gameTitle: String = "",
-    val gameCoverUrl: String? = null,
-    val gameConsoleName: String = "",
-    val ownerId: String,
-    val ownerUsername: String = "",
-    val status: String = "active",
-    val memberCount: Int = 0,
-    val activeUserId: String? = null,
-    val lastActivityAt: String = "",
-    val createdAt: String = "",
-    val updatedAt: String = "",
-    val members: List<SharedSessionMemberDto> = emptyList(),
-)
-
-@Serializable
-data class SharedSessionMemberDto(
-    val userId: String,
-    val username: String,
-    val avatarUrl: String? = null,
-    val role: String = "member",
-    val joinedAt: String = "",
-    val lastPlayedAt: String? = null,
-    val isOnline: Boolean = false,
-)
-
-@Serializable
-data class SharedSessionInvitationDto(
-    val id: String,
-    val sharedSessionId: String,
-    val sharedSessionName: String = "",
-    val gameId: String = "",
-    val gameTitle: String = "",
-    val gameCoverUrl: String? = null,
-    val gameConsoleName: String = "",
-    val inviterUsername: String = "",
-    val inviterAvatarUrl: String? = null,
-    val createdAt: String = "",
-)
-
-@Serializable
-data class SharedSessionSaveDto(
-    val id: Long,
-    val sharedSessionId: String = "",
-    val gameId: Long = 0,
-    val userId: Long = 0,
-    val username: String = "",
-    val avatarUrl: String? = null,
-    val name: String,
-    val fileSize: Long = 0,
-    val isAuto: Boolean = false,
-    val createdAt: String = "",
-    val updatedAt: String = "",
-)
-
-// SharedSessionsResponse / SharedSessionInvitationsResponse removed — server
-// returns bare arrays for GET /api/shared-sessions and
-// GET /api/user/shared-session-invites. See SpelaApiClient.
-
-@Serializable
-data class CreateSharedSessionRequest(
-    val name: String,
-    val gameId: String,
-    val description: String = "",
-)
-
-@Serializable
-data class InviteToSharedSessionRequest(
-    val username: String,
-)
-
-@Serializable
-data class TakeTurnResponse(
-    val turnToken: String,
-)
-
-@Serializable
-data class SharedSessionInvitationCountResponse(
-    val count: Int = 0,
-)
+typealias SharedSessionDto = com.spela.client.models.SharedSessionResponse
+typealias SharedSessionDetailDto = com.spela.client.models.SharedSessionDetailResponse
+typealias SharedSessionMemberDto = com.spela.client.models.SharedSessionMemberResponse
+typealias SharedSessionInvitationDto = com.spela.client.models.SharedSessionInviteResponse
+typealias SharedSessionSaveDto = com.spela.client.models.SharedSessionSaveResponse
+typealias CreateSharedSessionRequest = com.spela.client.models.CreateSharedSessionRequest
+typealias InviteToSharedSessionRequest = com.spela.client.models.InviteToSharedSessionRequest
+typealias TakeTurnResponse = com.spela.client.models.SharedSessionTakeTurnResponse
+typealias SharedSessionInvitationCountResponse = com.spela.client.models.SharedSessionInviteCountResponse
 
 // BIOS — BiosFileDto / BiosConsoleDto / BiosConsoleFileDto /
 // BiosStatusResponse replaced by:

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -246,19 +246,9 @@ data class SharedSessionSaveDto(
     val updatedAt: String = "",
 )
 
-@Serializable
-data class SharedSessionsResponse(
-    val data: List<SharedSessionDto> = emptyList(),
-    val total: Long = 0,
-    val page: Int = 1,
-    val pageSize: Int = 20,
-)
-
-@Serializable
-data class SharedSessionInvitationsResponse(
-    val data: List<SharedSessionInvitationDto> = emptyList(),
-    val total: Long = 0,
-)
+// SharedSessionsResponse / SharedSessionInvitationsResponse removed — server
+// returns bare arrays for GET /api/shared-sessions and
+// GET /api/user/shared-session-invites. See SpelaApiClient.
 
 @Serializable
 data class CreateSharedSessionRequest(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSessionRepositoryImpl.kt
@@ -1,8 +1,8 @@
 package com.spela.player.data.repository
 
+import com.spela.client.models.CreateSharedSessionRequest
+import com.spela.client.models.InviteToSharedSessionRequest
 import com.spela.player.data.remote.api.SpelaApiClient
-import com.spela.player.data.remote.dto.CreateSharedSessionRequest
-import com.spela.player.data.remote.dto.InviteToSharedSessionRequest
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.SharedSession
 import com.spela.player.domain.model.SharedSessionDetail
@@ -27,12 +27,15 @@ class SharedSessionRepositoryImpl(
     }
 
     override suspend fun getPendingInvitationCount(): Result<Int> = runCatching {
-        apiClient.getPendingInvitationCount().count
+        apiClient.getPendingInvitationCount().count.toInt()
     }
 
     override suspend fun createSharedSession(name: String, gameId: String, description: String): Result<SharedSessionDetail> =
         runCatching {
-            apiClient.createSharedSession(CreateSharedSessionRequest(name, gameId, description)).toDomain()
+            // description is retained on the repository API for backwards
+            // compatibility but is not sent — the server's
+            // CreateSharedSessionRequest only accepts name + gameId.
+            apiClient.createSharedSession(CreateSharedSessionRequest(name = name, gameId = gameId)).toDomain()
         }
 
     override suspend fun deleteSharedSession(sharedSessionId: String): Result<Unit> = runCatching {
@@ -40,7 +43,7 @@ class SharedSessionRepositoryImpl(
     }
 
     override suspend fun inviteUser(sharedSessionId: String, username: String): Result<Unit> = runCatching {
-        apiClient.inviteToSharedSession(sharedSessionId, InviteToSharedSessionRequest(username))
+        apiClient.inviteToSharedSession(sharedSessionId, InviteToSharedSessionRequest(username = username))
     }
 
     override suspend fun acceptInvitation(invitationId: String): Result<Unit> = runCatching {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSessionRepositoryImpl.kt
@@ -15,7 +15,7 @@ class SharedSessionRepositoryImpl(
 ) : SharedSessionRepository {
 
     override suspend fun getMySharedSessions(page: Int, pageSize: Int): Result<List<SharedSession>> = runCatching {
-        apiClient.getMySharedSessions(page, pageSize).data.map { it.toDomain() }
+        apiClient.getMySharedSessions(page, pageSize).map { it.toDomain() }
     }
 
     override suspend fun getSharedSession(sharedSessionId: String): Result<SharedSessionDetail> = runCatching {
@@ -23,7 +23,7 @@ class SharedSessionRepositoryImpl(
     }
 
     override suspend fun getSharedSessionInvitations(): Result<List<SharedSessionInvitation>> = runCatching {
-        apiClient.getSharedSessionInvitations().data.map { it.toDomain() }
+        apiClient.getSharedSessionInvitations().map { it.toDomain() }
     }
 
     override suspend fun getPendingInvitationCount(): Result<Int> = runCatching {


### PR DESCRIPTION
Closes #488. The shared-session feature has been 404'ing on the deployed player since the server's huma migration renamed several paths. This PR realigns the hand-written `SpelaApiClient` calls with the actual server paths.

## Why this happened (and how to prevent it in future)

We've only been using the generated Kotlin client for *types*, not for *HTTP calls*. The hand-written `SpelaApiClient` has hardcoded URL strings, so when the server migrated paths during the huma rollout, nothing type-checked the drift. The generated \`*Api\` classes in \`player/shared-api/.../com/spela/client/apis/\` would eliminate this by construction — they pull URLs from the spec. **Filed as a follow-up issue — #492** (see below).

## Part 1 — URL fixes (commit `dc48d4a6`)

| Old path | New path |
|---|---|
| `GET /shared-sessions/invitations` | `GET /user/shared-session-invites` |
| `GET /shared-sessions/invitations/count` | `GET /user/shared-session-invites/count` |
| `POST /shared-sessions/{id}/invitations` | `POST /shared-sessions/{id}/invites` |
| `POST /shared-sessions/invitations/{id}/accept` | `POST /user/shared-session-invites/{id}/accept` |
| `POST /shared-sessions/invitations/{id}/reject` | `POST /user/shared-session-invites/{id}/decline` |
| `POST /shared-sessions/{id}/turn/take` | `POST /shared-sessions/{id}/take-turn` |
| `POST /shared-sessions/{id}/turn/release` | `POST /shared-sessions/{id}/release-turn` |
| `DELETE /shared-sessions/{id}/members/me` | `POST /shared-sessions/{id}/leave` |

Public repository method names unchanged (`rejectInvitation`, `leaveSharedSession`) — this is an internal path fix.

`copy-to-game` is **not registered anywhere on the server** (verified). Left the player's path alone with an inline comment — server side needs to ship this endpoint before the feature works end-to-end.

## Part 2 — Shape fix (commit `5b41a050`)

The list endpoints return bare JSON arrays, not the `{data, total, page, pageSize}` wrapper the hand-written DTOs expected:

- `GET /shared-sessions` → `List<SharedSessionResponse>?`
- `GET /user/shared-session-invites` → `List<...>?`

Dropped the paginated wrappers. Page/pageSize parameters kept on the method signature (ignored) so the repository caller is unchanged.

## Part 3 — DTO migration to generated (commit `a9dff172`)

9 hand-written DTOs typealiased to their generated counterparts now that the ambiguity is resolved:

- `SharedSessionDto` → `SharedSessionResponse`
- `SharedSessionDetailDto` → `SharedSessionDetailResponse`
- `SharedSessionMemberDto` → `SharedSessionMemberResponse`
- `SharedSessionInvitationDto` → `SharedSessionInviteResponse`
- `SharedSessionSaveDto` → `SharedSessionSaveResponse`
- `TakeTurnResponse` → `SharedSessionTakeTurnResponse`
- `SharedSessionInvitationCountResponse` → `SharedSessionInviteCountResponse`
- `CreateSharedSessionRequest` / `InviteToSharedSessionRequest` → generated same names

## 14 silent deserialization bugs found (now 26 total across the migration)

These hand-written DTO fields were never delivered by the server — they always fell back to Kotlin defaults:

- `SharedSessionDto.description` / `.gameConsoleName` (server: `consoleName`) / `.lastActivityAt` (now mapped from `updatedAt`)
- `SharedSessionDetailDto.description` / `.gameConsoleName` / `.lastActivityAt`
- `SharedSessionMemberDto.lastPlayedAt` / `.isOnline`
- `SharedSessionInvitationDto.gameId` / `.gameCoverUrl` / `.gameConsoleName` / `.inviterAvatarUrl`
- `SharedSessionSaveDto.gameId` / `.userId` / `.avatarUrl`
- `CreateSharedSessionRequest.description` (request body field never read by server)

Domain models kept unchanged — the ghost fields fall back to their Kotlin defaults in the mappers so existing UI code (`sharedSession.description`, `member.isOnline`) keeps compiling. Flagged for a cleanup PR if the UI code genuinely never reads them.

## Test plan

- [x] `./gradlew :shared:compileKotlinDesktop :shared:compileTestKotlinDesktop :desktop:compileKotlinDesktop` — green
- [x] `./run-desktop-tests.sh` — **470/470 pass** (SessionsUiTest 6/18 pre-existing)
- [ ] **Android E2E smoke test recommended before merge** — per CLAUDE.md, the path-mismatch class of bug doesn't show up in desktop tests with fake repos; it needs real-network round-trip. Suggested path: login → Shared Sessions tab → invitations list loads → create shared session → take-turn / release-turn.
- [ ] CI green

Refs #488.