### PR TITLE
feat(web): migrate use-bios to typedApi

### DIFF
--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -47,7 +47,7 @@ export function AppLayout() {
   const netplayBadge = netplayInviteCountData?.count;
   const { data: biosData } = useBiosStatus();
   const hasMissingBios =
-    biosData?.consoles.some((c) => c.status === "missing") ?? false;
+    biosData?.consoles?.some((c) => c.status === "missing") ?? false;
   const { data: igdbStatus } = useIgdbStatus();
   const igdbNotConfigured = !(igdbStatus?.configured ?? true);
   const { data: health } = useHealth();

--- a/web/src/hooks/__tests__/use-bios.test.ts
+++ b/web/src/hooks/__tests__/use-bios.test.ts
@@ -11,19 +11,39 @@ import {
 
 vi.mock("@/lib/api-client", () => ({
   api: {
-    get: vi.fn(),
     upload: vi.fn(),
-    delete: vi.fn(),
   },
+  typedApi: {
+    GET: vi.fn(),
+    DELETE: vi.fn(),
+    POST: vi.fn(),
+  },
+  unwrap: vi.fn(<T,>(p: Promise<{ data?: T; error?: unknown; response: Response }>) =>
+    p.then((r) => {
+      if (r.error !== undefined) throw r.error;
+      return r.data;
+    }),
+  ),
 }));
 
-import { api } from "@/lib/api-client";
+import { api, typedApi } from "@/lib/api-client";
 
 const mockApi = api as unknown as {
-  get: ReturnType<typeof vi.fn>;
   upload: ReturnType<typeof vi.fn>;
-  delete: ReturnType<typeof vi.fn>;
 };
+
+const mockTypedApi = typedApi as unknown as {
+  GET: ReturnType<typeof vi.fn>;
+  DELETE: ReturnType<typeof vi.fn>;
+  POST: ReturnType<typeof vi.fn>;
+};
+
+function ok(data: unknown) {
+  return Promise.resolve({
+    data,
+    response: new Response(null, { status: 200 }),
+  });
+}
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -80,7 +100,7 @@ const mockBiosResponse = {
 
 describe("useBiosStatus", () => {
   it("fetches enriched BIOS data", async () => {
-    mockApi.get.mockResolvedValue(mockBiosResponse);
+    mockTypedApi.GET.mockReturnValue(ok(mockBiosResponse));
 
     const { result } = renderHook(() => useBiosStatus(), {
       wrapper: createWrapper(),
@@ -88,14 +108,14 @@ describe("useBiosStatus", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/bios");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith("/api/bios");
     expect(result.current.data).toEqual(mockBiosResponse);
     expect(result.current.data?.consoles).toHaveLength(1);
-    expect(result.current.data?.consoles[0].status).toBe("ready");
+    expect(result.current.data?.consoles?.[0].status).toBe("ready");
   });
 
   it("handles fetch error", async () => {
-    mockApi.get.mockRejectedValue(new Error("Server error"));
+    mockTypedApi.GET.mockReturnValue(Promise.reject(new Error("Server error")));
 
     const { result } = renderHook(() => useBiosStatus(), {
       wrapper: createWrapper(),
@@ -108,7 +128,7 @@ describe("useBiosStatus", () => {
 
 describe("useBiosFiles", () => {
   it("returns only the files array for backward compatibility", async () => {
-    mockApi.get.mockResolvedValue(mockBiosResponse);
+    mockTypedApi.GET.mockReturnValue(ok(mockBiosResponse));
 
     const { result } = renderHook(() => useBiosFiles(), {
       wrapper: createWrapper(),
@@ -173,7 +193,7 @@ describe("useUploadBiosFile", () => {
 
 describe("useDeleteBiosFile", () => {
   it("deletes a BIOS file", async () => {
-    mockApi.delete.mockResolvedValue(undefined);
+    mockTypedApi.DELETE.mockReturnValue(ok(undefined));
 
     const { result } = renderHook(() => useDeleteBiosFile(), {
       wrapper: createWrapper(),
@@ -182,11 +202,14 @@ describe("useDeleteBiosFile", () => {
     result.current.mutate("scph5501.bin");
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.delete).toHaveBeenCalledWith("/admin/bios/scph5501.bin");
+    expect(mockTypedApi.DELETE).toHaveBeenCalledWith(
+      "/api/admin/bios/{filename}",
+      { params: { path: { filename: "scph5501.bin" } } },
+    );
   });
 
   it("handles delete error", async () => {
-    mockApi.delete.mockRejectedValue(new Error("Not found"));
+    mockTypedApi.DELETE.mockReturnValue(Promise.reject(new Error("Not found")));
 
     const { result } = renderHook(() => useDeleteBiosFile(), {
       wrapper: createWrapper(),

--- a/web/src/hooks/use-bios.ts
+++ b/web/src/hooks/use-bios.ts
@@ -1,11 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
-import type { BiosFile, BiosResponse } from "@/types/api";
+import { api, typedApi, unwrap } from "@/lib/api-client";
+import type { BiosFile } from "@/types/api";
 
 export function useBiosStatus() {
   return useQuery({
     queryKey: ["bios"],
-    queryFn: () => api.get<BiosResponse>("/bios"),
+    queryFn: () => unwrap(typedApi.GET("/api/bios")),
   });
 }
 
@@ -18,6 +18,8 @@ export function useBiosFiles() {
   };
 }
 
+// Multipart upload still goes through api.upload — typedApi multipart needs
+// a custom bodySerializer; tracked in #518.
 export function useUploadBiosFile() {
   const queryClient = useQueryClient();
 
@@ -38,7 +40,11 @@ export function useDeleteBiosFile() {
 
   return useMutation({
     mutationFn: async (filename: string) => {
-      await api.delete(`/admin/bios/${encodeURIComponent(filename)}`);
+      await unwrap(
+        typedApi.DELETE("/api/admin/bios/{filename}", {
+          params: { path: { filename } },
+        }),
+      );
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["bios"] });
@@ -50,8 +56,7 @@ export function useDownloadBios() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: () =>
-      api.post<{ message: string; missing: number }>("/admin/bios/download"),
+    mutationFn: () => unwrap(typedApi.POST("/api/admin/bios/download")),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["bios"] });
     },

--- a/web/src/pages/admin/bios-page.tsx
+++ b/web/src/pages/admin/bios-page.tsx
@@ -126,7 +126,7 @@ export function AdminBiosPage() {
     );
   }
 
-  const consoles = biosData?.consoles ?? [];
+  const consoles = (biosData?.consoles ?? []) as BiosConsole[];
   const sortedConsoles = sortConsoles(consoles);
   const hasFiles = (biosData?.files ?? []).length > 0;
 

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -69,12 +69,12 @@ export function ConsoleDetailPage() {
     { enabled: isSmallLibrary },
   );
 
-  const biosConsole = biosData?.consoles.find((c) => c.consoleId === id);
+  const biosConsole = biosData?.consoles?.find((c) => c.consoleId === id);
   const showBiosWarning =
     biosConsole?.status === "missing" && biosConsole.biosRequired;
   const missingBiosFiles =
     biosConsole?.files
-      .filter((f) => f.status === "missing" && f.required)
+      ?.filter((f) => f.status === "missing" && f.required)
       .map((f) => f.fileName) ?? [];
 
   return (

--- a/web/src/pages/console-games-page.tsx
+++ b/web/src/pages/console-games-page.tsx
@@ -158,12 +158,12 @@ export function ConsoleGamesPage() {
 
   const games = data?.data ?? [];
 
-  const biosConsole = biosData?.consoles.find((c) => c.consoleId === id);
+  const biosConsole = biosData?.consoles?.find((c) => c.consoleId === id);
   const showBiosWarning =
     biosConsole?.status === "missing" && biosConsole.biosRequired;
   const missingBiosFiles =
     biosConsole?.files
-      .filter((f) => f.status === "missing" && f.required)
+      ?.filter((f) => f.status === "missing" && f.required)
       .map((f) => f.fileName) ?? [];
 
   return (

--- a/web/src/pages/dashboard-page.tsx
+++ b/web/src/pages/dashboard-page.tsx
@@ -215,7 +215,7 @@ export function DashboardPage() {
   const hasMissingBios =
     isAdmin &&
     !biosDismissed &&
-    (biosData?.consoles.some((c) => c.status === "missing") ?? false);
+    (biosData?.consoles?.some((c) => c.status === "missing") ?? false);
   const showIgdbWarning =
     isAdmin && !igdbDismissed && igdbStatus && !igdbStatus.configured;
   const recentGames = useRecentGames();

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -184,7 +184,7 @@ export function GameDetailPage() {
     );
   }
 
-  const biosConsole = biosData?.consoles.find(
+  const biosConsole = biosData?.consoles?.find(
     (c) => c.consoleId === game?.consoleId,
   );
   const showBiosWarning =
@@ -193,7 +193,7 @@ export function GameDetailPage() {
       (biosConsole?.status === "missing" && biosConsole.biosRequired));
   const missingBiosFiles =
     biosConsole?.files
-      .filter((f) => f.status === "missing" && f.required)
+      ?.filter((f) => f.status === "missing" && f.required)
       .map((f) => f.fileName) ?? [];
 
   function handleDownloadRom() {

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -55,14 +55,14 @@ export function PlayPage() {
   const { data: biosData } = useBiosStatus();
   const { isAdmin } = useAuth();
 
-  const biosConsole = biosData?.consoles.find(
+  const biosConsole = biosData?.consoles?.find(
     (c) => c.consoleId === game?.consoleId,
   );
   const biosMissing =
     biosConsole?.status === "missing" && biosConsole.biosRequired;
   const missingBiosFiles =
     biosConsole?.files
-      .filter((f) => f.status === "missing" && f.required)
+      ?.filter((f) => f.status === "missing" && f.required)
       .map((f) => f.fileName) ?? [];
 
   const { data: autoSaveInfo, isLoading: autoSaveInfoLoading } = useAutoSaveInfo(
@@ -229,7 +229,7 @@ export function PlayPage() {
         : "";
       // Filter BIOS files for the current console only
       const consoleBiosFiles = biosConsole?.files
-        .filter((f) => f.status !== "missing")
+        ?.filter((f) => f.status !== "missing")
         .map((f) => f.fileName) ?? [];
       const biosUrls =
         consoleBiosFiles.length > 0
@@ -295,7 +295,7 @@ export function PlayPage() {
 
       // Build authenticated BIOS file URLs (filtered for current console)
       const consoleBiosFiles2 = biosConsole?.files
-        .filter((f) => f.status !== "missing")
+        ?.filter((f) => f.status !== "missing")
         .map((f) => f.fileName) ?? [];
       const biosUrls =
         consoleBiosFiles2.length > 0


### PR DESCRIPTION
## Summary

- Switches `useBiosStatus`, `useDeleteBiosFile`, and `useDownloadBios` to `typedApi.GET/DELETE/POST`.
- Keeps `useUploadBiosFile` on legacy `api.upload` until the openapi-fetch multipart bodySerializer helper lands (tracked in #518).
- Six consumer files (`app-layout`, `console-detail-page`, `console-games-page`, `dashboard-page`, `game-detail-page`, `play-page`) now optional-chain `biosData?.consoles` / `biosConsole?.files` because the OpenAPI spec types those arrays as nullable.
- The admin `bios-page.tsx` casts the consoles array to the local `BiosConsole[]` type because the spec types `status` as a plain `string` while the consumer expects the strict union.
- Rewrites `use-bios.test.ts` to mock `typedApi` (`GET`/`DELETE`) using the established `ok()` + pass-through `unwrap` pattern from #510/#511/#520.

Refs #518.

## Test plan

- [x] `npx tsc -b --noEmit`
- [x] `npx vitest run` — 1466 tests passing
- [x] BIOS page still renders status warnings, missing-file lists, and download button correctly