### PR TITLE
feat(server): migrate ROM + challenge downloads to huma

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ChallengesApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ChallengesApi.kt
@@ -150,6 +150,38 @@ open class ChallengesApi : ApiClient {
 
 
     /**
+     * Download a challenge&#39;s starting save state
+     * Returns the save file that seeds the challenge run. Responds with application/octet-stream.
+     * @param id Challenge ID.
+     * @return void
+     */
+    open suspend fun downloadChallengeSave(id: kotlin.String): HttpResponse<Unit> {
+
+        val localVariableAuthNames = listOf<String>()
+
+        val localVariableBody = 
+            io.ktor.client.utils.EmptyContent
+
+        val localVariableQuery = mutableMapOf<String, List<String>>()
+        val localVariableHeaders = mutableMapOf<String, String>()
+
+        val localVariableConfig = RequestConfig<kotlin.Any?>(
+            RequestMethod.GET,
+            "/api/challenges/{id}/save/download".replace("{" + "id" + "}", "$id"),
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false,
+        )
+
+        return request(
+            localVariableConfig,
+            localVariableBody,
+            localVariableAuthNames
+        ).wrap()
+    }
+
+
+    /**
      * Get a challenge by ID
      * Returns a single challenge including creator, game and console metadata. Expired challenges are lazily closed on read.
      * @param id Challenge ID.
@@ -206,6 +238,38 @@ open class ChallengesApi : ApiClient {
         val localVariableConfig = RequestConfig<kotlin.Any?>(
             RequestMethod.GET,
             "/api/challenges/{id}/leaderboard".replace("{" + "id" + "}", "$id"),
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false,
+        )
+
+        return request(
+            localVariableConfig,
+            localVariableBody,
+            localVariableAuthNames
+        ).wrap()
+    }
+
+
+    /**
+     * Get a challenge&#39;s screenshot
+     * Returns the screenshot image that illustrates the challenge state.
+     * @param id Challenge ID.
+     * @return void
+     */
+    open suspend fun getChallengeScreenshot(id: kotlin.String): HttpResponse<Unit> {
+
+        val localVariableAuthNames = listOf<String>()
+
+        val localVariableBody = 
+            io.ktor.client.utils.EmptyContent
+
+        val localVariableQuery = mutableMapOf<String, List<String>>()
+        val localVariableHeaders = mutableMapOf<String, String>()
+
+        val localVariableConfig = RequestConfig<kotlin.Any?>(
+            RequestMethod.GET,
+            "/api/challenges/{id}/screenshot".replace("{" + "id" + "}", "$id"),
             query = localVariableQuery,
             headers = localVariableHeaders,
             requiresAuthentication = false,

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/GamesApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/GamesApi.kt
@@ -53,6 +53,111 @@ open class GamesApi : ApiClient {
     ): super(baseUrl = baseUrl, httpClient = httpClient)
 
     /**
+     * Download a game&#39;s ROM file
+     * Serves the game&#39;s ROM file. For .scummvm games, packages the entire game directory as tar. For .cue/.gdi multi-file disc games, serves a tar (default) or zip (?format&#x3D;zip) bundle of all companion files.
+     * @param id Game ID.
+     * @param filename Optional download filename — server ignores it; lets clients control the saved filename. (optional)
+     * @param format &#39;zip&#39; to force ZIP packaging for multi-file disc games. Default is .tar (or single-file passthrough). (optional)
+     * @return void
+     */
+    open suspend fun downloadGame(id: kotlin.String, filename: kotlin.String? = null, format: kotlin.String? = null): HttpResponse<Unit> {
+
+        val localVariableAuthNames = listOf<String>()
+
+        val localVariableBody = 
+            io.ktor.client.utils.EmptyContent
+
+        val localVariableQuery = mutableMapOf<String, List<String>>()
+        format?.apply { localVariableQuery["format"] = listOf("$format") }
+        val localVariableHeaders = mutableMapOf<String, String>()
+
+        val localVariableConfig = RequestConfig<kotlin.Any?>(
+            RequestMethod.GET,
+            "/api/games/{id}/download".replace("{" + "id" + "}", "$id").replace("{" + "filename" + "}", "$filename"),
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false,
+        )
+
+        return request(
+            localVariableConfig,
+            localVariableBody,
+            localVariableAuthNames
+        ).wrap()
+    }
+
+
+    /**
+     * Download a specific disc of a multi-disc game
+     * For single-file disc formats (.iso, .chd) serves the file directly; for multi-file (.cue+.bin) serves an uncompressed tar (or zip when ?format&#x3D;zip).
+     * @param id Game ID.
+     * @param discNumber Disc number (1-based).
+     * @param format &#39;zip&#39; for ZIP packaging (used by EmulatorJS), default is .tar. (optional)
+     * @return void
+     */
+    open suspend fun downloadGameDisc(id: kotlin.String, discNumber: kotlin.String, format: kotlin.String? = null): HttpResponse<Unit> {
+
+        val localVariableAuthNames = listOf<String>()
+
+        val localVariableBody = 
+            io.ktor.client.utils.EmptyContent
+
+        val localVariableQuery = mutableMapOf<String, List<String>>()
+        format?.apply { localVariableQuery["format"] = listOf("$format") }
+        val localVariableHeaders = mutableMapOf<String, String>()
+
+        val localVariableConfig = RequestConfig<kotlin.Any?>(
+            RequestMethod.GET,
+            "/api/games/{id}/discs/{discNumber}/download".replace("{" + "id" + "}", "$id").replace("{" + "discNumber" + "}", "$discNumber"),
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false,
+        )
+
+        return request(
+            localVariableConfig,
+            localVariableBody,
+            localVariableAuthNames
+        ).wrap()
+    }
+
+
+    /**
+     * Download a game&#39;s ROM file (with explicit filename)
+     * Same as downloadGame; the filename path segment is captured but ignored server-side and lets clients control the saved filename.
+     * @param id Game ID.
+     * @param filename Optional download filename — server ignores it; lets clients control the saved filename. (optional)
+     * @param format &#39;zip&#39; to force ZIP packaging for multi-file disc games. Default is .tar (or single-file passthrough). (optional)
+     * @return void
+     */
+    open suspend fun downloadGameWithFilename(id: kotlin.String, filename: kotlin.String? = null, format: kotlin.String? = null): HttpResponse<Unit> {
+
+        val localVariableAuthNames = listOf<String>()
+
+        val localVariableBody = 
+            io.ktor.client.utils.EmptyContent
+
+        val localVariableQuery = mutableMapOf<String, List<String>>()
+        format?.apply { localVariableQuery["format"] = listOf("$format") }
+        val localVariableHeaders = mutableMapOf<String, String>()
+
+        val localVariableConfig = RequestConfig<kotlin.Any?>(
+            RequestMethod.GET,
+            "/api/games/{id}/download/{filename}".replace("{" + "id" + "}", "$id").replace("{" + "filename" + "}", "$filename"),
+            query = localVariableQuery,
+            headers = localVariableHeaders,
+            requiresAuthentication = false,
+        )
+
+        return request(
+            localVariableConfig,
+            localVariableBody,
+            localVariableAuthNames
+        ).wrap()
+    }
+
+
+    /**
      * Get other games by the same developer
      * Returns up to 20 other games by the same developer that are in the local library.
      * @param id Game ID.

--- a/server/internal/api/challenge_handler.go
+++ b/server/internal/api/challenge_handler.go
@@ -422,47 +422,11 @@ func (h *ChallengeHandler) DeleteChallenge(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"message": "challenge deleted"})
 }
 
-// DownloadChallengeSave serves the challenge's starting save state.
-func (h *ChallengeHandler) DownloadChallengeSave(c *gin.Context) {
-	id := c.Param("id")
+// DownloadChallengeSave has been migrated to huma — see
+// HumaDownloadChallengeSave in huma_downloads.go.
 
-	var challenge db.Challenge
-	if err := h.DB.First(&challenge, id).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "challenge not found"})
-		return
-	}
-
-	path := h.Storage.ChallengeSavePath(challenge.ID)
-	if !storage.ValidateROMPath(path, []string{h.Storage.SaveDir}) {
-		c.JSON(http.StatusForbidden, ErrorResponse{Error: "access denied"})
-		return
-	}
-	c.Header("Content-Disposition", "attachment; filename=\"challenge_save\"")
-	c.File(path)
-}
-
-// GetChallengeScreenshot serves the challenge's screenshot.
-func (h *ChallengeHandler) GetChallengeScreenshot(c *gin.Context) {
-	id := c.Param("id")
-
-	var challenge db.Challenge
-	if err := h.DB.First(&challenge, id).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "challenge not found"})
-		return
-	}
-
-	if challenge.ScreenshotPath == "" {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "no screenshot available"})
-		return
-	}
-
-	path := h.Storage.ChallengeScreenshotPath(challenge.ID)
-	if !storage.ValidateROMPath(path, []string{h.Storage.SaveDir}) {
-		c.JSON(http.StatusForbidden, ErrorResponse{Error: "access denied"})
-		return
-	}
-	c.File(path)
-}
+// GetChallengeScreenshot has been migrated to huma — see
+// HumaGetChallengeScreenshot in huma_downloads.go.
 
 // StartAttempt begins a new challenge attempt (server records StartedAt).
 func (h *ChallengeHandler) StartAttempt(c *gin.Context) {

--- a/server/internal/api/game_handler.go
+++ b/server/internal/api/game_handler.go
@@ -5,7 +5,6 @@ import (
 	"archive/zip"
 	"fmt"
 	"io"
-	"io/fs"
 	"log/slog"
 	"net/http"
 	"os"
@@ -393,97 +392,8 @@ func (h *GameHandler) GetGame(c *gin.Context) {
 	c.JSON(http.StatusOK, resp)
 }
 
-// DownloadGame serves the ROM file for a game.
-func (h *GameHandler) DownloadGame(c *gin.Context) {
-	id := c.Param("id")
-	var game db.Game
-	if err := h.DB.First(&game, id).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "game not found"})
-		return
-	}
-
-	// Resolve relative path to absolute for filesystem access
-	absPath, err := storage.ResolveGamePath(game.FilePath, h.GameDirs)
-	if err != nil {
-		db.RecordOperationalEvent(h.DB, db.SystemEventInput{
-			EventType: db.SystemEventROMFileMissing,
-			Metadata: db.ROMFileMissingMetadata{
-				GameID:       game.ID,
-				GameTitle:    game.Title,
-				ExpectedPath: game.FilePath,
-			},
-		})
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "game file not found"})
-		return
-	}
-
-	// Security: validate the file path is within allowed directories
-	if !storage.ValidateROMPath(absPath, h.GameDirs) {
-		c.JSON(http.StatusForbidden, ErrorResponse{Error: "file access denied"})
-		return
-	}
-
-	// For .cue/.gdi files, serve a tar/zip bundle with companion track files.
-	// This handles both new games (with disc records) and old DB entries
-	// (without disc records) that were created before the scanner change.
-	lower := strings.ToLower(game.FileName)
-
-	// For .scummvm files, serve the entire game directory as a tar archive.
-	// The .scummvm file lives inside a directory of game data files.
-	// absPath resolves to the game directory (FilePath stores the directory, not the .scummvm file).
-	if strings.HasSuffix(lower, ".scummvm") {
-		var files []string
-		filepath.WalkDir(absPath, func(p string, d fs.DirEntry, err error) error {
-			if err != nil || d.IsDir() {
-				return nil
-			}
-			files = append(files, p)
-			return nil
-		})
-
-		if len(files) > 0 {
-			c.Header("Content-Type", "application/x-tar")
-			c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", game.FileName+".tar"))
-			c.Status(http.StatusOK)
-			if err := serveTar(c.Writer, files); err != nil {
-				slog.Warn("error streaming tar for ScummVM game", "game", game.Title, "error", err)
-			}
-			return
-		}
-	}
-
-	if strings.HasSuffix(lower, ".cue") || strings.HasSuffix(lower, ".gdi") {
-		companions, _, err := scanner.DiscCompanionFiles(absPath)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to read disc files"})
-			return
-		}
-
-		format := c.Query("format")
-		if format == "zip" {
-			c.Header("Content-Type", "application/zip")
-			c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", game.FileName+".zip"))
-			c.Status(http.StatusOK)
-			if err := serveZip(c.Writer, companions); err != nil {
-				slog.Warn("error streaming zip for .cue game", "game", game.Title, "error", err)
-			}
-			return
-		}
-
-		if len(companions) > 1 {
-			c.Header("Content-Type", "application/x-tar")
-			c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", game.FileName+".tar"))
-			c.Status(http.StatusOK)
-			if err := serveTar(c.Writer, companions); err != nil {
-				slog.Warn("error streaming tar for .cue game", "game", game.Title, "error", err)
-			}
-			return
-		}
-	}
-
-	c.Header("Content-Disposition", fmt.Sprintf("inline; filename=%q", game.FileName))
-	c.File(absPath)
-}
+// DownloadGame has been migrated to huma — see HumaDownloadGame in
+// huma_downloads.go.
 
 // UpdateMetadata manually updates game metadata.
 func (h *GameHandler) UpdateMetadata(c *gin.Context) {
@@ -812,75 +722,8 @@ func (h *GameHandler) StopPlaying(c *gin.Context) {
 	c.JSON(http.StatusOK, gin.H{"status": "cleared"})
 }
 
-// DownloadDisc serves files for a specific disc in a multi-disc game.
-// For single-file disc formats (.iso, .chd), serves the file directly.
-// For multi-file disc formats (.cue+.bin), streams an uncompressed tar.
-func (h *GameHandler) DownloadDisc(c *gin.Context) {
-	gameID := c.Param("id")
-	discNumberStr := c.Param("discNumber")
-	discNumber, err := strconv.Atoi(discNumberStr)
-	if err != nil {
-		c.JSON(http.StatusBadRequest, ErrorResponse{Error: "invalid disc number"})
-		return
-	}
-
-	var disc db.GameDisc
-	if err := h.DB.Where("game_id = ? AND disc_number = ?", gameID, discNumber).First(&disc).Error; err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "disc not found"})
-		return
-	}
-
-	// Resolve relative path to absolute for filesystem access
-	absDiscPath, err := storage.ResolveGamePath(disc.FilePath, h.GameDirs)
-	if err != nil {
-		c.JSON(http.StatusNotFound, ErrorResponse{Error: "disc file not found"})
-		return
-	}
-
-	// Security: validate the disc file path is within allowed directories
-	if !storage.ValidateROMPath(absDiscPath, h.GameDirs) {
-		c.JSON(http.StatusForbidden, ErrorResponse{Error: "file access denied"})
-		return
-	}
-
-	// Get companion files for this disc
-	companions, _, err := scanner.DiscCompanionFiles(absDiscPath)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, ErrorResponse{Error: "failed to read disc files"})
-		return
-	}
-
-	// EmulatorJS (browser emulation) supports zip but not tar, so the web
-	// frontend requests format=zip. This must be checked before the single-file
-	// early return so that even single-file discs (.iso, .chd) get zipped.
-	format := c.Query("format")
-	if format == "zip" {
-		c.Header("Content-Type", "application/zip")
-		c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", disc.FileName+".zip"))
-		c.Status(http.StatusOK)
-
-		if err := serveZip(c.Writer, companions); err != nil {
-			slog.Warn("error streaming zip for disc", "disc", discNumber, "error", err)
-		}
-		return
-	}
-
-	if len(companions) == 1 {
-		// Single file (.iso, .chd, etc.) — serve directly
-		c.Header("Content-Disposition", fmt.Sprintf("inline; filename=%q", disc.FileName))
-		c.File(companions[0])
-		return
-	}
-
-	// Default: tar stream (used by native player app)
-	c.Header("Content-Type", "application/x-tar")
-	c.Header("Content-Disposition", fmt.Sprintf("attachment; filename=%q", disc.FileName+".tar"))
-	c.Status(http.StatusOK)
-
-	if err := serveTar(c.Writer, companions); err != nil {
-		slog.Warn("error streaming tar for disc", "disc", discNumber, "error", err)
-	}
-}
+// DownloadDisc has been migrated to huma — see HumaDownloadDisc in
+// huma_downloads.go.
 
 // serveTar streams files as an uncompressed tar archive.
 func serveTar(w io.Writer, filePaths []string) error {

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -13,6 +15,7 @@ import (
 	"github.com/danielgtaylor/huma/v2"
 	"github.com/spela/server/internal/bios"
 	"github.com/spela/server/internal/db"
+	"github.com/spela/server/internal/scanner"
 	"github.com/spela/server/internal/storage"
 	"gorm.io/gorm"
 )
@@ -120,6 +123,28 @@ type ConsoleAssetInput struct {
 // BrandingLogoInput is the empty input for GET /api/branding/logo.
 type BrandingLogoInput struct{}
 
+// GameDownloadInput is the input for GET /api/games/{id}/download(/{filename}).
+// The filename is captured but unused — it lets the client request the file
+// under a download-friendly name without changing the served bytes.
+type GameDownloadInput struct {
+	ID       string `path:"id" doc:"Game ID."`
+	Filename string `path:"filename" required:"false" doc:"Optional download filename — server ignores it; lets clients control the saved filename."`
+	Format   string `query:"format" required:"false" doc:"'zip' to force ZIP packaging for multi-file disc games. Default is .tar (or single-file passthrough)."`
+}
+
+// GameDiscDownloadInput is the input for GET
+// /api/games/{id}/discs/{discNumber}/download.
+type GameDiscDownloadInput struct {
+	ID         string `path:"id" doc:"Game ID."`
+	DiscNumber string `path:"discNumber" doc:"Disc number (1-based)."`
+	Format     string `query:"format" required:"false" doc:"'zip' for ZIP packaging (used by EmulatorJS), default is .tar."`
+}
+
+// ChallengeAssetInput is the input for the two challenge download endpoints.
+type ChallengeAssetInput struct {
+	ID string `path:"id" doc:"Challenge ID."`
+}
+
 // --- Registration ------------------------------------------------------------
 
 // RegisterDownloadRoutes wires the non-wildcard binary download endpoints
@@ -141,6 +166,8 @@ func RegisterDownloadRoutes(
 	sharedSaveH *SharedSaveHandler,
 	sharedSessionH *SharedSessionHandler,
 	consoleH *ConsoleHandler,
+	gameH *GameHandler,
+	challengeH *ChallengeHandler,
 	jwtSecret string,
 	database *gorm.DB,
 	userLimiter *RateLimiter,
@@ -298,6 +325,61 @@ func RegisterDownloadRoutes(
 		Description: "Serves the embedded spela-logo.png branding asset.",
 		Tags:        []string{"branding"},
 	}, humaGetBrandingLogo)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "downloadGame",
+		Method:      http.MethodGet,
+		Path:        "/api/games/{id}/download",
+		Summary:     "Download a game's ROM file",
+		Description: "Serves the game's ROM file. For .scummvm games, packages the entire game directory as tar. For .cue/.gdi multi-file disc games, serves a tar (default) or zip (?format=zip) bundle of all companion files.",
+		Tags:        []string{"games"},
+		Middlewares: authedDownloadMW,
+		Security:    sec,
+	}, gameH.HumaDownloadGame)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "downloadGameWithFilename",
+		Method:      http.MethodGet,
+		Path:        "/api/games/{id}/download/{filename}",
+		Summary:     "Download a game's ROM file (with explicit filename)",
+		Description: "Same as downloadGame; the filename path segment is captured but ignored server-side and lets clients control the saved filename.",
+		Tags:        []string{"games"},
+		Middlewares: authedDownloadMW,
+		Security:    sec,
+	}, gameH.HumaDownloadGame)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "downloadGameDisc",
+		Method:      http.MethodGet,
+		Path:        "/api/games/{id}/discs/{discNumber}/download",
+		Summary:     "Download a specific disc of a multi-disc game",
+		Description: "For single-file disc formats (.iso, .chd) serves the file directly; for multi-file (.cue+.bin) serves an uncompressed tar (or zip when ?format=zip).",
+		Tags:        []string{"games"},
+		Middlewares: authedDownloadMW,
+		Security:    sec,
+	}, gameH.HumaDownloadDisc)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "downloadChallengeSave",
+		Method:      http.MethodGet,
+		Path:        "/api/challenges/{id}/save/download",
+		Summary:     "Download a challenge's starting save state",
+		Description: "Returns the save file that seeds the challenge run. Responds with application/octet-stream.",
+		Tags:        []string{"challenges"},
+		Middlewares: authedMW,
+		Security:    sec,
+	}, challengeH.HumaDownloadChallengeSave)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "getChallengeScreenshot",
+		Method:      http.MethodGet,
+		Path:        "/api/challenges/{id}/screenshot",
+		Summary:     "Get a challenge's screenshot",
+		Description: "Returns the screenshot image that illustrates the challenge state.",
+		Tags:        []string{"challenges"},
+		Middlewares: authedMW,
+		Security:    sec,
+	}, challengeH.HumaGetChallengeScreenshot)
 }
 
 // --- Handlers ----------------------------------------------------------------
@@ -579,4 +661,201 @@ func humaGetBrandingLogo(_ context.Context, _ *BrandingLogoInput) (*huma.StreamR
 		return nil, huma.Error404NotFound("logo not found")
 	}
 	return streamBytesInline(data, "image/png"), nil
+}
+
+// HumaDownloadGame is the huma implementation of GET /api/games/{id}/download
+// (and the {filename}-suffixed variant). Handles three packaging modes:
+//   - .scummvm games: tar of the entire game directory.
+//   - .cue/.gdi multi-file disc games: tar (default) or zip (?format=zip).
+//   - everything else: served inline.
+func (h *GameHandler) HumaDownloadGame(_ context.Context, in *GameDownloadInput) (*huma.StreamResponse, error) {
+	var game db.Game
+	if err := h.DB.First(&game, in.ID).Error; err != nil {
+		return nil, huma.Error404NotFound("game not found")
+	}
+
+	absPath, err := storage.ResolveGamePath(game.FilePath, h.GameDirs)
+	if err != nil {
+		db.RecordOperationalEvent(h.DB, db.SystemEventInput{
+			EventType: db.SystemEventROMFileMissing,
+			Metadata: db.ROMFileMissingMetadata{
+				GameID:       game.ID,
+				GameTitle:    game.Title,
+				ExpectedPath: game.FilePath,
+			},
+		})
+		return nil, huma.Error404NotFound("game file not found")
+	}
+
+	if !storage.ValidateROMPath(absPath, h.GameDirs) {
+		return nil, huma.Error403Forbidden("file access denied")
+	}
+
+	lower := strings.ToLower(game.FileName)
+
+	// .scummvm — tar of the directory
+	if strings.HasSuffix(lower, ".scummvm") {
+		var files []string
+		filepath.WalkDir(absPath, func(p string, d fs.DirEntry, err error) error {
+			if err != nil || d.IsDir() {
+				return nil
+			}
+			files = append(files, p)
+			return nil
+		})
+		if len(files) > 0 {
+			downloadName := game.FileName + ".tar"
+			return streamArchiveTar(files, downloadName, game.Title), nil
+		}
+	}
+
+	// .cue/.gdi — multi-file disc; tar or zip
+	if strings.HasSuffix(lower, ".cue") || strings.HasSuffix(lower, ".gdi") {
+		companions, _, err := scanner.DiscCompanionFiles(absPath)
+		if err != nil {
+			return nil, huma.Error500InternalServerError("failed to read disc files")
+		}
+		if in.Format == "zip" {
+			return streamArchiveZip(companions, game.FileName+".zip", game.Title), nil
+		}
+		if len(companions) > 1 {
+			return streamArchiveTar(companions, game.FileName+".tar", game.Title), nil
+		}
+	}
+
+	// Fallback: inline single file. Match the gin "inline" Content-Disposition
+	// (the file may be a ROM that the client renders inline rather than saves).
+	return &huma.StreamResponse{
+		Body: func(hctx huma.Context) {
+			f, err := os.Open(absPath)
+			if err != nil {
+				hctx.SetStatus(http.StatusInternalServerError)
+				return
+			}
+			defer f.Close()
+			hctx.SetHeader("Content-Type", "application/octet-stream")
+			hctx.SetHeader("Content-Disposition", fmt.Sprintf("inline; filename=%q", game.FileName))
+			_, _ = io.Copy(hctx.BodyWriter(), f)
+		},
+	}, nil
+}
+
+// HumaDownloadDisc is the huma implementation of GET
+// /api/games/{id}/discs/{discNumber}/download.
+func (h *GameHandler) HumaDownloadDisc(_ context.Context, in *GameDiscDownloadInput) (*huma.StreamResponse, error) {
+	discNumber, err := strconv.Atoi(in.DiscNumber)
+	if err != nil {
+		return nil, huma.Error400BadRequest("invalid disc number")
+	}
+
+	var disc db.GameDisc
+	if err := h.DB.Where("game_id = ? AND disc_number = ?", in.ID, discNumber).First(&disc).Error; err != nil {
+		return nil, huma.Error404NotFound("disc not found")
+	}
+
+	absDiscPath, err := storage.ResolveGamePath(disc.FilePath, h.GameDirs)
+	if err != nil {
+		return nil, huma.Error404NotFound("disc file not found")
+	}
+	if !storage.ValidateROMPath(absDiscPath, h.GameDirs) {
+		return nil, huma.Error403Forbidden("file access denied")
+	}
+
+	companions, _, err := scanner.DiscCompanionFiles(absDiscPath)
+	if err != nil {
+		return nil, huma.Error500InternalServerError("failed to read disc files")
+	}
+
+	if in.Format == "zip" {
+		return streamArchiveZip(companions, disc.FileName+".zip", "disc "+in.DiscNumber), nil
+	}
+	if len(companions) == 1 {
+		// Single file (.iso, .chd) — serve inline
+		return &huma.StreamResponse{
+			Body: func(hctx huma.Context) {
+				f, err := os.Open(companions[0])
+				if err != nil {
+					hctx.SetStatus(http.StatusInternalServerError)
+					return
+				}
+				defer f.Close()
+				hctx.SetHeader("Content-Type", "application/octet-stream")
+				hctx.SetHeader("Content-Disposition", fmt.Sprintf("inline; filename=%q", disc.FileName))
+				_, _ = io.Copy(hctx.BodyWriter(), f)
+			},
+		}, nil
+	}
+
+	return streamArchiveTar(companions, disc.FileName+".tar", "disc "+in.DiscNumber), nil
+}
+
+// streamArchiveTar returns a StreamResponse that writes an uncompressed tar
+// of the given files. Errors during streaming are logged but not surfaced —
+// once headers are sent the response body is one-way.
+func streamArchiveTar(files []string, downloadName, contextName string) *huma.StreamResponse {
+	return &huma.StreamResponse{
+		Body: func(hctx huma.Context) {
+			hctx.SetHeader("Content-Type", "application/x-tar")
+			hctx.SetHeader("Content-Disposition", fmt.Sprintf("attachment; filename=%q", downloadName))
+			if err := serveTar(hctx.BodyWriter(), files); err != nil {
+				slog.Warn("error streaming tar", "context", contextName, "error", err)
+			}
+		},
+	}
+}
+
+// streamArchiveZip returns a StreamResponse that writes a zip archive.
+func streamArchiveZip(files []string, downloadName, contextName string) *huma.StreamResponse {
+	return &huma.StreamResponse{
+		Body: func(hctx huma.Context) {
+			hctx.SetHeader("Content-Type", "application/zip")
+			hctx.SetHeader("Content-Disposition", fmt.Sprintf("attachment; filename=%q", downloadName))
+			if err := serveZip(hctx.BodyWriter(), files); err != nil {
+				slog.Warn("error streaming zip", "context", contextName, "error", err)
+			}
+		},
+	}
+}
+
+// HumaDownloadChallengeSave is the huma implementation of GET
+// /api/challenges/{id}/save/download.
+func (h *ChallengeHandler) HumaDownloadChallengeSave(_ context.Context, in *ChallengeAssetInput) (*huma.StreamResponse, error) {
+	var challenge db.Challenge
+	if err := h.DB.First(&challenge, in.ID).Error; err != nil {
+		return nil, huma.Error404NotFound("challenge not found")
+	}
+	path := h.Storage.ChallengeSavePath(challenge.ID)
+	if !storage.ValidateROMPath(path, []string{h.Storage.SaveDir}) {
+		return nil, huma.Error403Forbidden("access denied")
+	}
+	return streamFileFromDisk(path, "challenge_save", "application/octet-stream"), nil
+}
+
+// HumaGetChallengeScreenshot is the huma implementation of GET
+// /api/challenges/{id}/screenshot. Mirrors the gin handler — no
+// Content-Disposition (rendered inline by <img>).
+func (h *ChallengeHandler) HumaGetChallengeScreenshot(_ context.Context, in *ChallengeAssetInput) (*huma.StreamResponse, error) {
+	var challenge db.Challenge
+	if err := h.DB.First(&challenge, in.ID).Error; err != nil {
+		return nil, huma.Error404NotFound("challenge not found")
+	}
+	if challenge.ScreenshotPath == "" {
+		return nil, huma.Error404NotFound("no screenshot available")
+	}
+	path := h.Storage.ChallengeScreenshotPath(challenge.ID)
+	if !storage.ValidateROMPath(path, []string{h.Storage.SaveDir}) {
+		return nil, huma.Error403Forbidden("access denied")
+	}
+	return &huma.StreamResponse{
+		Body: func(hctx huma.Context) {
+			f, err := os.Open(path)
+			if err != nil {
+				hctx.SetStatus(http.StatusInternalServerError)
+				return
+			}
+			defer f.Close()
+			hctx.SetHeader("Content-Type", "image/png")
+			_, _ = io.Copy(hctx.BodyWriter(), f)
+		},
+	}, nil
 }

--- a/server/internal/api/huma_setup_test.go
+++ b/server/internal/api/huma_setup_test.go
@@ -356,6 +356,12 @@ func TestOpenAPISpec_HasNewOperations(t *testing.T) {
 		{"/api/consoles/{id}/logo.png", "get", "getConsoleLogoPng"},
 		{"/api/consoles/{id}/preview-screenshot", "get", "getConsolePreviewScreenshot"},
 		{"/api/branding/logo", "get", "getBrandingLogo"},
+		// ROM + challenge downloads
+		{"/api/games/{id}/download", "get", "downloadGame"},
+		{"/api/games/{id}/download/{filename}", "get", "downloadGameWithFilename"},
+		{"/api/games/{id}/discs/{discNumber}/download", "get", "downloadGameDisc"},
+		{"/api/challenges/{id}/save/download", "get", "downloadChallengeSave"},
+		{"/api/challenges/{id}/screenshot", "get", "getChallengeScreenshot"},
 	}
 
 	// Operations that are intentionally public (no auth) — typically images

--- a/server/internal/api/router.go
+++ b/server/internal/api/router.go
@@ -241,7 +241,7 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 	RegisterSharedUploadRoutes(humaAPI, sharedSaveHandler, sharedSessionHandler, cfg.JWTSecret, cfg.DB, userLimiter, uploadLimiter)
 	RegisterNetplayRoutes(humaAPI, netplayHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	RegisterChallengeRoutes(humaAPI, challengeHandler, cfg.JWTSecret, cfg.DB, userLimiter)
-	RegisterDownloadRoutes(humaAPI, coreHandler, biosHandler, sessionHandler, sharedSaveHandler, sharedSessionHandler, consoleHandler, cfg.JWTSecret, cfg.DB, userLimiter, downloadLimiter)
+	RegisterDownloadRoutes(humaAPI, coreHandler, biosHandler, sessionHandler, sharedSaveHandler, sharedSessionHandler, consoleHandler, gameHandler, challengeHandler, cfg.JWTSecret, cfg.DB, userLimiter, downloadLimiter)
 	RegisterAdminRoutes(humaAPI, adminHandler, cfg.JWTSecret, cfg.DB, userLimiter)
 	adminSystemEventHandler := &SystemEventHandler{DB: cfg.DB}
 	RegisterSystemEventRoutes(humaAPI, adminSystemEventHandler, cfg.JWTSecret, cfg.DB, userLimiter)
@@ -315,12 +315,9 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		//   RegisterExploreChallengeRoutes  (easy-to-complete/hardest-games/almost-done/fresh-challenges/active-challenges)
 		//   RegisterExploreWizardRoutes     (wizard + wizard/results)
 
-		// Games — most endpoints migrated to huma (see RegisterGameRoutes above).
-		// Download endpoints stay on gin because they use c.File()/tar+zip streaming
-		// that doesn't map cleanly to huma typed outputs.
-		api.GET("/games/:id/download", downloadLimiter.RateLimit(), gameHandler.DownloadGame)
-		api.GET("/games/:id/download/:filename", downloadLimiter.RateLimit(), gameHandler.DownloadGame)
-		api.GET("/games/:id/discs/:discNumber/download", downloadLimiter.RateLimit(), gameHandler.DownloadDisc)
+		// Games — fully migrated to huma. JSON endpoints in RegisterGameRoutes
+		// above; download + tar/zip streaming endpoints in RegisterDownloadRoutes
+		// above (downloadGame / downloadGameWithFilename / downloadGameDisc).
 		// /games/:id/artwork — migrated to huma (see RegisterArtworkRoutes above).
 		// /games/:id/similar + /games/:id/developer-games — migrated to huma
 		// (see RegisterDiscoveryRoutes above).
@@ -388,12 +385,10 @@ func NewRouter(cfg Config) (*gin.Engine, func()) {
 		// /users/:id/play-heatmap — migrated to huma (see RegisterUserExtraRoutes above).
 
 		// Challenges — most endpoints migrated to huma
-		// (see RegisterChallengeRoutes above). CreateChallenge stays on raw
-		// gin (multipart upload) along with the save / screenshot file
-		// downloads.
+		// (see RegisterChallengeRoutes above). Save + screenshot downloads
+		// migrated to huma (see RegisterDownloadRoutes). CreateChallenge
+		// stays on raw gin (multipart upload).
 		api.POST("/challenges", challengeHandler.CreateChallenge)
-		api.GET("/challenges/:id/save/download", challengeHandler.DownloadChallengeSave)
-		api.GET("/challenges/:id/screenshot", challengeHandler.GetChallengeScreenshot)
 
 		// Enrichment: Themes, Keywords, Series, Franchises — migrated to huma
 		// (see RegisterEnrichmentRoutes above).

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -1388,6 +1388,46 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/challenges/{id}/save/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download a challenge's starting save state
+         * @description Returns the save file that seeds the challenge run. Responds with application/octet-stream.
+         */
+        get: operations["downloadChallengeSave"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/challenges/{id}/screenshot": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get a challenge's screenshot
+         * @description Returns the screenshot image that illustrates the challenge state.
+         */
+        get: operations["getChallengeScreenshot"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/collections": {
         parameters: {
             query?: never;
@@ -2692,6 +2732,66 @@ export interface paths {
          * @description Returns up to 20 other games by the same developer that are in the local library.
          */
         get: operations["getDeveloperGames"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/games/{id}/discs/{discNumber}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download a specific disc of a multi-disc game
+         * @description For single-file disc formats (.iso, .chd) serves the file directly; for multi-file (.cue+.bin) serves an uncompressed tar (or zip when ?format=zip).
+         */
+        get: operations["downloadGameDisc"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/games/{id}/download": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download a game's ROM file
+         * @description Serves the game's ROM file. For .scummvm games, packages the entire game directory as tar. For .cue/.gdi multi-file disc games, serves a tar (default) or zip (?format=zip) bundle of all companion files.
+         */
+        get: operations["downloadGame"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/games/{id}/download/{filename}": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Download a game's ROM file (with explicit filename)
+         * @description Same as downloadGame; the filename path segment is captured but ignored server-side and lets clients control the saved filename.
+         */
+        get: operations["downloadGameWithFilename"];
         put?: never;
         post?: never;
         delete?: never;
@@ -11077,6 +11177,66 @@ export interface operations {
             };
         };
     };
+    downloadChallengeSave: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Challenge ID. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    getChallengeScreenshot: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path: {
+                /** @description Challenge ID. */
+                id: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
     listMyCollections: {
         parameters: {
             query?: {
@@ -13317,6 +13477,111 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["DeveloperGameResponse"][] | null;
                 };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    downloadGameDisc: {
+        parameters: {
+            query?: {
+                /** @description 'zip' for ZIP packaging (used by EmulatorJS), default is .tar. */
+                format?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Game ID. */
+                id: string;
+                /** @description Disc number (1-based). */
+                discNumber: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    downloadGame: {
+        parameters: {
+            query?: {
+                /** @description 'zip' to force ZIP packaging for multi-file disc games. Default is .tar (or single-file passthrough). */
+                format?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Game ID. */
+                id: string;
+                /** @description Optional download filename — server ignores it; lets clients control the saved filename. */
+                filename: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    downloadGameWithFilename: {
+        parameters: {
+            query?: {
+                /** @description 'zip' to force ZIP packaging for multi-file disc games. Default is .tar (or single-file passthrough). */
+                format?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Game ID. */
+                id: string;
+                /** @description Optional download filename — server ignores it; lets clients control the saved filename. */
+                filename: string;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
             /** @description Error */
             default: {

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -14324,6 +14324,90 @@
         ]
       }
     },
+    "/api/challenges/{id}/save/download": {
+      "get": {
+        "description": "Returns the save file that seeds the challenge run. Responds with application/octet-stream.",
+        "operationId": "downloadChallengeSave",
+        "parameters": [
+          {
+            "description": "Challenge ID.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Challenge ID.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Download a challenge's starting save state",
+        "tags": [
+          "challenges"
+        ]
+      }
+    },
+    "/api/challenges/{id}/screenshot": {
+      "get": {
+        "description": "Returns the screenshot image that illustrates the challenge state.",
+        "operationId": "getChallengeScreenshot",
+        "parameters": [
+          {
+            "description": "Challenge ID.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Challenge ID.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Get a challenge's screenshot",
+        "tags": [
+          "challenges"
+        ]
+      }
+    },
     "/api/collections": {
       "get": {
         "description": "Paginated list of the caller's collections, newest first. Supports optional name substring search.",
@@ -18238,6 +18322,190 @@
           }
         ],
         "summary": "Get other games by the same developer",
+        "tags": [
+          "games"
+        ]
+      }
+    },
+    "/api/games/{id}/discs/{discNumber}/download": {
+      "get": {
+        "description": "For single-file disc formats (.iso, .chd) serves the file directly; for multi-file (.cue+.bin) serves an uncompressed tar (or zip when ?format=zip).",
+        "operationId": "downloadGameDisc",
+        "parameters": [
+          {
+            "description": "Game ID.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Game ID.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Disc number (1-based).",
+            "in": "path",
+            "name": "discNumber",
+            "required": true,
+            "schema": {
+              "description": "Disc number (1-based).",
+              "type": "string"
+            }
+          },
+          {
+            "description": "'zip' for ZIP packaging (used by EmulatorJS), default is .tar.",
+            "explode": false,
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "description": "'zip' for ZIP packaging (used by EmulatorJS), default is .tar.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Download a specific disc of a multi-disc game",
+        "tags": [
+          "games"
+        ]
+      }
+    },
+    "/api/games/{id}/download": {
+      "get": {
+        "description": "Serves the game's ROM file. For .scummvm games, packages the entire game directory as tar. For .cue/.gdi multi-file disc games, serves a tar (default) or zip (?format=zip) bundle of all companion files.",
+        "operationId": "downloadGame",
+        "parameters": [
+          {
+            "description": "Game ID.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Game ID.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional download filename — server ignores it; lets clients control the saved filename.",
+            "in": "path",
+            "name": "filename",
+            "schema": {
+              "description": "Optional download filename — server ignores it; lets clients control the saved filename.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "'zip' to force ZIP packaging for multi-file disc games. Default is .tar (or single-file passthrough).",
+            "explode": false,
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "description": "'zip' to force ZIP packaging for multi-file disc games. Default is .tar (or single-file passthrough).",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Download a game's ROM file",
+        "tags": [
+          "games"
+        ]
+      }
+    },
+    "/api/games/{id}/download/{filename}": {
+      "get": {
+        "description": "Same as downloadGame; the filename path segment is captured but ignored server-side and lets clients control the saved filename.",
+        "operationId": "downloadGameWithFilename",
+        "parameters": [
+          {
+            "description": "Game ID.",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Game ID.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Optional download filename — server ignores it; lets clients control the saved filename.",
+            "in": "path",
+            "name": "filename",
+            "schema": {
+              "description": "Optional download filename — server ignores it; lets clients control the saved filename.",
+              "type": "string"
+            }
+          },
+          {
+            "description": "'zip' to force ZIP packaging for multi-file disc games. Default is .tar (or single-file passthrough).",
+            "explode": false,
+            "in": "query",
+            "name": "format",
+            "schema": {
+              "description": "'zip' to force ZIP packaging for multi-file disc games. Default is .tar (or single-file passthrough).",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Download a game's ROM file (with explicit filename)",
         "tags": [
           "games"
         ]


### PR DESCRIPTION
Stacked on #505. Final batch of binary downloads — after this lands, the only gin routes left are the wildcard image serve, WebSockets, and the test-mode reset.

## Migrated (5 endpoints)

| Method | Path | Operation |
|---|---|---|
| GET | /api/games/{id}/download | downloadGame |
| GET | /api/games/{id}/download/{filename} | downloadGameWithFilename |
| GET | /api/games/{id}/discs/{discNumber}/download | downloadGameDisc |
| GET | /api/challenges/{id}/save/download | downloadChallengeSave |
| GET | /api/challenges/{id}/screenshot | getChallengeScreenshot |

The ROM handlers are the most complex: .scummvm games tar the entire game directory, .cue/.gdi multi-file disc games tar (default) or zip (?format=zip), single-file games stream inline. Two helper functions (streamArchiveTar, streamArchiveZip) wrap the existing serveTar/serveZip writers so the huma handlers stay readable.

## Final state of gin routes

- \`/api/images/*filepath\` — wildcard path; OpenAPI 3.1 path params are single-segment, image paths legitimately contain slashes
- \`/api/ws\`, \`/api/netplay/sessions/{id}/ws\` — WebSocket; huma doesn't model handshakes
- \`/api/test/reset\` — test-only

Everything else flows through huma → OpenAPI spec → generated TS types + Kotlin \`*Api\` classes.

## Test plan

- [x] \`go build ./...\` clean
- [x] Game + challenge tests pass
- [x] Full \`go test ./internal/api/ -short\` passes
- [x] \`TestOpenAPISpec_HasNewOperations\` covers the 5 new operations
- [x] Kotlin compile passes
- [ ] CI Go tests
- [ ] CI Player unit tests
- [ ] CI Web unit tests