### PR TITLE
chore(player): replace custom ConsoleDto with generated ConsoleResponse

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -37,29 +37,6 @@ fun UserDto.toDomain(): User = User(
     avatarUrl = avatarUrl,
 )
 
-fun ConsoleDto.toDomain(): Console = Console(
-    id = id,
-    name = name,
-    abbreviation = abbreviation,
-    gameCount = gameCount,
-    code = code,
-    colorTheme = colorTheme,
-    coverAspectRatio = coverAspectRatio,
-    defaultCore = defaultCore,
-    iconUrl = iconUrl,
-    logoUrl = logoPngUrl.ifEmpty { logoUrl },
-    saveStateSupport = saveStateSupport,
-    browserPlayable = browserPlayable,
-    playable = playable,
-    generation = generation,
-    makerName = maker?.name,
-    makerCode = maker?.code,
-    mediaTypeName = mediaType?.name,
-    releaseYear = releaseYear,
-    unitsSold = unitsSold,
-    summary = summary,
-)
-
 fun com.spela.client.models.ConsoleResponse.toDomain(): Console = Console(
     id = id,
     name = name,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -17,52 +17,14 @@ import kotlinx.serialization.Serializable
 
 typealias UserDto = com.spela.client.models.UserResponse
 
-@Serializable
-data class HardwareMakerDto(
-    val code: String,
-    val name: String,
-)
-
-@Serializable
-data class MediaTypeCategoryDto(
-    val code: String,
-    val name: String,
-)
-
-@Serializable
-data class MediaTypeDto(
-    val code: String,
-    val name: String,
-    val category: MediaTypeCategoryDto,
-)
-
-/** Matches ConsoleResponse in responses.go */
-@Serializable
-data class ConsoleDto(
-    val id: String,
-    val name: String,
-    val abbreviation: String,
-    val code: String = "",
-    val extensions: List<String> = emptyList(),
-    val defaultCore: String = "",
-    val coverAspectRatio: Double = 0.75,
-    val colorTheme: String = "#6366f1",
-    val iconUrl: String = "",
-    val logoUrl: String = "",
-    val logoPngUrl: String = "",
-    val gameCount: Int = 0,
-    val saveStateSupport: Boolean = true,
-    val browserPlayable: Boolean = false,
-    val playable: Boolean = true,
-    val generation: Int = 0,
-    val maker: HardwareMakerDto? = null,
-    val mediaType: MediaTypeDto? = null,
-    val releaseYear: Int? = null,
-    val unitsSold: Long? = null,
-    val summary: String? = null,
-    val createdAt: String? = null,
-    val updatedAt: String? = null,
-)
+// ConsoleDto / HardwareMakerDto / MediaTypeDto / MediaTypeCategoryDto
+// replaced by generated counterparts in com.spela.client.models:
+//   ConsoleDto            -> ConsoleResponse
+//   HardwareMakerDto      -> HardwareMakerResponse
+//   MediaTypeDto          -> MediaTypeResponse
+//   MediaTypeCategoryDto  -> MediaTypeCategoryResponse
+// Generated ConsoleResponse has @Required timestamps (Instant) and
+// non-null maker / mediaType; mapping lives in DtoMappers.kt.
 
 // GameDto / GameDiscDto / GameVariantDto / ParentGameDto / RomHackGameDto
 // replaced by generated counterparts in com.spela.client.models — see

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -56,12 +56,47 @@ private fun testGameResponse(
     )
 }
 
-class GameRepositoryImplTest {
-
-    private val sampleConsoles = listOf(
-        ConsoleDto("1", "NES", "NES", gameCount = 10),
-        ConsoleDto("2", "SNES", "SNES", gameCount = 5),
+private fun testConsoleResponse(
+    id: String,
+    name: String,
+    abbreviation: String,
+    gameCount: Long = 0L,
+    coverAspectRatio: Double = 0.75,
+): com.spela.client.models.ConsoleResponse {
+    val now = kotlin.time.Instant.fromEpochSeconds(0)
+    return com.spela.client.models.ConsoleResponse(
+        abbreviation = abbreviation,
+        browserPlayable = false,
+        code = "",
+        colorTheme = "#6366f1",
+        coverAspectRatio = coverAspectRatio,
+        createdAt = now,
+        defaultCore = "",
+        emulatorJsCore = "",
+        extensions = emptyList(),
+        gameCount = gameCount,
+        generation = 0L,
+        iconUrl = "",
+        id = id,
+        logoPngUrl = "",
+        logoUrl = "",
+        maker = com.spela.client.models.HardwareMakerResponse(code = "", name = ""),
+        mediaType = com.spela.client.models.MediaTypeResponse(
+            code = "",
+            name = "",
+            category = com.spela.client.models.MediaTypeCategoryResponse(code = "", name = ""),
+        ),
+        name = name,
+        playable = true,
+        releaseYear = null,
+        saveStateSupport = true,
+        summary = null,
+        unitsSold = null,
+        updatedAt = now,
     )
+}
+
+class GameRepositoryImplTest {
 
     private val sampleGames = listOf(
         testGameResponse("1", "Super Mario Bros.", "1", consoleName = "NES", fileName = "smb.nes", fileSize = 40960, releaseDate = "1985-09-13"),
@@ -69,8 +104,11 @@ class GameRepositoryImplTest {
     )
 
     @Test
-    fun consoleDtoMapsCorrectly() {
-        val mapped = sampleConsoles.map { it.toDomain() }
+    fun consoleResponseMapsCorrectly() {
+        val mapped = listOf(
+            testConsoleResponse("1", "NES", "NES", gameCount = 10L),
+            testConsoleResponse("2", "SNES", "SNES", gameCount = 5L),
+        ).map { it.toDomain() }
 
         assertEquals(2, mapped.size)
         assertEquals("NES", mapped[0].name)
@@ -80,8 +118,8 @@ class GameRepositoryImplTest {
     }
 
     @Test
-    fun consoleDtoMapsCoverAspectRatio() {
-        val dto = ConsoleDto("1", "NES", "NES", coverAspectRatio = 0.75)
+    fun consoleResponseMapsCoverAspectRatio() {
+        val dto = testConsoleResponse("1", "NES", "NES", coverAspectRatio = 0.75)
         val domain = dto.toDomain()
         assertEquals(0.75, domain.coverAspectRatio)
     }


### PR DESCRIPTION
## Summary

\`ConsoleDto\` + \`HardwareMakerDto\` + \`MediaTypeDto\` + \`MediaTypeCategoryDto\` were the last non-trivial hand-written DTO tree in \`Dtos.kt\` — everything else in the file is either a comment pointer or a typealias to \`com.spela.client.models\`. \`SpelaApiClient.getConsoles()\` already returned \`ConsoleResponse\`; the hand-written \`ConsoleDto\` + its \`toDomain\` mapper survived only to satisfy \`GameRepositoryImplTest\`'s two \`consoleDto*MapsCorrectly\` assertions.

- Delete \`ConsoleDto\` + \`HardwareMakerDto\` + \`MediaTypeDto\` + \`MediaTypeCategoryDto\`; leave a pointer comment.
- Delete \`ConsoleDto.toDomain()\` — \`ConsoleResponse.toDomain()\` already exists and is the mapper used everywhere in production.
- Rename the two test cases to \`consoleResponseMapsCorrectly\` / \`consoleResponseMapsCoverAspectRatio\` and build the response via a local \`testConsoleResponse()\` helper. The generated type has \`@Required\` \`Instant\`s + non-null \`maker\` / \`mediaType\`, so the helper fills those with sensible test defaults.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop :shared:compileTestKotlinDesktop\` — builds clean
- [x] \`./gradlew :shared:desktopTest --tests GameRepositoryImplTest\` — passes
- [x] \`./gradlew :shared:detektMainDesktop\` — clean