### PR TITLE
chore(web): alias 2 more api.ts types (AchievementTimelineEntry, WizardOption)

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -406,16 +406,7 @@ export interface AchievementLeaderboard {
   }[];
 }
 
-export interface AchievementTimelineEntry {
-  achievementRaId: number;
-  title: string;
-  description: string;
-  points: number;
-  badgeUrl: string;
-  unlockedAt: string;
-  isHardcore: boolean;
-  playTimeAtUnlock: number;
-}
+export type AchievementTimelineEntry = Schemas["RATimelineEntryResponse"];
 
 export interface AchievementTimeline {
   raGameId: number;
@@ -1286,12 +1277,7 @@ export interface ActiveChallengesResponse {
 
 // --- Phase 14: Wild Features — Wizard, Badges, Completionist Map ---
 
-export interface WizardOption {
-  id: string;
-  label: string;
-  description?: string;
-  imageUrl?: string;
-}
+export type WizardOption = Schemas["WizardOption"];
 
 export interface WizardStep {
   step: number;


### PR DESCRIPTION
Ninth batch of #489 pruning.

| Hand-written | Generated |
|---|---|
| \`AchievementTimelineEntry\` | \`Schemas[\"RATimelineEntryResponse\"]\` |
| \`WizardOption\` | \`Schemas[\"WizardOption\"]\` |

Exact-shape matches. No consumer changes required.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 1466 tests pass