### PR TITLE
feat(web): migrate use-saved-searches to typedApi (with test rewrite)

### DIFF
--- a/web/src/hooks/__tests__/use-saved-searches.test.tsx
+++ b/web/src/hooks/__tests__/use-saved-searches.test.tsx
@@ -3,17 +3,30 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useSavedSearches, useCreateSavedSearch, useDeleteSavedSearch } from "../use-saved-searches";
 
-const mockGet = vi.fn();
-const mockPost = vi.fn();
-const mockDelete = vi.fn();
-
 vi.mock("@/lib/api-client", () => ({
-  api: {
-    get: (...args: unknown[]) => mockGet(...args),
-    post: (...args: unknown[]) => mockPost(...args),
-    delete: (...args: unknown[]) => mockDelete(...args),
-  },
+  typedApi: { GET: vi.fn(), POST: vi.fn(), PUT: vi.fn(), DELETE: vi.fn() },
+  unwrap: vi.fn(<T,>(p: Promise<{ data?: T; error?: unknown; response: Response }>) =>
+    p.then((r) => {
+      if (r.error !== undefined) throw r.error;
+      return r.data;
+    }),
+  ),
 }));
+
+import { typedApi } from "@/lib/api-client";
+
+const mockTypedApi = typedApi as unknown as {
+  GET: ReturnType<typeof vi.fn>;
+  POST: ReturnType<typeof vi.fn>;
+  DELETE: ReturnType<typeof vi.fn>;
+};
+
+function ok(data: unknown) {
+  return Promise.resolve({
+    data,
+    response: new Response(null, { status: 200 }),
+  });
+}
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -33,10 +46,10 @@ describe("useSavedSearches", () => {
     const data = [
       { id: "1", name: "RPGs", filters: { genres: "RPG" }, createdAt: "2026-01-01T00:00:00Z" },
     ];
-    mockGet.mockResolvedValueOnce(data);
+    mockTypedApi.GET.mockReturnValue(ok(data));
     const { result } = renderHook(() => useSavedSearches(), { wrapper: createWrapper() });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockGet).toHaveBeenCalledWith("/user/saved-searches");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith("/api/user/saved-searches");
     expect(result.current.data).toEqual(data);
   });
 });
@@ -44,20 +57,25 @@ describe("useSavedSearches", () => {
 describe("useCreateSavedSearch", () => {
   it("creates a saved search", async () => {
     const created = { id: "2", name: "Test", filters: { genres: "Action" }, createdAt: "2026-01-01T00:00:00Z" };
-    mockPost.mockResolvedValueOnce(created);
+    mockTypedApi.POST.mockReturnValue(ok(created));
     const { result } = renderHook(() => useCreateSavedSearch(), { wrapper: createWrapper() });
     result.current.mutate({ name: "Test", filters: { genres: "Action" } });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockPost).toHaveBeenCalledWith("/user/saved-searches", { name: "Test", filters: { genres: "Action" } });
+    expect(mockTypedApi.POST).toHaveBeenCalledWith("/api/user/saved-searches", {
+      body: { name: "Test", filters: { genres: "Action" } },
+    });
   });
 });
 
 describe("useDeleteSavedSearch", () => {
   it("deletes a saved search", async () => {
-    mockDelete.mockResolvedValueOnce({ status: "deleted" });
+    mockTypedApi.DELETE.mockReturnValue(ok({ status: "deleted" }));
     const { result } = renderHook(() => useDeleteSavedSearch(), { wrapper: createWrapper() });
     result.current.mutate("123");
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockDelete).toHaveBeenCalledWith("/user/saved-searches/123");
+    expect(mockTypedApi.DELETE).toHaveBeenCalledWith(
+      "/api/user/saved-searches/{id}",
+      { params: { path: { id: "123" } } },
+    );
   });
 });

--- a/web/src/hooks/use-saved-searches.ts
+++ b/web/src/hooks/use-saved-searches.ts
@@ -1,11 +1,10 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type { SavedSearch } from "@/types/api";
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export function useSavedSearches() {
   return useQuery({
     queryKey: ["saved-searches"],
-    queryFn: () => api.get<SavedSearch[]>("/user/saved-searches"),
+    queryFn: () => unwrap(typedApi.GET("/api/user/saved-searches")),
   });
 }
 
@@ -13,8 +12,13 @@ export function useCreateSavedSearch() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: { name: string; filters: Record<string, string | number> }) =>
-      api.post<SavedSearch>("/user/saved-searches", data),
+    mutationFn: (data: {
+      name: string;
+      filters: Record<string, string | number>;
+    }) =>
+      unwrap(
+        typedApi.POST("/api/user/saved-searches", { body: data }),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["saved-searches"] });
     },
@@ -26,7 +30,11 @@ export function useDeleteSavedSearch() {
 
   return useMutation({
     mutationFn: (id: string) =>
-      api.delete(`/user/saved-searches/${id}`),
+      unwrap(
+        typedApi.DELETE("/api/user/saved-searches/{id}", {
+          params: { path: { id } },
+        }),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["saved-searches"] });
     },

--- a/web/src/pages/console-games-page.tsx
+++ b/web/src/pages/console-games-page.tsx
@@ -34,7 +34,7 @@ import { Pagination } from "@/components/pagination";
 import { BiosWarningBanner } from "@/features/bios/components/bios-warning-banner";
 import { useAuth } from "@/hooks/use-auth";
 import { useDefaultRegionFilters } from "@/hooks/use-default-region-filters";
-import type { GameFilters } from "@/types/api";
+import type { GameFilters, SavedSearch } from "@/types/api";
 
 type ViewMode = "grid" | "list";
 
@@ -202,7 +202,7 @@ export function ConsoleGamesPage() {
           consoles={consoles}
           themes={themes}
           keywords={keywords}
-          savedSearches={savedSearches}
+          savedSearches={savedSearches as SavedSearch[] | undefined}
           onSaveSearch={handleSaveSearch}
           onDeleteSearch={(deleteId) => deleteSearch.mutate(deleteId)}
           onApplySearch={handleApplySearch}

--- a/web/src/pages/games-page.tsx
+++ b/web/src/pages/games-page.tsx
@@ -26,7 +26,7 @@ import {
   useDeleteSavedSearch,
 } from "@/hooks/use-saved-searches";
 import { useDefaultRegionFilters } from "@/hooks/use-default-region-filters";
-import type { GameFilters } from "@/types/api";
+import type { GameFilters, SavedSearch } from "@/types/api";
 
 type ViewMode = "grid" | "list";
 
@@ -171,7 +171,7 @@ export function GamesPage() {
           consoles={consoles}
           themes={themes}
           keywords={keywords}
-          savedSearches={savedSearches}
+          savedSearches={savedSearches as SavedSearch[] | undefined}
           onSaveSearch={handleSaveSearch}
           onDeleteSearch={(id) => deleteSearch.mutate(id)}
           onApplySearch={handleApplySearch}


### PR DESCRIPTION
Batch 5 of incremental call-site migrations. Switches the three saved-searches hooks (useSavedSearches, useCreateSavedSearch, useDeleteSavedSearch) to typedApi.GET/POST/DELETE + unwrap. Test rewritten to mock typedApi instead of api, following the same pattern as #510.

## Consumer cast fixes

\`console-games-page.tsx\` and \`games-page.tsx\` both pass \`savedSearches\` into \`AdvancedFilterPanel\` which expects the hand-written \`SavedSearch[]\` (with \`filters: Record<string, string|number>\`). The generated spec correctly types \`filters\` as \`unknown\` (free-form JSON), so a cast bridges the two. The runtime values continue to conform to the stricter shape — the cast just acknowledges what the spec already encodes.

## Test plan

- [x] \`npx tsc -b --noEmit\` clean
- [x] All web tests pass (incl. rewritten use-saved-searches test)
- [ ] CI Web unit tests
- [ ] CI Go tests
- [ ] CI Player unit tests