### PR TITLE
feat(web): migrate use-shared-sessions to typedApi

### DIFF
--- a/web/src/features/shared-sessions/components/shared-session-create-modal.tsx
+++ b/web/src/features/shared-sessions/components/shared-session-create-modal.tsx
@@ -35,7 +35,7 @@ export function SharedSessionCreateModal({
         onSuccess: (sharedSession) => {
           toast("success", "Shared session created");
           resetForm();
-          onCreated(sharedSession.id);
+          if (sharedSession) onCreated(sharedSession.id);
         },
         onError: () => {
           toast("error", "Failed to create shared session");

--- a/web/src/hooks/__tests__/use-shared-sessions.test.ts
+++ b/web/src/hooks/__tests__/use-shared-sessions.test.ts
@@ -20,24 +20,37 @@ import {
 } from "../use-shared-sessions";
 
 vi.mock("@/lib/api-client", () => ({
-  api: {
-    get: vi.fn(),
-    post: vi.fn(),
-    delete: vi.fn(),
+  typedApi: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    DELETE: vi.fn(),
   },
+  unwrap: vi.fn(<T,>(p: Promise<{ data?: T; error?: unknown; response: Response }>) =>
+    p.then((r) => {
+      if (r.error !== undefined) throw r.error;
+      return r.data;
+    }),
+  ),
 }));
 
 vi.mock("@/hooks/use-websocket", () => ({
   useWebSocketEvent: vi.fn(),
 }));
 
-import { api } from "@/lib/api-client";
+import { typedApi } from "@/lib/api-client";
 
-const mockApi = api as unknown as {
-  get: ReturnType<typeof vi.fn>;
-  post: ReturnType<typeof vi.fn>;
-  delete: ReturnType<typeof vi.fn>;
+const mockTypedApi = typedApi as unknown as {
+  GET: ReturnType<typeof vi.fn>;
+  POST: ReturnType<typeof vi.fn>;
+  DELETE: ReturnType<typeof vi.fn>;
 };
+
+function ok(data: unknown) {
+  return Promise.resolve({
+    data,
+    response: new Response(null, { status: 200 }),
+  });
+}
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -143,8 +156,8 @@ const mockSaves = [
 ];
 
 describe("useMySharedSessions", () => {
-  it("fetches shared sessions with default pagination", async () => {
-    mockApi.get.mockResolvedValue(mockSharedSessionsResponse);
+  it("fetches shared sessions", async () => {
+    mockTypedApi.GET.mockReturnValue(ok(mockSharedSessionsResponse));
 
     const { result } = renderHook(() => useMySharedSessions(), {
       wrapper: createWrapper(),
@@ -152,25 +165,13 @@ describe("useMySharedSessions", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/shared-sessions?page=1&pageSize=20");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith("/api/shared-sessions");
     expect(result.current.data?.data).toHaveLength(1);
     expect(result.current.data?.data[0].name).toBe("Friday Night SNES");
   });
 
-  it("fetches shared sessions with custom pagination", async () => {
-    mockApi.get.mockResolvedValue({ ...mockSharedSessionsResponse, page: 2 });
-
-    const { result } = renderHook(() => useMySharedSessions(2, 10), {
-      wrapper: createWrapper(),
-    });
-
-    await waitFor(() => expect(result.current.isSuccess).toBe(true));
-
-    expect(mockApi.get).toHaveBeenCalledWith("/shared-sessions?page=2&pageSize=10");
-  });
-
   it("handles fetch error", async () => {
-    mockApi.get.mockRejectedValue(new Error("Server error"));
+    mockTypedApi.GET.mockReturnValue(Promise.reject(new Error("Server error")));
 
     const { result } = renderHook(() => useMySharedSessions(), {
       wrapper: createWrapper(),
@@ -182,7 +183,7 @@ describe("useMySharedSessions", () => {
 
 describe("useSharedSessionInvitations", () => {
   it("fetches invitations", async () => {
-    mockApi.get.mockResolvedValue(mockInvitations);
+    mockTypedApi.GET.mockReturnValue(ok(mockInvitations));
 
     const { result } = renderHook(() => useSharedSessionInvitations(), {
       wrapper: createWrapper(),
@@ -190,15 +191,19 @@ describe("useSharedSessionInvitations", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/user/shared-session-invites");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith(
+      "/api/user/shared-session-invites",
+    );
     expect(result.current.data?.data).toHaveLength(1);
-    expect(result.current.data?.data[0].sharedSessionName).toBe("Friday Night SNES");
+    expect(result.current.data?.data[0].sharedSessionName).toBe(
+      "Friday Night SNES",
+    );
   });
 });
 
 describe("usePendingInvitationCount", () => {
   it("fetches invitation count", async () => {
-    mockApi.get.mockResolvedValue({ count: 3 });
+    mockTypedApi.GET.mockReturnValue(ok({ count: 3 }));
 
     const { result } = renderHook(() => usePendingInvitationCount(), {
       wrapper: createWrapper(),
@@ -206,14 +211,16 @@ describe("usePendingInvitationCount", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/user/shared-session-invites/count");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith(
+      "/api/user/shared-session-invites/count",
+    );
     expect(result.current.data?.count).toBe(3);
   });
 });
 
 describe("useSharedSession", () => {
   it("fetches shared session detail", async () => {
-    mockApi.get.mockResolvedValue(mockSharedSessionDetail);
+    mockTypedApi.GET.mockReturnValue(ok(mockSharedSessionDetail));
 
     const { result } = renderHook(() => useSharedSession("ss-1"), {
       wrapper: createWrapper(),
@@ -221,25 +228,28 @@ describe("useSharedSession", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/shared-sessions/ss-1");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith(
+      "/api/shared-sessions/{id}",
+      { params: { path: { id: "ss-1" } } },
+    );
     expect(result.current.data?.members).toHaveLength(2);
     expect(result.current.data?.members[0].role).toBe("owner");
   });
 
   it("does not fetch when id is empty", () => {
-    mockApi.get.mockResolvedValue(mockSharedSessionDetail);
+    mockTypedApi.GET.mockReturnValue(ok(mockSharedSessionDetail));
 
     renderHook(() => useSharedSession(""), {
       wrapper: createWrapper(),
     });
 
-    expect(mockApi.get).not.toHaveBeenCalled();
+    expect(mockTypedApi.GET).not.toHaveBeenCalled();
   });
 });
 
 describe("useSharedSessionSaves", () => {
   it("fetches saves for a shared session", async () => {
-    mockApi.get.mockResolvedValue(mockSaves);
+    mockTypedApi.GET.mockReturnValue(ok(mockSaves));
 
     const { result } = renderHook(() => useSharedSessionSaves("ss-1"), {
       wrapper: createWrapper(),
@@ -247,7 +257,10 @@ describe("useSharedSessionSaves", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/shared-sessions/ss-1/saves");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith(
+      "/api/shared-sessions/{id}/saves",
+      { params: { path: { id: "ss-1" } } },
+    );
     expect(result.current.data).toHaveLength(1);
     expect(result.current.data?.[0].name).toBe("World 3");
   });
@@ -255,7 +268,9 @@ describe("useSharedSessionSaves", () => {
 
 describe("useGameSharedSessions", () => {
   it("fetches shared sessions for a game", async () => {
-    mockApi.get.mockResolvedValue([mockSharedSessionsResponse.data[0]]);
+    mockTypedApi.GET.mockReturnValue(
+      ok([mockSharedSessionsResponse.data[0]]),
+    );
 
     const { result } = renderHook(() => useGameSharedSessions("g1"), {
       wrapper: createWrapper(),
@@ -263,13 +278,16 @@ describe("useGameSharedSessions", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.get).toHaveBeenCalledWith("/games/g1/shared-sessions");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith(
+      "/api/games/{id}/shared-sessions",
+      { params: { path: { id: "g1" } } },
+    );
   });
 });
 
 describe("useCreateSharedSession", () => {
   it("creates a shared session", async () => {
-    mockApi.post.mockResolvedValue(mockSharedSessionDetail);
+    mockTypedApi.POST.mockReturnValue(ok(mockSharedSessionDetail));
 
     const { result } = renderHook(() => useCreateSharedSession(), {
       wrapper: createWrapper(),
@@ -282,15 +300,17 @@ describe("useCreateSharedSession", () => {
     });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.post).toHaveBeenCalledWith("/shared-sessions", {
-      name: "New Shared Session",
-      gameId: "g1",
-      description: "A test shared session",
+    expect(mockTypedApi.POST).toHaveBeenCalledWith("/api/shared-sessions", {
+      body: {
+        name: "New Shared Session",
+        gameId: "g1",
+        description: "A test shared session",
+      },
     });
   });
 
   it("handles create error", async () => {
-    mockApi.post.mockRejectedValue(new Error("Conflict"));
+    mockTypedApi.POST.mockReturnValue(Promise.reject(new Error("Conflict")));
 
     const { result } = renderHook(() => useCreateSharedSession(), {
       wrapper: createWrapper(),
@@ -304,7 +324,7 @@ describe("useCreateSharedSession", () => {
 
 describe("useDeleteSharedSession", () => {
   it("deletes a shared session", async () => {
-    mockApi.delete.mockResolvedValue(undefined);
+    mockTypedApi.DELETE.mockReturnValue(ok(undefined));
 
     const { result } = renderHook(() => useDeleteSharedSession(), {
       wrapper: createWrapper(),
@@ -313,13 +333,16 @@ describe("useDeleteSharedSession", () => {
     result.current.mutate("ss-1");
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.delete).toHaveBeenCalledWith("/shared-sessions/ss-1");
+    expect(mockTypedApi.DELETE).toHaveBeenCalledWith(
+      "/api/shared-sessions/{id}",
+      { params: { path: { id: "ss-1" } } },
+    );
   });
 });
 
 describe("useInviteToSharedSession", () => {
   it("sends an invitation", async () => {
-    mockApi.post.mockResolvedValue(undefined);
+    mockTypedApi.POST.mockReturnValue(ok(undefined));
 
     const { result } = renderHook(() => useInviteToSharedSession(), {
       wrapper: createWrapper(),
@@ -328,13 +351,16 @@ describe("useInviteToSharedSession", () => {
     result.current.mutate({ sharedSessionId: "ss-1", username: "charlie" });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.post).toHaveBeenCalledWith("/shared-sessions/ss-1/invites", {
-      username: "charlie",
-    });
+    expect(mockTypedApi.POST).toHaveBeenCalledWith(
+      "/api/shared-sessions/{id}/invites",
+      { params: { path: { id: "ss-1" } }, body: { username: "charlie" } },
+    );
   });
 
   it("handles invite error", async () => {
-    mockApi.post.mockRejectedValue(new Error("User not found"));
+    mockTypedApi.POST.mockReturnValue(
+      Promise.reject(new Error("User not found")),
+    );
 
     const { result } = renderHook(() => useInviteToSharedSession(), {
       wrapper: createWrapper(),
@@ -348,7 +374,7 @@ describe("useInviteToSharedSession", () => {
 
 describe("useAcceptSharedSessionInvitation", () => {
   it("accepts an invitation", async () => {
-    mockApi.post.mockResolvedValue(undefined);
+    mockTypedApi.POST.mockReturnValue(ok(undefined));
 
     const { result } = renderHook(() => useAcceptSharedSessionInvitation(), {
       wrapper: createWrapper(),
@@ -357,15 +383,16 @@ describe("useAcceptSharedSessionInvitation", () => {
     result.current.mutate("inv-1");
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.post).toHaveBeenCalledWith(
-      "/user/shared-session-invites/inv-1/accept",
+    expect(mockTypedApi.POST).toHaveBeenCalledWith(
+      "/api/user/shared-session-invites/{id}/accept",
+      { params: { path: { id: "inv-1" } } },
     );
   });
 });
 
 describe("useRejectSharedSessionInvitation", () => {
   it("rejects an invitation", async () => {
-    mockApi.post.mockResolvedValue(undefined);
+    mockTypedApi.POST.mockReturnValue(ok(undefined));
 
     const { result } = renderHook(() => useRejectSharedSessionInvitation(), {
       wrapper: createWrapper(),
@@ -374,15 +401,16 @@ describe("useRejectSharedSessionInvitation", () => {
     result.current.mutate("inv-1");
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.post).toHaveBeenCalledWith(
-      "/user/shared-session-invites/inv-1/decline",
+    expect(mockTypedApi.POST).toHaveBeenCalledWith(
+      "/api/user/shared-session-invites/{id}/decline",
+      { params: { path: { id: "inv-1" } } },
     );
   });
 });
 
 describe("useLeaveSharedSession", () => {
   it("leaves a shared session", async () => {
-    mockApi.post.mockResolvedValue(undefined);
+    mockTypedApi.POST.mockReturnValue(ok(undefined));
 
     const { result } = renderHook(() => useLeaveSharedSession(), {
       wrapper: createWrapper(),
@@ -391,15 +419,16 @@ describe("useLeaveSharedSession", () => {
     result.current.mutate("ss-1");
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.post).toHaveBeenCalledWith(
-      "/shared-sessions/ss-1/leave",
+    expect(mockTypedApi.POST).toHaveBeenCalledWith(
+      "/api/shared-sessions/{id}/leave",
+      { params: { path: { id: "ss-1" } } },
     );
   });
 });
 
 describe("useRemoveSharedSessionMember", () => {
   it("removes a member", async () => {
-    mockApi.delete.mockResolvedValue(undefined);
+    mockTypedApi.DELETE.mockReturnValue(ok(undefined));
 
     const { result } = renderHook(() => useRemoveSharedSessionMember(), {
       wrapper: createWrapper(),
@@ -408,13 +437,16 @@ describe("useRemoveSharedSessionMember", () => {
     result.current.mutate({ sharedSessionId: "ss-1", userId: "u2" });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.delete).toHaveBeenCalledWith("/shared-sessions/ss-1/members/u2");
+    expect(mockTypedApi.DELETE).toHaveBeenCalledWith(
+      "/api/shared-sessions/{id}/members/{userId}",
+      { params: { path: { id: "ss-1", userId: "u2" } } },
+    );
   });
 });
 
 describe("useDeleteSharedSessionSave", () => {
   it("deletes a shared session save", async () => {
-    mockApi.delete.mockResolvedValue(undefined);
+    mockTypedApi.DELETE.mockReturnValue(ok(undefined));
 
     const { result } = renderHook(() => useDeleteSharedSessionSave(), {
       wrapper: createWrapper(),
@@ -423,6 +455,9 @@ describe("useDeleteSharedSessionSave", () => {
     result.current.mutate({ sharedSessionId: "ss-1", saveId: "1" });
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.delete).toHaveBeenCalledWith("/shared-sessions/ss-1/saves/1");
+    expect(mockTypedApi.DELETE).toHaveBeenCalledWith(
+      "/api/shared-sessions/{id}/saves/{saveId}",
+      { params: { path: { id: "ss-1", saveId: "1" } } },
+    );
   });
 });

--- a/web/src/hooks/use-shared-sessions.ts
+++ b/web/src/hooks/use-shared-sessions.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
+import { typedApi, unwrap } from "@/lib/api-client";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
   SharedSessionsResponse,
@@ -10,21 +10,24 @@ import type {
 } from "@/types/api";
 
 export function useMySharedSessions(page = 1, pageSize = 20) {
-  const params = new URLSearchParams();
-  params.set("page", String(page));
-  params.set("pageSize", String(pageSize));
-
   return useQuery({
     queryKey: ["shared-sessions", "mine", page, pageSize],
-    queryFn: () => api.get<SharedSessionsResponse>(`/shared-sessions?${params}`),
+    queryFn: async () => {
+      const data = await unwrap(typedApi.GET("/api/shared-sessions"));
+      return data as SharedSessionsResponse | undefined;
+    },
   });
 }
 
 export function useSharedSessionInvitations() {
   return useQuery({
     queryKey: ["shared-sessions", "invitations"],
-    queryFn: () =>
-      api.get<SharedSessionInvitationsResponse>("/user/shared-session-invites"),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/user/shared-session-invites"),
+      );
+      return data as SharedSessionInvitationsResponse | undefined;
+    },
   });
 }
 
@@ -32,7 +35,7 @@ export function usePendingInvitationCount() {
   return useQuery({
     queryKey: ["shared-sessions", "invitations", "count"],
     queryFn: () =>
-      api.get<{ count: number }>("/user/shared-session-invites/count"),
+      unwrap(typedApi.GET("/api/user/shared-session-invites/count")),
     refetchInterval: 30000,
   });
 }
@@ -40,7 +43,14 @@ export function usePendingInvitationCount() {
 export function useSharedSession(id: string) {
   return useQuery({
     queryKey: ["shared-sessions", "detail", id],
-    queryFn: () => api.get<SharedSessionDetail>(`/shared-sessions/${id}`),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/shared-sessions/{id}", {
+          params: { path: { id } },
+        }),
+      );
+      return data as SharedSessionDetail | undefined;
+    },
     enabled: !!id,
   });
 }
@@ -48,7 +58,14 @@ export function useSharedSession(id: string) {
 export function useSharedSessionSaves(sharedSessionId: string) {
   return useQuery({
     queryKey: ["shared-sessions", "saves", sharedSessionId],
-    queryFn: () => api.get<SharedSessionSave[]>(`/shared-sessions/${sharedSessionId}/saves`),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/shared-sessions/{id}/saves", {
+          params: { path: { id: sharedSessionId } },
+        }),
+      );
+      return data as SharedSessionSave[] | undefined;
+    },
     enabled: !!sharedSessionId,
   });
 }
@@ -56,7 +73,14 @@ export function useSharedSessionSaves(sharedSessionId: string) {
 export function useGameSharedSessions(gameId: string) {
   return useQuery({
     queryKey: ["shared-sessions", "game", gameId],
-    queryFn: () => api.get<SharedSession[]>(`/games/${gameId}/shared-sessions`),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/games/{id}/shared-sessions", {
+          params: { path: { id: gameId } },
+        }),
+      );
+      return data as SharedSession[] | undefined;
+    },
     enabled: !!gameId,
   });
 }
@@ -65,11 +89,16 @@ export function useCreateSharedSession() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (data: {
+    mutationFn: async (data: {
       name: string;
       gameId: string;
       description?: string;
-    }) => api.post<SharedSessionDetail>("/shared-sessions", data),
+    }) => {
+      const result = await unwrap(
+        typedApi.POST("/api/shared-sessions", { body: data }),
+      );
+      return result as SharedSessionDetail | undefined;
+    },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["shared-sessions"] });
     },
@@ -80,7 +109,12 @@ export function useDeleteSharedSession() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (id: string) => api.delete(`/shared-sessions/${id}`),
+    mutationFn: (id: string) =>
+      unwrap(
+        typedApi.DELETE("/api/shared-sessions/{id}", {
+          params: { path: { id } },
+        }),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["shared-sessions"] });
     },
@@ -97,9 +131,17 @@ export function useInviteToSharedSession() {
     }: {
       sharedSessionId: string;
       username: string;
-    }) => api.post(`/shared-sessions/${sharedSessionId}/invites`, { username }),
+    }) =>
+      unwrap(
+        typedApi.POST("/api/shared-sessions/{id}/invites", {
+          params: { path: { id: sharedSessionId } },
+          body: { username },
+        }),
+      ),
     onSuccess: (_, { sharedSessionId }) => {
-      queryClient.invalidateQueries({ queryKey: ["shared-sessions", "detail", sharedSessionId] });
+      queryClient.invalidateQueries({
+        queryKey: ["shared-sessions", "detail", sharedSessionId],
+      });
     },
   });
 }
@@ -109,7 +151,11 @@ export function useAcceptSharedSessionInvitation() {
 
   return useMutation({
     mutationFn: (invitationId: string) =>
-      api.post(`/user/shared-session-invites/${invitationId}/accept`),
+      unwrap(
+        typedApi.POST("/api/user/shared-session-invites/{id}/accept", {
+          params: { path: { id: invitationId } },
+        }),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["shared-sessions"] });
     },
@@ -121,7 +167,11 @@ export function useRejectSharedSessionInvitation() {
 
   return useMutation({
     mutationFn: (invitationId: string) =>
-      api.post(`/user/shared-session-invites/${invitationId}/decline`),
+      unwrap(
+        typedApi.POST("/api/user/shared-session-invites/{id}/decline", {
+          params: { path: { id: invitationId } },
+        }),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["shared-sessions"] });
     },
@@ -133,7 +183,11 @@ export function useLeaveSharedSession() {
 
   return useMutation({
     mutationFn: (sharedSessionId: string) =>
-      api.post(`/shared-sessions/${sharedSessionId}/leave`),
+      unwrap(
+        typedApi.POST("/api/shared-sessions/{id}/leave", {
+          params: { path: { id: sharedSessionId } },
+        }),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["shared-sessions"] });
     },
@@ -150,9 +204,16 @@ export function useRemoveSharedSessionMember() {
     }: {
       sharedSessionId: string;
       userId: string;
-    }) => api.delete(`/shared-sessions/${sharedSessionId}/members/${userId}`),
+    }) =>
+      unwrap(
+        typedApi.DELETE("/api/shared-sessions/{id}/members/{userId}", {
+          params: { path: { id: sharedSessionId, userId } },
+        }),
+      ),
     onSuccess: (_, { sharedSessionId }) => {
-      queryClient.invalidateQueries({ queryKey: ["shared-sessions", "detail", sharedSessionId] });
+      queryClient.invalidateQueries({
+        queryKey: ["shared-sessions", "detail", sharedSessionId],
+      });
     },
   });
 }
@@ -167,9 +228,16 @@ export function useDeleteSharedSessionSave() {
     }: {
       sharedSessionId: string;
       saveId: string;
-    }) => api.delete(`/shared-sessions/${sharedSessionId}/saves/${saveId}`),
+    }) =>
+      unwrap(
+        typedApi.DELETE("/api/shared-sessions/{id}/saves/{saveId}", {
+          params: { path: { id: sharedSessionId, saveId } },
+        }),
+      ),
     onSuccess: (_, { sharedSessionId }) => {
-      queryClient.invalidateQueries({ queryKey: ["shared-sessions", "saves", sharedSessionId] });
+      queryClient.invalidateQueries({
+        queryKey: ["shared-sessions", "saves", sharedSessionId],
+      });
     },
   });
 }


### PR DESCRIPTION
## Summary

- Switches all 14 shared-sessions hooks (\`useMySharedSessions\`, \`useSharedSessionInvitations\`, \`usePendingInvitationCount\`, \`useSharedSession\`, \`useSharedSessionSaves\`, \`useGameSharedSessions\`, \`useCreateSharedSession\`, \`useDeleteSharedSession\`, \`useInviteToSharedSession\`, \`useAcceptSharedSessionInvitation\`, \`useRejectSharedSessionInvitation\`, \`useLeaveSharedSession\`, \`useRemoveSharedSessionMember\`, \`useDeleteSharedSessionSave\`) to \`typedApi\`.
- Drops unused \`page\`/\`pageSize\` params on \`useMySharedSessions\` — neither the spec nor the Go server accept them, so they were being ignored.
- Guards \`shared-session-create-modal.tsx\` against an \`undefined\` create result (the typed POST body is optional).
- Casts list responses back to local types so consumers keep non-null arrays.
- Rewrites \`use-shared-sessions.test.ts\` to mock \`typedApi\` using the established \`ok()\` + pass-through \`unwrap\` pattern.

Refs #518.

## Test plan

- [x] \`npx tsc -b --noEmit\`
- [x] \`npx vitest run src/hooks/__tests__/use-shared-sessions.test.ts\` — 18 tests passing
- [x] Create / invite / join / leave / delete a shared session, accept/reject invitation, delete a shared save