### PR TITLE
feat(web): migrate health/stats/cheats hooks to typedApi

### DIFF
--- a/web/src/hooks/use-cheats.ts
+++ b/web/src/hooks/use-cheats.ts
@@ -1,39 +1,17 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-
-interface CheatStats {
-  totalCheats: number;
-  gamesWithCheats: number;
-  totalGames: number;
-  verifiedGames: number;
-}
-
-interface ImportResult {
-  totalGames: number;
-  cheatsImported: number;
-  gamesImported: number;
-  skipped: number;
-  failed: number;
-}
-
-interface CheatCode {
-  id: number;
-  index: number;
-  description: string;
-  code: string;
-}
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export function useCheatStats() {
   return useQuery({
     queryKey: ["admin", "cheat-stats"],
-    queryFn: () => api.get<CheatStats>("/admin/cheats/stats"),
+    queryFn: () => unwrap(typedApi.GET("/api/admin/cheats/stats")),
   });
 }
 
 export function useImportCheats() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => api.post<ImportResult>("/admin/cheats/import"),
+    mutationFn: () => unwrap(typedApi.POST("/api/admin/cheats/import")),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["admin", "cheat-stats"] });
     },
@@ -43,7 +21,12 @@ export function useImportCheats() {
 export function useGameCheats(gameId: string) {
   return useQuery({
     queryKey: ["game", gameId, "cheats"],
-    queryFn: () => api.get<CheatCode[]>(`/games/${gameId}/cheats`),
+    queryFn: () =>
+      unwrap(
+        typedApi.GET("/api/games/{id}/cheats", {
+          params: { path: { id: gameId } },
+        }),
+      ),
     enabled: !!gameId,
   });
 }

--- a/web/src/hooks/use-health.ts
+++ b/web/src/hooks/use-health.ts
@@ -1,15 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-
-interface HealthResponse {
-  status: string;
-  version: string;
-}
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export function useHealth() {
   return useQuery({
     queryKey: ["health"],
-    queryFn: () => api.get<HealthResponse>("/health"),
+    queryFn: () => unwrap(typedApi.GET("/api/health")),
     staleTime: 5 * 60 * 1000,
   });
 }

--- a/web/src/hooks/use-stats.ts
+++ b/web/src/hooks/use-stats.ts
@@ -1,29 +1,23 @@
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type {
-  MostPlayedGamesResponse,
-  MostActivePlayersResponse,
-  UserStats,
-} from "@/types/api";
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export function useMostPlayedGames() {
   return useQuery({
     queryKey: ["stats", "most-played"],
-    queryFn: () => api.get<MostPlayedGamesResponse>("/stats/most-played"),
+    queryFn: () => unwrap(typedApi.GET("/api/stats/most-played")),
   });
 }
 
 export function useMostActivePlayers() {
   return useQuery({
     queryKey: ["stats", "most-active-players"],
-    queryFn: () =>
-      api.get<MostActivePlayersResponse>("/stats/most-active-players"),
+    queryFn: () => unwrap(typedApi.GET("/api/stats/most-active-players")),
   });
 }
 
 export function useUserStats() {
   return useQuery({
     queryKey: ["user-stats"],
-    queryFn: () => api.get<UserStats>("/user/stats"),
+    queryFn: () => unwrap(typedApi.GET("/api/user/stats")),
   });
 }

--- a/web/src/pages/stats-page.tsx
+++ b/web/src/pages/stats-page.tsx
@@ -172,7 +172,7 @@ export function StatsPage() {
             <MostPlayedSkeleton />
           ) : (
             <div className="space-y-2">
-              {mostPlayed?.games.slice(0, 25).map((entry, index) => {
+              {mostPlayed?.games?.slice(0, 25).map((entry, index) => {
                 const rank = index + 1;
                 return (
                   <Link


### PR DESCRIPTION
First batch of incremental call-site migrations to the typedApi client added in #504. Picks the simplest hooks (useHealth, useMostPlayedGames, useMostActivePlayers, useUserStats, useCheatStats, useImportCheats, useGameCheats) — all read-only or mutation-only with no path or query parameters that surface type divergences.

## What changes

- 7 hooks switched from \`api.get<T>()\` / \`api.post<T>()\` (legacy, takes interpolated path + explicit response generic) to \`unwrap(typedApi.GET("/api/...", { params: { path: { id } } }))\` (typed, returns inferred response type from the spec).
- Hand-written types (\`HealthResponse\`, \`MostPlayedGamesResponse\`, \`MostActivePlayersResponse\`, \`UserStats\`, \`CheatStats\`, \`ImportResult\`, \`CheatCode\`) removed from per-hook imports — consumers now get the generated type via type inference.
- One consumer-side fix: \`stats-page.tsx\` adds an optional chain on \`mostPlayed?.games\` because the generated spec correctly types it as nullable.

## Test plan

- [x] \`npx tsc -b --noEmit\` clean
- [x] All 1466 existing web tests pass
- [ ] CI Web unit tests
- [ ] CI Go tests
- [ ] CI Player unit tests