### PR TITLE
chore(web): alias FeaturedGame to generated FeaturedGameResponse

### DIFF
--- a/web/src/features/explore/components/__tests__/explore-page.test.tsx
+++ b/web/src/features/explore/components/__tests__/explore-page.test.tsx
@@ -93,6 +93,8 @@ function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
     title: "Featured Game",
     heroUrl: "/hero/test.jpg",
     logoUrl: "/logo/test.png",
+    consoleId: "2",
+    consoleName: "Super Nintendo",
     consoleAbbreviation: "snes",
     consoleColor: "#805ad5",
     igdbCriticsRating: 92.5,

--- a/web/src/features/explore/components/__tests__/hero-carousel.test.tsx
+++ b/web/src/features/explore/components/__tests__/hero-carousel.test.tsx
@@ -11,6 +11,8 @@ function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
     title: "Test Game",
     heroUrl: "/hero/test.jpg",
     logoUrl: "/logo/test.png",
+    consoleId: "2",
+    consoleName: "Super Nintendo",
     consoleAbbreviation: "snes",
     consoleColor: "#805ad5",
     igdbCriticsRating: 92.5,
@@ -23,7 +25,7 @@ function makeFeaturedGame(overrides: Partial<FeaturedGame> = {}): FeaturedGame {
 
 const mockGames: FeaturedGame[] = [
   makeFeaturedGame({ gameId: "1", title: "Game One" }),
-  makeFeaturedGame({ gameId: "2", title: "Game Two", logoUrl: null }),
+  makeFeaturedGame({ gameId: "2", title: "Game Two", logoUrl: "" }),
   makeFeaturedGame({ gameId: "3", title: "Game Three" }),
 ];
 
@@ -100,7 +102,7 @@ describe("HeroCarousel", () => {
 
   it("falls back to text title when logoUrl is null", () => {
     renderCarousel({
-      games: [makeFeaturedGame({ gameId: "2", title: "No Logo Game", logoUrl: null })],
+      games: [makeFeaturedGame({ gameId: "2", title: "No Logo Game", logoUrl: "" })],
     });
     expect(screen.getByTestId("hero-title-text-2")).toBeInTheDocument();
     expect(screen.getByText("No Logo Game")).toBeInTheDocument();

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -884,18 +884,7 @@ export interface MoodDefinition {
 
 // --- Explore ---
 
-export interface FeaturedGame {
-  gameId: string;
-  title: string;
-  heroUrl: string;
-  logoUrl: string | null;
-  consoleAbbreviation: string;
-  consoleColor: string;
-  igdbCriticsRating: number;
-  genre: string;
-  isFavorite: boolean;
-  isPlayLater: boolean;
-}
+export type FeaturedGame = Schemas["FeaturedGameResponse"];
 
 export interface ExploreRow {
   id: string;


### PR DESCRIPTION
Part of #489.

## Type aliased
- \`FeaturedGame\` → \`Schemas[\"FeaturedGameResponse\"]\`

## Consumer fixes
Hand-written \`logoUrl: string | null\` narrows to \`string\` in the generated spec. The server field is a plain Go string (zero value \`\"\"\`), so null can't actually appear on the wire. Two test fixtures in \`hero-carousel.test.tsx\` that set \`logoUrl: null\` become \`logoUrl: \"\"\`; the consumer already uses a truthy check (\`game.logoUrl ? ...\`) so the ' no logo' branch still renders.

Hand-written FeaturedGame was also missing \`consoleId\` / \`consoleName\` — generated \`FeaturedGameResponse\` requires both. The two fixture factories now set them.

## Tests
- \`npx tsc --noEmit\` clean
- Affected tests pass (hero-carousel: 10/10, explore-page: 42/42)