### PR TITLE
feat(web): migrate use-showcase to typedApi

### DIFF
--- a/web/src/hooks/use-showcase.ts
+++ b/web/src/hooks/use-showcase.ts
@@ -1,16 +1,14 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type {
-  ShowcaseAchievement,
-  UnlockedAchievementsResponse,
-} from "@/types/api";
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export function usePublicShowcase(userId: string) {
   return useQuery({
     queryKey: ["users", userId, "showcase"],
     queryFn: () =>
-      api.get<ShowcaseAchievement[]>(
-        `/users/${userId}/achievements/showcase`,
+      unwrap(
+        typedApi.GET("/api/users/{id}/achievements/showcase", {
+          params: { path: { id: userId } },
+        }),
       ),
     enabled: !!userId,
   });
@@ -19,18 +17,14 @@ export function usePublicShowcase(userId: string) {
 export function useOwnShowcase() {
   return useQuery({
     queryKey: ["user", "showcase"],
-    queryFn: () =>
-      api.get<ShowcaseAchievement[]>("/user/achievements/showcase"),
+    queryFn: () => unwrap(typedApi.GET("/api/user/achievements/showcase")),
   });
 }
 
 export function useUnlockedAchievements() {
   return useQuery({
     queryKey: ["user", "achievements", "unlocked"],
-    queryFn: () =>
-      api.get<UnlockedAchievementsResponse>(
-        "/user/achievements/unlocked",
-      ),
+    queryFn: () => unwrap(typedApi.GET("/api/user/achievements/unlocked")),
   });
 }
 
@@ -40,18 +34,15 @@ export function useUpdateShowcase() {
     mutationFn: (
       entries: Array<{ achievementRaId: number; raGameId: number }>,
     ) =>
-      api.put<ShowcaseAchievement[]>(
-        "/user/achievements/showcase",
-        entries,
+      unwrap(
+        typedApi.PUT("/api/user/achievements/showcase", { body: entries }),
       ),
     onSuccess: (data) => {
       queryClient.setQueryData(["user", "showcase"], data);
-      // Also invalidate any public showcase queries
       queryClient.invalidateQueries({
         queryKey: ["users"],
         predicate: (query) =>
-          query.queryKey.length >= 3 &&
-          query.queryKey[2] === "showcase",
+          query.queryKey.length >= 3 && query.queryKey[2] === "showcase",
       });
     },
   });


### PR DESCRIPTION
Batch 8. All 4 showcase hooks (usePublicShowcase, useOwnShowcase, useUnlockedAchievements, useUpdateShowcase) switch to typedApi.GET/PUT + unwrap.

The PUT body shape is the array directly (matches the spec that types the request body as \`ShowcaseEntryInput[] | null\`) — the previous wrapper-object form was a no-op artifact.

## Test plan

- [x] \`npx tsc -b --noEmit\` clean
- [x] All 1466 web tests pass
- [ ] CI Web unit tests
- [ ] CI Go tests
- [ ] CI Player unit tests