### PR TITLE
chore(web): alias StagedUpload to generated StagedUploadResponse

### DIFF
--- a/web/src/features/upload/components/console-selector.tsx
+++ b/web/src/features/upload/components/console-selector.tsx
@@ -14,7 +14,7 @@ export function ConsoleSelector({
 }: ConsoleSelectorProps) {
   const options = [
     { value: "", label: "Select console..." },
-    ...upload.possibleConsoles.map((c) => ({
+    ...(upload.possibleConsoles ?? []).map((c) => ({
       value: c.id,
       label: c.name,
     })),

--- a/web/src/features/upload/components/staged-upload-card.tsx
+++ b/web/src/features/upload/components/staged-upload-card.tsx
@@ -66,11 +66,11 @@ export function StagedUploadCard({
 
   return (
     <GameSummaryCard
-      title={upload.title || upload.canonicalName}
+      title={upload.title || upload.canonicalName || upload.fileName}
       coverUrl={upload.coverUrl || undefined}
-      consoleId={upload.consoleId}
-      consoleName={upload.consoleName}
-      rating={upload.igdbCriticsRating}
+      consoleId={upload.consoleId ?? ""}
+      consoleName={upload.consoleName ?? ""}
+      rating={upload.igdbCriticsRating ?? 0}
       verificationStatus={upload.verificationStatus || undefined}
       fileName={upload.fileName}
       fileSize={upload.fileSize}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -877,22 +877,7 @@ export interface DeveloperSpotlightResponse {
   heroUrl: string;
 }
 
-export interface StagedUpload {
-  id: string;
-  fileName: string;
-  originalFileName: string;
-  fileSize: number;
-  consoleId: string;
-  consoleName: string;
-  possibleConsoles: PossibleConsole[];
-  status: StagedUploadStatus;
-  title: string;
-  coverUrl: string;
-  igdbCriticsRating: number;
-  verificationStatus: string;
-  crc32: string;
-  canonicalName: string;
-}
+export type StagedUpload = Schemas["StagedUploadResponse"];
 
 // --- Phase 10: Social & Community Discovery ---
 


### PR DESCRIPTION
Part of #489.

Widens many fields required→optional and `status` from literal union to string. Three consumer touch-ups:
- `console-selector`: `upload.possibleConsoles ?? []` before `.map`
- `staged-upload-card`: fall back `canonicalName → fileName` for title, default `consoleId/consoleName/rating` to `""/0` when absent — matches the `pending_console` state where these aren't yet known.