### PR TITLE
chore(web): alias 16 Game-composite types to generated

### DIFF
--- a/web/src/features/explore/components/achievement-shelves.tsx
+++ b/web/src/features/explore/components/achievement-shelves.tsx
@@ -42,7 +42,7 @@ export function EasyToCompleteShelf({
       isLoading={isLoading}
       isEmpty={!data?.games || data.games.length === 0}
     >
-      {data?.games.map((item) => (
+      {data?.games?.map((item) => (
         <div
           key={item.game.id}
           className="flex-shrink-0"
@@ -91,7 +91,7 @@ export function HardestGamesShelf({
       isLoading={isLoading}
       isEmpty={!data?.games || data.games.length === 0}
     >
-      {data?.games.map((item) => (
+      {data?.games?.map((item) => (
         <div
           key={item.game.id}
           className="flex-shrink-0"
@@ -140,7 +140,7 @@ export function AlmostDoneShelf({
       isLoading={isLoading}
       isEmpty={!data?.games || data.games.length === 0}
     >
-      {data?.games.map((item) => (
+      {data?.games?.map((item) => (
         <div
           key={item.game.id}
           className="flex-shrink-0"
@@ -205,7 +205,7 @@ export function FreshChallengesShelf({
       isLoading={isLoading}
       isEmpty={!data?.games || data.games.length === 0}
     >
-      {data?.games.map((item) => (
+      {data?.games?.map((item) => (
         <div
           key={item.game.id}
           className="flex-shrink-0"

--- a/web/src/features/explore/components/social-shelves.tsx
+++ b/web/src/features/explore/components/social-shelves.tsx
@@ -24,7 +24,7 @@ import type {
 // --- Trending Shelf ---
 
 interface TrendingShelfProps {
-  games: TrendingGame[] | undefined;
+  games: TrendingGame[] | null | undefined;
   isLoading: boolean;
   onToggleFavorite?: (game: Game) => void;
   onTogglePlayLater?: (game: Game) => void;
@@ -73,7 +73,7 @@ export function TrendingShelf({
 // --- Community Top Shelf ---
 
 interface CommunityTopShelfProps {
-  games: CommunityTopGame[] | undefined;
+  games: CommunityTopGame[] | null | undefined;
   isLoading: boolean;
   onToggleFavorite?: (game: Game) => void;
   onTogglePlayLater?: (game: Game) => void;
@@ -125,7 +125,7 @@ export function CommunityTopShelf({
 // --- Cult Classics Shelf ---
 
 interface CultClassicsShelfProps {
-  games: CultClassicGame[] | undefined;
+  games: CultClassicGame[] | null | undefined;
   isLoading: boolean;
   onToggleFavorite?: (game: Game) => void;
   onTogglePlayLater?: (game: Game) => void;
@@ -175,7 +175,7 @@ export function CultClassicsShelf({
 // --- Recently Reviewed Shelf ---
 
 interface RecentlyReviewedShelfProps {
-  reviews: RecentReviewItem[] | undefined;
+  reviews: RecentReviewItem[] | null | undefined;
   isLoading: boolean;
   onToggleFavorite?: (game: Game) => void;
   onTogglePlayLater?: (game: Game) => void;
@@ -250,7 +250,7 @@ export function RecentlyReviewedShelf({
 // --- Active Now Shelf ---
 
 interface ActiveNowShelfProps {
-  games: ActiveNowItem[] | undefined;
+  games: ActiveNowItem[] | null | undefined;
   isLoading: boolean;
   onToggleFavorite?: (game: Game) => void;
   onTogglePlayLater?: (game: Game) => void;

--- a/web/src/features/explore/components/temporal-shelves.tsx
+++ b/web/src/features/explore/components/temporal-shelves.tsx
@@ -38,7 +38,7 @@ export function OnThisDayShelf({
       isLoading={isLoading}
       isEmpty={!data?.games || data.games.length === 0}
     >
-      {data?.games.map((game) => (
+      {data?.games?.map((game) => (
         <div
           key={game.id}
           className="flex-shrink-0"
@@ -157,7 +157,7 @@ export function BestOfYearSection({
 // --- Anniversaries Shelf ---
 
 interface AnniversariesShelfProps {
-  anniversaries: AnniversaryItem[] | undefined;
+  anniversaries: AnniversaryItem[] | null | undefined;
   isLoading: boolean;
   onToggleFavorite?: (game: Game) => void;
   onTogglePlayLater?: (game: Game) => void;
@@ -228,7 +228,7 @@ export function DecadeSpotlight({
       isLoading={isLoading}
       isEmpty={!data?.games || data.games.length === 0}
     >
-      {data?.games.map((game) => (
+      {data?.games?.map((game) => (
         <div
           key={game.id}
           className="flex-shrink-0"

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -820,124 +820,34 @@ export type StagedUpload = Schemas["StagedUploadResponse"];
 
 // --- Phase 10: Social & Community Discovery ---
 
-export interface TrendingGame {
-  game: Game;
-  playersThisWeek: number;
-}
-
-export interface TrendingResponse {
-  games: TrendingGame[];
-}
-
-export interface CommunityTopGame {
-  game: Game;
-  avgRating: number;
-  ratingCount: number;
-}
-
-export interface CommunityTopResponse {
-  games: CommunityTopGame[];
-}
-
-export interface CultClassicGame {
-  game: Game;
-  communityRating: number;
-  igdbCriticsRating: number;
-  ratingCount: number;
-}
-
-export interface CultClassicsResponse {
-  games: CultClassicGame[];
-}
-
-export interface RecentReviewItem {
-  game: Game;
-  rating: number;
-  review: string;
-  reviewerName: string;
-  reviewedAt: string;
-}
-
-export interface RecentlyReviewedResponse {
-  reviews: RecentReviewItem[];
-}
-
-export interface ActiveNowItem {
-  game: Game;
-  activeSessions: number;
-  activeChallenges: number;
-}
-
-export interface ActiveNowResponse {
-  games: ActiveNowItem[];
-}
+export type TrendingGame = Schemas["TrendingGameResponse"];
+export type TrendingResponse = Schemas["TrendingResponse"];
+export type CommunityTopGame = Schemas["CommunityTopGame"];
+export type CommunityTopResponse = Schemas["CommunityTopResponse"];
+export type CultClassicGame = Schemas["CultClassicGame"];
+export type CultClassicsResponse = Schemas["CultClassicsResponse"];
+export type RecentReviewItem = Schemas["RecentReviewItem"];
+export type RecentlyReviewedResponse = Schemas["RecentlyReviewedResponse"];
+export type ActiveNowItem = Schemas["ActiveNowItem"];
+export type ActiveNowResponse = Schemas["ActiveNowResponse"];
 
 // --- Phase 11: Temporal Discovery ---
 
-export interface OnThisDayResponse {
-  date: string;
-  games: Game[];
-}
-
-export interface BestOfYearResponse {
-  year: number;
-  games: Game[];
-}
-
-export interface AnniversaryItem {
-  game: Game;
-  yearsAgo: number;
-  playedAt: string;
-}
-
-export interface YourAnniversariesResponse {
-  anniversaries: AnniversaryItem[];
-}
-
-export interface DecadeResponse {
-  decade: string;
-  label: string;
-  games: Game[];
-}
+export type OnThisDayResponse = Schemas["OnThisDayResponse"];
+export type BestOfYearResponse = Schemas["BestOfYearResponse"];
+export type AnniversaryItem = Schemas["AnniversaryItem"];
+export type YourAnniversariesResponse = Schemas["AnniversariesResponse"];
+export type DecadeResponse = Schemas["DecadesResponse"];
 
 // --- Phase 12: Achievement & Challenge Discovery ---
 
-export interface AchievementGameItem {
-  game: Game;
-  totalAchievements: number;
-  avgCompletion: number;
-  playersAttempted: number;
-  playersCompleted: number;
-}
-
-export interface EasyToCompleteResponse {
-  games: AchievementGameItem[];
-}
-
-export interface HardestGamesResponse {
-  games: AchievementGameItem[];
-}
-
-export interface AlmostDoneGame {
-  game: Game;
-  unlockedCount: number;
-  totalCount: number;
-  completionPercent: number;
-}
-
-export interface AlmostDoneResponse {
-  games: AlmostDoneGame[];
-}
-
-export interface FreshChallengeGame {
-  game: Game;
-  totalAchievements: number;
-  totalPoints: number;
-}
-
-export interface FreshChallengesResponse {
-  games: FreshChallengeGame[];
-}
+export type AchievementGameItem = Schemas["AchievementGameResponse"];
+export type EasyToCompleteResponse = Schemas["EasyToCompleteResponse"];
+export type HardestGamesResponse = Schemas["HardestGamesResponse"];
+export type AlmostDoneGame = Schemas["AlmostDoneGame"];
+export type AlmostDoneResponse = Schemas["AlmostDoneResponse"];
+export type FreshChallengeGame = Schemas["FreshChallengeGame"];
+export type FreshChallengesResponse = Schemas["FreshChallengesResponse"];
 
 export interface ExploreChallenge {
   id: string;


### PR DESCRIPTION
Part of #489.

Now that `Game = GameResponse`, this batch retires 16 hand-written composite interfaces that just embedded `Game`. Saves 124 lines of api.ts.

## Aliased
- Social: `TrendingGame`, `TrendingResponse`, `CommunityTopGame`, `CommunityTopResponse`, `CultClassicGame`, `CultClassicsResponse`, `RecentReviewItem`, `RecentlyReviewedResponse`, `ActiveNowItem`, `ActiveNowResponse`
- Temporal: `OnThisDayResponse`, `BestOfYearResponse`, `AnniversaryItem`, `YourAnniversariesResponse`, `DecadeResponse`
- Achievement/Challenge: `AchievementGameItem`, `EasyToCompleteResponse`, `HardestGamesResponse`, `AlmostDoneGame`, `AlmostDoneResponse`, `FreshChallengeGame`, `FreshChallengesResponse`

Name differences (hand-written vs generated): `TrendingGame → TrendingGameResponse`, `AchievementGameItem → AchievementGameResponse`, `YourAnniversariesResponse → AnniversariesResponse`, `DecadeResponse → DecadesResponse`.

## Consumer fixes
Inner-array widening `T[] → T[] | null` required two small follow-ups:
- 5 shelf-prop signatures widened to `T[] | null | undefined` in `social-shelves.tsx` and `temporal-shelves.tsx`
- 6 `data?.games.map(...)` → `data?.games?.map(...)` in `achievement-shelves.tsx` and `temporal-shelves.tsx` (optional chain needed a second `?` because the inner array can itself be null)

## Tests
- `npm run build` clean
- `npx vitest run` — 1469/1469 pass