### PR TITLE
chore(player): remove dead copy-to-game code path

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -792,8 +792,6 @@ class FakeSharedSessionRepository : SharedSessionRepository {
         Result.success(ByteArray(256) { it.toByte() })
     override suspend fun uploadSharedSessionAutoSave(sharedSessionId: String, turnToken: String, data: ByteArray): Result<SharedSessionSave> =
         Result.success(SharedSessionSave(id = 1, sharedSessionId = sharedSessionId, name = "Auto Save", isAuto = true, fileSize = data.size.toLong()))
-    override suspend fun copySharedSessionSaveToGame(sharedSessionId: String, saveId: Long): Result<Unit> =
-        Result.success(Unit)
 }
 
 class FakeCollectionRepository : CollectionRepository {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1093,15 +1093,6 @@ class SpelaApiClient(
         return sharedSessionsApi.downloadSharedSessionAutoSave(sharedSessionId).response.body<ByteArray>()
     }
 
-    suspend fun copySharedSessionSaveToGame(sharedSessionId: String, saveId: Long) {
-        // NOTE: This endpoint is not currently registered on the server — it is
-        // missing from both the huma handlers and the remaining gin routes
-        // (see server/internal/api/huma_shared.go and server/internal/api/router.go).
-        // The path is kept at its original (pre-huma) location so that if the
-        // server adds it back at the same path, the player will continue to work.
-        client.post("$baseUrl/api/shared-sessions/$sharedSessionId/saves/$saveId/copy-to-game")
-    }
-
     suspend fun uploadSharedSessionAutoSave(
         sharedSessionId: String,
         turnToken: String,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSessionRepositoryImpl.kt
@@ -103,10 +103,6 @@ class SharedSessionRepositoryImpl(
         apiClient.downloadSharedSessionAutoSave(sharedSessionId)
     }
 
-    override suspend fun copySharedSessionSaveToGame(sharedSessionId: String, saveId: Long): Result<Unit> = runCatching {
-        apiClient.copySharedSessionSaveToGame(sharedSessionId, saveId)
-    }
-
     override suspend fun uploadSharedSessionAutoSave(
         sharedSessionId: String,
         turnToken: String,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SharedSessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SharedSessionRepository.kt
@@ -27,5 +27,4 @@ interface SharedSessionRepository {
     suspend fun downloadSharedSessionSave(sharedSessionId: String, saveId: Long): Result<ByteArray>
     suspend fun downloadSharedSessionAutoSave(sharedSessionId: String): Result<ByteArray>
     suspend fun uploadSharedSessionAutoSave(sharedSessionId: String, turnToken: String, data: ByteArray): Result<SharedSessionSave>
-    suspend fun copySharedSessionSaveToGame(sharedSessionId: String, saveId: Long): Result<Unit>
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/SharedSessionIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/SharedSessionIntent.kt
@@ -18,7 +18,6 @@ sealed interface SharedSessionDetailIntent {
     data class LeaveSharedSession(val sharedSessionId: String) : SharedSessionDetailIntent
     data class TakeTurn(val sharedSessionId: String) : SharedSessionDetailIntent
     data class ReleaseTurn(val sharedSessionId: String) : SharedSessionDetailIntent
-    data class CopySaveToGame(val sharedSessionId: String, val saveId: Long) : SharedSessionDetailIntent
     data object DismissError : SharedSessionDetailIntent
     data object DismissSuccess : SharedSessionDetailIntent
     data object ShowInviteSheet : SharedSessionDetailIntent

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SharedSessionState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/SharedSessionState.kt
@@ -25,7 +25,6 @@ data class SharedSessionDetailState(
     val isTakingTurn: Boolean = false,
     val isReleasingTurn: Boolean = false,
     val turnToken: String? = null,
-    val copyingSaveId: Long? = null,
     val error: String? = null,
     val successMessage: String? = null,
     val showInviteSheet: Boolean = false,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sharedsession/SharedSessionDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sharedsession/SharedSessionDetailComponents.kt
@@ -13,10 +13,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Save
 import androidx.compose.material.icons.filled.Stop
-import androidx.compose.material.icons.outlined.ContentCopy
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -258,8 +255,6 @@ internal fun InviteSection(
 @Composable
 internal fun SharedSessionSaveItem(
     save: SharedSessionSave,
-    isCopying: Boolean = false,
-    onCopyToGame: (() -> Unit)? = null,
     modifier: Modifier = Modifier,
 ) {
     SpCard(
@@ -300,28 +295,6 @@ internal fun SharedSessionSaveItem(
             }
             if (save.isAuto) {
                 SpChip(text = "Auto", color = SpColor.Primary)
-            }
-            if (onCopyToGame != null) {
-                if (isCopying) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(24.dp),
-                        strokeWidth = 2.dp,
-                        color = SpColor.Primary,
-                    )
-                } else {
-                    IconButton(
-                        onClick = onCopyToGame,
-                        modifier = Modifier.semantics {
-                            contentDescription = "Copy ${save.name} to your library"
-                        },
-                    ) {
-                        Icon(
-                            imageVector = Icons.Outlined.ContentCopy,
-                            contentDescription = null,
-                            tint = SpColor.OnBackgroundTertiary,
-                        )
-                    }
-                }
             }
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
@@ -171,12 +171,6 @@ fun SharedSessionDetailScreen(
                             ) { save ->
                                 SharedSessionSaveItem(
                                     save = save,
-                                    isCopying = state.copyingSaveId == save.id,
-                                    onCopyToGame = {
-                                        viewModel.onIntent(
-                                            SharedSessionDetailIntent.CopySaveToGame(sharedSessionId, save.id)
-                                        )
-                                    },
                                     modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal, vertical = SpSpacing.XSmall),
                                 )
                             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SharedSessionDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SharedSessionDetailViewModel.kt
@@ -40,7 +40,6 @@ class SharedSessionDetailViewModel(
             is SharedSessionDetailIntent.LeaveSharedSession -> leaveSharedSession(intent.sharedSessionId)
             is SharedSessionDetailIntent.TakeTurn -> takeTurn(intent.sharedSessionId)
             is SharedSessionDetailIntent.ReleaseTurn -> releaseTurn(intent.sharedSessionId)
-            is SharedSessionDetailIntent.CopySaveToGame -> copySaveToGame(intent.sharedSessionId, intent.saveId)
             SharedSessionDetailIntent.DismissError -> _state.update { it.copy(error = null) }
             SharedSessionDetailIntent.DismissSuccess -> _state.update { it.copy(successMessage = null) }
             SharedSessionDetailIntent.ShowInviteSheet -> inviteDelegate.show()
@@ -124,20 +123,6 @@ class SharedSessionDetailViewModel(
                 },
                 onFailure = { error ->
                     _state.update { it.copy(error = error.message, isTakingTurn = false) }
-                },
-            )
-        }
-    }
-
-    private fun copySaveToGame(sharedSessionId: String, saveId: Long) {
-        _state.update { it.copy(copyingSaveId = saveId) }
-        scope.launch(dispatchers.io) {
-            sharedSessionRepository.copySharedSessionSaveToGame(sharedSessionId, saveId).fold(
-                onSuccess = {
-                    _state.update { it.copy(copyingSaveId = null, successMessage = "Save copied to your library") }
-                },
-                onFailure = { error ->
-                    _state.update { it.copy(copyingSaveId = null, error = error.message) }
                 },
             )
         }

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SharedSessionDetailViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SharedSessionDetailViewModelTest.kt
@@ -267,43 +267,6 @@ class SharedSessionDetailViewModelTest {
     }
 
     @Test
-    fun copySaveToGameShowsSuccessMessage() = runTest(testDispatcher) {
-        val vm = createViewModel()
-        vm.onIntent(SharedSessionDetailIntent.CopySaveToGame("ss1", 1))
-        advanceUntilIdle()
-
-        val state = vm.state.value
-        assertEquals("Save copied to your library", state.successMessage)
-        assertNull(state.copyingSaveId)
-    }
-
-    @Test
-    fun copySaveToGameFailureShowsError() = runTest(testDispatcher) {
-        fakeRepo.shouldFail = true
-        val vm = createViewModel()
-        vm.onIntent(SharedSessionDetailIntent.CopySaveToGame("ss1", 1))
-        advanceUntilIdle()
-
-        val state = vm.state.value
-        assertNotNull(state.error)
-        assertNull(state.copyingSaveId)
-    }
-
-    @Test
-    fun copySaveToGameSetsCopyingSaveId() = runTest(testDispatcher) {
-        val vm = createViewModel()
-        vm.onIntent(SharedSessionDetailIntent.CopySaveToGame("ss1", 42))
-
-        // Before advancing, should have copyingSaveId set
-        assertEquals(42L, vm.state.value.copyingSaveId)
-
-        advanceUntilIdle()
-
-        // After completing, should be cleared
-        assertNull(vm.state.value.copyingSaveId)
-    }
-
-    @Test
     fun dismissSuccessClearsSuccessMessage() = runTest(testDispatcher) {
         val vm = createViewModel()
         vm.onIntent(SharedSessionDetailIntent.InviteUser("ss1", "bob"))

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SharedSessionsViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SharedSessionsViewModelTest.kt
@@ -267,6 +267,4 @@ class FakeSharedSessionRepo : SharedSessionRepository {
     override suspend fun uploadSharedSessionAutoSave(sharedSessionId: String, turnToken: String, data: ByteArray): Result<SharedSessionSave> =
         if (shouldFail) Result.failure(Exception("Network error"))
         else Result.success(SharedSessionSave(id = 1, sharedSessionId = sharedSessionId, name = "Auto Save", isAuto = true))
-    override suspend fun copySharedSessionSaveToGame(sharedSessionId: String, saveId: Long): Result<Unit> =
-        if (shouldFail) Result.failure(Exception("Network error")) else Result.success(Unit)
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -303,7 +303,6 @@ private class PlayFromSharedSaveTestSharedSessionRepository : SharedSessionRepos
     override suspend fun downloadSharedSessionAutoSave(sharedSessionId: String) = Result.success(byteArrayOf())
     override suspend fun uploadSharedSessionAutoSave(sharedSessionId: String, turnToken: String, data: ByteArray) =
         Result.success(SharedSessionSave(id = 1, sharedSessionId = sharedSessionId, name = "Auto Save", isAuto = true))
-    override suspend fun copySharedSessionSaveToGame(sharedSessionId: String, saveId: Long) = Result.success(Unit)
 }
 
 private class PlayFromSharedSaveTestChallengeRepository : ChallengeRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
@@ -270,7 +270,6 @@ private class StubSharedSessionRepository : SharedSessionRepository {
     override suspend fun downloadSharedSessionAutoSave(sharedSessionId: String) = Result.success(byteArrayOf())
     override suspend fun uploadSharedSessionAutoSave(sharedSessionId: String, turnToken: String, data: ByteArray) =
         Result.success(SharedSessionSave(id = 1, sharedSessionId = sharedSessionId, name = "Auto Save", isAuto = true))
-    override suspend fun copySharedSessionSaveToGame(sharedSessionId: String, saveId: Long) = Result.success(Unit)
 }
 
 private class StubChallengeRepository : ChallengeRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
@@ -291,7 +291,6 @@ private class SharedSaveTestSharedSessionRepository : SharedSessionRepository {
     override suspend fun downloadSharedSessionAutoSave(sharedSessionId: String) = Result.success(byteArrayOf())
     override suspend fun uploadSharedSessionAutoSave(sharedSessionId: String, turnToken: String, data: ByteArray) =
         Result.success(SharedSessionSave(id = 1, sharedSessionId = sharedSessionId, name = "Auto Save", isAuto = true))
-    override suspend fun copySharedSessionSaveToGame(sharedSessionId: String, saveId: Long) = Result.success(Unit)
 }
 
 private class SharedSaveTestChallengeRepository : ChallengeRepository {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -340,7 +340,6 @@ class StubSharedSessionRepository : SharedSessionRepository {
         uploadSharedSessionAutoSaveCallCount++
         return Result.success(SharedSessionSave(id = 1, sharedSessionId = sharedSessionId, name = "Auto Save", isAuto = true))
     }
-    override suspend fun copySharedSessionSaveToGame(sharedSessionId: String, saveId: Long) = Result.success(Unit)
 }
 
 class StubSessionRepository : SessionRepository {


### PR DESCRIPTION
## Summary

Remove the orphan \"copy shared-session save to game\" code path from the player app. The backing endpoint (\`POST /api/shared-sessions/{id}/saves/{saveId}/copy-to-game\`) was dropped server-side in commit \`8b7bcb49\` (March) when game-scoped saves were removed — the old destination (per-game personal save list) ceased to exist when every save became session-scoped. The player code was missed in that refactor and has been calling a non-existent endpoint ever since; any user tapping the \"Copy to Game\" button on a shared session save has been getting a 404.

## Removed

- \`SpelaApiClient.copySharedSessionSaveToGame\`
- \`SharedSessionRepository\` interface method + \`SharedSessionRepositoryImpl\` override
- \`SharedSessionDetailIntent.CopySaveToGame\`
- \`SharedSessionDetailViewModel.copySaveToGame\` + \`copyingSaveId\` state field
- Copy button in \`SharedSessionSaveItem\` + wiring from \`SharedSessionDetailScreen\`
- 3 tests in \`SharedSessionDetailViewModelTest\` + 5 fake-repo stub overrides

15 files, -106 lines, 0 additions.

## Follow-up

Issue #553 — re-implement this UX on top of **session cloning** as the core primitive. Cloning any session (own or shared) into a new personal session subsumes the old copy-to-game semantics and also enables other workflows like checkpointing your own session before a risky attempt.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop\` — clean
- [x] \`./gradlew :shared:desktopTest\` — 470/470 pass