### PR TITLE
chore(web): retire hand-written ScrapeStatus interface

### DIFF
--- a/web/src/hooks/__tests__/use-scrape-progress.test.ts
+++ b/web/src/hooks/__tests__/use-scrape-progress.test.ts
@@ -197,7 +197,6 @@ describe("useScrapeProgress", () => {
         active: true,
         current: 7,
         total: 20,
-        gameName: "Mega Man",
         successes: 5,
         failures: 2,
         verified: 3,
@@ -209,7 +208,6 @@ describe("useScrapeProgress", () => {
     expect(result.current.phase).toBe("active");
     expect(result.current.current).toBe(7);
     expect(result.current.total).toBe(20);
-    expect(result.current.gameName).toBe("Mega Man");
     expect(result.current.successes).toBe(5);
     expect(result.current.failures).toBe(2);
     expect(result.current.verified).toBe(3);
@@ -221,7 +219,6 @@ describe("useScrapeProgress", () => {
         active: true,
         current: 7,
         total: 20,
-        gameName: "Mega Man",
         successes: 5,
         failures: 2,
         verified: 3,

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -8,6 +8,7 @@ import type {
   IgdbSearchResult,
   RateLimitStatus,
   CoreCompatibilityResponse,
+  ScrapeStatusResponse,
 } from "@/types/api";
 
 export function useAdminUsers() {
@@ -299,25 +300,12 @@ export function useTestIgdbCredentials() {
   });
 }
 
-export interface ScrapeStatus {
-  active: boolean;
-  current?: number;
-  total?: number;
-  gameId?: number;
-  gameName?: string;
-  consoleName?: string;
-  consoleAbbr?: string;
-  successes?: number;
-  failures?: number;
-  verified?: number;
-}
-
 export function useScrapeStatus() {
   return useQuery({
     queryKey: ["admin", "scrape-status"],
     queryFn: async () => {
       const data = await unwrap(typedApi.GET("/api/admin/scrape/status"));
-      return data as ScrapeStatus | undefined;
+      return data as ScrapeStatusResponse | undefined;
     },
     refetchInterval: 3000, // Poll every 3s to catch status changes
   });

--- a/web/src/hooks/use-scrape-progress.ts
+++ b/web/src/hooks/use-scrape-progress.ts
@@ -56,19 +56,17 @@ export function useScrapeProgress(): ScrapeProgressState {
   const [error, setError] = useState<string | null>(null);
   // Sync from polled status — this runs on every status refetch (3s interval).
   // Allows the UI to pick up status after page refresh or WebSocket disconnect.
+  // gameId/gameName/consoleName/consoleAbbr only arrive via the WebSocket
+  // scrape_progress event; the polled status endpoint only exposes counters.
   useEffect(() => {
     if (!initialStatus) return;
     if (initialStatus.active) {
       setPhase("active");
-      setCurrent(initialStatus.current ?? 0);
-      setTotal(initialStatus.total ?? 0);
-      setGameId(initialStatus.gameId ?? 0);
-      setGameName(initialStatus.gameName ?? "");
-      setConsoleName(initialStatus.consoleName ?? "");
-      setConsoleAbbr(initialStatus.consoleAbbr ?? "");
-      setSuccesses(initialStatus.successes ?? 0);
-      setFailures(initialStatus.failures ?? 0);
-      setVerified(initialStatus.verified ?? 0);
+      setCurrent(initialStatus.current);
+      setTotal(initialStatus.total);
+      setSuccesses(initialStatus.successes);
+      setFailures(initialStatus.failures);
+      setVerified(initialStatus.verified);
     } else if (phase === "active") {
       // Status went from active to inactive — scrape finished while we were polling
       setPhase("idle");

--- a/web/src/pages/collection-detail-page.tsx
+++ b/web/src/pages/collection-detail-page.tsx
@@ -78,7 +78,7 @@ export function CollectionDetailPage() {
   function openEditModal() {
     if (!collection) return;
     setEditName(collection.name);
-    setEditDescription(collection.description ?? "");
+    setEditDescription(collection.description);
     setEditIsPublic(collection.isPublic);
     setShowEditModal(true);
   }


### PR DESCRIPTION
## Summary
More scar tissue cleanup after the omitempty sweep. Two related changes:

1. **Retire \`ScrapeStatus\` hand-written interface.** It marked every counter as optional, so \`use-scrape-progress\` had to \`?? 0\` / \`?? \"\"\` every field. Now the generated \`ScrapeStatusResponse\` is \`@Required\` everywhere, so the guards are dead.

2. **Drop \`gameId\`/\`gameName\`/\`consoleName\`/\`consoleAbbr\` setters from the HTTP status hydration.** These fields never existed on the HTTP endpoint — see \`server/internal/api/huma_scraper.go:55\` — they only arrive via the WebSocket \`scrape_progress\` event. The useEffect was always setting them to \`\"\"\` (undefined ?? \"\"). Harmless in practice since WebSocket fires right after, but it's misleading dead code.

Bonus: one stale \`collection.description ?? \"\"\` in \`collection-detail-page.tsx\` — CollectionResponse.description is \`string\`.

## Part of #489.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [x] All 1468 unit tests pass locally
- [ ] CI green