### PR TITLE
feat(web): migrate top-lists/profile/storage/heatmap/play-stats to typedApi

### DIFF
--- a/web/src/hooks/use-play-heatmap.ts
+++ b/web/src/hooks/use-play-heatmap.ts
@@ -1,11 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type { DailyPlayActivity } from "@/types/api";
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export function useMyPlayHeatmap() {
   return useQuery({
     queryKey: ["user", "play-heatmap"],
-    queryFn: () => api.get<DailyPlayActivity[]>("/user/play-heatmap"),
+    queryFn: () => unwrap(typedApi.GET("/api/user/play-heatmap")),
   });
 }
 
@@ -13,7 +12,11 @@ export function useUserPlayHeatmap(userId: string) {
   return useQuery({
     queryKey: ["users", userId, "play-heatmap"],
     queryFn: () =>
-      api.get<DailyPlayActivity[]>(`/users/${userId}/play-heatmap`),
+      unwrap(
+        typedApi.GET("/api/users/{id}/play-heatmap", {
+          params: { path: { id: userId } },
+        }),
+      ),
     enabled: !!userId,
   });
 }

--- a/web/src/hooks/use-play-stats.ts
+++ b/web/src/hooks/use-play-stats.ts
@@ -1,11 +1,10 @@
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type { PlayStatsEntry } from "@/types/api";
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export function usePlayStats() {
   return useQuery({
     queryKey: ["user", "play-stats"],
-    queryFn: () => api.get<PlayStatsEntry[]>("/user/play-stats"),
+    queryFn: () => unwrap(typedApi.GET("/api/user/play-stats")),
     staleTime: 60_000,
   });
 }

--- a/web/src/hooks/use-public-profile.ts
+++ b/web/src/hooks/use-public-profile.ts
@@ -1,11 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type { PublicProfile } from "@/types/api";
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export function usePublicProfile(userId: string) {
   return useQuery({
     queryKey: ["users", userId, "profile"],
-    queryFn: () => api.get<PublicProfile>(`/users/${userId}/profile`),
+    queryFn: () =>
+      unwrap(
+        typedApi.GET("/api/users/{id}/profile", {
+          params: { path: { id: userId } },
+        }),
+      ),
     enabled: !!userId,
   });
 }

--- a/web/src/hooks/use-storage.ts
+++ b/web/src/hooks/use-storage.ts
@@ -1,11 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type { StorageInfo, CompactSavesResult } from "@/types/api";
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export function useStorage() {
   return useQuery({
     queryKey: ["user", "storage"],
-    queryFn: () => api.get<StorageInfo>("/user/storage"),
+    queryFn: () => unwrap(typedApi.GET("/api/user/storage")),
   });
 }
 
@@ -13,7 +12,7 @@ export function useCompactSaves() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: () => api.post<CompactSavesResult>("/user/saves/compact"),
+    mutationFn: () => unwrap(typedApi.POST("/api/user/saves/compact")),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["user", "storage"] });
     },

--- a/web/src/hooks/use-top-lists.ts
+++ b/web/src/hooks/use-top-lists.ts
@@ -1,31 +1,30 @@
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type { TopListGame, TopRatedGame, LongestGame } from "@/types/api";
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export function useTopRated() {
   return useQuery({
     queryKey: ["top-lists", "top-rated"],
-    queryFn: () => api.get<TopListGame[]>("/top-lists/top-rated"),
+    queryFn: () => unwrap(typedApi.GET("/api/top-lists/top-rated")),
   });
 }
 
 export function useTopRatedCritics() {
   return useQuery({
     queryKey: ["top-lists", "top-rated-critics"],
-    queryFn: () => api.get<TopListGame[]>("/top-lists/top-rated-critics"),
+    queryFn: () => unwrap(typedApi.GET("/api/top-lists/top-rated-critics")),
   });
 }
 
 export function useLongestGames() {
   return useQuery({
     queryKey: ["top-lists", "longest"],
-    queryFn: () => api.get<LongestGame[]>("/top-lists/longest"),
+    queryFn: () => unwrap(typedApi.GET("/api/top-lists/longest")),
   });
 }
 
 export function useTopRatedGlobal() {
   return useQuery({
     queryKey: ["top-rated-global"],
-    queryFn: () => api.get<TopRatedGame[]>("/top-rated"),
+    queryFn: () => unwrap(typedApi.GET("/api/top-rated")),
   });
 }

--- a/web/src/pages/storage-page.tsx
+++ b/web/src/pages/storage-page.tsx
@@ -50,6 +50,7 @@ export function StoragePage() {
   function handleCompact() {
     compactSaves.mutate(undefined, {
       onSuccess: (result) => {
+        if (!result) return;
         if (result.deletedCount === 0) {
           toast("info", "No saves to compact. Storage is already optimized.");
         } else {
@@ -89,10 +90,8 @@ export function StoragePage() {
     );
   }
 
-  const totalSaves = storage.byConsole.reduce(
-    (acc, c) => acc + c.saveCount,
-    0,
-  );
+  const byConsole = storage.byConsole ?? [];
+  const totalSaves = byConsole.reduce((acc, c) => acc + c.saveCount, 0);
   const hasSaves = totalSaves > 0;
 
   return (
@@ -141,7 +140,7 @@ export function StoragePage() {
         </div>
         <div className="px-5 pb-5">
           {hasSaves ? (
-            <ConsoleBreakdownTable consoles={storage.byConsole} />
+            <ConsoleBreakdownTable consoles={byConsole} />
           ) : (
             <EmptyState
               icon={Archive}

--- a/web/src/pages/user-profile-page.tsx
+++ b/web/src/pages/user-profile-page.tsx
@@ -198,30 +198,30 @@ export function UserProfilePage() {
 
       {/* Game sections */}
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
-        {profile.topGames.length > 0 && (
+        {(profile.topGames?.length ?? 0) > 0 && (
           <ProfileSection title="Most Played" icon={Trophy}>
             <div className="space-y-1">
-              {profile.topGames.map((game) => (
+              {profile.topGames?.map((game) => (
                 <ProfileGameCard key={game.id} game={game} />
               ))}
             </div>
           </ProfileSection>
         )}
 
-        {profile.favoriteGames.length > 0 && (
+        {(profile.favoriteGames?.length ?? 0) > 0 && (
           <ProfileSection title="Favorites" icon={Heart}>
             <div className="space-y-1">
-              {profile.favoriteGames.map((game) => (
+              {profile.favoriteGames?.map((game) => (
                 <ProfileGameCard key={game.id} game={game} />
               ))}
             </div>
           </ProfileSection>
         )}
 
-        {profile.recentGames.length > 0 && (
+        {(profile.recentGames?.length ?? 0) > 0 && (
           <ProfileSection title="Recently Played" icon={Clock}>
             <div className="space-y-1">
-              {profile.recentGames.map((game) => (
+              {profile.recentGames?.map((game) => (
                 <ProfileGameCard key={game.id} game={game} />
               ))}
             </div>


### PR DESCRIPTION
Batch 2 of incremental call-site migrations to typedApi (continues #507). Picks 5 hooks without unit-test files so the migration stays mechanical:

- useTopRated, useTopRatedCritics, useLongestGames, useTopRatedGlobal
- usePublicProfile
- useStorage, useCompactSaves
- useMyPlayHeatmap, useUserPlayHeatmap
- usePlayStats

## Real type divergences fixed

The generated spec correctly typed several arrays as nullable; the hand-written types claimed otherwise. These were silent footguns:

- \`storage-page.tsx\` — \`storage.byConsole\` and the compact-saves \`result\` are guarded.
- \`user-profile-page.tsx\` — \`profile.topGames\`, \`profile.favoriteGames\`, \`profile.recentGames\` are optional-chained.

## Test plan

- [x] \`npx tsc -b --noEmit\` clean
- [x] All 1466 web tests pass
- [ ] CI Web unit tests
- [ ] CI Go tests
- [ ] CI Player unit tests