### PR TITLE
chore(web): remove unused api.ts types MostPlayedGame and ActivePlayer

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -351,21 +351,6 @@ export type UnlockedAchievement = Schemas["RAUnlockedAchievementResponse"];
 
 export type GameStatsPlayer = Schemas["GameStatsTopPlayer"];
 
-export interface MostPlayedGame {
-  game: Game;
-  totalPlayers: number;
-  totalPlayTime: number;
-}
-
-export interface ActivePlayer {
-  userId: string;
-  username: string;
-  avatarUrl?: string;
-  totalPlayTime: number;
-  gamesPlayed: number;
-  lastPlayed: string;
-}
-
 export type AchievementLeaderboard = Schemas["AchievementLeaderboardResponse"];
 
 export type AchievementTimelineEntry = Schemas["RATimelineEntryResponse"];


### PR DESCRIPTION
Part of #489.

Both types have zero importers in the \`web/src\` tree — \`grep -rn\` confirms. Generated equivalents (\`MostPlayedEntry\`, \`ActivePlayerEntry\`) are already in \`@/generated/api\` if anything ever needs them.

## Tests
- \`npm run build\` clean