### PR TITLE
refactor(player): separate Publisher domain type, state, and screen from Developer

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -972,13 +972,40 @@ fun com.spela.client.models.DeveloperDetailResponse.toDomain(): DeveloperDetail 
     relatedDevelopers = relatedDevelopers.orEmpty().map { it.toDomain() },
 )
 
-// PublisherDetailResponse is shape-symmetric with DeveloperDetailResponse —
-// the "counterpart" fields are `developers` / `relatedPublishers` instead of
-// `publishers` / `relatedDevelopers`. The DeveloperDetail domain model holds
-// them as `publishers` / `relatedDevelopers` regardless of which side the
-// page is viewing; callers render the chips with the appropriate label based
-// on `isDeveloper`.
-fun com.spela.client.models.PublisherDetailResponse.toDomain(): DeveloperDetail = DeveloperDetail(
+fun com.spela.client.models.GenreCount.toPublisherGenreBreakdown(): PublisherDetailGenreBreakdown =
+    PublisherDetailGenreBreakdown(
+        name = name,
+        gameCount = gameCount.toInt(),
+    )
+
+fun com.spela.client.models.PlatformCount.toPublisherPlatformBreakdown(): PublisherDetailPlatformBreakdown =
+    PublisherDetailPlatformBreakdown(
+        consoleName = consoleName,
+        consoleId = consoleId,
+        count = count.toInt(),
+    )
+
+fun com.spela.client.models.EntityUserStats.toPublisherUserStats(): PublisherDetailUserStats =
+    PublisherDetailUserStats(
+        totalPlayTime = totalPlayTime,
+        gamesPlayed = gamesPlayed.toInt(),
+        favoriteCount = favoriteCount.toInt(),
+        mostPlayedGame = mostPlayedGame.takeIf { it.id.isNotEmpty() }?.toDomain(),
+    )
+
+fun com.spela.client.models.NameCount.toPublisherDeveloper(): PublisherDetailDeveloper =
+    PublisherDetailDeveloper(
+        name = name,
+        count = count.toInt(),
+    )
+
+fun com.spela.client.models.RelatedPublisher.toDomain(): RelatedPublisher = RelatedPublisher(
+    name = name,
+    gameCount = gameCount.toInt(),
+    sharedDevelopers = sharedDevelopers.orEmpty(),
+)
+
+fun com.spela.client.models.PublisherDetailResponse.toDomain(): PublisherDetail = PublisherDetail(
     name = name,
     gameCount = gameCount.toInt(),
     avgRating = avgRating,
@@ -986,22 +1013,16 @@ fun com.spela.client.models.PublisherDetailResponse.toDomain(): DeveloperDetail 
     heroUrl = heroUrl,
     companyInfo = companyInfo?.toDomain(),
     topGames = topGames.orEmpty().map { it.toDomain() },
-    genreBreakdown = genreBreakdown.orEmpty().map { it.toDeveloperGenreBreakdown() },
-    platformBreakdown = platformBreakdown.orEmpty().map { it.toDeveloperPlatformBreakdown() },
-    userStats = userStats?.toDeveloperUserStats(),
-    publishers = developers.orEmpty().map { it.toDeveloperPublisher() },
+    genreBreakdown = genreBreakdown.orEmpty().map { it.toPublisherGenreBreakdown() },
+    platformBreakdown = platformBreakdown.orEmpty().map { it.toPublisherPlatformBreakdown() },
+    userStats = userStats?.toPublisherUserStats(),
+    developers = developers.orEmpty().map { it.toPublisherDeveloper() },
     games = games.orEmpty().map { it.toDomain() },
     activeYears = activeYears?.toDomain(),
     ratingDistribution = ratingDistribution.toDomain(),
     primaryGenre = primaryGenre,
     timeline = timeline.orEmpty().map { it.toDomain() },
-    relatedDevelopers = relatedPublishers.orEmpty().map { it.toDomain() },
-)
-
-fun com.spela.client.models.RelatedPublisher.toDomain(): RelatedDeveloper = RelatedDeveloper(
-    name = name,
-    gameCount = gameCount.toInt(),
-    sharedPublishers = sharedDevelopers.orEmpty(),
+    relatedPublishers = relatedPublishers.orEmpty().map { it.toDomain() },
 )
 
 fun com.spela.client.models.DeveloperSpotlightResponse.toDomain(): DeveloperSpotlight = DeveloperSpotlight(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.spela.player.data.repository
 import com.spela.player.data.remote.api.SpelaApiClient
 import com.spela.player.data.remote.dto.GameDto
 import com.spela.player.data.remote.dto.toDeveloperUserStats
+import com.spela.player.data.remote.dto.toPublisherUserStats
 import com.spela.player.data.remote.dto.toDomain
 import com.spela.player.domain.model.AchievementGameItem
 import com.spela.player.domain.model.ActiveNowItem
@@ -14,6 +15,7 @@ import com.spela.player.domain.model.ConsoleHighlight
 import com.spela.player.domain.model.ConsoleShowcase
 import com.spela.player.domain.model.CultClassicGame
 import com.spela.player.domain.model.DeveloperDetail
+import com.spela.player.domain.model.PublisherDetail
 import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.DeveloperSummary
 import com.spela.player.domain.model.ExploreChallenge
@@ -209,7 +211,7 @@ class ExploreRepositoryImpl(
         resolveEntityDetail(apiClient.getDeveloperDetail(name))
     }
 
-    override suspend fun getPublisherDetail(name: String): Result<DeveloperDetail> = runCatching {
+    override suspend fun getPublisherDetail(name: String): Result<PublisherDetail> = runCatching {
         resolveEntityDetail(apiClient.getPublisherDetail(name))
     }
 
@@ -441,13 +443,35 @@ class ExploreRepositoryImpl(
             games = dto.games,
         )
 
-    private fun resolveEntityDetail(dto: com.spela.client.models.PublisherDetailResponse): DeveloperDetail =
-        dto.toDomain().applyUrlResolution(
-            heroUrl = dto.heroUrl,
-            companyInfo = dto.companyInfo,
-            topGames = dto.topGames,
-            userStats = dto.userStats,
-            games = dto.games,
+    private fun resolveEntityDetail(dto: com.spela.client.models.PublisherDetailResponse): PublisherDetail =
+        dto.toDomain().copy(
+            heroUrl = apiClient.resolveUrl(dto.heroUrl),
+            companyInfo = dto.companyInfo?.let { info ->
+                info.toDomain().copy(
+                    logoUrl = apiClient.resolveUrl(info.logoUrl),
+                )
+            },
+            topGames = dto.topGames.orEmpty().map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                )
+            },
+            userStats = dto.userStats?.let { stats ->
+                stats.toPublisherUserStats().copy(
+                    mostPlayedGame = stats.mostPlayedGame
+                        .takeIf { it.id.isNotEmpty() }
+                        ?.let { gameDto ->
+                            gameDto.toDomain().copy(
+                                coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                            )
+                        },
+                )
+            },
+            games = dto.games.orEmpty().map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                )
+            },
         )
 
     private fun DeveloperDetail.applyUrlResolution(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -147,11 +147,11 @@ data class DeveloperDetailPlatformBreakdown(
 )
 
 data class DeveloperDetailUserStats(
-    val totalPlayTime: Long,
-    val gamesPlayed: Int,
-    val favoriteCount: Int,
-    val mostPlayedGame: Game?,
-)
+    override val totalPlayTime: Long,
+    override val gamesPlayed: Int,
+    override val favoriteCount: Int,
+    override val mostPlayedGame: Game?,
+) : MakerUserStats
 
 data class DeveloperDetailPublisher(
     val name: String,
@@ -200,25 +200,105 @@ data class RelatedDeveloper(
     val sharedPublishers: List<String>,
 )
 
-data class DeveloperDetail(
+data class RelatedPublisher(
     val name: String,
     val gameCount: Int,
-    val avgRating: Double,
-    val consoles: List<String>,
-    val heroUrl: String? = null,
-    val companyInfo: CompanyInfo? = null,
-    val topGames: List<Game> = emptyList(),
+    val sharedDevelopers: List<String>,
+)
+
+data class PublisherDetailGenreBreakdown(
+    val name: String,
+    val gameCount: Int,
+)
+
+data class PublisherDetailPlatformBreakdown(
+    val consoleName: String,
+    val consoleId: String,
+    val count: Int,
+)
+
+data class PublisherDetailUserStats(
+    override val totalPlayTime: Long,
+    override val gamesPlayed: Int,
+    override val favoriteCount: Int,
+    override val mostPlayedGame: Game?,
+) : MakerUserStats
+
+data class PublisherDetailDeveloper(
+    val name: String,
+    val count: Int,
+)
+
+/**
+ * Common fields for a company-maker detail page (developer or publisher). Each
+ * side has its own counterpart-company fields, which live on the concrete
+ * subtype — `DeveloperDetail.publishers / relatedDevelopers` vs.
+ * `PublisherDetail.developers / relatedPublishers`. Shared UI components
+ * consume this interface so they don't need developer-specific types.
+ */
+sealed interface MakerDetail {
+    val name: String
+    val gameCount: Int
+    val avgRating: Double
+    val consoles: List<String>
+    val heroUrl: String?
+    val companyInfo: CompanyInfo?
+    val topGames: List<Game>
+    val userStats: MakerUserStats?
+    val games: List<Game>
+    val activeYears: ActiveYears?
+    val ratingDistribution: RatingDistribution?
+    val primaryGenre: String?
+    val timeline: List<TimelineEntry>
+}
+
+/** Common shape consumed by the shared user-stats UI card. */
+sealed interface MakerUserStats {
+    val totalPlayTime: Long
+    val gamesPlayed: Int
+    val favoriteCount: Int
+    val mostPlayedGame: Game?
+}
+
+data class DeveloperDetail(
+    override val name: String,
+    override val gameCount: Int,
+    override val avgRating: Double,
+    override val consoles: List<String>,
+    override val heroUrl: String? = null,
+    override val companyInfo: CompanyInfo? = null,
+    override val topGames: List<Game> = emptyList(),
     val genreBreakdown: List<DeveloperDetailGenreBreakdown> = emptyList(),
     val platformBreakdown: List<DeveloperDetailPlatformBreakdown> = emptyList(),
-    val userStats: DeveloperDetailUserStats? = null,
+    override val userStats: DeveloperDetailUserStats? = null,
     val publishers: List<DeveloperDetailPublisher> = emptyList(),
-    val games: List<Game>,
-    val activeYears: ActiveYears? = null,
-    val ratingDistribution: RatingDistribution? = null,
-    val primaryGenre: String? = null,
-    val timeline: List<TimelineEntry> = emptyList(),
+    override val games: List<Game>,
+    override val activeYears: ActiveYears? = null,
+    override val ratingDistribution: RatingDistribution? = null,
+    override val primaryGenre: String? = null,
+    override val timeline: List<TimelineEntry> = emptyList(),
     val relatedDevelopers: List<RelatedDeveloper> = emptyList(),
-)
+) : MakerDetail
+
+data class PublisherDetail(
+    override val name: String,
+    override val gameCount: Int,
+    override val avgRating: Double,
+    override val consoles: List<String>,
+    override val heroUrl: String? = null,
+    override val companyInfo: CompanyInfo? = null,
+    override val topGames: List<Game> = emptyList(),
+    val genreBreakdown: List<PublisherDetailGenreBreakdown> = emptyList(),
+    val platformBreakdown: List<PublisherDetailPlatformBreakdown> = emptyList(),
+    override val userStats: PublisherDetailUserStats? = null,
+    val developers: List<PublisherDetailDeveloper> = emptyList(),
+    override val games: List<Game>,
+    override val activeYears: ActiveYears? = null,
+    override val ratingDistribution: RatingDistribution? = null,
+    override val primaryGenre: String? = null,
+    override val timeline: List<TimelineEntry> = emptyList(),
+    val relatedPublishers: List<RelatedPublisher> = emptyList(),
+) : MakerDetail
 
 data class DeveloperSpotlight(
     val name: String,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/ExploreRepository.kt
@@ -12,6 +12,7 @@ import com.spela.player.domain.model.CultClassicGame
 import com.spela.player.domain.model.DeveloperDetail
 import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.DeveloperSummary
+import com.spela.player.domain.model.PublisherDetail
 import com.spela.player.domain.model.ExploreChallenge
 import com.spela.player.domain.model.ExploreRow
 import com.spela.player.domain.model.FeaturedGame
@@ -58,7 +59,7 @@ interface ExploreRepository {
     suspend fun getPlayersLikeYou(): Result<PlayersLikeYouResult>
     suspend fun getDevelopers(): Result<List<DeveloperSummary>>
     suspend fun getDeveloperDetail(name: String): Result<DeveloperDetail>
-    suspend fun getPublisherDetail(name: String): Result<DeveloperDetail>
+    suspend fun getPublisherDetail(name: String): Result<PublisherDetail>
     suspend fun getDeveloperSpotlight(): Result<DeveloperSpotlight>
     suspend fun getConsoleShowcase(consoleId: String): Result<ConsoleShowcase>
     suspend fun getConsoleHighlights(): Result<List<ConsoleHighlight>>

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -112,6 +112,7 @@ import com.spela.player.presentation.ui.screen.ChallengeListScreen
 import com.spela.player.presentation.ui.screen.GlobalChallengesScreen
 import com.spela.player.presentation.ui.screen.StatsScreen
 import com.spela.player.presentation.ui.screen.ExploreDeveloperScreen
+import com.spela.player.presentation.ui.screen.ExplorePublisherScreen
 import com.spela.player.presentation.ui.screen.ExploreGalleryScreen
 import com.spela.player.presentation.ui.screen.ExploreKeywordScreen
 import com.spela.player.presentation.ui.screen.ExploreMoodScreen
@@ -740,7 +741,6 @@ fun SpelaApp(
                                 if (exploreViewModel != null) {
                                     ExploreDeveloperScreen(
                                         name = screen.name,
-                                        isDeveloper = true,
                                         viewModel = exploreViewModel,
                                         onGameSelected = { gameId ->
                                             navigationViewModel.onIntent(
@@ -771,23 +771,22 @@ fun SpelaApp(
 
                             is SpScreen.ExplorePublisher -> {
                                 if (exploreViewModel != null) {
-                                    ExploreDeveloperScreen(
+                                    ExplorePublisherScreen(
                                         name = screen.name,
-                                        isDeveloper = false,
                                         viewModel = exploreViewModel,
                                         onGameSelected = { gameId ->
                                             navigationViewModel.onIntent(
                                                 NavigationIntent.NavigateTo(SpScreen.GameDetail(gameId))
                                             )
                                         },
-                                        onPublisherSelected = { publisherName ->
-                                            navigationViewModel.onIntent(
-                                                NavigationIntent.NavigateTo(SpScreen.ExplorePublisher(publisherName))
-                                            )
-                                        },
                                         onDeveloperSelected = { developerName ->
                                             navigationViewModel.onIntent(
                                                 NavigationIntent.NavigateTo(SpScreen.ExploreDeveloper(developerName))
+                                            )
+                                        },
+                                        onPublisherSelected = { publisherName ->
+                                            navigationViewModel.onIntent(
+                                                NavigationIntent.NavigateTo(SpScreen.ExplorePublisher(publisherName))
                                             )
                                         },
                                         onNavigateToGames = { devName, isDev ->

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/DeveloperDetailComponents.kt
@@ -48,9 +48,9 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.domain.model.CompanyInfo
-import com.spela.player.domain.model.DeveloperDetail
-import com.spela.player.domain.model.DeveloperDetailUserStats
 import com.spela.player.domain.model.Game
+import com.spela.player.domain.model.MakerDetail
+import com.spela.player.domain.model.MakerUserStats
 import androidx.compose.ui.focus.focusRequester
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpCarousel
@@ -73,7 +73,7 @@ private val HeroLabelText = Color.White.copy(alpha = 0.40f)
 
 @Composable
 internal fun DeveloperHeroBanner(
-    detail: DeveloperDetail,
+    detail: MakerDetail,
     modifier: Modifier = Modifier,
 ) {
     val companyInfo = detail.companyInfo
@@ -248,7 +248,7 @@ internal fun DeveloperHeroBanner(
 
 @Composable
 private fun DeveloperInfoSection(
-    detail: DeveloperDetail,
+    detail: MakerDetail,
     modifier: Modifier = Modifier,
 ) {
     data class Stat(val icon: ImageVector, val value: String, val label: String)
@@ -350,7 +350,7 @@ internal fun DeveloperTopRatedCard(
 
 @Composable
 internal fun DeveloperUserStatsCard(
-    userStats: DeveloperDetailUserStats,
+    userStats: MakerUserStats,
     totalGames: Int,
     onGameSelected: (String) -> Unit,
     modifier: Modifier = Modifier,
@@ -380,7 +380,8 @@ internal fun DeveloperUserStatsCard(
             )
         }
 
-        if (userStats.mostPlayedGame != null) {
+        val mostPlayedGame = userStats.mostPlayedGame
+        if (mostPlayedGame != null) {
             Spacer(Modifier.height(SpSpacing.Medium))
             Row(
                 modifier = Modifier.fillMaxWidth(),
@@ -396,7 +397,7 @@ internal fun DeveloperUserStatsCard(
                     modifier = Modifier
                         .weight(1f)
                         .testTag("developer_most_played_game"),
-                    onClick = { onGameSelected(userStats.mostPlayedGame.id) },
+                    onClick = { onGameSelected(mostPlayedGame.id) },
                 ) {
                     Row(
                         modifier = Modifier.padding(SpSpacing.Small),
@@ -404,8 +405,8 @@ internal fun DeveloperUserStatsCard(
                         horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
                     ) {
                         SpCoverArt(
-                            imageUrl = userStats.mostPlayedGame.coverUrl,
-                            contentDescription = "${userStats.mostPlayedGame.title} cover",
+                            imageUrl = mostPlayedGame.coverUrl,
+                            contentDescription = "${mostPlayedGame.title} cover",
                             modifier = Modifier
                                 .width(32.dp)
                                 .height(42.dp)
@@ -413,7 +414,7 @@ internal fun DeveloperUserStatsCard(
                             aspectRatio = 0.75f,
                         )
                         Text(
-                            text = userStats.mostPlayedGame.title,
+                            text = mostPlayedGame.title,
                             style = SpTypography.TitleSmall,
                             color = SpColor.OnCard,
                             maxLines = 1,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DeveloperGamesScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DeveloperGamesScreen.kt
@@ -52,6 +52,7 @@ import com.spela.player.presentation.ui.theme.LocalTitleBarInset
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.domain.model.Game
 import com.spela.player.presentation.viewmodel.ExploreViewModel
 
 private data class DeveloperGamesSortOption(val key: String, val label: String)
@@ -73,7 +74,39 @@ fun DeveloperGamesScreen(
     onGameSelected: (String) -> Unit,
     onBack: () -> Unit,
 ) {
-    val state by viewModel.developerDetailState.collectAsState()
+    val developerState by viewModel.developerDetailState.collectAsState()
+    val publisherState by viewModel.publisherDetailState.collectAsState()
+
+    // Unify the two side-specific states into a small view object for this
+    // screen. The fields consumed here (detail?.let present, sortedFilteredGames,
+    // gamesSearchQuery, gamesSortBy, isLoading) have identical shape on both
+    // sides; only the detail type differs and this screen only needs a
+    // non-null check.
+    data class GamesView(
+        val hasDetail: Boolean,
+        val isLoading: Boolean,
+        val sortedFilteredGames: List<Game>,
+        val gamesSearchQuery: String,
+        val gamesSortBy: String,
+    )
+
+    val state = if (isDeveloper) {
+        GamesView(
+            hasDetail = developerState.detail != null,
+            isLoading = developerState.isLoading,
+            sortedFilteredGames = developerState.sortedFilteredGames,
+            gamesSearchQuery = developerState.gamesSearchQuery,
+            gamesSortBy = developerState.gamesSortBy,
+        )
+    } else {
+        GamesView(
+            hasDetail = publisherState.detail != null,
+            isLoading = publisherState.isLoading,
+            sortedFilteredGames = publisherState.sortedFilteredGames,
+            gamesSearchQuery = publisherState.gamesSearchQuery,
+            gamesSortBy = publisherState.gamesSortBy,
+        )
+    }
 
     var isSearchVisible by rememberSaveable { mutableStateOf(false) }
     var showSortMenu by remember { mutableStateOf(false) }
@@ -81,9 +114,20 @@ fun DeveloperGamesScreen(
 
     val sortedGames = state.sortedFilteredGames
 
+    // Both sides accept the same filter setters (they just write to the
+    // appropriate state flow — see ExploreViewModel.setPublisher* helpers).
+    val setSearch: (String) -> Unit = { query ->
+        if (isDeveloper) viewModel.setDeveloperGamesSearch(query)
+        else viewModel.setPublisherGamesSearchQuery(query)
+    }
+    val setSort: (String) -> Unit = { sortBy ->
+        if (isDeveloper) viewModel.setDeveloperGamesSort(sortBy)
+        else viewModel.setPublisherGamesSortBy(sortBy)
+    }
+
     PlatformBackHandler {
         if (isSearchVisible) {
-            viewModel.setDeveloperGamesSearch("")
+            setSearch("")
             isSearchVisible = false
         } else {
             onBack()
@@ -92,7 +136,7 @@ fun DeveloperGamesScreen(
 
     // Load data if not already loaded
     LaunchedEffect(name, isDeveloper) {
-        if (state.detail == null && !state.isLoading) {
+        if (!state.hasDetail && !state.isLoading) {
             if (isDeveloper) {
                 viewModel.loadDeveloperDetail(name)
             } else {
@@ -125,7 +169,7 @@ fun DeveloperGamesScreen(
                 if (isSearchVisible) {
                     SpSearchField(
                         value = state.gamesSearchQuery,
-                        onValueChange = { viewModel.setDeveloperGamesSearch(it) },
+                        onValueChange = { setSearch(it) },
                         modifier = Modifier
                             .fillMaxWidth()
                             .padding(vertical = SpSpacing.Small)
@@ -137,7 +181,7 @@ fun DeveloperGamesScreen(
                                 icon = Icons.Filled.Close,
                                 contentDescription = "Close search",
                                 onClick = {
-                                    viewModel.setDeveloperGamesSearch("")
+                                    setSearch("")
                                     isSearchVisible = false
                                 },
                             )
@@ -176,7 +220,7 @@ fun DeveloperGamesScreen(
                                 DropdownMenuItem(
                                     text = { Text(option.label) },
                                     onClick = {
-                                        viewModel.setDeveloperGamesSort(option.key)
+                                        setSort(option.key)
                                         showSortMenu = false
                                     },
                                     leadingIcon = if (state.gamesSortBy == option.key) {
@@ -190,7 +234,7 @@ fun DeveloperGamesScreen(
             }
 
             // Loading / empty / game grid
-            if (state.isLoading && state.detail == null) {
+            if (state.isLoading && !state.hasDetail) {
                 item(span = { GridItemSpan(maxLineSpan) }) {
                     Box(
                         modifier = Modifier.fillMaxWidth().height(300.dp),
@@ -231,7 +275,7 @@ fun DeveloperGamesScreen(
                 showBack = true,
                 onBack = {
                     if (isSearchVisible) {
-                        viewModel.setDeveloperGamesSearch("")
+                        setSearch("")
                         isSearchVisible = false
                     } else {
                         onBack()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExploreDeveloperScreen.kt
@@ -51,7 +51,6 @@ import com.spela.player.presentation.viewmodel.ExploreViewModel
 @Composable
 fun ExploreDeveloperScreen(
     name: String,
-    isDeveloper: Boolean = true,
     viewModel: ExploreViewModel,
     onGameSelected: (String) -> Unit,
     onPublisherSelected: (String) -> Unit = {},
@@ -63,12 +62,8 @@ fun ExploreDeveloperScreen(
 
     val state by viewModel.developerDetailState.collectAsState()
 
-    LaunchedEffect(name, isDeveloper) {
-        if (isDeveloper) {
-            viewModel.loadDeveloperDetail(name)
-        } else {
-            viewModel.loadPublisherDetail(name)
-        }
+    LaunchedEffect(name) {
+        viewModel.loadDeveloperDetail(name)
     }
 
     val isGamepad = LocalInputMode.current == InputMode.GAMEPAD
@@ -177,7 +172,7 @@ fun ExploreDeveloperScreen(
                                         SpButton(
                                             text = "See all games",
                                             style = SpButtonStyle.Ghost,
-                                            onClick = { onNavigateToGames(name, isDeveloper) },
+                                            onClick = { onNavigateToGames(name, true) },
                                             modifier = Modifier.testTag("developer_see_all_games"),
                                         )
                                     }
@@ -202,7 +197,7 @@ fun ExploreDeveloperScreen(
                                         SpButton(
                                             text = "See all",
                                             style = SpButtonStyle.Ghost,
-                                            onClick = { onNavigateToGames(name, isDeveloper) },
+                                            onClick = { onNavigateToGames(name, true) },
                                         )
                                     }
                                 } else null,
@@ -267,7 +262,7 @@ fun ExploreDeveloperScreen(
                     ) {
                         SpEmptyState(
                             icon = Icons.Filled.Code,
-                            title = if (isDeveloper) "Developer not found" else "Publisher not found",
+                            title = "Developer not found",
                             message = "Could not load details.",
                             modifier = Modifier.testTag("developer_error_state"),
                         )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExplorePublisherScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ExplorePublisherScreen.kt
@@ -1,0 +1,288 @@
+package com.spela.player.presentation.ui.screen
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.ui.layout.layout
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Code
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
+import com.spela.player.presentation.ui.components.PlatformBackHandler
+import com.spela.player.presentation.ui.components.SpButton
+import com.spela.player.presentation.ui.components.SpButtonStyle
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpGameGrid
+import com.spela.player.presentation.ui.components.SpGridGameCard
+import com.spela.player.presentation.ui.components.SpEmptyState
+import com.spela.player.presentation.ui.components.SpSectionList
+import com.spela.player.presentation.ui.components.SpSnackbar
+import com.spela.player.presentation.ui.components.SpSnackbarData
+import com.spela.player.presentation.ui.components.SpSnackbarType
+import com.spela.player.presentation.ui.components.SpTitledSection
+import com.spela.player.presentation.ui.components.SpScreen
+import com.spela.player.presentation.ui.components.SpScreenTopSpacer
+import com.spela.player.presentation.ui.components.SpTopBar
+import com.spela.player.presentation.ui.feature.explore.DeveloperCompanyDescription
+import com.spela.player.presentation.ui.feature.explore.DeveloperDetailSkeleton
+import com.spela.player.presentation.ui.feature.explore.DeveloperHeroBanner
+import com.spela.player.presentation.ui.feature.explore.DeveloperTopRatedRow
+import com.spela.player.presentation.ui.feature.explore.DeveloperUserStatsCard
+import com.spela.player.presentation.ui.gamepad.InputMode
+import com.spela.player.presentation.ui.gamepad.LocalInputMode
+import com.spela.player.presentation.ui.gamepad.autoFocus
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun ExplorePublisherScreen(
+    name: String,
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+    onDeveloperSelected: (String) -> Unit = {},
+    onPublisherSelected: (String) -> Unit = {},
+    onNavigateToGames: ((name: String, isDeveloper: Boolean) -> Unit)? = null,
+    onBack: () -> Unit,
+) {
+    PlatformBackHandler { onBack() }
+
+    val state by viewModel.publisherDetailState.collectAsState()
+
+    LaunchedEffect(name) {
+        viewModel.loadPublisherDetail(name)
+    }
+
+    val isGamepad = LocalInputMode.current == InputMode.GAMEPAD
+
+    SpScreen(modifier = Modifier.testTag("publisher_detail_screen")) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+        ) {
+            when {
+                state.isLoading && state.detail == null -> {
+                    if (isGamepad) {
+                        SpScreenTopSpacer()
+                    } else {
+                        SpTopBar(
+                            title = name,
+                            showBack = true,
+                            onBack = onBack,
+                        )
+                    }
+                    DeveloperDetailSkeleton()
+                }
+
+                state.detail != null -> {
+                    val detail = state.detail!!
+                    val horizontalPadding = SpSpacing.ScreenHorizontal
+
+                    Box(modifier = Modifier.fillMaxSize()) {
+                        SpSectionList(
+                            modifier = Modifier.fillMaxSize().testTag("publisher_detail_content"),
+                        ) {
+                            // 0. Hero Banner — full-width edge-to-edge
+                            DeveloperHeroBanner(
+                                detail = detail,
+                                modifier = Modifier
+                                    .autoFocus()
+                                    .layout { measurable, constraints ->
+                                        val extraWidth = (horizontalPadding * 2).roundToPx()
+                                        val newConstraints = constraints.copy(
+                                            maxWidth = constraints.maxWidth + extraWidth,
+                                            minWidth = if (constraints.minWidth > 0) constraints.minWidth + extraWidth else 0,
+                                        )
+                                        val placeable = measurable.measure(newConstraints)
+                                        layout(placeable.width, placeable.height) {
+                                            placeable.place(-horizontalPadding.roundToPx(), 0)
+                                        }
+                                    }
+                                    .testTag("publisher_hero_banner"),
+                            )
+                            // 1. About (company description)
+                            val companyInfo = detail.companyInfo
+                            if (companyInfo?.description != null) {
+                                SpTitledSection(title = "About") {
+                                    DeveloperCompanyDescription(
+                                        companyInfo = companyInfo,
+                                        modifier = Modifier.testTag("publisher_company_description_section"),
+                                    )
+                                }
+                            }
+
+                            // 2. Related chips — developers who worked with this publisher,
+                            // and related publishers with similar portfolios.
+                            val hasDevelopers = detail.developers.isNotEmpty()
+                            val hasRelated = detail.relatedPublishers.isNotEmpty()
+                            if (hasDevelopers || hasRelated) {
+                                FlowRow(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .testTag("publisher_related_chips"),
+                                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                                    verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+                                ) {
+                                    detail.developers.forEach { developer ->
+                                        SpChip(
+                                            text = "${developer.name} (${developer.count})",
+                                            onClick = { onDeveloperSelected(developer.name) },
+                                            modifier = Modifier
+                                                .testTag("publisher_developer_chip_${developer.name}")
+                                                .semantics {
+                                                    contentDescription = "${developer.name}, ${developer.count} games"
+                                                    role = Role.Button
+                                                },
+                                        )
+                                    }
+                                    detail.relatedPublishers.forEach { related ->
+                                        SpChip(
+                                            text = related.name,
+                                            onClick = { onPublisherSelected(related.name) },
+                                            modifier = Modifier
+                                                .testTag("publisher_related_chip_${related.name}")
+                                                .semantics {
+                                                    contentDescription = "${related.name}, ${related.gameCount} games"
+                                                    role = Role.Button
+                                                },
+                                        )
+                                    }
+                                }
+                            }
+
+                            // 3. Top Rated
+                            if (detail.topGames.size >= 3) {
+                                SpTitledSection(
+                                    title = "Top Rated",
+                                    edgeToEdgeContent = true,
+                                    titleTrailing = if (detail.games.isNotEmpty() && onNavigateToGames != null) {
+                                        {
+                                            SpButton(
+                                                text = "See all games",
+                                                style = SpButtonStyle.Ghost,
+                                                onClick = { onNavigateToGames(name, false) },
+                                                modifier = Modifier.testTag("publisher_see_all_games"),
+                                            )
+                                        }
+                                    } else {
+                                        null
+                                    },
+                                ) {
+                                    DeveloperTopRatedRow(
+                                        topGames = detail.topGames,
+                                        onGameSelected = onGameSelected,
+                                        modifier = Modifier.testTag("publisher_top_rated_section"),
+                                    )
+                                }
+                            }
+
+                            // 4. Games grid
+                            if (detail.games.isNotEmpty()) {
+                                SpTitledSection(
+                                    title = "Games",
+                                    titleTrailing = if (detail.games.size > 12 && onNavigateToGames != null) {
+                                        {
+                                            SpButton(
+                                                text = "See all",
+                                                style = SpButtonStyle.Ghost,
+                                                onClick = { onNavigateToGames(name, false) },
+                                            )
+                                        }
+                                    } else null,
+                                ) {
+                                    SpGameGrid(
+                                        items = detail.games.take(12).map { game ->
+                                            @Composable {
+                                                SpGridGameCard(
+                                                    title = game.title,
+                                                    subtitle = game.consoleName,
+                                                    coverUrl = game.coverUrl,
+                                                    onClick = { onGameSelected(game.id) },
+                                                    rating = game.communityRating,
+                                                    isFavorite = game.isFavorite,
+                                                    isInPlayLater = game.isInPlayLater,
+                                                )
+                                            }
+                                        },
+                                    )
+                                }
+                            }
+
+                            // 5. Your Stats
+                            val userStats = detail.userStats
+                            if (userStats != null) {
+                                SpTitledSection(title = "Your Stats") {
+                                    DeveloperUserStatsCard(
+                                        userStats = userStats,
+                                        totalGames = detail.gameCount,
+                                        onGameSelected = onGameSelected,
+                                        modifier = Modifier.testTag("publisher_user_stats"),
+                                    )
+                                }
+                            }
+                        }
+                        // Top bar overlaid on everything — floats over the banner
+                        if (isGamepad) {
+                            SpScreenTopSpacer()
+                        } else {
+                            SpTopBar(
+                                title = "",
+                                showBack = true,
+                                onBack = onBack,
+                                onGradient = true,
+                            )
+                        }
+                    } // Box
+                }
+
+                else -> {
+                    if (isGamepad) {
+                        SpScreenTopSpacer()
+                    } else {
+                        SpTopBar(
+                            title = name,
+                            showBack = true,
+                            onBack = onBack,
+                        )
+                    }
+                    Box(
+                        modifier = Modifier.fillMaxSize(),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        SpEmptyState(
+                            icon = Icons.Filled.Code,
+                            title = "Publisher not found",
+                            message = "Could not load details.",
+                            modifier = Modifier.testTag("publisher_error_state"),
+                        )
+                    }
+                }
+            }
+        }
+
+        SpSnackbar(
+            data = state.error?.let {
+                SpSnackbarData(
+                    message = it,
+                    type = SpSnackbarType.Error,
+                    actionLabel = "Dismiss",
+                    onAction = { viewModel.dismissPublisherDetailError() },
+                )
+            },
+            onDismiss = { viewModel.dismissPublisherDetailError() },
+            modifier = Modifier.align(Alignment.BottomCenter),
+        )
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -10,6 +10,7 @@ import com.spela.player.domain.model.ConsoleHighlight
 import com.spela.player.domain.model.ConsoleShowcase
 import com.spela.player.domain.model.CultClassicGame
 import com.spela.player.domain.model.DeveloperDetail
+import com.spela.player.domain.model.PublisherDetail
 import com.spela.player.domain.model.DeveloperSpotlight
 import com.spela.player.domain.model.ExploreChallenge
 import com.spela.player.domain.model.ExploreRow
@@ -117,6 +118,44 @@ data class MoodDetailState(
 data class DeveloperDetailState(
     val name: String = "",
     val detail: DeveloperDetail? = null,
+    val consoleFilter: String? = null,
+    val genreFilter: String? = null,
+    val gamesSearchQuery: String = "",
+    val gamesSortBy: String = "title",  // "title", "rating", "releaseDate"
+    val isLoading: Boolean = false,
+    val error: String? = null,
+) {
+    val filteredGames: List<Game>
+        get() {
+            val games = detail?.games ?: return emptyList()
+            var result = games
+            if (consoleFilter != null) {
+                result = result.filter { it.consoleName.equals(consoleFilter, ignoreCase = true) }
+            }
+            if (genreFilter != null) {
+                result = result.filter { game ->
+                    game.genre?.split(",")?.map { it.trim() }?.any { it.equals(genreFilter, ignoreCase = true) } == true
+                }
+            }
+            return result
+        }
+
+    val sortedFilteredGames: List<Game>
+        get() {
+            val filtered = if (gamesSearchQuery.length >= 2) {
+                filteredGames.filter { it.title.contains(gamesSearchQuery, ignoreCase = true) }
+            } else filteredGames
+            return when (gamesSortBy) {
+                "rating" -> filtered.sortedByDescending { it.igdbCriticsRating }
+                "releaseDate" -> filtered.sortedBy { it.releaseDate ?: "" }
+                else -> filtered.sortedBy { it.title.lowercase() }
+            }
+        }
+}
+
+data class PublisherDetailState(
+    val name: String = "",
+    val detail: PublisherDetail? = null,
     val consoleFilter: String? = null,
     val genreFilter: String? = null,
     val gamesSearchQuery: String = "",
@@ -269,6 +308,9 @@ class ExploreViewModel(
     private val _developerDetailState = MutableStateFlow(DeveloperDetailState())
     val developerDetailState: StateFlow<DeveloperDetailState> = _developerDetailState.asStateFlow()
 
+    private val _publisherDetailState = MutableStateFlow(PublisherDetailState())
+    val publisherDetailState: StateFlow<PublisherDetailState> = _publisherDetailState.asStateFlow()
+
     private val _consoleShowcaseState = MutableStateFlow(ConsoleShowcaseState())
     val consoleShowcaseState: StateFlow<ConsoleShowcaseState> = _consoleShowcaseState.asStateFlow()
 
@@ -301,6 +343,7 @@ class ExploreViewModel(
     private var forYouJob: Job? = null
     private var developerSpotlightJob: Job? = null
     private var developerDetailJob: Job? = null
+    private var publisherDetailJob: Job? = null
     private var consoleHighlightsJob: Job? = null
     private var consoleShowcaseJob: Job? = null
     private var artworkShowcaseJob: Job? = null
@@ -601,20 +644,40 @@ class ExploreViewModel(
     }
 
     fun loadPublisherDetail(name: String) {
-        developerDetailJob?.cancel()
-        _developerDetailState.update {
-            DeveloperDetailState(name = name, isLoading = true)
+        publisherDetailJob?.cancel()
+        _publisherDetailState.update {
+            PublisherDetailState(name = name, isLoading = true)
         }
-        developerDetailJob = scope.launch(dispatchers.io) {
+        publisherDetailJob = scope.launch(dispatchers.io) {
             exploreRepository.getPublisherDetail(name).fold(
                 onSuccess = { detail ->
-                    _developerDetailState.update { it.copy(detail = detail, isLoading = false) }
+                    _publisherDetailState.update { it.copy(detail = detail, isLoading = false) }
                 },
                 onFailure = { error ->
-                    _developerDetailState.update { it.copy(isLoading = false, error = error.message) }
+                    _publisherDetailState.update { it.copy(isLoading = false, error = error.message) }
                 },
             )
         }
+    }
+
+    fun setPublisherConsoleFilter(abbreviation: String?) {
+        _publisherDetailState.update { it.copy(consoleFilter = abbreviation) }
+    }
+
+    fun setPublisherGenreFilter(genre: String?) {
+        _publisherDetailState.update { it.copy(genreFilter = genre) }
+    }
+
+    fun setPublisherGamesSearchQuery(query: String) {
+        _publisherDetailState.update { it.copy(gamesSearchQuery = query) }
+    }
+
+    fun setPublisherGamesSortBy(sortBy: String) {
+        _publisherDetailState.update { it.copy(gamesSortBy = sortBy) }
+    }
+
+    fun dismissPublisherDetailError() {
+        _publisherDetailState.update { it.copy(error = null) }
     }
 
     fun setDeveloperConsoleFilter(abbreviation: String?) {


### PR DESCRIPTION
## Summary

Publisher and Developer were sharing the same \`DeveloperDetail\` domain model, a single \`developerDetailState\` in \`ExploreViewModel\`, and one \`ExploreDeveloperScreen\` with an \`isDeveloper\` branch. After #560 also routed publisher responses through a \`DeveloperDetail\`-typed mapper, there was no place in the player app where a publisher was actually a Publisher.

This splits the two sides end-to-end.

### Domain
- New \`PublisherDetail\` / \`PublisherDetailGenreBreakdown\` / \`PublisherDetailPlatformBreakdown\` / \`PublisherDetailUserStats\` / \`PublisherDetailDeveloper\` / \`RelatedPublisher\` mirroring the developer-side shapes.
- New \`MakerDetail\` + \`MakerUserStats\` sealed interfaces expose the genuinely shared fields; \`DeveloperDetail\` and \`PublisherDetail\` both implement them so shared UI composables can consume either without importing developer-specific types.

### Mapper
- \`PublisherDetailResponse.toDomain()\` now returns \`PublisherDetail\` (was \`DeveloperDetail\`) using publisher-side sub-mappers.
- \`RelatedPublisher.toDomain()\` returns a domain \`RelatedPublisher\` (was being coerced to \`RelatedDeveloper\`).

### Repository + ViewModel
- \`ExploreRepository.getPublisherDetail()\` returns \`Result<PublisherDetail>\`.
- \`ExploreRepositoryImpl\` resolves cover/hero/logo URLs through a \`PublisherDetail\`-typed path; developer path unchanged.
- \`ExploreViewModel\` has \`publisherDetailState\` (parallel to \`developerDetailState\`); \`loadPublisherDetail\` writes there.

### Screens
- **New \`ExplorePublisherScreen\`** owns publisher-specific labels, test tags, and chip routing: developers chips → \`onDeveloperSelected\`, \`relatedPublishers\` chips → \`onPublisherSelected\`. **This fixes the latent click-routing bug** I flagged in #560: publisher-page chips used to be labelled and routed as developer chips.
- \`ExploreDeveloperScreen\` drops the \`isDeveloper\` parameter and its publisher branch; no longer loads publisher state.
- \`SpelaApp\` routes \`SpScreen.ExplorePublisher\` to the new screen.
- Shared composables (\`DeveloperHeroBanner\`, \`DeveloperUserStatsCard\`, \`DeveloperDetailSkeleton\`, \`DeveloperCompanyDescription\`, \`DeveloperTopRatedRow\`) take the \`MakerDetail\` / \`MakerUserStats\` interfaces.

### Known follow-up
\`DeveloperGamesScreen\` still carries an \`isDeveloper\` flag (shared games grid for both sides) but now collects both states and dispatches to the right setters. Filed as a future cleanup to extract a \`PublisherGamesScreen\`.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop :shared:compileTestKotlinDesktop\` — clean
- [x] \`./gradlew :shared:detektMainDesktop\` — clean
- [x] \`./gradlew :shared:desktopTest\` — all pass except the known-flaky \`FramerateRegressionTest\` p95 perf test (CI-skipped, passes in CI)