### PR TITLE
chore(web): migrate useSetupDiagnostics to typedApi

### DIFF
--- a/web/src/hooks/use-setup-diagnostics.ts
+++ b/web/src/hooks/use-setup-diagnostics.ts
@@ -1,24 +1,16 @@
 import { useQuery } from "@tanstack/react-query";
 
-export interface DiagnosticCheck {
-  id: string;
-  label: string;
-  status: "ok" | "warning" | "error";
-  detail?: string;
-  fix?: string;
-}
+import { typedApi, unwrap } from "@/lib/api-client";
+import type { components } from "@/generated/api";
 
-interface DiagnosticsResponse {
-  checks: DiagnosticCheck[];
-}
+export type DiagnosticCheck = components["schemas"]["DiagnosticCheck"];
 
 export function useSetupDiagnostics(enabled = true) {
   return useQuery({
     queryKey: ["setup", "diagnostics"],
-    queryFn: async (): Promise<DiagnosticsResponse> => {
-      const res = await fetch("/api/setup/diagnostics");
-      if (!res.ok) throw new Error("Failed to fetch diagnostics");
-      return res.json();
+    queryFn: async () => {
+      const data = await unwrap(typedApi.GET("/api/setup/diagnostics"));
+      return { checks: data?.checks ?? [] };
     },
     enabled,
   });


### PR DESCRIPTION
Tiny migration for the #518 tracker. Replaces the raw \`fetch()\` + hand-rolled \`DiagnosticCheck\` interface with \`typedApi.GET(\"/api/setup/diagnostics\")\` and the generated \`components[\"schemas\"][\"DiagnosticCheck\"]\` type. Consumer shape (\`data?.checks\`) is preserved via a \`?? []\` fallback for the nullable generated array.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 1466 tests pass