### PR TITLE
chore(web): remove passthrough  casts; consolidate multipart

### DIFF
--- a/web/src/hooks/__tests__/use-bios.test.ts
+++ b/web/src/hooks/__tests__/use-bios.test.ts
@@ -21,7 +21,10 @@ vi.mock("@/lib/api-client", () => ({
       return r.data;
     }),
   ),
-  multipartBodySerializer: (body: unknown) => body as FormData,
+  multipart: (formData: FormData) => ({
+    body: formData,
+    bodySerializer: (body: unknown) => body as FormData,
+  }),
 }));
 
 import { typedApi } from "@/lib/api-client";

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -1,15 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
-import type {
-  User,
-  DeletedUser,
-  ServerSettingsMap,
-  MetadataMatchesResponse,
-  IgdbSearchResult,
-  RateLimitStatus,
-  CoreCompatibilityResponse,
-  ScrapeStatusResponse,
-} from "@/types/api";
+import type { User } from "@/types/api";
 
 export function useAdminUsers() {
   return useQuery({
@@ -74,10 +65,7 @@ export function useCreateUser() {
 export function useServerSettings() {
   return useQuery({
     queryKey: ["admin", "settings"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/admin/settings"));
-      return data as ServerSettingsMap | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/admin/settings")),
   });
 }
 
@@ -194,24 +182,14 @@ export function useCancelScrape() {
 export function useMetadataMatches() {
   return useQuery({
     queryKey: ["admin", "metadata-matches"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/admin/metadata-matches"),
-      );
-      return data as MetadataMatchesResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/admin/metadata-matches")),
   });
 }
 
 export function useDeletedUsers() {
   return useQuery({
     queryKey: ["admin", "users", "deleted"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/admin/users/deleted"),
-      );
-      return data as DeletedUser[] | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/admin/users/deleted")),
   });
 }
 
@@ -303,10 +281,7 @@ export function useTestIgdbCredentials() {
 export function useScrapeStatus() {
   return useQuery({
     queryKey: ["admin", "scrape-status"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/admin/scrape/status"));
-      return data as ScrapeStatusResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/admin/scrape/status")),
     refetchInterval: 3000, // Poll every 3s to catch status changes
   });
 }
@@ -489,14 +464,12 @@ export function useUpdateGameMetadata() {
 export function useIgdbSearch(gameId: string, query: string) {
   return useQuery({
     queryKey: ["admin", "igdb-search", gameId, query],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/admin/games/{id}/igdb-search", {
           params: { path: { id: gameId }, query: { q: query } },
         }),
-      );
-      return data as IgdbSearchResult[] | undefined;
-    },
+      ),
     enabled: query.length >= 2,
   });
 }
@@ -532,14 +505,12 @@ export function useApplyIgdbMatch() {
 export function useUserRateLimit(userId: string) {
   return useQuery({
     queryKey: ["admin", "users", userId, "rate-limit"],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/admin/users/{id}/rate-limit", {
           params: { path: { id: userId } },
         }),
-      );
-      return data as RateLimitStatus | undefined;
-    },
+      ),
     enabled: !!userId,
   });
 }
@@ -566,11 +537,6 @@ export function useResetRateLimit() {
 export function useCoreCompatibility() {
   return useQuery({
     queryKey: ["admin", "core-compatibility"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/admin/core-compatibility"),
-      );
-      return data as CoreCompatibilityResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/admin/core-compatibility")),
   });
 }

--- a/web/src/hooks/use-bios.ts
+++ b/web/src/hooks/use-bios.ts
@@ -1,10 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  multipartBodySerializer,
-  typedApi,
-  unwrap,
-} from "@/lib/api-client";
-import type { BiosFile } from "@/types/api";
+import { multipart, typedApi, unwrap } from "@/lib/api-client";
 
 export function useBiosStatus() {
   return useQuery({
@@ -26,16 +21,10 @@ export function useUploadBiosFile() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (file: File) => {
+    mutationFn: (file: File) => {
       const formData = new FormData();
       formData.append("file", file);
-      const data = await unwrap(
-        typedApi.POST("/api/admin/bios", {
-          body: formData as unknown as never,
-          bodySerializer: multipartBodySerializer,
-        }),
-      );
-      return data as BiosFile | undefined;
+      return unwrap(typedApi.POST("/api/admin/bios", multipart(formData)));
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["bios"] });

--- a/web/src/hooks/use-challenges.ts
+++ b/web/src/hooks/use-challenges.ts
@@ -5,7 +5,6 @@ import type {
   Challenge,
   ChallengesResponse,
   ChallengeFilters,
-  ChallengeLeaderboardResponse,
   ChallengeLeaderboardEntry,
   ChallengeAttempt,
 } from "@/types/api";
@@ -99,14 +98,12 @@ export function useChallengeLeaderboard(
 ) {
   return useQuery({
     queryKey: ["challenge", challengeId, "leaderboard", page, pageSize],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/challenges/{id}/leaderboard", {
           params: { path: { id: challengeId }, query: { page, pageSize } },
         }),
-      );
-      return data as ChallengeLeaderboardResponse | undefined;
-    },
+      ),
     enabled: !!challengeId,
   });
 }

--- a/web/src/hooks/use-consoles.ts
+++ b/web/src/hooks/use-consoles.ts
@@ -1,28 +1,22 @@
 import { useQuery } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
-import type { Console, Game } from "@/types/api";
 
 export function useConsoles() {
   return useQuery({
     queryKey: ["consoles"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/consoles"));
-      return data as Console[] | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/consoles")),
   });
 }
 
 export function useConsoleGames(consoleId: string) {
   return useQuery({
     queryKey: ["consoles", consoleId, "games"],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/consoles/{id}/games", {
           params: { path: { id: consoleId } },
         }),
-      );
-      return data as Game[] | undefined;
-    },
+      ),
     enabled: !!consoleId,
   });
 }

--- a/web/src/hooks/use-emulator-saves.ts
+++ b/web/src/hooks/use-emulator-saves.ts
@@ -1,10 +1,5 @@
 import { useCallback, useRef, useState } from "react";
-import {
-  api,
-  multipartBodySerializer,
-  typedApi,
-  unwrap,
-} from "@/lib/api-client";
+import { api, multipart, typedApi, unwrap } from "@/lib/api-client";
 import { uint8ArrayToBase64 } from "@/lib/encoding";
 import { useSaveQueue } from "./use-save-queue";
 import { useAutoSave } from "./use-auto-save";
@@ -74,8 +69,7 @@ export function useEmulatorSaves({
           unwrap(
             typedApi.POST("/api/sessions/{id}/saves/auto", {
               params: { path: { id: sessionId } },
-              body: formData as unknown as never,
-              bodySerializer: multipartBodySerializer,
+              ...multipart(formData),
             }),
           )
             .then(() => exitResolve())

--- a/web/src/hooks/use-explore.ts
+++ b/web/src/hooks/use-explore.ts
@@ -1,49 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
-import type {
-  FeaturedGame,
-  FeaturedSeries,
-  SeriesDetail,
-  FranchiseDetail,
-  GameSeriesLink,
-  GameFranchiseLink,
-  ExploreRowsResponse,
-  Theme,
-  Keyword,
-  GamesResponse,
-  MoodDefinition,
-  Game,
-  ForYouResponse,
-  TasteProfile,
-  PlayersLikeYouResponse,
-  DeveloperListResponse,
-  DeveloperDetailResponse,
-  PublisherDetailResponse,
-  DeveloperSpotlightResponse,
-  ConsoleShowcase,
-  ConsoleHighlightsResponse,
-  ScreenshotGalleryResponse,
-  ArtworkGalleryResponse,
-  CoverGalleryResponse,
-  TrendingResponse,
-  CommunityTopResponse,
-  CultClassicsResponse,
-  RecentlyReviewedResponse,
-  ActiveNowResponse,
-  OnThisDayResponse,
-  BestOfYearResponse,
-  YourAnniversariesResponse,
-  DecadeResponse,
-  EasyToCompleteResponse,
-  HardestGamesResponse,
-  AlmostDoneResponse,
-  FreshChallengesResponse,
-  ActiveChallengesResponse,
-  WizardResponse,
-  WizardResultsResponse,
-  ExplorerBadgesResponse,
-  CompletionistMapResponse,
-} from "@/types/api";
 
 // Cache durations for explore data that changes infrequently.
 // Prevents re-fetching 25+ queries every time the user navigates back.
@@ -56,10 +12,7 @@ const STALE_SHORT = 30 * 1000; // 30s — live data (trending, active-now)
 export function useExploreFeatured() {
   return useQuery({
     queryKey: ["explore", "featured"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/featured"));
-      return data as FeaturedGame[] | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/featured")),
     staleTime: STALE_LONG,
   });
 }
@@ -67,10 +20,7 @@ export function useExploreFeatured() {
 export function useExploreRows() {
   return useQuery({
     queryKey: ["explore", "rows"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/rows"));
-      return data as ExploreRowsResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/rows")),
     staleTime: STALE_LONG,
   });
 }
@@ -78,12 +28,7 @@ export function useExploreRows() {
 export function useConsoleHighlights() {
   return useQuery({
     queryKey: ["console-highlights"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/explore/console-highlights"),
-      );
-      return data as ConsoleHighlightsResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/console-highlights")),
     staleTime: STALE_LONG,
   });
 }
@@ -91,10 +36,7 @@ export function useConsoleHighlights() {
 export function useMoods() {
   return useQuery({
     queryKey: ["explore", "moods"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/moods"));
-      return data as MoodDefinition[] | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/moods")),
     staleTime: STALE_LONG,
   });
 }
@@ -104,10 +46,7 @@ export function useMoods() {
 export function useForYou(enabled = true) {
   return useQuery({
     queryKey: ["explore", "for-you"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/for-you"));
-      return data as ForYouResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/for-you")),
     staleTime: STALE_MEDIUM,
     enabled,
   });
@@ -116,12 +55,7 @@ export function useForYou(enabled = true) {
 export function usePlayersLikeYou(enabled = true) {
   return useQuery({
     queryKey: ["explore", "players-like-you"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/explore/players-like-you"),
-      );
-      return data as PlayersLikeYouResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/players-like-you")),
     staleTime: STALE_MEDIUM,
     enabled,
   });
@@ -130,10 +64,7 @@ export function usePlayersLikeYou(enabled = true) {
 export function useTrending(enabled = true) {
   return useQuery({
     queryKey: ["explore", "trending"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/trending"));
-      return data as TrendingResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/trending")),
     staleTime: STALE_SHORT,
     enabled,
   });
@@ -142,10 +73,7 @@ export function useTrending(enabled = true) {
 export function useCommunityTop(enabled = true) {
   return useQuery({
     queryKey: ["explore", "community-top"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/community-top"));
-      return data as CommunityTopResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/community-top")),
     staleTime: STALE_MEDIUM,
     enabled,
   });
@@ -154,10 +82,7 @@ export function useCommunityTop(enabled = true) {
 export function useCultClassics(enabled = true) {
   return useQuery({
     queryKey: ["explore", "cult-classics"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/cult-classics"));
-      return data as CultClassicsResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/cult-classics")),
     staleTime: STALE_LONG,
     enabled,
   });
@@ -166,10 +91,7 @@ export function useCultClassics(enabled = true) {
 export function useActiveNow(enabled = true) {
   return useQuery({
     queryKey: ["explore", "active-now"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/active-now"));
-      return data as ActiveNowResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/active-now")),
     staleTime: STALE_SHORT,
     enabled,
   });
@@ -178,12 +100,7 @@ export function useActiveNow(enabled = true) {
 export function useRecentlyReviewed(enabled = true) {
   return useQuery({
     queryKey: ["explore", "recently-reviewed"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/explore/recently-reviewed"),
-      );
-      return data as RecentlyReviewedResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/recently-reviewed")),
     staleTime: STALE_SHORT,
     enabled,
   });
@@ -192,10 +109,7 @@ export function useRecentlyReviewed(enabled = true) {
 export function useOnThisDay(enabled = true) {
   return useQuery({
     queryKey: ["explore", "on-this-day"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/on-this-day"));
-      return data as OnThisDayResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/on-this-day")),
     staleTime: STALE_LONG,
     enabled,
   });
@@ -204,14 +118,12 @@ export function useOnThisDay(enabled = true) {
 export function useBestOfYear(year: number, enabled = true) {
   return useQuery({
     queryKey: ["explore", "best-of-year", year],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/explore/best-of-year/{year}", {
           params: { path: { year: String(year) } },
         }),
-      );
-      return data as BestOfYearResponse | undefined;
-    },
+      ),
     staleTime: STALE_LONG,
     enabled,
   });
@@ -220,12 +132,7 @@ export function useBestOfYear(year: number, enabled = true) {
 export function useYourAnniversaries(enabled = true) {
   return useQuery({
     queryKey: ["explore", "your-anniversaries"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/explore/your-anniversaries"),
-      );
-      return data as YourAnniversariesResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/your-anniversaries")),
     staleTime: STALE_MEDIUM,
     enabled,
   });
@@ -234,14 +141,12 @@ export function useYourAnniversaries(enabled = true) {
 export function useDecade(decade: string, enabled = true) {
   return useQuery({
     queryKey: ["explore", "decades", decade],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/explore/decades/{decade}", {
           params: { path: { decade } },
         }),
-      );
-      return data as DecadeResponse | undefined;
-    },
+      ),
     staleTime: STALE_LONG,
     enabled: !!decade && enabled,
   });
@@ -250,12 +155,7 @@ export function useDecade(decade: string, enabled = true) {
 export function useEasyToComplete(enabled = true) {
   return useQuery({
     queryKey: ["explore", "easy-to-complete"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/explore/easy-to-complete"),
-      );
-      return data as EasyToCompleteResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/easy-to-complete")),
     staleTime: STALE_MEDIUM,
     enabled,
   });
@@ -264,10 +164,7 @@ export function useEasyToComplete(enabled = true) {
 export function useHardestGames(enabled = true) {
   return useQuery({
     queryKey: ["explore", "hardest-games"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/hardest-games"));
-      return data as HardestGamesResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/hardest-games")),
     staleTime: STALE_LONG,
     enabled,
   });
@@ -276,10 +173,7 @@ export function useHardestGames(enabled = true) {
 export function useAlmostDone(enabled = true) {
   return useQuery({
     queryKey: ["explore", "almost-done"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/almost-done"));
-      return data as AlmostDoneResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/almost-done")),
     staleTime: STALE_MEDIUM,
     enabled,
   });
@@ -288,12 +182,7 @@ export function useAlmostDone(enabled = true) {
 export function useFreshChallenges(enabled = true) {
   return useQuery({
     queryKey: ["explore", "fresh-challenges"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/explore/fresh-challenges"),
-      );
-      return data as FreshChallengesResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/fresh-challenges")),
     staleTime: STALE_MEDIUM,
     enabled,
   });
@@ -302,12 +191,7 @@ export function useFreshChallenges(enabled = true) {
 export function useActiveChallenges(enabled = true) {
   return useQuery({
     queryKey: ["explore", "active-challenges"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/explore/active-challenges"),
-      );
-      return data as ActiveChallengesResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/active-challenges")),
     staleTime: STALE_MEDIUM,
     enabled,
   });
@@ -316,10 +200,7 @@ export function useActiveChallenges(enabled = true) {
 export function useThemes(enabled = true) {
   return useQuery({
     queryKey: ["themes"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/themes"));
-      return data as Theme[] | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/themes")),
     staleTime: STALE_LONG,
     enabled,
   });
@@ -328,12 +209,8 @@ export function useThemes(enabled = true) {
 export function useKeywords(limit = 30, enabled = true) {
   return useQuery({
     queryKey: ["keywords", limit],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/keywords", { params: { query: { limit } } }),
-      );
-      return data as Keyword[] | undefined;
-    },
+    queryFn: () =>
+      unwrap(typedApi.GET("/api/keywords", { params: { query: { limit } } })),
     staleTime: STALE_LONG,
     enabled,
   });
@@ -342,10 +219,7 @@ export function useKeywords(limit = 30, enabled = true) {
 export function useFeaturedSeries(enabled = true) {
   return useQuery({
     queryKey: ["explore", "series", "featured"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/series/featured"));
-      return data as FeaturedSeries[] | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/series/featured")),
     staleTime: STALE_LONG,
     enabled,
   });
@@ -354,12 +228,7 @@ export function useFeaturedSeries(enabled = true) {
 export function useDeveloperSpotlight(enabled = true) {
   return useQuery({
     queryKey: ["explore", "developers", "spotlight"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/explore/developers/spotlight"),
-      );
-      return data as DeveloperSpotlightResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/developers/spotlight")),
     staleTime: STALE_LONG,
     enabled,
   });
@@ -368,14 +237,12 @@ export function useDeveloperSpotlight(enabled = true) {
 export function useArtworkGallery(page: number, enabled = true) {
   return useQuery({
     queryKey: ["artwork-gallery", page],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/explore/artwork", {
           params: { query: { page } },
         }),
-      );
-      return data as ArtworkGalleryResponse | undefined;
-    },
+      ),
     staleTime: STALE_LONG,
     enabled,
   });
@@ -390,17 +257,15 @@ export function useThemeGames(
 ) {
   return useQuery({
     queryKey: ["themes", themeId, "games", page, pageSize],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/themes/{id}/games", {
           params: {
             path: { id: themeId as string },
             query: { page, pageSize },
           },
         }),
-      );
-      return data as GamesResponse | undefined;
-    },
+      ),
     enabled: !!themeId,
     staleTime: STALE_LONG,
   });
@@ -413,17 +278,15 @@ export function useKeywordGames(
 ) {
   return useQuery({
     queryKey: ["keywords", keywordId, "games", page, pageSize],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/keywords/{id}/games", {
           params: {
             path: { id: keywordId as string },
             query: { page, pageSize },
           },
         }),
-      );
-      return data as GamesResponse | undefined;
-    },
+      ),
     enabled: !!keywordId,
     staleTime: STALE_LONG,
   });
@@ -432,14 +295,12 @@ export function useKeywordGames(
 export function useSeriesDetail(id: string | undefined) {
   return useQuery({
     queryKey: ["series", id],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/series/{id}", {
           params: { path: { id: id as string } },
         }),
-      );
-      return data as SeriesDetail | undefined;
-    },
+      ),
     enabled: !!id,
     staleTime: STALE_LONG,
   });
@@ -448,14 +309,12 @@ export function useSeriesDetail(id: string | undefined) {
 export function useFranchiseDetail(id: string | undefined) {
   return useQuery({
     queryKey: ["franchises", id],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/franchises/{id}", {
           params: { path: { id: id as string } },
         }),
-      );
-      return data as FranchiseDetail | undefined;
-    },
+      ),
     enabled: !!id,
     staleTime: STALE_LONG,
   });
@@ -464,14 +323,12 @@ export function useFranchiseDetail(id: string | undefined) {
 export function useGameSeries(gameId: string | undefined) {
   return useQuery({
     queryKey: ["games", gameId, "series"],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/games/{id}/series", {
           params: { path: { id: gameId as string } },
         }),
-      );
-      return data as GameSeriesLink[] | undefined;
-    },
+      ),
     enabled: !!gameId,
     staleTime: STALE_LONG,
   });
@@ -480,14 +337,12 @@ export function useGameSeries(gameId: string | undefined) {
 export function useGameFranchises(gameId: string | undefined) {
   return useQuery({
     queryKey: ["games", gameId, "franchises"],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/games/{id}/franchises", {
           params: { path: { id: gameId as string } },
         }),
-      );
-      return data as GameFranchiseLink[] | undefined;
-    },
+      ),
     enabled: !!gameId,
     staleTime: STALE_LONG,
   });
@@ -496,14 +351,12 @@ export function useGameFranchises(gameId: string | undefined) {
 export function useMoodGames(mood: string | undefined) {
   return useQuery({
     queryKey: ["explore", "mood", mood],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/explore/mood/{mood}", {
           params: { path: { mood: mood as string } },
         }),
-      );
-      return data as Game[] | undefined;
-    },
+      ),
     enabled: !!mood,
     staleTime: STALE_MEDIUM,
   });
@@ -512,10 +365,7 @@ export function useMoodGames(mood: string | undefined) {
 export function useSurpriseGame() {
   return useQuery({
     queryKey: ["explore", "surprise"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/surprise"));
-      return data as Game | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/surprise")),
     enabled: false,
   });
 }
@@ -523,10 +373,7 @@ export function useSurpriseGame() {
 export function useTasteProfile() {
   return useQuery({
     queryKey: ["user", "taste-profile"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/user/taste-profile"));
-      return data as TasteProfile | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/user/taste-profile")),
     staleTime: STALE_MEDIUM,
   });
 }
@@ -534,10 +381,7 @@ export function useTasteProfile() {
 export function useDevelopers() {
   return useQuery({
     queryKey: ["explore", "developers"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/developers"));
-      return data as DeveloperListResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/developers")),
     staleTime: STALE_LONG,
   });
 }
@@ -545,14 +389,12 @@ export function useDevelopers() {
 export function useDeveloperDetail(name: string) {
   return useQuery({
     queryKey: ["explore", "developers", name],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/explore/developers/{name}", {
           params: { path: { name } },
         }),
-      );
-      return data as DeveloperDetailResponse | undefined;
-    },
+      ),
     enabled: !!name,
     staleTime: STALE_LONG,
   });
@@ -561,14 +403,12 @@ export function useDeveloperDetail(name: string) {
 export function usePublisherDetail(name: string) {
   return useQuery({
     queryKey: ["explore", "publishers", name],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/explore/publishers/{name}", {
           params: { path: { name } },
         }),
-      );
-      return data as PublisherDetailResponse | undefined;
-    },
+      ),
     enabled: !!name,
     staleTime: STALE_LONG,
   });
@@ -577,14 +417,12 @@ export function usePublisherDetail(name: string) {
 export function useConsoleShowcase(consoleId: string) {
   return useQuery({
     queryKey: ["console-showcase", consoleId],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/explore/consoles/{id}/showcase", {
           params: { path: { id: consoleId } },
         }),
-      );
-      return data as ConsoleShowcase | undefined;
-    },
+      ),
     enabled: !!consoleId,
     staleTime: STALE_LONG,
   });
@@ -596,8 +434,8 @@ export function useScreenshotGallery(
 ) {
   return useQuery({
     queryKey: ["screenshot-gallery", page, filters],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/explore/screenshots", {
           params: {
             query: {
@@ -607,9 +445,7 @@ export function useScreenshotGallery(
             },
           },
         }),
-      );
-      return data as ScreenshotGalleryResponse | undefined;
-    },
+      ),
     staleTime: STALE_LONG,
   });
 }
@@ -617,8 +453,8 @@ export function useScreenshotGallery(
 export function useCoverGallery(page: number, consoleFilter?: string) {
   return useQuery({
     queryKey: ["cover-gallery", page, consoleFilter],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/explore/covers", {
           params: {
             query: {
@@ -627,9 +463,7 @@ export function useCoverGallery(page: number, consoleFilter?: string) {
             },
           },
         }),
-      );
-      return data as CoverGalleryResponse | undefined;
-    },
+      ),
     staleTime: STALE_LONG,
   });
 }
@@ -639,10 +473,7 @@ export function useCoverGallery(page: number, consoleFilter?: string) {
 export function useWizardSteps() {
   return useQuery({
     queryKey: ["explore", "wizard"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/explore/wizard"));
-      return data as WizardResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/explore/wizard")),
     staleTime: STALE_LONG,
   });
 }
@@ -655,14 +486,12 @@ export function useWizardResults(
 ) {
   return useQuery({
     queryKey: ["explore", "wizard", "results", mood, era, vibe],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/explore/wizard/results", {
           params: { query: { mood, era, vibe } },
         }),
-      );
-      return data as WizardResultsResponse | undefined;
-    },
+      ),
     enabled,
   });
 }
@@ -670,10 +499,7 @@ export function useWizardResults(
 export function useExplorerBadges() {
   return useQuery({
     queryKey: ["user", "explorer-badges"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/user/explorer-badges"));
-      return data as ExplorerBadgesResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/user/explorer-badges")),
     staleTime: STALE_MEDIUM,
   });
 }
@@ -681,10 +507,7 @@ export function useExplorerBadges() {
 export function useCompletionistMap() {
   return useQuery({
     queryKey: ["user", "completionist-map"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/user/completionist-map"));
-      return data as CompletionistMapResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/user/completionist-map")),
     staleTime: STALE_MEDIUM,
   });
 }

--- a/web/src/hooks/use-games.ts
+++ b/web/src/hooks/use-games.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import { multipartBodySerializer, typedApi, unwrap } from "@/lib/api-client";
-import type { Game, GamesResponse, GameFilters, ReplaceROMResponse } from "@/types/api";
+import { multipart, typedApi, unwrap } from "@/lib/api-client";
+import type { Game, GameFilters } from "@/types/api";
 
 export function useGames(filters?: GameFilters, options?: { enabled?: boolean }) {
   const query: Record<string, string | number | boolean | undefined> = {};
@@ -31,12 +31,7 @@ export function useGames(filters?: GameFilters, options?: { enabled?: boolean })
 
   return useQuery({
     queryKey: ["games", filters],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/games", { params: { query } }),
-      );
-      return data as GamesResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/games", { params: { query } })),
     enabled: options?.enabled,
   });
 }
@@ -44,12 +39,8 @@ export function useGames(filters?: GameFilters, options?: { enabled?: boolean })
 export function useGame(id: string) {
   return useQuery({
     queryKey: ["game", id],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/games/{id}", { params: { path: { id } } }),
-      );
-      return data as Game | undefined;
-    },
+    queryFn: () =>
+      unwrap(typedApi.GET("/api/games/{id}", { params: { path: { id } } })),
     enabled: !!id,
   });
 }
@@ -57,20 +48,14 @@ export function useGame(id: string) {
 export function useRecentGames() {
   return useQuery({
     queryKey: ["games", "recent"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/user/recent"));
-      return data as Game[] | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/user/recent")),
   });
 }
 
 export function useFavoriteGames() {
   return useQuery({
     queryKey: ["games", "favorites"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/user/favorites"));
-      return data as Game[] | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/user/favorites")),
   });
 }
 
@@ -126,17 +111,15 @@ export function useReplaceRom() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({ gameId, file }: { gameId: string; file: File }) => {
+    mutationFn: ({ gameId, file }: { gameId: string; file: File }) => {
       const formData = new FormData();
       formData.append("file", file);
-      const data = await unwrap(
+      return unwrap(
         typedApi.PUT("/api/admin/games/{id}/replace-rom", {
           params: { path: { id: gameId } },
-          body: formData as unknown as never,
-          bodySerializer: multipartBodySerializer,
+          ...multipart(formData),
         }),
       );
-      return data as ReplaceROMResponse | undefined;
     },
     onSuccess: (_data, { gameId }) => {
       queryClient.invalidateQueries({ queryKey: ["game", gameId] });

--- a/web/src/hooks/use-play-later.ts
+++ b/web/src/hooks/use-play-later.ts
@@ -5,10 +5,7 @@ import type { Game } from "@/types/api";
 export function usePlayLaterGames() {
   return useQuery({
     queryKey: ["games", "play-later"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/user/play-later"));
-      return data as Game[] | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/user/play-later")),
   });
 }
 

--- a/web/src/hooks/use-preferences.ts
+++ b/web/src/hooks/use-preferences.ts
@@ -5,10 +5,7 @@ import type { UserPreferences } from "@/types/api";
 export function useUserPreferences() {
   return useQuery({
     queryKey: ["user", "preferences"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/user/preferences"));
-      return data as UserPreferences | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/user/preferences")),
   });
 }
 

--- a/web/src/hooks/use-retroachievements.ts
+++ b/web/src/hooks/use-retroachievements.ts
@@ -1,23 +1,11 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
-import type {
-  RAStatus,
-  RALinkRequest,
-  RASettingsRequest,
-  GameAchievements,
-  GameAchievementProgressResponse,
-  AchievementLeaderboard,
-  AchievementTimeline,
-  RecentAchievement,
-} from "@/types/api";
+import type { RALinkRequest, RASettingsRequest } from "@/types/api";
 
 export function useRAStatus() {
   return useQuery({
     queryKey: ["ra-status"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/user/ra/status"));
-      return data as RAStatus | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/user/ra/status")),
   });
 }
 
@@ -59,14 +47,12 @@ export function useRASettings() {
 export function useGameAchievements(gameId: string | undefined) {
   return useQuery({
     queryKey: ["game-achievements", gameId],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/games/{id}/achievements", {
           params: { path: { id: gameId as string } },
         }),
-      );
-      return data as GameAchievements | undefined;
-    },
+      ),
     enabled: !!gameId,
     refetchInterval: (query) => {
       // Poll every 2 seconds while the server is processing an RA fetch.
@@ -83,11 +69,11 @@ export function useGameAchievementProgress(gameId: string | undefined) {
   return useQuery({
     queryKey: ["game-achievement-progress", gameId],
     queryFn: async () => {
-      const data = (await unwrap(
+      const data = await unwrap(
         typedApi.GET("/api/games/{id}/achievements/progress", {
           params: { path: { id: gameId as string } },
         }),
-      )) as GameAchievementProgressResponse | undefined;
+      );
       return data?.progress ?? null;
     },
     enabled: !!gameId,
@@ -97,14 +83,12 @@ export function useGameAchievementProgress(gameId: string | undefined) {
 export function useAchievementLeaderboard(gameId: string | undefined) {
   return useQuery({
     queryKey: ["achievement-leaderboard", gameId],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/games/{id}/achievements/leaderboard", {
           params: { path: { id: gameId as string } },
         }),
-      );
-      return data as AchievementLeaderboard | undefined;
-    },
+      ),
     enabled: !!gameId,
   });
 }
@@ -112,14 +96,12 @@ export function useAchievementLeaderboard(gameId: string | undefined) {
 export function useAchievementTimeline(gameId: string | undefined) {
   return useQuery({
     queryKey: ["achievement-timeline", gameId],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/games/{id}/achievements/timeline", {
           params: { path: { id: gameId as string } },
         }),
-      );
-      return data as AchievementTimeline | undefined;
-    },
+      ),
     enabled: !!gameId,
   });
 }
@@ -131,7 +113,7 @@ export function useRecentAchievements() {
       const data = await unwrap(
         typedApi.GET("/api/user/achievements/recent"),
       );
-      return (data?.achievements ?? []) as RecentAchievement[];
+      return data?.achievements ?? [];
     },
   });
 }

--- a/web/src/hooks/use-rom-hacks.ts
+++ b/web/src/hooks/use-rom-hacks.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { multipartBodySerializer, typedApi, unwrap } from "@/lib/api-client";
+import { multipart, typedApi, unwrap } from "@/lib/api-client";
 
 interface CreateRomHackParams {
   baseGameId: string;
@@ -9,16 +9,11 @@ interface CreateRomHackParams {
   title?: string;
 }
 
-interface CreateRomHackResponse {
-  id: string;
-  title: string;
-}
-
 export function useCreateRomHack() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (params: CreateRomHackParams) => {
+    mutationFn: (params: CreateRomHackParams) => {
       const formData = new FormData();
       formData.append("baseGameId", params.baseGameId);
       formData.append("patchFile", params.patchFile);
@@ -29,13 +24,9 @@ export function useCreateRomHack() {
       if (params.mode === "standalone" && params.title) {
         formData.append("title", params.title);
       }
-      const data = await unwrap(
-        typedApi.POST("/api/admin/rom-hacks", {
-          body: formData as unknown as never,
-          bodySerializer: multipartBodySerializer,
-        }),
+      return unwrap(
+        typedApi.POST("/api/admin/rom-hacks", multipart(formData)),
       );
-      return data as CreateRomHackResponse | undefined;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["games"] });

--- a/web/src/hooks/use-save-queue.ts
+++ b/web/src/hooks/use-save-queue.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { multipartBodySerializer, typedApi, unwrap } from "@/lib/api-client";
+import { multipart, typedApi, unwrap } from "@/lib/api-client";
 
 export interface SaveQueueItem {
   sessionId: string;
@@ -57,16 +57,14 @@ export function useSaveQueue({
         await unwrap(
           typedApi.POST("/api/sessions/{id}/saves/auto", {
             params: { path: { id: item.sessionId } },
-            body: formData as unknown as never,
-            bodySerializer: multipartBodySerializer,
+            ...multipart(formData),
           }),
         );
       } else {
         await unwrap(
           typedApi.POST("/api/sessions/{id}/saves", {
             params: { path: { id: item.sessionId } },
-            body: formData as unknown as never,
-            bodySerializer: multipartBodySerializer,
+            ...multipart(formData),
           }),
         );
       }

--- a/web/src/hooks/use-sessions.ts
+++ b/web/src/hooks/use-sessions.ts
@@ -1,22 +1,15 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
-import type {
-  GameSession,
-  SessionSave,
-  SessionCheatConfig,
-} from "@/types/api";
 
 export function useGameSessions(gameId: string) {
   return useQuery({
     queryKey: ["game-sessions", gameId],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/games/{id}/sessions", {
           params: { path: { id: gameId } },
         }),
-      );
-      return data as GameSession[] | undefined;
-    },
+      ),
     enabled: !!gameId,
   });
 }
@@ -87,14 +80,12 @@ export function useSession(sessionId: string) {
 export function useSessionSaves(sessionId: string) {
   return useQuery({
     queryKey: ["session-saves", sessionId],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/sessions/{id}/saves", {
           params: { path: { id: sessionId } },
         }),
-      );
-      return data as SessionSave[] | undefined;
-    },
+      ),
     enabled: !!sessionId,
   });
 }
@@ -102,14 +93,12 @@ export function useSessionSaves(sessionId: string) {
 export function useSessionCheats(sessionId: string) {
   return useQuery({
     queryKey: ["session-cheats", sessionId],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/sessions/{id}/cheats", {
           params: { path: { id: sessionId } },
         }),
-      );
-      return data as SessionCheatConfig | undefined;
-    },
+      ),
     enabled: !!sessionId,
   });
 }
@@ -192,14 +181,12 @@ export function useDeleteSessionSave() {
 export function useAutoSaveInfo(sessionId: string | undefined) {
   return useQuery({
     queryKey: ["session-saves", sessionId],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/sessions/{id}/saves", {
           params: { path: { id: sessionId as string } },
         }),
-      );
-      return data as SessionSave[] | undefined;
-    },
+      ),
     enabled: !!sessionId,
     select: (saves) => saves?.find((s) => s.isAuto) ?? null,
   });

--- a/web/src/hooks/use-shared-sessions.ts
+++ b/web/src/hooks/use-shared-sessions.ts
@@ -4,7 +4,6 @@ import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
   SharedSessionDetail,
   SharedSessionInvitation,
-  SharedSessionSave,
   SharedSession,
 } from "@/types/api";
 
@@ -57,14 +56,12 @@ export function useSharedSession(id: string) {
 export function useSharedSessionSaves(sharedSessionId: string) {
   return useQuery({
     queryKey: ["shared-sessions", "saves", sharedSessionId],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/shared-sessions/{id}/saves", {
           params: { path: { id: sharedSessionId } },
         }),
-      );
-      return data as SharedSessionSave[] | undefined;
-    },
+      ),
     enabled: !!sharedSessionId,
   });
 }

--- a/web/src/hooks/use-social.ts
+++ b/web/src/hooks/use-social.ts
@@ -4,7 +4,6 @@ import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
   ActivityEvent,
   ActivityFeedResponse,
-  UserSearchResponse,
 } from "@/types/api";
 
 export function useOnlineUsers() {
@@ -18,14 +17,12 @@ export function useOnlineUsers() {
 export function useActivityFeed(page: number = 1, pageSize: number = 20) {
   return useQuery({
     queryKey: ["social", "activity", page, pageSize],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/social/activity", {
           params: { query: { page, pageSize } },
         }),
-      );
-      return data as ActivityFeedResponse | undefined;
-    },
+      ),
   });
 }
 
@@ -36,14 +33,12 @@ export function useSearchUsers(
 ) {
   return useQuery({
     queryKey: ["users", "search", query, page, pageSize],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/users/search", {
           params: { query: { q: query, page, pageSize } },
         }),
-      );
-      return data as UserSearchResponse | undefined;
-    },
+      ),
   });
 }
 

--- a/web/src/hooks/use-uploads.ts
+++ b/web/src/hooks/use-uploads.ts
@@ -1,10 +1,5 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
-import {
-  multipartBodySerializer,
-  typedApi,
-  unwrap,
-} from "@/lib/api-client";
-import type { StagedUpload } from "@/types/api";
+import { multipart, typedApi, unwrap } from "@/lib/api-client";
 
 export function useUploadWritable() {
   return useQuery({
@@ -24,18 +19,12 @@ export function useUploadRoms() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async (files: File[]) => {
+    mutationFn: (files: File[]) => {
       const formData = new FormData();
       for (const file of files) {
         formData.append("files", file);
       }
-      const data = await unwrap(
-        typedApi.POST("/api/admin/uploads", {
-          body: formData as unknown as never,
-          bodySerializer: multipartBodySerializer,
-        }),
-      );
-      return data as StagedUpload[] | undefined;
+      return unwrap(typedApi.POST("/api/admin/uploads", multipart(formData)));
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["admin", "uploads"] });

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -168,37 +168,56 @@ export const typedApi = createClient<paths>({
   fetch: authedFetch,
 });
 
-// Multipart bodySerializer for openapi-fetch. The generated path spec types
-// file fields as `string` (from `format: binary` in OpenAPI), so multipart
-// call sites need to pass a FormData-compatible body via an `unknown` cast.
-// Use like:
+// Multipart helper. The generated OpenAPI types file fields as `string`
+// (from `format: binary`), so a FormData body doesn't structurally match
+// the inferred `body` parameter of typedApi.POST/PUT. `multipart()` returns
+// the openapi-fetch options bag with the body cast (and matching
+// bodySerializer) in one place — call sites stay free of `as`.
 //
+// Usage:
 //   const formData = new FormData();
 //   formData.append("file", file);
-//   await typedApi.POST("/api/admin/bios", {
-//     body: formData as unknown as never,
-//     bodySerializer: multipartBodySerializer,
+//   await typedApi.POST("/api/admin/bios", multipart(formData));
+//
+//   await typedApi.PUT("/api/admin/games/{id}/replace-rom", {
+//     ...multipart(formData),
+//     params: { path: { id: gameId } },
 //   });
 //
 // The serializer returns the FormData as-is so the browser sets the correct
 // multipart/form-data Content-Type + boundary.
-export function multipartBodySerializer(body: unknown): FormData {
-  if (body instanceof FormData) return body;
-  throw new Error(
-    "multipartBodySerializer expects a FormData body; got " + typeof body,
-  );
+export function multipart(formData: FormData): {
+  body: never;
+  bodySerializer: (body: unknown) => FormData;
+} {
+  return {
+    body: formData as unknown as never,
+    bodySerializer: (body) => {
+      if (body instanceof FormData) return body;
+      throw new Error(
+        "multipart bodySerializer expects FormData; got " + typeof body,
+      );
+    },
+  };
 }
 
 // unwrap resolves a { data, error, response } FetchResponse into the success
 // value, throwing ApiError on failure. Hook call sites wrap their typedApi
 // calls in unwrap() so errors bubble through react-query's onError / try-
 // catch paths like a throwing fetcher.
+//
+// Special case: huma serialises Go nil slices as JSON `null`, so flat-list
+// endpoints (e.g. GET /api/consoles, /api/themes) come back typed as
+// `T[] | null` from openapi-fetch. We coerce a top-level `null` body to
+// `undefined` so consumers get a single absence sentinel — every list-based
+// query already treats `data == null/undefined` as "no data yet". This avoids
+// pushing `?? []` boilerplate to every page-level prop site.
 export async function unwrap<D, E>(
   promise: Promise<
     | { data: D; error?: never; response: Response }
     | { data?: never; error: E; response: Response }
   >,
-): Promise<D> {
+): Promise<Exclude<D, null>> {
   const { data, error, response } = await promise;
   if (error !== undefined) {
     const message =
@@ -208,7 +227,7 @@ export async function unwrap<D, E>(
     throw new ApiError(response.status, message);
   }
   if (response.status === 204) {
-    return undefined as D;
+    return undefined as Exclude<D, null>;
   }
-  return data as D;
+  return (data ?? undefined) as Exclude<D, null>;
 }


### PR DESCRIPTION
Removes ~70 of the remaining \`as\` casts in \`src/hooks/\` and centralises the multipart-body workaround.

## 1. Drop \`return data as XResponse | undefined\` casts (65 sites)

When the cast target was just an alias of the openapi-fetch-inferred response type, \`data\` is already correctly typed by \`unwrap()\` — the cast was load-bearing scaffolding from the pre-typedApi era and it hides shape-mismatch bugs (cf. #611, where a paginated cast over a flat response silently masked an always-empty list).

Hooks now read:
\`\`\`ts
queryFn: () => unwrap(typedApi.GET(\"/api/foo\")),
\`\`\`

Touched: \`use-consoles\`, \`use-games\`, \`use-play-later\`, \`use-uploads\`, \`use-bios\`, \`use-explore\` (41!), \`use-retroachievements\`, \`use-sessions\`, \`use-social\`, \`use-rom-hacks\`, \`use-shared-sessions\`, \`use-preferences\`, \`use-admin\`, \`use-challenges\`. Now-unused type imports pruned.

**Casts intentionally kept** (~20): view-model narrowings that re-tighten open string fields back to literal unions for exhaustive switches — \`Challenge\`, \`NetplaySession\`, \`SharedSession\`, \`User\` (role), plus 5 hand-written admin interfaces. These need a different fix (mapper / assertion helpers) — separate follow-up.

## 2. Centralise multipart body cast

\`body: formData as unknown as never, bodySerializer: multipartBodySerializer\` appeared verbatim at 7 call sites. New \`multipart(formData)\` helper returns \`{ body, bodySerializer }\` with the cast hidden inside:

\`\`\`ts
typedApi.POST(\"/api/admin/bios\", multipart(formData))
typedApi.POST(\"/api/sessions/{id}/saves\", {
  params: { path: { id } },
  ...multipart(formData),
})
\`\`\`

The only \`as unknown as never\` left in src/ now lives inside \`multipart()\` itself.

## 3. Coerce null lists to undefined inside \`unwrap()\`

The original \`as Console[] | undefined\` casts were silently squashing the \`| null\` half — huma serialises Go nil slices as JSON \`null\`, so flat-list endpoints come back typed as \`T[] | null\`. Removing the casts surfaced this honestly, but consumers everywhere assume \`T[] | undefined\` semantics (TanStack Query data as \"loading vs present\").

\`unwrap()\` now returns \`Exclude<D, null>\` and coerces a top-level \`null\` body to \`undefined\`. One change in one place; no \`?? []\` pollution at every page-level prop site. The \"empty list\" and \"not loaded\" cases unify, matching how every existing list view already renders.

## Verified
- \`npx tsc --noEmit\` clean
- \`npm run build\` clean
- All 1468 unit tests pass

## Test plan
- [ ] CI green