### PR TITLE
refactor(web): alias Theme/Keyword types to generated schemas

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -1290,17 +1290,11 @@ export interface PossibleConsole {
 
 // --- Themes & Keywords ---
 
-export interface Theme {
-  id: string;
-  name: string;
-  gameCount: number;
-}
-
-export interface Keyword {
-  id: string;
-  name: string;
-  gameCount: number;
-}
+// Theme / Keyword are exact structural matches of the generated
+// ThemeResponse / KeywordResponse; aliasing them unblocks typedApi migration
+// of useThemes / useKeywords (no consumer changes needed).
+export type Theme = Schemas["ThemeResponse"];
+export type Keyword = Schemas["KeywordResponse"];
 
 // --- Series & Franchises ---
 


### PR DESCRIPTION
Both hand-written \`Theme\` and \`Keyword\` had identical structure to the generated \`ThemeResponse\`/\`KeywordResponse\`. Aliasing them is a no-op at runtime but unblocks future typedApi migrations of \`useThemes\`/\`useKeywords\` — consumers that previously required a cast to bridge the two type systems now work directly.

First step in pruning \`web/src/types/api.ts\` per #518.

## Test plan

- [x] \`npx tsc -b --noEmit\` clean
- [x] All 1466 web tests pass
- [ ] CI Web unit tests
- [ ] CI Go tests
- [ ] CI Player unit tests