### PR TITLE
feat(web): migrate use-consoles to typedApi

### DIFF
--- a/web/src/hooks/use-consoles.ts
+++ b/web/src/hooks/use-consoles.ts
@@ -1,18 +1,28 @@
 import { useQuery } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
+import { typedApi, unwrap } from "@/lib/api-client";
 import type { Console, Game } from "@/types/api";
 
 export function useConsoles() {
   return useQuery({
     queryKey: ["consoles"],
-    queryFn: () => api.get<Console[]>("/consoles"),
+    queryFn: async () => {
+      const data = await unwrap(typedApi.GET("/api/consoles"));
+      return data as Console[] | undefined;
+    },
   });
 }
 
 export function useConsoleGames(consoleId: string) {
   return useQuery({
     queryKey: ["consoles", consoleId, "games"],
-    queryFn: () => api.get<Game[]>(`/consoles/${consoleId}/games`),
+    queryFn: async () => {
+      const data = await unwrap(
+        typedApi.GET("/api/consoles/{id}/games", {
+          params: { path: { id: consoleId } },
+        }),
+      );
+      return data as Game[] | undefined;
+    },
     enabled: !!consoleId,
   });
 }


### PR DESCRIPTION
## Summary

- Switches \`useConsoles\` and \`useConsoleGames\` to \`typedApi.GET\`.
- Casts responses back to \`Console[]\` / \`Game[]\` so consumers keep non-null arrays (the spec marks list responses nullable).

Refs #518.

## Test plan

- [x] \`npx tsc -b --noEmit\`
- [x] Browse /consoles and /consoles/:id/games end-to-end in the app