### PR TITLE
feat(web): migrate use-play-session to typedApi

### DIFF
--- a/web/src/hooks/use-play-session.ts
+++ b/web/src/hooks/use-play-session.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef } from "react";
-import { api } from "@/lib/api-client";
+import { typedApi } from "@/lib/api-client";
 import type { EmulatorStatus } from "./use-emulator-iframe";
 
 export function usePlaySession(
@@ -14,7 +14,12 @@ export function usePlaySession(
     const seconds = Math.floor((now - lastReportedRef.current) / 1000);
     if (seconds > 5) {
       lastReportedRef.current = now;
-      api.post(`/games/${gameId}/play-time`, { seconds }).catch(() => {});
+      typedApi
+        .POST("/api/games/{id}/play-time", {
+          params: { path: { id: gameId } },
+          body: { seconds },
+        })
+        .catch(() => {});
     }
   }, [gameId]);
 


### PR DESCRIPTION
Batch 11. usePlaySession.flushPlayTime switches to typedApi.POST. Same fire-and-forget semantics; the inner Promise is still .catch-suppressed since play-time tracking is best-effort.

## Test plan

- [x] tsc clean
- [x] All web tests pass
- [ ] CI Web unit tests
- [ ] CI Go tests
- [ ] CI Player unit tests