### PR TITLE
chore(player): remove dead CoreNameResponse DTO

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -142,12 +142,6 @@ typealias DeviceDto = com.spela.client.models.DeviceResponse
 // `consoleName`. The hand-written names were dead; new mapper reads
 // the real fields.
 
-/** Wrapper for GET /api/games/:id/core when core is not in DB */
-@Serializable
-data class CoreNameResponse(
-    val coreName: String,
-)
-
 // RetroAchievements
 
 // RA DTOs replaced by generated counterparts in


### PR DESCRIPTION
## Summary

Client-side placeholder for the bare `{coreName: "..."}` fallback that `/api/games/{id}/core` used to return when the Core row was missing. #556 replaced that fallback with 404 + concrete Core, so the type has no callers.

## Test plan

- [x] `grep -r CoreNameResponse` shows only the one definition
- [x] `./gradlew :shared:compileKotlinDesktop` — builds clean