### PR TITLE
chore: regen Kotlin player client after omitempty sweep (#489)

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/AdminApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/AdminApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -81,10 +73,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/AuthApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/AuthApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -39,10 +31,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/BiosApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/BiosApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -35,10 +27,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/BrandingApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/BrandingApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -32,10 +24,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ChallengesApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ChallengesApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -38,10 +30,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/CheatsApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/CheatsApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -34,10 +26,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/CollectionsApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/CollectionsApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -39,10 +31,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ConsolesApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ConsolesApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -35,10 +27,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
@@ -340,13 +328,13 @@ open class ConsolesApi : ApiClient {
      * @param id Console abbreviation (e.g. &#39;snes&#39;) or code.
      * @param page 1-based page number. (optional, default to 1L)
      * @param pageSize Page size. (optional, default to 50L)
-     * @param sortBy Sort column. (optional, default to SortBy.title)
-     * @param sortOrder Sort direction. (optional, default to SortOrder.asc)
+     * @param sortBy Sort column. (optional, default to title)
+     * @param sortOrder Sort direction. (optional, default to asc)
      * @param search Substring match on title. (optional)
      * @param letter Alphabet quick-jump filter (&#39;A&#39;-&#39;Z&#39; or &#39;#&#39; for non-alpha). (optional)
      * @param region Region filter (comma-separated for multi-select). (optional)
-     * @param grouped Show only primary variants. (optional, default to Grouped.`true`)
-     * @param hidePreRelease Hide betas/protos/samples. (optional, default to HidePreRelease.`true`)
+     * @param grouped Show only primary variants. (optional, default to true)
+     * @param hidePreRelease Hide betas/protos/samples. (optional, default to true)
      * @return PaginatedResponseGameResponse
      */
     @Suppress("UNCHECKED_CAST")

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/CoresApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/CoresApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -33,10 +25,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/DevicesApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/DevicesApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -39,10 +31,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/EnrichmentApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/EnrichmentApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -43,10 +35,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ExploreApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ExploreApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -64,10 +56,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/FavoritesApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/FavoritesApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -34,10 +26,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/GamesApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/GamesApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -43,10 +35,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
@@ -484,8 +472,8 @@ open class GamesApi : ApiClient {
      * @param ratingMin Minimum rating (0-100). (optional)
      * @param ratingMax Maximum rating (0-100). (optional)
      * @param playStatus Restrict to unplayed | played | favorited | play-later for the current user. (optional)
-     * @param grouped Show only primary variants. (optional, default to Grouped.`true`)
-     * @param hidePreRelease Hide betas/protos/samples. (optional, default to HidePreRelease.`true`)
+     * @param grouped Show only primary variants. (optional, default to true)
+     * @param hidePreRelease Hide betas/protos/samples. (optional, default to true)
      * @param sortBy Sort column (title, created_at, file_size, rating, release_date). (optional)
      * @param sort Legacy alias for sortBy. (optional)
      * @param sortOrder Sort direction (asc, desc). (optional)

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/MakersApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/MakersApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -33,10 +25,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/NetplayApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/NetplayApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -43,10 +35,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/PlayLaterApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/PlayLaterApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -35,10 +27,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ProfilesApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ProfilesApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -35,10 +27,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/RatingsApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/RatingsApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -37,10 +29,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/RetroachievementsApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/RetroachievementsApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -46,10 +38,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ScraperApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/ScraperApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -38,10 +30,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SearchApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SearchApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -33,10 +25,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SessionsApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SessionsApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -44,10 +36,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SetupApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SetupApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -33,10 +25,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SharedSavesApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SharedSavesApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -35,10 +27,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SharedSessionsApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SharedSessionsApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -44,10 +36,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SocialApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SocialApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -37,10 +29,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/StatsApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/StatsApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -35,10 +27,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SystemApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SystemApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -35,10 +27,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/TopListsApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/TopListsApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -34,10 +26,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/UserApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/UserApi.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.apis
@@ -49,10 +41,6 @@ import io.ktor.client.request.forms.formData
 import io.ktor.client.engine.HttpClientEngine
 import kotlinx.serialization.json.Json
 import io.ktor.http.ParametersBuilder
-import io.ktor.http.Headers
-import io.ktor.http.HttpHeaders
-import io.ktor.http.ContentType
-import io.ktor.http.content.PartData
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/infrastructure/Base64ByteArray.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/infrastructure/Base64ByteArray.kt
@@ -3,14 +3,13 @@ package com.spela.client.infrastructure
 import kotlinx.serialization.*
 import kotlinx.serialization.descriptors.*
 import kotlinx.serialization.encoding.*
-import kotlin.io.encoding.Base64
 
 @Serializable(Base64ByteArray.Companion::class)
 class Base64ByteArray(val value: ByteArray) {
     companion object : KSerializer<Base64ByteArray> {
         override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("Base64ByteArray", PrimitiveKind.STRING)
-        override fun serialize(encoder: Encoder, value: Base64ByteArray): Unit = encoder.encodeString(Base64.encode(value.value))
-        override fun deserialize(decoder: Decoder): Base64ByteArray = Base64ByteArray(Base64.decode(decoder.decodeString()))
+        override fun serialize(encoder: Encoder, value: Base64ByteArray): Unit = encoder.encodeString(value.value.encodeBase64())
+        override fun deserialize(decoder: Decoder): Base64ByteArray = Base64ByteArray(decoder.decodeString().decodeBase64Bytes())
     }
 
     override fun equals(other: Any?): Boolean {
@@ -25,6 +24,6 @@ class Base64ByteArray(val value: ByteArray) {
     }
 
     override fun toString(): String {
-        return "Base64ByteArray(${value.toHexString()})"
+        return "Base64ByteArray(${hex(value)})"
     }
 }

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/infrastructure/Bytes.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/infrastructure/Bytes.kt
@@ -1,0 +1,104 @@
+package com.spela.client.infrastructure
+
+import io.ktor.utils.io.core.*
+import kotlinx.io.Source
+import kotlinx.io.readByteArray
+import kotlin.experimental.and
+
+private val digits = "0123456789abcdef".toCharArray()
+private const val BASE64_ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+private const val BASE64_MASK: Byte = 0x3f
+private const val BASE64_PAD = '='
+private val BASE64_INVERSE_ALPHABET = IntArray(256) { BASE64_ALPHABET.indexOf(it.toChar()) }
+
+private fun String.toCharArray(): CharArray = CharArray(length) { get(it) }
+private fun ByteArray.clearFrom(from: Int) = (from until size).forEach { this[it] = 0 }
+private fun Int.toBase64(): Char = BASE64_ALPHABET[this]
+private fun Byte.fromBase64(): Byte = BASE64_INVERSE_ALPHABET[toInt() and 0xff].toByte() and BASE64_MASK
+internal fun ByteArray.encodeBase64(): String = buildPacket { writeFully(this@encodeBase64) }.encodeBase64()
+internal fun String.decodeBase64Bytes(): ByteArray =
+    buildPacket { writeText(dropLastWhile { it == BASE64_PAD }) }.decodeBase64Bytes().readByteArray()
+
+/**
+ * Encode [bytes] as a HEX string with no spaces, newlines and `0x` prefixes.
+ *
+ * Taken from https://github.com/ktorio/ktor/blob/master/ktor-utils/common/src/io/ktor/util/Crypto.kt
+ */
+internal fun hex(bytes: ByteArray): String {
+    val result = CharArray(bytes.size * 2)
+    var resultIndex = 0
+    val digits = digits
+
+    for (element in bytes) {
+        val b = element.toInt() and 0xff
+        result[resultIndex++] = digits[b shr 4]
+        result[resultIndex++] = digits[b and 0x0f]
+    }
+
+    return result.concatToString()
+}
+
+/**
+ * Decode bytes from HEX string. It should be no spaces and `0x` prefixes.
+ *
+ * Taken from https://github.com/ktorio/ktor/blob/master/ktor-utils/common/src/io/ktor/util/Crypto.kt
+ */
+internal fun hex(s: String): ByteArray {
+    val result = ByteArray(s.length / 2)
+    for (idx in result.indices) {
+        val srcIdx = idx * 2
+        val high = s[srcIdx].toString().toInt(16) shl 4
+        val low = s[srcIdx + 1].toString().toInt(16)
+        result[idx] = (high or low).toByte()
+    }
+
+    return result
+}
+
+/**
+ * Encode [ByteReadPacket] in base64 format.
+ *
+ * Taken from https://github.com/ktorio/ktor/blob/424d1d2cfaa3281302c60af9500f738c8c2fc846/ktor-utils/common/src/io/ktor/util/Base64.kt
+ */
+private fun Source.encodeBase64(): String = buildString {
+    val data = ByteArray(3)
+    while (remaining > 0) {
+        val read = readAvailable(data)
+        data.clearFrom(read)
+
+        val padSize = (data.size - read) * 8 / 6
+        val chunk = ((data[0].toInt() and 0xFF) shl 16) or
+                ((data[1].toInt() and 0xFF) shl 8) or
+                (data[2].toInt() and 0xFF)
+
+        for (index in data.size downTo padSize) {
+            val char = (chunk shr (6 * index)) and BASE64_MASK.toInt()
+            append(char.toBase64())
+        }
+
+        repeat(padSize) { append(BASE64_PAD) }
+    }
+}
+
+/**
+ * Decode [ByteReadPacket] from base64 format
+ *
+ * Taken from https://github.com/ktorio/ktor/blob/424d1d2cfaa3281302c60af9500f738c8c2fc846/ktor-utils/common/src/io/ktor/util/Base64.kt
+ */
+@Suppress("DEPRECATION")
+private fun ByteReadPacket.decodeBase64Bytes(): Input = buildPacket {
+    val data = ByteArray(4)
+
+    while (remaining > 0) {
+        val read = readAvailable(data)
+
+        val chunk = data.foldIndexed(0) { index, result, current ->
+            result or (current.fromBase64().toInt() shl ((3 - index) * 6))
+        }
+
+        for (index in data.size - 2 downTo (data.size - read)) {
+            val origin = (chunk shr (8 * index)) and 0xff
+            writeByte(origin.toByte())
+        }
+    }
+}

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/infrastructure/OctetByteArray.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/infrastructure/OctetByteArray.kt
@@ -8,8 +8,8 @@ import kotlinx.serialization.encoding.*
 class OctetByteArray(val value: ByteArray) {
     companion object : KSerializer<OctetByteArray> {
         override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("OctetByteArray", PrimitiveKind.STRING)
-        override fun serialize(encoder: Encoder, value: OctetByteArray): Unit = encoder.encodeString(value.value.toHexString())
-        override fun deserialize(decoder: Decoder): OctetByteArray = OctetByteArray(decoder.decodeString().hexToByteArray())
+        override fun serialize(encoder: Encoder, value: OctetByteArray): Unit = encoder.encodeString(hex(value.value))
+        override fun deserialize(decoder: Decoder): OctetByteArray = OctetByteArray(hex(decoder.decodeString()))
     }
 
     override fun equals(other: Any?): Boolean {
@@ -24,6 +24,6 @@ class OctetByteArray(val value: ByteArray) {
     }
 
     override fun toString(): String {
-        return "OctetByteArray(${value.toHexString()})"
+        return "OctetByteArray(${hex(value)})"
     }
 }

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/infrastructure/PartConfig.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/infrastructure/PartConfig.kt
@@ -4,16 +4,8 @@ package com.spela.client.infrastructure
  * Defines a config object for a given part of a multi-part request.
  * NOTE: Headers is a Map<String,String> because rfc2616 defines
  *       multi-valued headers as csv-only.
- * 
- * @property headers The headers for this part
- * @property body The body content for this part
- * @property serializer Optional custom serializer for JSON content. When provided, this will be
- *                      used instead of the default serialization for parts with application/json
- *                      content-type. This allows capturing type information at the call site to
- *                      avoid issues with type erasure in kotlinx.serialization.
  */
 data class PartConfig<T>(
     val headers: MutableMap<String, String> = mutableMapOf(),
-    val body: T? = null,
-    val serializer: ((Any?) -> String)? = null
+    val body: T? = null
 )

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/Achievement.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/Achievement.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AchievementGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AchievementGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AchievementLeaderboardResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AchievementLeaderboardResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AchievementTimelineResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AchievementTimelineResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveChallengesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveChallengesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveNowItem.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveNowItem.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveNowResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveNowResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActivePlayerEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActivePlayerEntry.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -46,7 +38,7 @@ data class ActivePlayerEntry (
 
     @SerialName(value = "gamesPlayed") @Required val gamesPlayed: kotlin.Long,
 
-    @SerialName(value = "lastPlayed") @Required val lastPlayed: kotlin.time.Instant,
+    @SerialName(value = "lastPlayed") @Required val lastPlayed: kotlinx.datetime.Instant,
 
     @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveYears.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveYears.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActivityEventResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActivityEventResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,25 +23,31 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param avatarUrl 
+ * @param consoleName 
  * @param createdAt 
  * @param eventType 
+ * @param gameCoverUrl 
  * @param gameId 
  * @param gameTitle 
  * @param id 
+ * @param metadata 
  * @param userId 
  * @param username 
- * @param avatarUrl 
- * @param consoleName 
- * @param gameCoverUrl 
- * @param metadata 
  */
 @Serializable
 
 data class ActivityEventResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
+    @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "eventType") @Required val eventType: kotlin.String,
+
+    @SerialName(value = "gameCoverUrl") @Required val gameCoverUrl: kotlin.String,
 
     @SerialName(value = "gameId") @Required val gameId: kotlin.String,
 
@@ -57,19 +55,13 @@ data class ActivityEventResponse (
 
     @SerialName(value = "id") @Required val id: kotlin.String,
 
+    @SerialName(value = "metadata") @Required val metadata: kotlin.String,
+
     @SerialName(value = "userId") @Required val userId: kotlin.String,
 
-    @SerialName(value = "username") @Required val username: kotlin.String,
+    @SerialName(value = "username") @Required val username: kotlin.String
 
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null,
-
-    @SerialName(value = "consoleName") val consoleName: kotlin.String? = null,
-
-    @SerialName(value = "gameCoverUrl") val gameCoverUrl: kotlin.String? = null,
-
-    @SerialName(value = "metadata") val metadata: kotlinx.serialization.json.JsonObject? = null
-
-) {
+) : kotlin.collections.HashMap<String, kotlinx.serialization.json.JsonElement>() {
 
 
 }

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AddGameToCollectionRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AddGameToCollectionRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AdminCreateRomHackResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AdminCreateRomHackResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AdminCreateUserRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AdminCreateUserRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AdminRAStatusResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AdminRAStatusResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AdminStatsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AdminStatsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AdminUpdateUserRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AdminUpdateUserRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AgeRatingResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AgeRatingResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AlmostDoneGame.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AlmostDoneGame.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AlmostDoneResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AlmostDoneResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AnniversariesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AnniversariesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AnniversaryItem.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AnniversaryItem.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -42,7 +34,7 @@ data class AnniversaryItem (
 
     @SerialName(value = "game") @Required val game: GameResponse,
 
-    @SerialName(value = "playedAt") @Required val playedAt: kotlin.time.Instant,
+    @SerialName(value = "playedAt") @Required val playedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "yearsAgo") @Required val yearsAgo: kotlin.Long
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ApplyIGDBMatchRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ApplyIGDBMatchRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ArtworkGalleryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ArtworkGalleryResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ArtworkItem.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ArtworkItem.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthLoginRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthLoginRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthLoginResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthLoginResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthLogoutResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthLogoutResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthRefreshRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthRefreshRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthRegisterRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthRegisterRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthRegisterResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AuthRegisterResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,34 +24,34 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
- * @param dollarSchema A URL to the JSON Schema for this object.
  * @param accessToken Bearer access token.
  * @param message Human-readable status message (only set when pending).
  * @param pending True when the new account is awaiting admin approval. When true, no tokens are returned.
  * @param refreshToken Refresh token (rotate via /api/auth/refresh).
  * @param user Registered user profile.
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
 data class AuthRegisterResponse (
 
-    /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
     /* Bearer access token. */
-    @SerialName(value = "accessToken") val accessToken: kotlin.String? = null,
+    @SerialName(value = "accessToken") @Required val accessToken: kotlin.String,
 
     /* Human-readable status message (only set when pending). */
-    @SerialName(value = "message") val message: kotlin.String? = null,
+    @SerialName(value = "message") @Required val message: kotlin.String,
 
     /* True when the new account is awaiting admin approval. When true, no tokens are returned. */
-    @SerialName(value = "pending") val pending: kotlin.Boolean? = null,
+    @SerialName(value = "pending") @Required val pending: kotlin.Boolean,
 
     /* Refresh token (rotate via /api/auth/refresh). */
-    @SerialName(value = "refreshToken") val refreshToken: kotlin.String? = null,
+    @SerialName(value = "refreshToken") @Required val refreshToken: kotlin.String,
 
     /* Registered user profile. */
-    @SerialName(value = "user") val user: UserResponse? = null
+    @SerialName(value = "user") @Required val user: UserResponse,
+
+    /* A URL to the JSON Schema for this object. */
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BackfillImagesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BackfillImagesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BestOfYearResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BestOfYearResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BiosDownloadStartedResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BiosDownloadStartedResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BiosFileResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BiosFileResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,22 +24,28 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param consoleId 
+ * @param consoleName 
+ * @param description 
+ * @param expectedMd5 
  * @param md5 
  * @param name 
  * @param required 
  * @param propertySize 
  * @param status 
- * @param dollarSchema A URL to the JSON Schema for this object.
- * @param consoleName 
- * @param description 
- * @param expectedMd5 
  * @param subDir 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
 data class BiosFileResponse (
 
     @SerialName(value = "consoleId") @Required val consoleId: kotlin.String?,
+
+    @SerialName(value = "consoleName") @Required val consoleName: kotlin.String?,
+
+    @SerialName(value = "description") @Required val description: kotlin.String?,
+
+    @SerialName(value = "expectedMd5") @Required val expectedMd5: kotlin.String,
 
     @SerialName(value = "md5") @Required val md5: kotlin.String,
 
@@ -59,16 +57,10 @@ data class BiosFileResponse (
 
     @SerialName(value = "status") @Required val status: kotlin.String,
 
+    @SerialName(value = "subDir") @Required val subDir: kotlin.String,
+
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "consoleName") val consoleName: kotlin.String? = null,
-
-    @SerialName(value = "description") val description: kotlin.String? = null,
-
-    @SerialName(value = "expectedMd5") val expectedMd5: kotlin.String? = null,
-
-    @SerialName(value = "subDir") val subDir: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BiosListResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BiosListResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BulkDeleteSessionSavesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BulkDeleteSessionSavesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ChallengeAttemptResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ChallengeAttemptResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,7 +23,9 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param avatarUrl 
  * @param challengeId 
+ * @param completedAt 
  * @param durationMs 
  * @param id 
  * @param isBest 
@@ -40,14 +34,16 @@ import kotlinx.serialization.encoding.*
  * @param userId 
  * @param username 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param avatarUrl 
- * @param completedAt 
  */
 @Serializable
 
 data class ChallengeAttemptResponse (
 
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
     @SerialName(value = "challengeId") @Required val challengeId: kotlin.String,
+
+    @SerialName(value = "completedAt") @Required val completedAt: kotlinx.datetime.Instant?,
 
     @SerialName(value = "durationMs") @Required val durationMs: kotlin.Long,
 
@@ -55,7 +51,7 @@ data class ChallengeAttemptResponse (
 
     @SerialName(value = "isBest") @Required val isBest: kotlin.Boolean,
 
-    @SerialName(value = "startedAt") @Required val startedAt: kotlin.time.Instant,
+    @SerialName(value = "startedAt") @Required val startedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "status") @Required val status: kotlin.String,
 
@@ -64,11 +60,7 @@ data class ChallengeAttemptResponse (
     @SerialName(value = "username") @Required val username: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null,
-
-    @SerialName(value = "completedAt") val completedAt: kotlin.time.Instant? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ChallengeLeaderboardEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ChallengeLeaderboardEntry.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,12 +24,12 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param attemptId 
+ * @param avatarUrl 
  * @param completedAt 
  * @param durationMs 
  * @param rank 
  * @param userId 
  * @param username 
- * @param avatarUrl 
  */
 @Serializable
 
@@ -45,7 +37,9 @@ data class ChallengeLeaderboardEntry (
 
     @SerialName(value = "attemptId") @Required val attemptId: kotlin.String,
 
-    @SerialName(value = "completedAt") @Required val completedAt: kotlin.time.Instant,
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
+    @SerialName(value = "completedAt") @Required val completedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "durationMs") @Required val durationMs: kotlin.Long,
 
@@ -53,9 +47,7 @@ data class ChallengeLeaderboardEntry (
 
     @SerialName(value = "userId") @Required val userId: kotlin.String,
 
-    @SerialName(value = "username") @Required val username: kotlin.String,
-
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null
+    @SerialName(value = "username") @Required val username: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ChallengeResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ChallengeResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -33,26 +25,26 @@ import kotlinx.serialization.encoding.*
  *
  * @param attemptCount 
  * @param completionCount 
+ * @param consoleName 
+ * @param coreName 
  * @param createdAt 
+ * @param creatorAvatar 
  * @param creatorId 
  * @param creatorUsername 
+ * @param description 
  * @param difficulty 
+ * @param expiresAt 
+ * @param gameCoverUrl 
  * @param gameId 
  * @param gameTitle 
  * @param id 
  * @param name 
  * @param saveFileSize 
+ * @param screenshotUrl 
  * @param status 
  * @param type 
  * @param updatedAt 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param consoleName 
- * @param coreName 
- * @param creatorAvatar 
- * @param description 
- * @param expiresAt 
- * @param gameCoverUrl 
- * @param screenshotUrl 
  */
 @Serializable
 
@@ -62,13 +54,25 @@ data class ChallengeResponse (
 
     @SerialName(value = "completionCount") @Required val completionCount: kotlin.Long,
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
+
+    @SerialName(value = "coreName") @Required val coreName: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "creatorAvatar") @Required val creatorAvatar: kotlin.String,
 
     @SerialName(value = "creatorId") @Required val creatorId: kotlin.String,
 
     @SerialName(value = "creatorUsername") @Required val creatorUsername: kotlin.String,
 
+    @SerialName(value = "description") @Required val description: kotlin.String,
+
     @SerialName(value = "difficulty") @Required val difficulty: kotlin.String,
+
+    @SerialName(value = "expiresAt") @Required val expiresAt: kotlinx.datetime.Instant?,
+
+    @SerialName(value = "gameCoverUrl") @Required val gameCoverUrl: kotlin.String,
 
     @SerialName(value = "gameId") @Required val gameId: kotlin.String,
 
@@ -80,28 +84,16 @@ data class ChallengeResponse (
 
     @SerialName(value = "saveFileSize") @Required val saveFileSize: kotlin.Long,
 
+    @SerialName(value = "screenshotUrl") @Required val screenshotUrl: kotlin.String,
+
     @SerialName(value = "status") @Required val status: kotlin.String,
 
     @SerialName(value = "type") @Required val type: kotlin.String,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "consoleName") val consoleName: kotlin.String? = null,
-
-    @SerialName(value = "coreName") val coreName: kotlin.String? = null,
-
-    @SerialName(value = "creatorAvatar") val creatorAvatar: kotlin.String? = null,
-
-    @SerialName(value = "description") val description: kotlin.String? = null,
-
-    @SerialName(value = "expiresAt") val expiresAt: kotlin.time.Instant? = null,
-
-    @SerialName(value = "gameCoverUrl") val gameCoverUrl: kotlin.String? = null,
-
-    @SerialName(value = "screenshotUrl") val screenshotUrl: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ChangePasswordRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ChangePasswordRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CheatStatsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CheatStatsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CheckUploadsWritableResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CheckUploadsWritableResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,20 +23,20 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param reason 
  * @param writable 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param reason 
  */
 @Serializable
 
 data class CheckUploadsWritableResponse (
 
+    @SerialName(value = "reason") @Required val reason: kotlin.String,
+
     @SerialName(value = "writable") @Required val writable: kotlin.Boolean,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "reason") val reason: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CollectionDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CollectionDetailResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,7 +24,10 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param avatarUrl 
+ * @param coverUrl 
  * @param createdAt 
+ * @param description 
  * @param gameCount 
  * @param games 
  * @param id 
@@ -42,15 +37,18 @@ import kotlinx.serialization.encoding.*
  * @param userId 
  * @param username 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param avatarUrl 
- * @param coverUrl 
- * @param description 
  */
 @Serializable
 
 data class CollectionDetailResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
+    @SerialName(value = "coverUrl") @Required val coverUrl: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "description") @Required val description: kotlin.String,
 
     @SerialName(value = "gameCount") @Required val gameCount: kotlin.Long,
 
@@ -62,20 +60,14 @@ data class CollectionDetailResponse (
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "userId") @Required val userId: kotlin.String,
 
     @SerialName(value = "username") @Required val username: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null,
-
-    @SerialName(value = "coverUrl") val coverUrl: kotlin.String? = null,
-
-    @SerialName(value = "description") val description: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CollectionResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CollectionResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,7 +23,10 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param avatarUrl 
+ * @param coverUrl 
  * @param createdAt 
+ * @param description 
  * @param gameCount 
  * @param id 
  * @param isPublic 
@@ -40,15 +35,18 @@ import kotlinx.serialization.encoding.*
  * @param userId 
  * @param username 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param avatarUrl 
- * @param coverUrl 
- * @param description 
  */
 @Serializable
 
 data class CollectionResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
+    @SerialName(value = "coverUrl") @Required val coverUrl: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "description") @Required val description: kotlin.String,
 
     @SerialName(value = "gameCount") @Required val gameCount: kotlin.Long,
 
@@ -58,20 +56,14 @@ data class CollectionResponse (
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "userId") @Required val userId: kotlin.String,
 
     @SerialName(value = "username") @Required val username: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null,
-
-    @SerialName(value = "coverUrl") val coverUrl: kotlin.String? = null,
-
-    @SerialName(value = "description") val description: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CommunityTopGame.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CommunityTopGame.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CommunityTopResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CommunityTopResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CompactSavesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CompactSavesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CompanyInfo.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CompanyInfo.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -42,17 +34,17 @@ import kotlinx.serialization.encoding.*
 
 data class CompanyInfo (
 
-    @SerialName(value = "country") val country: kotlin.String? = null,
+    @SerialName(value = "country") @Required val country: kotlin.String,
 
-    @SerialName(value = "description") val description: kotlin.String? = null,
+    @SerialName(value = "description") @Required val description: kotlin.String,
 
-    @SerialName(value = "foundedYear") val foundedYear: kotlin.Long? = null,
+    @SerialName(value = "foundedYear") @Required val foundedYear: kotlin.Long,
 
-    @SerialName(value = "logoUrl") val logoUrl: kotlin.String? = null,
+    @SerialName(value = "logoUrl") @Required val logoUrl: kotlin.String,
 
-    @SerialName(value = "websiteUrl") val websiteUrl: kotlin.String? = null,
+    @SerialName(value = "websiteUrl") @Required val websiteUrl: kotlin.String,
 
-    @SerialName(value = "wikipediaUrl") val wikipediaUrl: kotlin.String? = null
+    @SerialName(value = "wikipediaUrl") @Required val wikipediaUrl: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CompletionistConsole.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CompletionistConsole.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CompletionistMapResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CompletionistMapResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleBiosStatus.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleBiosStatus.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleFileStatus.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleFileStatus.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -52,7 +44,7 @@ data class ConsoleFileStatus (
 
     @SerialName(value = "status") @Required val status: kotlin.String,
 
-    @SerialName(value = "subDir") val subDir: kotlin.String? = null
+    @SerialName(value = "subDir") @Required val subDir: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleHighlight.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleHighlight.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -56,7 +48,7 @@ data class ConsoleHighlight (
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "topGame") val topGame: GameResponse? = null
+    @SerialName(value = "topGame") @Required val topGame: GameResponse
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleHighlightsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleHighlightsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleKeyMappingDTO.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleKeyMappingDTO.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,16 +23,16 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
- * @param selectedMapping 
  * @param customMapping 
+ * @param selectedMapping 
  */
 @Serializable
 
 data class ConsoleKeyMappingDTO (
 
-    @SerialName(value = "selectedMapping") @Required val selectedMapping: kotlin.String,
+    @SerialName(value = "customMapping") @Required val customMapping: kotlin.collections.Map<kotlin.String, kotlin.String>,
 
-    @SerialName(value = "customMapping") val customMapping: kotlin.collections.Map<kotlin.String, kotlin.String>? = null
+    @SerialName(value = "selectedMapping") @Required val selectedMapping: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -48,6 +40,8 @@ import kotlinx.serialization.encoding.*
  * @param id 
  * @param logoPngUrl 
  * @param logoUrl 
+ * @param maker 
+ * @param mediaType 
  * @param name 
  * @param playable 
  * @param releaseYear 
@@ -55,8 +49,6 @@ import kotlinx.serialization.encoding.*
  * @param summary 
  * @param unitsSold 
  * @param updatedAt 
- * @param maker 
- * @param mediaType 
  */
 @Serializable
 
@@ -72,7 +64,7 @@ data class ConsoleResponse (
 
     @SerialName(value = "coverAspectRatio") @Required val coverAspectRatio: kotlin.Double,
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "defaultCore") @Required val defaultCore: kotlin.String,
 
@@ -92,6 +84,10 @@ data class ConsoleResponse (
 
     @SerialName(value = "logoUrl") @Required val logoUrl: kotlin.String,
 
+    @SerialName(value = "maker") @Required val maker: HardwareMakerResponse,
+
+    @SerialName(value = "mediaType") @Required val mediaType: MediaTypeResponse,
+
     @SerialName(value = "name") @Required val name: kotlin.String,
 
     @SerialName(value = "playable") @Required val playable: kotlin.Boolean,
@@ -104,11 +100,7 @@ data class ConsoleResponse (
 
     @SerialName(value = "unitsSold") @Required val unitsSold: kotlin.Long?,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
-
-    @SerialName(value = "maker") val maker: HardwareMakerResponse? = null,
-
-    @SerialName(value = "mediaType") val mediaType: MediaTypeResponse? = null
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleShowcaseResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleShowcaseResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/Core.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/Core.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,23 +24,27 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param createdAt 
+ * @param description 
  * @param displayName 
+ * @param downloadUrl 
  * @param id 
  * @param name 
  * @param platforms 
  * @param updatedAt 
- * @param dollarSchema A URL to the JSON Schema for this object.
- * @param description 
- * @param downloadUrl 
  * @param version 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
 data class Core (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "description") @Required val description: kotlin.String,
 
     @SerialName(value = "displayName") @Required val displayName: kotlin.String,
+
+    @SerialName(value = "downloadUrl") @Required val downloadUrl: kotlin.String,
 
     @SerialName(value = "id") @Required val id: kotlin.Long,
 
@@ -56,16 +52,12 @@ data class Core (
 
     @SerialName(value = "platforms") @Required val platforms: kotlin.String,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "version") @Required val version: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "description") val description: kotlin.String? = null,
-
-    @SerialName(value = "downloadUrl") val downloadUrl: kotlin.String? = null,
-
-    @SerialName(value = "version") val version: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoreCompatibilityEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoreCompatibilityEntry.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoreCompatibilityResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoreCompatibilityResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoverGalleryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoverGalleryResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoverItem.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoverItem.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoverOption.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoverOption.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,22 +23,22 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
- * @param source 
- * @param url 
  * @param label 
  * @param libretroName 
+ * @param source 
+ * @param url 
  */
 @Serializable
 
 data class CoverOption (
 
+    @SerialName(value = "label") @Required val label: kotlin.String,
+
+    @SerialName(value = "libretroName") @Required val libretroName: kotlin.String,
+
     @SerialName(value = "source") @Required val source: kotlin.String,
 
-    @SerialName(value = "url") @Required val url: kotlin.String,
-
-    @SerialName(value = "label") val label: kotlin.String? = null,
-
-    @SerialName(value = "libretroName") val libretroName: kotlin.String? = null
+    @SerialName(value = "url") @Required val url: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CreateCollectionRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CreateCollectionRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CreateNetplaySessionRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CreateNetplaySessionRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CreateOrUpdateRatingRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CreateOrUpdateRatingRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CreateSessionRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CreateSessionRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CreateSharedSessionRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CreateSharedSessionRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CultClassicGame.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CultClassicGame.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CultClassicsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CultClassicsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DecadesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DecadesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeletedStatusResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeletedStatusResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeletedUserResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeletedUserResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -43,9 +35,9 @@ import kotlinx.serialization.encoding.*
 
 data class DeletedUserResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
-    @SerialName(value = "deletedAt") @Required val deletedAt: kotlin.time.Instant,
+    @SerialName(value = "deletedAt") @Required val deletedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "disabled") @Required val disabled: kotlin.Boolean,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperDetailResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -41,30 +33,34 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param activeYears 
  * @param avgRating 
+ * @param companyInfo 
  * @param consoles 
  * @param gameCount 
  * @param games 
  * @param genreBreakdown 
+ * @param heroUrl 
  * @param name 
  * @param platformBreakdown 
+ * @param primaryGenre 
  * @param publishers 
  * @param ratingDistribution 
- * @param topGames 
- * @param dollarSchema A URL to the JSON Schema for this object.
- * @param activeYears 
- * @param companyInfo 
- * @param heroUrl 
- * @param primaryGenre 
  * @param relatedDevelopers 
  * @param timeline 
+ * @param topGames 
  * @param userStats 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
 data class DeveloperDetailResponse (
 
+    @SerialName(value = "activeYears") @Required val activeYears: ActiveYears,
+
     @SerialName(value = "avgRating") @Required val avgRating: kotlin.Double,
+
+    @SerialName(value = "companyInfo") @Required val companyInfo: CompanyInfo,
 
     @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<kotlin.String>?,
 
@@ -74,32 +70,28 @@ data class DeveloperDetailResponse (
 
     @SerialName(value = "genreBreakdown") @Required val genreBreakdown: kotlin.collections.List<GenreCount>?,
 
+    @SerialName(value = "heroUrl") @Required val heroUrl: kotlin.String,
+
     @SerialName(value = "name") @Required val name: kotlin.String,
 
     @SerialName(value = "platformBreakdown") @Required val platformBreakdown: kotlin.collections.List<PlatformCount>?,
+
+    @SerialName(value = "primaryGenre") @Required val primaryGenre: kotlin.String,
 
     @SerialName(value = "publishers") @Required val publishers: kotlin.collections.List<NameCount>?,
 
     @SerialName(value = "ratingDistribution") @Required val ratingDistribution: RatingDistribution,
 
+    @SerialName(value = "relatedDevelopers") @Required val relatedDevelopers: kotlin.collections.List<RelatedDeveloper>?,
+
+    @SerialName(value = "timeline") @Required val timeline: kotlin.collections.List<TimelineEntry>?,
+
     @SerialName(value = "topGames") @Required val topGames: kotlin.collections.List<GameResponse>?,
 
+    @SerialName(value = "userStats") @Required val userStats: EntityUserStats,
+
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "activeYears") val activeYears: ActiveYears? = null,
-
-    @SerialName(value = "companyInfo") val companyInfo: CompanyInfo? = null,
-
-    @SerialName(value = "heroUrl") val heroUrl: kotlin.String? = null,
-
-    @SerialName(value = "primaryGenre") val primaryGenre: kotlin.String? = null,
-
-    @SerialName(value = "relatedDevelopers") val relatedDevelopers: kotlin.collections.List<RelatedDeveloper>? = null,
-
-    @SerialName(value = "timeline") val timeline: kotlin.collections.List<TimelineEntry>? = null,
-
-    @SerialName(value = "userStats") val userStats: EntityUserStats? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperListResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperListResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperSpotlightResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperSpotlightResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperSummary.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperSummary.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/Device.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/Device.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -45,19 +37,19 @@ import kotlinx.serialization.encoding.*
 
 data class Device (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "deviceUuid") @Required val deviceUuid: kotlin.String,
 
     @SerialName(value = "id") @Required val id: kotlin.Long,
 
-    @SerialName(value = "lastSeenAt") @Required val lastSeenAt: kotlin.time.Instant,
+    @SerialName(value = "lastSeenAt") @Required val lastSeenAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
     @SerialName(value = "platform") @Required val platform: kotlin.String,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "userId") @Required val userId: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DevicePreferencesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DevicePreferencesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeviceResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeviceResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -48,19 +40,19 @@ data class DeviceResponse (
 
     @SerialName(value = "consoleShaders") @Required val consoleShaders: kotlin.collections.Map<kotlin.String, kotlin.String>,
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "deviceUuid") @Required val deviceUuid: kotlin.String,
 
     @SerialName(value = "id") @Required val id: kotlin.Long,
 
-    @SerialName(value = "lastSeenAt") @Required val lastSeenAt: kotlin.time.Instant,
+    @SerialName(value = "lastSeenAt") @Required val lastSeenAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
     @SerialName(value = "platform") @Required val platform: kotlin.String,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "userId") @Required val userId: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DiagnosticCheck.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DiagnosticCheck.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,25 +23,25 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param detail 
+ * @param fix 
  * @param id 
  * @param label 
  * @param status 
- * @param detail 
- * @param fix 
  */
 @Serializable
 
 data class DiagnosticCheck (
 
+    @SerialName(value = "detail") @Required val detail: kotlin.String,
+
+    @SerialName(value = "fix") @Required val fix: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
     @SerialName(value = "label") @Required val label: kotlin.String,
 
-    @SerialName(value = "status") @Required val status: kotlin.String,
-
-    @SerialName(value = "detail") val detail: kotlin.String? = null,
-
-    @SerialName(value = "fix") val fix: kotlin.String? = null
+    @SerialName(value = "status") @Required val status: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DiscResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DiscResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DismissedResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DismissedResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DuplicateSessionRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DuplicateSessionRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EasyToCompleteResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EasyToCompleteResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EnrichmentStartedResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EnrichmentStartedResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EnrichmentStatusResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EnrichmentStatusResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,12 +24,12 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param active 
- * @param dollarSchema A URL to the JSON Schema for this object.
  * @param current 
  * @param failures 
  * @param gameName 
  * @param successes 
  * @param total 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
@@ -45,18 +37,18 @@ data class EnrichmentStatusResponse (
 
     @SerialName(value = "active") @Required val active: kotlin.Boolean,
 
+    @SerialName(value = "current") @Required val current: kotlin.Long,
+
+    @SerialName(value = "failures") @Required val failures: kotlin.Long,
+
+    @SerialName(value = "gameName") @Required val gameName: kotlin.String,
+
+    @SerialName(value = "successes") @Required val successes: kotlin.Long,
+
+    @SerialName(value = "total") @Required val total: kotlin.Long,
+
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "current") val current: kotlin.Long? = null,
-
-    @SerialName(value = "failures") val failures: kotlin.Long? = null,
-
-    @SerialName(value = "gameName") val gameName: kotlin.String? = null,
-
-    @SerialName(value = "successes") val successes: kotlin.Long? = null,
-
-    @SerialName(value = "total") val total: kotlin.Long? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EntityUserStats.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EntityUserStats.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -34,8 +26,8 @@ import kotlinx.serialization.encoding.*
  *
  * @param favoriteCount 
  * @param gamesPlayed 
- * @param totalPlayTime 
  * @param mostPlayedGame 
+ * @param totalPlayTime 
  */
 @Serializable
 
@@ -45,9 +37,9 @@ data class EntityUserStats (
 
     @SerialName(value = "gamesPlayed") @Required val gamesPlayed: kotlin.Long,
 
-    @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long,
+    @SerialName(value = "mostPlayedGame") @Required val mostPlayedGame: GameResponse,
 
-    @SerialName(value = "mostPlayedGame") val mostPlayedGame: GameResponse? = null
+    @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExploreChallengeResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExploreChallengeResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -33,18 +25,18 @@ import kotlinx.serialization.encoding.*
  *
  * @param attemptCount 
  * @param completionCount 
+ * @param consoleName 
  * @param createdAt 
  * @param creatorUsername 
+ * @param description 
  * @param difficulty 
+ * @param expiresAt 
+ * @param gameCoverUrl 
  * @param gameId 
  * @param gameTitle 
  * @param id 
  * @param name 
  * @param type 
- * @param consoleName 
- * @param description 
- * @param expiresAt 
- * @param gameCoverUrl 
  */
 @Serializable
 
@@ -54,11 +46,19 @@ data class ExploreChallengeResponse (
 
     @SerialName(value = "completionCount") @Required val completionCount: kotlin.Long,
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "creatorUsername") @Required val creatorUsername: kotlin.String,
 
+    @SerialName(value = "description") @Required val description: kotlin.String,
+
     @SerialName(value = "difficulty") @Required val difficulty: kotlin.String,
+
+    @SerialName(value = "expiresAt") @Required val expiresAt: kotlinx.datetime.Instant?,
+
+    @SerialName(value = "gameCoverUrl") @Required val gameCoverUrl: kotlin.String,
 
     @SerialName(value = "gameId") @Required val gameId: kotlin.String,
 
@@ -68,15 +68,7 @@ data class ExploreChallengeResponse (
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "type") @Required val type: kotlin.String,
-
-    @SerialName(value = "consoleName") val consoleName: kotlin.String? = null,
-
-    @SerialName(value = "description") val description: kotlin.String? = null,
-
-    @SerialName(value = "expiresAt") val expiresAt: kotlin.time.Instant? = null,
-
-    @SerialName(value = "gameCoverUrl") val gameCoverUrl: kotlin.String? = null
+    @SerialName(value = "type") @Required val type: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExploreRowResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExploreRowResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExploreRowsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExploreRowsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExplorerBadge.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExplorerBadge.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExplorerBadgesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExplorerBadgesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FeaturedGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FeaturedGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FeaturedSeriesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FeaturedSeriesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,11 +24,11 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param consoleCount 
+ * @param heroUrl 
  * @param id 
  * @param libraryGames 
  * @param name 
  * @param totalGames 
- * @param heroUrl 
  */
 @Serializable
 
@@ -44,15 +36,15 @@ data class FeaturedSeriesResponse (
 
     @SerialName(value = "consoleCount") @Required val consoleCount: kotlin.Long,
 
+    @SerialName(value = "heroUrl") @Required val heroUrl: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
     @SerialName(value = "libraryGames") @Required val libraryGames: kotlin.Long,
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "totalGames") @Required val totalGames: kotlin.Long,
-
-    @SerialName(value = "heroUrl") val heroUrl: kotlin.String? = null
+    @SerialName(value = "totalGames") @Required val totalGames: kotlin.Long
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ForYouResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ForYouResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ForYouRowResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ForYouRowResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -33,10 +25,10 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param games 
- * @param title 
- * @param type 
  * @param genre 
  * @param sourceGame 
+ * @param title 
+ * @param type 
  */
 @Serializable
 
@@ -44,13 +36,13 @@ data class ForYouRowResponse (
 
     @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>?,
 
+    @SerialName(value = "genre") @Required val genre: kotlin.String,
+
+    @SerialName(value = "sourceGame") @Required val sourceGame: GameResponse,
+
     @SerialName(value = "title") @Required val title: kotlin.String,
 
-    @SerialName(value = "type") @Required val type: kotlin.String,
-
-    @SerialName(value = "genre") val genre: kotlin.String? = null,
-
-    @SerialName(value = "sourceGame") val sourceGame: GameResponse? = null
+    @SerialName(value = "type") @Required val type: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FormFile.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FormFile.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -48,7 +40,7 @@ data class FormFile (
 
     @SerialName(value = "Size") @Required val propertySize: kotlin.Long
 
-) {
+) : kotlin.collections.HashMap<String, kotlinx.serialization.json.JsonElement>() {
 
 
 }

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FranchiseDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FranchiseDetailResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -35,14 +27,14 @@ import kotlinx.serialization.encoding.*
  *
  * @param consoles 
  * @param games 
+ * @param heroUrl 
  * @param id 
  * @param igdbFranchiseId 
  * @param libraryGames 
+ * @param logoUrl 
  * @param name 
  * @param totalGames 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param heroUrl 
- * @param logoUrl 
  */
 @Serializable
 
@@ -52,22 +44,22 @@ data class FranchiseDetailResponse (
 
     @SerialName(value = "games") @Required val games: kotlin.collections.List<SeriesGameResponse>?,
 
+    @SerialName(value = "heroUrl") @Required val heroUrl: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
     @SerialName(value = "igdbFranchiseId") @Required val igdbFranchiseId: kotlin.Long,
 
     @SerialName(value = "libraryGames") @Required val libraryGames: kotlin.Long,
 
+    @SerialName(value = "logoUrl") @Required val logoUrl: kotlin.String,
+
     @SerialName(value = "name") @Required val name: kotlin.String,
 
     @SerialName(value = "totalGames") @Required val totalGames: kotlin.Long,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "heroUrl") val heroUrl: kotlin.String? = null,
-
-    @SerialName(value = "logoUrl") val logoUrl: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FranchiseResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FranchiseResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FreshChallengeGame.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FreshChallengeGame.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FreshChallengesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FreshChallengesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameAchievementProgressResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameAchievementProgressResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameAchievementsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameAchievementsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -34,11 +26,11 @@ import kotlinx.serialization.encoding.*
  *
  * @param achievements Achievement definitions for this game (empty when unknown).
  * @param raGameId RetroAchievements game ID (0 when unknown).
+ * @param status Only set to 'pending' when the data is being fetched asynchronously; clients should retry.
+ * @param title RetroAchievements game title; present when achievement data is available.
  * @param totalCount Total number of achievements for this game.
  * @param totalPoints Total number of points available across all achievements.
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param status Only set to 'pending' when the data is being fetched asynchronously; clients should retry.
- * @param title RetroAchievements game title; present when achievement data is available.
  */
 @Serializable
 
@@ -50,6 +42,12 @@ data class GameAchievementsResponse (
     /* RetroAchievements game ID (0 when unknown). */
     @SerialName(value = "raGameId") @Required val raGameId: kotlin.Long,
 
+    /* Only set to 'pending' when the data is being fetched asynchronously; clients should retry. */
+    @SerialName(value = "status") @Required val status: GameAchievementsResponse.Status,
+
+    /* RetroAchievements game title; present when achievement data is available. */
+    @SerialName(value = "title") @Required val title: kotlin.String,
+
     /* Total number of achievements for this game. */
     @SerialName(value = "totalCount") @Required val totalCount: kotlin.Long,
 
@@ -57,13 +55,7 @@ data class GameAchievementsResponse (
     @SerialName(value = "totalPoints") @Required val totalPoints: kotlin.Long,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    /* Only set to 'pending' when the data is being fetched asynchronously; clients should retry. */
-    @SerialName(value = "status") val status: GameAchievementsResponse.Status? = null,
-
-    /* RetroAchievements game title; present when achievement data is available. */
-    @SerialName(value = "title") val title: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameArtworkResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameArtworkResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,26 +23,26 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
- * @param dollarSchema A URL to the JSON Schema for this object.
  * @param gridUrl 
  * @param heroUrl 
  * @param iconUrl 
  * @param logoUrl 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
 data class GameArtworkResponse (
 
+    @SerialName(value = "gridUrl") @Required val gridUrl: kotlin.String,
+
+    @SerialName(value = "heroUrl") @Required val heroUrl: kotlin.String,
+
+    @SerialName(value = "iconUrl") @Required val iconUrl: kotlin.String,
+
+    @SerialName(value = "logoUrl") @Required val logoUrl: kotlin.String,
+
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "gridUrl") val gridUrl: kotlin.String? = null,
-
-    @SerialName(value = "heroUrl") val heroUrl: kotlin.String? = null,
-
-    @SerialName(value = "iconUrl") val iconUrl: kotlin.String? = null,
-
-    @SerialName(value = "logoUrl") val logoUrl: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameCheatResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameCheatResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameCoversResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameCoversResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameFranchiseResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameFranchiseResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameHeroesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameHeroesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameKeyMappingResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameKeyMappingResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameRatingResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameRatingResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,22 +23,24 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param avatarUrl 
  * @param createdAt 
  * @param gameId 
  * @param id 
  * @param rating 
+ * @param review 
  * @param updatedAt 
  * @param userId 
  * @param username 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param avatarUrl 
- * @param review 
  */
 @Serializable
 
 data class GameRatingResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "gameId") @Required val gameId: kotlin.String,
 
@@ -54,18 +48,16 @@ data class GameRatingResponse (
 
     @SerialName(value = "rating") @Required val rating: kotlin.Long,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "review") @Required val review: kotlin.String,
+
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "userId") @Required val userId: kotlin.String,
 
     @SerialName(value = "username") @Required val username: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null,
-
-    @SerialName(value = "review") val review: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -39,83 +31,91 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param achievementsWarning 
+ * @param ageRatings 
  * @param averageRating 
+ * @param biosStatus 
  * @param consoleId 
  * @param consoleName 
+ * @param coreOverride 
  * @param coverAspectRatio 
  * @param coverUrl 
  * @param createdAt 
  * @param description 
  * @param developer 
  * @param discCount 
+ * @param discs 
  * @param fileName 
  * @param fileSize 
+ * @param gameModes 
  * @param genre 
+ * @param groupKey 
+ * @param heroUrl 
  * @param id 
  * @param igdbCriticsRating 
+ * @param igdbUserRating 
+ * @param igdbUserRatingCount 
  * @param isFavorite 
  * @param isInPlayLater 
  * @param isPreRelease 
+ * @param languageSupports 
  * @param lastPlayedAt 
+ * @param logoUrl 
+ * @param parentGame 
+ * @param partyInfo 
  * @param playable 
  * @param players 
  * @param publisher 
  * @param ratingCount 
- * @param releaseDate 
- * @param scrapeAttempts 
- * @param screenshotUrls 
- * @param title 
- * @param totalPlayTime 
- * @param updatedAt 
- * @param dollarSchema A URL to the JSON Schema for this object.
- * @param achievementsWarning 
- * @param ageRatings 
- * @param biosStatus 
- * @param coreOverride 
- * @param discs 
- * @param gameModes 
- * @param groupKey 
- * @param heroUrl 
- * @param igdbUserRating 
- * @param igdbUserRatingCount 
- * @param languageSupports 
- * @param logoUrl 
- * @param parentGame 
- * @param partyInfo 
  * @param region 
+ * @param releaseDate 
  * @param releaseDates 
  * @param revision 
  * @param romHacks 
+ * @param scrapeAttempts 
  * @param scraperId 
+ * @param screenshotUrls 
  * @param storyline 
  * @param tags 
  * @param timeToBeatCompletely 
  * @param timeToBeatHastily 
  * @param timeToBeatNormally 
+ * @param title 
+ * @param totalPlayTime 
  * @param totalRating 
  * @param totalRatingCount 
+ * @param updatedAt 
  * @param userRating 
  * @param variantCount 
  * @param variants 
  * @param verificationStatus 
  * @param verificationTag 
  * @param videos 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
 data class GameResponse (
 
+    @SerialName(value = "achievementsWarning") @Required val achievementsWarning: kotlin.String,
+
+    @SerialName(value = "ageRatings") @Required val ageRatings: kotlin.collections.List<AgeRatingResponse>?,
+
     @SerialName(value = "averageRating") @Required val averageRating: kotlin.Double,
+
+    @SerialName(value = "biosStatus") @Required val biosStatus: kotlin.String,
 
     @SerialName(value = "consoleId") @Required val consoleId: kotlin.String,
 
     @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
 
+    @SerialName(value = "coreOverride") @Required val coreOverride: kotlin.String,
+
     @SerialName(value = "coverAspectRatio") @Required val coverAspectRatio: kotlin.Double,
 
     @SerialName(value = "coverUrl") @Required val coverUrl: kotlin.String,
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "description") @Required val description: kotlin.String,
 
@@ -123,15 +123,27 @@ data class GameResponse (
 
     @SerialName(value = "discCount") @Required val discCount: kotlin.Long,
 
+    @SerialName(value = "discs") @Required val discs: kotlin.collections.List<DiscResponse>?,
+
     @SerialName(value = "fileName") @Required val fileName: kotlin.String,
 
     @SerialName(value = "fileSize") @Required val fileSize: kotlin.Long,
 
+    @SerialName(value = "gameModes") @Required val gameModes: kotlin.String,
+
     @SerialName(value = "genre") @Required val genre: kotlin.String,
+
+    @SerialName(value = "groupKey") @Required val groupKey: kotlin.String,
+
+    @SerialName(value = "heroUrl") @Required val heroUrl: kotlin.String,
 
     @SerialName(value = "id") @Required val id: kotlin.String,
 
     @SerialName(value = "igdbCriticsRating") @Required val igdbCriticsRating: kotlin.Double,
+
+    @SerialName(value = "igdbUserRating") @Required val igdbUserRating: kotlin.Double,
+
+    @SerialName(value = "igdbUserRatingCount") @Required val igdbUserRatingCount: kotlin.Long,
 
     @SerialName(value = "isFavorite") @Required val isFavorite: kotlin.Boolean,
 
@@ -139,7 +151,15 @@ data class GameResponse (
 
     @SerialName(value = "isPreRelease") @Required val isPreRelease: kotlin.Boolean,
 
-    @SerialName(value = "lastPlayedAt") @Required val lastPlayedAt: kotlin.time.Instant?,
+    @SerialName(value = "languageSupports") @Required val languageSupports: kotlin.collections.List<LanguageSupportResponse>?,
+
+    @SerialName(value = "lastPlayedAt") @Required val lastPlayedAt: kotlinx.datetime.Instant?,
+
+    @SerialName(value = "logoUrl") @Required val logoUrl: kotlin.String,
+
+    @SerialName(value = "parentGame") @Required val parentGame: ParentGameResponse,
+
+    @SerialName(value = "partyInfo") @Required val partyInfo: kotlin.String,
 
     @SerialName(value = "playable") @Required val playable: kotlin.Boolean,
 
@@ -149,84 +169,56 @@ data class GameResponse (
 
     @SerialName(value = "ratingCount") @Required val ratingCount: kotlin.Long,
 
+    @SerialName(value = "region") @Required val region: kotlin.String,
+
     @SerialName(value = "releaseDate") @Required val releaseDate: kotlin.String,
+
+    @SerialName(value = "releaseDates") @Required val releaseDates: kotlin.collections.List<ReleaseDateResponse>?,
+
+    @SerialName(value = "revision") @Required val revision: kotlin.String,
+
+    @SerialName(value = "romHacks") @Required val romHacks: kotlin.collections.List<RomHackGameResponse>?,
 
     @SerialName(value = "scrapeAttempts") @Required val scrapeAttempts: kotlin.Long,
 
+    @SerialName(value = "scraperId") @Required val scraperId: kotlin.String,
+
     @SerialName(value = "screenshotUrls") @Required val screenshotUrls: kotlin.collections.List<kotlin.String>?,
+
+    @SerialName(value = "storyline") @Required val storyline: kotlin.String,
+
+    @SerialName(value = "tags") @Required val tags: kotlin.String,
+
+    @SerialName(value = "timeToBeatCompletely") @Required val timeToBeatCompletely: kotlin.Long,
+
+    @SerialName(value = "timeToBeatHastily") @Required val timeToBeatHastily: kotlin.Long,
+
+    @SerialName(value = "timeToBeatNormally") @Required val timeToBeatNormally: kotlin.Long,
 
     @SerialName(value = "title") @Required val title: kotlin.String,
 
     @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "totalRating") @Required val totalRating: kotlin.Double,
+
+    @SerialName(value = "totalRatingCount") @Required val totalRatingCount: kotlin.Long,
+
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "userRating") @Required val userRating: kotlin.Long?,
+
+    @SerialName(value = "variantCount") @Required val variantCount: kotlin.Long,
+
+    @SerialName(value = "variants") @Required val variants: kotlin.collections.List<VariantResponse>?,
+
+    @SerialName(value = "verificationStatus") @Required val verificationStatus: kotlin.String,
+
+    @SerialName(value = "verificationTag") @Required val verificationTag: kotlin.String,
+
+    @SerialName(value = "videos") @Required val videos: kotlin.collections.List<VideoResponse>?,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "achievementsWarning") val achievementsWarning: kotlin.String? = null,
-
-    @SerialName(value = "ageRatings") val ageRatings: kotlin.collections.List<AgeRatingResponse>? = null,
-
-    @SerialName(value = "biosStatus") val biosStatus: kotlin.String? = null,
-
-    @SerialName(value = "coreOverride") val coreOverride: kotlin.String? = null,
-
-    @SerialName(value = "discs") val discs: kotlin.collections.List<DiscResponse>? = null,
-
-    @SerialName(value = "gameModes") val gameModes: kotlin.String? = null,
-
-    @SerialName(value = "groupKey") val groupKey: kotlin.String? = null,
-
-    @SerialName(value = "heroUrl") val heroUrl: kotlin.String? = null,
-
-    @SerialName(value = "igdbUserRating") val igdbUserRating: kotlin.Double? = null,
-
-    @SerialName(value = "igdbUserRatingCount") val igdbUserRatingCount: kotlin.Long? = null,
-
-    @SerialName(value = "languageSupports") val languageSupports: kotlin.collections.List<LanguageSupportResponse>? = null,
-
-    @SerialName(value = "logoUrl") val logoUrl: kotlin.String? = null,
-
-    @SerialName(value = "parentGame") val parentGame: ParentGameResponse? = null,
-
-    @SerialName(value = "partyInfo") val partyInfo: kotlin.String? = null,
-
-    @SerialName(value = "region") val region: kotlin.String? = null,
-
-    @SerialName(value = "releaseDates") val releaseDates: kotlin.collections.List<ReleaseDateResponse>? = null,
-
-    @SerialName(value = "revision") val revision: kotlin.String? = null,
-
-    @SerialName(value = "romHacks") val romHacks: kotlin.collections.List<RomHackGameResponse>? = null,
-
-    @SerialName(value = "scraperId") val scraperId: kotlin.String? = null,
-
-    @SerialName(value = "storyline") val storyline: kotlin.String? = null,
-
-    @SerialName(value = "tags") val tags: kotlin.String? = null,
-
-    @SerialName(value = "timeToBeatCompletely") val timeToBeatCompletely: kotlin.Long? = null,
-
-    @SerialName(value = "timeToBeatHastily") val timeToBeatHastily: kotlin.Long? = null,
-
-    @SerialName(value = "timeToBeatNormally") val timeToBeatNormally: kotlin.Long? = null,
-
-    @SerialName(value = "totalRating") val totalRating: kotlin.Double? = null,
-
-    @SerialName(value = "totalRatingCount") val totalRatingCount: kotlin.Long? = null,
-
-    @SerialName(value = "userRating") val userRating: kotlin.Long? = null,
-
-    @SerialName(value = "variantCount") val variantCount: kotlin.Long? = null,
-
-    @SerialName(value = "variants") val variants: kotlin.collections.List<VariantResponse>? = null,
-
-    @SerialName(value = "verificationStatus") val verificationStatus: kotlin.String? = null,
-
-    @SerialName(value = "verificationTag") val verificationTag: kotlin.String? = null,
-
-    @SerialName(value = "videos") val videos: kotlin.collections.List<VideoResponse>? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameSeriesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameSeriesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameSessionResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameSessionResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,10 +24,14 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param cheatsEnabled 
+ * @param coreName 
  * @param createdAt 
  * @param gameId 
  * @param id 
  * @param isSharedSession 
+ * @param lastPlayedAt 
+ * @param lastPlayedBy 
+ * @param lastPlayedByUsername 
  * @param memberAvatars 
  * @param memberCount 
  * @param memberUsernames 
@@ -43,15 +39,11 @@ import kotlinx.serialization.encoding.*
  * @param ownerId 
  * @param ownerUsername 
  * @param saveCount 
+ * @param screenshotUrl 
+ * @param sharedSessionId 
  * @param totalPlayTime 
  * @param updatedAt 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param coreName 
- * @param lastPlayedAt 
- * @param lastPlayedBy 
- * @param lastPlayedByUsername 
- * @param screenshotUrl 
- * @param sharedSessionId 
  */
 @Serializable
 
@@ -59,13 +51,21 @@ data class GameSessionResponse (
 
     @SerialName(value = "cheatsEnabled") @Required val cheatsEnabled: kotlin.Boolean,
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "coreName") @Required val coreName: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "gameId") @Required val gameId: kotlin.String,
 
     @SerialName(value = "id") @Required val id: kotlin.String,
 
     @SerialName(value = "isSharedSession") @Required val isSharedSession: kotlin.Boolean,
+
+    @SerialName(value = "lastPlayedAt") @Required val lastPlayedAt: kotlinx.datetime.Instant?,
+
+    @SerialName(value = "lastPlayedBy") @Required val lastPlayedBy: kotlin.String?,
+
+    @SerialName(value = "lastPlayedByUsername") @Required val lastPlayedByUsername: kotlin.String?,
 
     @SerialName(value = "memberAvatars") @Required val memberAvatars: kotlin.collections.List<kotlin.String>?,
 
@@ -81,24 +81,16 @@ data class GameSessionResponse (
 
     @SerialName(value = "saveCount") @Required val saveCount: kotlin.Long,
 
+    @SerialName(value = "screenshotUrl") @Required val screenshotUrl: kotlin.String,
+
+    @SerialName(value = "sharedSessionId") @Required val sharedSessionId: kotlin.String?,
+
     @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "coreName") val coreName: kotlin.String? = null,
-
-    @SerialName(value = "lastPlayedAt") val lastPlayedAt: kotlin.time.Instant? = null,
-
-    @SerialName(value = "lastPlayedBy") val lastPlayedBy: kotlin.String? = null,
-
-    @SerialName(value = "lastPlayedByUsername") val lastPlayedByUsername: kotlin.String? = null,
-
-    @SerialName(value = "screenshotUrl") val screenshotUrl: kotlin.String? = null,
-
-    @SerialName(value = "sharedSessionId") val sharedSessionId: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameStatsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameStatsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameStatsTopPlayer.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameStatsTopPlayer.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GenreCount.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GenreCount.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HardestGamesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HardestGamesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HardwareMakerResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HardwareMakerResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HealthResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HealthResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HeatmapEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HeatmapEntry.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HeroOption.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HeroOption.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HumaError.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HumaError.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,8 +24,8 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param error 
- * @param dollarSchema A URL to the JSON Schema for this object.
  * @param message 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
@@ -41,10 +33,10 @@ data class HumaError (
 
     @SerialName(value = "error") @Required val error: kotlin.String,
 
-    /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
+    @SerialName(value = "message") @Required val message: kotlin.String,
 
-    @SerialName(value = "message") val message: kotlin.String? = null
+    /* A URL to the JSON Schema for this object. */
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/IGDBSearchResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/IGDBSearchResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,10 +23,10 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
- * @param igdbId 
- * @param name 
  * @param coverUrl 
  * @param developer 
+ * @param igdbId 
+ * @param name 
  * @param releaseYear 
  * @param summary 
  */
@@ -42,17 +34,17 @@ import kotlinx.serialization.encoding.*
 
 data class IGDBSearchResult (
 
+    @SerialName(value = "coverUrl") @Required val coverUrl: kotlin.String,
+
+    @SerialName(value = "developer") @Required val developer: kotlin.String,
+
     @SerialName(value = "igdbId") @Required val igdbId: kotlin.Long,
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "coverUrl") val coverUrl: kotlin.String? = null,
+    @SerialName(value = "releaseYear") @Required val releaseYear: kotlin.Long,
 
-    @SerialName(value = "developer") val developer: kotlin.String? = null,
-
-    @SerialName(value = "releaseYear") val releaseYear: kotlin.Long? = null,
-
-    @SerialName(value = "summary") val summary: kotlin.String? = null
+    @SerialName(value = "summary") @Required val summary: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/IGDBStatusResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/IGDBStatusResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ImportResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ImportResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/InviteToSharedSessionRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/InviteToSharedSessionRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/JoinByInviteCodeRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/JoinByInviteCodeRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/KeywordResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/KeywordResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/LanguageSupportResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/LanguageSupportResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/LeaveNetplaySessionResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/LeaveNetplaySessionResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/LinkRAAccountRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/LinkRAAccountRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ListMyNetplayInvitesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ListMyNetplayInvitesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/LongestGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/LongestGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MakerDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MakerDetailResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -34,9 +26,9 @@ import kotlinx.serialization.encoding.*
  *
  * @param code 
  * @param consoleCount 
+ * @param consoles 
  * @param name 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param consoles 
  */
 @Serializable
 
@@ -46,12 +38,12 @@ data class MakerDetailResponse (
 
     @SerialName(value = "consoleCount") @Required val consoleCount: kotlin.Long,
 
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<ConsoleResponse>?,
+
     @SerialName(value = "name") @Required val name: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "consoles") val consoles: kotlin.collections.List<ConsoleResponse>? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MediaTypeCategoryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MediaTypeCategoryResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MediaTypeResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MediaTypeResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MessageResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MessageResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MetadataMatchesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MetadataMatchesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MoodResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MoodResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MostActivePlayersResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MostActivePlayersResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MostPlayedEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MostPlayedEntry.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MostPlayedResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MostPlayedResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/NameCount.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/NameCount.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/NetplayInviteResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/NetplayInviteResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,29 +23,33 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param consoleName 
  * @param createdAt 
+ * @param gameCoverUrl 
  * @param gameId 
  * @param gameTitle 
  * @param hostUsername 
  * @param id 
  * @param inputDelay 
+ * @param inviteeAvatarUrl 
  * @param inviteeId 
  * @param inviteeUsername 
+ * @param inviterAvatarUrl 
  * @param inviterId 
  * @param inviterUsername 
  * @param netplaySessionId 
  * @param status 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param consoleName 
- * @param gameCoverUrl 
- * @param inviteeAvatarUrl 
- * @param inviterAvatarUrl 
  */
 @Serializable
 
 data class NetplayInviteResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "gameCoverUrl") @Required val gameCoverUrl: kotlin.String,
 
     @SerialName(value = "gameId") @Required val gameId: kotlin.String,
 
@@ -65,9 +61,13 @@ data class NetplayInviteResponse (
 
     @SerialName(value = "inputDelay") @Required val inputDelay: kotlin.Long,
 
+    @SerialName(value = "inviteeAvatarUrl") @Required val inviteeAvatarUrl: kotlin.String,
+
     @SerialName(value = "inviteeId") @Required val inviteeId: kotlin.String,
 
     @SerialName(value = "inviteeUsername") @Required val inviteeUsername: kotlin.String,
+
+    @SerialName(value = "inviterAvatarUrl") @Required val inviterAvatarUrl: kotlin.String,
 
     @SerialName(value = "inviterId") @Required val inviterId: kotlin.String,
 
@@ -78,15 +78,7 @@ data class NetplayInviteResponse (
     @SerialName(value = "status") @Required val status: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "consoleName") val consoleName: kotlin.String? = null,
-
-    @SerialName(value = "gameCoverUrl") val gameCoverUrl: kotlin.String? = null,
-
-    @SerialName(value = "inviteeAvatarUrl") val inviteeAvatarUrl: kotlin.String? = null,
-
-    @SerialName(value = "inviterAvatarUrl") val inviterAvatarUrl: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/NetplayInviteUserRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/NetplayInviteUserRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/NetplaySessionResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/NetplaySessionResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,42 +23,60 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param clientAvatarUrl 
  * @param clientId 
+ * @param clientUsername 
+ * @param consoleId 
+ * @param consoleName 
+ * @param coreName 
  * @param coverAspectRatio 
  * @param createdAt 
+ * @param endReason 
+ * @param endedAt 
+ * @param gameCoverUrl 
  * @param gameId 
  * @param gameTitle 
+ * @param hostAvatarUrl 
  * @param hostId 
  * @param hostUsername 
  * @param id 
  * @param inputDelay 
  * @param inviteCode 
+ * @param startedAt 
  * @param status 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param clientAvatarUrl 
- * @param clientUsername 
- * @param consoleId 
- * @param consoleName 
- * @param coreName 
- * @param endReason 
- * @param endedAt 
- * @param gameCoverUrl 
- * @param hostAvatarUrl 
- * @param startedAt 
  */
 @Serializable
 
 data class NetplaySessionResponse (
 
+    @SerialName(value = "clientAvatarUrl") @Required val clientAvatarUrl: kotlin.String,
+
     @SerialName(value = "clientId") @Required val clientId: kotlin.String?,
+
+    @SerialName(value = "clientUsername") @Required val clientUsername: kotlin.String,
+
+    @SerialName(value = "consoleId") @Required val consoleId: kotlin.String,
+
+    @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
+
+    @SerialName(value = "coreName") @Required val coreName: kotlin.String,
 
     @SerialName(value = "coverAspectRatio") @Required val coverAspectRatio: kotlin.Double,
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "endReason") @Required val endReason: kotlin.String,
+
+    @SerialName(value = "endedAt") @Required val endedAt: kotlinx.datetime.Instant?,
+
+    @SerialName(value = "gameCoverUrl") @Required val gameCoverUrl: kotlin.String,
 
     @SerialName(value = "gameId") @Required val gameId: kotlin.String,
 
     @SerialName(value = "gameTitle") @Required val gameTitle: kotlin.String,
+
+    @SerialName(value = "hostAvatarUrl") @Required val hostAvatarUrl: kotlin.String,
 
     @SerialName(value = "hostId") @Required val hostId: kotlin.String,
 
@@ -78,30 +88,12 @@ data class NetplaySessionResponse (
 
     @SerialName(value = "inviteCode") @Required val inviteCode: kotlin.String,
 
+    @SerialName(value = "startedAt") @Required val startedAt: kotlinx.datetime.Instant?,
+
     @SerialName(value = "status") @Required val status: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "clientAvatarUrl") val clientAvatarUrl: kotlin.String? = null,
-
-    @SerialName(value = "clientUsername") val clientUsername: kotlin.String? = null,
-
-    @SerialName(value = "consoleId") val consoleId: kotlin.String? = null,
-
-    @SerialName(value = "consoleName") val consoleName: kotlin.String? = null,
-
-    @SerialName(value = "coreName") val coreName: kotlin.String? = null,
-
-    @SerialName(value = "endReason") val endReason: kotlin.String? = null,
-
-    @SerialName(value = "endedAt") val endedAt: kotlin.time.Instant? = null,
-
-    @SerialName(value = "gameCoverUrl") val gameCoverUrl: kotlin.String? = null,
-
-    @SerialName(value = "hostAvatarUrl") val hostAvatarUrl: kotlin.String? = null,
-
-    @SerialName(value = "startedAt") val startedAt: kotlin.time.Instant? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnThisDayResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnThisDayResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnlineUserGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnlineUserGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,9 +24,9 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param consoleName 
+ * @param coverUrl 
  * @param id 
  * @param title 
- * @param coverUrl 
  */
 @Serializable
 
@@ -42,11 +34,11 @@ data class OnlineUserGameResponse (
 
     @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
 
+    @SerialName(value = "coverUrl") @Required val coverUrl: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
-    @SerialName(value = "title") @Required val title: kotlin.String,
-
-    @SerialName(value = "coverUrl") val coverUrl: kotlin.String? = null
+    @SerialName(value = "title") @Required val title: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnlineUserResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnlineUserResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,22 +24,22 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
- * @param id 
- * @param username 
  * @param avatarUrl 
  * @param currentGame 
+ * @param id 
+ * @param username 
  */
 @Serializable
 
 data class OnlineUserResponse (
 
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
+    @SerialName(value = "currentGame") @Required val currentGame: OnlineUserGameResponse,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
-    @SerialName(value = "username") @Required val username: kotlin.String,
-
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null,
-
-    @SerialName(value = "currentGame") val currentGame: OnlineUserGameResponse? = null
+    @SerialName(value = "username") @Required val username: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnlineUsersResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnlineUsersResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseActivityEventResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseActivityEventResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -42,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class PaginatedResponseActivityEventResponse (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<ActivityEventResponse>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<@Contextual ActivityEventResponse>?,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseChallengeLeaderboardEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseChallengeLeaderboardEntry.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseChallengeResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseChallengeResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseCollectionResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseCollectionResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseGameRatingResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseGameRatingResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseNetplaySessionResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseNetplaySessionResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseSharedSaveResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseSharedSaveResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseUserSearchResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseUserSearchResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ParentGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ParentGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,19 +23,19 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param coverUrl 
  * @param id 
  * @param title 
- * @param coverUrl 
  */
 @Serializable
 
 data class ParentGameResponse (
 
+    @SerialName(value = "coverUrl") @Required val coverUrl: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
-    @SerialName(value = "title") @Required val title: kotlin.String,
-
-    @SerialName(value = "coverUrl") val coverUrl: kotlin.String? = null
+    @SerialName(value = "title") @Required val title: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PendingNetplayInviteCountResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PendingNetplayInviteCountResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PlatformCount.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PlatformCount.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PlayStatsEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PlayStatsEntry.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PlayersLikeYouResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PlayersLikeYouResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PossibleConsoleResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PossibleConsoleResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PublicProfileGame.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PublicProfileGame.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,10 +24,10 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param consoleName 
- * @param id 
- * @param title 
  * @param coverUrl 
+ * @param id 
  * @param playTime 
+ * @param title 
  */
 @Serializable
 
@@ -43,13 +35,13 @@ data class PublicProfileGame (
 
     @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
 
+    @SerialName(value = "coverUrl") @Required val coverUrl: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
-    @SerialName(value = "title") @Required val title: kotlin.String,
+    @SerialName(value = "playTime") @Required val playTime: kotlin.Long,
 
-    @SerialName(value = "coverUrl") val coverUrl: kotlin.String? = null,
-
-    @SerialName(value = "playTime") val playTime: kotlin.Long? = null
+    @SerialName(value = "title") @Required val title: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PublicProfileResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PublicProfileResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -33,6 +25,8 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param avatarUrl 
+ * @param currentGame 
  * @param favoriteGames 
  * @param gamesPlayed 
  * @param id 
@@ -43,12 +37,14 @@ import kotlinx.serialization.encoding.*
  * @param totalPlayTime 
  * @param username 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param avatarUrl 
- * @param currentGame 
  */
 @Serializable
 
 data class PublicProfileResponse (
+
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
+    @SerialName(value = "currentGame") @Required val currentGame: OnlineUserGameResponse,
 
     @SerialName(value = "favoriteGames") @Required val favoriteGames: kotlin.collections.List<PublicProfileGame>?,
 
@@ -58,7 +54,7 @@ data class PublicProfileResponse (
 
     @SerialName(value = "isOnline") @Required val isOnline: kotlin.Boolean,
 
-    @SerialName(value = "memberSince") @Required val memberSince: kotlin.time.Instant,
+    @SerialName(value = "memberSince") @Required val memberSince: kotlinx.datetime.Instant,
 
     @SerialName(value = "recentGames") @Required val recentGames: kotlin.collections.List<PublicProfileGame>?,
 
@@ -69,11 +65,7 @@ data class PublicProfileResponse (
     @SerialName(value = "username") @Required val username: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null,
-
-    @SerialName(value = "currentGame") val currentGame: OnlineUserGameResponse? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PublisherDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PublisherDetailResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -41,30 +33,34 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param activeYears 
  * @param avgRating 
+ * @param companyInfo 
  * @param consoles 
  * @param developers 
  * @param gameCount 
  * @param games 
  * @param genreBreakdown 
+ * @param heroUrl 
  * @param name 
  * @param platformBreakdown 
- * @param ratingDistribution 
- * @param topGames 
- * @param dollarSchema A URL to the JSON Schema for this object.
- * @param activeYears 
- * @param companyInfo 
- * @param heroUrl 
  * @param primaryGenre 
+ * @param ratingDistribution 
  * @param relatedPublishers 
  * @param timeline 
+ * @param topGames 
  * @param userStats 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
 data class PublisherDetailResponse (
 
+    @SerialName(value = "activeYears") @Required val activeYears: ActiveYears,
+
     @SerialName(value = "avgRating") @Required val avgRating: kotlin.Double,
+
+    @SerialName(value = "companyInfo") @Required val companyInfo: CompanyInfo,
 
     @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<kotlin.String>?,
 
@@ -76,30 +72,26 @@ data class PublisherDetailResponse (
 
     @SerialName(value = "genreBreakdown") @Required val genreBreakdown: kotlin.collections.List<GenreCount>?,
 
+    @SerialName(value = "heroUrl") @Required val heroUrl: kotlin.String,
+
     @SerialName(value = "name") @Required val name: kotlin.String,
 
     @SerialName(value = "platformBreakdown") @Required val platformBreakdown: kotlin.collections.List<PlatformCount>?,
 
+    @SerialName(value = "primaryGenre") @Required val primaryGenre: kotlin.String,
+
     @SerialName(value = "ratingDistribution") @Required val ratingDistribution: RatingDistribution,
+
+    @SerialName(value = "relatedPublishers") @Required val relatedPublishers: kotlin.collections.List<RelatedPublisher>?,
+
+    @SerialName(value = "timeline") @Required val timeline: kotlin.collections.List<TimelineEntry>?,
 
     @SerialName(value = "topGames") @Required val topGames: kotlin.collections.List<GameResponse>?,
 
+    @SerialName(value = "userStats") @Required val userStats: EntityUserStats,
+
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "activeYears") val activeYears: ActiveYears? = null,
-
-    @SerialName(value = "companyInfo") val companyInfo: CompanyInfo? = null,
-
-    @SerialName(value = "heroUrl") val heroUrl: kotlin.String? = null,
-
-    @SerialName(value = "primaryGenre") val primaryGenre: kotlin.String? = null,
-
-    @SerialName(value = "relatedPublishers") val relatedPublishers: kotlin.collections.List<RelatedPublisher>? = null,
-
-    @SerialName(value = "timeline") val timeline: kotlin.collections.List<TimelineEntry>? = null,
-
-    @SerialName(value = "userStats") val userStats: EntityUserStats? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RALeaderboardEntryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RALeaderboardEntryResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -48,11 +40,11 @@ data class RALeaderboardEntryResponse (
 
     @SerialName(value = "earnedPoints") @Required val earnedPoints: kotlin.Long,
 
-    @SerialName(value = "firstUnlockedAt") @Required val firstUnlockedAt: kotlin.time.Instant,
+    @SerialName(value = "firstUnlockedAt") @Required val firstUnlockedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "isComplete") @Required val isComplete: kotlin.Boolean,
 
-    @SerialName(value = "lastUnlockedAt") @Required val lastUnlockedAt: kotlin.time.Instant,
+    @SerialName(value = "lastUnlockedAt") @Required val lastUnlockedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "unlockedCount") @Required val unlockedCount: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RAProgressEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RAProgressEntry.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RARecentAchievementResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RARecentAchievementResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -70,7 +62,7 @@ data class RARecentAchievementResponse (
 
     @SerialName(value = "title") @Required val title: kotlin.String,
 
-    @SerialName(value = "unlockedAt") @Required val unlockedAt: kotlin.time.Instant
+    @SerialName(value = "unlockedAt") @Required val unlockedAt: kotlinx.datetime.Instant
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RAStatusResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RAStatusResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RATimelineEntryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RATimelineEntryResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -58,7 +50,7 @@ data class RATimelineEntryResponse (
 
     @SerialName(value = "title") @Required val title: kotlin.String,
 
-    @SerialName(value = "unlockedAt") @Required val unlockedAt: kotlin.time.Instant
+    @SerialName(value = "unlockedAt") @Required val unlockedAt: kotlinx.datetime.Instant
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RATokenResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RATokenResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RAUnlockedAchievementResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RAUnlockedAchievementResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RateLimitResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RateLimitResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -44,7 +36,7 @@ data class RateLimitResponse (
 
     @SerialName(value = "isLockedOut") @Required val isLockedOut: kotlin.Boolean,
 
-    @SerialName(value = "lockedUntil") @Required val lockedUntil: kotlin.time.Instant?,
+    @SerialName(value = "lockedUntil") @Required val lockedUntil: kotlinx.datetime.Instant?,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RatingDistribution.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RatingDistribution.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RatingSummaryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RatingSummaryResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RecentAchievementsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RecentAchievementsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RecentReviewItem.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RecentReviewItem.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -48,7 +40,7 @@ data class RecentReviewItem (
 
     @SerialName(value = "review") @Required val review: kotlin.String,
 
-    @SerialName(value = "reviewedAt") @Required val reviewedAt: kotlin.time.Instant,
+    @SerialName(value = "reviewedAt") @Required val reviewedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "reviewerName") @Required val reviewerName: kotlin.String
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RecentlyReviewedResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RecentlyReviewedResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RefreshAchievementsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RefreshAchievementsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RegisterDeviceRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RegisterDeviceRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RelatedDeveloper.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RelatedDeveloper.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RelatedPublisher.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RelatedPublisher.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReleaseDateResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReleaseDateResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,8 +24,8 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param date 
- * @param region 
  * @param platform 
+ * @param region 
  */
 @Serializable
 
@@ -41,9 +33,9 @@ data class ReleaseDateResponse (
 
     @SerialName(value = "date") @Required val date: kotlin.String,
 
-    @SerialName(value = "region") @Required val region: kotlin.String,
+    @SerialName(value = "platform") @Required val platform: kotlin.String,
 
-    @SerialName(value = "platform") val platform: kotlin.String? = null
+    @SerialName(value = "region") @Required val region: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RenameSharedSessionSaveRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RenameSharedSessionSaveRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReorderPlayLaterRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReorderPlayLaterRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReplaceROMResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReplaceROMResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReplaceROMResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReplaceROMResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,15 +23,17 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param canonicalName 
  * @param crc32 
  * @param previousCrc32 
  * @param previousStatus 
  * @param verified 
- * @param canonicalName 
  */
 @Serializable
 
 data class ReplaceROMResult (
+
+    @SerialName(value = "canonicalName") @Required val canonicalName: kotlin.String,
 
     @SerialName(value = "crc32") @Required val crc32: kotlin.String,
 
@@ -47,9 +41,7 @@ data class ReplaceROMResult (
 
     @SerialName(value = "previousStatus") @Required val previousStatus: kotlin.String,
 
-    @SerialName(value = "verified") @Required val verified: kotlin.Boolean,
-
-    @SerialName(value = "canonicalName") val canonicalName: kotlin.String? = null
+    @SerialName(value = "verified") @Required val verified: kotlin.Boolean
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReportEmulatorErrorRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReportEmulatorErrorRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReportedResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReportedResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RomHackGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RomHackGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,19 +23,19 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param coverUrl 
  * @param id 
  * @param title 
- * @param coverUrl 
  */
 @Serializable
 
 data class RomHackGameResponse (
 
+    @SerialName(value = "coverUrl") @Required val coverUrl: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
-    @SerialName(value = "title") @Required val title: kotlin.String,
-
-    @SerialName(value = "coverUrl") val coverUrl: kotlin.String? = null
+    @SerialName(value = "title") @Required val title: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SavedSearchRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SavedSearchRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SavedSearchResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SavedSearchResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -41,7 +33,7 @@ import kotlinx.serialization.encoding.*
 
 data class SavedSearchResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "filters") @Required val filters: kotlinx.serialization.json.JsonElement?,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScanStartedResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScanStartedResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScanStatusResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScanStatusResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,11 +24,11 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param active 
- * @param dollarSchema A URL to the JSON Schema for this object.
  * @param current 
  * @param message 
  * @param phase 
  * @param total 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
@@ -44,16 +36,16 @@ data class ScanStatusResponse (
 
     @SerialName(value = "active") @Required val active: kotlin.Boolean,
 
+    @SerialName(value = "current") @Required val current: kotlin.Long,
+
+    @SerialName(value = "message") @Required val message: kotlin.String,
+
+    @SerialName(value = "phase") @Required val phase: kotlin.String,
+
+    @SerialName(value = "total") @Required val total: kotlin.Long,
+
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "current") val current: kotlin.Long? = null,
-
-    @SerialName(value = "message") val message: kotlin.String? = null,
-
-    @SerialName(value = "phase") val phase: kotlin.String? = null,
-
-    @SerialName(value = "total") val total: kotlin.Long? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScrapeGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScrapeGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScrapeStartedResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScrapeStartedResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,29 +23,29 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
- * @param total 
- * @param dollarSchema A URL to the JSON Schema for this object.
  * @param added 
  * @param jobId 
  * @param message 
+ * @param total 
  * @param totalItems 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
 data class ScrapeStartedResponse (
 
+    @SerialName(value = "added") @Required val added: kotlin.Long,
+
+    @SerialName(value = "jobId") @Required val jobId: kotlin.Long,
+
+    @SerialName(value = "message") @Required val message: kotlin.String,
+
     @SerialName(value = "total") @Required val total: kotlin.Long,
 
+    @SerialName(value = "totalItems") @Required val totalItems: kotlin.Long,
+
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "added") val added: kotlin.Long? = null,
-
-    @SerialName(value = "jobId") val jobId: kotlin.Long? = null,
-
-    @SerialName(value = "message") val message: kotlin.String? = null,
-
-    @SerialName(value = "totalItems") val totalItems: kotlin.Long? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScrapeStatusCountsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScrapeStatusCountsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScrapeStatusResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScrapeStatusResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,7 +24,6 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param active 
- * @param dollarSchema A URL to the JSON Schema for this object.
  * @param current 
  * @param failures 
  * @param jobId 
@@ -41,6 +32,7 @@ import kotlinx.serialization.encoding.*
  * @param successes 
  * @param total 
  * @param verified 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
@@ -48,24 +40,24 @@ data class ScrapeStatusResponse (
 
     @SerialName(value = "active") @Required val active: kotlin.Boolean,
 
+    @SerialName(value = "current") @Required val current: kotlin.Long,
+
+    @SerialName(value = "failures") @Required val failures: kotlin.Long,
+
+    @SerialName(value = "jobId") @Required val jobId: kotlin.Long,
+
+    @SerialName(value = "mode") @Required val mode: kotlin.String,
+
+    @SerialName(value = "startedAt") @Required val startedAt: kotlinx.datetime.Instant?,
+
+    @SerialName(value = "successes") @Required val successes: kotlin.Long,
+
+    @SerialName(value = "total") @Required val total: kotlin.Long,
+
+    @SerialName(value = "verified") @Required val verified: kotlin.Long,
+
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "current") val current: kotlin.Long? = null,
-
-    @SerialName(value = "failures") val failures: kotlin.Long? = null,
-
-    @SerialName(value = "jobId") val jobId: kotlin.Long? = null,
-
-    @SerialName(value = "mode") val mode: kotlin.String? = null,
-
-    @SerialName(value = "startedAt") val startedAt: kotlin.time.Instant? = null,
-
-    @SerialName(value = "successes") val successes: kotlin.Long? = null,
-
-    @SerialName(value = "total") val total: kotlin.Long? = null,
-
-    @SerialName(value = "verified") val verified: kotlin.Long? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScraperSourceResultResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScraperSourceResultResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScreenshotGalleryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScreenshotGalleryResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScreenshotItem.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScreenshotItem.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchCollectionResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchCollectionResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchCompanyResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchCompanyResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchConsoleResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchConsoleResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchFranchiseResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchFranchiseResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchGameResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchGameResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchSeriesResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchSeriesResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCollectionResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCollectionResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCompanyResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCompanyResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchConsoleResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchConsoleResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchFranchiseResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchFranchiseResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchGameResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchGameResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchSeriesResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchSeriesResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SeriesConsoleInfo.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SeriesConsoleInfo.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SeriesDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SeriesDetailResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -35,14 +27,14 @@ import kotlinx.serialization.encoding.*
  *
  * @param consoles 
  * @param games 
+ * @param heroUrl 
  * @param id 
  * @param igdbCollectionId 
  * @param libraryGames 
+ * @param logoUrl 
  * @param name 
  * @param totalGames 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param heroUrl 
- * @param logoUrl 
  */
 @Serializable
 
@@ -52,22 +44,22 @@ data class SeriesDetailResponse (
 
     @SerialName(value = "games") @Required val games: kotlin.collections.List<SeriesGameResponse>?,
 
+    @SerialName(value = "heroUrl") @Required val heroUrl: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
     @SerialName(value = "igdbCollectionId") @Required val igdbCollectionId: kotlin.Long,
 
     @SerialName(value = "libraryGames") @Required val libraryGames: kotlin.Long,
 
+    @SerialName(value = "logoUrl") @Required val logoUrl: kotlin.String,
+
     @SerialName(value = "name") @Required val name: kotlin.String,
 
     @SerialName(value = "totalGames") @Required val totalGames: kotlin.Long,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "heroUrl") val heroUrl: kotlin.String? = null,
-
-    @SerialName(value = "logoUrl") val logoUrl: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SeriesGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SeriesGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,20 +23,26 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param consoleAbbreviation 
+ * @param consoleColor 
+ * @param consoleName 
  * @param coverUrl 
  * @param igdbCriticsRating 
  * @param igdbGameId 
  * @param inLibrary 
  * @param localGameId 
  * @param name 
- * @param consoleAbbreviation 
- * @param consoleColor 
- * @param consoleName 
  * @param releaseDate 
  */
 @Serializable
 
 data class SeriesGameResponse (
+
+    @SerialName(value = "consoleAbbreviation") @Required val consoleAbbreviation: kotlin.String,
+
+    @SerialName(value = "consoleColor") @Required val consoleColor: kotlin.String,
+
+    @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
 
     @SerialName(value = "coverUrl") @Required val coverUrl: kotlin.String?,
 
@@ -58,13 +56,7 @@ data class SeriesGameResponse (
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "consoleAbbreviation") val consoleAbbreviation: kotlin.String? = null,
-
-    @SerialName(value = "consoleColor") val consoleColor: kotlin.String? = null,
-
-    @SerialName(value = "consoleName") val consoleName: kotlin.String? = null,
-
-    @SerialName(value = "releaseDate") val releaseDate: kotlin.String? = null
+    @SerialName(value = "releaseDate") @Required val releaseDate: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SeriesListResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SeriesListResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionCheatsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionCheatsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionSaveData.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionSaveData.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -42,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class SessionSaveData (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "fileSize") @Required val fileSize: kotlin.Long,
 
@@ -50,7 +42,7 @@ data class SessionSaveData (
 
     @SerialName(value = "sessionId") @Required val sessionId: kotlin.Long,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionSaveResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionSaveResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,29 +23,35 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param coreMatch 
+ * @param coreName 
  * @param createdAt 
+ * @param currentCore 
  * @param fileSize 
  * @param id 
  * @param isAuto 
  * @param isCurrent 
  * @param name 
+ * @param notes 
+ * @param screenshotUrl 
  * @param sessionId 
+ * @param slot 
  * @param updatedAt 
  * @param userId 
  * @param username 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param coreMatch 
- * @param coreName 
- * @param currentCore 
- * @param notes 
- * @param screenshotUrl 
- * @param slot 
  */
 @Serializable
 
 data class SessionSaveResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "coreMatch") @Required val coreMatch: kotlin.Boolean?,
+
+    @SerialName(value = "coreName") @Required val coreName: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "currentCore") @Required val currentCore: kotlin.String,
 
     @SerialName(value = "fileSize") @Required val fileSize: kotlin.Long,
 
@@ -65,28 +63,22 @@ data class SessionSaveResponse (
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
+    @SerialName(value = "notes") @Required val notes: kotlin.String,
+
+    @SerialName(value = "screenshotUrl") @Required val screenshotUrl: kotlin.String,
+
     @SerialName(value = "sessionId") @Required val sessionId: kotlin.String,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "slot") @Required val slot: kotlin.Long?,
+
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "userId") @Required val userId: kotlin.String,
 
     @SerialName(value = "username") @Required val username: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "coreMatch") val coreMatch: kotlin.Boolean? = null,
-
-    @SerialName(value = "coreName") val coreName: kotlin.String? = null,
-
-    @SerialName(value = "currentCore") val currentCore: kotlin.String? = null,
-
-    @SerialName(value = "notes") val notes: kotlin.String? = null,
-
-    @SerialName(value = "screenshotUrl") val screenshotUrl: kotlin.String? = null,
-
-    @SerialName(value = "slot") val slot: kotlin.Long? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionStorageConsoleBreakdown.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionStorageConsoleBreakdown.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetGameCoverRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetGameCoverRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetGameHeroRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetGameHeroRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetUploadConsoleRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetUploadConsoleRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetupDiagnosticsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetupDiagnosticsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetupStatusResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetupStatusResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSaveResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSaveResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,24 +23,28 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param avatarUrl 
  * @param createdAt 
+ * @param description 
  * @param downloadCount 
  * @param fileSize 
  * @param gameId 
  * @param id 
  * @param name 
+ * @param screenshotUrl 
  * @param userId 
  * @param username 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param avatarUrl 
- * @param description 
- * @param screenshotUrl 
  */
 @Serializable
 
 data class SharedSaveResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "description") @Required val description: kotlin.String,
 
     @SerialName(value = "downloadCount") @Required val downloadCount: kotlin.Long,
 
@@ -60,18 +56,14 @@ data class SharedSaveResponse (
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
+    @SerialName(value = "screenshotUrl") @Required val screenshotUrl: kotlin.String,
+
     @SerialName(value = "userId") @Required val userId: kotlin.String,
 
     @SerialName(value = "username") @Required val username: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null,
-
-    @SerialName(value = "description") val description: kotlin.String? = null,
-
-    @SerialName(value = "screenshotUrl") val screenshotUrl: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionDetailResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -33,7 +25,11 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param activeUserId 
+ * @param activeUsername 
+ * @param consoleName 
+ * @param coreName 
  * @param createdAt 
+ * @param gameCoverUrl 
  * @param gameId 
  * @param gameTitle 
  * @param id 
@@ -42,15 +38,11 @@ import kotlinx.serialization.encoding.*
  * @param name 
  * @param ownerId 
  * @param ownerUsername 
+ * @param sessionId 
  * @param status 
  * @param turnTakenAt 
  * @param updatedAt 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param activeUsername 
- * @param consoleName 
- * @param coreName 
- * @param gameCoverUrl 
- * @param sessionId 
  */
 @Serializable
 
@@ -58,7 +50,15 @@ data class SharedSessionDetailResponse (
 
     @SerialName(value = "activeUserId") @Required val activeUserId: kotlin.String?,
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "activeUsername") @Required val activeUsername: kotlin.String,
+
+    @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
+
+    @SerialName(value = "coreName") @Required val coreName: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "gameCoverUrl") @Required val gameCoverUrl: kotlin.String,
 
     @SerialName(value = "gameId") @Required val gameId: kotlin.String,
 
@@ -76,24 +76,16 @@ data class SharedSessionDetailResponse (
 
     @SerialName(value = "ownerUsername") @Required val ownerUsername: kotlin.String,
 
+    @SerialName(value = "sessionId") @Required val sessionId: kotlin.String?,
+
     @SerialName(value = "status") @Required val status: kotlin.String,
 
-    @SerialName(value = "turnTakenAt") @Required val turnTakenAt: kotlin.time.Instant?,
+    @SerialName(value = "turnTakenAt") @Required val turnTakenAt: kotlinx.datetime.Instant?,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "activeUsername") val activeUsername: kotlin.String? = null,
-
-    @SerialName(value = "consoleName") val consoleName: kotlin.String? = null,
-
-    @SerialName(value = "coreName") val coreName: kotlin.String? = null,
-
-    @SerialName(value = "gameCoverUrl") val gameCoverUrl: kotlin.String? = null,
-
-    @SerialName(value = "sessionId") val sessionId: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionHeartbeatResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionHeartbeatResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -41,7 +33,7 @@ data class SharedSessionHeartbeatResponse (
 
     @SerialName(value = "sharedSessionId") @Required val sharedSessionId: kotlin.String,
 
-    @SerialName(value = "turnTakenAt") @Required val turnTakenAt: kotlin.time.Instant,
+    @SerialName(value = "turnTakenAt") @Required val turnTakenAt: kotlinx.datetime.Instant,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionInviteCountResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionInviteCountResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionInviteResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionInviteResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,11 +23,15 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param consoleName 
  * @param createdAt 
+ * @param gameCoverUrl 
+ * @param gameId 
  * @param gameTitle 
  * @param id 
  * @param inviteeId 
  * @param inviteeUsername 
+ * @param inviterAvatarUrl 
  * @param inviterId 
  * @param inviterUsername 
  * @param sharedSessionId 
@@ -47,7 +43,13 @@ import kotlinx.serialization.encoding.*
 
 data class SharedSessionInviteResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "gameCoverUrl") @Required val gameCoverUrl: kotlin.String,
+
+    @SerialName(value = "gameId") @Required val gameId: kotlin.String,
 
     @SerialName(value = "gameTitle") @Required val gameTitle: kotlin.String,
 
@@ -56,6 +58,8 @@ data class SharedSessionInviteResponse (
     @SerialName(value = "inviteeId") @Required val inviteeId: kotlin.String,
 
     @SerialName(value = "inviteeUsername") @Required val inviteeUsername: kotlin.String,
+
+    @SerialName(value = "inviterAvatarUrl") @Required val inviterAvatarUrl: kotlin.String,
 
     @SerialName(value = "inviterId") @Required val inviterId: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionMemberResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionMemberResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,28 +23,28 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param avatarUrl 
  * @param id 
  * @param joinedAt 
  * @param role 
  * @param userId 
  * @param username 
- * @param avatarUrl 
  */
 @Serializable
 
 data class SharedSessionMemberResponse (
 
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
-    @SerialName(value = "joinedAt") @Required val joinedAt: kotlin.time.Instant,
+    @SerialName(value = "joinedAt") @Required val joinedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "role") @Required val role: kotlin.String,
 
     @SerialName(value = "userId") @Required val userId: kotlin.String,
 
-    @SerialName(value = "username") @Required val username: kotlin.String,
-
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null
+    @SerialName(value = "username") @Required val username: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,7 +24,11 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param activeUserId 
+ * @param activeUsername 
+ * @param consoleName 
+ * @param coreName 
  * @param createdAt 
+ * @param gameCoverUrl 
  * @param gameId 
  * @param gameTitle 
  * @param id 
@@ -40,15 +36,11 @@ import kotlinx.serialization.encoding.*
  * @param name 
  * @param ownerId 
  * @param ownerUsername 
+ * @param sessionId 
  * @param status 
  * @param turnTakenAt 
  * @param updatedAt 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param activeUsername 
- * @param consoleName 
- * @param coreName 
- * @param gameCoverUrl 
- * @param sessionId 
  */
 @Serializable
 
@@ -56,7 +48,15 @@ data class SharedSessionResponse (
 
     @SerialName(value = "activeUserId") @Required val activeUserId: kotlin.String?,
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "activeUsername") @Required val activeUsername: kotlin.String,
+
+    @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
+
+    @SerialName(value = "coreName") @Required val coreName: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "gameCoverUrl") @Required val gameCoverUrl: kotlin.String,
 
     @SerialName(value = "gameId") @Required val gameId: kotlin.String,
 
@@ -72,24 +72,16 @@ data class SharedSessionResponse (
 
     @SerialName(value = "ownerUsername") @Required val ownerUsername: kotlin.String,
 
+    @SerialName(value = "sessionId") @Required val sessionId: kotlin.String?,
+
     @SerialName(value = "status") @Required val status: kotlin.String,
 
-    @SerialName(value = "turnTakenAt") @Required val turnTakenAt: kotlin.time.Instant?,
+    @SerialName(value = "turnTakenAt") @Required val turnTakenAt: kotlinx.datetime.Instant?,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "activeUsername") val activeUsername: kotlin.String? = null,
-
-    @SerialName(value = "consoleName") val consoleName: kotlin.String? = null,
-
-    @SerialName(value = "coreName") val coreName: kotlin.String? = null,
-
-    @SerialName(value = "gameCoverUrl") val gameCoverUrl: kotlin.String? = null,
-
-    @SerialName(value = "sessionId") val sessionId: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionSaveResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionSaveResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -36,18 +28,18 @@ import kotlinx.serialization.encoding.*
  * @param id 
  * @param isAuto 
  * @param name 
+ * @param screenshotUrl 
  * @param sharedSessionId 
  * @param updatedAt 
  * @param userId 
  * @param username 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param screenshotUrl 
  */
 @Serializable
 
 data class SharedSessionSaveResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "fileSize") @Required val fileSize: kotlin.Long,
 
@@ -57,18 +49,18 @@ data class SharedSessionSaveResponse (
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
+    @SerialName(value = "screenshotUrl") @Required val screenshotUrl: kotlin.String,
+
     @SerialName(value = "sharedSessionId") @Required val sharedSessionId: kotlin.String,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "userId") @Required val userId: kotlin.String,
 
     @SerialName(value = "username") @Required val username: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "screenshotUrl") val screenshotUrl: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionTakeTurnResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionTakeTurnResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -39,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class SharedSessionTakeTurnResponse (
 
-    @SerialName(value = "turnTakenAt") @Required val turnTakenAt: kotlin.time.Instant,
+    @SerialName(value = "turnTakenAt") @Required val turnTakenAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "turnToken") @Required val turnToken: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ShowcaseEntryInput.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ShowcaseEntryInput.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ShowcaseEntryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ShowcaseEntryResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,13 +24,13 @@ import kotlinx.serialization.encoding.*
  * 
  *
  * @param achievementRaId 
- * @param raGameId 
- * @param showcaseOrder 
  * @param badgeUrl 
  * @param description 
  * @param gameTitle 
  * @param points 
+ * @param raGameId 
  * @param rarityPercent 
+ * @param showcaseOrder 
  * @param title 
  */
 @Serializable
@@ -47,21 +39,21 @@ data class ShowcaseEntryResponse (
 
     @SerialName(value = "achievementRaId") @Required val achievementRaId: kotlin.Long,
 
+    @SerialName(value = "badgeUrl") @Required val badgeUrl: kotlin.String,
+
+    @SerialName(value = "description") @Required val description: kotlin.String,
+
+    @SerialName(value = "gameTitle") @Required val gameTitle: kotlin.String,
+
+    @SerialName(value = "points") @Required val points: kotlin.Long,
+
     @SerialName(value = "raGameId") @Required val raGameId: kotlin.Long,
+
+    @SerialName(value = "rarityPercent") @Required val rarityPercent: kotlin.Double,
 
     @SerialName(value = "showcaseOrder") @Required val showcaseOrder: kotlin.Long,
 
-    @SerialName(value = "badgeUrl") val badgeUrl: kotlin.String? = null,
-
-    @SerialName(value = "description") val description: kotlin.String? = null,
-
-    @SerialName(value = "gameTitle") val gameTitle: kotlin.String? = null,
-
-    @SerialName(value = "points") val points: kotlin.Long? = null,
-
-    @SerialName(value = "rarityPercent") val rarityPercent: kotlin.Double? = null,
-
-    @SerialName(value = "title") val title: kotlin.String? = null
+    @SerialName(value = "title") @Required val title: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SimilarGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SimilarGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/StagedUploadResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/StagedUploadResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -32,12 +24,6 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
- * @param fileName 
- * @param fileSize 
- * @param id 
- * @param originalFileName 
- * @param status 
- * @param dollarSchema A URL to the JSON Schema for this object.
  * @param canonicalName 
  * @param consoleId 
  * @param consoleName 
@@ -46,63 +32,69 @@ import kotlinx.serialization.encoding.*
  * @param description 
  * @param developer 
  * @param duplicateOfGameId 
+ * @param fileName 
+ * @param fileSize 
  * @param genre 
+ * @param id 
  * @param igdbCriticsRating 
+ * @param originalFileName 
  * @param players 
  * @param possibleConsoles 
  * @param publisher 
  * @param releaseDate 
+ * @param status 
  * @param title 
  * @param verificationStatus 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
 data class StagedUploadResponse (
 
+    @SerialName(value = "canonicalName") @Required val canonicalName: kotlin.String,
+
+    @SerialName(value = "consoleId") @Required val consoleId: kotlin.String?,
+
+    @SerialName(value = "consoleName") @Required val consoleName: kotlin.String?,
+
+    @SerialName(value = "coverUrl") @Required val coverUrl: kotlin.String,
+
+    @SerialName(value = "crc32") @Required val crc32: kotlin.String,
+
+    @SerialName(value = "description") @Required val description: kotlin.String,
+
+    @SerialName(value = "developer") @Required val developer: kotlin.String,
+
+    @SerialName(value = "duplicateOfGameId") @Required val duplicateOfGameId: kotlin.String?,
+
     @SerialName(value = "fileName") @Required val fileName: kotlin.String,
 
     @SerialName(value = "fileSize") @Required val fileSize: kotlin.Long,
 
+    @SerialName(value = "genre") @Required val genre: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
+
+    @SerialName(value = "igdbCriticsRating") @Required val igdbCriticsRating: kotlin.Double,
 
     @SerialName(value = "originalFileName") @Required val originalFileName: kotlin.String,
 
+    @SerialName(value = "players") @Required val players: kotlin.Long,
+
+    @SerialName(value = "possibleConsoles") @Required val possibleConsoles: kotlin.collections.List<PossibleConsoleResponse>?,
+
+    @SerialName(value = "publisher") @Required val publisher: kotlin.String,
+
+    @SerialName(value = "releaseDate") @Required val releaseDate: kotlin.String,
+
     @SerialName(value = "status") @Required val status: kotlin.String,
 
+    @SerialName(value = "title") @Required val title: kotlin.String,
+
+    @SerialName(value = "verificationStatus") @Required val verificationStatus: kotlin.String,
+
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "canonicalName") val canonicalName: kotlin.String? = null,
-
-    @SerialName(value = "consoleId") val consoleId: kotlin.String? = null,
-
-    @SerialName(value = "consoleName") val consoleName: kotlin.String? = null,
-
-    @SerialName(value = "coverUrl") val coverUrl: kotlin.String? = null,
-
-    @SerialName(value = "crc32") val crc32: kotlin.String? = null,
-
-    @SerialName(value = "description") val description: kotlin.String? = null,
-
-    @SerialName(value = "developer") val developer: kotlin.String? = null,
-
-    @SerialName(value = "duplicateOfGameId") val duplicateOfGameId: kotlin.String? = null,
-
-    @SerialName(value = "genre") val genre: kotlin.String? = null,
-
-    @SerialName(value = "igdbCriticsRating") val igdbCriticsRating: kotlin.Double? = null,
-
-    @SerialName(value = "players") val players: kotlin.Long? = null,
-
-    @SerialName(value = "possibleConsoles") val possibleConsoles: kotlin.collections.List<PossibleConsoleResponse>? = null,
-
-    @SerialName(value = "publisher") val publisher: kotlin.String? = null,
-
-    @SerialName(value = "releaseDate") val releaseDate: kotlin.String? = null,
-
-    @SerialName(value = "title") val title: kotlin.String? = null,
-
-    @SerialName(value = "verificationStatus") val verificationStatus: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/StatusMessageResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/StatusMessageResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SteamGridDBStatusResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SteamGridDBStatusResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/StorageUsageResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/StorageUsageResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventCategoryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventCategoryResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -34,10 +26,9 @@ import kotlinx.serialization.encoding.*
  * @param categoryCode 
  * @param categoryName 
  * @param createdAt 
+ * @param dismissedAt 
  * @param eventType 
  * @param id 
- * @param dollarSchema A URL to the JSON Schema for this object.
- * @param dismissedAt 
  * @param ip 
  * @param metadata 
  * @param metadataRaw 
@@ -45,6 +36,7 @@ import kotlinx.serialization.encoding.*
  * @param reason 
  * @param userId 
  * @param username 
+ * @param dollarSchema A URL to the JSON Schema for this object.
  */
 @Serializable
 
@@ -54,32 +46,32 @@ data class SystemEventResponse (
 
     @SerialName(value = "categoryName") @Required val categoryName: kotlin.String,
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
+
+    @SerialName(value = "dismissedAt") @Required val dismissedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "eventType") @Required val eventType: kotlin.String,
 
     @SerialName(value = "id") @Required val id: kotlin.Long,
 
+    @SerialName(value = "ip") @Required val ip: kotlin.String,
+
+    @SerialName(value = "metadata") @Required val metadata: kotlin.String,
+
+    @SerialName(value = "metadataRaw") @Required val metadataRaw: kotlin.String,
+
+    @SerialName(value = "path") @Required val path: kotlin.String,
+
+    @SerialName(value = "reason") @Required val reason: kotlin.String,
+
+    @SerialName(value = "userId") @Required val userId: kotlin.Long,
+
+    @SerialName(value = "username") @Required val username: kotlin.String,
+
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
-    @SerialName(value = "dismissedAt") val dismissedAt: kotlin.time.Instant? = null,
-
-    @SerialName(value = "ip") val ip: kotlin.String? = null,
-
-    @SerialName(value = "metadata") val metadata: kotlinx.serialization.json.JsonObject? = null,
-
-    @SerialName(value = "metadataRaw") val metadataRaw: kotlin.String? = null,
-
-    @SerialName(value = "path") val path: kotlin.String? = null,
-
-    @SerialName(value = "reason") val reason: kotlin.String? = null,
-
-    @SerialName(value = "userId") val userId: kotlin.Long? = null,
-
-    @SerialName(value = "username") val username: kotlin.String? = null
-
-) {
+) : kotlin.collections.HashMap<String, kotlinx.serialization.json.JsonElement>() {
 
 
 }

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventTypeInfo.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventTypeInfo.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventTypesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventTypesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventsListResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventsListResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -42,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class SystemEventsListResponse (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<SystemEventResponse>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<@Contextual SystemEventResponse>?,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TasteProfileConsole.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TasteProfileConsole.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TasteProfileGenre.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TasteProfileGenre.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TasteProfileResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TasteProfileResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TasteProfileTheme.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TasteProfileTheme.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TestIGDBRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TestIGDBRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TestIGDBResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TestIGDBResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,20 +23,20 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param error 
  * @param success 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param error 
  */
 @Serializable
 
 data class TestIGDBResponse (
 
+    @SerialName(value = "error") @Required val error: kotlin.String,
+
     @SerialName(value = "success") @Required val success: kotlin.Boolean,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "error") val error: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ThemeResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ThemeResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TimelineEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TimelineEntry.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TimelineGame.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TimelineGame.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TopListGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TopListGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TopRatedGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TopRatedGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TrendingGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TrendingGameResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TrendingResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TrendingResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UnlockedAchievementsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UnlockedAchievementsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateChallengeRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateChallengeRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateCollectionRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateCollectionRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateDevicePreferencesRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateDevicePreferencesRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateDeviceRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateDeviceRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateGameKeyMappingRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateGameKeyMappingRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateGameMetadataRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateGameMetadataRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateGamePlayTimeRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateGamePlayTimeRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateGamePlayTimeResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateGamePlayTimeResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -39,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class UpdateGamePlayTimeResponse (
 
-    @SerialName(value = "lastPlayed") @Required val lastPlayed: kotlin.time.Instant,
+    @SerialName(value = "lastPlayed") @Required val lastPlayed: kotlinx.datetime.Instant,
 
     @SerialName(value = "playTime") @Required val playTime: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateNetplaySettingsRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateNetplaySettingsRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdatePreferencesRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdatePreferencesRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateProfileRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateProfileRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateRASettingsRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateRASettingsRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSessionCheatsRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSessionCheatsRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSessionPlayTimeRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSessionPlayTimeRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSessionRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSessionRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSessionSaveRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSessionSaveRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSharedSessionRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSharedSessionRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateVerificationTagRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateVerificationTagRequest.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateVerificationTagResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateVerificationTagResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserPreferencesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserPreferencesResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,6 +23,7 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param avatarUrl 
  * @param createdAt 
  * @param disabled 
  * @param email 
@@ -40,13 +33,14 @@ import kotlinx.serialization.encoding.*
  * @param updatedAt 
  * @param username 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param avatarUrl 
  */
 @Serializable
 
 data class UserResponse (
 
-    @SerialName(value = "createdAt") @Required val createdAt: kotlin.time.Instant,
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
+    @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "disabled") @Required val disabled: kotlin.Boolean,
 
@@ -58,14 +52,12 @@ data class UserResponse (
 
     @SerialName(value = "role") @Required val role: kotlin.String,
 
-    @SerialName(value = "updatedAt") @Required val updatedAt: kotlin.time.Instant,
+    @SerialName(value = "updatedAt") @Required val updatedAt: kotlinx.datetime.Instant,
 
     @SerialName(value = "username") @Required val username: kotlin.String,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserSearchResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserSearchResult.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,19 +23,19 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
+ * @param avatarUrl 
  * @param id 
  * @param username 
- * @param avatarUrl 
  */
 @Serializable
 
 data class UserSearchResult (
 
+    @SerialName(value = "avatarUrl") @Required val avatarUrl: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
-    @SerialName(value = "username") @Required val username: kotlin.String,
-
-    @SerialName(value = "avatarUrl") val avatarUrl: kotlin.String? = null
+    @SerialName(value = "username") @Required val username: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserStatsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserStatsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -36,10 +28,10 @@ import kotlinx.serialization.encoding.*
  * @param gamesPlayed 
  * @param lastPlayedAt 
  * @param longestStreak 
+ * @param mostPlayedGame 
  * @param mostPlayedGameTime 
  * @param totalPlayTime 
  * @param dollarSchema A URL to the JSON Schema for this object.
- * @param mostPlayedGame 
  */
 @Serializable
 
@@ -49,18 +41,18 @@ data class UserStatsResponse (
 
     @SerialName(value = "gamesPlayed") @Required val gamesPlayed: kotlin.Long,
 
-    @SerialName(value = "lastPlayedAt") @Required val lastPlayedAt: kotlin.time.Instant?,
+    @SerialName(value = "lastPlayedAt") @Required val lastPlayedAt: kotlinx.datetime.Instant?,
 
     @SerialName(value = "longestStreak") @Required val longestStreak: kotlin.Long,
+
+    @SerialName(value = "mostPlayedGame") @Required val mostPlayedGame: GameResponse,
 
     @SerialName(value = "mostPlayedGameTime") @Required val mostPlayedGameTime: kotlin.Long,
 
     @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long,
 
     /* A URL to the JSON Schema for this object. */
-    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null,
-
-    @SerialName(value = "mostPlayedGame") val mostPlayedGame: GameResponse? = null
+    @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/VariantResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/VariantResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -35,10 +27,10 @@ import kotlinx.serialization.encoding.*
  * @param fileSize 
  * @param id 
  * @param isPreRelease 
- * @param title 
  * @param region 
  * @param revision 
  * @param tags 
+ * @param title 
  * @param verificationStatus 
  */
 @Serializable
@@ -53,15 +45,15 @@ data class VariantResponse (
 
     @SerialName(value = "isPreRelease") @Required val isPreRelease: kotlin.Boolean,
 
+    @SerialName(value = "region") @Required val region: kotlin.String,
+
+    @SerialName(value = "revision") @Required val revision: kotlin.String,
+
+    @SerialName(value = "tags") @Required val tags: kotlin.String,
+
     @SerialName(value = "title") @Required val title: kotlin.String,
 
-    @SerialName(value = "region") val region: kotlin.String? = null,
-
-    @SerialName(value = "revision") val revision: kotlin.String? = null,
-
-    @SerialName(value = "tags") val tags: kotlin.String? = null,
-
-    @SerialName(value = "verificationStatus") val verificationStatus: kotlin.String? = null
+    @SerialName(value = "verificationStatus") @Required val verificationStatus: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/VideoResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/VideoResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,16 +23,16 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
- * @param videoId 
  * @param name 
+ * @param videoId 
  */
 @Serializable
 
 data class VideoResponse (
 
-    @SerialName(value = "videoId") @Required val videoId: kotlin.String,
+    @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "name") val name: kotlin.String? = null
+    @SerialName(value = "videoId") @Required val videoId: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardOption.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardOption.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models
@@ -31,22 +23,22 @@ import kotlinx.serialization.encoding.*
 /**
  * 
  *
- * @param id 
- * @param label 
  * @param description 
+ * @param id 
  * @param imageUrl 
+ * @param label 
  */
 @Serializable
 
 data class WizardOption (
 
+    @SerialName(value = "description") @Required val description: kotlin.String,
+
     @SerialName(value = "id") @Required val id: kotlin.String,
 
-    @SerialName(value = "label") @Required val label: kotlin.String,
+    @SerialName(value = "imageUrl") @Required val imageUrl: kotlin.String,
 
-    @SerialName(value = "description") val description: kotlin.String? = null,
-
-    @SerialName(value = "imageUrl") val imageUrl: kotlin.String? = null
+    @SerialName(value = "label") @Required val label: kotlin.String
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardResultsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardResultsResponse.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardStep.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardStep.kt
@@ -8,17 +8,9 @@
 
 @file:Suppress(
     "ArrayInDataClass",
-    "DuplicatedCode",
     "EnumEntryName",
     "RemoveRedundantQualifierName",
-    "RemoveRedundantCallsOfConversionMethods",
-    "REDUNDANT_CALL_OF_CONVERSION_METHOD",
-    "RedundantUnitReturnType",
-    "RemoveEmptyClassBody",
-    "UnnecessaryVariable",
-    "UnusedImport",
-    "UnnecessaryVariable",
-    "unused"
+    "UnusedImport"
 )
 
 package com.spela.client.models

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -53,6 +53,38 @@ private fun testGameResponse(
         title = title,
         totalPlayTime = totalPlayTime,
         updatedAt = now,
+        achievementsWarning = "",
+        ageRatings = null,
+        biosStatus = "",
+        coreOverride = "",
+        discs = null,
+        gameModes = "",
+        groupKey = "",
+        heroUrl = "",
+        igdbUserRating = 0.0,
+        igdbUserRatingCount = 0L,
+        languageSupports = null,
+        logoUrl = "",
+        parentGame = com.spela.client.models.ParentGameResponse(id = "", title = "", coverUrl = ""),
+        partyInfo = "",
+        region = "",
+        releaseDates = null,
+        revision = "",
+        romHacks = null,
+        scraperId = "",
+        storyline = "",
+        tags = "",
+        timeToBeatCompletely = 0L,
+        timeToBeatHastily = 0L,
+        timeToBeatNormally = 0L,
+        totalRating = 0.0,
+        totalRatingCount = 0L,
+        userRating = 0L,
+        variantCount = 0L,
+        variants = null,
+        verificationStatus = "",
+        verificationTag = "",
+        videos = null,
     )
 }
 
@@ -226,6 +258,7 @@ class GameRepositoryImplTest {
             username = "Alice",
             avatarUrl = "/avatars/alice.png",
             description = "Before final boss",
+            screenshotUrl = "",
         )
         val domain = response.toDomain()
         assertEquals("ss1", domain.id)
@@ -249,7 +282,9 @@ class GameRepositoryImplTest {
             name = "Untitled",
             userId = "u",
             username = "bob",
-            description = null,
+            avatarUrl = "",
+            description = "",
+            screenshotUrl = "",
         )
         assertEquals("", response.toDomain().description)
     }
@@ -339,7 +374,8 @@ class GameRepositoryImplTest {
             updatedAt = now,
             userId = "u1",
             username = "mattias",
-            review = null,
+            avatarUrl = "",
+            review = "",
         )
         assertEquals("", response.toDomain().review)
     }
@@ -472,6 +508,12 @@ class GameRepositoryImplTest {
             isCurrent = false,
             createdAt = now,
             updatedAt = now,
+            coreMatch = false,
+            coreName = "",
+            currentCore = "",
+            notes = "",
+            screenshotUrl = "",
+            slot = 0L,
         )
         val domain = dto.toDomain()
 
@@ -489,6 +531,7 @@ class GameRepositoryImplTest {
             accessToken = "access123",
             refreshToken = "refresh456",
             user = UserDto(
+                avatarUrl = "",
                 createdAt = now,
                 disabled = false,
                 email = "test@example.com",
@@ -541,7 +584,9 @@ class GameRepositoryImplTest {
         val now = kotlin.time.Instant.fromEpochSeconds(0)
         val dto = com.spela.client.models.Core(
             createdAt = now,
+            description = "",
             displayName = "Nestopia UE",
+            downloadUrl = "",
             id = 1,
             name = "nestopia",
             platforms = "windows,linux,macos,android",

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GameRepositoryOfflineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GameRepositoryOfflineTest.kt
@@ -44,14 +44,24 @@ private fun gameJson(
     val screenshots = screenshotUrls?.joinToString(",", "[", "]") { "\"$it\"" } ?: "null"
     val lastPlayed = lastPlayedAt?.let { "\"$it\"" } ?: "null"
     return """{"id":"$id","title":"$title","consoleId":"1","consoleName":"NES",""" +
-        """"averageRating":0,"coverAspectRatio":0.75,"coverUrl":"/covers/smb.png",""" +
+        """"achievementsWarning":"","ageRatings":null,"averageRating":0,"biosStatus":"",""" +
+        """"coreOverride":"","coverAspectRatio":0.75,"coverUrl":"/covers/smb.png",""" +
         """"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z",""" +
         """"description":"A classic platformer","developer":"Nintendo",""" +
-        """"discCount":0,"fileName":"smb.nes","fileSize":40960,"genre":"Platformer",""" +
-        """"igdbCriticsRating":0,"isFavorite":$isFavorite,"isInPlayLater":false,"isPreRelease":false,""" +
-        """"lastPlayedAt":$lastPlayed,"playable":true,"players":1,"publisher":"Nintendo",""" +
-        """"ratingCount":0,"releaseDate":"1985-09-13","scrapeAttempts":0,""" +
-        """"screenshotUrls":$screenshots,"totalPlayTime":$totalPlayTime}"""
+        """"discCount":0,"discs":null,"fileName":"smb.nes","fileSize":40960,""" +
+        """"gameModes":"","genre":"Platformer","groupKey":"","heroUrl":"",""" +
+        """"igdbCriticsRating":0,"igdbUserRating":0,"igdbUserRatingCount":0,""" +
+        """"isFavorite":$isFavorite,"isInPlayLater":false,"isPreRelease":false,""" +
+        """"languageSupports":null,"lastPlayedAt":$lastPlayed,"logoUrl":"",""" +
+        """"parentGame":{"id":"","title":"","coverUrl":""},"partyInfo":"",""" +
+        """"playable":true,"players":1,"publisher":"Nintendo",""" +
+        """"ratingCount":0,"region":"","releaseDate":"1985-09-13","releaseDates":null,""" +
+        """"revision":"","romHacks":null,"scrapeAttempts":0,"scraperId":"",""" +
+        """"screenshotUrls":$screenshots,"storyline":"","tags":"",""" +
+        """"timeToBeatCompletely":0,"timeToBeatHastily":0,"timeToBeatNormally":0,""" +
+        """"totalPlayTime":$totalPlayTime,"totalRating":0,"totalRatingCount":0,""" +
+        """"userRating":null,"variantCount":0,"variants":null,""" +
+        """"verificationStatus":"","verificationTag":"","videos":null}"""
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)


### PR DESCRIPTION
## Summary
Regenerates the player app's Kotlin OpenAPI client against the updated server OpenAPI spec (post-#605 omitempty sweep). Fields previously nullable/optional are now `@Required`, matching the reality that the server always emits them.

Part of #489 — the final step in end-to-end type tightening across all three layers (Go server → TypeScript web → Kotlin player app).

Updates desktop test fixtures in `GameRepositoryImplTest` and `GameRepositoryOfflineTest` to supply the newly-required fields.

## Changes
- 331 generated files regenerated (+1210 −3788) — mostly removed `?` from fields that the server always emits
- Test fixtures updated with defaults for newly-required fields
- Mock JSON in `gameJson()` helper now includes all required GameResponse fields

## Verified
- [x] `:shared-api:compileKotlinDesktop`
- [x] `:shared-api:compileDebugKotlinAndroid`
- [x] `:shared:compileKotlinDesktop`
- [x] `:shared:compileDebugKotlinAndroid`
- [x] `:shared:desktopTest` (all tests pass)

## Test plan
- [ ] CI green