### PR TITLE
chore(web): alias BiosFile to generated BiosFileResponse

### DIFF
--- a/web/src/features/bios/components/__tests__/bios-upload-results.test.tsx
+++ b/web/src/features/bios/components/__tests__/bios-upload-results.test.tsx
@@ -58,8 +58,8 @@ describe("BiosUploadResults", () => {
         result: makeBiosFile({
           name: "unknown.bin",
           consoleId: null,
-          consoleName: null,
-          description: null,
+          consoleName: undefined,
+          description: undefined,
           status: "present",
           required: false,
         }),

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -552,17 +552,7 @@ export interface NetplayInvitesResponse {
   total: number;
 }
 
-export interface BiosFile {
-  name: string;
-  size: number;
-  md5: string;
-  expectedMd5?: string;
-  consoleId: string | null;
-  consoleName: string | null;
-  description: string | null;
-  required: boolean;
-  status: "valid" | "present" | "invalid" | "missing";
-}
+export type BiosFile = Schemas["BiosFileResponse"];
 
 export interface BiosConsoleFile {
   fileName: string;


### PR DESCRIPTION
Part of #489.

## Type aliased
- \`BiosFile\` → \`Schemas[\"BiosFileResponse\"]\`

## Shape differences
- \`status\` widens from \`\"valid\" | \"present\" | \"invalid\" | \"missing\"\` to \`string\` — consumers use \`===\` equality against those literals, which remains safe.
- \`consoleName\` and \`description\` widen from required-nullable (\`string | null\`) to optional (\`string?\`). The unrecognized-file branch in the test fixture switches \`null\` → \`undefined\` accordingly.

## Tests
- \`npx tsc --noEmit\` clean
- bios unit tests and use-bios hooks: 26/26 pass