### PR TITLE
chore(web): replace 12 hand-written types in api.ts with generated schema aliases

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -44,11 +44,7 @@ export interface User {
   updatedAt: string;
 }
 
-export interface RateLimitStatus {
-  failedCount: number;
-  lockedUntil: string | null;
-  isLockedOut: boolean;
-}
+export type RateLimitStatus = Schemas["RateLimitResponse"];
 
 // System event audit log (admin-only). Mirrors the SystemEvent model on
 // the server. The metadata blob is per-event-type and may include things like
@@ -116,15 +112,7 @@ export interface SystemEventTypeInfo {
   category: SystemEventCategoryCode;
 }
 
-export interface DeletedUser {
-  id: string;
-  username: string;
-  email: string;
-  role: "owner" | "admin" | "user";
-  disabled: boolean;
-  createdAt: string;
-  deletedAt: string;
-}
+export type DeletedUser = Schemas["DeletedUserResponse"];
 
 export interface AuthTokens {
   accessToken: string;
@@ -132,21 +120,11 @@ export interface AuthTokens {
   user: User;
 }
 
-export interface HardwareMaker {
-  code: string;
-  name: string;
-}
+export type HardwareMaker = Schemas["HardwareMakerResponse"];
 
-export interface MediaTypeCategory {
-  code: string;
-  name: string;
-}
+export type MediaTypeCategory = Schemas["MediaTypeCategoryResponse"];
 
-export interface MediaType {
-  code: string;
-  name: string;
-  category: MediaTypeCategory;
-}
+export type MediaType = Schemas["MediaTypeResponse"];
 
 // ConsoleResponse from backend responses.go DTO layer
 export interface Console {
@@ -175,11 +153,7 @@ export interface Console {
   updatedAt: string;
 }
 
-export interface GameDisc {
-  discNumber: number;
-  fileName: string;
-  fileSize: number;
-}
+export type GameDisc = Schemas["DiscResponse"];
 
 // GameVariant from backend — represents a variant in the game detail response
 export interface GameVariant {
@@ -257,26 +231,13 @@ export interface Game {
   updatedAt: string;
 }
 
-export interface ReleaseDateInfo {
-  region: string;
-  date: string;
-  platform?: string;
-}
+export type ReleaseDateInfo = Schemas["ReleaseDateResponse"];
 
-export interface VideoInfo {
-  videoId: string;
-  name?: string;
-}
+export type VideoInfo = Schemas["VideoResponse"];
 
-export interface LanguageSupportInfo {
-  language: string;
-  supportType: string;
-}
+export type LanguageSupportInfo = Schemas["LanguageSupportResponse"];
 
-export interface AgeRatingInfo {
-  category: string;
-  rating: string;
-}
+export type AgeRatingInfo = Schemas["AgeRatingResponse"];
 
 // Backend stores settings as flat key-value pairs
 export type ServerSettingsMap = Record<string, string>;
@@ -343,17 +304,7 @@ export interface IgdbSearchResult {
   summary?: string;
 }
 
-export interface Device {
-  id: number;
-  userId: number;
-  deviceUuid: string;
-  name: string;
-  platform: string;
-  lastSeenAt: string;
-  createdAt: string;
-  updatedAt: string;
-  consoleShaders: Record<string, string>;
-}
+export type Device = Schemas["DeviceResponse"];
 
 export interface ConsoleKeyMapping {
   selectedMapping: string;
@@ -391,15 +342,7 @@ export interface RASettingsRequest {
   hardcoreEnabled: boolean;
 }
 
-export interface Achievement {
-  id: number;
-  title: string;
-  description: string;
-  points: number;
-  badgeUrl: string;
-  type: string;
-  rarityPercent: number;
-}
+export type Achievement = Schemas["Achievement"];
 
 export interface GameAchievements {
   status?: "pending";


### PR DESCRIPTION
Part of #489.

First batch of api.ts pruning: 12 hand-written types whose shapes match their generated counterparts exactly (or where the generated adds only a \`readonly \$schema?: string\` metadata field). Replace each \`export interface X { ... }\` with \`export type X = Schemas[\"YResponse\"]\` so the name consumers already import stays stable while pointing at the spec-derived source of truth.

| Hand-written | Generated |
|---|---|
| \`RateLimitStatus\` | \`Schemas[\"RateLimitResponse\"]\` |
| \`DeletedUser\` | \`Schemas[\"DeletedUserResponse\"]\` |
| \`HardwareMaker\` | \`Schemas[\"HardwareMakerResponse\"]\` |
| \`MediaTypeCategory\` | \`Schemas[\"MediaTypeCategoryResponse\"]\` |
| \`MediaType\` | \`Schemas[\"MediaTypeResponse\"]\` |
| \`GameDisc\` | \`Schemas[\"DiscResponse\"]\` |
| \`ReleaseDateInfo\` | \`Schemas[\"ReleaseDateResponse\"]\` |
| \`VideoInfo\` | \`Schemas[\"VideoResponse\"]\` |
| \`LanguageSupportInfo\` | \`Schemas[\"LanguageSupportResponse\"]\` |
| \`AgeRatingInfo\` | \`Schemas[\"AgeRatingResponse\"]\` |
| \`Achievement\` | \`Schemas[\"Achievement\"]\` |
| \`Device\` | \`Schemas[\"DeviceResponse\"]\` |

57 lines removed from api.ts. No consumer changes needed — the names persist and the generated types are structural supersets (the \`readonly \$schema?: string\` is optional, so existing call sites keep compiling).

Remaining ~18 shallow-diff types (User, Game, Console, Challenge, NetplaySession, etc.) need per-consumer review before we can alias them — e.g. \`User.role\` is a literal union locally and \`string\` on the server; consumers may use that for \`switch\` exhaustiveness. Those land in follow-up PRs.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 1466 tests pass