### PR TITLE
chore(web): alias GameAchievements and GameAchievementProgressResponse to generated

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -324,20 +324,11 @@ export type RASettingsRequest = Schemas["UpdateRASettingsRequest"];
 
 export type Achievement = Schemas["Achievement"];
 
-export interface GameAchievements {
-  status?: "pending";
-  raGameId: number;
-  totalCount: number;
-  totalPoints: number;
-  achievements: Achievement[];
-}
+export type GameAchievements = Schemas["GameAchievementsResponse"];
 
 export type GameAchievementProgress = Schemas["RAProgressEntry"];
 
-export interface GameAchievementProgressResponse {
-  raGameId: number;
-  progress: GameAchievementProgress[];
-}
+export type GameAchievementProgressResponse = Schemas["GameAchievementProgressResponse"];
 
 export type ShowcaseAchievement = Schemas["ShowcaseEntryResponse"];
 


### PR DESCRIPTION
Part of #489. Both widen the inner achievements/progress arrays to nullable; consumers already guard. GameAchievements gains an optional `title` field from the generated shape.