### PR TITLE
chore(web): alias 3 more api.ts types (RecentAchievement, PublicProfileGame, ChallengeLeaderboardEntry)

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -428,20 +428,7 @@ export interface AchievementTimeline {
   earnedPoints: number;
 }
 
-export interface RecentAchievement {
-  achievementRaId: number;
-  title: string;
-  description: string;
-  points: number;
-  badgeUrl: string;
-  unlockedAt: string;
-  isHardcore: boolean;
-  playTimeAtUnlock: number;
-  gameId: string;
-  gameTitle: string;
-  consoleName: string;
-  coverUrl: string;
-}
+export type RecentAchievement = Schemas["RARecentAchievementResponse"];
 
 export type UserSearchResult = Schemas["UserSearchResult"];
 
@@ -469,13 +456,7 @@ export type SharedSave = Schemas["SharedSaveResponse"];
 
 export type Collection = Schemas["CollectionResponse"];
 
-export interface PublicProfileGame {
-  id: string;
-  title: string;
-  coverUrl?: string;
-  consoleName: string;
-  playTime?: number;
-}
+export type PublicProfileGame = Schemas["PublicProfileGame"];
 
 export interface SharedSession {
   id: string;
@@ -792,14 +773,7 @@ export interface ChallengeAttempt {
   isBest: boolean;
 }
 
-export interface ChallengeLeaderboardEntry {
-  rank: number;
-  userId: string;
-  username: string;
-  avatarUrl?: string;
-  durationMs: number;
-  completedAt: string;
-}
+export type ChallengeLeaderboardEntry = Schemas["ChallengeLeaderboardEntry"];
 
 export interface ChallengeLeaderboardResponse {
   data: ChallengeLeaderboardEntry[];


### PR DESCRIPTION
Seventh batch of #489 pruning.

| Hand-written | Generated |
|---|---|
| \`RecentAchievement\` | \`Schemas[\"RARecentAchievementResponse\"]\` |
| \`PublicProfileGame\` | \`Schemas[\"PublicProfileGame\"]\` |
| \`ChallengeLeaderboardEntry\` | \`Schemas[\"ChallengeLeaderboardEntry\"]\` |

\`RecentAchievement\` + \`PublicProfileGame\` are exact-shape matches. \`ChallengeLeaderboardEntry\` aliasing adds \`attemptId\` (required) that the server already sends but the hand-written type was missing — the single consumer (\`useChallengeLeaderboardRealtime\` WebSocket payload) only reads \`challengeId\`, so there's no field-access breakage.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 1466 tests pass