### PR TITLE
chore(web): alias UserSearchResponse, ActivityFeedResponse to generated paginated wrappers

### DIFF
--- a/web/src/features/bios/components/__tests__/bios-upload-results.test.tsx
+++ b/web/src/features/bios/components/__tests__/bios-upload-results.test.tsx
@@ -58,8 +58,8 @@ describe("BiosUploadResults", () => {
         result: makeBiosFile({
           name: "unknown.bin",
           consoleId: null,
-          consoleName: null,
-          description: null,
+          consoleName: undefined,
+          description: undefined,
           status: "present",
           required: false,
         }),

--- a/web/src/features/game-detail/components/achievement-timeline.tsx
+++ b/web/src/features/game-detail/components/achievement-timeline.tsx
@@ -10,7 +10,7 @@ import type {
 interface TimelineViewProps {
   timeline:
     | {
-        timeline: AchievementTimelineEntry[];
+        timeline: AchievementTimelineEntry[] | null;
         unlockedCount: number;
         earnedPoints: number;
       }

--- a/web/src/features/social/components/activity-feed.tsx
+++ b/web/src/features/social/components/activity-feed.tsx
@@ -34,7 +34,7 @@ export function ActivityFeed({
   const { data, isLoading } = useActivityFeed(1, maxItems ?? 20);
   useActivityRealtime();
 
-  const events = maxItems ? data?.data.slice(0, maxItems) : data?.data;
+  const events = maxItems ? data?.data?.slice(0, maxItems) : data?.data;
 
   return (
     <div data-testid="activity-feed">

--- a/web/src/pages/activity-page.tsx
+++ b/web/src/pages/activity-page.tsx
@@ -56,7 +56,7 @@ export function ActivityPage() {
           )}
 
           {/* Pagination */}
-          {data && data.data.length > 0 && (
+          {data && (data.data?.length ?? 0) > 0 && (
             <div className="flex items-center justify-center gap-3 mt-8">
               <Button
                 variant="secondary"

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -383,16 +383,7 @@ export interface AchievementLeaderboard {
 
 export type AchievementTimelineEntry = Schemas["RATimelineEntryResponse"];
 
-export interface AchievementTimeline {
-  raGameId: number;
-  gameTitle: string;
-  totalPlayTime: number;
-  timeline: AchievementTimelineEntry[];
-  totalAchievements: number;
-  unlockedCount: number;
-  totalPoints: number;
-  earnedPoints: number;
-}
+export type AchievementTimeline = Schemas["AchievementTimelineResponse"];
 
 export type RecentAchievement = Schemas["RARecentAchievementResponse"];
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -552,17 +552,7 @@ export interface NetplayInvitesResponse {
   total: number;
 }
 
-export interface BiosFile {
-  name: string;
-  size: number;
-  md5: string;
-  expectedMd5?: string;
-  consoleId: string | null;
-  consoleName: string | null;
-  description: string | null;
-  required: boolean;
-  status: "valid" | "present" | "invalid" | "missing";
-}
+export type BiosFile = Schemas["BiosFileResponse"];
 
 export interface BiosConsoleFile {
   fileName: string;

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -376,23 +376,13 @@ export type RecentAchievement = Schemas["RARecentAchievementResponse"];
 
 export type UserSearchResult = Schemas["UserSearchResult"];
 
-export interface UserSearchResponse {
-  data: UserSearchResult[];
-  total: number;
-  page: number;
-  pageSize: number;
-}
+export type UserSearchResponse = Schemas["PaginatedResponseUserSearchResult"];
 
 export type OnlineUser = Schemas["OnlineUserResponse"];
 
 export type ActivityEvent = Schemas["ActivityEventResponse"];
 
-export interface ActivityFeedResponse {
-  data: ActivityEvent[];
-  total: number;
-  page: number;
-  pageSize: number;
-}
+export type ActivityFeedResponse = Schemas["PaginatedResponseActivityEventResponse"];
 
 export type GameRating = Schemas["GameRatingResponse"];
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -366,20 +366,7 @@ export interface ActivePlayer {
   lastPlayed: string;
 }
 
-export interface AchievementLeaderboard {
-  raGameId: number;
-  totalAchievements: number;
-  leaderboard: {
-    userId: string;
-    username: string;
-    avatarUrl?: string;
-    unlockedCount: number;
-    earnedPoints: number;
-    lastUnlockedAt: string;
-    firstUnlockedAt: string;
-    isComplete: boolean;
-  }[];
-}
+export type AchievementLeaderboard = Schemas["AchievementLeaderboardResponse"];
 
 export type AchievementTimelineEntry = Schemas["RATimelineEntryResponse"];
 


### PR DESCRIPTION
Part of #489.

**Stacked on #587, #588, #589.** Once those merge, this PR becomes a 3-file diff.

## Types aliased
- \`ActivityFeedResponse\` → \`Schemas[\"PaginatedResponseActivityEventResponse\"]\`
- \`UserSearchResponse\` → \`Schemas[\"PaginatedResponseUserSearchResult\"]\`

## Consumer fixes
Both widen \`data: T[]\` → \`T[] | null\`. Two bare \`data.data\` accesses needed null guards:
- \`activity-feed.tsx\` — optional chaining on the slice
- \`activity-page.tsx\` — use \`(data.data?.length ?? 0) > 0\`

invite-modal already guards with \`searchResponse?.data ?? []\`.

## Tests
- \`npm run build\` clean
- Affected unit tests pass