### PR TITLE
chore(web): replace view-model  casts with runtime-narrowing predicates

### DIFF
--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -1,13 +1,24 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
+import type { UserResponse } from "@/generated/schemas";
 import type { User } from "@/types/api";
+import { asUserRole } from "@/types/view-model-narrowing";
+
+// Map the wire User (role: string) to the view-model User (role: UserRole).
+// Shared between use-admin.ts and use-auth.tsx.
+export function toUser(wire: UserResponse): User {
+  return {
+    ...wire,
+    role: asUserRole(wire.role),
+  };
+}
 
 export function useAdminUsers() {
   return useQuery({
     queryKey: ["admin", "users"],
     queryFn: async () => {
       const data = await unwrap(typedApi.GET("/api/admin/users"));
-      return data as User[] | undefined;
+      return data?.map(toUser);
     },
   });
 }

--- a/web/src/hooks/use-auth.tsx
+++ b/web/src/hooks/use-auth.tsx
@@ -7,6 +7,11 @@ import {
   type ReactNode,
 } from "react";
 import { api, typedApi, unwrap, ApiError } from "@/lib/api-client";
+import { toUser } from "@/hooks/use-admin";
+import type {
+  AuthLoginResponse,
+  AuthRegisterResponse,
+} from "@/generated/schemas";
 import type { User, AuthTokens } from "@/types/api";
 
 interface AuthContextValue {
@@ -28,6 +33,28 @@ interface AuthContextValue {
 
 const AuthContext = createContext<AuthContextValue | null>(null);
 
+// Map the wire AuthLoginResponse to the view-model AuthTokens (nested user
+// has its `role` field narrowed from plain `string` to the UserRole union).
+function toAuthTokens(wire: AuthLoginResponse): AuthTokens {
+  return {
+    ...wire,
+    user: toUser(wire.user),
+  };
+}
+
+function errorStatus(err: unknown): number {
+  if (err instanceof ApiError) return err.status;
+  if (
+    err !== null &&
+    typeof err === "object" &&
+    "status" in err &&
+    typeof (err as { status: unknown }).status === "number"
+  ) {
+    return (err as { status: number }).status;
+  }
+  return 0;
+}
+
 export function useAuth() {
   const ctx = useContext(AuthContext);
   if (!ctx) throw new Error("useAuth must be used within AuthProvider");
@@ -46,16 +73,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const fetchProfile = (retriesLeft: number): void => {
       unwrap(typedApi.GET("/api/user/profile"))
         .then((u) => {
-          setUser(u as User);
+          if (u) setUser(toUser(u));
           setIsLoading(false);
         })
         .catch((err: unknown) => {
-          const status =
-            err instanceof ApiError
-              ? err.status
-              : err instanceof Error && "status" in err
-                ? (err as Error & { status: number }).status
-                : 0;
+          const status = errorStatus(err);
           if (status === 401 || status === 403) {
             api.clearTokens();
             setIsLoading(false);
@@ -72,11 +94,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     // Check setup status first
     unwrap(typedApi.GET("/api/auth/setup-status"))
       .then((data) => {
-        const d = data as { needsSetup: boolean; registrationEnabled: boolean };
-        setNeedsSetup(d.needsSetup);
-        setRegistrationEnabled(d.registrationEnabled);
+        if (!data) {
+          setNeedsSetup(false);
+          setIsLoading(false);
+          return;
+        }
+        setNeedsSetup(data.needsSetup);
+        setRegistrationEnabled(data.registrationEnabled);
 
-        if (d.needsSetup) {
+        if (data.needsSetup) {
           setIsLoading(false);
           return;
         }
@@ -96,11 +122,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   }, []);
 
   const login = useCallback(async (username: string, password: string) => {
-    const data = (await unwrap(
+    const wire = await unwrap(
       typedApi.POST("/api/auth/login", { body: { username, password } }),
-    )) as AuthTokens;
-    api.setTokens(data.accessToken, data.refreshToken);
-    setUser(data.user);
+    );
+    if (!wire) throw new ApiError(500, "Login returned no body");
+    const tokens = toAuthTokens(wire);
+    api.setTokens(tokens.accessToken, tokens.refreshToken);
+    setUser(tokens.user);
   }, []);
 
   const register = useCallback(
@@ -109,15 +137,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       email: string,
       password: string,
     ): Promise<{ pending: boolean }> => {
-      const data = (await unwrap(
+      const wire: AuthRegisterResponse | undefined = await unwrap(
         typedApi.POST("/api/auth/register", {
           body: { username, email, password },
         }),
-      )) as AuthTokens | { pending: true; message: string };
-      if ("pending" in data && data.pending) {
+      );
+      if (!wire) throw new ApiError(500, "Registration returned no body");
+      if (wire.pending) {
         return { pending: true };
       }
-      const tokens = data as AuthTokens;
+      // AuthRegisterResponse shape matches AuthLoginResponse when not pending.
+      const tokens: AuthTokens = {
+        accessToken: wire.accessToken,
+        refreshToken: wire.refreshToken,
+        user: toUser(wire.user),
+      };
       api.setTokens(tokens.accessToken, tokens.refreshToken);
       setUser(tokens.user);
       return { pending: false };
@@ -127,13 +161,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const setup = useCallback(
     async (username: string, email: string, password: string) => {
-      const data = (await unwrap(
+      const wire = await unwrap(
         typedApi.POST("/api/auth/setup", {
           body: { username, email, password },
         }),
-      )) as AuthTokens;
-      api.setTokens(data.accessToken, data.refreshToken);
-      setUser(data.user);
+      );
+      if (!wire) throw new ApiError(500, "Setup returned no body");
+      const tokens = toAuthTokens(wire);
+      api.setTokens(tokens.accessToken, tokens.refreshToken);
+      setUser(tokens.user);
       setNeedsSetup(false);
     },
     [],

--- a/web/src/hooks/use-challenges.ts
+++ b/web/src/hooks/use-challenges.ts
@@ -2,12 +2,51 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
+  ChallengeAttemptResponse,
+  ChallengeResponse,
+  PaginatedResponseChallengeResponse,
+} from "@/generated/schemas";
+import type {
   Challenge,
   ChallengesResponse,
   ChallengeFilters,
   ChallengeLeaderboardEntry,
   ChallengeAttempt,
 } from "@/types/api";
+import {
+  asAttemptStatus,
+  asChallengeDifficulty,
+  asChallengeStatus,
+  asChallengeType,
+} from "@/types/view-model-narrowing";
+
+// Map wire shapes (type/difficulty/status emitted as `string`) to the
+// view-model shapes (literal unions). If the server ever emits a value
+// outside the claimed union, the narrowing helper throws — loud, not silent.
+function toChallenge(wire: ChallengeResponse): Challenge {
+  return {
+    ...wire,
+    type: asChallengeType(wire.type),
+    difficulty: asChallengeDifficulty(wire.difficulty),
+    status: asChallengeStatus(wire.status),
+  };
+}
+
+function toChallengesResponse(
+  wire: PaginatedResponseChallengeResponse,
+): ChallengesResponse {
+  return {
+    ...wire,
+    data: wire.data?.map(toChallenge) ?? null,
+  };
+}
+
+function toChallengeAttempt(wire: ChallengeAttemptResponse): ChallengeAttempt {
+  return {
+    ...wire,
+    status: asAttemptStatus(wire.status),
+  };
+}
 
 const sortMapping: Record<string, string> = {
   most_attempted: "popular",
@@ -36,7 +75,7 @@ export function useChallenges(filters: ChallengeFilters = {}) {
       const data = await unwrap(
         typedApi.GET("/api/challenges", { params: { query } }),
       );
-      return data as ChallengesResponse | undefined;
+      return data && toChallengesResponse(data);
     },
   });
 }
@@ -50,7 +89,7 @@ export function useChallenge(id: string) {
           params: { path: { id } },
         }),
       );
-      return data as Challenge | undefined;
+      return data && toChallenge(data);
     },
     enabled: !!id,
   });
@@ -69,7 +108,7 @@ export function useGameChallenges(
           params: { path: { id: gameId }, query: { page, pageSize } },
         }),
       );
-      return data as ChallengesResponse | undefined;
+      return data && toChallengesResponse(data);
     },
     enabled: !!gameId,
   });
@@ -84,7 +123,7 @@ export function useMyChallenges(page: number = 1, pageSize: number = 20) {
           params: { query: { page, pageSize } },
         }),
       );
-      return data as ChallengesResponse | undefined;
+      return data && toChallengesResponse(data);
     },
   });
 }
@@ -117,7 +156,7 @@ export function useMyAttempts(challengeId: string) {
           params: { path: { id: challengeId } },
         }),
       );
-      return data as ChallengeAttempt[] | undefined;
+      return data?.map(toChallengeAttempt);
     },
     enabled: !!challengeId,
   });

--- a/web/src/hooks/use-netplay.ts
+++ b/web/src/hooks/use-netplay.ts
@@ -2,11 +2,58 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
+  NetplayInviteResponse,
+  NetplaySessionResponse,
+  PaginatedResponseNetplaySessionResponse,
+  ListMyNetplayInvitesResponse,
+} from "@/generated/schemas";
+import type {
   NetplaySession,
   NetplaySessionsResponse,
   NetplayInvite,
   NetplayInvitesResponse,
 } from "@/types/api";
+import {
+  asNetplayInviteStatus,
+  asNetplaySessionStatus,
+  asOptionalNetplayEndReason,
+} from "@/types/view-model-narrowing";
+
+// Map the wire shape (huma emits status/endReason as plain `string`) to the
+// view-model shape (literal unions). Each helper throws if the server ever
+// emits a value outside the claimed union — loud, not silent.
+function toNetplaySession(wire: NetplaySessionResponse): NetplaySession {
+  return {
+    ...wire,
+    status: asNetplaySessionStatus(wire.status),
+    endReason: asOptionalNetplayEndReason(wire.endReason),
+  };
+}
+
+function toNetplaySessionsResponse(
+  wire: PaginatedResponseNetplaySessionResponse,
+): NetplaySessionsResponse {
+  return {
+    ...wire,
+    data: wire.data?.map(toNetplaySession) ?? null,
+  };
+}
+
+function toNetplayInvite(wire: NetplayInviteResponse): NetplayInvite {
+  return {
+    ...wire,
+    status: asNetplayInviteStatus(wire.status),
+  };
+}
+
+function toNetplayInvitesResponse(
+  wire: ListMyNetplayInvitesResponse,
+): NetplayInvitesResponse {
+  return {
+    ...wire,
+    data: wire.data?.map(toNetplayInvite) ?? null,
+  };
+}
 
 export function useNetplaySessions(page = 1, pageSize = 20) {
   return useQuery({
@@ -17,7 +64,7 @@ export function useNetplaySessions(page = 1, pageSize = 20) {
           params: { query: { page, pageSize } },
         }),
       );
-      return data as NetplaySessionsResponse | undefined;
+      return data && toNetplaySessionsResponse(data);
     },
   });
 }
@@ -31,7 +78,7 @@ export function useNetplaySession(id: string) {
           params: { path: { id } },
         }),
       );
-      return data as NetplaySession | undefined;
+      return data && toNetplaySession(data);
     },
     enabled: !!id,
   });
@@ -45,7 +92,7 @@ export function useCreateNetplaySession() {
       const result = await unwrap(
         typedApi.POST("/api/netplay/sessions", { body: data }),
       );
-      return result as NetplaySession | undefined;
+      return result && toNetplaySession(result);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["netplay", "sessions"] });
@@ -63,7 +110,7 @@ export function useJoinNetplaySession() {
           body: { inviteCode },
         }),
       );
-      return data as NetplaySession | undefined;
+      return data && toNetplaySession(data);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["netplay", "sessions"] });
@@ -104,7 +151,7 @@ export function useUpdateNetplaySettings() {
           body: { inputDelay },
         }),
       );
-      return data as NetplaySession | undefined;
+      return data && toNetplaySession(data);
     },
     onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: ["netplay", "sessions", id] });
@@ -135,7 +182,7 @@ export function useNetplayInvites() {
     queryKey: ["netplay", "invites"],
     queryFn: async () => {
       const data = await unwrap(typedApi.GET("/api/netplay/invites"));
-      return data as NetplayInvitesResponse | undefined;
+      return data && toNetplayInvitesResponse(data);
     },
   });
 }
@@ -157,7 +204,7 @@ export function useSessionNetplayInvites(sessionId: string) {
           params: { path: { id: sessionId } },
         }),
       );
-      return data as NetplayInvite[] | undefined;
+      return data?.map(toNetplayInvite);
     },
     enabled: !!sessionId,
   });

--- a/web/src/hooks/use-shared-sessions.ts
+++ b/web/src/hooks/use-shared-sessions.ts
@@ -2,17 +2,55 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
 import type {
+  SharedSessionDetailResponse,
+  SharedSessionMemberResponse,
+  SharedSessionResponse,
+} from "@/generated/schemas";
+import type {
   SharedSessionDetail,
-  SharedSessionInvitation,
+  SharedSessionMember,
   SharedSession,
 } from "@/types/api";
+import {
+  asSharedSessionMemberRole,
+  asSharedSessionStatus,
+} from "@/types/view-model-narrowing";
+
+// Map wire shapes (status/role emitted as `string`) to the view-model
+// shapes (literal unions). If the server ever emits a value outside the
+// claimed union, the narrowing helper throws — loud, not silent.
+function toSharedSession(wire: SharedSessionResponse): SharedSession {
+  return {
+    ...wire,
+    status: asSharedSessionStatus(wire.status),
+  };
+}
+
+function toSharedSessionMember(
+  wire: SharedSessionMemberResponse,
+): SharedSessionMember {
+  return {
+    ...wire,
+    role: asSharedSessionMemberRole(wire.role),
+  };
+}
+
+function toSharedSessionDetail(
+  wire: SharedSessionDetailResponse,
+): SharedSessionDetail {
+  return {
+    ...wire,
+    status: asSharedSessionStatus(wire.status),
+    members: wire.members?.map(toSharedSessionMember) ?? null,
+  };
+}
 
 export function useMySharedSessions() {
   return useQuery({
     queryKey: ["shared-sessions", "mine"],
     queryFn: async () => {
       const data = await unwrap(typedApi.GET("/api/shared-sessions"));
-      return data as SharedSession[] | null | undefined;
+      return data?.map(toSharedSession);
     },
   });
 }
@@ -21,10 +59,12 @@ export function useSharedSessionInvitations() {
   return useQuery({
     queryKey: ["shared-sessions", "invitations"],
     queryFn: async () => {
+      // SharedSessionInvitation is a pure alias of the wire shape — no
+      // narrowing needed. openapi-fetch returns the correct type already.
       const data = await unwrap(
         typedApi.GET("/api/user/shared-session-invites"),
       );
-      return data as SharedSessionInvitation[] | null | undefined;
+      return data;
     },
   });
 }
@@ -47,7 +87,7 @@ export function useSharedSession(id: string) {
           params: { path: { id } },
         }),
       );
-      return data as SharedSessionDetail | undefined;
+      return data && toSharedSessionDetail(data);
     },
     enabled: !!id,
   });
@@ -75,7 +115,7 @@ export function useGameSharedSessions(gameId: string) {
           params: { path: { id: gameId } },
         }),
       );
-      return data as SharedSession[] | undefined;
+      return data?.map(toSharedSession);
     },
     enabled: !!gameId,
   });
@@ -93,7 +133,7 @@ export function useCreateSharedSession() {
       const result = await unwrap(
         typedApi.POST("/api/shared-sessions", { body: data }),
       );
-      return result as SharedSessionDetail | undefined;
+      return result && toSharedSessionDetail(result);
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["shared-sessions"] });

--- a/web/src/types/view-model-narrowing.ts
+++ b/web/src/types/view-model-narrowing.ts
@@ -1,0 +1,103 @@
+// View-model narrowing helpers.
+//
+// The huma-generated wire types (see src/generated/api.d.ts) type enum-like
+// fields as plain `string`, because huma flattens Go iota / string-enum
+// types to their JSON representation without emitting JSON Schema enums.
+// The frontend narrows these fields to literal unions so switch statements
+// and Record<Status, _> mappings stay exhaustiveness-checked.
+//
+// We used to bridge the wire type and view-model type with `as` casts —
+// but that hides latent bugs: if the server ever emits a value outside the
+// claimed union, the cast lies and downstream code breaks silently. These
+// helpers replace those casts with runtime-validated narrowings so unknown
+// server values become loud errors.
+//
+// Each helper takes a `string` and returns the narrowed literal type, or
+// throws. The error is intentionally noisy — if it fires, either the server
+// introduced a new value the frontend hasn't handled, or the transport
+// layer lied.
+
+import type {
+  AttemptStatus,
+  ChallengeDifficulty,
+  ChallengeStatus,
+  ChallengeType,
+  NetplayEndReason,
+  NetplayInviteStatus,
+  NetplaySessionStatus,
+  SharedSessionMemberRole,
+  SharedSessionStatus,
+  UserRole,
+} from "@/types/api";
+
+export function asUserRole(s: string): UserRole {
+  if (s === "owner" || s === "admin" || s === "user") return s;
+  throw new Error(`Unexpected user role from server: ${s}`);
+}
+
+export function asChallengeType(s: string): ChallengeType {
+  if (s === "completion" || s === "speedrun" || s === "survival") return s;
+  throw new Error(`Unexpected challenge type from server: ${s}`);
+}
+
+export function asChallengeDifficulty(s: string): ChallengeDifficulty {
+  if (s === "easy" || s === "medium" || s === "hard") return s;
+  throw new Error(`Unexpected challenge difficulty from server: ${s}`);
+}
+
+export function asChallengeStatus(s: string): ChallengeStatus {
+  if (s === "active" || s === "closed" || s === "expired") return s;
+  throw new Error(`Unexpected challenge status from server: ${s}`);
+}
+
+export function asAttemptStatus(s: string): AttemptStatus {
+  if (s === "in_progress" || s === "completed" || s === "abandoned") return s;
+  throw new Error(`Unexpected attempt status from server: ${s}`);
+}
+
+export function asNetplaySessionStatus(s: string): NetplaySessionStatus {
+  if (s === "waiting" || s === "in_progress" || s === "ended") return s;
+  throw new Error(`Unexpected netplay session status from server: ${s}`);
+}
+
+// endReason is optional on the view-model: the server emits an empty string
+// on the wire until a session has actually ended. We map "" to undefined so
+// consumers can use truthiness to check whether an end reason exists, and
+// narrow any non-empty value.
+export function asOptionalNetplayEndReason(
+  s: string | null | undefined,
+): NetplayEndReason | undefined {
+  if (!s) return undefined;
+  if (
+    s === "host_left" ||
+    s === "client_left" ||
+    s === "timeout" ||
+    s === "completed" ||
+    s === "admin_deleted"
+  ) {
+    return s;
+  }
+  throw new Error(`Unexpected netplay end reason from server: ${s}`);
+}
+
+export function asNetplayInviteStatus(s: string): NetplayInviteStatus {
+  if (
+    s === "pending" ||
+    s === "accepted" ||
+    s === "declined" ||
+    s === "expired"
+  ) {
+    return s;
+  }
+  throw new Error(`Unexpected netplay invite status from server: ${s}`);
+}
+
+export function asSharedSessionStatus(s: string): SharedSessionStatus {
+  if (s === "active" || s === "paused" || s === "completed") return s;
+  throw new Error(`Unexpected shared session status from server: ${s}`);
+}
+
+export function asSharedSessionMemberRole(s: string): SharedSessionMemberRole {
+  if (s === "owner" || s === "member") return s;
+  throw new Error(`Unexpected shared session member role from server: ${s}`);
+}


### PR DESCRIPTION
## Summary

The last ~23 \`return data as X | undefined\` casts in \`src/hooks/\` were **view-model narrowings** — they claimed a wire \`status: string\` was actually \`status: \"active\" | \"closed\" | \"expired\"\` without checking. If the server ever emits a value outside the union, the cast lies and downstream exhaustive switches break silently. Same class of latent bug as #611.

This PR replaces every cast with a runtime-validated mapper.

## Changes

### New: \`src/types/view-model-narrowing.ts\`

10 assertion functions — one per literal union used in the view-model layer:

- \`asUserRole\`, \`asChallengeType\`, \`asChallengeDifficulty\`, \`asChallengeStatus\`, \`asAttemptStatus\`
- \`asNetplaySessionStatus\`, \`asOptionalNetplayEndReason\`, \`asNetplayInviteStatus\`
- \`asSharedSessionStatus\`, \`asSharedSessionMemberRole\`

Each returns the narrowed literal or throws on an unknown server value. The throw is deliberately noisy — if it fires, either the server added a new value the frontend hasn't handled, or the transport layer lied.

### Hook mappers

Each affected hook gains a tiny \`toX(wire): ViewModel\` function that spreads the wire object and narrows enum fields via the assertion helpers. No \`as\` in the mapper bodies — TypeScript flow analysis narrows each \`if\`-branch honestly.

| Hook | Mappers added |
|---|---|
| \`use-challenges\` | \`toChallenge\`, \`toChallengeAttempt\`, \`toChallengesResponse\` |
| \`use-netplay\` | \`toNetplaySession\`, \`toNetplayInvite\`, + paginated wrappers |
| \`use-shared-sessions\` | \`toSharedSession\`, \`toSharedSessionMember\`, \`toSharedSessionDetail\` |
| \`use-admin\` (exported) | \`toUser\` (reused by \`use-auth\`) |
| \`use-auth\` | \`toAuthTokens\` (composes \`toUser\`) |

Paginated wrappers use \`{ ...data, data: data.data?.map(toX) ?? null }\` to preserve shape while mapping.

### Special case: \`NetplayEndReason\`

Optional on the view-model, but the server emits \`\"\"\` while a session is live. \`asOptionalNetplayEndReason\` maps falsy → \`undefined\` and narrows any non-empty value — preserving the optional semantics without losing validation.

## Before / after

\`\`\`ts
// BEFORE — silent lie
queryFn: async () => {
  const data = await unwrap(typedApi.GET(\"/api/challenges\", { params: { query } }));
  return data as ChallengesResponse | undefined;
},

// AFTER — validated narrowing
queryFn: async () => {
  const data = await unwrap(typedApi.GET(\"/api/challenges\", { params: { query } }));
  return data && toChallengesResponse(data);
},
\`\`\`

## Net effect

**Zero \`return data as X\` / \`return result as X\` anywhere in \`src/\`.**

Remaining \`as\` usages in hooks are out-of-scope for this cleanup (path-param coercions for \`enabled: !!id\` gates, request-body \`Record<string, unknown>\` widening, \`payload as never\` for websocket typing).

## Verified
- \`npx tsc --noEmit\` clean
- \`npm run build\` clean
- All 1468 unit tests pass

Closes the view-model-narrowing task of the wider \`as\`-removal effort (started in #614, continued in #615).

## Test plan
- [ ] CI green