### PR TITLE
chore(web): alias 5 more api.ts types to generated schemas

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -295,21 +295,11 @@ export interface MetadataMatchesResponse {
   incomplete: Game[];
 }
 
-export interface IgdbSearchResult {
-  igdbId: number;
-  name: string;
-  coverUrl?: string;
-  releaseYear?: number;
-  developer?: string;
-  summary?: string;
-}
+export type IgdbSearchResult = Schemas["IGDBSearchResult"];
 
 export type Device = Schemas["DeviceResponse"];
 
-export interface ConsoleKeyMapping {
-  selectedMapping: string;
-  customMapping?: Record<string, string>;
-}
+export type ConsoleKeyMapping = Schemas["ConsoleKeyMappingDTO"];
 
 export interface UserPreferences {
   showPerformanceOverlay: boolean;
@@ -900,13 +890,7 @@ export interface CompleteAttemptResponse {
 
 // --- Replace ROM ---
 
-export interface ReplaceROMResult {
-  verified: boolean;
-  crc32: string;
-  canonicalName?: string;
-  previousStatus: string;
-  previousCrc32: string;
-}
+export type ReplaceROMResult = Schemas["ReplaceROMResult"];
 
 export interface ReplaceROMResponse {
   game: Game;
@@ -923,10 +907,7 @@ export type StagedUploadStatus =
   | "accepted"
   | "rejected";
 
-export interface PossibleConsole {
-  id: string;
-  name: string;
-}
+export type PossibleConsole = Schemas["PossibleConsoleResponse"];
 
 // --- Themes & Keywords ---
 
@@ -947,12 +928,7 @@ export interface FeaturedSeries {
   heroUrl: string;
 }
 
-export interface SeriesConsole {
-  abbreviation: string;
-  name: string;
-  color: string;
-  gameCount: number;
-}
+export type SeriesConsole = Schemas["SeriesConsoleInfo"];
 
 export interface SeriesGame {
   igdbGameId: number;


### PR DESCRIPTION
Second batch of #489 pruning. These hand-written types all match their generated counterparts **exactly** — replacing each \`export interface X { ... }\` with a \`Schemas[\"Y\"]\` alias so the name consumers already import stays stable.

| Hand-written | Generated |
|---|---|
| \`IgdbSearchResult\` | \`Schemas[\"IGDBSearchResult\"]\` |
| \`PossibleConsole\` | \`Schemas[\"PossibleConsoleResponse\"]\` |
| \`ConsoleKeyMapping\` | \`Schemas[\"ConsoleKeyMappingDTO\"]\` |
| \`SeriesConsole\` | \`Schemas[\"SeriesConsoleInfo\"]\` |
| \`ReplaceROMResult\` | \`Schemas[\"ReplaceROMResult\"]\` |

No \`\$schema?\` superset in this batch — the shape is byte-identical. No consumer changes required.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 1466 tests pass