### PR TITLE
chore(web): alias 3 more api.ts types (GameStatsPlayer, StorageConsoleBreakdown, UserSearchResult)

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -374,12 +374,7 @@ export interface UnlockedAchievement {
   consoleName: string;
 }
 
-export interface GameStatsPlayer {
-  userId: string;
-  username: string;
-  avatarUrl?: string;
-  playTime: number;
-}
+export type GameStatsPlayer = Schemas["GameStatsTopPlayer"];
 
 export interface MostPlayedGame {
   game: Game;
@@ -448,11 +443,7 @@ export interface RecentAchievement {
   coverUrl: string;
 }
 
-export interface UserSearchResult {
-  id: string;
-  username: string;
-  avatarUrl?: string;
-}
+export type UserSearchResult = Schemas["UserSearchResult"];
 
 export interface UserSearchResponse {
   data: UserSearchResult[];
@@ -1378,10 +1369,5 @@ export interface CompletionistMapResponse {
   overallPct: number;
 }
 
-export interface StorageConsoleBreakdown {
-  consoleId: string;
-  consoleName: string;
-  bytes: number;
-  saveCount: number;
-}
+export type StorageConsoleBreakdown = Schemas["SessionStorageConsoleBreakdown"];
 


### PR DESCRIPTION
Sixth batch of #489 pruning.

| Hand-written | Generated |
|---|---|
| \`GameStatsPlayer\` | \`Schemas[\"GameStatsTopPlayer\"]\` |
| \`StorageConsoleBreakdown\` | \`Schemas[\"SessionStorageConsoleBreakdown\"]\` |
| \`UserSearchResult\` | \`Schemas[\"UserSearchResult\"]\` |

\`GameStatsPlayer\` narrows \`avatarUrl\` from optional (hand-written) to required (generated). The server always sends a string (possibly empty) for this field — aliasing matches wire reality rather than the laxer type the codebase carried. No consumer changes required.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 1466 tests pass