### PR TITLE
fix(api): UpdateGameMetadataRequest can clear fields via explicit zero values

### DIFF
--- a/server/internal/api/game_handler_test.go
+++ b/server/internal/api/game_handler_test.go
@@ -101,6 +101,72 @@ func TestUpdateMetadata_PartyInfo(t *testing.T) {
 	assert.Equal(t, "Assembly 1993, 1st place", getResp["partyInfo"])
 }
 
+// TestUpdateMetadata_CanClearFields verifies that sending explicit empty /
+// zero values clears fields via the admin game metadata endpoint. Prior to
+// issue #450 the handler used non-empty semantics (`if req.Title != ""`) so
+// admins couldn't clear a field once set — sending {"title": ""} was a no-op
+// rather than a clear. Pointer-based request fields now distinguish "absent"
+// (leave alone) from "present and zero" (clear).
+func TestUpdateMetadata_CanClearFields(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	// Seed a game with non-empty metadata.
+	var console db.Console
+	require.NoError(t, database.Where("abbreviation = ?", "ADEMO").First(&console).Error)
+	game := db.Game{
+		ConsoleID:         console.ID,
+		Title:             "Original Title",
+		Description:       "Seed description",
+		Developer:         "Seed Dev",
+		Publisher:         "Seed Pub",
+		Genre:             "Action",
+		Players:           4,
+		IGDBCriticsRating: 82.5,
+		PartyInfo:         "Assembly 1993",
+		FileName:          "seed.adf",
+		FilePath:          "/tmp/seed.adf",
+		FileSize:          100,
+	}
+	require.NoError(t, database.Create(&game).Error)
+	gameID := fmt.Sprintf("%d", game.ID)
+
+	// Clear a subset via explicit zero values.
+	body, _ := json.Marshal(map[string]interface{}{
+		"description":       "",
+		"publisher":         "",
+		"genre":             "",
+		"players":           0,
+		"igdbCriticsRating": 0.0,
+		"partyInfo":         "",
+		// title / developer / coverUrl intentionally omitted — those must
+		// remain at their seeded values.
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/admin/games/"+gameID+"/metadata", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var updated db.Game
+	require.NoError(t, database.First(&updated, game.ID).Error)
+
+	// Cleared fields — all present-but-zero in the request.
+	assert.Empty(t, updated.Description, "description should be cleared by explicit empty")
+	assert.Empty(t, updated.Publisher, "publisher should be cleared")
+	assert.Empty(t, updated.Genre, "genre should be cleared")
+	assert.Zero(t, updated.Players, "players should be cleared to 0")
+	assert.Zero(t, updated.IGDBCriticsRating, "rating should be cleared to 0")
+	assert.Empty(t, updated.PartyInfo, "partyInfo should be cleared")
+
+	// Untouched fields — absent from the request.
+	assert.Equal(t, "Original Title", updated.Title, "omitted title must not be cleared")
+	assert.Equal(t, "Seed Dev", updated.Developer, "omitted developer must not be cleared")
+}
+
 // TestUpdatePlayTime_CreatesPlayHistory verifies that UpdatePlayTime creates
 // a PlayHistory record when the user starts playing a game for the first time.
 // This is a regression guard: PlayHistory should only be created by play-time

--- a/server/internal/api/huma_admin_games.go
+++ b/server/internal/api/huma_admin_games.go
@@ -408,41 +408,41 @@ func (h *GameHandler) HumaUpdateMetadata(ctx context.Context, in *UpdateGameMeta
 	}
 
 	req := in.Body
-	if req.Title != "" {
-		game.Title = req.Title
+	if req.Title != nil {
+		game.Title = *req.Title
 	}
-	if req.Description != "" {
-		game.Description = req.Description
+	if req.Description != nil {
+		game.Description = *req.Description
 	}
-	if req.CoverURL != "" {
-		game.CoverURL = req.CoverURL
+	if req.CoverURL != nil {
+		game.CoverURL = *req.CoverURL
 	}
-	if req.ScreenshotURL != "" {
-		game.ScreenshotURL = req.ScreenshotURL
+	if req.ScreenshotURL != nil {
+		game.ScreenshotURL = *req.ScreenshotURL
 	}
-	if req.Developer != "" {
-		game.Developer = req.Developer
+	if req.Developer != nil {
+		game.Developer = *req.Developer
 	}
-	if req.Publisher != "" {
-		game.Publisher = req.Publisher
+	if req.Publisher != nil {
+		game.Publisher = *req.Publisher
 	}
-	if req.ReleaseDate != "" {
-		game.ReleaseDate = req.ReleaseDate
+	if req.ReleaseDate != nil {
+		game.ReleaseDate = *req.ReleaseDate
 	}
-	if req.Genre != "" {
-		game.Genre = req.Genre
+	if req.Genre != nil {
+		game.Genre = *req.Genre
 	}
-	if req.Players > 0 {
-		game.Players = req.Players
+	if req.Players != nil {
+		game.Players = *req.Players
 	}
-	if req.IGDBCriticsRating > 0 {
-		game.IGDBCriticsRating = req.IGDBCriticsRating
+	if req.IGDBCriticsRating != nil {
+		game.IGDBCriticsRating = *req.IGDBCriticsRating
 	}
-	if req.CoreOverride != "" {
-		game.CoreOverride = req.CoreOverride
+	if req.CoreOverride != nil {
+		game.CoreOverride = *req.CoreOverride
 	}
-	if req.PartyInfo != "" {
-		game.PartyInfo = req.PartyInfo
+	if req.PartyInfo != nil {
+		game.PartyInfo = *req.PartyInfo
 	}
 
 	if err := h.DB.Save(&game).Error; err != nil {

--- a/server/internal/api/requests.go
+++ b/server/internal/api/requests.go
@@ -68,21 +68,23 @@ type AdminUpdateUserRequest struct {
 // --- Games (admin metadata + play time) ---
 
 // UpdateGameMetadataRequest is the body for PUT /api/admin/games/:id/metadata.
-// All fields are optional in the huma schema so partial updates succeed with
+// Every field is a pointer so admin UIs can clear a value (send null or
+// explicit empty string / zero) vs. leave it untouched (omit the key). Fields
+// are declared optional in the huma schema so partial updates succeed with
 // the historical 200 rather than huma's 422 "missing fields" validation.
 type UpdateGameMetadataRequest struct {
-	Title             string  `json:"title,omitempty"`
-	Description       string  `json:"description,omitempty"`
-	CoverURL          string  `json:"coverUrl,omitempty"`
-	ScreenshotURL     string  `json:"screenshotUrl,omitempty"`
-	Developer         string  `json:"developer,omitempty"`
-	Publisher         string  `json:"publisher,omitempty"`
-	ReleaseDate       string  `json:"releaseDate,omitempty"`
-	Genre             string  `json:"genre,omitempty"`
-	Players           int     `json:"players,omitempty"`
-	IGDBCriticsRating float64 `json:"igdbCriticsRating,omitempty"`
-	CoreOverride      string  `json:"coreOverride,omitempty"`
-	PartyInfo         string  `json:"partyInfo,omitempty"`
+	Title             *string  `json:"title,omitempty"`
+	Description       *string  `json:"description,omitempty"`
+	CoverURL          *string  `json:"coverUrl,omitempty"`
+	ScreenshotURL     *string  `json:"screenshotUrl,omitempty"`
+	Developer         *string  `json:"developer,omitempty"`
+	Publisher         *string  `json:"publisher,omitempty"`
+	ReleaseDate       *string  `json:"releaseDate,omitempty"`
+	Genre             *string  `json:"genre,omitempty"`
+	Players           *int     `json:"players,omitempty"`
+	IGDBCriticsRating *float64 `json:"igdbCriticsRating,omitempty"`
+	CoreOverride      *string  `json:"coreOverride,omitempty"`
+	PartyInfo         *string  `json:"partyInfo,omitempty"`
 }
 
 // UpdateGamePlayTimeRequest is the body for POST /api/games/:id/play-time.


### PR DESCRIPTION
Closes #450.

The admin metadata update handler previously used non-empty semantics:

\`\`\`go
if req.Title != \"\" { game.Title = req.Title }
\`\`\`

so an admin could not clear a field via the API — sending \`{\"title\": \"\"}\` was a silent no-op. Other partial-update handlers (\`UpdateSessionRequest\`, \`UpdateCollectionRequest\`) already use pointer semantics to distinguish "absent" from "present and zero".

Convert every field on \`UpdateGameMetadataRequest\` to its pointer form (\`*string\` / \`*int\` / \`*float64\`) and dereference only when non-nil. A client that omits a key still gets "leave alone"; a client that sends \`{\"title\": \"\"}\` now clears the title as expected.

## Compatibility

- Wire format unchanged on read paths — this only affects write requests.
- Huma emits \`*string\` with \`omitempty\` to the same OpenAPI schema as \`string\` with \`omitempty\` (optional, type string), so no TypeScript or Kotlin client regen is required. The sole web caller (\`useUpdateGameMetadata\`) is unused in the app today, so there's nothing to break.
- Existing callers that never relied on \`""\` as a clear signal continue working.

Added \`TestUpdateMetadata_CanClearFields\` as a regression guard.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./internal/api/ -run '^TestUpdateMetadata'\` — passes (existing \`TestUpdateMetadata_PartyInfo\` + new \`TestUpdateMetadata_CanClearFields\`)
- [x] \`npx tsc --noEmit\` in web — clean