### PR TITLE
chore(web): alias 4 more api.ts types (DeveloperSummary, DeveloperListResponse, PlatformCount, NameCount)

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -952,27 +952,10 @@ export interface PlayersLikeYouResponse {
 
 // --- Developers & Publishers ---
 
-export interface DeveloperSummary {
-  name: string;
-  gameCount: number;
-  avgRating: number;
-  consoles: string[];
-}
-
-export interface DeveloperListResponse {
-  developers: DeveloperSummary[];
-}
-
-export interface PlatformCount {
-  consoleName: string;
-  consoleId: string;
-  count: number;
-}
-
-export interface NameCount {
-  name: string;
-  count: number;
-}
+export type DeveloperSummary = Schemas["DeveloperSummary"];
+export type DeveloperListResponse = Schemas["DeveloperListResponse"];
+export type PlatformCount = Schemas["PlatformCount"];
+export type NameCount = Schemas["NameCount"];
 
 export interface EntityUserStats {
   totalPlayTime: number;


### PR DESCRIPTION
Part of #489 — four more Category A drop-ins.

## Types aliased
- \`DeveloperSummary\` → \`Schemas[\"DeveloperSummary\"]\` (widens \`consoles: string[]\` to \`string[] | null\`)
- \`DeveloperListResponse\` → \`Schemas[\"DeveloperListResponse\"]\` (widens \`developers\` to nullable)
- \`PlatformCount\` → \`Schemas[\"PlatformCount\"]\` (exact shape)
- \`NameCount\` → \`Schemas[\"NameCount\"]\` (exact shape)

## No consumer changes required
- \`DeveloperSummary\`: the only consumer (\`console-showcase-sections.tsx\`) reads \`name\`, \`gameCount\`, \`avgRating\` — never \`.consoles\`, so widening is invisible.
- \`DeveloperListResponse\`: the only wrapper (\`useDevelopers\` in \`use-explore.ts\`) is currently unused.
- \`PlatformCount\` / \`NameCount\`: shapes match exactly.

## Tests
- \`npx tsc --noEmit\` clean
- \`npx vitest run\` — 1466/1466 pass