### PR TITLE
chore(web): retire hand-written admin-hook interfaces

### DIFF
--- a/web/src/features/admin/components/scrape-status-card.tsx
+++ b/web/src/features/admin/components/scrape-status-card.tsx
@@ -10,8 +10,8 @@ import {
   useScrapeStatusCounts,
   useScrapeMetadata,
   useScrapeStatus,
-  type ScrapeSourceCounts,
 } from "@/hooks/use-admin";
+import type { ScraperSourceResultResponse } from "@/generated/schemas";
 import { useScrapeProgress } from "@/hooks/use-scrape-progress";
 
 const SOURCE_LABELS: Record<string, string> = {
@@ -25,7 +25,7 @@ function sourceLabel(source: string): string {
 }
 
 interface SourceSectionProps {
-  counts: ScrapeSourceCounts;
+  counts: ScraperSourceResultResponse;
   scrapeActive: boolean;
   onRetryNotFound: () => void;
   onRetryErrors: () => void;
@@ -107,6 +107,7 @@ export function ScrapeStatusCard() {
   const scrapeMetadata = useScrapeMetadata();
   const { toast } = useToast();
 
+  const sources = data?.sources ?? [];
   const scrapeActive =
     scrapeStatusData?.active === true || scrape.phase === "active";
 
@@ -158,13 +159,12 @@ export function ScrapeStatusCard() {
           </div>
         )}
 
-        {!isLoading && (!data || data.sources.length === 0) && (
+        {!isLoading && sources.length === 0 && (
           <p className="text-sm text-surface-500">No scrape data available.</p>
         )}
 
         {!isLoading &&
-          data &&
-          data.sources.map((counts, i) => (
+          sources.map((counts, i) => (
             <div key={counts.source}>
               {i > 0 && (
                 <Divider className="mb-5" />

--- a/web/src/features/game-detail/components/cover-art-selector.tsx
+++ b/web/src/features/game-detail/components/cover-art-selector.tsx
@@ -1,10 +1,7 @@
 import { Check } from "lucide-react";
 import { useToast, Modal } from "@/components/ui";
-import {
-  useGameCovers,
-  useSetGameCover,
-  type CoverOption,
-} from "@/hooks/use-admin";
+import { useGameCovers, useSetGameCover } from "@/hooks/use-admin";
+import type { CoverOption } from "@/generated/schemas";
 import { cn } from "@/lib/cn";
 
 interface CoverArtSelectorProps {
@@ -22,7 +19,8 @@ export function CoverArtSelector({
   const setCover = useSetGameCover();
   const { toast } = useToast();
 
-  const hasCovers = data && data.covers.length >= 2;
+  const covers = data?.covers ?? [];
+  const hasCovers = covers.length >= 2;
 
   function handleSelect(cover: CoverOption) {
     if (cover.source === data!.active && cover.source !== "libretro-regional") {
@@ -57,9 +55,9 @@ export function CoverArtSelector({
         </p>
       ) : (
       <div className="flex flex-wrap gap-4" data-testid="cover-art-selector">
-        {data!.covers.map((cover, index) => {
+        {covers.map((cover, index) => {
           const isActive =
-            cover.source === data.active &&
+            cover.source === data!.active &&
             cover.source !== "libretro-regional";
           const label = cover.label ?? cover.source;
           const key =

--- a/web/src/features/game-detail/components/hero-art-selector.tsx
+++ b/web/src/features/game-detail/components/hero-art-selector.tsx
@@ -1,10 +1,7 @@
 import { Check } from "lucide-react";
 import { useToast, Modal } from "@/components/ui";
-import {
-  useGameHeroes,
-  useSetGameHero,
-  type HeroOption,
-} from "@/hooks/use-admin";
+import { useGameHeroes, useSetGameHero } from "@/hooks/use-admin";
+import type { HeroOption } from "@/generated/schemas";
 import { cn } from "@/lib/cn";
 
 interface HeroArtSelectorProps {
@@ -22,7 +19,8 @@ export function HeroArtSelector({
   const setHero = useSetGameHero();
   const { toast } = useToast();
 
-  const hasHeroes = data && data.heroes.length >= 2;
+  const heroes = data?.heroes ?? [];
+  const hasHeroes = heroes.length >= 2;
 
   function handleSelect(hero: HeroOption) {
     setHero.mutate(
@@ -55,8 +53,8 @@ export function HeroArtSelector({
           className="flex flex-wrap gap-4"
           data-testid="hero-art-selector"
         >
-          {data!.heroes.map((hero) => {
-            const isActive = data.activeUrl && hero.thumb === data.activeUrl;
+          {heroes.map((hero) => {
+            const isActive = data!.activeUrl && hero.thumb === data!.activeUrl;
             return (
               <button
                 key={hero.id}

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -106,18 +106,13 @@ export function useScanLibrary() {
   });
 }
 
-export interface ScrapeStartResponse {
-  message: string;
-  total: number;
-}
-
 export type ScrapeMode = "new" | "all" | "fallback" | "ra";
 
 export function useScrapeMetadata() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({
+    mutationFn: ({
       mode = "new",
       console,
       source,
@@ -136,10 +131,7 @@ export function useScrapeMetadata() {
         query.mode = mode;
       }
       if (console) query.console = console;
-      const data = await unwrap(
-        typedApi.POST("/api/admin/scrape", { params: { query } }),
-      );
-      return data as ScrapeStartResponse | undefined;
+      return unwrap(typedApi.POST("/api/admin/scrape", { params: { query } }));
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["games"] });
@@ -149,27 +141,10 @@ export function useScrapeMetadata() {
   });
 }
 
-export interface ScrapeSourceCounts {
-  source: string;
-  matched: number;
-  notFound: number;
-  notFoundEligible: number;
-  error: number;
-  errorEligible: number;
-  notAttempted: number;
-}
-
-export interface ScrapeStatusCountsResponse {
-  sources: ScrapeSourceCounts[];
-}
-
 export function useScrapeStatusCounts() {
   return useQuery({
     queryKey: ["admin", "scrape-counts"],
-    queryFn: async () => {
-      const data = await unwrap(typedApi.GET("/api/admin/scrape/counts"));
-      return data as ScrapeStatusCountsResponse | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/admin/scrape/counts")),
   });
 }
 
@@ -286,50 +261,23 @@ export function useScrapeStatus() {
   });
 }
 
-export interface ScanStatus {
-  active: boolean;
-  phase?: string;
-  current?: number;
-  total?: number;
-  message?: string;
-}
-
 export function useScanStatus() {
   return useQuery({
     queryKey: ["admin", "scan-status"],
-    queryFn: async () => {
-      const data = await unwrap(
-        typedApi.GET("/api/admin/games/scan/status"),
-      );
-      return data as ScanStatus | undefined;
-    },
+    queryFn: () => unwrap(typedApi.GET("/api/admin/games/scan/status")),
     refetchInterval: 3000,
   });
-}
-
-export interface CoverOption {
-  source: "libretro" | "igdb" | "custom" | "libretro-regional";
-  url: string;
-  label?: string;
-  libretroName?: string;
-}
-
-export interface GameCoversResponse {
-  active: string;
-  covers: CoverOption[];
 }
 
 export function useGameCovers(gameId: string) {
   return useQuery({
     queryKey: ["admin", "game-covers", gameId],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/admin/games/{id}/covers", {
           params: { path: { id: gameId } },
         }),
-      );
-      return data as GameCoversResponse | undefined;
-    },
+      ),
     enabled: !!gameId,
   });
 }
@@ -338,22 +286,21 @@ export function useSetGameCover() {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: async ({
+    mutationFn: ({
       gameId,
       source,
       libretroName,
     }: {
       gameId: string;
-      source: CoverOption["source"];
+      source: string;
       libretroName?: string;
-    }) => {
-      await unwrap(
+    }) =>
+      unwrap(
         typedApi.PUT("/api/admin/games/{id}/covers", {
           params: { path: { id: gameId } },
           body: { source, libretroName },
         }),
-      );
-    },
+      ),
     onSuccess: (_data, { gameId }) => {
       queryClient.invalidateQueries({ queryKey: ["game", gameId] });
       queryClient.invalidateQueries({ queryKey: ["games"] });
@@ -364,28 +311,15 @@ export function useSetGameCover() {
   });
 }
 
-export interface HeroOption {
-  url: string;
-  thumb: string;
-  id: number;
-}
-
-export interface GameHeroesResponse {
-  activeUrl: string;
-  heroes: HeroOption[];
-}
-
 export function useGameHeroes(gameId: string) {
   return useQuery({
     queryKey: ["admin", "game-heroes", gameId],
-    queryFn: async () => {
-      const data = await unwrap(
+    queryFn: () =>
+      unwrap(
         typedApi.GET("/api/admin/games/{id}/heroes", {
           params: { path: { id: gameId } },
         }),
-      );
-      return data as GameHeroesResponse | undefined;
-    },
+      ),
     enabled: !!gameId,
   });
 }


### PR DESCRIPTION
## Summary

Drop 8 hand-written TS interfaces in \`use-admin.ts\` that duplicate generated schema types. Also removes 5 \`as XResponse | undefined\` casts along the way.

| Hand-written | Generated |
|---|---|
| \`ScrapeStartResponse\` | \`ScrapeStartedResponse\` (unused — consumers never read body) |
| \`ScrapeSourceCounts\` | \`ScraperSourceResultResponse\` |
| \`ScrapeStatusCountsResponse\` | same name, generated directly |
| \`ScanStatus\` | \`ScanStatusResponse\` |
| \`CoverOption\` | \`Schemas[\"CoverOption\"]\` |
| \`GameCoversResponse\` | \`Schemas[\"GameCoversResponse\"]\` |
| \`HeroOption\` | \`Schemas[\"HeroOption\"]\` |
| \`GameHeroesResponse\` | \`Schemas[\"GameHeroesResponse\"]\` |

### Semantic widening

- \`CoverOption.source\` loses its literal union (\`\"libretro\" | \"igdb\" | ...\`) in exchange for \`string\`. Consumers only do string equality, not exhaustive switches, so no compile-time safety lost in practice.
- Nested nullable arrays surface honestly: \`GameCoversResponse.covers\`, \`GameHeroesResponse.heroes\`, \`ScrapeStatusCountsResponse.sources\` are \`T[] | null\` on the wire. Consumers now \`?? []\` once at the top of each component.

### Verified
- \`npx tsc --noEmit\` clean
- \`npm run build\` clean
- All 1468 unit tests pass

Part of the ongoing \`as\`-removal effort from #614.

### Test plan
- [ ] CI green