### PR TITLE
feat(web): add multipart bodySerializer helper for typedApi

### DIFF
--- a/web/src/hooks/__tests__/use-bios.test.ts
+++ b/web/src/hooks/__tests__/use-bios.test.ts
@@ -10,9 +10,6 @@ import {
 } from "../use-bios";
 
 vi.mock("@/lib/api-client", () => ({
-  api: {
-    upload: vi.fn(),
-  },
   typedApi: {
     GET: vi.fn(),
     DELETE: vi.fn(),
@@ -24,13 +21,10 @@ vi.mock("@/lib/api-client", () => ({
       return r.data;
     }),
   ),
+  multipartBodySerializer: (body: unknown) => body as FormData,
 }));
 
-import { api, typedApi } from "@/lib/api-client";
-
-const mockApi = api as unknown as {
-  upload: ReturnType<typeof vi.fn>;
-};
+import { typedApi } from "@/lib/api-client";
 
 const mockTypedApi = typedApi as unknown as {
   GET: ReturnType<typeof vi.fn>;
@@ -154,7 +148,7 @@ describe("useUploadBiosFile", () => {
       required: true,
       status: "valid" as const,
     };
-    mockApi.upload.mockResolvedValue(uploadResult);
+    mockTypedApi.POST.mockReturnValue(ok(uploadResult));
 
     const { result } = renderHook(() => useUploadBiosFile(), {
       wrapper: createWrapper(),
@@ -167,15 +161,20 @@ describe("useUploadBiosFile", () => {
 
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
-    expect(mockApi.upload).toHaveBeenCalledWith(
-      "/admin/bios",
-      expect.any(FormData),
+    expect(mockTypedApi.POST).toHaveBeenCalledWith(
+      "/api/admin/bios",
+      expect.objectContaining({
+        body: expect.any(FormData),
+        bodySerializer: expect.any(Function),
+      }),
     );
     expect(result.current.data).toEqual(uploadResult);
   });
 
   it("handles upload error", async () => {
-    mockApi.upload.mockRejectedValue(new Error("413 Payload Too Large"));
+    mockTypedApi.POST.mockReturnValue(
+      Promise.reject(new Error("413 Payload Too Large")),
+    );
 
     const { result } = renderHook(() => useUploadBiosFile(), {
       wrapper: createWrapper(),

--- a/web/src/hooks/use-bios.ts
+++ b/web/src/hooks/use-bios.ts
@@ -1,5 +1,9 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { api, typedApi, unwrap } from "@/lib/api-client";
+import {
+  multipartBodySerializer,
+  typedApi,
+  unwrap,
+} from "@/lib/api-client";
 import type { BiosFile } from "@/types/api";
 
 export function useBiosStatus() {
@@ -18,8 +22,6 @@ export function useBiosFiles() {
   };
 }
 
-// Multipart upload still goes through api.upload — typedApi multipart needs
-// a custom bodySerializer; tracked in #518.
 export function useUploadBiosFile() {
   const queryClient = useQueryClient();
 
@@ -27,7 +29,13 @@ export function useUploadBiosFile() {
     mutationFn: async (file: File) => {
       const formData = new FormData();
       formData.append("file", file);
-      return api.upload<BiosFile>("/admin/bios", formData);
+      const data = await unwrap(
+        typedApi.POST("/api/admin/bios", {
+          body: formData as unknown as never,
+          bodySerializer: multipartBodySerializer,
+        }),
+      );
+      return data as BiosFile | undefined;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["bios"] });

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -224,6 +224,27 @@ export const typedApi = createClient<paths>({
   fetch: authedFetch,
 });
 
+// Multipart bodySerializer for openapi-fetch. The generated path spec types
+// file fields as `string` (from `format: binary` in OpenAPI), so multipart
+// call sites need to pass a FormData-compatible body via an `unknown` cast.
+// Use like:
+//
+//   const formData = new FormData();
+//   formData.append("file", file);
+//   await typedApi.POST("/api/admin/bios", {
+//     body: formData as unknown as never,
+//     bodySerializer: multipartBodySerializer,
+//   });
+//
+// The serializer returns the FormData as-is so the browser sets the correct
+// multipart/form-data Content-Type + boundary.
+export function multipartBodySerializer(body: unknown): FormData {
+  if (body instanceof FormData) return body;
+  throw new Error(
+    "multipartBodySerializer expects a FormData body; got " + typeof body,
+  );
+}
+
 // unwrap resolves a { data, error, response } FetchResponse into the success
 // value, throwing ApiError on failure. Matches the throw-on-error behavior
 // of the legacy `api` object so migrated call sites don't need to reshape


### PR DESCRIPTION
## Summary

Adds a \`multipartBodySerializer\` helper to \`api-client.ts\` that enables \`typedApi\` to handle multipart/form-data requests. openapi-fetch's default bodySerializer is \`JSON.stringify\`, which mangles FormData; this helper passes FormData through unchanged so the browser sets the multipart/form-data Content-Type + boundary itself.

Usage pattern:
\`\`\`ts
const formData = new FormData();
formData.append(\"file\", file);
await typedApi.POST(\"/api/admin/bios\", {
  body: formData as unknown as never,
  bodySerializer: multipartBodySerializer,
});
\`\`\`

The \`as unknown as never\` cast is needed because the generated spec types file fields as \`string\` (from \`format: binary\` in OpenAPI).

Also migrates \`useUploadBiosFile\` as the first consumer — this unblocks the other multipart hooks (use-uploads' useUploadRoms, use-rom-hacks, use-save-queue, use-games' useReplaceRom), which can follow the same pattern in follow-up PRs.

Refs #518.

## Test plan

- [x] \`npx tsc -b --noEmit\`
- [x] \`npx vitest run\` — 1466 tests passing
- [x] Upload a BIOS file from admin/bios and verify it lands on the server