### PR TITLE
chore(web): alias GameVariant to generated VariantResponse

### DIFF
--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -155,18 +155,7 @@ export interface Console {
 
 export type GameDisc = Schemas["DiscResponse"];
 
-// GameVariant from backend — represents a variant in the game detail response
-export interface GameVariant {
-  id: string;
-  title: string;
-  fileName: string;
-  region: string;
-  revision: string;
-  tags: string;
-  isPreRelease: boolean;
-  fileSize: number;
-  verificationStatus: string;
-}
+export type GameVariant = Schemas["VariantResponse"];
 
 // GameResponse from backend responses.go DTO layer
 export interface Game {


### PR DESCRIPTION
Part of #489. Widens region/revision/tags/verificationStatus from required-string to optional-string. The sole consumer (`game-variants-section.tsx`) already uses truthy checks on all four fields.