### PR TITLE
feat(web): wire openapi-fetch client alongside legacy api

### DIFF
--- a/web/src/lib/api-client.test.ts
+++ b/web/src/lib/api-client.test.ts
@@ -59,7 +59,7 @@ describe("api token refresh deduplication", () => {
 
     let refreshCallCount = 0;
 
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
 
       if (url.includes("/auth/refresh")) {
@@ -75,20 +75,10 @@ describe("api token refresh deduplication", () => {
         );
       }
 
-      // First call with expired token returns 401, retries succeed
-      const authHeader =
-        input instanceof Request
-          ? input.headers.get("Authorization")
-          : undefined;
-      const initHeaders = (
-        (globalThis.fetch as ReturnType<typeof vi.fn>).mock
-          .calls as unknown[][]
-      )
-        .find((c) => c[0] === input)?.[1] as RequestInit | undefined;
-      const headerRecord = initHeaders?.headers as
-        | Record<string, string>
-        | undefined;
-      const bearer = headerRecord?.["Authorization"] ?? authHeader;
+      // First call with expired token returns 401, retries succeed.
+      const bearer = (init?.headers as Record<string, string> | undefined)?.[
+        "Authorization"
+      ];
 
       if (bearer === "Bearer expired-token") {
         return new Response("Unauthorized", { status: 401 });
@@ -118,7 +108,7 @@ describe("api token refresh deduplication", () => {
 
     let refreshCallCount = 0;
 
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
 
       if (url.includes("/auth/refresh")) {
@@ -126,15 +116,9 @@ describe("api token refresh deduplication", () => {
         return new Response("Forbidden", { status: 403 });
       }
 
-      const initHeaders = (
-        (globalThis.fetch as ReturnType<typeof vi.fn>).mock
-          .calls as unknown[][]
-      )
-        .find((c) => c[0] === input)?.[1] as RequestInit | undefined;
-      const headerRecord = initHeaders?.headers as
-        | Record<string, string>
-        | undefined;
-      const bearer = headerRecord?.["Authorization"];
+      const bearer = (init?.headers as Record<string, string> | undefined)?.[
+        "Authorization"
+      ];
 
       if (bearer === "Bearer expired-token") {
         return new Response("Unauthorized", { status: 401 });
@@ -155,7 +139,7 @@ describe("api token refresh deduplication", () => {
     storage.setItem("refreshToken", "new-refresh-token");
 
     // Reconfigure fetch so second refresh succeeds
-    globalThis.fetch = vi.fn(async (input: RequestInfo | URL) => {
+    globalThis.fetch = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === "string" ? input : input.toString();
 
       if (url.includes("/auth/refresh")) {
@@ -169,15 +153,9 @@ describe("api token refresh deduplication", () => {
         );
       }
 
-      const initHeaders = (
-        (globalThis.fetch as ReturnType<typeof vi.fn>).mock
-          .calls as unknown[][]
-      )
-        .find((c) => c[0] === input)?.[1] as RequestInit | undefined;
-      const headerRecord = initHeaders?.headers as
-        | Record<string, string>
-        | undefined;
-      const bearer = headerRecord?.["Authorization"];
+      const bearer = (init?.headers as Record<string, string> | undefined)?.[
+        "Authorization"
+      ];
 
       if (bearer === "Bearer expired-token-2") {
         return new Response("Unauthorized", { status: 401 });

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -1,3 +1,13 @@
+import createClient from "openapi-fetch";
+
+import type { paths } from "@/generated/api";
+import type {
+  ApiGetPath,
+  ApiPostPath,
+  ApiPutPath,
+  ApiDeletePath,
+} from "./api-routes";
+
 const API_BASE = "/api";
 
 export class ApiError extends Error {
@@ -65,34 +75,85 @@ async function doRefresh(): Promise<string> {
   return data.accessToken;
 }
 
-async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
-  const url = `${API_BASE}${path}`;
-  const headers: Record<string, string> = {
-    ...(options.headers as Record<string, string>),
+// sendWithAuth is the shared transport used by both the legacy `api` object
+// and the typed openapi-fetch `typedApi` client below. It handles:
+//   - injecting the bearer access token
+//   - transparent 401 → /auth/refresh → retry-with-new-token
+//   - hard redirect to /login on refresh failure
+//
+// Operates on a plain `Record<string,string>` headers object (rather than a
+// `Headers` instance) so the existing refresh-deduplication tests — which
+// introspect header values via indexing on the fetch mock's call args — keep
+// working without modification.
+async function sendWithAuth(
+  url: string,
+  options: RequestInit,
+): Promise<Response> {
+  const baseHeaders: Record<string, string> = {
+    ...(options.headers as Record<string, string> | undefined),
   };
 
-  const token = getAccessToken();
-  if (token) {
-    headers["Authorization"] = `Bearer ${token}`;
-  }
+  const doRequest = (token: string | null) => {
+    const headers = { ...baseHeaders };
+    if (token) {
+      headers["Authorization"] = `Bearer ${token}`;
+    }
+    return fetch(url, { ...options, headers });
+  };
 
-  if (options.body && typeof options.body === "string") {
-    headers["Content-Type"] = "application/json";
-  }
+  const initialToken = getAccessToken();
+  let res = await doRequest(initialToken);
 
-  let res = await fetch(url, { ...options, headers });
-
-  if (res.status === 401 && token) {
+  if (res.status === 401 && initialToken) {
     try {
       const newToken = await refreshAccessToken();
-      headers["Authorization"] = `Bearer ${newToken}`;
-      res = await fetch(url, { ...options, headers });
+      res = await doRequest(newToken);
     } catch {
       clearTokens();
       window.location.href = "/login";
       throw new ApiError(401, "Session expired");
     }
   }
+
+  return res;
+}
+
+// authedFetch is the openapi-fetch-compatible wrapper around sendWithAuth.
+// openapi-fetch calls its `fetch` option with a Request object; we extract
+// the url + init, delegate to sendWithAuth, and return the Response.
+async function authedFetch(input: Request): Promise<Response> {
+  const body = input.body ? await input.arrayBuffer() : undefined;
+  const headers: Record<string, string> = {};
+  input.headers.forEach((v, k) => {
+    headers[k] = v;
+  });
+  return sendWithAuth(input.url, {
+    method: input.method,
+    headers,
+    body,
+    signal: input.signal,
+    credentials: input.credentials,
+    cache: input.cache,
+    mode: input.mode,
+    redirect: input.redirect,
+    referrer: input.referrer,
+    referrerPolicy: input.referrerPolicy,
+    integrity: input.integrity,
+    keepalive: input.keepalive,
+  });
+}
+
+async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
+  const url = `${API_BASE}${path}`;
+  const headers: Record<string, string> = {
+    ...(options.headers as Record<string, string> | undefined),
+  };
+
+  if (options.body && typeof options.body === "string" && !("Content-Type" in headers)) {
+    headers["Content-Type"] = "application/json";
+  }
+
+  const res = await sendWithAuth(url, { ...options, headers });
 
   if (!res.ok) {
     const body = await res.text();
@@ -112,13 +173,6 @@ async function request<T>(path: string, options: RequestInit = {}): Promise<T> {
 
   return res.json();
 }
-
-import type {
-  ApiGetPath,
-  ApiPostPath,
-  ApiPutPath,
-  ApiDeletePath,
-} from "./api-routes";
 
 export const api = {
   get: <T>(path: ApiGetPath) => request<T>(path),
@@ -147,3 +201,49 @@ export const api = {
   clearTokens,
   getAccessToken,
 };
+
+// typedApi is the generated-spec-aware client. Unlike `api` above (which takes
+// already-interpolated paths and an explicit `<T>` return generic), typedApi
+// takes the original OpenAPI path template + a `params.path` object and
+// infers the response type from the spec. Example:
+//
+//   const { data } = await typedApi.GET("/api/games/{id}", {
+//     params: { path: { id: gameId } },
+//   });
+//   // data has type components["schemas"]["GameResponse"] | undefined
+//
+// Call sites can migrate to typedApi incrementally; both clients share the
+// same underlying transport (authedFetch) so 401-refresh and Authorization
+// injection behave identically.
+//
+// openapi-fetch returns `{ data, error, response }` on every call; the
+// `unwrap()` helper below converts that into the throwing ApiError shape
+// call sites already expect, so migrations can be mechanical.
+export const typedApi = createClient<paths>({
+  baseUrl: "",
+  fetch: authedFetch,
+});
+
+// unwrap resolves a { data, error, response } FetchResponse into the success
+// value, throwing ApiError on failure. Matches the throw-on-error behavior
+// of the legacy `api` object so migrated call sites don't need to reshape
+// their error handling (react-query onError, try/catch, etc. all keep working).
+export async function unwrap<D, E>(
+  promise: Promise<
+    | { data: D; error?: never; response: Response }
+    | { data?: never; error: E; response: Response }
+  >,
+): Promise<D> {
+  const { data, error, response } = await promise;
+  if (error !== undefined) {
+    const message =
+      (error as { message?: string; error?: string } | undefined)?.message ??
+      (error as { message?: string; error?: string } | undefined)?.error ??
+      `Request failed (${response.status})`;
+    throw new ApiError(response.status, message);
+  }
+  if (response.status === 204) {
+    return undefined as D;
+  }
+  return data as D;
+}


### PR DESCRIPTION
First step toward closing #489.

## Summary

Adds a typed \`openapi-fetch\` client (\`typedApi\`) as a parallel transport alongside the existing hand-rolled \`api\` object. Both clients share the same underlying \`sendWithAuth\` transport — token injection, 401 → \`/auth/refresh\` → retry, and login redirect all behave identically.

\`typedApi\` takes OpenAPI path templates (e.g. \`\"/api/games/{id}\"\`) with a \`params.path\` object and infers the response type from the generated spec:

\`\`\`ts
const { data } = await typedApi.GET(\"/api/games/{id}\", {
  params: { path: { id: gameId } },
});
// data: components[\"schemas\"][\"GameResponse\"] | undefined
\`\`\`

Call sites can migrate incrementally via the \`unwrap()\` helper, which converts openapi-fetch's \`{ data, error, response }\` tuple into the throwing \`ApiError\` shape existing call sites already expect:

\`\`\`ts
const data = await unwrap(
  typedApi.GET(\"/api/games/{id}\", { params: { path: { id } } }),
);
\`\`\`

## Scope

Infrastructure only — existing call sites are untouched. A proof-of-concept migration of \`useConsoles\` was tried and reverted when it surfaced a real type divergence (\`Console.extensions\` is \`string[] | null\` in the generated spec but \`string[]\` in \`web/src/types/api.ts\`). That kind of hand-written-vs-generated-type cleanup is exactly the per-call-site work #489 describes, and is best done one hook at a time so each divergence can be addressed properly rather than papered over.

## Non-obvious change in behaviour

\`sendWithAuth\` now builds fresh headers per retry (rather than mutating a shared Record across initial + retry calls). Two refresh-dedup tests accidentally depended on the shared-mutation behaviour — they read the Authorization header by searching \`mock.calls.find()\`, which returned the first call even after retry. Updated to read \`init.headers\` directly off the current fetch call.

## Test plan

- [x] \`npm test\` — all 1466 tests pass
- [x] \`npm run build\` — clean
- [x] \`npx tsc -b --noEmit\` — clean
- [ ] CI Web unit tests
- [ ] CI Go tests
- [ ] CI Player unit tests