### PR TITLE
fix(#606): enrich SharedSessionInviteResponse, align frontend to real wire shape

### DIFF
--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -818,16 +818,20 @@ type SharedSessionMemberResponse struct {
 
 // SharedSessionInviteResponse is the API response for a shared session invite.
 type SharedSessionInviteResponse struct {
-	ID                  string    `json:"id"`
-	SharedSessionID     string    `json:"sharedSessionId"`
-	SharedSessionName   string    `json:"sharedSessionName"`
-	GameTitle           string    `json:"gameTitle"`
-	InviterID           string    `json:"inviterId"`
-	InviterUsername     string    `json:"inviterUsername"`
-	InviteeID           string    `json:"inviteeId"`
-	InviteeUsername     string    `json:"inviteeUsername"`
-	Status              string    `json:"status"`
-	CreatedAt           time.Time `json:"createdAt"`
+	ID                string    `json:"id"`
+	SharedSessionID   string    `json:"sharedSessionId"`
+	SharedSessionName string    `json:"sharedSessionName"`
+	GameID            string    `json:"gameId"`
+	GameTitle         string    `json:"gameTitle"`
+	GameCoverURL      string    `json:"gameCoverUrl"`
+	ConsoleName       string    `json:"consoleName"`
+	InviterID         string    `json:"inviterId"`
+	InviterUsername   string    `json:"inviterUsername"`
+	InviterAvatarURL  string    `json:"inviterAvatarUrl"`
+	InviteeID         string    `json:"inviteeId"`
+	InviteeUsername   string    `json:"inviteeUsername"`
+	Status            string    `json:"status"`
+	CreatedAt         time.Time `json:"createdAt"`
 }
 
 // SharedSessionSaveResponse is the API response for a shared session save state.

--- a/server/internal/api/shared_session_handler.go
+++ b/server/internal/api/shared_session_handler.go
@@ -129,14 +129,20 @@ func (h *SharedSessionHandler) toSharedSessionInviteResponse(inv db.SharedSessio
 
 	sharedSessionName := inv.SharedSession.Name
 	gameTitle := inv.SharedSession.Game.Title
+	gameCoverURL := resolveImageURL(inv.SharedSession.Game.CoverURL)
+	consoleName := inv.SharedSession.Game.Console.Name
 
 	return SharedSessionInviteResponse{
 		ID:                strconv.FormatUint(uint64(inv.ID), 10),
 		SharedSessionID:   strconv.FormatUint(uint64(inv.SharedSessionID), 10),
 		SharedSessionName: sharedSessionName,
+		GameID:            strconv.FormatUint(uint64(inv.SharedSession.GameID), 10),
 		GameTitle:         gameTitle,
+		GameCoverURL:      gameCoverURL,
+		ConsoleName:       consoleName,
 		InviterID:         strconv.FormatUint(uint64(inv.InviterID), 10),
 		InviterUsername:   inviterName,
+		InviterAvatarURL:  inv.Inviter.AvatarURL,
 		InviteeID:         strconv.FormatUint(uint64(inv.InviteeID), 10),
 		InviteeUsername:   inviteeName,
 		Status:            inv.Status,

--- a/web/src/features/shared-sessions/components/__tests__/invitation-card.test.tsx
+++ b/web/src/features/shared-sessions/components/__tests__/invitation-card.test.tsx
@@ -15,7 +15,12 @@ function makeInvitation(
     gameTitle: "Super Mario World",
     gameCoverUrl: "https://example.com/cover.png",
     consoleName: "SNES",
+    inviterId: "u1",
     inviterUsername: "alice",
+    inviterAvatarUrl: "",
+    inviteeId: "u2",
+    inviteeUsername: "bob",
+    status: "pending",
     createdAt: "2026-02-13T10:00:00Z",
     ...overrides,
   };

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -7935,12 +7935,16 @@ export interface components {
              * @example https://example.com/api/schemas/SharedSessionInviteResponse.json
              */
             readonly $schema?: string;
+            consoleName: string;
             /** Format: date-time */
             createdAt: string;
+            gameCoverUrl: string;
+            gameId: string;
             gameTitle: string;
             id: string;
             inviteeId: string;
             inviteeUsername: string;
+            inviterAvatarUrl: string;
             inviterId: string;
             inviterUsername: string;
             sharedSessionId: string;

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -8696,8 +8696,17 @@
             "readOnly": true,
             "type": "string"
           },
+          "consoleName": {
+            "type": "string"
+          },
           "createdAt": {
             "format": "date-time",
+            "type": "string"
+          },
+          "gameCoverUrl": {
+            "type": "string"
+          },
+          "gameId": {
             "type": "string"
           },
           "gameTitle": {
@@ -8710,6 +8719,9 @@
             "type": "string"
           },
           "inviteeUsername": {
+            "type": "string"
+          },
+          "inviterAvatarUrl": {
             "type": "string"
           },
           "inviterId": {
@@ -8732,9 +8744,13 @@
           "id",
           "sharedSessionId",
           "sharedSessionName",
+          "gameId",
           "gameTitle",
+          "gameCoverUrl",
+          "consoleName",
           "inviterId",
           "inviterUsername",
+          "inviterAvatarUrl",
           "inviteeId",
           "inviteeUsername",
           "status",

--- a/web/src/hooks/__tests__/use-shared-sessions.test.ts
+++ b/web/src/hooks/__tests__/use-shared-sessions.test.ts
@@ -124,21 +124,24 @@ const mockSharedSessionDetail = {
   ],
 };
 
-const mockInvitations = {
-  data: [
-    {
-      id: "inv-1",
-      sharedSessionId: "ss-1",
-      sharedSessionName: "Friday Night SNES",
-      gameId: "g1",
-      gameTitle: "Super Mario World",
-      gameConsoleName: "SNES",
-      inviterUsername: "alice",
-      createdAt: "2026-02-13T10:00:00Z",
-    },
-  ],
-  total: 1,
-};
+const mockInvitations = [
+  {
+    id: "inv-1",
+    sharedSessionId: "ss-1",
+    sharedSessionName: "Friday Night SNES",
+    gameId: "g1",
+    gameTitle: "Super Mario World",
+    gameCoverUrl: "",
+    consoleName: "SNES",
+    inviterId: "u1",
+    inviterUsername: "alice",
+    inviterAvatarUrl: "",
+    inviteeId: "u2",
+    inviteeUsername: "bob",
+    status: "pending",
+    createdAt: "2026-02-13T10:00:00Z",
+  },
+];
 
 const mockSaves = [
   {
@@ -194,8 +197,8 @@ describe("useSharedSessionInvitations", () => {
     expect(mockTypedApi.GET).toHaveBeenCalledWith(
       "/api/user/shared-session-invites",
     );
-    expect(result.current.data?.data).toHaveLength(1);
-    expect(result.current.data?.data?.[0].sharedSessionName).toBe(
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].sharedSessionName).toBe(
       "Friday Night SNES",
     );
   });

--- a/web/src/hooks/use-shared-sessions.ts
+++ b/web/src/hooks/use-shared-sessions.ts
@@ -4,7 +4,7 @@ import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
   SharedSessionsResponse,
   SharedSessionDetail,
-  SharedSessionInvitationsResponse,
+  SharedSessionInvitation,
   SharedSessionSave,
   SharedSession,
 } from "@/types/api";
@@ -26,7 +26,7 @@ export function useSharedSessionInvitations() {
       const data = await unwrap(
         typedApi.GET("/api/user/shared-session-invites"),
       );
-      return data as SharedSessionInvitationsResponse | undefined;
+      return data as SharedSessionInvitation[] | null | undefined;
     },
   });
 }

--- a/web/src/pages/__tests__/shared-sessions-page.test.tsx
+++ b/web/src/pages/__tests__/shared-sessions-page.test.tsx
@@ -57,22 +57,24 @@ const mockSharedSessions = {
   pageSize: 24,
 };
 
-const mockInvitations = {
-  data: [
-    {
-      id: "inv-1",
-      sharedSessionId: "ss-2",
-      sharedSessionName: "RPG Club",
-      gameId: "g2",
-      gameTitle: "Chrono Trigger",
-      gameCoverUrl: "https://example.com/chrono.png",
-      gameConsoleName: "SNES",
-      inviterUsername: "bob",
-      createdAt: "2026-02-13T10:00:00Z",
-    },
-  ],
-  total: 1,
-};
+const mockInvitations = [
+  {
+    id: "inv-1",
+    sharedSessionId: "ss-2",
+    sharedSessionName: "RPG Club",
+    gameId: "g2",
+    gameTitle: "Chrono Trigger",
+    gameCoverUrl: "https://example.com/chrono.png",
+    consoleName: "SNES",
+    inviterId: "u1",
+    inviterUsername: "bob",
+    inviterAvatarUrl: "",
+    inviteeId: "u2",
+    inviteeUsername: "alice",
+    status: "pending",
+    createdAt: "2026-02-13T10:00:00Z",
+  },
+];
 
 function renderPage() {
   const queryClient = new QueryClient({
@@ -154,7 +156,7 @@ describe("SharedSessionsPage", () => {
 
   it("shows empty state when no invitations", async () => {
     mockUseSharedSessionInvitations.mockReturnValue({
-      data: { data: [], total: 0 },
+      data: [],
       isLoading: false,
     });
     renderPage();

--- a/web/src/pages/shared-sessions-page.tsx
+++ b/web/src/pages/shared-sessions-page.tsx
@@ -71,8 +71,8 @@ export function SharedSessionsPage() {
   useSharedSessionRealtime();
 
   const sharedSessions = sharedSessionsData?.data ?? [];
-  const invitations = invitationsData?.data ?? [];
-  const invitationCount = invitationsData?.total ?? 0;
+  const invitations = invitationsData ?? [];
+  const invitationCount = invitations.length;
 
   function handleTabChange(tab: Tab) {
     setActiveTab(tab);

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -259,21 +259,11 @@ export type SharedSessionDetail = Omit<
   members: SharedSessionMember[] | null;
 };
 
-// Frontend-only shape assembled from the list-my-pending-invites endpoint's
-// response (which is an array of these). The generated SharedSessionInviteResponse
-// is the POST-invite mutation response, not the list item — different fields.
-export interface SharedSessionInvitation {
-  id: string;
-  sharedSessionId: string;
-  sharedSessionName: string;
-  gameId: string;
-  gameTitle: string;
-  gameCoverUrl?: string;
-  consoleName: string;
-  inviterUsername: string;
-  inviterAvatarUrl?: string;
-  createdAt: string;
-}
+// The wire response for GET /api/user/shared-session-invites is
+// SharedSessionInviteResponse[] — flat array, not paginated. The server
+// now includes game/console/inviter enrichment fields directly; consumers
+// import SharedSessionInviteResponse from @/generated/schemas.
+export type SharedSessionInvitation = Schemas["SharedSessionInviteResponse"];
 
 export type SharedSessionSave = Schemas["SharedSessionSaveResponse"];
 
@@ -294,7 +284,6 @@ export interface PaginatedFlat<T> {
 }
 
 export type SharedSessionsResponse = Paginated<SharedSession>;
-export type SharedSessionInvitationsResponse = PaginatedFlat<SharedSessionInvitation>;
 
 export type NetplaySessionStatus = "waiting" | "in_progress" | "ended";
 export type NetplayEndReason =


### PR DESCRIPTION
Closes #606.

## Problem
The shared-sessions invitations UI (`invitation-card.tsx`) rendered fields the server never actually sent — `gameCoverUrl`, `consoleName`, `inviterAvatarUrl`, `gameId` were all undefined at runtime. On top of that, the hook cast the flat-array response to a paginated wrapper, so `invitationsData?.data` and `?.total` were always undefined. Net effect: the invitations list silently rendered empty.

## Fix

**Server** — enrich `SharedSessionInviteResponse` with the four missing fields. The existing handler already preloads `SharedSession.Game.Console` and `Inviter`, so the data is available without new queries.

**Web** — `SharedSessionInvitation` now aliases `Schemas["SharedSessionInviteResponse"]` (real wire shape). `SharedSessionInvitationsResponse` deleted — it was a fiction; the endpoint returns `T[]`. Hook returns the array, consumer uses `invitations.length`. Test fixtures across 3 files updated to match.

## Tests
- `go build ./... && go test ./internal/api/ -run SharedSession` passes
- `npm run openapi:gen && npm run build` clean
- `npx vitest run` — 1468/1468 pass