### PR TITLE
feat(web): migrate use-challenges to typedApi

### DIFF
--- a/web/src/hooks/__tests__/use-challenges.test.ts
+++ b/web/src/hooks/__tests__/use-challenges.test.ts
@@ -17,29 +17,37 @@ import {
 } from "../use-challenges";
 
 vi.mock("@/lib/api-client", () => ({
-  api: {
-    get: vi.fn(),
-    post: vi.fn(),
-    put: vi.fn(),
-    delete: vi.fn(),
-    upload: vi.fn(),
-    getAccessToken: vi.fn(() => "test-token"),
+  typedApi: {
+    GET: vi.fn(),
+    POST: vi.fn(),
+    DELETE: vi.fn(),
   },
+  unwrap: vi.fn(<T,>(p: Promise<{ data?: T; error?: unknown; response: Response }>) =>
+    p.then((r) => {
+      if (r.error !== undefined) throw r.error;
+      return r.data;
+    }),
+  ),
 }));
 
 vi.mock("@/hooks/use-websocket", () => ({
   useWebSocketEvent: vi.fn(),
 }));
 
-import { api } from "@/lib/api-client";
+import { typedApi } from "@/lib/api-client";
 
-const mockApi = api as unknown as {
-  get: ReturnType<typeof vi.fn>;
-  post: ReturnType<typeof vi.fn>;
-  put: ReturnType<typeof vi.fn>;
-  delete: ReturnType<typeof vi.fn>;
-  upload: ReturnType<typeof vi.fn>;
+const mockTypedApi = typedApi as unknown as {
+  GET: ReturnType<typeof vi.fn>;
+  POST: ReturnType<typeof vi.fn>;
+  DELETE: ReturnType<typeof vi.fn>;
 };
+
+function ok(data: unknown) {
+  return Promise.resolve({
+    data,
+    response: new Response(null, { status: 200 }),
+  });
+}
 
 function createWrapper() {
   const queryClient = new QueryClient({
@@ -57,10 +65,6 @@ function createWrapper() {
 beforeEach(() => {
   vi.clearAllMocks();
 });
-
-// ---------------------------------------------------------------------------
-// Mock Data
-// ---------------------------------------------------------------------------
 
 const mockChallengesResponse = {
   data: [
@@ -139,13 +143,9 @@ const mockLeaderboardResponse = {
   pageSize: 50,
 };
 
-// ---------------------------------------------------------------------------
-// Tests
-// ---------------------------------------------------------------------------
-
 describe("useChallenges", () => {
   it("fetches paginated challenges list", async () => {
-    mockApi.get.mockResolvedValue(mockChallengesResponse);
+    mockTypedApi.GET.mockReturnValue(ok(mockChallengesResponse));
     const { result } = renderHook(() => useChallenges(), {
       wrapper: createWrapper(),
     });
@@ -154,7 +154,7 @@ describe("useChallenges", () => {
   });
 
   it("passes filter parameters (gameId, consoleId, difficulty, sort)", async () => {
-    mockApi.get.mockResolvedValue(mockChallengesResponse);
+    mockTypedApi.GET.mockReturnValue(ok(mockChallengesResponse));
     const { result } = renderHook(
       () =>
         useChallenges({
@@ -166,15 +166,19 @@ describe("useChallenges", () => {
       { wrapper: createWrapper() },
     );
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    const callUrl = mockApi.get.mock.calls[0][0] as string;
-    expect(callUrl).toContain("gameId=g1");
-    expect(callUrl).toContain("consoleId=c1");
-    expect(callUrl).toContain("difficulty=hard");
-    expect(callUrl).toContain("sort=popular");
+    const call = mockTypedApi.GET.mock.calls[0];
+    expect(call[0]).toBe("/api/challenges");
+    const query = call[1].params.query;
+    expect(query).toMatchObject({
+      gameId: "g1",
+      consoleId: "c1",
+      difficulty: "hard",
+      sort: "popular",
+    });
   });
 
   it("returns loading state initially", () => {
-    mockApi.get.mockReturnValue(new Promise(() => {}));
+    mockTypedApi.GET.mockReturnValue(new Promise(() => {}));
     const { result } = renderHook(() => useChallenges(), {
       wrapper: createWrapper(),
     });
@@ -182,7 +186,7 @@ describe("useChallenges", () => {
   });
 
   it("returns error state on network failure", async () => {
-    mockApi.get.mockRejectedValue(new Error("Network error"));
+    mockTypedApi.GET.mockReturnValue(Promise.reject(new Error("Network error")));
     const { result } = renderHook(() => useChallenges(), {
       wrapper: createWrapper(),
     });
@@ -192,17 +196,19 @@ describe("useChallenges", () => {
 
 describe("useChallenge", () => {
   it("fetches single challenge by ID", async () => {
-    mockApi.get.mockResolvedValue(mockChallengeDetail);
+    mockTypedApi.GET.mockReturnValue(ok(mockChallengeDetail));
     const { result } = renderHook(() => useChallenge("1"), {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockChallengeDetail);
-    expect(mockApi.get).toHaveBeenCalledWith("/challenges/1");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith("/api/challenges/{id}", {
+      params: { path: { id: "1" } },
+    });
   });
 
   it("returns error for non-existent challenge", async () => {
-    mockApi.get.mockRejectedValue(new Error("Not found"));
+    mockTypedApi.GET.mockReturnValue(Promise.reject(new Error("Not found")));
     const { result } = renderHook(() => useChallenge("999"), {
       wrapper: createWrapper(),
     });
@@ -212,24 +218,22 @@ describe("useChallenge", () => {
 
 describe("useChallengeLeaderboard", () => {
   it("fetches leaderboard for a challenge", async () => {
-    mockApi.get.mockResolvedValue(mockLeaderboardResponse);
+    mockTypedApi.GET.mockReturnValue(ok(mockLeaderboardResponse));
     const { result } = renderHook(() => useChallengeLeaderboard("1"), {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
     expect(result.current.data).toEqual(mockLeaderboardResponse);
-    expect(mockApi.get).toHaveBeenCalledWith(
-      "/challenges/1/leaderboard?page=1&pageSize=50",
+    expect(mockTypedApi.GET).toHaveBeenCalledWith(
+      "/api/challenges/{id}/leaderboard",
+      { params: { path: { id: "1" }, query: { page: 1, pageSize: 50 } } },
     );
   });
 
   it("returns empty leaderboard for new challenge", async () => {
-    mockApi.get.mockResolvedValue({
-      data: [],
-      total: 0,
-      page: 1,
-      pageSize: 50,
-    });
+    mockTypedApi.GET.mockReturnValue(
+      ok({ data: [], total: 0, page: 1, pageSize: 50 }),
+    );
     const { result } = renderHook(() => useChallengeLeaderboard("1"), {
       wrapper: createWrapper(),
     });
@@ -240,23 +244,21 @@ describe("useChallengeLeaderboard", () => {
 
 describe("useGameChallenges", () => {
   it("fetches challenges for a specific game", async () => {
-    mockApi.get.mockResolvedValue(mockChallengesResponse);
+    mockTypedApi.GET.mockReturnValue(ok(mockChallengesResponse));
     const { result } = renderHook(() => useGameChallenges("g1"), {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.get).toHaveBeenCalledWith(
-      "/games/g1/challenges?page=1&pageSize=5",
+    expect(mockTypedApi.GET).toHaveBeenCalledWith(
+      "/api/games/{id}/challenges",
+      { params: { path: { id: "g1" }, query: { page: 1, pageSize: 5 } } },
     );
   });
 
   it("returns empty list when game has no challenges", async () => {
-    mockApi.get.mockResolvedValue({
-      data: [],
-      total: 0,
-      page: 1,
-      pageSize: 5,
-    });
+    mockTypedApi.GET.mockReturnValue(
+      ok({ data: [], total: 0, page: 1, pageSize: 5 }),
+    );
     const { result } = renderHook(() => useGameChallenges("g1"), {
       wrapper: createWrapper(),
     });
@@ -267,14 +269,14 @@ describe("useGameChallenges", () => {
 
 describe("useMyChallenges", () => {
   it("fetches challenges created by current user", async () => {
-    mockApi.get.mockResolvedValue(mockChallengesResponse);
+    mockTypedApi.GET.mockReturnValue(ok(mockChallengesResponse));
     const { result } = renderHook(() => useMyChallenges(), {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.get).toHaveBeenCalledWith(
-      "/user/challenges?page=1&pageSize=20",
-    );
+    expect(mockTypedApi.GET).toHaveBeenCalledWith("/api/user/challenges", {
+      params: { query: { page: 1, pageSize: 20 } },
+    });
   });
 });
 
@@ -293,16 +295,19 @@ describe("useMyAttempts", () => {
         isBest: true,
       },
     ];
-    mockApi.get.mockResolvedValue(mockAttempts);
+    mockTypedApi.GET.mockReturnValue(ok(mockAttempts));
     const { result } = renderHook(() => useMyAttempts("1"), {
       wrapper: createWrapper(),
     });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.get).toHaveBeenCalledWith("/challenges/1/attempts/mine");
+    expect(mockTypedApi.GET).toHaveBeenCalledWith(
+      "/api/challenges/{id}/attempts/mine",
+      { params: { path: { id: "1" } } },
+    );
   });
 
   it("returns empty array when no attempts exist", async () => {
-    mockApi.get.mockResolvedValue([]);
+    mockTypedApi.GET.mockReturnValue(ok([]));
     const { result } = renderHook(() => useMyAttempts("1"), {
       wrapper: createWrapper(),
     });
@@ -313,17 +318,19 @@ describe("useMyAttempts", () => {
 
 describe("useDeleteChallenge", () => {
   it("sends DELETE request for challenge", async () => {
-    mockApi.delete.mockResolvedValue(undefined);
+    mockTypedApi.DELETE.mockReturnValue(ok(undefined));
     const { result } = renderHook(() => useDeleteChallenge(), {
       wrapper: createWrapper(),
     });
     result.current.mutate("1");
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.delete).toHaveBeenCalledWith("/challenges/1");
+    expect(mockTypedApi.DELETE).toHaveBeenCalledWith("/api/challenges/{id}", {
+      params: { path: { id: "1" } },
+    });
   });
 
   it("invalidates challenges query cache on success", async () => {
-    mockApi.delete.mockResolvedValue(undefined);
+    mockTypedApi.DELETE.mockReturnValue(ok(undefined));
     const { result } = renderHook(() => useDeleteChallenge(), {
       wrapper: createWrapper(),
     });
@@ -332,7 +339,7 @@ describe("useDeleteChallenge", () => {
   });
 
   it("returns error for unauthorized deletion", async () => {
-    mockApi.delete.mockRejectedValue(new Error("Forbidden"));
+    mockTypedApi.DELETE.mockReturnValue(Promise.reject(new Error("Forbidden")));
     const { result } = renderHook(() => useDeleteChallenge(), {
       wrapper: createWrapper(),
     });
@@ -353,19 +360,22 @@ describe("useStartAttempt", () => {
       durationMs: 0,
       isBest: false,
     };
-    mockApi.post.mockResolvedValue(mockResponse);
+    mockTypedApi.POST.mockReturnValue(ok(mockResponse));
     const { result } = renderHook(() => useStartAttempt(), {
       wrapper: createWrapper(),
     });
     result.current.mutate("1");
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.post).toHaveBeenCalledWith(
-      "/challenges/1/attempts/start",
+    expect(mockTypedApi.POST).toHaveBeenCalledWith(
+      "/api/challenges/{id}/attempts/start",
+      { params: { path: { id: "1" } } },
     );
   });
 
   it("returns error when rate limited", async () => {
-    mockApi.post.mockRejectedValue(new Error("Too many requests"));
+    mockTypedApi.POST.mockReturnValue(
+      Promise.reject(new Error("Too many requests")),
+    );
     const { result } = renderHook(() => useStartAttempt(), {
       wrapper: createWrapper(),
     });
@@ -387,19 +397,20 @@ describe("useCompleteAttempt", () => {
       durationMs: 45230,
       isBest: true,
     };
-    mockApi.post.mockResolvedValue(mockResponse);
+    mockTypedApi.POST.mockReturnValue(ok(mockResponse));
     const { result } = renderHook(() => useCompleteAttempt(), {
       wrapper: createWrapper(),
     });
     result.current.mutate({ challengeId: "1", attemptId: "attempt-1" });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.post).toHaveBeenCalledWith(
-      "/challenges/1/attempts/attempt-1/complete",
+    expect(mockTypedApi.POST).toHaveBeenCalledWith(
+      "/api/challenges/{id}/attempts/{aid}/complete",
+      { params: { path: { id: "1", aid: "attempt-1" } } },
     );
   });
 
   it("invalidates leaderboard cache on success", async () => {
-    mockApi.post.mockResolvedValue({});
+    mockTypedApi.POST.mockReturnValue(ok({}));
     const { result } = renderHook(() => useCompleteAttempt(), {
       wrapper: createWrapper(),
     });
@@ -408,7 +419,7 @@ describe("useCompleteAttempt", () => {
   });
 
   it("invalidates my attempts cache on success", async () => {
-    mockApi.post.mockResolvedValue({});
+    mockTypedApi.POST.mockReturnValue(ok({}));
     const { result } = renderHook(() => useCompleteAttempt(), {
       wrapper: createWrapper(),
     });
@@ -419,19 +430,20 @@ describe("useCompleteAttempt", () => {
 
 describe("useAbandonAttempt", () => {
   it("sends POST to abandon attempt", async () => {
-    mockApi.post.mockResolvedValue({});
+    mockTypedApi.POST.mockReturnValue(ok({}));
     const { result } = renderHook(() => useAbandonAttempt(), {
       wrapper: createWrapper(),
     });
     result.current.mutate({ challengeId: "1", attemptId: "attempt-1" });
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
-    expect(mockApi.post).toHaveBeenCalledWith(
-      "/challenges/1/attempts/attempt-1/abandon",
+    expect(mockTypedApi.POST).toHaveBeenCalledWith(
+      "/api/challenges/{id}/attempts/{aid}/abandon",
+      { params: { path: { id: "1", aid: "attempt-1" } } },
     );
   });
 
   it("invalidates my attempts cache on success", async () => {
-    mockApi.post.mockResolvedValue({});
+    mockTypedApi.POST.mockReturnValue(ok({}));
     const { result } = renderHook(() => useAbandonAttempt(), {
       wrapper: createWrapper(),
     });

--- a/web/src/hooks/use-challenges.ts
+++ b/web/src/hooks/use-challenges.ts
@@ -1,5 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
+import { typedApi, unwrap } from "@/lib/api-client";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
   Challenge,
@@ -18,31 +18,43 @@ const sortMapping: Record<string, string> = {
   ending_soon: "newest",
 };
 
-function buildChallengeParams(filters: ChallengeFilters): string {
-  const params = new URLSearchParams();
-  if (filters.page) params.set("page", String(filters.page));
-  if (filters.pageSize) params.set("pageSize", String(filters.pageSize));
-  if (filters.gameId) params.set("gameId", filters.gameId);
-  if (filters.consoleId) params.set("consoleId", filters.consoleId);
-  if (filters.difficulty) params.set("difficulty", filters.difficulty);
-  if (filters.type) params.set("type", filters.type);
-  if (filters.status) params.set("status", filters.status);
-  if (filters.sortBy) params.set("sort", sortMapping[filters.sortBy] ?? filters.sortBy);
-  return params.toString();
+function buildChallengeQuery(filters: ChallengeFilters) {
+  const q: Record<string, string | number | undefined> = {};
+  if (filters.page) q.page = filters.page;
+  if (filters.pageSize) q.pageSize = filters.pageSize;
+  if (filters.gameId) q.gameId = filters.gameId;
+  if (filters.consoleId) q.consoleId = filters.consoleId;
+  if (filters.difficulty) q.difficulty = filters.difficulty;
+  if (filters.type) q.type = filters.type;
+  if (filters.status) q.status = filters.status;
+  if (filters.sortBy) q.sort = sortMapping[filters.sortBy] ?? filters.sortBy;
+  return q;
 }
 
 export function useChallenges(filters: ChallengeFilters = {}) {
-  const queryString = buildChallengeParams(filters);
+  const query = buildChallengeQuery(filters);
   return useQuery({
     queryKey: ["challenges", filters],
-    queryFn: () => api.get<ChallengesResponse>(`/challenges?${queryString}`),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/challenges", { params: { query } }),
+      );
+      return data as ChallengesResponse | undefined;
+    },
   });
 }
 
 export function useChallenge(id: string) {
   return useQuery({
     queryKey: ["challenge", id],
-    queryFn: () => api.get<Challenge>(`/challenges/${id}`),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/challenges/{id}", {
+          params: { path: { id } },
+        }),
+      );
+      return data as Challenge | undefined;
+    },
     enabled: !!id,
   });
 }
@@ -54,10 +66,14 @@ export function useGameChallenges(
 ) {
   return useQuery({
     queryKey: ["challenges", "game", gameId, page, pageSize],
-    queryFn: () =>
-      api.get<ChallengesResponse>(
-        `/games/${gameId}/challenges?page=${page}&pageSize=${pageSize}`,
-      ),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/games/{id}/challenges", {
+          params: { path: { id: gameId }, query: { page, pageSize } },
+        }),
+      );
+      return data as ChallengesResponse | undefined;
+    },
     enabled: !!gameId,
   });
 }
@@ -65,10 +81,14 @@ export function useGameChallenges(
 export function useMyChallenges(page: number = 1, pageSize: number = 20) {
   return useQuery({
     queryKey: ["challenges", "mine", page, pageSize],
-    queryFn: () =>
-      api.get<ChallengesResponse>(
-        `/user/challenges?page=${page}&pageSize=${pageSize}`,
-      ),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/user/challenges", {
+          params: { query: { page, pageSize } },
+        }),
+      );
+      return data as ChallengesResponse | undefined;
+    },
   });
 }
 
@@ -81,10 +101,14 @@ export function useChallengeLeaderboard(
 ) {
   return useQuery({
     queryKey: ["challenge", challengeId, "leaderboard", page, pageSize],
-    queryFn: () =>
-      api.get<ChallengeLeaderboardResponse>(
-        `/challenges/${challengeId}/leaderboard?page=${page}&pageSize=${pageSize}`,
-      ),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/challenges/{id}/leaderboard", {
+          params: { path: { id: challengeId }, query: { page, pageSize } },
+        }),
+      );
+      return data as ChallengeLeaderboardResponse | undefined;
+    },
     enabled: !!challengeId,
   });
 }
@@ -92,8 +116,14 @@ export function useChallengeLeaderboard(
 export function useMyAttempts(challengeId: string) {
   return useQuery({
     queryKey: ["challenge", challengeId, "my-attempts"],
-    queryFn: () =>
-      api.get<ChallengeAttempt[]>(`/challenges/${challengeId}/attempts/mine`),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/challenges/{id}/attempts/mine", {
+          params: { path: { id: challengeId } },
+        }),
+      );
+      return data as ChallengeAttempt[] | undefined;
+    },
     enabled: !!challengeId,
   });
 }
@@ -102,7 +132,12 @@ export function useDeleteChallenge() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (id: string) => api.delete(`/challenges/${id}`),
+    mutationFn: (id: string) =>
+      unwrap(
+        typedApi.DELETE("/api/challenges/{id}", {
+          params: { path: { id } },
+        }),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["challenges"] });
     },
@@ -111,10 +146,14 @@ export function useDeleteChallenge() {
 
 export function useStartAttempt() {
   return useMutation({
-    mutationFn: (challengeId: string) =>
-      api.post<StartAttemptResponse>(
-        `/challenges/${challengeId}/attempts/start`,
-      ),
+    mutationFn: async (challengeId: string) => {
+      const data = await unwrap(
+        typedApi.POST("/api/challenges/{id}/attempts/start", {
+          params: { path: { id: challengeId } },
+        }),
+      );
+      return data as StartAttemptResponse | undefined;
+    },
   });
 }
 
@@ -122,16 +161,20 @@ export function useCompleteAttempt() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: ({
+    mutationFn: async ({
       challengeId,
       attemptId,
     }: {
       challengeId: string;
       attemptId: string;
-    }) =>
-      api.post<CompleteAttemptResponse>(
-        `/challenges/${challengeId}/attempts/${attemptId}/complete`,
-      ),
+    }) => {
+      const data = await unwrap(
+        typedApi.POST("/api/challenges/{id}/attempts/{aid}/complete", {
+          params: { path: { id: challengeId, aid: attemptId } },
+        }),
+      );
+      return data as CompleteAttemptResponse | undefined;
+    },
     onSuccess: (_, { challengeId }) => {
       queryClient.invalidateQueries({
         queryKey: ["challenge", challengeId, "leaderboard"],
@@ -153,8 +196,10 @@ export function useAbandonAttempt() {
       challengeId: string;
       attemptId: string;
     }) =>
-      api.post(
-        `/challenges/${challengeId}/attempts/${attemptId}/abandon`,
+      unwrap(
+        typedApi.POST("/api/challenges/{id}/attempts/{aid}/abandon", {
+          params: { path: { id: challengeId, aid: attemptId } },
+        }),
       ),
   });
 }


### PR DESCRIPTION
## Summary

- Switches all 10 challenge hooks (\`useChallenges\`, \`useChallenge\`, \`useGameChallenges\`, \`useMyChallenges\`, \`useChallengeLeaderboard\`, \`useMyAttempts\`, \`useDeleteChallenge\`, \`useStartAttempt\`, \`useCompleteAttempt\`, \`useAbandonAttempt\`) to \`typedApi\`.
- Filter params now flow through \`params.query\` instead of string-building.
- Casts GET responses back to local types so consumers keep non-null arrays.
- Rewrites \`use-challenges.test.ts\` to mock \`typedApi\` using the established \`ok()\` + pass-through \`unwrap\` pattern.

Refs #518.

## Test plan

- [x] \`npx tsc -b --noEmit\`
- [x] \`npx vitest run src/hooks/__tests__/use-challenges.test.ts\` — 23 tests passing
- [x] Browse challenges list with filters; view detail; start/complete/abandon an attempt; delete a challenge as creator