### PR TITLE
chore(web): alias 4 more api.ts types (TimelineGame, TimelineEntry, RelatedDeveloper, RelatedPublisher)

### DIFF
--- a/web/src/features/explore/components/__tests__/release-timeline.test.tsx
+++ b/web/src/features/explore/components/__tests__/release-timeline.test.tsx
@@ -8,20 +8,20 @@ const mockTimeline: TimelineEntry[] = [
   {
     year: 1992,
     games: [
-      { id: "g1", title: "Mega Man X", coverUrl: "/covers/mmx.jpg", rating: 95 },
-      { id: "g2", title: "Street Fighter II", coverUrl: "/covers/sf2.jpg", rating: 90 },
+      { id: "g1", title: "Mega Man X", coverUrl: "/covers/mmx.jpg", igdbCriticsRating: 95 },
+      { id: "g2", title: "Street Fighter II", coverUrl: "/covers/sf2.jpg", igdbCriticsRating: 90 },
     ],
   },
   {
     year: 1990,
     games: [
-      { id: "g3", title: "Final Fight", coverUrl: "/covers/ff.jpg", rating: 80 },
+      { id: "g3", title: "Final Fight", coverUrl: "/covers/ff.jpg", igdbCriticsRating: 80 },
     ],
   },
   {
     year: 1995,
     games: [
-      { id: "g4", title: "Mega Man X3", coverUrl: "/covers/mmx3.jpg", rating: 0 },
+      { id: "g4", title: "Mega Man X3", coverUrl: "/covers/mmx3.jpg", igdbCriticsRating: 0 },
     ],
   },
 ];

--- a/web/src/features/explore/components/release-timeline.tsx
+++ b/web/src/features/explore/components/release-timeline.tsx
@@ -35,7 +35,7 @@ function TimelineYearColumn({ entry }: { entry: TimelineEntry }) {
     <div className="flex-shrink-0 min-w-[100px]" data-testid={`timeline-year-${entry.year}`}>
       <p className="text-sm font-bold text-surface-200 mb-2">{entry.year}</p>
       <div className="flex flex-wrap gap-1.5" style={{ maxWidth: "120px" }}>
-        {entry.games.map((game) => (
+        {entry.games?.map((game) => (
           <TimelineCover key={game.id} game={game} />
         ))}
       </div>
@@ -46,7 +46,7 @@ function TimelineYearColumn({ entry }: { entry: TimelineEntry }) {
 function TimelineCover({
   game,
 }: {
-  game: TimelineEntry["games"][number];
+  game: NonNullable<TimelineEntry["games"]>[number];
 }) {
   const [showTooltip, setShowTooltip] = useState(false);
 
@@ -71,8 +71,8 @@ function TimelineCover({
           data-testid={`timeline-tooltip-${game.id}`}
         >
           <p className="text-xs font-medium text-surface-100">{game.title}</p>
-          {game.rating > 0 && (
-            <p className="text-xs text-amber-400">{game.rating.toFixed(1)}</p>
+          {game.igdbCriticsRating > 0 && (
+            <p className="text-xs text-amber-400">{game.igdbCriticsRating.toFixed(1)}</p>
           )}
         </div>
       )}

--- a/web/src/pages/developer-detail-page.tsx
+++ b/web/src/pages/developer-detail-page.tsx
@@ -358,7 +358,7 @@ export function DeveloperDetailPage() {
                 <span className="text-xs text-surface-400">
                   {rel.gameCount} {rel.gameCount === 1 ? "game" : "games"}
                 </span>
-                {rel.sharedPublishers.length > 0 && (
+                {rel.sharedPublishers && rel.sharedPublishers.length > 0 && (
                   <span className="text-xs text-surface-500">
                     via {rel.sharedPublishers.join(", ")}
                   </span>

--- a/web/src/pages/publisher-detail-page.tsx
+++ b/web/src/pages/publisher-detail-page.tsx
@@ -358,7 +358,7 @@ export function PublisherDetailPage() {
                 <span className="text-xs text-surface-400">
                   {rel.gameCount} {rel.gameCount === 1 ? "game" : "games"}
                 </span>
-                {rel.sharedDevelopers.length > 0 && (
+                {rel.sharedDevelopers && rel.sharedDevelopers.length > 0 && (
                   <span className="text-xs text-surface-500">
                     via {rel.sharedDevelopers.join(", ")}
                   </span>

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -987,29 +987,10 @@ export type ActiveYears = Schemas["ActiveYears"];
 
 export type RatingDistribution = Schemas["RatingDistribution"];
 
-export interface TimelineGame {
-  id: string;
-  title: string;
-  coverUrl: string;
-  rating: number;
-}
-
-export interface TimelineEntry {
-  year: number;
-  games: TimelineGame[];
-}
-
-export interface RelatedDeveloper {
-  name: string;
-  gameCount: number;
-  sharedPublishers: string[];
-}
-
-export interface RelatedPublisher {
-  name: string;
-  gameCount: number;
-  sharedDevelopers: string[];
-}
+export type TimelineGame = Schemas["TimelineGame"];
+export type TimelineEntry = Schemas["TimelineEntry"];
+export type RelatedDeveloper = Schemas["RelatedDeveloper"];
+export type RelatedPublisher = Schemas["RelatedPublisher"];
 
 export interface DeveloperDetailResponse {
   name: string;


### PR DESCRIPTION
Part of #489 — Category A drop-ins plus two small consumer fixes.

## Types aliased
- \`TimelineGame\` → \`Schemas[\"TimelineGame\"]\`
- \`TimelineEntry\` → \`Schemas[\"TimelineEntry\"]\`
- \`RelatedDeveloper\` → \`Schemas[\"RelatedDeveloper\"]\`
- \`RelatedPublisher\` → \`Schemas[\"RelatedPublisher\"]\`

## Consumer fixes
- \`release-timeline.tsx\`: hand-written \`TimelineGame.rating\` never existed on the wire — the server returns \`igdbCriticsRating\`. That means the rating badge in the hover tooltip was always hidden (\`undefined > 0\` is false). Rename the reads (and mock data in the test file) to match the actual schema — now the badge renders as originally intended.
- \`developer-detail-page.tsx\` / \`publisher-detail-page.tsx\`: generated \`sharedPublishers\` / \`sharedDevelopers\` are \`string[] | null\`; add a null guard before \`.length\` / \`.join\`.

## Tests
- \`npx tsc --noEmit\` clean
- \`npx vitest run\` — 1466/1466 pass