### PR TITLE
fix(#611): SharedSessionsPage always-empty — align with flat server shape

### DIFF
--- a/web/src/hooks/__tests__/use-shared-sessions.test.ts
+++ b/web/src/hooks/__tests__/use-shared-sessions.test.ts
@@ -69,28 +69,23 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-const mockSharedSessionsResponse = {
-  data: [
-    {
-      id: "ss-1",
-      name: "Friday Night SNES",
-      gameId: "g1",
-      gameTitle: "Super Mario World",
-      gameCoverUrl: "https://example.com/cover.png",
-      gameConsoleName: "SNES",
-      ownerId: "u1",
-      ownerUsername: "alice",
-      status: "active",
-      memberCount: 3,
-      lastActivityAt: "2026-02-13T10:00:00Z",
-      createdAt: "2026-02-01T10:00:00Z",
-      updatedAt: "2026-02-13T10:00:00Z",
-    },
-  ],
-  total: 1,
-  page: 1,
-  pageSize: 20,
-};
+const mockSharedSessionsResponse = [
+  {
+    id: "ss-1",
+    name: "Friday Night SNES",
+    gameId: "g1",
+    gameTitle: "Super Mario World",
+    gameCoverUrl: "https://example.com/cover.png",
+    gameConsoleName: "SNES",
+    ownerId: "u1",
+    ownerUsername: "alice",
+    status: "active",
+    memberCount: 3,
+    lastActivityAt: "2026-02-13T10:00:00Z",
+    createdAt: "2026-02-01T10:00:00Z",
+    updatedAt: "2026-02-13T10:00:00Z",
+  },
+];
 
 const mockSharedSessionDetail = {
   id: "ss-1",
@@ -169,8 +164,8 @@ describe("useMySharedSessions", () => {
     await waitFor(() => expect(result.current.isSuccess).toBe(true));
 
     expect(mockTypedApi.GET).toHaveBeenCalledWith("/api/shared-sessions");
-    expect(result.current.data?.data).toHaveLength(1);
-    expect(result.current.data?.data?.[0].name).toBe("Friday Night SNES");
+    expect(result.current.data).toHaveLength(1);
+    expect(result.current.data?.[0].name).toBe("Friday Night SNES");
   });
 
   it("handles fetch error", async () => {
@@ -272,7 +267,7 @@ describe("useSharedSessionSaves", () => {
 describe("useGameSharedSessions", () => {
   it("fetches shared sessions for a game", async () => {
     mockTypedApi.GET.mockReturnValue(
-      ok([mockSharedSessionsResponse.data[0]]),
+      ok([mockSharedSessionsResponse[0]]),
     );
 
     const { result } = renderHook(() => useGameSharedSessions("g1"), {

--- a/web/src/hooks/use-shared-sessions.ts
+++ b/web/src/hooks/use-shared-sessions.ts
@@ -2,19 +2,18 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
-  SharedSessionsResponse,
   SharedSessionDetail,
   SharedSessionInvitation,
   SharedSessionSave,
   SharedSession,
 } from "@/types/api";
 
-export function useMySharedSessions(page = 1, pageSize = 20) {
+export function useMySharedSessions() {
   return useQuery({
-    queryKey: ["shared-sessions", "mine", page, pageSize],
+    queryKey: ["shared-sessions", "mine"],
     queryFn: async () => {
       const data = await unwrap(typedApi.GET("/api/shared-sessions"));
-      return data as SharedSessionsResponse | undefined;
+      return data as SharedSession[] | null | undefined;
     },
   });
 }

--- a/web/src/pages/__tests__/shared-sessions-page.test.tsx
+++ b/web/src/pages/__tests__/shared-sessions-page.test.tsx
@@ -34,28 +34,23 @@ import {
 const mockUseMySharedSessions = useMySharedSessions as ReturnType<typeof vi.fn>;
 const mockUseSharedSessionInvitations = useSharedSessionInvitations as ReturnType<typeof vi.fn>;
 
-const mockSharedSessions = {
-  data: [
-    {
-      id: "ss-1",
-      name: "Friday Night SNES",
-      gameId: "g1",
-      gameTitle: "Super Mario World",
-      gameCoverUrl: "https://example.com/cover.png",
-      gameConsoleName: "SNES",
-      ownerId: "u1",
-      ownerUsername: "alice",
-      status: "active",
-      memberCount: 3,
-      lastActivityAt: "2026-02-13T10:00:00Z",
-      createdAt: "2026-02-01T10:00:00Z",
-      updatedAt: "2026-02-13T10:00:00Z",
-    },
-  ],
-  total: 1,
-  page: 1,
-  pageSize: 24,
-};
+const mockSharedSessions = [
+  {
+    id: "ss-1",
+    name: "Friday Night SNES",
+    gameId: "g1",
+    gameTitle: "Super Mario World",
+    gameCoverUrl: "https://example.com/cover.png",
+    gameConsoleName: "SNES",
+    ownerId: "u1",
+    ownerUsername: "alice",
+    status: "active",
+    memberCount: 3,
+    lastActivityAt: "2026-02-13T10:00:00Z",
+    createdAt: "2026-02-01T10:00:00Z",
+    updatedAt: "2026-02-13T10:00:00Z",
+  },
+];
 
 const mockInvitations = [
   {
@@ -128,7 +123,7 @@ describe("SharedSessionsPage", () => {
 
   it("shows empty state when no shared sessions", () => {
     mockUseMySharedSessions.mockReturnValue({
-      data: { data: [], total: 0, page: 1, pageSize: 24 },
+      data: [],
       isLoading: false,
     });
     renderPage();

--- a/web/src/pages/shared-sessions-page.tsx
+++ b/web/src/pages/shared-sessions-page.tsx
@@ -22,7 +22,6 @@ import {
 import { SharedSessionCard } from "@/features/shared-sessions/components/shared-session-card";
 import { SharedSessionCreateModal } from "@/features/shared-sessions/components/shared-session-create-modal";
 import { InvitationCard } from "@/features/shared-sessions/components/invitation-card";
-import { Pagination } from "@/components/pagination";
 
 type Tab = "mine" | "invitations";
 
@@ -53,30 +52,25 @@ function InvitationsSkeleton() {
 export function SharedSessionsPage() {
   const navigate = useNavigate();
   const [activeTab, setActiveTab] = useState<Tab>("mine");
-  const [page, setPage] = useState(1);
-  const pageSize = 24;
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [acceptingId, setAcceptingId] = useState<string | null>(null);
   const [rejectingId, setRejectingId] = useState<string | null>(null);
 
   const { toast } = useToast();
-  const { data: sharedSessionsData, isLoading: sharedSessionsLoading } = useMySharedSessions(
-    page,
-    pageSize,
-  );
+  const { data: sharedSessionsData, isLoading: sharedSessionsLoading } =
+    useMySharedSessions();
   const { data: invitationsData, isLoading: invitationsLoading } =
     useSharedSessionInvitations();
   const acceptInvitation = useAcceptSharedSessionInvitation();
   const rejectInvitation = useRejectSharedSessionInvitation();
   useSharedSessionRealtime();
 
-  const sharedSessions = sharedSessionsData?.data ?? [];
+  const sharedSessions = sharedSessionsData ?? [];
   const invitations = invitationsData ?? [];
   const invitationCount = invitations.length;
 
   function handleTabChange(tab: Tab) {
     setActiveTab(tab);
-    setPage(1);
   }
 
   function handleAccept(invitationId: string) {
@@ -163,15 +157,6 @@ export function SharedSessionsPage() {
                 <SharedSessionCard key={sharedSession.id} sharedSession={sharedSession} />
               ))}
             </div>
-          )}
-
-          {sharedSessionsData && (
-            <Pagination
-              total={sharedSessionsData.total}
-              pageSize={pageSize}
-              currentPage={page}
-              onPageChange={setPage}
-            />
           )}
         </>
       )}

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -283,7 +283,6 @@ export interface PaginatedFlat<T> {
   total: number;
 }
 
-export type SharedSessionsResponse = Paginated<SharedSession>;
 
 export type NetplaySessionStatus = "waiting" | "in_progress" | "ended";
 export type NetplayEndReason =


### PR DESCRIPTION
Fixes #611.

## What was wrong
The server returns a flat \`SharedSessionResponse[]\` from \`GET /api/shared-sessions\` — no pagination wrapper. But \`useMySharedSessions\` cast the response to \`Paginated<SharedSession> = { data, total, page, pageSize }\`, and the page read \`sharedSessionsData?.data ?? []\` which always evaluated to \`[]\`.

The existing tests missed it because both page-level and hook-level mocks used the paginated shape — i.e., they tested the buggy cast, not the real wire shape.

## Changes
- \`useMySharedSessions\` returns \`SharedSession[] | null | undefined\` (dropped unused page/pageSize params)
- \`SharedSessionsPage\` reads flat array, drops unused page state + Pagination component
- Retire \`SharedSessionsResponse = Paginated<SharedSession>\` alias (no users left)
- Fix both test files to mock the real flat shape

## Verified
- \`npx tsc --noEmit\` clean
- All 1468 unit tests pass

## Test plan
- [ ] CI green
- [ ] Manual smoke: navigate to /shared-sessions → list appears when user has sessions