### PR TITLE
chore(web): alias ShowcaseAchievement to generated ShowcaseEntryResponse

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -345,17 +345,7 @@ export interface GameAchievementProgressResponse {
   progress: GameAchievementProgress[];
 }
 
-export interface ShowcaseAchievement {
-  achievementRaId: number;
-  raGameId: number;
-  showcaseOrder: number;
-  title?: string;
-  description?: string;
-  points?: number;
-  badgeUrl?: string;
-  rarityPercent?: number;
-  gameTitle?: string;
-}
+export type ShowcaseAchievement = Schemas["ShowcaseEntryResponse"];
 
 export type UnlockedAchievement = Schemas["RAUnlockedAchievementResponse"];
 


### PR DESCRIPTION
Twelfth batch of #489 pruning.

| Hand-written | Generated |
|---|---|
| \`ShowcaseAchievement\` | \`Schemas[\"ShowcaseEntryResponse\"]\` |

Exact-shape match. No consumer changes required.

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 1466 tests pass