### PR TITLE
refactor(api): move SavedSearchRequest / SavedSearchResponse to requests.go / responses.go

### DIFF
--- a/server/internal/api/requests.go
+++ b/server/internal/api/requests.go
@@ -6,6 +6,8 @@ package api
 // by name and gives callers a single place to find request schemas.
 
 import (
+	"encoding/json"
+
 	"github.com/spela/server/internal/db"
 )
 
@@ -339,4 +341,14 @@ type TestIGDBRequest struct {
 type ShowcaseEntryInput struct {
 	AchievementRAID uint `json:"achievementRaId" binding:"required"`
 	RAGameID        uint `json:"raGameId" binding:"required"`
+}
+
+// --- Saved searches ---
+
+// SavedSearchRequest is the request body for creating a saved search.
+// Fields are marked optional in the huma schema so handler-side validation
+// owns the 400 response (the raw gin handler used binding:"required" tags).
+type SavedSearchRequest struct {
+	Name    string          `json:"name,omitempty" required:"false" binding:"required"`
+	Filters json.RawMessage `json:"filters,omitempty" required:"false" binding:"required"`
 }

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -1333,4 +1334,14 @@ type ScraperSourceResultResponse struct {
 	Error            int64  `json:"error"`
 	ErrorEligible    int64  `json:"errorEligible"`
 	NotAttempted     int64  `json:"notAttempted"`
+}
+
+// --- Saved searches ---
+
+// SavedSearchResponse is the API response for a saved search.
+type SavedSearchResponse struct {
+	ID        string          `json:"id"`
+	Name      string          `json:"name"`
+	Filters   json.RawMessage `json:"filters"`
+	CreatedAt time.Time       `json:"createdAt"`
 }

--- a/server/internal/api/saved_search_handler.go
+++ b/server/internal/api/saved_search_handler.go
@@ -1,31 +1,13 @@
 package api
 
 import (
-	"encoding/json"
-	"time"
-
 	"gorm.io/gorm"
 )
 
-// SavedSearchHandler handles saved search CRUD endpoints.
+// SavedSearchHandler handles saved search CRUD endpoints. Request and response
+// types live in requests.go / responses.go.
 type SavedSearchHandler struct {
 	DB *gorm.DB
-}
-
-// SavedSearchRequest is the request body for creating a saved search.
-// Fields are marked optional in the huma schema so handler-side validation
-// owns the 400 response (the raw gin handler used binding:"required" tags).
-type SavedSearchRequest struct {
-	Name    string          `json:"name,omitempty" required:"false" binding:"required"`
-	Filters json.RawMessage `json:"filters,omitempty" required:"false" binding:"required"`
-}
-
-// SavedSearchResponse is the API response for a saved search.
-type SavedSearchResponse struct {
-	ID        string          `json:"id"`
-	Name      string          `json:"name"`
-	Filters   json.RawMessage `json:"filters"`
-	CreatedAt time.Time       `json:"createdAt"`
 }
 
 // maxSavedSearchesPerUser is the maximum number of saved searches a user can have.


### PR DESCRIPTION
Closes #448.

Types were previously defined in \`saved_search_handler.go\` alongside the handler struct. #448 asked for centralization so OpenAPI generators — and anyone reading the codebase — find every request/response type in the same two files.

\`auth\` / \`user\` / \`refresh\` / \`change-password\` equivalents were already migrated to huma-adjacent files (\`huma_auth_handlers.go\`, \`huma_user_mutations.go\`) with exported PascalCase names during the huma migration, so they don't need further relocation — leaving them co-located with their handlers matches the convention the rest of \`huma_*.go\` uses. \`SavedSearch\` was the last hand-written handler that kept its types locally; moving them in line.

\`saved_search_handler.go\` now only holds \`SavedSearchHandler\` + the \`maxSavedSearchesPerUser\` constant.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./internal/api/ -run SavedSearch\` — passes