### PR TITLE
chore(player): route 11 non-progress HTTP calls through generated client

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -23,6 +23,7 @@ import com.spela.client.apis.SharedSavesApi
 import com.spela.client.apis.SharedSessionsApi
 import com.spela.client.apis.SocialApi
 import com.spela.client.apis.StatsApi
+import com.spela.client.apis.SystemApi
 import com.spela.client.apis.TopListsApi
 import com.spela.client.apis.UserApi
 import com.spela.player.data.remote.AuthFailureReason
@@ -144,6 +145,7 @@ class SpelaApiClient(
     private lateinit var sharedSessionsApi: SharedSessionsApi
     private lateinit var socialApi: SocialApi
     private lateinit var statsApi: StatsApi
+    private lateinit var systemApi: SystemApi
     private lateinit var topListsApi: TopListsApi
     private lateinit var userApi: UserApi
 
@@ -175,6 +177,7 @@ class SpelaApiClient(
         sharedSessionsApi = SharedSessionsApi(baseUrl, client)
         socialApi = SocialApi(baseUrl, client)
         statsApi = StatsApi(baseUrl, client)
+        systemApi = SystemApi(baseUrl, client)
         topListsApi = TopListsApi(baseUrl, client)
         userApi = UserApi(baseUrl, client)
     }
@@ -211,7 +214,7 @@ class SpelaApiClient(
 
     suspend fun healthCheck(): Boolean {
         return try {
-            client.get("$baseUrl/api/health")
+            systemApi.getHealth()
             true
         } catch (_: Exception) {
             false
@@ -806,11 +809,10 @@ class SpelaApiClient(
     }
 
     suspend fun downloadM3U(gameId: String): ByteArray {
-        val response = client.get("$baseUrl/api/games/$gameId/download")
-        if (!response.status.isSuccess()) {
-            throw RuntimeException("M3U download failed: HTTP ${response.status.value}")
-        }
-        return response.body()
+        // Same /api/games/{id}/download endpoint as downloadGame(); server
+        // returns the M3U playlist for multi-disc titles when no disc is
+        // specified. No progress callback needed here.
+        return gamesApi.downloadGame(gameId).response.body<ByteArray>()
     }
 
     // BIOS
@@ -820,7 +822,7 @@ class SpelaApiClient(
     }
 
     suspend fun downloadBiosFile(filename: String): ByteArray {
-        return client.get("$baseUrl/api/bios/${filename.encodeURLPath()}").body()
+        return biosApi.downloadBios(filename).response.body<ByteArray>()
     }
 
     // Cores
@@ -892,7 +894,7 @@ class SpelaApiClient(
     }
 
     suspend fun downloadSharedSave(gameId: String, saveId: String): ByteArray {
-        return client.get("$baseUrl/api/games/$gameId/shared-saves/$saveId/download").body()
+        return sharedSavesApi.downloadSharedSave(gameId, saveId).response.body<ByteArray>()
     }
 
     suspend fun deleteSharedSave(gameId: String, saveId: String) {
@@ -1101,11 +1103,11 @@ class SpelaApiClient(
     }
 
     suspend fun downloadSharedSessionSave(sharedSessionId: String, saveId: Long): ByteArray {
-        return client.get("$baseUrl/api/shared-sessions/$sharedSessionId/saves/$saveId/download").body()
+        return sharedSessionsApi.downloadSharedSessionSave(sharedSessionId, saveId.toString()).response.body<ByteArray>()
     }
 
     suspend fun downloadSharedSessionAutoSave(sharedSessionId: String): ByteArray {
-        return client.get("$baseUrl/api/shared-sessions/$sharedSessionId/saves/auto").body()
+        return sharedSessionsApi.downloadSharedSessionAutoSave(sharedSessionId).response.body<ByteArray>()
     }
 
     suspend fun copySharedSessionSaveToGame(sharedSessionId: String, saveId: Long) {
@@ -1327,7 +1329,7 @@ class SpelaApiClient(
     }
 
     suspend fun downloadChallengeSave(challengeId: String): ByteArray {
-        return client.get("$baseUrl/api/challenges/$challengeId/save/download").body()
+        return challengesApi.downloadChallengeSave(challengeId).response.body<ByteArray>()
     }
 
     suspend fun startChallengeAttempt(
@@ -1612,11 +1614,7 @@ class SpelaApiClient(
     }
 
     suspend fun downloadSessionSave(sessionId: String, saveId: String): ByteArray {
-        val response = client.get("$baseUrl/api/sessions/$sessionId/saves/$saveId")
-        if (!response.status.isSuccess()) {
-            throw RuntimeException("Session save download failed: HTTP ${response.status.value}")
-        }
-        return response.body()
+        return sessionsApi.downloadSessionSave(sessionId, saveId).response.body<ByteArray>()
     }
 
     suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String = "") {
@@ -1641,11 +1639,7 @@ class SpelaApiClient(
     }
 
     suspend fun downloadSessionAutoSave(sessionId: String): ByteArray {
-        val response = client.get("$baseUrl/api/sessions/$sessionId/saves/auto")
-        if (!response.status.isSuccess()) {
-            throw RuntimeException("Session auto-save download failed: HTTP ${response.status.value}")
-        }
-        return response.body()
+        return sessionsApi.downloadSessionAutoSave(sessionId).response.body<ByteArray>()
     }
 
     suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): com.spela.client.models.SessionSaveResponse {
@@ -1672,11 +1666,7 @@ class SpelaApiClient(
     }
 
     suspend fun downloadSlotSave(sessionId: String, slot: Int): ByteArray {
-        val response = client.get("$baseUrl/api/sessions/$sessionId/saves/slot/$slot")
-        if (!response.status.isSuccess()) {
-            throw RuntimeException("Slot save download failed: HTTP ${response.status.value}")
-        }
-        return response.body()
+        return sessionsApi.downloadSessionSlotSave(sessionId, slot.toString()).response.body<ByteArray>()
     }
 
     suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String = "") {
@@ -1695,11 +1685,7 @@ class SpelaApiClient(
     }
 
     suspend fun downloadSessionSram(sessionId: String): ByteArray {
-        val response = client.get("$baseUrl/api/sessions/$sessionId/sram")
-        if (!response.status.isSuccess()) {
-            throw RuntimeException("Session SRAM download failed: HTTP ${response.status.value}")
-        }
-        return response.body()
+        return sessionsApi.downloadSessionSRAM(sessionId).response.body<ByteArray>()
     }
 
     suspend fun getSessionCheats(sessionId: String): com.spela.client.models.SessionCheatsResponse {


### PR DESCRIPTION
## Summary

Migrates 11 raw \`HttpClient\` calls in \`SpelaApiClient\` to their generated-API equivalents. Scope was picked by checking which endpoints the OpenAPI spec already exposes on the generated Kotlin client and whose response shape is compatible.

### Migrated
| Method | Old | New |
|---|---|---|
| \`healthCheck\` | raw \`client.get(/api/health)\` | \`systemApi.getHealth()\` |
| \`downloadM3U\` | raw \`client.get(/api/games/{id}/download)\` | \`gamesApi.downloadGame(id)\` |
| \`downloadBiosFile\` | raw | \`biosApi.downloadBios(filename)\` |
| \`downloadSharedSave\` | raw | \`sharedSavesApi.downloadSharedSave(gameId, saveId)\` |
| \`downloadSharedSessionSave\` | raw | \`sharedSessionsApi.downloadSharedSessionSave(id, saveId)\` |
| \`downloadSharedSessionAutoSave\` | raw | \`sharedSessionsApi.downloadSharedSessionAutoSave(id)\` |
| \`downloadChallengeSave\` | raw | \`challengesApi.downloadChallengeSave(id)\` |
| \`downloadSessionSave\` | raw | \`sessionsApi.downloadSessionSave(id, saveId)\` |
| \`downloadSessionAutoSave\` | raw | \`sessionsApi.downloadSessionAutoSave(id)\` |
| \`downloadSlotSave\` | raw | \`sessionsApi.downloadSessionSlotSave(id, slot)\` |
| \`downloadSessionSram\` | raw | \`sessionsApi.downloadSessionSRAM(id)\` |

Binary responses use \`.response.body<ByteArray>()\` because the generated \`HttpResponse<T>\` wrapper is typed with \`T = Unit\` for octet-stream endpoints — \`.response\` exposes the underlying Ktor \`HttpResponse\` from which \`ByteArray\` can be extracted.

Also drops defensive \`if (!response.status.isSuccess()) throw ...\` checks on the 4 session-save downloads — the shared \`HttpClient\` config already has \`expectSuccess = true\`, so non-2xx throws \`ClientRequestException\` automatically.

Raw \`HttpClient\` calls in \`SpelaApiClient\`: **21 → 10**.

### Remaining raw calls (all kept intentionally, documented in-file)

- Token refresh inside the \`Auth\` interceptor — can't self-refer without infinite recursion
- \`downloadGame\` / \`downloadCore\` with \`onDownload\` progress callbacks — the generated API doesn't let you inject per-call Ktor blocks
- \`getPublisherDetail\` coercing to \`DeveloperDetailResponse\` — true shape divergence (\`developers\`/\`publishers\`, \`relatedPublishers\`/\`relatedDevelopers\`); migration requires a mapper or domain refactor
- \`getGameAchievements\` / \`getAchievementProgress\` — local DTO uses \`Int\` timestamps vs generated \`Long\`
- \`getRecommendedCore\` — server returns one of two shapes; generated types as \`Any\`, raw call reads as string and uses custom parsing
- \`linkRA\` — needs \`RAStatusResponse\` (has \`hardcoreEnabled\`), generated returns \`RALinkResponse\` (doesn't)
- \`getFilteredGames\` — forwards an open-ended filter map; generated \`listGames\` enumerates each filter
- \`copy-to-game\` — endpoint not registered on server currently

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop\` — clean
- [x] \`./gradlew :shared:desktopTest\` — 469/470 pass (1 flaky framerate perf test, unrelated)