### PR TITLE
chore(web): alias CoreCompatibilityEntry to generated

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -612,13 +612,7 @@ export interface SessionSave {
   createdAt: string;
 }
 
-export interface CoreCompatibilityEntry {
-  consoleId: string;
-  consoleName: string;
-  nativeCore: string;
-  webCore: string;
-  matched: boolean;
-}
+export type CoreCompatibilityEntry = Schemas["CoreCompatibilityEntry"];
 
 export interface CoreCompatibilityResponse {
   consoles: CoreCompatibilityEntry[];


### PR DESCRIPTION
Thirteenth batch of #489 pruning.

| Hand-written | Generated |
|---|---|
| \`CoreCompatibilityEntry\` | \`Schemas[\"CoreCompatibilityEntry\"]\` |

Exact-shape match. No consumer changes required.

This is the last of the straight exact-shape drop-ins — see the [progress comment on #489](https://github.com/mattias800/spela/issues/489#issuecomment-4279078729) for what remains (mostly blocked on a \`Game\` type migration, or needs per-consumer null guards for nullable arrays).

## Test plan

- [x] \`npx tsc --noEmit\` — clean
- [x] \`npx vitest run\` — 1466 tests pass