### PR TITLE
chore(web): alias ChallengeLeaderboardResponse to generated paginated wrapper

### DIFF
--- a/web/src/features/explore/components/mood-picker.tsx
+++ b/web/src/features/explore/components/mood-picker.tsx
@@ -43,7 +43,7 @@ export function MoodPicker({ moods, isLoading }: MoodPickerProps) {
             to={`/explore/mood/${mood.id}`}
             data-testid={`mood-card-${mood.id}`}
             className="group/mood block rounded-xl overflow-hidden shadow-md transition-all duration-200 hover:scale-[1.02] hover:brightness-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 focus-visible:ring-offset-surface-950"
-            style={{ background: buildGradient(mood.gradient) }}
+            style={{ background: buildGradient(mood.gradient ?? []) }}
           >
             <div className="relative h-32 flex flex-col justify-end p-4">
               {/* Subtle overlay for text readability */}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -558,9 +558,7 @@ export type SessionSave = Schemas["SessionSaveResponse"];
 
 export type CoreCompatibilityEntry = Schemas["CoreCompatibilityEntry"];
 
-export interface CoreCompatibilityResponse {
-  consoles: CoreCompatibilityEntry[];
-}
+export type CoreCompatibilityResponse = Schemas["CoreCompatibilityResponse"];
 
 export interface SessionCheatConfig {
   cheatsEnabled: boolean;

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -818,13 +818,7 @@ export interface ConsoleHighlightsResponse {
 
 // --- Moods ---
 
-export interface MoodDefinition {
-  id: string;
-  name: string;
-  description: string;
-  icon: string;
-  gradient: string[];
-}
+export type MoodDefinition = Schemas["MoodResponse"];
 
 // --- Explore ---
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -649,12 +649,7 @@ export interface ChallengeAttempt {
 
 export type ChallengeLeaderboardEntry = Schemas["ChallengeLeaderboardEntry"];
 
-export interface ChallengeLeaderboardResponse {
-  data: ChallengeLeaderboardEntry[];
-  total: number;
-  page: number;
-  pageSize: number;
-}
+export type ChallengeLeaderboardResponse = Schemas["PaginatedResponseChallengeLeaderboardEntry"];
 
 export interface StartAttemptResponse {
   attemptId: string;


### PR DESCRIPTION
Part of #489. Consumer (challenge-leaderboard.tsx) already guards `!data?.data` before iterating, so the nullable-array widening is handled.