### PR TITLE
chore(web): alias RALinkRequest and RASettingsRequest to generated schemas

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -319,14 +319,8 @@ export interface UserPreferences {
 
 export type RAStatus = Schemas["RAStatusResponse"];
 
-export interface RALinkRequest {
-  username: string;
-  password: string;
-}
-
-export interface RASettingsRequest {
-  hardcoreEnabled: boolean;
-}
+export type RALinkRequest = Schemas["LinkRAAccountRequest"];
+export type RASettingsRequest = Schemas["UpdateRASettingsRequest"];
 
 export type Achievement = Schemas["Achievement"];
 


### PR DESCRIPTION
Part of #489. Both fields widen (required→optional, non-null→nullable); this only matters when passing inputs, and object literals satisfy the looser types.