### PR TITLE
chore(player): auto-fix snake_case FormFile refs in regen-kotlin-api.sh

### DIFF
--- a/player/scripts/regen-kotlin-api.sh
+++ b/player/scripts/regen-kotlin-api.sh
@@ -67,6 +67,26 @@ echo "Post-processing: decode HTML-entity backticks in apis/*.kt..."
 find "$OUT_DIR/src/commonMain/kotlin/com/spela/client/apis" -name "*.kt" \
   -exec perl -i -pe 's/&#x60;/`/g' {} +
 
+echo "Post-processing: fix snake_case FormFile references in apis/*.kt..."
+# openapi-generator 7.21 emits broken snake_case identifier references
+# inside the formData{} block when a FormFile field name contains
+# underscores: the parameter is camelCased to 'patchFile' but the body
+# reads `append(patch_file)` — a non-existent identifier. This breaks
+# compilation. The spec treats all current form fields as camelCase, but
+# we guard against regressions by rewriting any `append(snake_case_name)`
+# inside an `?.apply { ... }` block to the matching camelCase identifier.
+find "$OUT_DIR/src/commonMain/kotlin/com/spela/client/apis" -name "*.kt" \
+  -exec perl -i -pe '
+    # Match `<name>?.apply { append(<snake>) }` where <snake> contains underscores.
+    # Convert <snake> to camelCase (strip underscores, upper the next char).
+    s{(\w+)\?\.apply \{ append\(([a-z][a-z0-9]*(?:_[a-z0-9]+)+)\) \}}{
+      my ($param, $snake) = ($1, $2);
+      my $camel = $snake;
+      $camel =~ s/_([a-z0-9])/uc($1)/ge;
+      "$param?.apply { append($camel) }";
+    }ge;
+  ' {} +
+
 echo "Staging new + modified files in git..."
 # Stage everything under the generated tree, including newly-created
 # files. Manual `git add` after a regen is easy to forget — and CI


### PR DESCRIPTION
Regression guard for the openapi-generator-kotlin bug that bit us in PR #498.

## Summary

openapi-generator-kotlin 7.21 emits broken Kotlin inside the \`formData{}\` block when a FormFile's field name contains underscores:

\`\`\`kotlin
// parameter is correctly camelCased
patchFile: FormPart<InputProvider>? = null

// but the body uses the snake_case name — a non-existent identifier
patchFile?.apply { append(patch_file) }   // ❌ Unresolved reference 'patch_file'
\`\`\`

We fixed it the first time by renaming the offending form fields to camelCase. This adds a post-processing \`perl -i -pe\` step to rewrite any \`<param>?.apply { append(<snake_case>) }\` pattern to use the matching camelCase identifier, so the next person to add a snake_case form field doesn't trip the same compile failure.

Current API is camelCase throughout — this is a no-op regression guard.

## Test plan

- [x] Ran \`player/scripts/regen-kotlin-api.sh\` locally — no generated-file changes (current spec has no snake_case form fields)
- [x] \`./gradlew :shared-api:compileKotlinDesktop\` passes
- [ ] CI