### PR TITLE
chore(web): add throwNever/fallbackNever exhaustive-switch helpers

### DIFF
--- a/web/src/lib/__tests__/exhaustive.test.ts
+++ b/web/src/lib/__tests__/exhaustive.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { throwNever, fallbackNever } from "@/lib/exhaustive";
+
+describe("throwNever", () => {
+  it("throws with the stringified value when called at runtime", () => {
+    expect(() => throwNever("unexpected" as never)).toThrow(
+      /Non-exhaustive switch.*unexpected/,
+    );
+  });
+
+  it("includes the context label when provided", () => {
+    expect(() => throwNever("x" as never, "handleStatus")).toThrow(
+      /in handleStatus/,
+    );
+  });
+});
+
+describe("fallbackNever", () => {
+  it("returns the provided default when an unknown tag reaches it", () => {
+    const result = fallbackNever("surprise" as never, "fallback");
+    expect(result).toBe("fallback");
+  });
+});

--- a/web/src/lib/exhaustive.ts
+++ b/web/src/lib/exhaustive.ts
@@ -1,0 +1,23 @@
+/**
+ * Runtime-safe exhaustive-switch helpers.
+ *
+ * The `never` parameter makes TypeScript flag any `default:` branch that
+ * becomes reachable — e.g. when a server-typed union is widened from a
+ * literal set to `string`, or a new case is added to a local union and a
+ * switch site isn't updated.
+ *
+ * Use `throwNever` when the path is unreachable in correct code (invariant
+ * violations should crash loud). Use `fallbackNever` in render paths where
+ * an unknown tag should degrade gracefully instead of blowing up the page.
+ */
+
+export function throwNever(value: never, context?: string): never {
+  const detail = context ? ` in ${context}` : "";
+  throw new Error(
+    `Non-exhaustive switch${detail}: unexpected value ${JSON.stringify(value)}`,
+  );
+}
+
+export function fallbackNever<T>(_value: never, defaultValue: T): T {
+  return defaultValue;
+}


### PR DESCRIPTION
Standing utility that will be used throughout the #489 alias migration.

Two flavors:
- `throwNever(x, context?)` — crash loud on invariant violation (unreachable code)
- `fallbackNever(x, defaultValue)` — degrade gracefully in render paths when an unknown server-side tag shouldn't blow up the page

The `never` parameter makes tsc flag any `default:` branch that becomes reachable — e.g. when an OpenAPI alias widens a literal union to `string`, or a new case is added to a local union without updating a switch.

No consumers yet; next PR (Game migration) will be the first to use them.