### PR TITLE
feat(web): migrate use-retroachievements to typedApi

### DIFF
--- a/web/src/hooks/__tests__/use-retroachievements.test.ts
+++ b/web/src/hooks/__tests__/use-retroachievements.test.ts
@@ -13,22 +13,35 @@ import {
 } from "../use-retroachievements";
 
 vi.mock("@/lib/api-client", () => ({
-  api: {
-    get: vi.fn(),
-    post: vi.fn(),
-    put: vi.fn(),
-    delete: vi.fn(),
+  typedApi: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    PUT: vi.fn(),
+    DELETE: vi.fn(),
   },
+  unwrap: vi.fn(<T,>(p: Promise<{ data?: T; error?: unknown; response: Response }>) =>
+    p.then((r) => {
+      if (r.error !== undefined) throw r.error;
+      return r.data;
+    }),
+  ),
 }));
 
-import { api } from "@/lib/api-client";
+import { typedApi } from "@/lib/api-client";
 
-const mockApi = api as unknown as {
-  get: ReturnType<typeof vi.fn>;
-  post: ReturnType<typeof vi.fn>;
-  put: ReturnType<typeof vi.fn>;
-  delete: ReturnType<typeof vi.fn>;
+const mockTypedApi = typedApi as unknown as {
+  GET: ReturnType<typeof vi.fn>;
+  POST: ReturnType<typeof vi.fn>;
+  PUT: ReturnType<typeof vi.fn>;
+  DELETE: ReturnType<typeof vi.fn>;
 };
+
+function ok(data: unknown) {
+  return Promise.resolve({
+    data,
+    response: new Response(null, { status: 200 }),
+  });
+}
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -88,7 +101,7 @@ const mockProgress = [
 
 describe("useRAStatus", () => {
   it("fetches RA status", async () => {
-    mockApi.get.mockResolvedValue(mockStatus);
+    mockTypedApi.GET.mockReturnValue(ok(mockStatus));
 
     const { result } = renderHook(() => useRAStatus(), {
       wrapper: createWrapper(),
@@ -96,12 +109,12 @@ describe("useRAStatus", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/user/ra/status");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith("/api/user/ra/status");
     expect(result.current.data).toEqual(mockStatus);
   });
 
   it("handles fetch error", async () => {
-    mockApi.get.mockRejectedValue(new Error("Network error"));
+    mockTypedApi.GET.mockReturnValue(Promise.reject(new Error("Network error")));
 
     const { result } = renderHook(() => useRAStatus(), {
       wrapper: createWrapper(),
@@ -114,7 +127,7 @@ describe("useRAStatus", () => {
 
 describe("useLinkRA", () => {
   it("sends link request", async () => {
-    mockApi.post.mockResolvedValue(mockStatus);
+    mockTypedApi.POST.mockReturnValue(ok(mockStatus));
 
     const { result } = renderHook(() => useLinkRA(), {
       wrapper: createWrapper(),
@@ -123,14 +136,15 @@ describe("useLinkRA", () => {
     result.current.mutate({ username: "player1", password: "secret" });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.post).toHaveBeenCalledWith("/user/ra/link", {
-      username: "player1",
-      password: "secret",
+    expect(mockTypedApi.POST).toHaveBeenCalledWith("/api/user/ra/link", {
+      body: { username: "player1", password: "secret" },
     });
   });
 
   it("handles link error", async () => {
-    mockApi.post.mockRejectedValue(new Error("Invalid credentials"));
+    mockTypedApi.POST.mockReturnValue(
+      Promise.reject(new Error("Invalid credentials")),
+    );
 
     const { result } = renderHook(() => useLinkRA(), {
       wrapper: createWrapper(),
@@ -145,7 +159,7 @@ describe("useLinkRA", () => {
 
 describe("useUnlinkRA", () => {
   it("sends unlink request", async () => {
-    mockApi.delete.mockResolvedValue(undefined);
+    mockTypedApi.DELETE.mockReturnValue(ok(undefined));
 
     const { result } = renderHook(() => useUnlinkRA(), {
       wrapper: createWrapper(),
@@ -154,11 +168,11 @@ describe("useUnlinkRA", () => {
     result.current.mutate();
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.delete).toHaveBeenCalledWith("/user/ra/link");
+    expect(mockTypedApi.DELETE).toHaveBeenCalledWith("/api/user/ra/link");
   });
 
   it("handles unlink error", async () => {
-    mockApi.delete.mockRejectedValue(new Error("Forbidden"));
+    mockTypedApi.DELETE.mockReturnValue(Promise.reject(new Error("Forbidden")));
 
     const { result } = renderHook(() => useUnlinkRA(), {
       wrapper: createWrapper(),
@@ -172,7 +186,7 @@ describe("useUnlinkRA", () => {
 
 describe("useRASettings", () => {
   it("sends settings update", async () => {
-    mockApi.put.mockResolvedValue({ ...mockStatus, hardcoreEnabled: true });
+    mockTypedApi.PUT.mockReturnValue(ok({ ...mockStatus, hardcoreEnabled: true }));
 
     const { result } = renderHook(() => useRASettings(), {
       wrapper: createWrapper(),
@@ -181,13 +195,13 @@ describe("useRASettings", () => {
     result.current.mutate({ hardcoreEnabled: true });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.put).toHaveBeenCalledWith("/user/ra/settings", {
-      hardcoreEnabled: true,
+    expect(mockTypedApi.PUT).toHaveBeenCalledWith("/api/user/ra/settings", {
+      body: { hardcoreEnabled: true },
     });
   });
 
   it("handles settings error", async () => {
-    mockApi.put.mockRejectedValue(new Error("Bad request"));
+    mockTypedApi.PUT.mockReturnValue(Promise.reject(new Error("Bad request")));
 
     const { result } = renderHook(() => useRASettings(), {
       wrapper: createWrapper(),
@@ -201,7 +215,7 @@ describe("useRASettings", () => {
 
 describe("useGameAchievements", () => {
   it("fetches achievements for a game", async () => {
-    mockApi.get.mockResolvedValue(mockAchievements);
+    mockTypedApi.GET.mockReturnValue(ok(mockAchievements));
 
     const { result } = renderHook(() => useGameAchievements("game-1"), {
       wrapper: createWrapper(),
@@ -209,7 +223,10 @@ describe("useGameAchievements", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/games/game-1/achievements");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith(
+      "/api/games/{id}/achievements",
+      { params: { path: { id: "game-1" } } },
+    );
     expect(result.current.data?.totalCount).toBe(2);
   });
 
@@ -218,11 +235,11 @@ describe("useGameAchievements", () => {
       wrapper: createWrapper(),
     });
 
-    expect(mockApi.get).not.toHaveBeenCalled();
+    expect(mockTypedApi.GET).not.toHaveBeenCalled();
   });
 
   it("handles fetch error", async () => {
-    mockApi.get.mockRejectedValue(new Error("Not found"));
+    mockTypedApi.GET.mockReturnValue(Promise.reject(new Error("Not found")));
 
     const { result } = renderHook(() => useGameAchievements("game-bad"), {
       wrapper: createWrapper(),
@@ -233,10 +250,10 @@ describe("useGameAchievements", () => {
 
   it("polls when status is pending and stops when data arrives", async () => {
     const pendingResponse = { status: "pending" as const };
-    mockApi.get
-      .mockResolvedValueOnce(pendingResponse)
-      .mockResolvedValueOnce(pendingResponse)
-      .mockResolvedValueOnce(mockAchievements);
+    mockTypedApi.GET
+      .mockReturnValueOnce(ok(pendingResponse))
+      .mockReturnValueOnce(ok(pendingResponse))
+      .mockReturnValueOnce(ok(mockAchievements));
 
     const { result } = renderHook(() => useGameAchievements("game-1"), {
       wrapper: createWrapper(),
@@ -261,7 +278,9 @@ describe("useGameAchievements", () => {
 
 describe("useGameAchievementProgress", () => {
   it("fetches achievement progress for a game", async () => {
-    mockApi.get.mockResolvedValue({ raGameId: 123, progress: mockProgress });
+    mockTypedApi.GET.mockReturnValue(
+      ok({ raGameId: 123, progress: mockProgress }),
+    );
 
     const { result } = renderHook(() => useGameAchievementProgress("game-1"), {
       wrapper: createWrapper(),
@@ -269,8 +288,9 @@ describe("useGameAchievementProgress", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith(
-      "/games/game-1/achievements/progress",
+    expect(mockTypedApi.GET).toHaveBeenCalledWith(
+      "/api/games/{id}/achievements/progress",
+      { params: { path: { id: "game-1" } } },
     );
     expect(result.current.data).toHaveLength(1);
     expect(result.current.data?.[0].playTimeAtUnlock).toBe(1200);
@@ -281,11 +301,11 @@ describe("useGameAchievementProgress", () => {
       wrapper: createWrapper(),
     });
 
-    expect(mockApi.get).not.toHaveBeenCalled();
+    expect(mockTypedApi.GET).not.toHaveBeenCalled();
   });
 
   it("handles fetch error", async () => {
-    mockApi.get.mockRejectedValue(new Error("Forbidden"));
+    mockTypedApi.GET.mockReturnValue(Promise.reject(new Error("Forbidden")));
 
     const { result } = renderHook(
       () => useGameAchievementProgress("game-bad"),
@@ -316,7 +336,7 @@ describe("useRecentAchievements", () => {
         coverUrl: "https://example.com/smb.png",
       },
     ];
-    mockApi.get.mockResolvedValue({ achievements: mockRecent });
+    mockTypedApi.GET.mockReturnValue(ok({ achievements: mockRecent }));
 
     const { result } = renderHook(() => useRecentAchievements(), {
       wrapper: createWrapper(),
@@ -324,13 +344,15 @@ describe("useRecentAchievements", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/user/achievements/recent");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith(
+      "/api/user/achievements/recent",
+    );
     expect(result.current.data).toHaveLength(1);
     expect(result.current.data?.[0].title).toBe("First Steps");
   });
 
   it("handles fetch error", async () => {
-    mockApi.get.mockRejectedValue(new Error("Unauthorized"));
+    mockTypedApi.GET.mockReturnValue(Promise.reject(new Error("Unauthorized")));
 
     const { result } = renderHook(() => useRecentAchievements(), {
       wrapper: createWrapper(),

--- a/web/src/hooks/use-retroachievements.ts
+++ b/web/src/hooks/use-retroachievements.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
+import { typedApi, unwrap } from "@/lib/api-client";
 import type {
   RAStatus,
   RALinkRequest,
@@ -14,7 +14,10 @@ import type {
 export function useRAStatus() {
   return useQuery({
     queryKey: ["ra-status"],
-    queryFn: () => api.get<RAStatus>("/user/ra/status"),
+    queryFn: async () => {
+      const data = await unwrap(typedApi.GET("/api/user/ra/status"));
+      return data as RAStatus | undefined;
+    },
   });
 }
 
@@ -22,7 +25,7 @@ export function useLinkRA() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data: RALinkRequest) =>
-      api.post<RAStatus>("/user/ra/link", data),
+      unwrap(typedApi.POST("/api/user/ra/link", { body: data })),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["ra-status"] });
       queryClient.invalidateQueries({ queryKey: ["user", "preferences"] });
@@ -33,7 +36,7 @@ export function useLinkRA() {
 export function useUnlinkRA() {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: () => api.delete("/user/ra/link"),
+    mutationFn: () => unwrap(typedApi.DELETE("/api/user/ra/link")),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["ra-status"] });
       queryClient.invalidateQueries({ queryKey: ["user", "preferences"] });
@@ -45,7 +48,7 @@ export function useRASettings() {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (data: RASettingsRequest) =>
-      api.put<RAStatus>("/user/ra/settings", data),
+      unwrap(typedApi.PUT("/api/user/ra/settings", { body: data })),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["ra-status"] });
       queryClient.invalidateQueries({ queryKey: ["user", "preferences"] });
@@ -56,7 +59,14 @@ export function useRASettings() {
 export function useGameAchievements(gameId: string | undefined) {
   return useQuery({
     queryKey: ["game-achievements", gameId],
-    queryFn: () => api.get<GameAchievements>(`/games/${gameId}/achievements`),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/games/{id}/achievements", {
+          params: { path: { id: gameId as string } },
+        }),
+      );
+      return data as GameAchievements | undefined;
+    },
     enabled: !!gameId,
     refetchInterval: (query) => {
       // Poll every 2 seconds while the server is processing an RA fetch.
@@ -72,12 +82,14 @@ export function useGameAchievements(gameId: string | undefined) {
 export function useGameAchievementProgress(gameId: string | undefined) {
   return useQuery({
     queryKey: ["game-achievement-progress", gameId],
-    queryFn: () =>
-      api
-        .get<GameAchievementProgressResponse>(
-          `/games/${gameId}/achievements/progress`,
-        )
-        .then((res) => res.progress ?? null),
+    queryFn: async () => {
+      const data = (await unwrap(
+        typedApi.GET("/api/games/{id}/achievements/progress", {
+          params: { path: { id: gameId as string } },
+        }),
+      )) as GameAchievementProgressResponse | undefined;
+      return data?.progress ?? null;
+    },
     enabled: !!gameId,
   });
 }
@@ -85,10 +97,14 @@ export function useGameAchievementProgress(gameId: string | undefined) {
 export function useAchievementLeaderboard(gameId: string | undefined) {
   return useQuery({
     queryKey: ["achievement-leaderboard", gameId],
-    queryFn: () =>
-      api.get<AchievementLeaderboard>(
-        `/games/${gameId}/achievements/leaderboard`,
-      ),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/games/{id}/achievements/leaderboard", {
+          params: { path: { id: gameId as string } },
+        }),
+      );
+      return data as AchievementLeaderboard | undefined;
+    },
     enabled: !!gameId,
   });
 }
@@ -96,8 +112,14 @@ export function useAchievementLeaderboard(gameId: string | undefined) {
 export function useAchievementTimeline(gameId: string | undefined) {
   return useQuery({
     queryKey: ["achievement-timeline", gameId],
-    queryFn: () =>
-      api.get<AchievementTimeline>(`/games/${gameId}/achievements/timeline`),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/games/{id}/achievements/timeline", {
+          params: { path: { id: gameId as string } },
+        }),
+      );
+      return data as AchievementTimeline | undefined;
+    },
     enabled: !!gameId,
   });
 }
@@ -105,9 +127,11 @@ export function useAchievementTimeline(gameId: string | undefined) {
 export function useRecentAchievements() {
   return useQuery({
     queryKey: ["recent-achievements"],
-    queryFn: () =>
-      api
-        .get<{ achievements: RecentAchievement[] }>("/user/achievements/recent")
-        .then((res) => res.achievements),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/user/achievements/recent"),
+      );
+      return (data?.achievements ?? []) as RecentAchievement[];
+    },
   });
 }


### PR DESCRIPTION
## Summary

- Switches all 8 RetroAchievements hooks (\`useRAStatus\`, \`useLinkRA\`, \`useUnlinkRA\`, \`useRASettings\`, \`useGameAchievements\`, \`useGameAchievementProgress\`, \`useAchievementLeaderboard\`, \`useAchievementTimeline\`, \`useRecentAchievements\`) to \`typedApi\`.
- \`getAchievementProgress\` is typed as \`unknown\` in the OpenAPI spec, so the result is cast to the hand-written \`GameAchievementProgressResponse\`.
- Casts the other GETs back to the local types so consumers keep non-null arrays (spec marks several fields nullable).
- Rewrites \`use-retroachievements.test.ts\` to mock \`typedApi\` using the established \`ok()\` + pass-through \`unwrap\` pattern.

Refs #518.

## Test plan

- [x] \`npx tsc -b --noEmit\`
- [x] \`npx vitest run src/hooks/__tests__/use-retroachievements.test.ts\` — 17 tests passing
- [x] Link/unlink an RA account, toggle hardcore, view achievements + leaderboard + timeline on game-detail