### PR TITLE
feat(web): migrate remaining non-hook call sites to typedApi

### DIFF
--- a/web/src/features/game-detail/components/verification-badge.tsx
+++ b/web/src/features/game-detail/components/verification-badge.tsx
@@ -2,7 +2,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import { CheckCircle2, AlertTriangle } from "lucide-react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { Badge, Button } from "@/components/ui";
-import { api } from "@/lib/api-client";
+import { typedApi, unwrap } from "@/lib/api-client";
 import type { Game } from "@/types/api";
 
 const PREDEFINED_TAGS = [
@@ -64,7 +64,12 @@ export function VerificationBadge({ game, isAdmin }: VerificationBadgeProps) {
 
   const mutation = useMutation({
     mutationFn: (tag: string) =>
-      api.put<void>(`/admin/games/${game.id}/verification-tag`, { tag }),
+      unwrap(
+        typedApi.PUT("/api/admin/games/{id}/verification-tag", {
+          params: { path: { id: game.id } },
+          body: { tag },
+        }),
+      ),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["game", game.id] });
       queryClient.invalidateQueries({ queryKey: ["games"] });

--- a/web/src/lib/__tests__/scrape-queue.test.ts
+++ b/web/src/lib/__tests__/scrape-queue.test.ts
@@ -2,9 +2,15 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { enqueueScrape, _resetScrapeQueue } from "../scrape-queue";
 
 vi.mock("@/lib/api-client", () => ({
-  api: {
-    post: vi.fn(),
+  typedApi: {
+    POST: vi.fn(),
   },
+  unwrap: vi.fn(<T,>(p: Promise<{ data?: T; error?: unknown; response: Response }>) =>
+    p.then((r) => {
+      if (r.error !== undefined) throw r.error;
+      return r.data;
+    }),
+  ),
 }));
 
 vi.mock("@/lib/query-client", () => ({
@@ -13,11 +19,18 @@ vi.mock("@/lib/query-client", () => ({
   },
 }));
 
-import { api } from "@/lib/api-client";
+import { typedApi } from "@/lib/api-client";
 
-const mockApi = api as unknown as {
-  post: ReturnType<typeof vi.fn>;
+const mockTypedApi = typedApi as unknown as {
+  POST: ReturnType<typeof vi.fn>;
 };
+
+function ok(data: unknown) {
+  return Promise.resolve({
+    data,
+    response: new Response(null, { status: 200 }),
+  });
+}
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -34,69 +47,73 @@ async function flushPromises() {
 }
 
 describe("scrape-queue", () => {
-  it("calls api.post for an enqueued game", async () => {
-    mockApi.post.mockResolvedValue(undefined);
+  it("calls typedApi.POST for an enqueued game", async () => {
+    mockTypedApi.POST.mockReturnValue(ok(undefined));
 
     enqueueScrape("game-1");
     await flushPromises();
 
-    expect(mockApi.post).toHaveBeenCalledWith("/games/game-1/scrape-if-needed");
-    expect(mockApi.post).toHaveBeenCalledTimes(1);
+    expect(mockTypedApi.POST).toHaveBeenCalledWith(
+      "/api/games/{id}/scrape-if-needed",
+      { params: { path: { id: "game-1" } } },
+    );
+    expect(mockTypedApi.POST).toHaveBeenCalledTimes(1);
   });
 
   it("deduplicates the same game id", async () => {
-    mockApi.post.mockResolvedValue(undefined);
+    mockTypedApi.POST.mockReturnValue(ok(undefined));
 
     enqueueScrape("game-1");
     enqueueScrape("game-1");
     enqueueScrape("game-1");
     await flushPromises();
 
-    expect(mockApi.post).toHaveBeenCalledTimes(1);
+    expect(mockTypedApi.POST).toHaveBeenCalledTimes(1);
   });
 
   it("processes multiple games sequentially", async () => {
     const callOrder: string[] = [];
-    mockApi.post.mockImplementation((url: string) => {
-      callOrder.push(url);
-      return Promise.resolve(undefined);
-    });
+    mockTypedApi.POST.mockImplementation(
+      (_url: string, opts: { params: { path: { id: string } } }) => {
+        callOrder.push(opts.params.path.id);
+        return ok(undefined);
+      },
+    );
 
     enqueueScrape("game-1");
     enqueueScrape("game-2");
     enqueueScrape("game-3");
     await flushPromises();
 
-    expect(callOrder).toEqual([
-      "/games/game-1/scrape-if-needed",
-      "/games/game-2/scrape-if-needed",
-      "/games/game-3/scrape-if-needed",
-    ]);
+    expect(callOrder).toEqual(["game-1", "game-2", "game-3"]);
   });
 
   it("silently handles API errors", async () => {
-    mockApi.post
-      .mockRejectedValueOnce(new Error("Network error"))
-      .mockResolvedValueOnce(undefined);
+    mockTypedApi.POST
+      .mockReturnValueOnce(Promise.reject(new Error("Network error")))
+      .mockReturnValueOnce(ok(undefined));
 
     enqueueScrape("game-1");
     enqueueScrape("game-2");
     await flushPromises();
 
-    expect(mockApi.post).toHaveBeenCalledTimes(2);
-    expect(mockApi.post).toHaveBeenCalledWith("/games/game-2/scrape-if-needed");
+    expect(mockTypedApi.POST).toHaveBeenCalledTimes(2);
+    expect(mockTypedApi.POST).toHaveBeenLastCalledWith(
+      "/api/games/{id}/scrape-if-needed",
+      { params: { path: { id: "game-2" } } },
+    );
   });
 
   it("does not re-enqueue after reset and re-add", async () => {
-    mockApi.post.mockResolvedValue(undefined);
+    mockTypedApi.POST.mockReturnValue(ok(undefined));
 
     enqueueScrape("game-1");
     await flushPromises();
-    expect(mockApi.post).toHaveBeenCalledTimes(1);
+    expect(mockTypedApi.POST).toHaveBeenCalledTimes(1);
 
     // Same ID should be deduped even after processing
     enqueueScrape("game-1");
     await flushPromises();
-    expect(mockApi.post).toHaveBeenCalledTimes(1);
+    expect(mockTypedApi.POST).toHaveBeenCalledTimes(1);
   });
 });

--- a/web/src/lib/scrape-queue.ts
+++ b/web/src/lib/scrape-queue.ts
@@ -1,4 +1,4 @@
-import { api } from "@/lib/api-client";
+import { typedApi, unwrap } from "@/lib/api-client";
 import { queryClient } from "@/lib/query-client";
 
 const THROTTLE_MS = 300;
@@ -14,7 +14,11 @@ async function processQueue() {
   while (queue.length > 0) {
     const gameId = queue.shift()!;
     try {
-      await api.post(`/games/${gameId}/scrape-if-needed`);
+      await unwrap(
+        typedApi.POST("/api/games/{id}/scrape-if-needed", {
+          params: { path: { id: gameId } },
+        }),
+      );
       queryClient.invalidateQueries({ queryKey: ["games"] });
     } catch {
       // Server increments scrapeAttempts regardless — silently continue

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -16,7 +16,7 @@ import { useToast } from "@/components/ui";
 import { useGamepadConnected } from "@/hooks/use-gamepad";
 import { useAutoSaveInfo } from "@/hooks/use-sessions";
 import { useQueryClient } from "@tanstack/react-query";
-import { api } from "@/lib/api-client";
+import { api, typedApi, unwrap } from "@/lib/api-client";
 import { toEmulatorJsShader } from "@/lib/shader-mapping";
 import { PlayToolbar } from "@/features/play/components/play-toolbar";
 import { EmulatorOverlay } from "@/features/play/components/emulator-overlay";
@@ -150,11 +150,15 @@ export function PlayPage() {
     },
     onError: (err) => {
       toast("error", `Emulator error: ${err}`);
-      api.post("/emulator/error", {
-        error: err,
-        gameId: id ?? "",
-        core: emulatorJsCore ?? "",
-      }).catch(() => {});
+      unwrap(
+        typedApi.POST("/api/emulator/error", {
+          body: {
+            error: err,
+            gameId: id ?? "",
+            core: emulatorJsCore ?? "",
+          },
+        }),
+      ).catch(() => {});
     },
     onSramUpdate: (data) => {
       saveManager.enqueueSave(data, true, "sram_autosave");


### PR DESCRIPTION
## Summary

Cleans up the three remaining non-hook call sites that still used legacy \`api.post/put\`:

- \`verification-badge.tsx\` — PUT \`/api/admin/games/{id}/verification-tag\`
- \`lib/scrape-queue.ts\` — POST \`/api/games/{id}/scrape-if-needed\`
- \`play-page.tsx\` — POST \`/api/emulator/error\` (error reporting side-channel)

Rewrites \`scrape-queue.test.ts\` to mock \`typedApi.POST\`.

\`play-page.tsx\` still imports \`api\` for \`getAccessToken()\` — that's token storage, not an HTTP call, and kept.

After this, the only callers of the legacy \`api.get/post/put/delete\` object are the multipart-upload hooks blocked by #518 (use-bios, use-uploads, use-rom-hacks, use-save-queue, use-games' useReplaceRom).

Refs #518.

## Test plan

- [x] \`npx tsc -b --noEmit\`
- [x] \`npx vitest run src/lib/__tests__/scrape-queue.test.ts\` — 5 tests passing