### PR TITLE
chore(player): dispatch getFilteredGames to generated listGames

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -570,17 +570,27 @@ class SpelaApiClient(
         page: Int? = null,
         pageSize: Int? = null,
     ): com.spela.client.models.PaginatedResponseGameResponse {
-        // The filter set is open-ended (`getFilteredGames` is invoked with arbitrary
-        // saved-search keys). Stay on the raw HttpClient so the full filter map is
-        // forwarded as-is; the generated listGames signature lists only the known
-        // filters and would silently drop anything else.
-        return client.get("$baseUrl/api/games") {
-            filters.forEach { (key, value) ->
-                parameter(key, value)
-            }
-            page?.let { parameter("page", it) }
-            pageSize?.let { parameter("pageSize", it) }
-        }.body()
+        return gamesApi.listGames(
+            page = page?.toLong(),
+            pageSize = pageSize?.toLong(),
+            consoles = filters["consoles"],
+            search = filters["search"],
+            letter = filters["letter"],
+            region = filters["region"],
+            genres = filters["genres"],
+            themes = filters["themes"],
+            keywords = filters["keywords"],
+            perspectives = filters["perspectives"],
+            developer = filters["developer"],
+            publisher = filters["publisher"],
+            yearMin = filters["yearMin"],
+            yearMax = filters["yearMax"],
+            ratingMin = filters["ratingMin"],
+            ratingMax = filters["ratingMax"],
+            playStatus = filters["playStatus"],
+            sortBy = filters["sortBy"],
+            sortOrder = filters["sortOrder"],
+        ).body()
     }
 
     /** Returns user's saved searches */


### PR DESCRIPTION
## Summary

\`SpelaApiClient.getFilteredGames\` kept a raw \`client.get(\"/api/games\") { filters.forEach { parameter(key, value) } }\` because the comment worried the typed generated \`listGames\` would silently drop unknown filter keys.

In practice the \`Map<String, String>\` only ever comes from \`GameFilters.toQueryMap()\`, which emits exactly the set of keys that \`ListGamesInput\` already enumerates on the server (\`search\`, \`consoles\`, \`genres\`, \`themes\`, \`keywords\`, \`perspectives\`, \`developer\`, \`publisher\`, \`yearMin\`, \`yearMax\`, \`ratingMin\`, \`ratingMax\`, \`playStatus\`, \`sortBy\`, \`sortOrder\`). No open-endedness in practice — the original worry was about a saved-search round-trip that is in fact closed over the same typed schema.

Dispatch the map to the generated \`gamesApi.listGames()\` typed args by key lookup. Drops the last raw-HTTP workaround for this endpoint.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop\` — builds clean
- [x] Existing explore-view-model flow unchanged: \`toQueryMap()\` keys resolve 1:1 to \`listGames\` parameters