### PR TITLE
chore(player): drop dead page/pageSize params on getMySharedSessions

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -988,10 +988,8 @@ class SpelaApiClient(
 
     // Shared Sessions
 
-    suspend fun getMySharedSessions(@Suppress("UNUSED_PARAMETER") page: Int = 1, @Suppress("UNUSED_PARAMETER") pageSize: Int = 20): List<SharedSessionDto> {
-        // Server returns a bare array (not a paginated wrapper). page/pageSize
-        // are kept on the signature so the repository caller does not need to
-        // change, but they are ignored because the server does not paginate.
+    suspend fun getMySharedSessions(): List<SharedSessionDto> {
+        // Server returns a bare array — not paginated.
         return sharedSessionsApi.listMySharedSessions().body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSessionRepositoryImpl.kt
@@ -14,8 +14,8 @@ class SharedSessionRepositoryImpl(
     private val apiClient: SpelaApiClient,
 ) : SharedSessionRepository {
 
-    override suspend fun getMySharedSessions(page: Int, pageSize: Int): Result<List<SharedSession>> = runCatching {
-        apiClient.getMySharedSessions(page, pageSize).map { it.toDomain() }
+    override suspend fun getMySharedSessions(): Result<List<SharedSession>> = runCatching {
+        apiClient.getMySharedSessions().map { it.toDomain() }
     }
 
     override suspend fun getSharedSession(sharedSessionId: String): Result<SharedSessionDetail> = runCatching {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SharedSessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SharedSessionRepository.kt
@@ -6,7 +6,7 @@ import com.spela.player.domain.model.SharedSessionInvitation
 import com.spela.player.domain.model.SharedSessionSave
 
 interface SharedSessionRepository {
-    suspend fun getMySharedSessions(page: Int = 1, pageSize: Int = 20): Result<List<SharedSession>>
+    suspend fun getMySharedSessions(): Result<List<SharedSession>>
     suspend fun getSharedSession(sharedSessionId: String): Result<SharedSessionDetail>
     suspend fun getSharedSessionInvitations(): Result<List<SharedSessionInvitation>>
     suspend fun getPendingInvitationCount(): Result<Int>

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SharedSessionsViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SharedSessionsViewModelTest.kt
@@ -221,7 +221,7 @@ class FakeSharedSessionRepo : SharedSessionRepository {
     var sharedSessionSaves: List<SharedSessionSave> = emptyList()
     var shouldFail = false
 
-    override suspend fun getMySharedSessions(page: Int, pageSize: Int): Result<List<SharedSession>> =
+    override suspend fun getMySharedSessions(): Result<List<SharedSession>> =
         if (shouldFail) Result.failure(Exception("Network error")) else Result.success(sharedSessions)
     override suspend fun getSharedSession(sharedSessionId: String): Result<SharedSessionDetail> =
         if (shouldFail) Result.failure(Exception("Network error"))

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -280,7 +280,7 @@ private class PlayFromSharedSaveTestGameStatsRepository : GameStatsRepository {
 }
 
 private class PlayFromSharedSaveTestSharedSessionRepository : SharedSessionRepository {
-    override suspend fun getMySharedSessions(page: Int, pageSize: Int) = Result.success(emptyList<SharedSession>())
+    override suspend fun getMySharedSessions() = Result.success(emptyList<SharedSession>())
     override suspend fun getSharedSession(sharedSessionId: String) = Result.failure<SharedSessionDetail>(Exception("stub"))
     override suspend fun getSharedSessionInvitations() = Result.success(emptyList<SharedSessionInvitation>())
     override suspend fun getPendingInvitationCount() = Result.success(0)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailRatingTest.kt
@@ -247,7 +247,7 @@ private class StubGameStatsRepository : GameStatsRepository {
 }
 
 private class StubSharedSessionRepository : SharedSessionRepository {
-    override suspend fun getMySharedSessions(page: Int, pageSize: Int) = Result.success(emptyList<SharedSession>())
+    override suspend fun getMySharedSessions() = Result.success(emptyList<SharedSession>())
     override suspend fun getSharedSession(sharedSessionId: String) = Result.failure<SharedSessionDetail>(Exception("stub"))
     override suspend fun getSharedSessionInvitations() = Result.success(emptyList<SharedSessionInvitation>())
     override suspend fun getPendingInvitationCount() = Result.success(0)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailSharedSaveTest.kt
@@ -268,7 +268,7 @@ private class SharedSaveTestGameStatsRepository : GameStatsRepository {
 }
 
 private class SharedSaveTestSharedSessionRepository : SharedSessionRepository {
-    override suspend fun getMySharedSessions(page: Int, pageSize: Int) = Result.success(emptyList<SharedSession>())
+    override suspend fun getMySharedSessions() = Result.success(emptyList<SharedSession>())
     override suspend fun getSharedSession(sharedSessionId: String) = Result.failure<SharedSessionDetail>(Exception("stub"))
     override suspend fun getSharedSessionInvitations() = Result.success(emptyList<SharedSessionInvitation>())
     override suspend fun getPendingInvitationCount() = Result.success(0)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -312,7 +312,7 @@ class StubSharedSessionRepository : SharedSessionRepository {
     var downloadSharedSessionAutoSaveResult: Result<ByteArray> = Result.success(byteArrayOf())
     var heartbeatResult: Result<Unit> = Result.success(Unit)
 
-    override suspend fun getMySharedSessions(page: Int, pageSize: Int) = Result.success(emptyList<SharedSession>())
+    override suspend fun getMySharedSessions() = Result.success(emptyList<SharedSession>())
     override suspend fun getSharedSession(sharedSessionId: String) = Result.failure<SharedSessionDetail>(Exception("stub"))
     override suspend fun getSharedSessionInvitations() = Result.success(emptyList<SharedSessionInvitation>())
     override suspend fun getPendingInvitationCount() = Result.success(0)


### PR DESCRIPTION
Mirror of #612 on the Kotlin side.

## Context
\`GET /api/shared-sessions\` returns a bare \`[]SharedSessionResponse\` — see \`server/internal/api/huma_shared.go:95\`. The server does not paginate this endpoint.

The player client's \`SpelaApiClient.getMySharedSessions(page, pageSize)\` carried \`@Suppress(\"UNUSED_PARAMETER\")\` on both args — the values were silently dropped. The domain interface and repository impl threaded them through, and all test stubs had to mirror the signature.

## Changes
Remove the dead params from the whole chain:
- \`SpelaApiClient.getMySharedSessions()\`
- \`SharedSessionRepository\` interface + impl
- 5 test stubs

Every caller was already using the defaults — no behaviour change.

## Verified
- \`:shared:compileKotlinDesktop\` ✅
- \`:shared:compileDebugKotlinAndroid\` ✅
- \`:shared:desktopTest\` ✅

## Test plan
- [ ] CI green