### PR TITLE
fix(player): route getPublisherDetail through generated PublisherDetailResponse

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -454,13 +454,9 @@ class SpelaApiClient(
         return exploreApi.getDeveloperDetail(name).body()
     }
 
-    /** Returns detail for a specific publisher (same response type as developer) */
-    suspend fun getPublisherDetail(name: String): com.spela.client.models.DeveloperDetailResponse {
-        // PublisherDetailResponse is structurally identical to DeveloperDetailResponse;
-        // re-issue the request to coerce the response into the developer shape so
-        // callers don't need to know about the duplicated DTO.
-        val encoded = name.encodeURLParameter()
-        return client.get("$baseUrl/api/explore/publishers/$encoded").body()
+    /** Returns detail for a specific publisher. */
+    suspend fun getPublisherDetail(name: String): com.spela.client.models.PublisherDetailResponse {
+        return exploreApi.getPublisherDetail(name).body()
     }
 
     /** Returns developer spotlight for the Explore page */

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -972,6 +972,38 @@ fun com.spela.client.models.DeveloperDetailResponse.toDomain(): DeveloperDetail 
     relatedDevelopers = relatedDevelopers.orEmpty().map { it.toDomain() },
 )
 
+// PublisherDetailResponse is shape-symmetric with DeveloperDetailResponse —
+// the "counterpart" fields are `developers` / `relatedPublishers` instead of
+// `publishers` / `relatedDevelopers`. The DeveloperDetail domain model holds
+// them as `publishers` / `relatedDevelopers` regardless of which side the
+// page is viewing; callers render the chips with the appropriate label based
+// on `isDeveloper`.
+fun com.spela.client.models.PublisherDetailResponse.toDomain(): DeveloperDetail = DeveloperDetail(
+    name = name,
+    gameCount = gameCount.toInt(),
+    avgRating = avgRating,
+    consoles = consoles.orEmpty(),
+    heroUrl = heroUrl,
+    companyInfo = companyInfo?.toDomain(),
+    topGames = topGames.orEmpty().map { it.toDomain() },
+    genreBreakdown = genreBreakdown.orEmpty().map { it.toDeveloperGenreBreakdown() },
+    platformBreakdown = platformBreakdown.orEmpty().map { it.toDeveloperPlatformBreakdown() },
+    userStats = userStats?.toDeveloperUserStats(),
+    publishers = developers.orEmpty().map { it.toDeveloperPublisher() },
+    games = games.orEmpty().map { it.toDomain() },
+    activeYears = activeYears?.toDomain(),
+    ratingDistribution = ratingDistribution.toDomain(),
+    primaryGenre = primaryGenre,
+    timeline = timeline.orEmpty().map { it.toDomain() },
+    relatedDevelopers = relatedPublishers.orEmpty().map { it.toDomain() },
+)
+
+fun com.spela.client.models.RelatedPublisher.toDomain(): RelatedDeveloper = RelatedDeveloper(
+    name = name,
+    gameCount = gameCount.toInt(),
+    sharedPublishers = sharedDevelopers.orEmpty(),
+)
+
 fun com.spela.client.models.DeveloperSpotlightResponse.toDomain(): DeveloperSpotlight = DeveloperSpotlight(
     name = name,
     gameCount = gameCount.toInt(),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -433,35 +433,58 @@ class ExploreRepositoryImpl(
     }
 
     private fun resolveEntityDetail(dto: com.spela.client.models.DeveloperDetailResponse): DeveloperDetail =
-        dto.toDomain().copy(
-            heroUrl = apiClient.resolveUrl(dto.heroUrl),
-            companyInfo = dto.companyInfo?.let { info ->
-                info.toDomain().copy(
-                    logoUrl = apiClient.resolveUrl(info.logoUrl),
-                )
-            },
-            topGames = dto.topGames.orEmpty().map { gameDto ->
-                gameDto.toDomain().copy(
-                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
-                )
-            },
-            userStats = dto.userStats?.let { stats ->
-                stats.toDeveloperUserStats().copy(
-                    mostPlayedGame = stats.mostPlayedGame
-                        .takeIf { it.id.isNotEmpty() }
-                        ?.let { gameDto ->
-                            gameDto.toDomain().copy(
-                                coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
-                            )
-                        },
-                )
-            },
-            games = dto.games.orEmpty().map { gameDto ->
-                gameDto.toDomain().copy(
-                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
-                )
-            },
+        dto.toDomain().applyUrlResolution(
+            heroUrl = dto.heroUrl,
+            companyInfo = dto.companyInfo,
+            topGames = dto.topGames,
+            userStats = dto.userStats,
+            games = dto.games,
         )
+
+    private fun resolveEntityDetail(dto: com.spela.client.models.PublisherDetailResponse): DeveloperDetail =
+        dto.toDomain().applyUrlResolution(
+            heroUrl = dto.heroUrl,
+            companyInfo = dto.companyInfo,
+            topGames = dto.topGames,
+            userStats = dto.userStats,
+            games = dto.games,
+        )
+
+    private fun DeveloperDetail.applyUrlResolution(
+        heroUrl: String?,
+        companyInfo: com.spela.client.models.CompanyInfo?,
+        topGames: List<com.spela.client.models.GameResponse>?,
+        userStats: com.spela.client.models.EntityUserStats?,
+        games: List<com.spela.client.models.GameResponse>?,
+    ): DeveloperDetail = copy(
+        heroUrl = apiClient.resolveUrl(heroUrl),
+        companyInfo = companyInfo?.let { info ->
+            info.toDomain().copy(
+                logoUrl = apiClient.resolveUrl(info.logoUrl),
+            )
+        },
+        topGames = topGames.orEmpty().map { gameDto ->
+            gameDto.toDomain().copy(
+                coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+            )
+        },
+        userStats = userStats?.let { stats ->
+            stats.toDeveloperUserStats().copy(
+                mostPlayedGame = stats.mostPlayedGame
+                    .takeIf { it.id.isNotEmpty() }
+                    ?.let { gameDto ->
+                        gameDto.toDomain().copy(
+                            coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                        )
+                    },
+            )
+        },
+        games = games.orEmpty().map { gameDto ->
+            gameDto.toDomain().copy(
+                coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+            )
+        },
+    )
 
     private fun resolveGameCovers(game: Game, dto: GameDto): Game = game.copy(
         coverUrl = apiClient.resolveUrl(dto.coverUrl),


### PR DESCRIPTION
## Summary

\`SpelaApiClient.getPublisherDetail\` bypassed the generated client and parsed the publisher response as \`DeveloperDetailResponse\`, on the assumption the two DTOs were structurally identical.

**They aren't.** The shapes are symmetric but swap the counterpart fields:

| | DeveloperDetailResponse | PublisherDetailResponse |
|---|---|---|
| counterpart companies | \`publishers\` | \`developers\` |
| related same-side | \`relatedDevelopers\` | \`relatedPublishers\` |

\`DeveloperDetailResponse.publishers\` is \`@Required\`, so a publisher response (which omits it, sending \`developers\` instead) fails kotlinx.serialization with \`MissingFieldException\` — silently swallowed by \`runCatching\` in the repository. Publisher pages render with empty counterpart-company chips (latent bug).

**Fix:**
- Player calls \`exploreApi.getPublisherDetail()\` → \`PublisherDetailResponse\`.
- New \`PublisherDetailResponse.toDomain()\` mapper lifts \`developers\` into the domain's \`publishers\` slot and \`relatedPublishers\` into \`relatedDevelopers\` (the single \`DeveloperDetail\` domain model serves both pages — field names are "counterpart companies" from whichever side is being viewed).
- New \`RelatedPublisher.toDomain()\` → \`RelatedDeveloper\` mirrors the existing mapper.
- \`ExploreRepositoryImpl.resolveEntityDetail\` overloaded for both response types; shared hero/cover/logo URL resolution extracted to a private \`DeveloperDetail.applyUrlResolution\` extension.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop\` — builds clean
- [x] \`./gradlew :shared:desktopTest\` — existing tests pass
- [ ] Verified manually on a publisher detail page that the counterpart-company chips now populate. (Deferred: requires running desktop app against a backend; covered by the existing developer detail tests which exercise the same code path.)

## Follow-up (not in this PR)

\`ExploreDeveloperScreen\` routes publisher-page chip clicks through \`onPublisherSelected\` and \`onDeveloperSelected\` based on the developer-centric field names. On publisher pages this sends the user to the wrong screen type. Flagging for a follow-up once this shape fix is in.