### PR TITLE
chore(server): rewrite 4 test files to use huma router

### DIFF
--- a/server/internal/api/admin_igdb_match_test.go
+++ b/server/internal/api/admin_igdb_match_test.go
@@ -7,93 +7,37 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
-	"time"
 
-	"github.com/gin-gonic/gin"
-	"github.com/spela/server/internal/auth"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/igdb"
-	"github.com/spela/server/internal/scraper"
-	"github.com/spela/server/internal/storage"
-	ws "github.com/spela/server/internal/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
-const igdbMatchTestSecret = "igdb-match-test-secret"
-
-func setupIGDBMatchTestEnv(t *testing.T, tokenServerURL, igdbServerURL string) (*gorm.DB, *gin.Engine, *scraper.Scraper) {
+// configureIGDBTestServers wires the IGDB package globals so both the Twitch
+// token exchange and IGDB v4 endpoint hit the supplied httptest servers, and
+// persists placeholder credentials in the DB so tryConfigureIGDB() will
+// construct a client pointing at them.
+func configureIGDBTestServers(t *testing.T, database *gorm.DB, tokenURL, igdbBaseURL string) {
 	t.Helper()
 
-	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
-	require.NoError(t, err)
-	require.NoError(t, database.AutoMigrate(
-		&db.User{}, &db.Console{}, &db.Game{}, &db.GameScreenshot{},
-		&db.GameDisc{}, &db.Favorite{}, &db.PlayHistory{}, &db.ServerSetting{},
-		&db.GameRating{}, &db.PlayLaterItem{}, &db.GameReleaseDate{},
-		&db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{},
-	))
-
-	if tokenServerURL != "" {
+	if tokenURL != "" {
 		origURL := igdb.TwitchTokenURLForTest()
-		igdb.SetTwitchTokenURLForTest(tokenServerURL)
+		igdb.SetTwitchTokenURLForTest(tokenURL)
 		t.Cleanup(func() { igdb.SetTwitchTokenURLForTest(origURL) })
 	}
-	if igdbServerURL != "" {
+	if igdbBaseURL != "" {
 		origBase := igdb.IGDBAPIBaseForTest()
-		igdb.SetIGDBAPIBaseForTest(igdbServerURL + "/v4")
+		igdb.SetIGDBAPIBaseForTest(igdbBaseURL + "/v4")
 		t.Cleanup(func() { igdb.SetIGDBAPIBaseForTest(origBase) })
 	}
-
-	tmpDir := t.TempDir()
-	store, err := storage.NewStorage(tmpDir+"/saves", tmpDir+"/cores", tmpDir+"/images", tmpDir+"/bios")
-	require.NoError(t, err)
-
-	hub := ws.NewHub(nil)
-	go hub.Run()
-
-	s := scraper.NewScraper(database, store, t.TempDir(), []string{tmpDir})
-	if tokenServerURL != "" && igdbServerURL != "" {
-		igdbClient := igdb.NewClient("test-id", "test-secret")
-		igdbClient.HTTPClient = &http.Client{Timeout: 5 * time.Second}
-		s.IGDBClient = igdbClient
+	if tokenURL != "" && igdbBaseURL != "" {
+		// Persist credentials so AdminHandler.tryConfigureIGDB() will build a
+		// client targeting the overridden URLs.
+		require.NoError(t, database.Create(&db.ServerSetting{Key: "igdb_client_id", Value: "test-id"}).Error)
+		require.NoError(t, database.Create(&db.ServerSetting{Key: "igdb_client_secret", Value: "test-secret"}).Error)
 	}
-
-	adminHandler := &AdminHandler{DB: database, Scraper: s, Hub: hub, Storage: store}
-
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	api := router.Group("/api")
-	api.Use(AuthMiddleware(igdbMatchTestSecret, database))
-	{
-		admin := api.Group("/admin")
-		admin.Use(AdminMiddleware())
-		{
-			admin.GET("/games/:id/igdb-search", adminHandler.SearchIGDB)
-			admin.POST("/games/:id/igdb-match", adminHandler.ApplyIGDBMatch)
-		}
-	}
-
-	return database, router, s
-}
-
-func createIGDBMatchTestUser(t *testing.T, database *gorm.DB) string {
-	t.Helper()
-	user := db.User{
-		Username:     "match-admin",
-		Email:        "match-admin@test.com",
-		PasswordHash: "unused",
-		Role:         "admin",
-	}
-	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), igdbMatchTestSecret)
-	require.NoError(t, err)
-	return token
 }
 
 func TestSearchIGDB_Success(t *testing.T) {
@@ -126,17 +70,20 @@ func TestSearchIGDB_Success(t *testing.T) {
 	}))
 	defer igdbServer.Close()
 
-	database, router, _ := setupIGDBMatchTestEnv(t, tokenServer.URL, igdbServer.URL)
-	token := createIGDBMatchTestUser(t, database)
+	database, cfg := setupTestEnv(t)
+	configureIGDBTestServers(t, database, tokenServer.URL, igdbServer.URL)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
-	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
-	require.NoError(t, database.Create(&console).Error)
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&console).Error)
 	game := db.Game{ConsoleID: console.ID, Title: "Aladdin", FileName: "Aladdin.sfc"}
 	require.NoError(t, database.Create(&game).Error)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-search?q=Aladdin", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -159,46 +106,52 @@ func TestSearchIGDB_Success(t *testing.T) {
 }
 
 func TestSearchIGDB_MissingQuery(t *testing.T) {
-	database, router, _ := setupIGDBMatchTestEnv(t, "", "")
-	token := createIGDBMatchTestUser(t, database)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
-	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
-	require.NoError(t, database.Create(&console).Error)
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&console).Error)
 	game := db.Game{ConsoleID: console.ID, Title: "Test", FileName: "Test.sfc"}
 	require.NoError(t, database.Create(&game).Error)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-search", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
 }
 
 func TestSearchIGDB_GameNotFound(t *testing.T) {
-	database, router, _ := setupIGDBMatchTestEnv(t, "", "")
-	token := createIGDBMatchTestUser(t, database)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/admin/games/99999/igdb-search?q=test", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestSearchIGDB_IGDBNotConfigured(t *testing.T) {
-	database, router, _ := setupIGDBMatchTestEnv(t, "", "")
-	token := createIGDBMatchTestUser(t, database)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
-	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
-	require.NoError(t, database.Create(&console).Error)
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&console).Error)
 	game := db.Game{ConsoleID: console.ID, Title: "Test", FileName: "Test.sfc"}
 	require.NoError(t, database.Create(&game).Error)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-search?q=test", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusServiceUnavailable, w.Code)
@@ -234,11 +187,14 @@ func TestApplyIGDBMatch_Success(t *testing.T) {
 	}))
 	defer igdbServer.Close()
 
-	database, router, _ := setupIGDBMatchTestEnv(t, tokenServer.URL, igdbServer.URL)
-	token := createIGDBMatchTestUser(t, database)
+	database, cfg := setupTestEnv(t)
+	configureIGDBTestServers(t, database, tokenServer.URL, igdbServer.URL)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
-	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
-	require.NoError(t, database.Create(&console).Error)
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&console).Error)
 
 	game := db.Game{
 		ConsoleID:      console.ID,
@@ -253,7 +209,7 @@ func TestApplyIGDBMatch_Success(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-match", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -266,25 +222,29 @@ func TestApplyIGDBMatch_Success(t *testing.T) {
 }
 
 func TestApplyIGDBMatch_GameNotFound(t *testing.T) {
-	database, router, _ := setupIGDBMatchTestEnv(t, "", "")
-	token := createIGDBMatchTestUser(t, database)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	body, _ := json.Marshal(map[string]int{"igdbId": 999})
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/admin/games/99999/igdb-match", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 }
 
 func TestApplyIGDBMatch_MissingIGDBID(t *testing.T) {
-	database, router, _ := setupIGDBMatchTestEnv(t, "", "")
-	token := createIGDBMatchTestUser(t, database)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
-	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
-	require.NoError(t, database.Create(&console).Error)
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&console).Error)
 	game := db.Game{ConsoleID: console.ID, Title: "Test", FileName: "Test.sfc"}
 	require.NoError(t, database.Create(&game).Error)
 
@@ -292,7 +252,7 @@ func TestApplyIGDBMatch_MissingIGDBID(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-match", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -314,11 +274,14 @@ func TestApplyIGDBMatch_IGDBNotFound(t *testing.T) {
 	}))
 	defer igdbServer.Close()
 
-	database, router, _ := setupIGDBMatchTestEnv(t, tokenServer.URL, igdbServer.URL)
-	token := createIGDBMatchTestUser(t, database)
+	database, cfg := setupTestEnv(t)
+	configureIGDBTestServers(t, database, tokenServer.URL, igdbServer.URL)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
-	console := db.Console{Abbreviation: "SNES", Name: "Super Nintendo"}
-	require.NoError(t, database.Create(&console).Error)
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&console).Error)
 	game := db.Game{ConsoleID: console.ID, Title: "Test", FileName: "Test.sfc"}
 	require.NoError(t, database.Create(&game).Error)
 
@@ -326,7 +289,7 @@ func TestApplyIGDBMatch_IGDBNotFound(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/admin/games/"+strconv.Itoa(int(game.ID))+"/igdb-match", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusInternalServerError, w.Code)

--- a/server/internal/api/admin_igdb_test.go
+++ b/server/internal/api/admin_igdb_test.go
@@ -7,75 +7,11 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/gin-gonic/gin"
-	"github.com/spela/server/internal/auth"
 	"github.com/spela/server/internal/db"
 	"github.com/spela/server/internal/igdb"
-	"github.com/spela/server/internal/scraper"
-	ws "github.com/spela/server/internal/websocket"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
-
-const igdbTestJWTSecret = "igdb-test-secret"
-
-func setupIGDBTestEnv(t *testing.T, twitchServer *httptest.Server) (*gorm.DB, *gin.Engine) {
-	t.Helper()
-
-	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
-	require.NoError(t, err)
-	require.NoError(t, database.AutoMigrate(&db.User{}, &db.ServerSetting{}))
-
-	if twitchServer != nil {
-		origURL := igdb.TwitchTokenURLForTest()
-		igdb.SetTwitchTokenURLForTest(twitchServer.URL)
-		t.Cleanup(func() { igdb.SetTwitchTokenURLForTest(origURL) })
-	}
-
-	hub := ws.NewHub(nil)
-	go hub.Run()
-
-	s := scraper.NewScraper(database, nil, t.TempDir(), nil)
-	adminHandler := &AdminHandler{DB: database, Scraper: s, Hub: hub}
-	igdbHandler := &IGDBHandler{DB: database}
-
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	api := router.Group("/api")
-	api.Use(AuthMiddleware(igdbTestJWTSecret, database))
-	{
-		admin := api.Group("/admin")
-		admin.Use(AdminMiddleware())
-		{
-			admin.POST("/igdb/test", igdbHandler.TestIGDB)
-			admin.GET("/igdb/status", igdbHandler.GetIGDBStatus)
-			admin.GET("/steamgriddb/status", adminHandler.GetSteamGridDBStatus)
-			admin.GET("/settings", adminHandler.GetSettings)
-			admin.PUT("/settings", adminHandler.UpdateSettings)
-		}
-	}
-
-	return database, router
-}
-
-func createIGDBTestUser(t *testing.T, database *gorm.DB, role db.UserRole) string {
-	t.Helper()
-	user := db.User{
-		Username:     "igdb-test-" + string(role),
-		Email:        "igdb-test-" + string(role) + "@test.com",
-		PasswordHash: "unused",
-		Role:         role,
-	}
-	require.NoError(t, database.Create(&user).Error)
-	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), igdbTestJWTSecret)
-	require.NoError(t, err)
-	return token
-}
 
 func TestIGDBTest_Success(t *testing.T) {
 	twitchServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -89,8 +25,14 @@ func TestIGDBTest_Success(t *testing.T) {
 	}))
 	defer twitchServer.Close()
 
-	database, router := setupIGDBTestEnv(t, twitchServer)
-	token := createIGDBTestUser(t, database, "admin")
+	origURL := igdb.TwitchTokenURLForTest()
+	igdb.SetTwitchTokenURLForTest(twitchServer.URL)
+	t.Cleanup(func() { igdb.SetTwitchTokenURLForTest(origURL) })
+
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	body, _ := json.Marshal(map[string]string{
 		"clientId":     "goodid",
@@ -99,14 +41,17 @@ func TestIGDBTest_Success(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/admin/igdb/test", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	var resp map[string]interface{}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, true, resp["success"])
-	assert.Nil(t, resp["error"])
+	// huma handler omits the error field when empty — it should be absent or empty.
+	if v, ok := resp["error"]; ok {
+		assert.Equal(t, "", v)
+	}
 }
 
 func TestIGDBTest_AuthFailure(t *testing.T) {
@@ -116,8 +61,14 @@ func TestIGDBTest_AuthFailure(t *testing.T) {
 	}))
 	defer twitchServer.Close()
 
-	database, router := setupIGDBTestEnv(t, twitchServer)
-	token := createIGDBTestUser(t, database, "admin")
+	origURL := igdb.TwitchTokenURLForTest()
+	igdb.SetTwitchTokenURLForTest(twitchServer.URL)
+	t.Cleanup(func() { igdb.SetTwitchTokenURLForTest(origURL) })
+
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	body, _ := json.Marshal(map[string]string{
 		"clientId":     "badid",
@@ -126,19 +77,21 @@ func TestIGDBTest_AuthFailure(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("POST", "/api/admin/igdb/test", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 	var resp map[string]interface{}
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, false, resp["success"])
-	assert.NotNil(t, resp["error"])
+	assert.NotEmpty(t, resp["error"])
 }
 
 func TestIGDBTest_EmptyFields(t *testing.T) {
-	database, router := setupIGDBTestEnv(t, nil)
-	token := createIGDBTestUser(t, database, "admin")
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	tests := []struct {
 		name string
@@ -156,7 +109,7 @@ func TestIGDBTest_EmptyFields(t *testing.T) {
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest("POST", "/api/admin/igdb/test", bytes.NewReader(body))
 			req.Header.Set("Content-Type", "application/json")
-			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Authorization", "Bearer "+adminToken)
 			router.ServeHTTP(w, req)
 
 			assert.Equal(t, http.StatusBadRequest, w.Code)
@@ -168,12 +121,14 @@ func TestIGDBTest_EmptyFields(t *testing.T) {
 }
 
 func TestIGDBStatus_NotConfigured(t *testing.T) {
-	database, router := setupIGDBTestEnv(t, nil)
-	token := createIGDBTestUser(t, database, "admin")
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/admin/igdb/status", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -185,8 +140,10 @@ func TestIGDBStatus_NotConfigured(t *testing.T) {
 
 func TestIGDBStatus_Connected(t *testing.T) {
 	// No twitch server needed — status only checks DB.
-	database, router := setupIGDBTestEnv(t, nil)
-	token := createIGDBTestUser(t, database, "admin")
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	// Set up IGDB credentials in DB
 	database.Create(&db.ServerSetting{Key: "igdb_client_id", Value: "configured-id"})
@@ -194,7 +151,7 @@ func TestIGDBStatus_Connected(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/admin/igdb/status", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -207,15 +164,17 @@ func TestIGDBStatus_Connected(t *testing.T) {
 func TestIGDBStatus_ConfiguredNoLiveCheck(t *testing.T) {
 	// Status endpoint only checks DB, does not make live API calls.
 	// Even with invalid credentials, it returns "connected" if credentials exist.
-	database, router := setupIGDBTestEnv(t, nil)
-	token := createIGDBTestUser(t, database, "admin")
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	database.Create(&db.ServerSetting{Key: "igdb_client_id", Value: "any-id"})
 	database.Create(&db.ServerSetting{Key: "igdb_client_secret", Value: "any-secret"})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/admin/igdb/status", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -226,8 +185,10 @@ func TestIGDBStatus_ConfiguredNoLiveCheck(t *testing.T) {
 }
 
 func TestSettingsMasking_IGDBSecret(t *testing.T) {
-	database, router := setupIGDBTestEnv(t, nil)
-	token := createIGDBTestUser(t, database, "admin")
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	// Store settings including IGDB secret
 	database.Create(&db.ServerSetting{Key: "igdb_client_id", Value: "my-client-id"})
@@ -236,7 +197,7 @@ func TestSettingsMasking_IGDBSecret(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/admin/settings", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -253,8 +214,10 @@ func TestSettingsMasking_IGDBSecret(t *testing.T) {
 
 func TestSettingsMasking_RoundTrip(t *testing.T) {
 	// BUG-1 regression: sending "********" back via PUT must NOT overwrite the real secret.
-	database, router := setupIGDBTestEnv(t, nil)
-	token := createIGDBTestUser(t, database, "admin")
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	// Store the real secret
 	database.Create(&db.ServerSetting{Key: "igdb_client_id", Value: "my-client-id"})
@@ -269,7 +232,7 @@ func TestSettingsMasking_RoundTrip(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/admin/settings", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
@@ -281,8 +244,10 @@ func TestSettingsMasking_RoundTrip(t *testing.T) {
 
 func TestSettingsMasking_NewSecretOverwrites(t *testing.T) {
 	// When admin provides a real new secret (not the mask), it should be saved.
-	database, router := setupIGDBTestEnv(t, nil)
-	token := createIGDBTestUser(t, database, "admin")
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	database.Create(&db.ServerSetting{Key: "igdb_client_secret", Value: "old-secret"})
 
@@ -292,7 +257,7 @@ func TestSettingsMasking_NewSecretOverwrites(t *testing.T) {
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("PUT", "/api/admin/settings", bytes.NewReader(body))
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusOK, w.Code)
 
@@ -302,15 +267,17 @@ func TestSettingsMasking_NewSecretOverwrites(t *testing.T) {
 }
 
 func TestSettingsMasking_EmptySecret(t *testing.T) {
-	database, router := setupIGDBTestEnv(t, nil)
-	token := createIGDBTestUser(t, database, "admin")
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	_, adminToken := createAdminUser(t, database)
 
 	// Store empty secret
 	database.Create(&db.ServerSetting{Key: "igdb_client_secret", Value: ""})
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/admin/settings", nil)
-	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -361,19 +328,24 @@ func TestGetSteamGridDBStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			database, router := setupIGDBTestEnv(t, nil)
-			token := createIGDBTestUser(t, database, "admin")
-
+			// Ensure env key is not leaked across subtests.
+			t.Setenv("SPELA_STEAMGRIDDB_API_KEY", "")
 			if tt.envKey != "" {
 				t.Setenv("SPELA_STEAMGRIDDB_API_KEY", tt.envKey)
 			}
+
+			database, cfg := setupTestEnv(t)
+			router, cleanup := NewRouter(*cfg)
+			defer cleanup()
+			_, adminToken := createAdminUser(t, database)
+
 			if tt.dbKey != "" {
 				database.Create(&db.ServerSetting{Key: "steamgriddb_api_key", Value: tt.dbKey})
 			}
 
 			w := httptest.NewRecorder()
 			req := httptest.NewRequest("GET", "/api/admin/steamgriddb/status", nil)
-			req.Header.Set("Authorization", "Bearer "+token)
+			req.Header.Set("Authorization", "Bearer "+adminToken)
 			router.ServeHTTP(w, req)
 
 			assert.Equal(t, http.StatusOK, w.Code)

--- a/server/internal/api/console_handler_test.go
+++ b/server/internal/api/console_handler_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -10,93 +11,75 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/db"
-	"github.com/spela/server/internal/storage"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
-// setupConsoleTestEnv creates an in-memory DB with auto-migrated tables and
-// seeded consoles, a temp-dir-backed Storage, and a fresh gin router. Tests
-// that exercise gin-only handlers register them on the returned router;
-// tests that exercise a now-huma endpoint use newConsoleHttpEnv instead.
-func setupConsoleTestEnv(t *testing.T) (*gorm.DB, *storage.Storage, *gin.Engine) {
+// seedConsoleMetadata migrates the metadata lookup tables and seeds them.
+// setupTestEnv seeds consoles but not the HardwareMaker/MediaType* lookup
+// tables; call this for tests that assert on console metadata fields
+// (maker, mediaType, releaseYear, summary, ...).
+func seedConsoleMetadata(t *testing.T, database *gorm.DB) {
 	t.Helper()
-
-	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
-	require.NoError(t, err)
-
-	err = database.AutoMigrate(&db.MediaTypeCategory{}, &db.MediaType{}, &db.HardwareMaker{}, &db.Console{}, &db.Game{}, &db.TopRatedGame{}, &db.GameReleaseDate{}, &db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{})
-	require.NoError(t, err)
-
-	err = db.SeedConsoles(database)
-	require.NoError(t, err)
-
+	require.NoError(t, database.AutoMigrate(
+		&db.MediaTypeCategory{}, &db.MediaType{}, &db.HardwareMaker{},
+	))
 	require.NoError(t, db.SeedMediaTypeCategories(database))
 	require.NoError(t, db.SeedMediaTypes(database))
 	require.NoError(t, db.SeedHardwareMakers(database))
 	require.NoError(t, db.SeedConsoleMetadata(database))
-
-	tmpDir := t.TempDir()
-	store, err := storage.NewStorage(
-		filepath.Join(tmpDir, "saves"),
-		filepath.Join(tmpDir, "cores"),
-		filepath.Join(tmpDir, "images"),
-		filepath.Join(tmpDir, "bios"),
-	)
-	require.NoError(t, err)
-
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-	return database, store, router
 }
 
-// setupConsolePreviewEnv builds the production router (NewRouter +
-// setupTestEnv) so the now-huma preview-screenshot endpoint is exercised
-// through the production stack. Returns the DB, Storage, and wired router.
-func setupConsolePreviewEnv(t *testing.T) (*gorm.DB, *storage.Storage, *gin.Engine) {
+// consoleAuthToken returns an auth token for a regular user so tests can call
+// the authenticated public console endpoints.
+func consoleAuthToken(t *testing.T, router http.Handler) string {
 	t.Helper()
-	database, cfg := setupTestEnv(t)
-	router, cleanup := NewRouter(*cfg)
-	t.Cleanup(cleanup)
-	return database, cfg.Storage, router
+	body, _ := json.Marshal(map[string]string{
+		"username": "consoletest",
+		"email":    "consoletest@example.com",
+		"password": "password123",
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
+
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	return resp["accessToken"].(string)
 }
 
 func TestListConsoles_OmitsConsolesWithNoGames(t *testing.T) {
-	database, store, router := setupConsoleTestEnv(t)
-
-	handler := &ConsoleHandler{DB: database, Storage: store}
-	router.GET("/api/consoles", handler.ListConsoles)
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	// With seeded consoles but no games, response should be empty
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/consoles", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var consoles []ConsoleResponse
-	err := json.Unmarshal(w.Body.Bytes(), &consoles)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &consoles))
 	assert.Empty(t, consoles, "should return no consoles when none have games")
 }
 
 func TestListConsoles_ReturnsConsolesWithGames(t *testing.T) {
-	database, store, router := setupConsoleTestEnv(t)
-
-	handler := &ConsoleHandler{DB: database, Storage: store}
-	router.GET("/api/consoles", handler.ListConsoles)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	// Add a game to NES console
 	var nesConsole db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
 
 	game := db.Game{
 		ConsoleID: nesConsole.ID,
@@ -106,33 +89,32 @@ func TestListConsoles_ReturnsConsolesWithGames(t *testing.T) {
 		FileSize:  1024,
 		IsPrimary: true,
 	}
-	err = database.Create(&game).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&game).Error)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/consoles", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var consoles []ConsoleResponse
-	err = json.Unmarshal(w.Body.Bytes(), &consoles)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &consoles))
 	assert.Len(t, consoles, 1, "should return only the console with games")
 	assert.Equal(t, "NES", consoles[0].Abbreviation)
 	assert.Equal(t, 1, consoles[0].GameCount)
 }
 
 func TestListConsoles_IncludesMetadata(t *testing.T) {
-	database, store, router := setupConsoleTestEnv(t)
-
-	handler := &ConsoleHandler{DB: database, Storage: store}
-	router.GET("/api/consoles", handler.ListConsoles)
+	database, cfg := setupTestEnv(t)
+	seedConsoleMetadata(t, database)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	// Add a game to NES so it appears in the list
 	var nesConsole db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
 
 	game := db.Game{
 		ConsoleID: nesConsole.ID,
@@ -142,18 +124,17 @@ func TestListConsoles_IncludesMetadata(t *testing.T) {
 		FileSize:  1024,
 		IsPrimary: true,
 	}
-	err = database.Create(&game).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&game).Error)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/consoles", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var consoles []ConsoleResponse
-	err = json.Unmarshal(w.Body.Bytes(), &consoles)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &consoles))
 	require.Len(t, consoles, 1)
 
 	nes := consoles[0]
@@ -182,7 +163,9 @@ func TestListConsoles_IncludesMetadata(t *testing.T) {
 }
 
 func TestGetPreviewScreenshot_ConsoleNotFound(t *testing.T) {
-	_, _, router := setupConsolePreviewEnv(t)
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/consoles/nonexistent/preview-screenshot", nil)
@@ -191,29 +174,28 @@ func TestGetPreviewScreenshot_ConsoleNotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	var resp map[string]interface{}
-	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, "console not found", resp["error"])
 }
 
 func TestGetPreviewScreenshot_CachedPreview(t *testing.T) {
-	database, store, router := setupConsolePreviewEnv(t)
+	database, cfg := setupTestEnv(t)
+	store := cfg.Storage
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
 
 	var console db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&console).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
 
 	// Create the cached preview file on disk.
 	previewDir := filepath.Join(store.ImageDir, "previews", console.Abbreviation)
-	err = os.MkdirAll(previewDir, 0755)
-	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(previewDir, 0755))
 
 	previewPath := filepath.Join(previewDir, "preview.png")
-	err = os.WriteFile(previewPath, []byte("fake-png-data"), 0644)
-	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(previewPath, []byte("fake-png-data"), 0644))
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/consoles/" + strings.ToLower(console.Abbreviation) + "/preview-screenshot", nil)
+	req := httptest.NewRequest("GET", "/api/consoles/"+strings.ToLower(console.Abbreviation)+"/preview-screenshot", nil)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusFound, w.Code)
@@ -223,7 +205,9 @@ func TestGetPreviewScreenshot_CachedPreview(t *testing.T) {
 }
 
 func TestGetPreviewScreenshot_NoPreviewAvailable(t *testing.T) {
-	database, _, router := setupConsolePreviewEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
 
 	// Create a console with an abbreviation that is NOT in either
 	// scraper.AbbreviationToLibRetro or previewFallbackGames.
@@ -232,27 +216,27 @@ func TestGetPreviewScreenshot_NoPreviewAvailable(t *testing.T) {
 		Abbreviation: "ZZZUNKNOWN",
 		Extensions:   ".zzz",
 	}
-	err := database.Create(&unknownConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&unknownConsole).Error)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/consoles/" + strings.ToLower(unknownConsole.Abbreviation) + "/preview-screenshot", nil)
+	req := httptest.NewRequest("GET", "/api/consoles/"+strings.ToLower(unknownConsole.Abbreviation)+"/preview-screenshot", nil)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	var resp map[string]interface{}
-	err = json.Unmarshal(w.Body.Bytes(), &resp)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, "no preview available for this console", resp["error"])
 }
 
 func TestGetPreviewScreenshot_IgnoresLocalGames(t *testing.T) {
-	database, store, router := setupConsolePreviewEnv(t)
+	database, cfg := setupTestEnv(t)
+	store := cfg.Storage
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
 
 	var console db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&console).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
 
 	// Create a game with a scraped screenshot — should be ignored.
 	game := db.Game{
@@ -263,18 +247,15 @@ func TestGetPreviewScreenshot_IgnoresLocalGames(t *testing.T) {
 		FileSize:      2048,
 		ScreenshotURL: "NES/42/screenshot.png",
 	}
-	err = database.Create(&game).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&game).Error)
 
 	// Create a cached CDN preview.
 	previewDir := filepath.Join(store.ImageDir, "previews", console.Abbreviation)
-	err = os.MkdirAll(previewDir, 0755)
-	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(previewDir, "preview.png"), []byte("cdn-preview"), 0644)
-	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(previewDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(previewDir, "preview.png"), []byte("cdn-preview"), 0644))
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/consoles/" + strings.ToLower(console.Abbreviation) + "/preview-screenshot", nil)
+	req := httptest.NewRequest("GET", "/api/consoles/"+strings.ToLower(console.Abbreviation)+"/preview-screenshot", nil)
 	router.ServeHTTP(w, req)
 
 	// Should serve the CDN preview, NOT the local game screenshot.
@@ -284,21 +265,21 @@ func TestGetPreviewScreenshot_IgnoresLocalGames(t *testing.T) {
 }
 
 func TestGetPreviewScreenshot_WorksWithNoLocalGames(t *testing.T) {
-	database, store, router := setupConsolePreviewEnv(t)
+	database, cfg := setupTestEnv(t)
+	store := cfg.Storage
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
 
 	var console db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&console).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
 
 	// No games exist at all — verify we still serve the cached CDN preview.
 	previewDir := filepath.Join(store.ImageDir, "previews", console.Abbreviation)
-	err = os.MkdirAll(previewDir, 0755)
-	require.NoError(t, err)
-	err = os.WriteFile(filepath.Join(previewDir, "preview.png"), []byte("cached-data"), 0644)
-	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(previewDir, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(previewDir, "preview.png"), []byte("cached-data"), 0644))
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/consoles/" + strings.ToLower(console.Abbreviation) + "/preview-screenshot", nil)
+	req := httptest.NewRequest("GET", "/api/consoles/"+strings.ToLower(console.Abbreviation)+"/preview-screenshot", nil)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusFound, w.Code)
@@ -306,44 +287,16 @@ func TestGetPreviewScreenshot_WorksWithNoLocalGames(t *testing.T) {
 	assert.Equal(t, expectedLocation, w.Header().Get("Location"))
 }
 
-// setupTopListTestEnv creates an in-memory DB with seeded consoles, a temp Storage,
-// and a gin router with the top-lists/top-rated route.
-func setupTopListTestEnv(t *testing.T) (*gorm.DB, *gin.Engine) {
-	t.Helper()
-
-	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
-	require.NoError(t, err)
-
-	err = database.AutoMigrate(&db.MediaTypeCategory{}, &db.MediaType{}, &db.HardwareMaker{}, &db.Console{}, &db.Game{}, &db.TopRatedGame{}, &db.GameReleaseDate{}, &db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{})
-	require.NoError(t, err)
-
-	err = db.SeedConsoles(database)
-	require.NoError(t, err)
-
-	require.NoError(t, db.SeedMediaTypeCategories(database))
-	require.NoError(t, db.SeedMediaTypes(database))
-	require.NoError(t, db.SeedHardwareMakers(database))
-	require.NoError(t, db.SeedConsoleMetadata(database))
-
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-
-	handler := &ConsoleHandler{DB: database}
-	router.GET("/api/top-lists/top-rated", handler.GetTopListAvailable)
-	router.GET("/api/top-lists/top-rated-critics", handler.GetTopListCritics)
-	router.GET("/api/top-lists/longest", handler.GetTopListLongest)
-
-	return database, router
-}
+// --- Top lists (available) ---
 
 func TestGetTopListAvailable_ReturnsOnlyLocalMatches(t *testing.T) {
-	database, router := setupTopListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
 
 	// Create two top-rated IGDB entries
 	database.Create(&db.TopRatedGame{
@@ -364,13 +317,13 @@ func TestGetTopListAvailable_ReturnsOnlyLocalMatches(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []TopListGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 
 	assert.Len(t, result, 1, "should return only the game with a local match")
 	assert.Equal(t, "Super Mario Bros.", result[0].Name)
@@ -380,11 +333,13 @@ func TestGetTopListAvailable_ReturnsOnlyLocalMatches(t *testing.T) {
 }
 
 func TestGetTopListAvailable_SortedByRatingDesc(t *testing.T) {
-	database, router := setupTopListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
 
 	// Create top-rated entries with varying ratings
 	database.Create(&db.TopRatedGame{
@@ -412,13 +367,13 @@ func TestGetTopListAvailable_SortedByRatingDesc(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []TopListGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 
 	require.Len(t, result, 3)
 	assert.Equal(t, "Game B", result[0].Name)
@@ -430,11 +385,13 @@ func TestGetTopListAvailable_SortedByRatingDesc(t *testing.T) {
 }
 
 func TestGetTopListAvailable_SequentialRanks(t *testing.T) {
-	database, router := setupTopListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
 
 	// Create two top-rated entries
 	database.Create(&db.TopRatedGame{
@@ -458,13 +415,13 @@ func TestGetTopListAvailable_SequentialRanks(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []TopListGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 
 	require.Len(t, result, 2)
 	assert.Equal(t, 1, result[0].Rank, "first result should have rank 1")
@@ -472,11 +429,13 @@ func TestGetTopListAvailable_SequentialRanks(t *testing.T) {
 }
 
 func TestGetTopListAvailable_EmptyWhenNoMatches(t *testing.T) {
-	database, router := setupTopListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
 
 	// Create top-rated entries with no local game matches
 	database.Create(&db.TopRatedGame{
@@ -486,40 +445,45 @@ func TestGetTopListAvailable_EmptyWhenNoMatches(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []TopListGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 
 	assert.Empty(t, result, "should return empty array when no local matches exist")
 }
 
 func TestGetTopListAvailable_EmptyWithNoData(t *testing.T) {
-	_, router := setupTopListTestEnv(t)
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	// No top-rated entries and no games at all
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []TopListGameResponse
-	err := json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 
 	assert.Empty(t, result, "should return empty array when no data exists")
 }
 
 func TestGetTopListAvailable_IncludesConsoleInfo(t *testing.T) {
-	database, router := setupTopListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var snesConsole db.Console
-	err := database.Where("abbreviation = ?", "SNES").First(&snesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snesConsole).Error)
 
 	database.Create(&db.TopRatedGame{
 		ConsoleID: snesConsole.ID, IGDBGameID: 100, Name: "Super Mario World",
@@ -534,13 +498,13 @@ func TestGetTopListAvailable_IncludesConsoleInfo(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []TopListGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 
 	require.Len(t, result, 1)
 	assert.Equal(t, "Super Nintendo", result[0].ConsoleName)
@@ -551,42 +515,14 @@ func TestGetTopListAvailable_IncludesConsoleInfo(t *testing.T) {
 
 // --- GetTopListLongest tests ---
 
-// setupLongestListTestEnv creates an in-memory DB with seeded consoles and a gin
-// router with the top-lists/longest route.
-func setupLongestListTestEnv(t *testing.T) (*gorm.DB, *gin.Engine) {
-	t.Helper()
-
-	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
-	})
-	require.NoError(t, err)
-
-	err = database.AutoMigrate(&db.MediaTypeCategory{}, &db.MediaType{}, &db.HardwareMaker{}, &db.Console{}, &db.Game{}, &db.TopRatedGame{}, &db.GameReleaseDate{}, &db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{})
-	require.NoError(t, err)
-
-	err = db.SeedConsoles(database)
-	require.NoError(t, err)
-
-	require.NoError(t, db.SeedMediaTypeCategories(database))
-	require.NoError(t, db.SeedMediaTypes(database))
-	require.NoError(t, db.SeedHardwareMakers(database))
-	require.NoError(t, db.SeedConsoleMetadata(database))
-
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-
-	handler := &ConsoleHandler{DB: database}
-	router.GET("/api/top-lists/longest", handler.GetTopListLongest)
-
-	return database, router
-}
-
 func TestGetTopListLongest_SortedByTimeToBeatDesc(t *testing.T) {
-	database, router := setupLongestListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
 
 	// Create games with varying time-to-beat values
 	database.Create(&db.Game{
@@ -607,13 +543,13 @@ func TestGetTopListLongest_SortedByTimeToBeatDesc(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/longest", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []LongestGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 
 	require.Len(t, result, 3)
 	assert.Equal(t, "Long Game", result[0].Name)
@@ -627,11 +563,13 @@ func TestGetTopListLongest_SortedByTimeToBeatDesc(t *testing.T) {
 }
 
 func TestGetTopListLongest_OnlyIncludesGamesWithTimeToBeat(t *testing.T) {
-	database, router := setupLongestListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
 
 	// Game with time-to-beat data
 	database.Create(&db.Game{
@@ -648,24 +586,26 @@ func TestGetTopListLongest_OnlyIncludesGamesWithTimeToBeat(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/longest", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []LongestGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 
 	assert.Len(t, result, 1, "should only include games with time_to_beat_normally > 0")
 	assert.Equal(t, "Has Time Data", result[0].Name)
 }
 
 func TestGetTopListLongest_EmptyWhenNoGamesHaveTimeData(t *testing.T) {
-	database, router := setupLongestListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
 
 	// Create games without time data
 	database.Create(&db.Game{
@@ -679,23 +619,25 @@ func TestGetTopListLongest_EmptyWhenNoGamesHaveTimeData(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/longest", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []LongestGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 
 	assert.Empty(t, result, "should return empty array when no games have time data")
 }
 
 func TestGetTopListLongest_SequentialRanks(t *testing.T) {
-	database, router := setupLongestListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
 
 	database.Create(&db.Game{
 		ConsoleID: nesConsole.ID, Title: "First",
@@ -715,13 +657,13 @@ func TestGetTopListLongest_SequentialRanks(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/longest", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []LongestGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 
 	require.Len(t, result, 3)
 	assert.Equal(t, 1, result[0].Rank, "first result should have rank 1")
@@ -730,11 +672,13 @@ func TestGetTopListLongest_SequentialRanks(t *testing.T) {
 }
 
 func TestGetTopListLongest_LimitOf50(t *testing.T) {
-	database, router := setupLongestListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&nesConsole).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
 
 	// Create 55 games with time-to-beat data
 	for i := 1; i <= 55; i++ {
@@ -751,13 +695,13 @@ func TestGetTopListLongest_LimitOf50(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/longest", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []LongestGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 
 	assert.Len(t, result, 50, "should be limited to 50 results")
 	// The first result should be the game with the highest time (55 * 10 = 550)
@@ -773,7 +717,10 @@ func TestGetTopListLongest_LimitOf50(t *testing.T) {
 func TestGetTopListAvailable_UsesTotalRatingNotUserRating(t *testing.T) {
 	// Bug: Audience list was empty because it used user_rating which IGDB
 	// often returns as null (stored as 0). Fix uses total_rating instead.
-	database, router := setupTopListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
 	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
@@ -792,6 +739,7 @@ func TestGetTopListAvailable_UsesTotalRatingNotUserRating(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -804,7 +752,10 @@ func TestGetTopListAvailable_UsesTotalRatingNotUserRating(t *testing.T) {
 }
 
 func TestGetTopListCritics_ReturnsGamesWithCriticRating(t *testing.T) {
-	database, router := setupTopListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
 	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
@@ -821,6 +772,7 @@ func TestGetTopListCritics_ReturnsGamesWithCriticRating(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/top-rated-critics", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -832,7 +784,10 @@ func TestGetTopListCritics_ReturnsGamesWithCriticRating(t *testing.T) {
 }
 
 func TestGetTopListAvailable_ExcludesDemoConsoles(t *testing.T) {
-	database, router := setupTopListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole, ademoConsole db.Console
 	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
@@ -860,6 +815,7 @@ func TestGetTopListAvailable_ExcludesDemoConsoles(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/top-rated", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	var result []TopListGameResponse
@@ -870,7 +826,10 @@ func TestGetTopListAvailable_ExcludesDemoConsoles(t *testing.T) {
 }
 
 func TestGetTopListLongest_CapsUnreasonableTimeToBeat(t *testing.T) {
-	database, router := setupTopListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole db.Console
 	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
@@ -891,6 +850,7 @@ func TestGetTopListLongest_CapsUnreasonableTimeToBeat(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/longest", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	var result []LongestGameResponse
@@ -901,7 +861,10 @@ func TestGetTopListLongest_CapsUnreasonableTimeToBeat(t *testing.T) {
 }
 
 func TestGetTopListLongest_ExcludesDemoConsoles(t *testing.T) {
-	database, router := setupTopListTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var nesConsole, ddemoConsole db.Console
 	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&nesConsole).Error)
@@ -920,6 +883,7 @@ func TestGetTopListLongest_ExcludesDemoConsoles(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-lists/longest", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	var result []LongestGameResponse
@@ -930,10 +894,10 @@ func TestGetTopListLongest_ExcludesDemoConsoles(t *testing.T) {
 }
 
 func TestGetTopRatedGlobal_DeduplicatesSameGameAcrossConsoles(t *testing.T) {
-	database, store, router := setupConsoleTestEnv(t)
-
-	handler := &ConsoleHandler{DB: database, Storage: store}
-	router.GET("/api/top-rated", handler.GetTopRatedGlobal)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	// Look up two different consoles
 	var snes, gba db.Console
@@ -969,6 +933,7 @@ func TestGetTopRatedGlobal_DeduplicatesSameGameAcrossConsoles(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-rated", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
@@ -987,10 +952,10 @@ func TestGetTopRatedGlobal_DeduplicatesSameGameAcrossConsoles(t *testing.T) {
 }
 
 func TestGetTopRatedGlobal_DeduplicatePrefersLocalLibraryMatch(t *testing.T) {
-	database, store, router := setupConsoleTestEnv(t)
-
-	handler := &ConsoleHandler{DB: database, Storage: store}
-	router.GET("/api/top-rated", handler.GetTopRatedGlobal)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := consoleAuthToken(t, router)
 
 	var snes, gba db.Console
 	require.NoError(t, database.Where("abbreviation = ?", "SNES").First(&snes).Error)
@@ -1016,6 +981,7 @@ func TestGetTopRatedGlobal_DeduplicatePrefersLocalLibraryMatch(t *testing.T) {
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/top-rated", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)

--- a/server/internal/api/game_discovery_handler_test.go
+++ b/server/internal/api/game_discovery_handler_test.go
@@ -1,68 +1,64 @@
 package api
 
 import (
+	"bytes"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
 	"testing"
 
-	"github.com/gin-gonic/gin"
 	"github.com/spela/server/internal/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gorm.io/driver/sqlite"
-	"gorm.io/gorm"
-	"gorm.io/gorm/logger"
 )
 
-func setupDiscoveryTestEnv(t *testing.T) (*gorm.DB, *gin.Engine) {
+// discoveryAuthToken registers a user and returns the access token for use
+// with authenticated discovery routes.
+func discoveryAuthToken(t *testing.T, router http.Handler) string {
 	t.Helper()
-
-	database, err := gorm.Open(sqlite.Open(":memory:"), &gorm.Config{
-		Logger: logger.Default.LogMode(logger.Silent),
+	body, _ := json.Marshal(map[string]string{
+		"username": "discoverytest",
+		"email":    "discoverytest@example.com",
+		"password": "password123",
 	})
-	require.NoError(t, err)
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/auth/register", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code)
 
-	err = database.AutoMigrate(
-		&db.Console{}, &db.Game{}, &db.SimilarGame{}, &db.GameReleaseDate{},
-		&db.GameVideo{}, &db.GameLanguageSupport{}, &db.GameAgeRating{},
-	)
-	require.NoError(t, err)
-
-	err = db.SeedConsoles(database)
-	require.NoError(t, err)
-
-	gin.SetMode(gin.TestMode)
-	router := gin.New()
-
-	handler := &GameDiscoveryHandler{DB: database}
-	router.GET("/api/games/:id/similar", handler.GetSimilarGames)
-	router.GET("/api/games/:id/developer-games", handler.GetDeveloperGames)
-
-	return database, router
+	var resp map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	return resp["accessToken"].(string)
 }
 
 func TestGetSimilarGames_GameNotFound(t *testing.T) {
-	_, router := setupDiscoveryTestEnv(t)
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := discoveryAuthToken(t, router)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/games/999/similar", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	var resp map[string]interface{}
-	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, "game not found", resp["error"])
 }
 
 func TestGetSimilarGames_NoScraperID(t *testing.T) {
-	database, router := setupDiscoveryTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := discoveryAuthToken(t, router)
 
 	var console db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&console).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
 
 	game := db.Game{
 		ConsoleID: console.ID,
@@ -72,27 +68,28 @@ func TestGetSimilarGames_NoScraperID(t *testing.T) {
 		FileSize:  1024,
 		ScraperID: "", // no IGDB scraper ID
 	}
-	err = database.Create(&game).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&game).Error)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/games/1/similar", nil)
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.Itoa(int(game.ID))+"/similar", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []SimilarGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 	assert.Empty(t, result)
 }
 
 func TestGetSimilarGames_ReturnsCachedData(t *testing.T) {
-	database, router := setupDiscoveryTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := discoveryAuthToken(t, router)
 
 	var console db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&console).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
 
 	game := db.Game{
 		ConsoleID: console.ID,
@@ -102,40 +99,37 @@ func TestGetSimilarGames_ReturnsCachedData(t *testing.T) {
 		FileSize:  1024,
 		ScraperID: "igdb:1234",
 	}
-	err = database.Create(&game).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&game).Error)
 
 	// Pre-populate cache
 	similar1 := db.SimilarGame{
-		GameID:         game.ID,
-		IGDBGameID:     5678,
-		Name:           "Super Mario Bros. 2",
-		CoverImageID:   "co9999",
-		CoverLocalPath: "NES/5678/cover.jpg",
+		GameID:            game.ID,
+		IGDBGameID:        5678,
+		Name:              "Super Mario Bros. 2",
+		CoverImageID:      "co9999",
+		CoverLocalPath:    "NES/5678/cover.jpg",
 		IGDBCriticsRating: 85.5,
 	}
 	similar2 := db.SimilarGame{
-		GameID:         game.ID,
-		IGDBGameID:     9012,
-		Name:           "Kirby's Adventure",
-		CoverImageID:   "co8888",
-		CoverLocalPath: "NES/9012/cover.jpg",
+		GameID:            game.ID,
+		IGDBGameID:        9012,
+		Name:              "Kirby's Adventure",
+		CoverImageID:      "co8888",
+		CoverLocalPath:    "NES/9012/cover.jpg",
 		IGDBCriticsRating: 82.0,
 	}
-	err = database.Create(&similar1).Error
-	require.NoError(t, err)
-	err = database.Create(&similar2).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&similar1).Error)
+	require.NoError(t, database.Create(&similar2).Error)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/games/1/similar", nil)
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.Itoa(int(game.ID))+"/similar", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []SimilarGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 	assert.Len(t, result, 2)
 	assert.Equal(t, "Super Mario Bros. 2", result[0].Name)
 	assert.Equal(t, 85.5, result[0].IGDBCriticsRating)
@@ -144,11 +138,13 @@ func TestGetSimilarGames_ReturnsCachedData(t *testing.T) {
 }
 
 func TestGetSimilarGames_CrossReferencesLocalLibrary(t *testing.T) {
-	database, router := setupDiscoveryTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := discoveryAuthToken(t, router)
 
 	var console db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&console).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
 
 	game := db.Game{
 		ConsoleID: console.ID,
@@ -158,8 +154,7 @@ func TestGetSimilarGames_CrossReferencesLocalLibrary(t *testing.T) {
 		FileSize:  1024,
 		ScraperID: "igdb:1234",
 	}
-	err = database.Create(&game).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&game).Error)
 
 	// Create a local game that matches one of the similar games
 	localMatch := db.Game{
@@ -169,55 +164,58 @@ func TestGetSimilarGames_CrossReferencesLocalLibrary(t *testing.T) {
 		FilePath:  "/tmp/kirby.nes",
 		FileSize:  2048,
 	}
-	err = database.Create(&localMatch).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&localMatch).Error)
 
 	// Pre-populate cache
 	similar := db.SimilarGame{
-		GameID:       game.ID,
-		IGDBGameID:   9012,
-		Name:         "Kirby's Adventure",
-		CoverImageID: "co8888",
+		GameID:            game.ID,
+		IGDBGameID:        9012,
+		Name:              "Kirby's Adventure",
+		CoverImageID:      "co8888",
 		IGDBCriticsRating: 82.0,
 	}
-	err = database.Create(&similar).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&similar).Error)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/games/1/similar", nil)
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.Itoa(int(game.ID))+"/similar", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []SimilarGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 	assert.Len(t, result, 1)
-	assert.NotNil(t, result[0].LocalGameId, "should have localGameId when local game matches")
-	assert.Equal(t, "2", *result[0].LocalGameId)
+	require.NotNil(t, result[0].LocalGameId, "should have localGameId when local game matches")
+	assert.Equal(t, strconv.Itoa(int(localMatch.ID)), *result[0].LocalGameId)
 }
 
 func TestGetDeveloperGames_GameNotFound(t *testing.T) {
-	_, router := setupDiscoveryTestEnv(t)
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := discoveryAuthToken(t, router)
 
 	w := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/api/games/999/developer-games", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusNotFound, w.Code)
 
 	var resp map[string]interface{}
-	err := json.Unmarshal(w.Body.Bytes(), &resp)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 	assert.Equal(t, "game not found", resp["error"])
 }
 
 func TestGetDeveloperGames_NoDeveloper(t *testing.T) {
-	database, router := setupDiscoveryTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := discoveryAuthToken(t, router)
 
 	var console db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&console).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
 
 	game := db.Game{
 		ConsoleID: console.ID,
@@ -227,27 +225,28 @@ func TestGetDeveloperGames_NoDeveloper(t *testing.T) {
 		FileSize:  1024,
 		Developer: "", // no developer
 	}
-	err = database.Create(&game).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&game).Error)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/games/1/developer-games", nil)
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.Itoa(int(game.ID))+"/developer-games", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []DeveloperGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 	assert.Empty(t, result)
 }
 
 func TestGetDeveloperGames_ReturnsOtherGames(t *testing.T) {
-	database, router := setupDiscoveryTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := discoveryAuthToken(t, router)
 
 	var console db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&console).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
 
 	game1 := db.Game{
 		ConsoleID: console.ID,
@@ -289,24 +288,20 @@ func TestGetDeveloperGames_ReturnsOtherGames(t *testing.T) {
 		Developer: "Sega",
 	}
 
-	err = database.Create(&game1).Error
-	require.NoError(t, err)
-	err = database.Create(&game2).Error
-	require.NoError(t, err)
-	err = database.Create(&game3).Error
-	require.NoError(t, err)
-	err = database.Create(&game4).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&game1).Error)
+	require.NoError(t, database.Create(&game2).Error)
+	require.NoError(t, database.Create(&game3).Error)
+	require.NoError(t, database.Create(&game4).Error)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/games/1/developer-games", nil)
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.Itoa(int(game1.ID))+"/developer-games", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []DeveloperGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 	assert.Len(t, result, 2, "should return 2 other Nintendo games, excluding the queried game and Sega game")
 
 	// Should be sorted alphabetically
@@ -314,8 +309,8 @@ func TestGetDeveloperGames_ReturnsOtherGames(t *testing.T) {
 	assert.Equal(t, "Super Mario Bros. 2", result[1].Name)
 
 	// Should include local game IDs
-	assert.Equal(t, "3", result[0].LocalGameId)
-	assert.Equal(t, "2", result[1].LocalGameId)
+	assert.Equal(t, strconv.Itoa(int(game3.ID)), result[0].LocalGameId)
+	assert.Equal(t, strconv.Itoa(int(game2.ID)), result[1].LocalGameId)
 
 	// Should resolve cover URLs
 	assert.Equal(t, "/api/images/NES/3/boxart.jpg", result[0].CoverUrl)
@@ -323,11 +318,13 @@ func TestGetDeveloperGames_ReturnsOtherGames(t *testing.T) {
 }
 
 func TestGetDeveloperGames_ExcludesQueriedGame(t *testing.T) {
-	database, router := setupDiscoveryTestEnv(t)
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := discoveryAuthToken(t, router)
 
 	var console db.Console
-	err := database.Where("abbreviation = ?", "NES").First(&console).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Where("abbreviation = ?", "NES").First(&console).Error)
 
 	game := db.Game{
 		ConsoleID: console.ID,
@@ -337,21 +334,22 @@ func TestGetDeveloperGames_ExcludesQueriedGame(t *testing.T) {
 		FileSize:  1024,
 		Developer: "SoloDev",
 	}
-	err = database.Create(&game).Error
-	require.NoError(t, err)
+	require.NoError(t, database.Create(&game).Error)
 
 	w := httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/games/1/developer-games", nil)
+	req := httptest.NewRequest("GET", "/api/games/"+strconv.Itoa(int(game.ID))+"/developer-games", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
 	router.ServeHTTP(w, req)
 
 	assert.Equal(t, http.StatusOK, w.Code)
 
 	var result []DeveloperGameResponse
-	err = json.Unmarshal(w.Body.Bytes(), &result)
-	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &result))
 	assert.Empty(t, result, "should not return the queried game itself")
 }
 
+// TestParseIGDBGameID exercises the package-private parseIGDBGameID helper.
+// This is a pure unit test — not wired to any HTTP route.
 func TestParseIGDBGameID(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary

`admin_igdb_test`, `admin_igdb_match_test`, `console_handler_test`, and `game_discovery_handler_test` all wired up raw gin routers and called handler methods directly (e.g. `adminHandler.GetSettings`, `igdbHandler.TestIGDB`). This kept the gin methods on those handler structs alive even though every route is already served by a huma handler in production.

All four files have been rewritten to use `setupTestEnv` + `NewRouter(*cfg)`, matching the pattern used by `admin_deleted_users_test`, `admin_cover_test`, `admin_rate_limit_test`, and `admin_handler_romhacks_test`. Tests now hit the exact same HTTP paths the frontend uses. No raw `gin.New()`, no `router.POST("/api/...", handler.X)` wiring, no direct handler method calls remain.

This unblocks stripping the final dead gin methods from `admin_handler_igdb`, `admin_handler_settings`, `admin_handler_scraper` (`GetSteamGridDBStatus`), `admin_igdb_handler`, `console_handler`, and `game_discovery_handler` in a follow-up PR.

## Tests preserved

Every `TestXxx` from the old files survives with equivalent semantics. No tests were dropped. Test count is unchanged: 43 top-level tests across the four files (plus the table-driven subtests inside them).

- `admin_igdb_test.go`: `TestIGDBTest_Success`, `TestIGDBTest_AuthFailure`, `TestIGDBTest_EmptyFields` (4 subtests), `TestIGDBStatus_NotConfigured`, `TestIGDBStatus_Connected`, `TestIGDBStatus_ConfiguredNoLiveCheck`, `TestSettingsMasking_IGDBSecret`, `TestSettingsMasking_RoundTrip`, `TestSettingsMasking_NewSecretOverwrites`, `TestSettingsMasking_EmptySecret`, `TestGetSteamGridDBStatus` (4 subtests).
- `admin_igdb_match_test.go`: `TestSearchIGDB_Success`, `TestSearchIGDB_MissingQuery`, `TestSearchIGDB_GameNotFound`, `TestSearchIGDB_IGDBNotConfigured`, `TestApplyIGDBMatch_Success`, `TestApplyIGDBMatch_GameNotFound`, `TestApplyIGDBMatch_MissingIGDBID`, `TestApplyIGDBMatch_IGDBNotFound`.
- `console_handler_test.go`: all 3 `TestListConsoles_*`, 4 `TestGetPreviewScreenshot_*`, 6 `TestGetTopListAvailable_*`, 5 `TestGetTopListLongest_*`, plus `TestGetTopListCritics_ReturnsGamesWithCriticRating`, `TestGetTopListAvailable_UsesTotalRatingNotUserRating`, and the 2 `TestGetTopRatedGlobal_*` dedup tests.
- `game_discovery_handler_test.go`: 4 `TestGetSimilarGames_*`, 4 `TestGetDeveloperGames_*`, and `TestParseIGDBGameID` (7 subtests).

## Notable shape changes

- `TestIGDBTest_Success`: the old gin handler returned `gin.H{"success": true}` (no `error` key). The huma handler returns `TestIGDBResponse` with an omitempty `error` field, so the assertion was relaxed from \`assert.Nil(resp["error"])\` to \`if v, ok := resp["error"]; ok { assert.Equal("", v) }\`. Behavior is unchanged; the wire format is almost identical.
- `TestParseIGDBGameID` remains a pure unit test of the package-private helper — it does not go through the router. The old file also exercised it directly, so this is unchanged.
- `TestListConsoles_IncludesMetadata`: `setupTestEnv` does not auto-migrate or seed the `MediaTypeCategory` / `MediaType` / `HardwareMaker` tables. Added a local `seedConsoleMetadata(t, database)` helper that does both, called only from the one test that asserts on these fields.
- IGDB tests that previously injected a test IGDB client on the scraper manually now persist placeholder credentials via `ServerSetting` so `tryConfigureIGDB()` (called by the huma handlers) constructs a client automatically. The Twitch token URL and IGDB v4 base URL overrides (`igdb.SetTwitchTokenURLForTest`, `igdb.SetIGDBAPIBaseForTest`) are preserved; they are what make the constructed client hit the test httptest.Servers.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/api/ -run "TestIGDB|TestSettingsMasking|TestGetSteamGridDBStatus" -count=1` passes
- [x] `go test ./internal/api/ -run "TestSearchIGDB|TestApplyIGDBMatch" -count=1` passes
- [x] `go test ./internal/api/ -run "TestListConsoles_|TestGetPreviewScreenshot|TestGetTopListAvailable|TestGetTopListLongest|TestGetTopListCritics|TestGetTopRatedGlobal" -count=1` passes
- [x] `go test ./internal/api/ -run "TestGetSimilarGames|TestGetDeveloperGames|TestParseIGDBGameID" -count=1` passes
- [x] Full `go test ./internal/api/ -count=1` passes (391s)