### PR TITLE
fix(web): address flaky React.createContext test error

### DIFF
--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -260,5 +260,21 @@ export default defineConfig({
     // on process isolation (no native modules, no globals to leak across
     // tests beyond what jsdom already isolates).
     pool: "threads",
+    // React 19 ships a minimal "react-server" conditional export at
+    // react.react-server.js that OMITS createContext/useState/useEffect/
+    // useContext. Under `pool: "threads"` the Node module graph is shared
+    // across tests — if any file's resolution hits the react-server build
+    // first (or a worker-init race partially loads the CJS module), the
+    // cached React module lacks these APIs for the rest of the run, and
+    // every subsequent test using createContext (QueryClientProvider,
+    // React Router) fails intermittently with:
+    //   TypeError: React.createContext is not a function
+    // Force React through Vite's transform pipeline so vite-plugin-react's
+    // condition handling applies consistently per-worker.
+    server: {
+      deps: {
+        inline: ["react", "react-dom"],
+      },
+    },
   },
 });


### PR DESCRIPTION
## Root cause

React 19's \`package.json\` has a \`\"react-server\"\` conditional export that resolves to \`react.react-server.js\` — a minimal RSC-only build that **omits \`createContext\`, \`useState\`, \`useEffect\`, \`useContext\`**, and similar client-only APIs.

Under Vitest's \`pool: \"threads\"\` (we switched from forks in ee2c5304 for speed) the Node module graph is shared across tests. If any single file's module resolution hits the react-server build first — or a worker-init race partially loads the CJS module — the cached React module lacks those APIs for the rest of the run. Every subsequent test that uses \`createContext\` (which QueryClientProvider and React Router both do internally) then fails with:

\`\`\`
TypeError: React.createContext is not a function
\`\`\`

Because module-cache pollution depends on which test runs first, the failure looked intermittent even though it's deterministic per worker-module-graph state.

## Fix

Force React and react-dom through Vite's transform pipeline via \`test.server.deps.inline\`. This way \`vite-plugin-react\`'s condition handling applies consistently per-worker instead of Node's raw exports-field resolution.

## Test plan

- [x] \`npx vitest run\` — all 1466 tests pass
- [x] Runtime dropped from ~60s to 28s (the fix also avoids redundant transforms)
- [x] Verified the specific failing test (\`explore-page.test.tsx\`) passes in isolation and as part of the full suite