### PR TITLE
feat(web): migrate use-search to typedApi

### DIFF
--- a/web/src/features/search/components/__tests__/search-palette.test.tsx
+++ b/web/src/features/search/components/__tests__/search-palette.test.tsx
@@ -15,11 +15,23 @@ vi.mock("react-router-dom", async () => {
   };
 });
 
+// mockGet retains the legacy signature ((path) => data) so the test bodies
+// don't need to change. The wrapper around typedApi.GET reshapes its output
+// into the { data, response } tuple openapi-fetch returns; unwrap then
+// strips the wrapper inside the hook.
 const mockGet = vi.fn();
 vi.mock("@/lib/api-client", () => ({
-  api: {
-    get: (...args: unknown[]) => mockGet(...args),
+  typedApi: {
+    GET: async (...args: unknown[]) => {
+      const data = await mockGet(...args);
+      return { data, response: new Response(null, { status: 200 }) };
+    },
   },
+  unwrap: <T,>(p: Promise<{ data?: T; error?: unknown; response: Response }>) =>
+    p.then((r) => {
+      if (r.error !== undefined) throw r.error;
+      return r.data;
+    }),
 }));
 
 function createWrapper() {

--- a/web/src/hooks/use-search.ts
+++ b/web/src/hooks/use-search.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
+import { typedApi, unwrap } from "@/lib/api-client";
 
 export interface GameSearchResult {
   id: string;
@@ -65,9 +65,11 @@ export function useSearch(query: string) {
   return useQuery({
     queryKey: ["search", query],
     queryFn: () =>
-      api.get<SearchResults>(
-        `/search?q=${encodeURIComponent(query)}&limit=5`,
-      ),
+      unwrap(
+        typedApi.GET("/api/search", {
+          params: { query: { q: query, limit: 5 } },
+        }),
+      ) as Promise<SearchResults>,
     enabled: query.length >= 2,
     staleTime: 30 * 1000,
   });


### PR DESCRIPTION
Batch 9. useSearch switches to typedApi.GET + unwrap with typed query params. The local exported types (GameSearchResult, ConsoleSearchResult, etc.) are kept since multiple components consume them; the hook casts the typedApi response to SearchResults to bridge unknown/null gaps in the spec until the consumers migrate to the generated schema.

## Test plan

- [x] \`npx tsc -b --noEmit\` clean
- [x] All 1466 web tests pass
- [ ] CI Web unit tests
- [ ] CI Go tests
- [ ] CI Player unit tests