### PR TITLE
feat(web): migrate game-stats hook to typedApi

### DIFF
--- a/web/src/features/game-detail/components/game-community-stats.tsx
+++ b/web/src/features/game-detail/components/game-community-stats.tsx
@@ -73,9 +73,10 @@ export function GameCommunityStats({ gameId, game }: GameCommunityStatsProps) {
     );
   }
 
+  const topPlayers = stats.topPlayers ?? [];
   const maxPlayTime =
-    stats.topPlayers.length > 0
-      ? Math.max(...stats.topPlayers.map((p) => p.playTime))
+    topPlayers.length > 0
+      ? Math.max(...topPlayers.map((p) => p.playTime))
       : 1;
 
   return (
@@ -117,13 +118,13 @@ export function GameCommunityStats({ gameId, game }: GameCommunityStatsProps) {
       </div>
 
       {/* Top Players */}
-      {stats.topPlayers.length > 0 && (
+      {topPlayers.length > 0 && (
         <div>
           <h3 className="text-sm font-semibold text-surface-400 uppercase tracking-wider mb-3">
             Top Players
           </h3>
           <div className="space-y-2">
-            {stats.topPlayers.map((player, index) => {
+            {topPlayers.map((player, index) => {
               const rank = index + 1;
               const isCurrentUser = player.userId === user?.id;
               const barWidth =

--- a/web/src/hooks/use-game-stats.ts
+++ b/web/src/hooks/use-game-stats.ts
@@ -1,11 +1,15 @@
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type { GameStats } from "@/types/api";
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export function useGameStats(gameId: string) {
   return useQuery({
     queryKey: ["game-stats", gameId],
-    queryFn: () => api.get<GameStats>(`/games/${gameId}/stats`),
+    queryFn: () =>
+      unwrap(
+        typedApi.GET("/api/games/{id}/stats", {
+          params: { path: { id: gameId } },
+        }),
+      ),
     enabled: !!gameId,
   });
 }


### PR DESCRIPTION
Batch 3 of incremental call-site migrations to typedApi (continues #508).

\`useGameStats\` switches to \`typedApi.GET\` with path params. The generated spec correctly types \`stats.topPlayers\` as nullable; the hand-written \`GameStats\` type claimed it was always non-null. \`game-community-stats.tsx\` now reads via \`topPlayers ?? []\`.

## Test plan

- [x] \`npx tsc -b --noEmit\` clean
- [x] All 1466 web tests pass
- [ ] CI Web unit tests
- [ ] CI Go tests
- [ ] CI Player unit tests