### PR TITLE
chore(web): alias AchievementLeaderboard to generated AchievementLeaderboardResponse

### DIFF
--- a/web/src/features/bios/components/__tests__/bios-upload-results.test.tsx
+++ b/web/src/features/bios/components/__tests__/bios-upload-results.test.tsx
@@ -58,8 +58,8 @@ describe("BiosUploadResults", () => {
         result: makeBiosFile({
           name: "unknown.bin",
           consoleId: null,
-          consoleName: null,
-          description: null,
+          consoleName: undefined,
+          description: undefined,
           status: "present",
           required: false,
         }),

--- a/web/src/features/game-detail/components/achievement-timeline.tsx
+++ b/web/src/features/game-detail/components/achievement-timeline.tsx
@@ -10,7 +10,7 @@ import type {
 interface TimelineViewProps {
   timeline:
     | {
-        timeline: AchievementTimelineEntry[];
+        timeline: AchievementTimelineEntry[] | null;
         unlockedCount: number;
         earnedPoints: number;
       }

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -383,16 +383,7 @@ export interface AchievementLeaderboard {
 
 export type AchievementTimelineEntry = Schemas["RATimelineEntryResponse"];
 
-export interface AchievementTimeline {
-  raGameId: number;
-  gameTitle: string;
-  totalPlayTime: number;
-  timeline: AchievementTimelineEntry[];
-  totalAchievements: number;
-  unlockedCount: number;
-  totalPoints: number;
-  earnedPoints: number;
-}
+export type AchievementTimeline = Schemas["AchievementTimelineResponse"];
 
 export type RecentAchievement = Schemas["RARecentAchievementResponse"];
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -552,17 +552,7 @@ export interface NetplayInvitesResponse {
   total: number;
 }
 
-export interface BiosFile {
-  name: string;
-  size: number;
-  md5: string;
-  expectedMd5?: string;
-  consoleId: string | null;
-  consoleName: string | null;
-  description: string | null;
-  required: boolean;
-  status: "valid" | "present" | "invalid" | "missing";
-}
+export type BiosFile = Schemas["BiosFileResponse"];
 
 export interface BiosConsoleFile {
   fileName: string;

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -366,20 +366,7 @@ export interface ActivePlayer {
   lastPlayed: string;
 }
 
-export interface AchievementLeaderboard {
-  raGameId: number;
-  totalAchievements: number;
-  leaderboard: {
-    userId: string;
-    username: string;
-    avatarUrl?: string;
-    unlockedCount: number;
-    earnedPoints: number;
-    lastUnlockedAt: string;
-    firstUnlockedAt: string;
-    isComplete: boolean;
-  }[];
-}
+export type AchievementLeaderboard = Schemas["AchievementLeaderboardResponse"];
 
 export type AchievementTimelineEntry = Schemas["RATimelineEntryResponse"];
 


### PR DESCRIPTION
Part of #489.

**Stacked on #587 and #588** — once those merge, this PR is a one-line diff.

## Type aliased
- \`AchievementLeaderboard\` → \`Schemas[\"AchievementLeaderboardResponse\"]\`

## Consumer
\`game-achievement-leaderboard.tsx\` already guards on \`!leaderboard.leaderboard\`, so the nullable array from the generated shape is handled at runtime. The inline entry type becomes \`RALeaderboardEntryResponse\` (avatarUrl widens from optional to required — consumers just pass it through).

## Tests
- \`npm run build\` clean
- \`game-achievement-leaderboard\` tests: 11/11 pass