### PR TITLE
feat(web): migrate use-preferences to typedApi

### DIFF
--- a/web/src/hooks/__tests__/use-preferences.test.ts
+++ b/web/src/hooks/__tests__/use-preferences.test.ts
@@ -5,18 +5,31 @@ import { createElement, type ReactNode } from "react";
 import { useUserPreferences, useUpdatePreferences } from "../use-preferences";
 
 vi.mock("@/lib/api-client", () => ({
-  api: {
-    get: vi.fn(),
-    put: vi.fn(),
+  typedApi: {
+    GET: vi.fn(),
+    PUT: vi.fn(),
   },
+  unwrap: vi.fn(<T,>(p: Promise<{ data?: T; error?: unknown; response: Response }>) =>
+    p.then((r) => {
+      if (r.error !== undefined) throw r.error;
+      return r.data;
+    }),
+  ),
 }));
 
-import { api } from "@/lib/api-client";
+import { typedApi } from "@/lib/api-client";
 
-const mockApi = api as unknown as {
-  get: ReturnType<typeof vi.fn>;
-  put: ReturnType<typeof vi.fn>;
+const mockTypedApi = typedApi as unknown as {
+  GET: ReturnType<typeof vi.fn>;
+  PUT: ReturnType<typeof vi.fn>;
 };
+
+function ok(data: unknown) {
+  return Promise.resolve({
+    data,
+    response: new Response(null, { status: 200 }),
+  });
+}
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -44,7 +57,7 @@ describe("useUserPreferences", () => {
       selectedShader: "crt-simple",
       consoleShaders: { "1": "bilinear" },
     };
-    mockApi.get.mockResolvedValue(prefs);
+    mockTypedApi.GET.mockReturnValue(ok(prefs));
 
     const { result } = renderHook(() => useUserPreferences(), {
       wrapper: createWrapper(),
@@ -52,12 +65,12 @@ describe("useUserPreferences", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/user/preferences");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith("/api/user/preferences");
     expect(result.current.data).toEqual(prefs);
   });
 
   it("handles fetch error", async () => {
-    mockApi.get.mockRejectedValue(new Error("Network error"));
+    mockTypedApi.GET.mockReturnValue(Promise.reject(new Error("Network error")));
 
     const { result } = renderHook(() => useUserPreferences(), {
       wrapper: createWrapper(),
@@ -70,7 +83,7 @@ describe("useUserPreferences", () => {
 
 describe("useUpdatePreferences", () => {
   it("sends partial update to the server", async () => {
-    mockApi.put.mockResolvedValue(undefined);
+    mockTypedApi.PUT.mockReturnValue(ok(undefined));
 
     const { result } = renderHook(() => useUpdatePreferences(), {
       wrapper: createWrapper(),
@@ -79,13 +92,13 @@ describe("useUpdatePreferences", () => {
     result.current.mutate({ autoSaveEnabled: true });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.put).toHaveBeenCalledWith("/user/preferences", {
-      autoSaveEnabled: true,
+    expect(mockTypedApi.PUT).toHaveBeenCalledWith("/api/user/preferences", {
+      body: { autoSaveEnabled: true },
     });
   });
 
   it("handles update error", async () => {
-    mockApi.put.mockRejectedValue(new Error("Forbidden"));
+    mockTypedApi.PUT.mockReturnValue(Promise.reject(new Error("Forbidden")));
 
     const { result } = renderHook(() => useUpdatePreferences(), {
       wrapper: createWrapper(),

--- a/web/src/hooks/use-preferences.ts
+++ b/web/src/hooks/use-preferences.ts
@@ -1,11 +1,14 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
+import { typedApi, unwrap } from "@/lib/api-client";
 import type { UserPreferences } from "@/types/api";
 
 export function useUserPreferences() {
   return useQuery({
     queryKey: ["user", "preferences"],
-    queryFn: () => api.get<UserPreferences>("/user/preferences"),
+    queryFn: async () => {
+      const data = await unwrap(typedApi.GET("/api/user/preferences"));
+      return data as UserPreferences | undefined;
+    },
   });
 }
 
@@ -14,7 +17,11 @@ export function useUpdatePreferences() {
 
   return useMutation({
     mutationFn: async (data: Partial<UserPreferences>) => {
-      await api.put("/user/preferences", data);
+      await unwrap(
+        typedApi.PUT("/api/user/preferences", {
+          body: data as Record<string, unknown>,
+        }),
+      );
     },
     onMutate: async (newData: Partial<UserPreferences>) => {
       await queryClient.cancelQueries({ queryKey: ["user", "preferences"] });


### PR DESCRIPTION
## Summary

- Switches \`useUserPreferences\` and \`useUpdatePreferences\` to \`typedApi.GET\` / \`PUT\`.
- The GET response is cast back to the local \`UserPreferences\` (the OpenAPI spec marks a few fields nullable where consumers expect them non-null).
- The PUT body is cast to \`Record<string, unknown>\` because the spec's \`UpdateUserPreferencesRequest\` requires all fields while hand-written \`Partial<UserPreferences>\` is used throughout the app.
- Rewrites \`use-preferences.test.ts\` to mock \`typedApi.GET/PUT\` using the established \`ok()\` + pass-through \`unwrap\` pattern.

Refs #518.

## Test plan

- [x] \`npx tsc -b --noEmit\`
- [x] \`npx vitest run src/hooks/__tests__/use-preferences.test.ts\` — 4 tests passing
- [x] Toggle shaders/auto-save/auto-load on preferences page; verify optimistic update and rollback on error