### PR TITLE
chore(web): alias 3 gallery responses to generated schemas

### DIFF
--- a/web/src/pages/explore-page.tsx
+++ b/web/src/pages/explore-page.tsx
@@ -406,7 +406,7 @@ export function ExplorePage() {
       />
 
       <ArtworkShowcase
-        artworks={artworkData?.artworks}
+        artworks={artworkData?.artworks ?? undefined}
         isLoading={isArtworkLoading}
       />
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -735,30 +735,15 @@ export interface FranchiseDetail {
 
 export type ScreenshotItem = Schemas["ScreenshotItem"];
 
-export interface ScreenshotGalleryResponse {
-  screenshots: ScreenshotItem[];
-  page: number;
-  totalPages: number;
-  totalCount: number;
-}
+export type ScreenshotGalleryResponse = Schemas["ScreenshotGalleryResponse"];
 
 export type ArtworkItem = Schemas["ArtworkItem"];
 
-export interface ArtworkGalleryResponse {
-  artworks: ArtworkItem[];
-  page: number;
-  totalPages: number;
-  totalCount: number;
-}
+export type ArtworkGalleryResponse = Schemas["ArtworkGalleryResponse"];
 
 export type CoverItem = Schemas["CoverItem"];
 
-export interface CoverGalleryResponse {
-  covers: CoverItem[];
-  page: number;
-  totalPages: number;
-  totalCount: number;
-}
+export type CoverGalleryResponse = Schemas["CoverGalleryResponse"];
 
 // --- Console Showcase ---
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -319,14 +319,8 @@ export interface UserPreferences {
 
 export type RAStatus = Schemas["RAStatusResponse"];
 
-export interface RALinkRequest {
-  username: string;
-  password: string;
-}
-
-export interface RASettingsRequest {
-  hardcoreEnabled: boolean;
-}
+export type RALinkRequest = Schemas["LinkRAAccountRequest"];
+export type RASettingsRequest = Schemas["UpdateRASettingsRequest"];
 
 export type Achievement = Schemas["Achievement"];
 


### PR DESCRIPTION
Part of #489. ScreenshotGalleryResponse, ArtworkGalleryResponse, CoverGalleryResponse all widen the inner array to nullable. screenshot-/cover-gallery-page guards with `?? []`; explore-page ArtworkShowcase caller gets an explicit `?? undefined` to satisfy the `ArtworkItem[] | undefined` prop signature.