### PR TITLE
fix(server): mark nullable pointer-to-struct response fields with omitempty

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleResponse.kt
@@ -48,8 +48,6 @@ import kotlinx.serialization.encoding.*
  * @param id 
  * @param logoPngUrl 
  * @param logoUrl 
- * @param maker 
- * @param mediaType 
  * @param name 
  * @param playable 
  * @param releaseYear 
@@ -57,6 +55,8 @@ import kotlinx.serialization.encoding.*
  * @param summary 
  * @param unitsSold 
  * @param updatedAt 
+ * @param maker 
+ * @param mediaType 
  */
 @Serializable
 
@@ -92,10 +92,6 @@ data class ConsoleResponse (
 
     @SerialName(value = "logoUrl") @Required val logoUrl: kotlin.String,
 
-    @SerialName(value = "maker") @Required val maker: HardwareMakerResponse,
-
-    @SerialName(value = "mediaType") @Required val mediaType: MediaTypeResponse,
-
     @SerialName(value = "name") @Required val name: kotlin.String,
 
     @SerialName(value = "playable") @Required val playable: kotlin.Boolean,
@@ -108,7 +104,11 @@ data class ConsoleResponse (
 
     @SerialName(value = "unitsSold") @Required val unitsSold: kotlin.Long?,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+
+    @SerialName(value = "maker") val maker: HardwareMakerResponse? = null,
+
+    @SerialName(value = "mediaType") val mediaType: MediaTypeResponse? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EntityUserStats.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EntityUserStats.kt
@@ -34,8 +34,8 @@ import kotlinx.serialization.encoding.*
  *
  * @param favoriteCount 
  * @param gamesPlayed 
- * @param mostPlayedGame 
  * @param totalPlayTime 
+ * @param mostPlayedGame 
  */
 @Serializable
 
@@ -45,9 +45,9 @@ data class EntityUserStats (
 
     @SerialName(value = "gamesPlayed") @Required val gamesPlayed: kotlin.Long,
 
-    @SerialName(value = "mostPlayedGame") @Required val mostPlayedGame: GameResponse,
+    @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long,
 
-    @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long
+    @SerialName(value = "mostPlayedGame") val mostPlayedGame: GameResponse? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserStatsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserStatsResponse.kt
@@ -36,10 +36,10 @@ import kotlinx.serialization.encoding.*
  * @param gamesPlayed 
  * @param lastPlayedAt 
  * @param longestStreak 
- * @param mostPlayedGame 
  * @param mostPlayedGameTime 
  * @param totalPlayTime 
  * @param dollarSchema A URL to the JSON Schema for this object.
+ * @param mostPlayedGame 
  */
 @Serializable
 
@@ -53,14 +53,14 @@ data class UserStatsResponse (
 
     @SerialName(value = "longestStreak") @Required val longestStreak: kotlin.Long,
 
-    @SerialName(value = "mostPlayedGame") @Required val mostPlayedGame: GameResponse,
-
     @SerialName(value = "mostPlayedGameTime") @Required val mostPlayedGameTime: kotlin.Long,
 
     @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
+
+    @SerialName(value = "mostPlayedGame") val mostPlayedGame: GameResponse? = null
 
 ) {
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -52,9 +52,9 @@ fun com.spela.client.models.ConsoleResponse.toDomain(): Console = Console(
     browserPlayable = browserPlayable,
     playable = playable,
     generation = generation.toInt(),
-    makerName = maker.name,
-    makerCode = maker.code,
-    mediaTypeName = mediaType.name,
+    makerName = maker?.name,
+    makerCode = maker?.code,
+    mediaTypeName = mediaType?.name,
     releaseYear = releaseYear?.toInt(),
     unitsSold = unitsSold,
     summary = summary,
@@ -455,7 +455,7 @@ fun com.spela.client.models.UserStatsResponse.toDomain(): UserStats = UserStats(
     longestStreak = longestStreak.toInt(),
     // Server emits an empty Game placeholder when the user has never
     // played anything — detect via empty id and pass null through.
-    mostPlayedGame = mostPlayedGame.takeIf { it.id.isNotEmpty() }?.toDomain(),
+    mostPlayedGame = mostPlayedGame?.takeIf { it.id.isNotEmpty() }?.toDomain(),
     mostPlayedGameTime = mostPlayedGameTime,
     lastPlayedAt = lastPlayedAt?.toString(),
 )
@@ -877,7 +877,7 @@ fun com.spela.client.models.EntityUserStats.toDeveloperUserStats(): DeveloperDet
         favoriteCount = favoriteCount.toInt(),
         // Server emits an empty Game placeholder when the user has never
         // played anything — detect via empty id and pass null through.
-        mostPlayedGame = mostPlayedGame.takeIf { it.id.isNotEmpty() }?.toDomain(),
+        mostPlayedGame = mostPlayedGame?.takeIf { it.id.isNotEmpty() }?.toDomain(),
     )
 
 fun com.spela.client.models.NameCount.toDeveloperPublisher(): DeveloperDetailPublisher =
@@ -967,7 +967,7 @@ fun com.spela.client.models.EntityUserStats.toPublisherUserStats(): PublisherDet
         totalPlayTime = totalPlayTime,
         gamesPlayed = gamesPlayed.toInt(),
         favoriteCount = favoriteCount.toInt(),
-        mostPlayedGame = mostPlayedGame.takeIf { it.id.isNotEmpty() }?.toDomain(),
+        mostPlayedGame = mostPlayedGame?.takeIf { it.id.isNotEmpty() }?.toDomain(),
     )
 
 fun com.spela.client.models.NameCount.toPublisherDeveloper(): PublisherDetailDeveloper =

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/Dtos.kt
@@ -1,7 +1,5 @@
 package com.spela.player.data.remote.dto
 
-import kotlinx.serialization.Serializable
-
 // Auth — LoginRequest / RegisterRequest / RefreshRequest / AuthResponse
 // replaced by generated counterparts in com.spela.client.models:
 //   LoginRequest    -> AuthLoginRequest

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -459,7 +459,7 @@ class ExploreRepositoryImpl(
             userStats = dto.userStats?.let { stats ->
                 stats.toPublisherUserStats().copy(
                     mostPlayedGame = stats.mostPlayedGame
-                        .takeIf { it.id.isNotEmpty() }
+                        ?.takeIf { it.id.isNotEmpty() }
                         ?.let { gameDto ->
                             gameDto.toDomain().copy(
                                 coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
@@ -495,7 +495,7 @@ class ExploreRepositoryImpl(
         userStats = userStats?.let { stats ->
             stats.toDeveloperUserStats().copy(
                 mostPlayedGame = stats.mostPlayedGame
-                    .takeIf { it.id.isNotEmpty() }
+                    ?.takeIf { it.id.isNotEmpty() }
                     ?.let { gameDto ->
                         gameDto.toDomain().copy(
                             coverUrl = apiClient.resolveUrl(gameDto.coverUrl),

--- a/server/internal/api/explore_handler.go
+++ b/server/internal/api/explore_handler.go
@@ -178,7 +178,7 @@ type EntityUserStats struct {
 	TotalPlayTime  int64         `json:"totalPlayTime"`
 	GamesPlayed    int           `json:"gamesPlayed"`
 	FavoriteCount  int           `json:"favoriteCount"`
-	MostPlayedGame *GameResponse `json:"mostPlayedGame"`
+	MostPlayedGame *GameResponse `json:"mostPlayedGame,omitempty"`
 }
 
 // DeveloperSpotlightResponse is the API response for the featured developer spotlight.

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -60,8 +60,8 @@ type ConsoleResponse struct {
 	UpdatedAt        time.Time              `json:"updatedAt"`
 	Name             string                 `json:"name"`
 	Abbreviation     string                 `json:"abbreviation"`
-	Maker            *HardwareMakerResponse `json:"maker"`
-	MediaType        *MediaTypeResponse     `json:"mediaType"`
+	Maker            *HardwareMakerResponse `json:"maker,omitempty"`
+	MediaType        *MediaTypeResponse     `json:"mediaType,omitempty"`
 	ReleaseYear      *int                   `json:"releaseYear"`
 	UnitsSold        *int64                 `json:"unitsSold"`
 	Summary          *string                `json:"summary"`
@@ -1053,7 +1053,7 @@ type UserStatsResponse struct {
 	GamesPlayed        int64         `json:"gamesPlayed"`
 	CurrentStreak      int           `json:"currentStreak"`
 	LongestStreak      int           `json:"longestStreak"`
-	MostPlayedGame     *GameResponse `json:"mostPlayedGame"`
+	MostPlayedGame     *GameResponse `json:"mostPlayedGame,omitempty"`
 	MostPlayedGameTime int64         `json:"mostPlayedGameTime"`
 	LastPlayedAt       *time.Time    `json:"lastPlayedAt"`
 }

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -5782,8 +5782,8 @@ export interface components {
             id: string;
             logoPngUrl: string;
             logoUrl: string;
-            maker: components["schemas"]["HardwareMakerResponse"];
-            mediaType: components["schemas"]["MediaTypeResponse"];
+            maker?: components["schemas"]["HardwareMakerResponse"];
+            mediaType?: components["schemas"]["MediaTypeResponse"];
             name: string;
             playable: boolean;
             /** Format: int64 */
@@ -6177,7 +6177,7 @@ export interface components {
             favoriteCount: number;
             /** Format: int64 */
             gamesPlayed: number;
-            mostPlayedGame: components["schemas"]["GameResponse"];
+            mostPlayedGame?: components["schemas"]["GameResponse"];
             /** Format: int64 */
             totalPlayTime: number;
         };
@@ -8580,7 +8580,7 @@ export interface components {
             lastPlayedAt: string | null;
             /** Format: int64 */
             longestStreak: number;
-            mostPlayedGame: components["schemas"]["GameResponse"];
+            mostPlayedGame?: components["schemas"]["GameResponse"];
             /** Format: int64 */
             mostPlayedGameTime: number;
             /** Format: int64 */

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -2011,8 +2011,6 @@
           "updatedAt",
           "name",
           "abbreviation",
-          "maker",
-          "mediaType",
           "releaseYear",
           "unitsSold",
           "summary",
@@ -3193,8 +3191,7 @@
         "required": [
           "totalPlayTime",
           "gamesPlayed",
-          "favoriteCount",
-          "mostPlayedGame"
+          "favoriteCount"
         ],
         "type": "object"
       },
@@ -10246,7 +10243,6 @@
           "gamesPlayed",
           "currentStreak",
           "longestStreak",
-          "mostPlayedGame",
           "mostPlayedGameTime",
           "lastPlayedAt"
         ],


### PR DESCRIPTION
## Summary

Fixes #564 — Android instrumented tests regressed 13/13 after #562 because the generated Kotlin \`ConsoleResponse.maker\` is \`@Required val maker: HardwareMakerResponse\` (non-null), but the server actually sends \`"maker": null\` for the two consoles without a hardware maker (Arcade, DOS Demos). kotlinx.serialization rejected the whole list, \`getConsoles()\` returned \`emptyList()\`, and the app rendered "Your library is empty".

Huma [explicitly disallows](https://github.com/danielgtaylor/huma/blob/v2.37.3/schema.go#L612) \`nullable: true\` on \`$ref\` fields, so we can't declare the truth directly in the spec. The fix instead uses Go's \`omitempty\` so nil pointers emit no key at all — Huma then correctly drops the field from \`required\` in the spec, and the Kotlin generator emits \`val maker: HardwareMakerResponse? = null\`.

Three fields were affected:
- \`ConsoleResponse.Maker\`
- \`ConsoleResponse.MediaType\`
- \`UserStatsResponse.MostPlayedGame\` / \`EntityUserStats.MostPlayedGame\`

## Call-site updates (all null-safe)

- \`ConsoleResponse.toDomain()\` — \`maker?.name\`, \`maker?.code\`, \`mediaType?.name\`
- Three \`mostPlayedGame.takeIf { it.id.isNotEmpty() }?.toDomain()\` sites in \`DtoMappers.kt\` → \`mostPlayedGame?.takeIf { ... }\`
- Two \`applyUrlResolution\` overrides in \`ExploreRepositoryImpl.kt\` — same pattern
- \`Dtos.kt\` drops its unused \`kotlinx.serialization.Serializable\` import

## Test plan

- [x] \`cd server && go build ./... && go test ./internal/api/\` — clean (565s)
- [x] \`./gradlew :shared:compileKotlinDesktop\` — clean
- [x] \`./gradlew :shared:desktopTest --tests '*GameRepositoryImpl*'\` — passes
- [x] \`./gradlew :shared:detektMainDesktop\` — clean
- [x] \`npx tsc --noEmit\` in web — clean
- [ ] Re-run Android instrumented suite on AYN Thor to confirm the Consoles tab now renders all 41 consoles.