### PR TITLE
feat(web): migrate use-social to typedApi

### DIFF
--- a/web/src/features/social/components/activity-event-item.tsx
+++ b/web/src/features/social/components/activity-event-item.tsx
@@ -136,7 +136,7 @@ export function ActivityEventItem({ event, compact }: ActivityEventItemProps) {
       <div className="relative flex-shrink-0 mt-0.5">
         <PlayerAvatar
           username={event.username}
-          avatarUrl={event.userAvatarUrl}
+          avatarUrl={event.avatarUrl}
         />
         <span className="absolute -bottom-1 -right-1 h-5 w-5 rounded-full bg-surface-900 flex items-center justify-center">
           {eventIcon(event.eventType)}
@@ -157,9 +157,9 @@ export function ActivityEventItem({ event, compact }: ActivityEventItemProps) {
           <span className="text-xs text-surface-500">
             {formatRelativeTime(event.createdAt)}
           </span>
-          {event.gameConsoleName && (
+          {event.consoleName && (
             <Badge variant="brand" className="text-[10px] px-1.5 py-0">
-              {event.gameConsoleName}
+              {event.consoleName}
             </Badge>
           )}
         </div>

--- a/web/src/hooks/__tests__/use-social.test.ts
+++ b/web/src/hooks/__tests__/use-social.test.ts
@@ -5,20 +5,33 @@ import { createElement, type ReactNode } from "react";
 import { useOnlineUsers, useActivityFeed } from "../use-social";
 
 vi.mock("@/lib/api-client", () => ({
-  api: {
-    get: vi.fn(),
+  typedApi: {
+    GET: vi.fn(),
   },
+  unwrap: vi.fn(<T,>(p: Promise<{ data?: T; error?: unknown; response: Response }>) =>
+    p.then((r) => {
+      if (r.error !== undefined) throw r.error;
+      return r.data;
+    }),
+  ),
 }));
 
 vi.mock("@/hooks/use-websocket", () => ({
   useWebSocketEvent: vi.fn(),
 }));
 
-import { api } from "@/lib/api-client";
+import { typedApi } from "@/lib/api-client";
 
-const mockApi = api as unknown as {
-  get: ReturnType<typeof vi.fn>;
+const mockTypedApi = typedApi as unknown as {
+  GET: ReturnType<typeof vi.fn>;
 };
+
+function ok(data: unknown) {
+  return Promise.resolve({
+    data,
+    response: new Response(null, { status: 200 }),
+  });
+}
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -63,12 +76,12 @@ const mockActivityFeed = {
       id: "evt-1",
       userId: "user-1",
       username: "alice",
-      userAvatarUrl: "https://example.com/avatar1.png",
+      avatarUrl: "https://example.com/avatar1.png",
       eventType: "started_playing",
       gameId: "game-1",
       gameTitle: "Super Mario Bros",
       gameCoverUrl: "https://example.com/cover.png",
-      gameConsoleName: "NES",
+      consoleName: "NES",
       metadata: {},
       createdAt: "2026-02-13T10:00:00Z",
     },
@@ -79,7 +92,7 @@ const mockActivityFeed = {
       eventType: "favorited_game",
       gameId: "game-2",
       gameTitle: "Zelda",
-      gameConsoleName: "NES",
+      consoleName: "NES",
       metadata: {},
       createdAt: "2026-02-13T09:00:00Z",
     },
@@ -91,7 +104,7 @@ const mockActivityFeed = {
 
 describe("useOnlineUsers", () => {
   it("fetches online users", async () => {
-    mockApi.get.mockResolvedValue(mockOnlineUsers);
+    mockTypedApi.GET.mockReturnValue(ok(mockOnlineUsers));
 
     const { result } = renderHook(() => useOnlineUsers(), {
       wrapper: createWrapper(),
@@ -99,16 +112,16 @@ describe("useOnlineUsers", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/social/online");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith("/api/social/online");
     expect(result.current.data?.users).toHaveLength(2);
-    expect(result.current.data?.users[0].username).toBe("alice");
-    expect(result.current.data?.users[0].currentGame?.title).toBe(
+    expect(result.current.data?.users?.[0].username).toBe("alice");
+    expect(result.current.data?.users?.[0].currentGame?.title).toBe(
       "Super Mario Bros",
     );
   });
 
   it("handles fetch error", async () => {
-    mockApi.get.mockRejectedValue(new Error("Network error"));
+    mockTypedApi.GET.mockReturnValue(Promise.reject(new Error("Network error")));
 
     const { result } = renderHook(() => useOnlineUsers(), {
       wrapper: createWrapper(),
@@ -120,7 +133,7 @@ describe("useOnlineUsers", () => {
 
 describe("useActivityFeed", () => {
   it("fetches activity feed with default pagination", async () => {
-    mockApi.get.mockResolvedValue(mockActivityFeed);
+    mockTypedApi.GET.mockReturnValue(ok(mockActivityFeed));
 
     const { result } = renderHook(() => useActivityFeed(), {
       wrapper: createWrapper(),
@@ -128,15 +141,15 @@ describe("useActivityFeed", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith(
-      "/social/activity?page=1&pageSize=20",
-    );
+    expect(mockTypedApi.GET).toHaveBeenCalledWith("/api/social/activity", {
+      params: { query: { page: 1, pageSize: 20 } },
+    });
     expect(result.current.data?.data).toHaveLength(2);
     expect(result.current.data?.total).toBe(2);
   });
 
   it("fetches activity feed with custom pagination", async () => {
-    mockApi.get.mockResolvedValue({ ...mockActivityFeed, page: 2 });
+    mockTypedApi.GET.mockReturnValue(ok({ ...mockActivityFeed, page: 2 }));
 
     const { result } = renderHook(() => useActivityFeed(2, 10), {
       wrapper: createWrapper(),
@@ -144,13 +157,13 @@ describe("useActivityFeed", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith(
-      "/social/activity?page=2&pageSize=10",
-    );
+    expect(mockTypedApi.GET).toHaveBeenCalledWith("/api/social/activity", {
+      params: { query: { page: 2, pageSize: 10 } },
+    });
   });
 
   it("handles fetch error", async () => {
-    mockApi.get.mockRejectedValue(new Error("Server error"));
+    mockTypedApi.GET.mockReturnValue(Promise.reject(new Error("Server error")));
 
     const { result } = renderHook(() => useActivityFeed(), {
       wrapper: createWrapper(),

--- a/web/src/hooks/use-social.ts
+++ b/web/src/hooks/use-social.ts
@@ -1,18 +1,16 @@
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
+import { typedApi, unwrap } from "@/lib/api-client";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
-  OnlineUsersResponse,
-  ActivityFeedResponse,
   ActivityEvent,
-  UserSearchResult,
+  ActivityFeedResponse,
   UserSearchResponse,
 } from "@/types/api";
 
 export function useOnlineUsers() {
   return useQuery({
     queryKey: ["social", "online"],
-    queryFn: () => api.get<OnlineUsersResponse>("/social/online"),
+    queryFn: () => unwrap(typedApi.GET("/api/social/online")),
     refetchInterval: 30000,
   });
 }
@@ -20,10 +18,14 @@ export function useOnlineUsers() {
 export function useActivityFeed(page: number = 1, pageSize: number = 20) {
   return useQuery({
     queryKey: ["social", "activity", page, pageSize],
-    queryFn: () =>
-      api.get<ActivityFeedResponse>(
-        `/social/activity?page=${page}&pageSize=${pageSize}`,
-      ),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/social/activity", {
+          params: { query: { page, pageSize } },
+        }),
+      );
+      return data as ActivityFeedResponse | undefined;
+    },
   });
 }
 
@@ -34,17 +36,21 @@ export function useSearchUsers(
 ) {
   return useQuery({
     queryKey: ["users", "search", query, page, pageSize],
-    queryFn: () =>
-      api.get<UserSearchResponse>(
-        `/users/search?q=${encodeURIComponent(query)}&page=${page}&pageSize=${pageSize}`,
-      ),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/users/search", {
+          params: { query: { q: query, page, pageSize } },
+        }),
+      );
+      return data as UserSearchResponse | undefined;
+    },
   });
 }
 
 export function useRecentPartners() {
   return useQuery({
     queryKey: ["users", "recent-partners"],
-    queryFn: () => api.get<UserSearchResult[]>("/users/recent-partners"),
+    queryFn: () => unwrap(typedApi.GET("/api/users/recent-partners")),
   });
 }
 
@@ -58,7 +64,7 @@ export function useActivityRealtime() {
         if (!old) return old;
         return {
           ...old,
-          data: [payload, ...old.data],
+          data: [payload, ...(old.data ?? [])],
           total: old.total + 1,
         };
       },

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -779,20 +779,12 @@ export interface ActivityEvent {
   id: string;
   userId: string;
   username: string;
-  userAvatarUrl?: string;
-  eventType:
-    | "started_playing"
-    | "favorited_game"
-    | "rated_game"
-    | "shared_save"
-    | "queued_play_later"
-    | "challenge_created"
-    | "challenge_completed"
-    | "challenge_record";
+  avatarUrl?: string;
+  eventType: string;
   gameId: string;
   gameTitle: string;
   gameCoverUrl?: string;
-  gameConsoleName: string;
+  consoleName?: string;
   metadata?: Record<string, unknown>;
   createdAt: string;
 }


### PR DESCRIPTION
## Summary

- Switches all four social hooks (\`useOnlineUsers\`, \`useActivityFeed\`, \`useSearchUsers\`, \`useRecentPartners\`) to \`typedApi\`.
- Fixes a real latent bug: the hand-written \`ActivityEvent\` type claimed fields \`userAvatarUrl\` and \`gameConsoleName\`, but the Go server has always returned \`avatarUrl\` / \`consoleName\`. Consumers (activity-event-item) read the missing fields as \`undefined\`, silently hiding avatars and console badges. Both types and consumers now align with the server truth (and the OpenAPI spec).
- Broadens \`ActivityEvent.eventType\` to \`string\`: the server emits more event types than the union listed, and the spec types the field as a plain string anyway.
- Casts the paginated \`useActivityFeed\` / \`useSearchUsers\` responses back to the local hand-written types so consumers keep non-null \`data\` / \`users\` arrays (the spec marks both as nullable).
- Rewrites \`use-social.test.ts\` to mock \`typedApi.GET\` using the established \`ok()\` + pass-through \`unwrap\` pattern.

Refs #518.

## Test plan

- [x] \`npx tsc -b --noEmit\`
- [x] \`npx vitest run src/hooks/__tests__/use-social.test.ts\` — 5 tests passing
- [x] Open activity feed; confirm avatars render and the console badge shows the right console name (previously broken)
- [x] Search users from the sharing modal; verify results pagination