### PR TITLE
chore: fix T[] | null root cause — non-nullable arrays end-to-end

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AchievementLeaderboardResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AchievementLeaderboardResponse.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.encoding.*
 
 data class AchievementLeaderboardResponse (
 
-    @SerialName(value = "leaderboard") @Required val leaderboard: kotlin.collections.List<RALeaderboardEntryResponse>?,
+    @SerialName(value = "leaderboard") @Required val leaderboard: kotlin.collections.List<RALeaderboardEntryResponse>,
 
     @SerialName(value = "raGameId") @Required val raGameId: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AchievementTimelineResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AchievementTimelineResponse.kt
@@ -44,7 +44,7 @@ data class AchievementTimelineResponse (
 
     @SerialName(value = "raGameId") @Required val raGameId: kotlin.Long,
 
-    @SerialName(value = "timeline") @Required val timeline: kotlin.collections.List<RATimelineEntryResponse>?,
+    @SerialName(value = "timeline") @Required val timeline: kotlin.collections.List<RATimelineEntryResponse>,
 
     @SerialName(value = "totalAchievements") @Required val totalAchievements: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveChallengesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveChallengesResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class ActiveChallengesResponse (
 
-    @SerialName(value = "challenges") @Required val challenges: kotlin.collections.List<ExploreChallengeResponse>?,
+    @SerialName(value = "challenges") @Required val challenges: kotlin.collections.List<ExploreChallengeResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveNowResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActiveNowResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class ActiveNowResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<ActiveNowItem>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<ActiveNowItem>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AlmostDoneResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AlmostDoneResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class AlmostDoneResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<AlmostDoneGame>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<AlmostDoneGame>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AnniversariesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/AnniversariesResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class AnniversariesResponse (
 
-    @SerialName(value = "anniversaries") @Required val anniversaries: kotlin.collections.List<AnniversaryItem>?,
+    @SerialName(value = "anniversaries") @Required val anniversaries: kotlin.collections.List<AnniversaryItem>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ArtworkGalleryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ArtworkGalleryResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class ArtworkGalleryResponse (
 
-    @SerialName(value = "artworks") @Required val artworks: kotlin.collections.List<ArtworkItem>?,
+    @SerialName(value = "artworks") @Required val artworks: kotlin.collections.List<ArtworkItem>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BestOfYearResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BestOfYearResponse.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.encoding.*
 
 data class BestOfYearResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>,
 
     @SerialName(value = "year") @Required val year: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BiosListResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/BiosListResponse.kt
@@ -33,9 +33,9 @@ import kotlinx.serialization.encoding.*
 
 data class BiosListResponse (
 
-    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<ConsoleBiosStatus>?,
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<ConsoleBiosStatus>,
 
-    @SerialName(value = "files") @Required val files: kotlin.collections.List<BiosFileResponse>?,
+    @SerialName(value = "files") @Required val files: kotlin.collections.List<BiosFileResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CollectionDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CollectionDetailResponse.kt
@@ -52,7 +52,7 @@ data class CollectionDetailResponse (
 
     @SerialName(value = "gameCount") @Required val gameCount: kotlin.Long,
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>,
 
     @SerialName(value = "id") @Required val id: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CommunityTopResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CommunityTopResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class CommunityTopResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<CommunityTopGame>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<CommunityTopGame>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CompletionistMapResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CompletionistMapResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class CompletionistMapResponse (
 
-    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<CompletionistConsole>?,
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<CompletionistConsole>,
 
     @SerialName(value = "overallPct") @Required val overallPct: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleBiosStatus.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleBiosStatus.kt
@@ -44,7 +44,7 @@ data class ConsoleBiosStatus (
 
     @SerialName(value = "consoleName") @Required val consoleName: kotlin.String,
 
-    @SerialName(value = "files") @Required val files: kotlin.collections.List<ConsoleFileStatus>?,
+    @SerialName(value = "files") @Required val files: kotlin.collections.List<ConsoleFileStatus>,
 
     @SerialName(value = "optionalPresent") @Required val optionalPresent: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleHighlightsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleHighlightsResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class ConsoleHighlightsResponse (
 
-    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<ConsoleHighlight>?,
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<ConsoleHighlight>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleResponse.kt
@@ -70,7 +70,7 @@ data class ConsoleResponse (
 
     @SerialName(value = "emulatorJsCore") @Required val emulatorJsCore: kotlin.String,
 
-    @SerialName(value = "extensions") @Required val extensions: kotlin.collections.List<kotlin.String>?,
+    @SerialName(value = "extensions") @Required val extensions: kotlin.collections.List<kotlin.String>,
 
     @SerialName(value = "gameCount") @Required val gameCount: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleShowcaseResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ConsoleShowcaseResponse.kt
@@ -42,17 +42,17 @@ data class ConsoleShowcaseResponse (
 
     @SerialName(value = "console") @Required val console: ConsoleResponse,
 
-    @SerialName(value = "essentials") @Required val essentials: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "essentials") @Required val essentials: kotlin.collections.List<GameResponse>,
 
-    @SerialName(value = "genreBreakdown") @Required val genreBreakdown: kotlin.collections.List<GenreCount>?,
+    @SerialName(value = "genreBreakdown") @Required val genreBreakdown: kotlin.collections.List<GenreCount>,
 
-    @SerialName(value = "hiddenGems") @Required val hiddenGems: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "hiddenGems") @Required val hiddenGems: kotlin.collections.List<GameResponse>,
 
-    @SerialName(value = "recentlyAdded") @Required val recentlyAdded: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "recentlyAdded") @Required val recentlyAdded: kotlin.collections.List<GameResponse>,
 
-    @SerialName(value = "recentlyPlayed") @Required val recentlyPlayed: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "recentlyPlayed") @Required val recentlyPlayed: kotlin.collections.List<GameResponse>,
 
-    @SerialName(value = "topDevelopers") @Required val topDevelopers: kotlin.collections.List<DeveloperSummary>?,
+    @SerialName(value = "topDevelopers") @Required val topDevelopers: kotlin.collections.List<DeveloperSummary>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoreCompatibilityResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoreCompatibilityResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class CoreCompatibilityResponse (
 
-    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<CoreCompatibilityEntry>?,
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<CoreCompatibilityEntry>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoverGalleryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CoverGalleryResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class CoverGalleryResponse (
 
-    @SerialName(value = "covers") @Required val covers: kotlin.collections.List<CoverItem>?,
+    @SerialName(value = "covers") @Required val covers: kotlin.collections.List<CoverItem>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CultClassicsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/CultClassicsResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class CultClassicsResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<CultClassicGame>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<CultClassicGame>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DecadesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DecadesResponse.kt
@@ -35,7 +35,7 @@ data class DecadesResponse (
 
     @SerialName(value = "decade") @Required val decade: kotlin.String,
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>,
 
     @SerialName(value = "label") @Required val label: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperDetailResponse.kt
@@ -62,31 +62,31 @@ data class DeveloperDetailResponse (
 
     @SerialName(value = "companyInfo") @Required val companyInfo: CompanyInfo,
 
-    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<kotlin.String>?,
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<kotlin.String>,
 
     @SerialName(value = "gameCount") @Required val gameCount: kotlin.Long,
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>,
 
-    @SerialName(value = "genreBreakdown") @Required val genreBreakdown: kotlin.collections.List<GenreCount>?,
+    @SerialName(value = "genreBreakdown") @Required val genreBreakdown: kotlin.collections.List<GenreCount>,
 
     @SerialName(value = "heroUrl") @Required val heroUrl: kotlin.String,
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "platformBreakdown") @Required val platformBreakdown: kotlin.collections.List<PlatformCount>?,
+    @SerialName(value = "platformBreakdown") @Required val platformBreakdown: kotlin.collections.List<PlatformCount>,
 
     @SerialName(value = "primaryGenre") @Required val primaryGenre: kotlin.String,
 
-    @SerialName(value = "publishers") @Required val publishers: kotlin.collections.List<NameCount>?,
+    @SerialName(value = "publishers") @Required val publishers: kotlin.collections.List<NameCount>,
 
     @SerialName(value = "ratingDistribution") @Required val ratingDistribution: RatingDistribution,
 
-    @SerialName(value = "relatedDevelopers") @Required val relatedDevelopers: kotlin.collections.List<RelatedDeveloper>?,
+    @SerialName(value = "relatedDevelopers") @Required val relatedDevelopers: kotlin.collections.List<RelatedDeveloper>,
 
-    @SerialName(value = "timeline") @Required val timeline: kotlin.collections.List<TimelineEntry>?,
+    @SerialName(value = "timeline") @Required val timeline: kotlin.collections.List<TimelineEntry>,
 
-    @SerialName(value = "topGames") @Required val topGames: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "topGames") @Required val topGames: kotlin.collections.List<GameResponse>,
 
     @SerialName(value = "userStats") @Required val userStats: EntityUserStats,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperListResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperListResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class DeveloperListResponse (
 
-    @SerialName(value = "developers") @Required val developers: kotlin.collections.List<DeveloperSummary>?,
+    @SerialName(value = "developers") @Required val developers: kotlin.collections.List<DeveloperSummary>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperSpotlightResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperSpotlightResponse.kt
@@ -38,7 +38,7 @@ data class DeveloperSpotlightResponse (
 
     @SerialName(value = "avgRating") @Required val avgRating: kotlin.Double,
 
-    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<kotlin.String>?,
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<kotlin.String>,
 
     @SerialName(value = "gameCount") @Required val gameCount: kotlin.Long,
 
@@ -46,7 +46,7 @@ data class DeveloperSpotlightResponse (
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "topGames") @Required val topGames: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "topGames") @Required val topGames: kotlin.collections.List<GameResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperSummary.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/DeveloperSummary.kt
@@ -34,7 +34,7 @@ data class DeveloperSummary (
 
     @SerialName(value = "avgRating") @Required val avgRating: kotlin.Double,
 
-    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<kotlin.String>?,
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<kotlin.String>,
 
     @SerialName(value = "gameCount") @Required val gameCount: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EasyToCompleteResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/EasyToCompleteResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class EasyToCompleteResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<AchievementGameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<AchievementGameResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExploreRowResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExploreRowResponse.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.encoding.*
 
 data class ExploreRowResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>,
 
     @SerialName(value = "id") @Required val id: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExploreRowsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExploreRowsResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class ExploreRowsResponse (
 
-    @SerialName(value = "rows") @Required val rows: kotlin.collections.List<ExploreRowResponse>?,
+    @SerialName(value = "rows") @Required val rows: kotlin.collections.List<ExploreRowResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExplorerBadgesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ExplorerBadgesResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class ExplorerBadgesResponse (
 
-    @SerialName(value = "badges") @Required val badges: kotlin.collections.List<ExplorerBadge>?,
+    @SerialName(value = "badges") @Required val badges: kotlin.collections.List<ExplorerBadge>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ForYouResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ForYouResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class ForYouResponse (
 
-    @SerialName(value = "rows") @Required val rows: kotlin.collections.List<ForYouRowResponse>?,
+    @SerialName(value = "rows") @Required val rows: kotlin.collections.List<ForYouRowResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ForYouRowResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ForYouRowResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class ForYouRowResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>,
 
     @SerialName(value = "genre") @Required val genre: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FranchiseDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FranchiseDetailResponse.kt
@@ -40,9 +40,9 @@ import kotlinx.serialization.encoding.*
 
 data class FranchiseDetailResponse (
 
-    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<SeriesConsoleInfo>?,
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<SeriesConsoleInfo>,
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<SeriesGameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<SeriesGameResponse>,
 
     @SerialName(value = "heroUrl") @Required val heroUrl: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FreshChallengesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/FreshChallengesResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class FreshChallengesResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<FreshChallengeGame>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<FreshChallengeGame>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameAchievementProgressResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameAchievementProgressResponse.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.encoding.*
 
 data class GameAchievementProgressResponse (
 
-    @SerialName(value = "progress") @Required val progress: kotlin.collections.List<RAProgressEntry>?,
+    @SerialName(value = "progress") @Required val progress: kotlin.collections.List<RAProgressEntry>,
 
     @SerialName(value = "raGameId") @Required val raGameId: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameAchievementsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameAchievementsResponse.kt
@@ -37,7 +37,7 @@ import kotlinx.serialization.encoding.*
 data class GameAchievementsResponse (
 
     /* Achievement definitions for this game (empty when unknown). */
-    @SerialName(value = "achievements") @Required val achievements: kotlin.collections.List<Achievement>?,
+    @SerialName(value = "achievements") @Required val achievements: kotlin.collections.List<Achievement>,
 
     /* RetroAchievements game ID (0 when unknown). */
     @SerialName(value = "raGameId") @Required val raGameId: kotlin.Long,

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameCoversResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameCoversResponse.kt
@@ -34,7 +34,7 @@ data class GameCoversResponse (
 
     @SerialName(value = "active") @Required val active: kotlin.String,
 
-    @SerialName(value = "covers") @Required val covers: kotlin.collections.List<CoverOption>?,
+    @SerialName(value = "covers") @Required val covers: kotlin.collections.List<CoverOption>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameHeroesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameHeroesResponse.kt
@@ -34,7 +34,7 @@ data class GameHeroesResponse (
 
     @SerialName(value = "activeUrl") @Required val activeUrl: kotlin.String,
 
-    @SerialName(value = "heroes") @Required val heroes: kotlin.collections.List<HeroOption>?,
+    @SerialName(value = "heroes") @Required val heroes: kotlin.collections.List<HeroOption>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameResponse.kt
@@ -99,7 +99,7 @@ data class GameResponse (
 
     @SerialName(value = "achievementsWarning") @Required val achievementsWarning: kotlin.String,
 
-    @SerialName(value = "ageRatings") @Required val ageRatings: kotlin.collections.List<AgeRatingResponse>?,
+    @SerialName(value = "ageRatings") @Required val ageRatings: kotlin.collections.List<AgeRatingResponse>,
 
     @SerialName(value = "averageRating") @Required val averageRating: kotlin.Double,
 
@@ -123,7 +123,7 @@ data class GameResponse (
 
     @SerialName(value = "discCount") @Required val discCount: kotlin.Long,
 
-    @SerialName(value = "discs") @Required val discs: kotlin.collections.List<DiscResponse>?,
+    @SerialName(value = "discs") @Required val discs: kotlin.collections.List<DiscResponse>,
 
     @SerialName(value = "fileName") @Required val fileName: kotlin.String,
 
@@ -151,7 +151,7 @@ data class GameResponse (
 
     @SerialName(value = "isPreRelease") @Required val isPreRelease: kotlin.Boolean,
 
-    @SerialName(value = "languageSupports") @Required val languageSupports: kotlin.collections.List<LanguageSupportResponse>?,
+    @SerialName(value = "languageSupports") @Required val languageSupports: kotlin.collections.List<LanguageSupportResponse>,
 
     @SerialName(value = "lastPlayedAt") @Required val lastPlayedAt: kotlinx.datetime.Instant?,
 
@@ -173,17 +173,17 @@ data class GameResponse (
 
     @SerialName(value = "releaseDate") @Required val releaseDate: kotlin.String,
 
-    @SerialName(value = "releaseDates") @Required val releaseDates: kotlin.collections.List<ReleaseDateResponse>?,
+    @SerialName(value = "releaseDates") @Required val releaseDates: kotlin.collections.List<ReleaseDateResponse>,
 
     @SerialName(value = "revision") @Required val revision: kotlin.String,
 
-    @SerialName(value = "romHacks") @Required val romHacks: kotlin.collections.List<RomHackGameResponse>?,
+    @SerialName(value = "romHacks") @Required val romHacks: kotlin.collections.List<RomHackGameResponse>,
 
     @SerialName(value = "scrapeAttempts") @Required val scrapeAttempts: kotlin.Long,
 
     @SerialName(value = "scraperId") @Required val scraperId: kotlin.String,
 
-    @SerialName(value = "screenshotUrls") @Required val screenshotUrls: kotlin.collections.List<kotlin.String>?,
+    @SerialName(value = "screenshotUrls") @Required val screenshotUrls: kotlin.collections.List<kotlin.String>,
 
     @SerialName(value = "storyline") @Required val storyline: kotlin.String,
 
@@ -209,13 +209,13 @@ data class GameResponse (
 
     @SerialName(value = "variantCount") @Required val variantCount: kotlin.Long,
 
-    @SerialName(value = "variants") @Required val variants: kotlin.collections.List<VariantResponse>?,
+    @SerialName(value = "variants") @Required val variants: kotlin.collections.List<VariantResponse>,
 
     @SerialName(value = "verificationStatus") @Required val verificationStatus: kotlin.String,
 
     @SerialName(value = "verificationTag") @Required val verificationTag: kotlin.String,
 
-    @SerialName(value = "videos") @Required val videos: kotlin.collections.List<VideoResponse>?,
+    @SerialName(value = "videos") @Required val videos: kotlin.collections.List<VideoResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameSessionResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameSessionResponse.kt
@@ -67,11 +67,11 @@ data class GameSessionResponse (
 
     @SerialName(value = "lastPlayedByUsername") @Required val lastPlayedByUsername: kotlin.String?,
 
-    @SerialName(value = "memberAvatars") @Required val memberAvatars: kotlin.collections.List<kotlin.String>?,
+    @SerialName(value = "memberAvatars") @Required val memberAvatars: kotlin.collections.List<kotlin.String>,
 
     @SerialName(value = "memberCount") @Required val memberCount: kotlin.Long,
 
-    @SerialName(value = "memberUsernames") @Required val memberUsernames: kotlin.collections.List<kotlin.String>?,
+    @SerialName(value = "memberUsernames") @Required val memberUsernames: kotlin.collections.List<kotlin.String>,
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameStatsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/GameStatsResponse.kt
@@ -36,7 +36,7 @@ data class GameStatsResponse (
 
     @SerialName(value = "averagePlayTime") @Required val averagePlayTime: kotlin.Long,
 
-    @SerialName(value = "topPlayers") @Required val topPlayers: kotlin.collections.List<GameStatsTopPlayer>?,
+    @SerialName(value = "topPlayers") @Required val topPlayers: kotlin.collections.List<GameStatsTopPlayer>,
 
     @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HardestGamesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/HardestGamesResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class HardestGamesResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<AchievementGameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<AchievementGameResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ListMyNetplayInvitesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ListMyNetplayInvitesResponse.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.encoding.*
 
 data class ListMyNetplayInvitesResponse (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<NetplayInviteResponse>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<NetplayInviteResponse>,
 
     @SerialName(value = "total") @Required val total: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MakerDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MakerDetailResponse.kt
@@ -38,7 +38,7 @@ data class MakerDetailResponse (
 
     @SerialName(value = "consoleCount") @Required val consoleCount: kotlin.Long,
 
-    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<ConsoleResponse>?,
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<ConsoleResponse>,
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MetadataMatchesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MetadataMatchesResponse.kt
@@ -33,11 +33,11 @@ import kotlinx.serialization.encoding.*
 
 data class MetadataMatchesResponse (
 
-    @SerialName(value = "incomplete") @Required val incomplete: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "incomplete") @Required val incomplete: kotlin.collections.List<GameResponse>,
 
-    @SerialName(value = "unscraped") @Required val unscraped: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "unscraped") @Required val unscraped: kotlin.collections.List<GameResponse>,
 
-    @SerialName(value = "unverified") @Required val unverified: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "unverified") @Required val unverified: kotlin.collections.List<GameResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MoodResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MoodResponse.kt
@@ -35,7 +35,7 @@ data class MoodResponse (
 
     @SerialName(value = "description") @Required val description: kotlin.String,
 
-    @SerialName(value = "gradient") @Required val gradient: kotlin.collections.List<kotlin.String>?,
+    @SerialName(value = "gradient") @Required val gradient: kotlin.collections.List<kotlin.String>,
 
     @SerialName(value = "icon") @Required val icon: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MostActivePlayersResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MostActivePlayersResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class MostActivePlayersResponse (
 
-    @SerialName(value = "players") @Required val players: kotlin.collections.List<ActivePlayerEntry>?,
+    @SerialName(value = "players") @Required val players: kotlin.collections.List<ActivePlayerEntry>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MostPlayedResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/MostPlayedResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class MostPlayedResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<MostPlayedEntry>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<MostPlayedEntry>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnThisDayResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnThisDayResponse.kt
@@ -34,7 +34,7 @@ data class OnThisDayResponse (
 
     @SerialName(value = "date") @Required val date: kotlin.String,
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnlineUsersResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/OnlineUsersResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class OnlineUsersResponse (
 
-    @SerialName(value = "users") @Required val users: kotlin.collections.List<OnlineUserResponse>?,
+    @SerialName(value = "users") @Required val users: kotlin.collections.List<OnlineUserResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseActivityEventResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseActivityEventResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class PaginatedResponseActivityEventResponse (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<@Contextual ActivityEventResponse>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<@Contextual ActivityEventResponse>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseChallengeLeaderboardEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseChallengeLeaderboardEntry.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class PaginatedResponseChallengeLeaderboardEntry (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<ChallengeLeaderboardEntry>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<ChallengeLeaderboardEntry>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseChallengeResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseChallengeResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class PaginatedResponseChallengeResponse (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<ChallengeResponse>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<ChallengeResponse>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseCollectionResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseCollectionResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class PaginatedResponseCollectionResponse (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<CollectionResponse>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<CollectionResponse>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseGameRatingResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseGameRatingResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class PaginatedResponseGameRatingResponse (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<GameRatingResponse>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<GameRatingResponse>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseGameResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseGameResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class PaginatedResponseGameResponse (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<GameResponse>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseNetplaySessionResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseNetplaySessionResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class PaginatedResponseNetplaySessionResponse (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<NetplaySessionResponse>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<NetplaySessionResponse>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseSharedSaveResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseSharedSaveResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class PaginatedResponseSharedSaveResponse (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<SharedSaveResponse>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<SharedSaveResponse>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseUserSearchResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PaginatedResponseUserSearchResult.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class PaginatedResponseUserSearchResult (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<UserSearchResult>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<UserSearchResult>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PlayersLikeYouResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PlayersLikeYouResponse.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.encoding.*
 
 data class PlayersLikeYouResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>,
 
     @SerialName(value = "similarUsersCount") @Required val similarUsersCount: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PublicProfileResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PublicProfileResponse.kt
@@ -46,7 +46,7 @@ data class PublicProfileResponse (
 
     @SerialName(value = "currentGame") @Required val currentGame: OnlineUserGameResponse,
 
-    @SerialName(value = "favoriteGames") @Required val favoriteGames: kotlin.collections.List<PublicProfileGame>?,
+    @SerialName(value = "favoriteGames") @Required val favoriteGames: kotlin.collections.List<PublicProfileGame>,
 
     @SerialName(value = "gamesPlayed") @Required val gamesPlayed: kotlin.Long,
 
@@ -56,9 +56,9 @@ data class PublicProfileResponse (
 
     @SerialName(value = "memberSince") @Required val memberSince: kotlinx.datetime.Instant,
 
-    @SerialName(value = "recentGames") @Required val recentGames: kotlin.collections.List<PublicProfileGame>?,
+    @SerialName(value = "recentGames") @Required val recentGames: kotlin.collections.List<PublicProfileGame>,
 
-    @SerialName(value = "topGames") @Required val topGames: kotlin.collections.List<PublicProfileGame>?,
+    @SerialName(value = "topGames") @Required val topGames: kotlin.collections.List<PublicProfileGame>,
 
     @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PublisherDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/PublisherDetailResponse.kt
@@ -62,31 +62,31 @@ data class PublisherDetailResponse (
 
     @SerialName(value = "companyInfo") @Required val companyInfo: CompanyInfo,
 
-    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<kotlin.String>?,
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<kotlin.String>,
 
-    @SerialName(value = "developers") @Required val developers: kotlin.collections.List<NameCount>?,
+    @SerialName(value = "developers") @Required val developers: kotlin.collections.List<NameCount>,
 
     @SerialName(value = "gameCount") @Required val gameCount: kotlin.Long,
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>,
 
-    @SerialName(value = "genreBreakdown") @Required val genreBreakdown: kotlin.collections.List<GenreCount>?,
+    @SerialName(value = "genreBreakdown") @Required val genreBreakdown: kotlin.collections.List<GenreCount>,
 
     @SerialName(value = "heroUrl") @Required val heroUrl: kotlin.String,
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "platformBreakdown") @Required val platformBreakdown: kotlin.collections.List<PlatformCount>?,
+    @SerialName(value = "platformBreakdown") @Required val platformBreakdown: kotlin.collections.List<PlatformCount>,
 
     @SerialName(value = "primaryGenre") @Required val primaryGenre: kotlin.String,
 
     @SerialName(value = "ratingDistribution") @Required val ratingDistribution: RatingDistribution,
 
-    @SerialName(value = "relatedPublishers") @Required val relatedPublishers: kotlin.collections.List<RelatedPublisher>?,
+    @SerialName(value = "relatedPublishers") @Required val relatedPublishers: kotlin.collections.List<RelatedPublisher>,
 
-    @SerialName(value = "timeline") @Required val timeline: kotlin.collections.List<TimelineEntry>?,
+    @SerialName(value = "timeline") @Required val timeline: kotlin.collections.List<TimelineEntry>,
 
-    @SerialName(value = "topGames") @Required val topGames: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "topGames") @Required val topGames: kotlin.collections.List<GameResponse>,
 
     @SerialName(value = "userStats") @Required val userStats: EntityUserStats,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RecentAchievementsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RecentAchievementsResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class RecentAchievementsResponse (
 
-    @SerialName(value = "achievements") @Required val achievements: kotlin.collections.List<RARecentAchievementResponse>?,
+    @SerialName(value = "achievements") @Required val achievements: kotlin.collections.List<RARecentAchievementResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RecentlyReviewedResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RecentlyReviewedResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class RecentlyReviewedResponse (
 
-    @SerialName(value = "reviews") @Required val reviews: kotlin.collections.List<RecentReviewItem>?,
+    @SerialName(value = "reviews") @Required val reviews: kotlin.collections.List<RecentReviewItem>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RelatedDeveloper.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RelatedDeveloper.kt
@@ -35,7 +35,7 @@ data class RelatedDeveloper (
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "sharedPublishers") @Required val sharedPublishers: kotlin.collections.List<kotlin.String>?
+    @SerialName(value = "sharedPublishers") @Required val sharedPublishers: kotlin.collections.List<kotlin.String>
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RelatedPublisher.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/RelatedPublisher.kt
@@ -35,7 +35,7 @@ data class RelatedPublisher (
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 
-    @SerialName(value = "sharedDevelopers") @Required val sharedDevelopers: kotlin.collections.List<kotlin.String>?
+    @SerialName(value = "sharedDevelopers") @Required val sharedDevelopers: kotlin.collections.List<kotlin.String>
 
 ) {
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReorderPlayLaterRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ReorderPlayLaterRequest.kt
@@ -30,7 +30,7 @@ import kotlinx.serialization.encoding.*
 
 data class ReorderPlayLaterRequest (
 
-    @SerialName(value = "gameIds") @Required val gameIds: kotlin.collections.List<kotlin.String>?,
+    @SerialName(value = "gameIds") @Required val gameIds: kotlin.collections.List<kotlin.String>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScrapeStatusCountsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScrapeStatusCountsResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class ScrapeStatusCountsResponse (
 
-    @SerialName(value = "sources") @Required val sources: kotlin.collections.List<ScraperSourceResultResponse>?,
+    @SerialName(value = "sources") @Required val sources: kotlin.collections.List<ScraperSourceResultResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScreenshotGalleryResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ScreenshotGalleryResponse.kt
@@ -36,7 +36,7 @@ data class ScreenshotGalleryResponse (
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 
-    @SerialName(value = "screenshots") @Required val screenshots: kotlin.collections.List<ScreenshotItem>?,
+    @SerialName(value = "screenshots") @Required val screenshots: kotlin.collections.List<ScreenshotItem>,
 
     @SerialName(value = "totalCount") @Required val totalCount: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchCollectionResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchCollectionResult.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class SearchCategoryResultSearchCollectionResult (
 
-    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchCollectionResult>?,
+    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchCollectionResult>,
 
     @SerialName(value = "total") @Required val total: kotlin.Long
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchCompanyResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchCompanyResult.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class SearchCategoryResultSearchCompanyResult (
 
-    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchCompanyResult>?,
+    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchCompanyResult>,
 
     @SerialName(value = "total") @Required val total: kotlin.Long
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchConsoleResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchConsoleResult.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class SearchCategoryResultSearchConsoleResult (
 
-    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchConsoleResult>?,
+    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchConsoleResult>,
 
     @SerialName(value = "total") @Required val total: kotlin.Long
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchFranchiseResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchFranchiseResult.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class SearchCategoryResultSearchFranchiseResult (
 
-    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchFranchiseResult>?,
+    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchFranchiseResult>,
 
     @SerialName(value = "total") @Required val total: kotlin.Long
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchGameResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchGameResult.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class SearchCategoryResultSearchGameResult (
 
-    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchGameResult>?,
+    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchGameResult>,
 
     @SerialName(value = "total") @Required val total: kotlin.Long
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchSeriesResult.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SearchCategoryResultSearchSeriesResult.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class SearchCategoryResultSearchSeriesResult (
 
-    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchSeriesResult>?,
+    @SerialName(value = "results") @Required val results: kotlin.collections.List<SearchSeriesResult>,
 
     @SerialName(value = "total") @Required val total: kotlin.Long
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SeriesDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SeriesDetailResponse.kt
@@ -40,9 +40,9 @@ import kotlinx.serialization.encoding.*
 
 data class SeriesDetailResponse (
 
-    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<SeriesConsoleInfo>?,
+    @SerialName(value = "consoles") @Required val consoles: kotlin.collections.List<SeriesConsoleInfo>,
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<SeriesGameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<SeriesGameResponse>,
 
     @SerialName(value = "heroUrl") @Required val heroUrl: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionCheatsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionCheatsResponse.kt
@@ -33,7 +33,7 @@ data class SessionCheatsResponse (
 
     @SerialName(value = "cheatsEnabled") @Required val cheatsEnabled: kotlin.Boolean,
 
-    @SerialName(value = "enabledIndices") @Required val enabledIndices: kotlin.collections.List<kotlin.Long>?,
+    @SerialName(value = "enabledIndices") @Required val enabledIndices: kotlin.collections.List<kotlin.Long>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetupDiagnosticsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SetupDiagnosticsResponse.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.encoding.*
 data class SetupDiagnosticsResponse (
 
     /* Ordered list of server health checks. */
-    @SerialName(value = "checks") @Required val checks: kotlin.collections.List<DiagnosticCheck>?,
+    @SerialName(value = "checks") @Required val checks: kotlin.collections.List<DiagnosticCheck>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionDetailResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SharedSessionDetailResponse.kt
@@ -68,7 +68,7 @@ data class SharedSessionDetailResponse (
 
     @SerialName(value = "memberCount") @Required val memberCount: kotlin.Long,
 
-    @SerialName(value = "members") @Required val members: kotlin.collections.List<SharedSessionMemberResponse>?,
+    @SerialName(value = "members") @Required val members: kotlin.collections.List<SharedSessionMemberResponse>,
 
     @SerialName(value = "name") @Required val name: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/StagedUploadResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/StagedUploadResponse.kt
@@ -81,7 +81,7 @@ data class StagedUploadResponse (
 
     @SerialName(value = "players") @Required val players: kotlin.Long,
 
-    @SerialName(value = "possibleConsoles") @Required val possibleConsoles: kotlin.collections.List<PossibleConsoleResponse>?,
+    @SerialName(value = "possibleConsoles") @Required val possibleConsoles: kotlin.collections.List<PossibleConsoleResponse>,
 
     @SerialName(value = "publisher") @Required val publisher: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/StorageUsageResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/StorageUsageResponse.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.encoding.*
 
 data class StorageUsageResponse (
 
-    @SerialName(value = "byConsole") @Required val byConsole: kotlin.collections.List<SessionStorageConsoleBreakdown>?,
+    @SerialName(value = "byConsole") @Required val byConsole: kotlin.collections.List<SessionStorageConsoleBreakdown>,
 
     @SerialName(value = "quotaBytes") @Required val quotaBytes: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventTypesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventTypesResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class SystemEventTypesResponse (
 
-    @SerialName(value = "types") @Required val types: kotlin.collections.List<SystemEventTypeInfo>?,
+    @SerialName(value = "types") @Required val types: kotlin.collections.List<SystemEventTypeInfo>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventsListResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SystemEventsListResponse.kt
@@ -34,7 +34,7 @@ import kotlinx.serialization.encoding.*
 
 data class SystemEventsListResponse (
 
-    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<@Contextual SystemEventResponse>?,
+    @SerialName(value = "data") @Required val `data`: kotlin.collections.List<@Contextual SystemEventResponse>,
 
     @SerialName(value = "page") @Required val page: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TasteProfileResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TasteProfileResponse.kt
@@ -36,11 +36,11 @@ import kotlinx.serialization.encoding.*
 
 data class TasteProfileResponse (
 
-    @SerialName(value = "genres") @Required val genres: kotlin.collections.List<TasteProfileGenre>?,
+    @SerialName(value = "genres") @Required val genres: kotlin.collections.List<TasteProfileGenre>,
 
-    @SerialName(value = "themes") @Required val themes: kotlin.collections.List<TasteProfileTheme>?,
+    @SerialName(value = "themes") @Required val themes: kotlin.collections.List<TasteProfileTheme>,
 
-    @SerialName(value = "topConsoles") @Required val topConsoles: kotlin.collections.List<TasteProfileConsole>?,
+    @SerialName(value = "topConsoles") @Required val topConsoles: kotlin.collections.List<TasteProfileConsole>,
 
     @SerialName(value = "totalPlayTime") @Required val totalPlayTime: kotlin.Long,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TimelineEntry.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TimelineEntry.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class TimelineEntry (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<TimelineGame>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<TimelineGame>,
 
     @SerialName(value = "year") @Required val year: kotlin.Long
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TrendingResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/TrendingResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class TrendingResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<TrendingGameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<TrendingGameResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UnlockedAchievementsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UnlockedAchievementsResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class UnlockedAchievementsResponse (
 
-    @SerialName(value = "achievements") @Required val achievements: kotlin.collections.List<RAUnlockedAchievementResponse>?,
+    @SerialName(value = "achievements") @Required val achievements: kotlin.collections.List<RAUnlockedAchievementResponse>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSessionCheatsRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdateSessionCheatsRequest.kt
@@ -33,7 +33,7 @@ data class UpdateSessionCheatsRequest (
 
     @SerialName(value = "cheatsEnabled") @Required val cheatsEnabled: kotlin.Boolean,
 
-    @SerialName(value = "enabledIndices") @Required val enabledIndices: kotlin.collections.List<kotlin.Long>?,
+    @SerialName(value = "enabledIndices") @Required val enabledIndices: kotlin.collections.List<kotlin.Long>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserPreferencesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserPreferencesResponse.kt
@@ -56,7 +56,7 @@ data class UserPreferencesResponse (
 
     @SerialName(value = "defaultSecondScreenPage") @Required val defaultSecondScreenPage: kotlin.String,
 
-    @SerialName(value = "preferredRegions") @Required val preferredRegions: kotlin.collections.List<kotlin.String>?,
+    @SerialName(value = "preferredRegions") @Required val preferredRegions: kotlin.collections.List<kotlin.String>,
 
     @SerialName(value = "raHardcoreEnabled") @Required val raHardcoreEnabled: kotlin.Boolean,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardResponse.kt
@@ -31,7 +31,7 @@ import kotlinx.serialization.encoding.*
 
 data class WizardResponse (
 
-    @SerialName(value = "steps") @Required val steps: kotlin.collections.List<WizardStep>?,
+    @SerialName(value = "steps") @Required val steps: kotlin.collections.List<WizardStep>,
 
     /* A URL to the JSON Schema for this object. */
     @SerialName(value = "\$schema") val dollarSchema: kotlin.String? = null

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardResultsResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardResultsResponse.kt
@@ -32,7 +32,7 @@ import kotlinx.serialization.encoding.*
 
 data class WizardResultsResponse (
 
-    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>?,
+    @SerialName(value = "games") @Required val games: kotlin.collections.List<GameResponse>,
 
     @SerialName(value = "title") @Required val title: kotlin.String,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardStep.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/WizardStep.kt
@@ -33,7 +33,7 @@ import kotlinx.serialization.encoding.*
 
 data class WizardStep (
 
-    @SerialName(value = "options") @Required val options: kotlin.collections.List<WizardOption>?,
+    @SerialName(value = "options") @Required val options: kotlin.collections.List<WizardOption>,
 
     @SerialName(value = "step") @Required val step: kotlin.Long,
 

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -49,28 +49,28 @@ private fun testGameResponse(
         ratingCount = 0L,
         releaseDate = releaseDate,
         scrapeAttempts = 0L,
-        screenshotUrls = screenshotUrls,
+        screenshotUrls = screenshotUrls ?: emptyList(),
         title = title,
         totalPlayTime = totalPlayTime,
         updatedAt = now,
         achievementsWarning = "",
-        ageRatings = null,
+        ageRatings = emptyList(),
         biosStatus = "",
         coreOverride = "",
-        discs = null,
+        discs = emptyList(),
         gameModes = "",
         groupKey = "",
         heroUrl = "",
         igdbUserRating = 0.0,
         igdbUserRatingCount = 0L,
-        languageSupports = null,
+        languageSupports = emptyList(),
         logoUrl = "",
         parentGame = com.spela.client.models.ParentGameResponse(id = "", title = "", coverUrl = ""),
         partyInfo = "",
         region = "",
-        releaseDates = null,
+        releaseDates = emptyList(),
         revision = "",
-        romHacks = null,
+        romHacks = emptyList(),
         scraperId = "",
         storyline = "",
         tags = "",
@@ -81,10 +81,10 @@ private fun testGameResponse(
         totalRatingCount = 0L,
         userRating = 0L,
         variantCount = 0L,
-        variants = null,
+        variants = emptyList(),
         verificationStatus = "",
         verificationTag = "",
-        videos = null,
+        videos = emptyList(),
     )
 }
 
@@ -192,9 +192,11 @@ class GameRepositoryImplTest {
     }
 
     @Test
-    fun completionistMapResponseHandlesNullConsolesList() {
+    fun completionistMapResponseHandlesEmptyConsolesList() {
+        // Server guarantees non-null lists after DefaultArrayNullable=false;
+        // this exercises the empty-but-present path.
         val response = com.spela.client.models.CompletionistMapResponse(
-            consoles = null,
+            consoles = emptyList(),
             overallPct = 0L,
             totalGames = 0L,
             totalPlayed = 0L,

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GameRepositoryOfflineTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/GameRepositoryOfflineTest.kt
@@ -41,27 +41,27 @@ private fun gameJson(
     totalPlayTime: Long = 0,
     screenshotUrls: List<String>? = null,
 ): String {
-    val screenshots = screenshotUrls?.joinToString(",", "[", "]") { "\"$it\"" } ?: "null"
+    val screenshots = screenshotUrls?.joinToString(",", "[", "]") { "\"$it\"" } ?: "[]"
     val lastPlayed = lastPlayedAt?.let { "\"$it\"" } ?: "null"
     return """{"id":"$id","title":"$title","consoleId":"1","consoleName":"NES",""" +
-        """"achievementsWarning":"","ageRatings":null,"averageRating":0,"biosStatus":"",""" +
+        """"achievementsWarning":"","ageRatings":[],"averageRating":0,"biosStatus":"",""" +
         """"coreOverride":"","coverAspectRatio":0.75,"coverUrl":"/covers/smb.png",""" +
         """"createdAt":"2024-01-01T00:00:00Z","updatedAt":"2024-01-01T00:00:00Z",""" +
         """"description":"A classic platformer","developer":"Nintendo",""" +
-        """"discCount":0,"discs":null,"fileName":"smb.nes","fileSize":40960,""" +
+        """"discCount":0,"discs":[],"fileName":"smb.nes","fileSize":40960,""" +
         """"gameModes":"","genre":"Platformer","groupKey":"","heroUrl":"",""" +
         """"igdbCriticsRating":0,"igdbUserRating":0,"igdbUserRatingCount":0,""" +
         """"isFavorite":$isFavorite,"isInPlayLater":false,"isPreRelease":false,""" +
-        """"languageSupports":null,"lastPlayedAt":$lastPlayed,"logoUrl":"",""" +
+        """"languageSupports":[],"lastPlayedAt":$lastPlayed,"logoUrl":"",""" +
         """"parentGame":{"id":"","title":"","coverUrl":""},"partyInfo":"",""" +
         """"playable":true,"players":1,"publisher":"Nintendo",""" +
-        """"ratingCount":0,"region":"","releaseDate":"1985-09-13","releaseDates":null,""" +
-        """"revision":"","romHacks":null,"scrapeAttempts":0,"scraperId":"",""" +
+        """"ratingCount":0,"region":"","releaseDate":"1985-09-13","releaseDates":[],""" +
+        """"revision":"","romHacks":[],"scrapeAttempts":0,"scraperId":"",""" +
         """"screenshotUrls":$screenshots,"storyline":"","tags":"",""" +
         """"timeToBeatCompletely":0,"timeToBeatHastily":0,"timeToBeatNormally":0,""" +
         """"totalPlayTime":$totalPlayTime,"totalRating":0,"totalRatingCount":0,""" +
-        """"userRating":null,"variantCount":0,"variants":null,""" +
-        """"verificationStatus":"","verificationTag":"","videos":null}"""
+        """"userRating":null,"variantCount":0,"variants":[],""" +
+        """"verificationStatus":"","verificationTag":"","videos":[]}"""
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/server/internal/api/explore_handler_developer.go
+++ b/server/internal/api/explore_handler_developer.go
@@ -22,7 +22,7 @@ import (
 // Returns nil if no related developers are found.
 func buildRelatedDevelopers(database *gorm.DB, developerName string, publishers []NameCount) []RelatedDeveloper {
 	if len(publishers) == 0 {
-		return nil
+		return []RelatedDeveloper{}
 	}
 
 	publisherNames := make([]string, len(publishers))
@@ -44,11 +44,11 @@ func buildRelatedDevelopers(database *gorm.DB, developerName string, publishers 
 		Group("developer, publisher").
 		Scan(&rows).Error; err != nil {
 		slog.Error("failed to fetch related developers", "error", err)
-		return nil
+		return []RelatedDeveloper{}
 	}
 
 	if len(rows) == 0 {
-		return nil
+		return []RelatedDeveloper{}
 	}
 
 	// Aggregate: for each developer, collect shared publishers and total game count
@@ -84,7 +84,7 @@ func buildRelatedDevelopers(database *gorm.DB, developerName string, publishers 
 		Group("developer").
 		Scan(&countRows).Error; err != nil {
 		slog.Error("failed to fetch related developer game counts", "error", err)
-		return nil
+		return []RelatedDeveloper{}
 	}
 
 	for _, cr := range countRows {
@@ -132,7 +132,7 @@ func buildRelatedDevelopers(database *gorm.DB, developerName string, publishers 
 // Returns nil if no related publishers are found.
 func buildRelatedPublishers(database *gorm.DB, publisherName string, developers []NameCount) []RelatedPublisher {
 	if len(developers) == 0 {
-		return nil
+		return []RelatedPublisher{}
 	}
 
 	developerNames := make([]string, len(developers))
@@ -154,11 +154,11 @@ func buildRelatedPublishers(database *gorm.DB, publisherName string, developers 
 		Group("publisher, developer").
 		Scan(&rows).Error; err != nil {
 		slog.Error("failed to fetch related publishers", "error", err)
-		return nil
+		return []RelatedPublisher{}
 	}
 
 	if len(rows) == 0 {
-		return nil
+		return []RelatedPublisher{}
 	}
 
 	// Aggregate: for each publisher, collect shared developers and total game count
@@ -194,7 +194,7 @@ func buildRelatedPublishers(database *gorm.DB, publisherName string, developers 
 		Group("publisher").
 		Scan(&countRows).Error; err != nil {
 		slog.Error("failed to fetch related publisher game counts", "error", err)
-		return nil
+		return []RelatedPublisher{}
 	}
 
 	for _, cr := range countRows {
@@ -545,7 +545,7 @@ func buildTimeline(games []db.Game) []TimelineEntry {
 		})
 	}
 	if datedCount < 3 || len(yearGames) < 2 {
-		return nil
+		return []TimelineEntry{}
 	}
 
 	years := make([]int, 0, len(yearGames))

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -5016,7 +5016,7 @@ func TestGetDeveloperDetail_Timeline_TooFewGames(t *testing.T) {
 	var resp DeveloperDetailResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 
-	assert.Nil(t, resp.Timeline)
+	assert.Empty(t, resp.Timeline)
 }
 
 func TestGetDeveloperDetail_Timeline_SingleYear(t *testing.T) {
@@ -5037,7 +5037,7 @@ func TestGetDeveloperDetail_Timeline_SingleYear(t *testing.T) {
 	var resp DeveloperDetailResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 
-	assert.Nil(t, resp.Timeline)
+	assert.Empty(t, resp.Timeline)
 }
 
 func TestGetDeveloperDetail_Timeline_NoDates(t *testing.T) {
@@ -5057,7 +5057,7 @@ func TestGetDeveloperDetail_Timeline_NoDates(t *testing.T) {
 	var resp DeveloperDetailResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 
-	assert.Nil(t, resp.Timeline)
+	assert.Empty(t, resp.Timeline)
 }
 
 // --- Publisher statistics fields tests ---
@@ -5173,7 +5173,7 @@ func TestGetDeveloperDetail_NonExistent_StatisticsDefaults(t *testing.T) {
 	assert.Equal(t, 0, resp.RatingDistribution.Poor)
 	assert.Equal(t, 0, resp.RatingDistribution.Unrated)
 	assert.Empty(t, resp.PrimaryGenre)
-	assert.Nil(t, resp.Timeline)
+	assert.Empty(t, resp.Timeline)
 }
 
 func TestGetPublisherDetail_NonExistent_StatisticsDefaults(t *testing.T) {
@@ -5196,7 +5196,7 @@ func TestGetPublisherDetail_NonExistent_StatisticsDefaults(t *testing.T) {
 	assert.Equal(t, 0, resp.RatingDistribution.Poor)
 	assert.Equal(t, 0, resp.RatingDistribution.Unrated)
 	assert.Empty(t, resp.PrimaryGenre)
-	assert.Nil(t, resp.Timeline)
+	assert.Empty(t, resp.Timeline)
 }
 
 // --- Related Developers tests ---
@@ -5262,7 +5262,7 @@ func TestGetDeveloperDetail_RelatedDevelopers_NoSharedPublishers(t *testing.T) {
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 
 	// No related developers since no other developer publishes with "Square"
-	assert.Nil(t, resp.RelatedDevelopers)
+	assert.Empty(t, resp.RelatedDevelopers)
 }
 
 func TestGetDeveloperDetail_RelatedDevelopers_SelfPublished(t *testing.T) {
@@ -5379,7 +5379,7 @@ func TestGetPublisherDetail_RelatedPublishers_NoSharedDevelopers(t *testing.T) {
 	var resp PublisherDetailResponse
 	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
 
-	assert.Nil(t, resp.RelatedPublishers)
+	assert.Empty(t, resp.RelatedPublishers)
 }
 
 func TestGetPublisherDetail_RelatedPublishers_SelfPublished(t *testing.T) {

--- a/server/internal/api/huma_achievements.go
+++ b/server/internal/api/huma_achievements.go
@@ -156,6 +156,9 @@ func (h *RAHandler) HumaGetGameAchievements(ctx context.Context, in *GetGameAchi
 		if err := json.Unmarshal([]byte(cache.AchievementJSON), &achievements); err != nil {
 			slog.Warn("failed to unmarshal cached achievement data, will re-fetch", "ra_game_id", raGameID, "error", err)
 		} else {
+			if achievements == nil {
+				achievements = []retroachievements.Achievement{}
+			}
 			return &GetGameAchievementsOutput{
 				Status: http.StatusOK,
 				Body: GameAchievementsResponse{
@@ -182,7 +185,11 @@ func (h *RAHandler) HumaGetGameAchievements(ctx context.Context, in *GetGameAchi
 			if err != nil {
 				slog.Error("failed to fetch RA game info", "ra_game_id", raGameID, "error", err)
 			} else {
-				achJSON, _ := json.Marshal(gameInfo.Achievements)
+				achievements := gameInfo.Achievements
+				if achievements == nil {
+					achievements = []retroachievements.Achievement{}
+				}
+				achJSON, _ := json.Marshal(achievements)
 				if cacheHit {
 					cache.Title = gameInfo.Title
 					cache.AchievementJSON = string(achJSON)
@@ -207,7 +214,7 @@ func (h *RAHandler) HumaGetGameAchievements(ctx context.Context, in *GetGameAchi
 					Body: GameAchievementsResponse{
 						RAGameID:     raGameID,
 						Title:        gameInfo.Title,
-						Achievements: gameInfo.Achievements,
+						Achievements: achievements,
 						TotalCount:   gameInfo.TotalCount,
 						TotalPoints:  gameInfo.TotalPoints,
 					},
@@ -237,6 +244,9 @@ func (h *RAHandler) HumaGetGameAchievements(ctx context.Context, in *GetGameAchi
 	if cacheHit {
 		var achievements []retroachievements.Achievement
 		if err := json.Unmarshal([]byte(cache.AchievementJSON), &achievements); err == nil {
+			if achievements == nil {
+				achievements = []retroachievements.Achievement{}
+			}
 			return &GetGameAchievementsOutput{
 				Status: http.StatusOK,
 				Body: GameAchievementsResponse{

--- a/server/internal/api/huma_admin_multipart.go
+++ b/server/internal/api/huma_admin_multipart.go
@@ -629,6 +629,7 @@ func (h *UploadHandler) HumaUploadROMs(_ context.Context, in *AdminUploadROMsInp
 			results = append(results, StagedUploadResponse{
 				OriginalFileName: f.Filename,
 				Status:           "rejected",
+				PossibleConsoles: []PossibleConsoleResponse{},
 			})
 			f.Close()
 			continue

--- a/server/internal/api/huma_bios.go
+++ b/server/internal/api/huma_bios.go
@@ -119,7 +119,7 @@ func (h *BiosHandler) HumaListBiosFiles(_ context.Context, _ *ListBiosFilesInput
 
 	matchedFiles := make(map[string]bool)
 
-	var fileResponses []BiosFileResponse
+	fileResponses := make([]BiosFileResponse, 0, len(allEntries))
 	for _, e := range allEntries {
 		consoleName := names[e.ConsoleID]
 		consoleID := e.ConsoleID
@@ -190,7 +190,7 @@ func (h *BiosHandler) HumaListBiosFiles(_ context.Context, _ *ListBiosFilesInput
 	}
 
 	consoleOrder := bios.ConsoleIDs()
-	var consoleSummaries []ConsoleBiosStatus
+	consoleSummaries := make([]ConsoleBiosStatus, 0, len(consoleOrder))
 	for _, cid := range consoleOrder {
 		cEntries := bios.ByConsole(cid)
 		consoleName := names[cid]
@@ -203,7 +203,7 @@ func (h *BiosHandler) HumaListBiosFiles(_ context.Context, _ *ListBiosFilesInput
 		hasInvalidRequired := false
 		hasMissingRequired := false
 
-		var consoleFiles []ConsoleFileStatus
+		consoleFiles := make([]ConsoleFileStatus, 0, len(cEntries))
 		for _, e := range cEntries {
 			if e.Required {
 				hasRequired = true

--- a/server/internal/api/huma_profiles.go
+++ b/server/internal/api/huma_profiles.go
@@ -376,7 +376,7 @@ func (h *ExploreHandler) HumaGetCompletionistMap(ctx context.Context, _ *GetComp
 		playedMap[pr.ConsoleID] = pr.PlayedGames
 	}
 
-	var consoles []CompletionistConsole
+	consoles := make([]CompletionistConsole, 0, len(consoleRows))
 	totalGames := 0
 	totalPlayed := 0
 

--- a/server/internal/api/huma_setup.go
+++ b/server/internal/api/huma_setup.go
@@ -10,6 +10,19 @@ import (
 	"gorm.io/gorm"
 )
 
+// init disables huma's default-nullable-array schema emission. Without
+// this, every `[]T` slice on a response body emits `"type": ["array",
+// "null"]` in OpenAPI (because a Go nil slice marshals to JSON null),
+// which propagates to the TS / Kotlin clients as `T[] | null`.
+//
+// Handlers are responsible for returning non-nil slices (init an empty
+// slice rather than `nil`) — huma doesn't enforce this at compile time,
+// but response tests and the recording code should surface any that
+// slip through.
+func init() {
+	huma.DefaultArrayNullable = false
+}
+
 // SetupHumaAPI attaches a huma.API instance to the gin engine. The returned
 // API is used by handlers to register typed operations alongside the existing
 // raw gin routes — both stacks coexist during the incremental migration to

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -405,7 +405,7 @@ func toGameResponseWithData(g db.Game, data *userGameData) GameResponse {
 		screenshots[i] = resolveImageURL(s)
 	}
 
-	var discs []DiscResponse
+	discs := make([]DiscResponse, 0, len(g.Discs))
 	for _, d := range g.Discs {
 		discs = append(discs, DiscResponse{
 			DiscNumber: d.DiscNumber,
@@ -462,6 +462,12 @@ func toGameResponseWithData(g db.Game, data *userGameData) GameResponse {
 		Tags:                g.Tags,
 		IsPreRelease:        g.IsPreRelease,
 		GroupKey:            g.GroupKey,
+		ReleaseDates:        []ReleaseDateResponse{},
+		Videos:              []VideoResponse{},
+		LanguageSupports:    []LanguageSupportResponse{},
+		AgeRatings:          []AgeRatingResponse{},
+		Variants:            []VariantResponse{},
+		RomHacks:            []RomHackGameResponse{},
 	}
 
 	// Map release dates

--- a/server/internal/api/upload_handler.go
+++ b/server/internal/api/upload_handler.go
@@ -88,6 +88,7 @@ func toStagedUploadResponse(su db.StagedUpload, database *gorm.DB) StagedUploadR
 		VerificationStatus: su.VerificationStatus,
 		CRC32:              su.CRC32,
 		CanonicalName:      su.CanonicalName,
+		PossibleConsoles:   []PossibleConsoleResponse{},
 	}
 
 	if su.ConsoleID != nil {
@@ -200,6 +201,7 @@ func (h *UploadHandler) stageROMFile(originalFilename string, ext string, writeF
 		return StagedUploadResponse{
 			OriginalFileName: originalFilename,
 			Status:           "rejected",
+			PossibleConsoles: []PossibleConsoleResponse{},
 		}
 	}
 
@@ -256,6 +258,7 @@ func (h *UploadHandler) stageROMFile(originalFilename string, ext string, writeF
 		return StagedUploadResponse{
 			OriginalFileName: originalFilename,
 			Status:           "rejected",
+			PossibleConsoles: []PossibleConsoleResponse{},
 		}
 	}
 
@@ -276,6 +279,7 @@ func (h *UploadHandler) processZipUploadFormFile(f huma.FormFile) []StagedUpload
 		return []StagedUploadResponse{{
 			OriginalFileName: f.Filename,
 			Status:           "rejected",
+			PossibleConsoles: []PossibleConsoleResponse{},
 		}}
 	}
 	tmpZipPath := tmpZipFile.Name()
@@ -287,6 +291,7 @@ func (h *UploadHandler) processZipUploadFormFile(f huma.FormFile) []StagedUpload
 		return []StagedUploadResponse{{
 			OriginalFileName: f.Filename,
 			Status:           "rejected",
+			PossibleConsoles: []PossibleConsoleResponse{},
 		}}
 	}
 	tmpZipFile.Close()
@@ -303,6 +308,7 @@ func (h *UploadHandler) extractAndStageZip(zipPath string, originalZipName strin
 		return []StagedUploadResponse{{
 			OriginalFileName: originalZipName,
 			Status:           "rejected",
+			PossibleConsoles: []PossibleConsoleResponse{},
 		}}
 	}
 	defer r.Close()
@@ -313,6 +319,7 @@ func (h *UploadHandler) extractAndStageZip(zipPath string, originalZipName strin
 		return []StagedUploadResponse{{
 			OriginalFileName: originalZipName,
 			Status:           "rejected",
+			PossibleConsoles: []PossibleConsoleResponse{},
 		}}
 	}
 
@@ -325,6 +332,7 @@ func (h *UploadHandler) extractAndStageZip(zipPath string, originalZipName strin
 			return []StagedUploadResponse{{
 				OriginalFileName: originalZipName,
 				Status:           "rejected",
+				PossibleConsoles: []PossibleConsoleResponse{},
 			}}
 		}
 	}
@@ -389,6 +397,7 @@ func (h *UploadHandler) extractAndStageZip(zipPath string, originalZipName strin
 		return []StagedUploadResponse{{
 			OriginalFileName: originalZipName,
 			Status:           "rejected",
+			PossibleConsoles: []PossibleConsoleResponse{},
 		}}
 	}
 

--- a/web/src/features/search/components/search-palette.tsx
+++ b/web/src/features/search/components/search-palette.tsx
@@ -84,13 +84,13 @@ export function SearchPalette() {
 
   const hasResults =
     results &&
-    ((results.games.results?.length ?? 0) > 0 ||
-      (results.consoles.results?.length ?? 0) > 0 ||
-      (results.developers.results?.length ?? 0) > 0 ||
-      (results.publishers.results?.length ?? 0) > 0 ||
-      (results.collections.results?.length ?? 0) > 0 ||
-      (results.series.results?.length ?? 0) > 0 ||
-      (results.franchises.results?.length ?? 0) > 0);
+    (results.games.results.length > 0 ||
+      results.consoles.results.length > 0 ||
+      results.developers.results.length > 0 ||
+      results.publishers.results.length > 0 ||
+      results.collections.results.length > 0 ||
+      results.series.results.length > 0 ||
+      results.franchises.results.length > 0);
 
   if (!open) return null;
 

--- a/web/src/features/search/components/search-results.tsx
+++ b/web/src/features/search/components/search-results.tsx
@@ -41,13 +41,12 @@ interface ResultItem {
 function buildSections(results: SearchResults): ResultSection[] {
   const sections: ResultSection[] = [];
 
-  const games = results.games.results ?? [];
-  if (games.length > 0) {
+  if (results.games.results.length > 0) {
     sections.push({
       key: "games",
       title: "Games",
       total: results.games.total,
-      items: games.map((g) => ({
+      items: results.games.results.map((g) => ({
         id: `game-${g.id}`,
         path: `/games/${g.id}`,
         render: (highlighted: boolean) => <GameRow game={g} highlighted={highlighted} />,
@@ -55,13 +54,12 @@ function buildSections(results: SearchResults): ResultSection[] {
     });
   }
 
-  const consoles = results.consoles.results ?? [];
-  if (consoles.length > 0) {
+  if (results.consoles.results.length > 0) {
     sections.push({
       key: "consoles",
       title: "Consoles",
       total: results.consoles.total,
-      items: consoles.map((c) => ({
+      items: results.consoles.results.map((c) => ({
         id: `console-${c.id}`,
         path: `/consoles/${c.id}`,
         render: (highlighted: boolean) => <ConsoleRow console={c} highlighted={highlighted} />,
@@ -69,13 +67,12 @@ function buildSections(results: SearchResults): ResultSection[] {
     });
   }
 
-  const developers = results.developers.results ?? [];
-  if (developers.length > 0) {
+  if (results.developers.results.length > 0) {
     sections.push({
       key: "developers",
       title: "Developers",
       total: results.developers.total,
-      items: developers.map((d) => ({
+      items: results.developers.results.map((d) => ({
         id: `dev-${d.name}`,
         path: `/explore/developers/${encodeURIComponent(d.name)}`,
         render: (highlighted: boolean) => <DeveloperRow developer={d} highlighted={highlighted} />,
@@ -83,13 +80,12 @@ function buildSections(results: SearchResults): ResultSection[] {
     });
   }
 
-  const publishers = results.publishers.results ?? [];
-  if (publishers.length > 0) {
+  if (results.publishers.results.length > 0) {
     sections.push({
       key: "publishers",
       title: "Publishers",
       total: results.publishers.total,
-      items: publishers.map((p) => ({
+      items: results.publishers.results.map((p) => ({
         id: `pub-${p.name}`,
         path: `/explore/publishers/${encodeURIComponent(p.name)}`,
         render: (highlighted: boolean) => <PublisherRow publisher={p} highlighted={highlighted} />,
@@ -97,13 +93,12 @@ function buildSections(results: SearchResults): ResultSection[] {
     });
   }
 
-  const collections = results.collections.results ?? [];
-  if (collections.length > 0) {
+  if (results.collections.results.length > 0) {
     sections.push({
       key: "collections",
       title: "Collections",
       total: results.collections.total,
-      items: collections.map((c) => ({
+      items: results.collections.results.map((c) => ({
         id: `col-${c.id}`,
         path: `/collections/${c.id}`,
         render: (highlighted: boolean) => <CollectionRow collection={c} highlighted={highlighted} />,
@@ -111,13 +106,12 @@ function buildSections(results: SearchResults): ResultSection[] {
     });
   }
 
-  const series = results.series.results ?? [];
-  if (series.length > 0) {
+  if (results.series.results.length > 0) {
     sections.push({
       key: "series",
       title: "Series",
       total: results.series.total,
-      items: series.map((s) => ({
+      items: results.series.results.map((s) => ({
         id: `series-${s.id}`,
         path: `/explore/series/${s.id}`,
         render: (highlighted: boolean) => <SeriesRow series={s} highlighted={highlighted} />,
@@ -125,13 +119,12 @@ function buildSections(results: SearchResults): ResultSection[] {
     });
   }
 
-  const franchises = results.franchises.results ?? [];
-  if (franchises.length > 0) {
+  if (results.franchises.results.length > 0) {
     sections.push({
       key: "franchises",
       title: "Franchises",
       total: results.franchises.total,
-      items: franchises.map((f) => ({
+      items: results.franchises.results.map((f) => ({
         id: `fran-${f.id}`,
         path: `/explore/franchise/${f.id}`,
         render: (highlighted: boolean) => <FranchiseRow franchise={f} highlighted={highlighted} />,

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -5106,7 +5106,7 @@ export interface components {
              * @example https://example.com/api/schemas/AchievementLeaderboardResponse.json
              */
             readonly $schema?: string;
-            leaderboard: components["schemas"]["RALeaderboardEntryResponse"][] | null;
+            leaderboard: components["schemas"]["RALeaderboardEntryResponse"][];
             /** Format: int64 */
             raGameId: number;
             /** Format: int64 */
@@ -5124,7 +5124,7 @@ export interface components {
             gameTitle: string;
             /** Format: int64 */
             raGameId: number;
-            timeline: components["schemas"]["RATimelineEntryResponse"][] | null;
+            timeline: components["schemas"]["RATimelineEntryResponse"][];
             /** Format: int64 */
             totalAchievements: number;
             /** Format: int64 */
@@ -5141,7 +5141,7 @@ export interface components {
              * @example https://example.com/api/schemas/ActiveChallengesResponse.json
              */
             readonly $schema?: string;
-            challenges: components["schemas"]["ExploreChallengeResponse"][] | null;
+            challenges: components["schemas"]["ExploreChallengeResponse"][];
         };
         ActiveNowItem: {
             /** Format: int64 */
@@ -5157,7 +5157,7 @@ export interface components {
              * @example https://example.com/api/schemas/ActiveNowResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["ActiveNowItem"][] | null;
+            games: components["schemas"]["ActiveNowItem"][];
         };
         ActivePlayerEntry: {
             avatarUrl: string;
@@ -5285,7 +5285,7 @@ export interface components {
              * @example https://example.com/api/schemas/AlmostDoneResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["AlmostDoneGame"][] | null;
+            games: components["schemas"]["AlmostDoneGame"][];
         };
         AnniversariesResponse: {
             /**
@@ -5294,7 +5294,7 @@ export interface components {
              * @example https://example.com/api/schemas/AnniversariesResponse.json
              */
             readonly $schema?: string;
-            anniversaries: components["schemas"]["AnniversaryItem"][] | null;
+            anniversaries: components["schemas"]["AnniversaryItem"][];
         };
         AnniversaryItem: {
             game: components["schemas"]["GameResponse"];
@@ -5320,7 +5320,7 @@ export interface components {
              * @example https://example.com/api/schemas/ArtworkGalleryResponse.json
              */
             readonly $schema?: string;
-            artworks: components["schemas"]["ArtworkItem"][] | null;
+            artworks: components["schemas"]["ArtworkItem"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -5445,7 +5445,7 @@ export interface components {
              * @example https://example.com/api/schemas/BestOfYearResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["GameResponse"][] | null;
+            games: components["schemas"]["GameResponse"][];
             /** Format: int64 */
             year: number;
         };
@@ -5486,8 +5486,8 @@ export interface components {
              * @example https://example.com/api/schemas/BiosListResponse.json
              */
             readonly $schema?: string;
-            consoles: components["schemas"]["ConsoleBiosStatus"][] | null;
-            files: components["schemas"]["BiosFileResponse"][] | null;
+            consoles: components["schemas"]["ConsoleBiosStatus"][];
+            files: components["schemas"]["BiosFileResponse"][];
         };
         BulkDeleteSessionSavesResponse: {
             /**
@@ -5621,7 +5621,7 @@ export interface components {
             description: string;
             /** Format: int64 */
             gameCount: number;
-            games: components["schemas"]["GameResponse"][] | null;
+            games: components["schemas"]["GameResponse"][];
             id: string;
             isPublic: boolean;
             name: string;
@@ -5666,7 +5666,7 @@ export interface components {
              * @example https://example.com/api/schemas/CommunityTopResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["CommunityTopGame"][] | null;
+            games: components["schemas"]["CommunityTopGame"][];
         };
         CompactSavesResponse: {
             /**
@@ -5706,7 +5706,7 @@ export interface components {
              * @example https://example.com/api/schemas/CompletionistMapResponse.json
              */
             readonly $schema?: string;
-            consoles: components["schemas"]["CompletionistConsole"][] | null;
+            consoles: components["schemas"]["CompletionistConsole"][];
             /** Format: int64 */
             overallPct: number;
             /** Format: int64 */
@@ -5718,7 +5718,7 @@ export interface components {
             biosRequired: boolean;
             consoleId: string;
             consoleName: string;
-            files: components["schemas"]["ConsoleFileStatus"][] | null;
+            files: components["schemas"]["ConsoleFileStatus"][];
             /** Format: int64 */
             optionalPresent: number;
             /** Format: int64 */
@@ -5754,7 +5754,7 @@ export interface components {
              * @example https://example.com/api/schemas/ConsoleHighlightsResponse.json
              */
             readonly $schema?: string;
-            consoles: components["schemas"]["ConsoleHighlight"][] | null;
+            consoles: components["schemas"]["ConsoleHighlight"][];
         };
         ConsoleKeyMappingDTO: {
             customMapping: {
@@ -5773,7 +5773,7 @@ export interface components {
             createdAt: string;
             defaultCore: string;
             emulatorJsCore: string;
-            extensions: string[] | null;
+            extensions: string[];
             /** Format: int64 */
             gameCount: number;
             /** Format: int64 */
@@ -5803,12 +5803,12 @@ export interface components {
              */
             readonly $schema?: string;
             console: components["schemas"]["ConsoleResponse"];
-            essentials: components["schemas"]["GameResponse"][] | null;
-            genreBreakdown: components["schemas"]["GenreCount"][] | null;
-            hiddenGems: components["schemas"]["GameResponse"][] | null;
-            recentlyAdded: components["schemas"]["GameResponse"][] | null;
-            recentlyPlayed: components["schemas"]["GameResponse"][] | null;
-            topDevelopers: components["schemas"]["DeveloperSummary"][] | null;
+            essentials: components["schemas"]["GameResponse"][];
+            genreBreakdown: components["schemas"]["GenreCount"][];
+            hiddenGems: components["schemas"]["GameResponse"][];
+            recentlyAdded: components["schemas"]["GameResponse"][];
+            recentlyPlayed: components["schemas"]["GameResponse"][];
+            topDevelopers: components["schemas"]["DeveloperSummary"][];
         };
         Core: {
             /**
@@ -5844,7 +5844,7 @@ export interface components {
              * @example https://example.com/api/schemas/CoreCompatibilityResponse.json
              */
             readonly $schema?: string;
-            consoles: components["schemas"]["CoreCompatibilityEntry"][] | null;
+            consoles: components["schemas"]["CoreCompatibilityEntry"][];
         };
         CoverGalleryResponse: {
             /**
@@ -5853,7 +5853,7 @@ export interface components {
              * @example https://example.com/api/schemas/CoverGalleryResponse.json
              */
             readonly $schema?: string;
-            covers: components["schemas"]["CoverItem"][] | null;
+            covers: components["schemas"]["CoverItem"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -5948,7 +5948,7 @@ export interface components {
              * @example https://example.com/api/schemas/CultClassicsResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["CultClassicGame"][] | null;
+            games: components["schemas"]["CultClassicGame"][];
         };
         DecadesResponse: {
             /**
@@ -5958,7 +5958,7 @@ export interface components {
              */
             readonly $schema?: string;
             decade: string;
-            games: components["schemas"]["GameResponse"][] | null;
+            games: components["schemas"]["GameResponse"][];
             label: string;
         };
         DeletedStatusResponse: {
@@ -5992,20 +5992,20 @@ export interface components {
             /** Format: double */
             avgRating: number;
             companyInfo: components["schemas"]["CompanyInfo"];
-            consoles: string[] | null;
+            consoles: string[];
             /** Format: int64 */
             gameCount: number;
-            games: components["schemas"]["GameResponse"][] | null;
-            genreBreakdown: components["schemas"]["GenreCount"][] | null;
+            games: components["schemas"]["GameResponse"][];
+            genreBreakdown: components["schemas"]["GenreCount"][];
             heroUrl: string;
             name: string;
-            platformBreakdown: components["schemas"]["PlatformCount"][] | null;
+            platformBreakdown: components["schemas"]["PlatformCount"][];
             primaryGenre: string;
-            publishers: components["schemas"]["NameCount"][] | null;
+            publishers: components["schemas"]["NameCount"][];
             ratingDistribution: components["schemas"]["RatingDistribution"];
-            relatedDevelopers: components["schemas"]["RelatedDeveloper"][] | null;
-            timeline: components["schemas"]["TimelineEntry"][] | null;
-            topGames: components["schemas"]["GameResponse"][] | null;
+            relatedDevelopers: components["schemas"]["RelatedDeveloper"][];
+            timeline: components["schemas"]["TimelineEntry"][];
+            topGames: components["schemas"]["GameResponse"][];
             userStats: components["schemas"]["EntityUserStats"];
         };
         DeveloperGameResponse: {
@@ -6020,7 +6020,7 @@ export interface components {
              * @example https://example.com/api/schemas/DeveloperListResponse.json
              */
             readonly $schema?: string;
-            developers: components["schemas"]["DeveloperSummary"][] | null;
+            developers: components["schemas"]["DeveloperSummary"][];
         };
         DeveloperSpotlightResponse: {
             /**
@@ -6031,17 +6031,17 @@ export interface components {
             readonly $schema?: string;
             /** Format: double */
             avgRating: number;
-            consoles: string[] | null;
+            consoles: string[];
             /** Format: int64 */
             gameCount: number;
             heroUrl: string;
             name: string;
-            topGames: components["schemas"]["GameResponse"][] | null;
+            topGames: components["schemas"]["GameResponse"][];
         };
         DeveloperSummary: {
             /** Format: double */
             avgRating: number;
-            consoles: string[] | null;
+            consoles: string[];
             /** Format: int64 */
             gameCount: number;
             name: string;
@@ -6141,7 +6141,7 @@ export interface components {
              * @example https://example.com/api/schemas/EasyToCompleteResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["AchievementGameResponse"][] | null;
+            games: components["schemas"]["AchievementGameResponse"][];
         };
         EnrichmentStartedResponse: {
             /**
@@ -6202,7 +6202,7 @@ export interface components {
             type: string;
         };
         ExploreRowResponse: {
-            games: components["schemas"]["GameResponse"][] | null;
+            games: components["schemas"]["GameResponse"][];
             id: string;
             title: string;
         };
@@ -6213,7 +6213,7 @@ export interface components {
              * @example https://example.com/api/schemas/ExploreRowsResponse.json
              */
             readonly $schema?: string;
-            rows: components["schemas"]["ExploreRowResponse"][] | null;
+            rows: components["schemas"]["ExploreRowResponse"][];
         };
         ExplorerBadge: {
             description: string;
@@ -6233,7 +6233,7 @@ export interface components {
              * @example https://example.com/api/schemas/ExplorerBadgesResponse.json
              */
             readonly $schema?: string;
-            badges: components["schemas"]["ExplorerBadge"][] | null;
+            badges: components["schemas"]["ExplorerBadge"][];
         };
         FeaturedGameResponse: {
             consoleAbbreviation: string;
@@ -6268,10 +6268,10 @@ export interface components {
              * @example https://example.com/api/schemas/ForYouResponse.json
              */
             readonly $schema?: string;
-            rows: components["schemas"]["ForYouRowResponse"][] | null;
+            rows: components["schemas"]["ForYouRowResponse"][];
         };
         ForYouRowResponse: {
-            games: components["schemas"]["GameResponse"][] | null;
+            games: components["schemas"]["GameResponse"][];
             genre: string;
             sourceGame: components["schemas"]["GameResponse"];
             title: string;
@@ -6291,8 +6291,8 @@ export interface components {
              * @example https://example.com/api/schemas/FranchiseDetailResponse.json
              */
             readonly $schema?: string;
-            consoles: components["schemas"]["SeriesConsoleInfo"][] | null;
-            games: components["schemas"]["SeriesGameResponse"][] | null;
+            consoles: components["schemas"]["SeriesConsoleInfo"][];
+            games: components["schemas"]["SeriesGameResponse"][];
             heroUrl: string;
             id: string;
             /** Format: int64 */
@@ -6324,7 +6324,7 @@ export interface components {
              * @example https://example.com/api/schemas/FreshChallengesResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["FreshChallengeGame"][] | null;
+            games: components["schemas"]["FreshChallengeGame"][];
         };
         GameAchievementProgressResponse: {
             /**
@@ -6333,7 +6333,7 @@ export interface components {
              * @example https://example.com/api/schemas/GameAchievementProgressResponse.json
              */
             readonly $schema?: string;
-            progress: components["schemas"]["RAProgressEntry"][] | null;
+            progress: components["schemas"]["RAProgressEntry"][];
             /** Format: int64 */
             raGameId: number;
         };
@@ -6345,7 +6345,7 @@ export interface components {
              */
             readonly $schema?: string;
             /** @description Achievement definitions for this game (empty when unknown). */
-            achievements: components["schemas"]["Achievement"][] | null;
+            achievements: components["schemas"]["Achievement"][];
             /**
              * Format: int64
              * @description RetroAchievements game ID (0 when unknown).
@@ -6397,7 +6397,7 @@ export interface components {
              */
             readonly $schema?: string;
             active: string;
-            covers: components["schemas"]["CoverOption"][] | null;
+            covers: components["schemas"]["CoverOption"][];
         };
         GameFranchiseResponse: {
             id: string;
@@ -6415,7 +6415,7 @@ export interface components {
              */
             readonly $schema?: string;
             activeUrl: string;
-            heroes: components["schemas"]["HeroOption"][] | null;
+            heroes: components["schemas"]["HeroOption"][];
         };
         GameKeyMappingResponse: {
             /**
@@ -6458,7 +6458,7 @@ export interface components {
              */
             readonly $schema?: string;
             achievementsWarning: string;
-            ageRatings: components["schemas"]["AgeRatingResponse"][] | null;
+            ageRatings: components["schemas"]["AgeRatingResponse"][];
             /** Format: double */
             averageRating: number;
             biosStatus: string;
@@ -6474,7 +6474,7 @@ export interface components {
             developer: string;
             /** Format: int64 */
             discCount: number;
-            discs: components["schemas"]["DiscResponse"][] | null;
+            discs: components["schemas"]["DiscResponse"][];
             fileName: string;
             /** Format: int64 */
             fileSize: number;
@@ -6492,7 +6492,7 @@ export interface components {
             isFavorite: boolean;
             isInPlayLater: boolean;
             isPreRelease: boolean;
-            languageSupports: components["schemas"]["LanguageSupportResponse"][] | null;
+            languageSupports: components["schemas"]["LanguageSupportResponse"][];
             /** Format: date-time */
             lastPlayedAt: string | null;
             logoUrl: string;
@@ -6506,13 +6506,13 @@ export interface components {
             ratingCount: number;
             region: string;
             releaseDate: string;
-            releaseDates: components["schemas"]["ReleaseDateResponse"][] | null;
+            releaseDates: components["schemas"]["ReleaseDateResponse"][];
             revision: string;
-            romHacks: components["schemas"]["RomHackGameResponse"][] | null;
+            romHacks: components["schemas"]["RomHackGameResponse"][];
             /** Format: int64 */
             scrapeAttempts: number;
             scraperId: string;
-            screenshotUrls: string[] | null;
+            screenshotUrls: string[];
             storyline: string;
             tags: string;
             /** Format: int64 */
@@ -6534,10 +6534,10 @@ export interface components {
             userRating: number | null;
             /** Format: int64 */
             variantCount: number;
-            variants: components["schemas"]["VariantResponse"][] | null;
+            variants: components["schemas"]["VariantResponse"][];
             verificationStatus: string;
             verificationTag: string;
-            videos: components["schemas"]["VideoResponse"][] | null;
+            videos: components["schemas"]["VideoResponse"][];
         };
         GameSeriesResponse: {
             id: string;
@@ -6565,10 +6565,10 @@ export interface components {
             lastPlayedAt: string | null;
             lastPlayedBy: string | null;
             lastPlayedByUsername: string | null;
-            memberAvatars: string[] | null;
+            memberAvatars: string[];
             /** Format: int64 */
             memberCount: number;
-            memberUsernames: string[] | null;
+            memberUsernames: string[];
             name: string;
             ownerId: string;
             ownerUsername: string;
@@ -6590,7 +6590,7 @@ export interface components {
             readonly $schema?: string;
             /** Format: int64 */
             averagePlayTime: number;
-            topPlayers: components["schemas"]["GameStatsTopPlayer"][] | null;
+            topPlayers: components["schemas"]["GameStatsTopPlayer"][];
             /** Format: int64 */
             totalPlayTime: number;
             /** Format: int64 */
@@ -6615,7 +6615,7 @@ export interface components {
              * @example https://example.com/api/schemas/HardestGamesResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["AchievementGameResponse"][] | null;
+            games: components["schemas"]["AchievementGameResponse"][];
         };
         HardwareMakerResponse: {
             code: string;
@@ -6755,7 +6755,7 @@ export interface components {
              * @example https://example.com/api/schemas/ListMyNetplayInvitesResponse.json
              */
             readonly $schema?: string;
-            data: components["schemas"]["NetplayInviteResponse"][] | null;
+            data: components["schemas"]["NetplayInviteResponse"][];
             /** Format: int64 */
             total: number;
         };
@@ -6784,7 +6784,7 @@ export interface components {
             code: string;
             /** Format: int64 */
             consoleCount: number;
-            consoles: components["schemas"]["ConsoleResponse"][] | null;
+            consoles: components["schemas"]["ConsoleResponse"][];
             name: string;
         };
         MediaTypeCategoryResponse: {
@@ -6813,13 +6813,13 @@ export interface components {
              * @example https://example.com/api/schemas/MetadataMatchesResponse.json
              */
             readonly $schema?: string;
-            incomplete: components["schemas"]["GameResponse"][] | null;
-            unscraped: components["schemas"]["GameResponse"][] | null;
-            unverified: components["schemas"]["GameResponse"][] | null;
+            incomplete: components["schemas"]["GameResponse"][];
+            unscraped: components["schemas"]["GameResponse"][];
+            unverified: components["schemas"]["GameResponse"][];
         };
         MoodResponse: {
             description: string;
-            gradient: string[] | null;
+            gradient: string[];
             icon: string;
             id: string;
             name: string;
@@ -6831,7 +6831,7 @@ export interface components {
              * @example https://example.com/api/schemas/MostActivePlayersResponse.json
              */
             readonly $schema?: string;
-            players: components["schemas"]["ActivePlayerEntry"][] | null;
+            players: components["schemas"]["ActivePlayerEntry"][];
         };
         MostPlayedEntry: {
             game: components["schemas"]["GameResponse"];
@@ -6847,7 +6847,7 @@ export interface components {
              * @example https://example.com/api/schemas/MostPlayedResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["MostPlayedEntry"][] | null;
+            games: components["schemas"]["MostPlayedEntry"][];
         };
         NameCount: {
             /** Format: int64 */
@@ -6931,7 +6931,7 @@ export interface components {
              */
             readonly $schema?: string;
             date: string;
-            games: components["schemas"]["GameResponse"][] | null;
+            games: components["schemas"]["GameResponse"][];
         };
         OnlineUserGameResponse: {
             consoleName: string;
@@ -6952,7 +6952,7 @@ export interface components {
              * @example https://example.com/api/schemas/OnlineUsersResponse.json
              */
             readonly $schema?: string;
-            users: components["schemas"]["OnlineUserResponse"][] | null;
+            users: components["schemas"]["OnlineUserResponse"][];
         };
         PaginatedResponseActivityEventResponse: {
             /**
@@ -6961,7 +6961,7 @@ export interface components {
              * @example https://example.com/api/schemas/PaginatedResponseActivityEventResponse.json
              */
             readonly $schema?: string;
-            data: components["schemas"]["ActivityEventResponse"][] | null;
+            data: components["schemas"]["ActivityEventResponse"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -6976,7 +6976,7 @@ export interface components {
              * @example https://example.com/api/schemas/PaginatedResponseChallengeLeaderboardEntry.json
              */
             readonly $schema?: string;
-            data: components["schemas"]["ChallengeLeaderboardEntry"][] | null;
+            data: components["schemas"]["ChallengeLeaderboardEntry"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -6991,7 +6991,7 @@ export interface components {
              * @example https://example.com/api/schemas/PaginatedResponseChallengeResponse.json
              */
             readonly $schema?: string;
-            data: components["schemas"]["ChallengeResponse"][] | null;
+            data: components["schemas"]["ChallengeResponse"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -7006,7 +7006,7 @@ export interface components {
              * @example https://example.com/api/schemas/PaginatedResponseCollectionResponse.json
              */
             readonly $schema?: string;
-            data: components["schemas"]["CollectionResponse"][] | null;
+            data: components["schemas"]["CollectionResponse"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -7021,7 +7021,7 @@ export interface components {
              * @example https://example.com/api/schemas/PaginatedResponseGameRatingResponse.json
              */
             readonly $schema?: string;
-            data: components["schemas"]["GameRatingResponse"][] | null;
+            data: components["schemas"]["GameRatingResponse"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -7036,7 +7036,7 @@ export interface components {
              * @example https://example.com/api/schemas/PaginatedResponseGameResponse.json
              */
             readonly $schema?: string;
-            data: components["schemas"]["GameResponse"][] | null;
+            data: components["schemas"]["GameResponse"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -7051,7 +7051,7 @@ export interface components {
              * @example https://example.com/api/schemas/PaginatedResponseNetplaySessionResponse.json
              */
             readonly $schema?: string;
-            data: components["schemas"]["NetplaySessionResponse"][] | null;
+            data: components["schemas"]["NetplaySessionResponse"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -7066,7 +7066,7 @@ export interface components {
              * @example https://example.com/api/schemas/PaginatedResponseSharedSaveResponse.json
              */
             readonly $schema?: string;
-            data: components["schemas"]["SharedSaveResponse"][] | null;
+            data: components["schemas"]["SharedSaveResponse"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -7081,7 +7081,7 @@ export interface components {
              * @example https://example.com/api/schemas/PaginatedResponseUserSearchResult.json
              */
             readonly $schema?: string;
-            data: components["schemas"]["UserSearchResult"][] | null;
+            data: components["schemas"]["UserSearchResult"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -7124,7 +7124,7 @@ export interface components {
              * @example https://example.com/api/schemas/PlayersLikeYouResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["GameResponse"][] | null;
+            games: components["schemas"]["GameResponse"][];
             /** Format: int64 */
             similarUsersCount: number;
         };
@@ -7149,15 +7149,15 @@ export interface components {
             readonly $schema?: string;
             avatarUrl: string;
             currentGame: components["schemas"]["OnlineUserGameResponse"];
-            favoriteGames: components["schemas"]["PublicProfileGame"][] | null;
+            favoriteGames: components["schemas"]["PublicProfileGame"][];
             /** Format: int64 */
             gamesPlayed: number;
             id: string;
             isOnline: boolean;
             /** Format: date-time */
             memberSince: string;
-            recentGames: components["schemas"]["PublicProfileGame"][] | null;
-            topGames: components["schemas"]["PublicProfileGame"][] | null;
+            recentGames: components["schemas"]["PublicProfileGame"][];
+            topGames: components["schemas"]["PublicProfileGame"][];
             /** Format: int64 */
             totalPlayTime: number;
             username: string;
@@ -7173,20 +7173,20 @@ export interface components {
             /** Format: double */
             avgRating: number;
             companyInfo: components["schemas"]["CompanyInfo"];
-            consoles: string[] | null;
-            developers: components["schemas"]["NameCount"][] | null;
+            consoles: string[];
+            developers: components["schemas"]["NameCount"][];
             /** Format: int64 */
             gameCount: number;
-            games: components["schemas"]["GameResponse"][] | null;
-            genreBreakdown: components["schemas"]["GenreCount"][] | null;
+            games: components["schemas"]["GameResponse"][];
+            genreBreakdown: components["schemas"]["GenreCount"][];
             heroUrl: string;
             name: string;
-            platformBreakdown: components["schemas"]["PlatformCount"][] | null;
+            platformBreakdown: components["schemas"]["PlatformCount"][];
             primaryGenre: string;
             ratingDistribution: components["schemas"]["RatingDistribution"];
-            relatedPublishers: components["schemas"]["RelatedPublisher"][] | null;
-            timeline: components["schemas"]["TimelineEntry"][] | null;
-            topGames: components["schemas"]["GameResponse"][] | null;
+            relatedPublishers: components["schemas"]["RelatedPublisher"][];
+            timeline: components["schemas"]["TimelineEntry"][];
+            topGames: components["schemas"]["GameResponse"][];
             userStats: components["schemas"]["EntityUserStats"];
         };
         RALeaderboardEntryResponse: {
@@ -7326,7 +7326,7 @@ export interface components {
              * @example https://example.com/api/schemas/RecentAchievementsResponse.json
              */
             readonly $schema?: string;
-            achievements: components["schemas"]["RARecentAchievementResponse"][] | null;
+            achievements: components["schemas"]["RARecentAchievementResponse"][];
         };
         RecentReviewItem: {
             game: components["schemas"]["GameResponse"];
@@ -7344,7 +7344,7 @@ export interface components {
              * @example https://example.com/api/schemas/RecentlyReviewedResponse.json
              */
             readonly $schema?: string;
-            reviews: components["schemas"]["RecentReviewItem"][] | null;
+            reviews: components["schemas"]["RecentReviewItem"][];
         };
         RefreshAchievementsResponse: {
             /**
@@ -7371,13 +7371,13 @@ export interface components {
             /** Format: int64 */
             gameCount: number;
             name: string;
-            sharedPublishers: string[] | null;
+            sharedPublishers: string[];
         };
         RelatedPublisher: {
             /** Format: int64 */
             gameCount: number;
             name: string;
-            sharedDevelopers: string[] | null;
+            sharedDevelopers: string[];
         };
         ReleaseDateResponse: {
             date: string;
@@ -7400,7 +7400,7 @@ export interface components {
              * @example https://example.com/api/schemas/ReorderPlayLaterRequest.json
              */
             readonly $schema?: string;
-            gameIds: string[] | null;
+            gameIds: string[];
         };
         ReplaceROMResponse: {
             /**
@@ -7526,7 +7526,7 @@ export interface components {
              * @example https://example.com/api/schemas/ScrapeStatusCountsResponse.json
              */
             readonly $schema?: string;
-            sources: components["schemas"]["ScraperSourceResultResponse"][] | null;
+            sources: components["schemas"]["ScraperSourceResultResponse"][];
         };
         ScrapeStatusResponse: {
             /**
@@ -7576,7 +7576,7 @@ export interface components {
             readonly $schema?: string;
             /** Format: int64 */
             page: number;
-            screenshots: components["schemas"]["ScreenshotItem"][] | null;
+            screenshots: components["schemas"]["ScreenshotItem"][];
             /** Format: int64 */
             totalCount: number;
             /** Format: int64 */
@@ -7591,32 +7591,32 @@ export interface components {
             url: string;
         };
         SearchCategoryResultSearchCollectionResult: {
-            results: components["schemas"]["SearchCollectionResult"][] | null;
+            results: components["schemas"]["SearchCollectionResult"][];
             /** Format: int64 */
             total: number;
         };
         SearchCategoryResultSearchCompanyResult: {
-            results: components["schemas"]["SearchCompanyResult"][] | null;
+            results: components["schemas"]["SearchCompanyResult"][];
             /** Format: int64 */
             total: number;
         };
         SearchCategoryResultSearchConsoleResult: {
-            results: components["schemas"]["SearchConsoleResult"][] | null;
+            results: components["schemas"]["SearchConsoleResult"][];
             /** Format: int64 */
             total: number;
         };
         SearchCategoryResultSearchFranchiseResult: {
-            results: components["schemas"]["SearchFranchiseResult"][] | null;
+            results: components["schemas"]["SearchFranchiseResult"][];
             /** Format: int64 */
             total: number;
         };
         SearchCategoryResultSearchGameResult: {
-            results: components["schemas"]["SearchGameResult"][] | null;
+            results: components["schemas"]["SearchGameResult"][];
             /** Format: int64 */
             total: number;
         };
         SearchCategoryResultSearchSeriesResult: {
-            results: components["schemas"]["SearchSeriesResult"][] | null;
+            results: components["schemas"]["SearchSeriesResult"][];
             /** Format: int64 */
             total: number;
         };
@@ -7699,8 +7699,8 @@ export interface components {
              * @example https://example.com/api/schemas/SeriesDetailResponse.json
              */
             readonly $schema?: string;
-            consoles: components["schemas"]["SeriesConsoleInfo"][] | null;
-            games: components["schemas"]["SeriesGameResponse"][] | null;
+            consoles: components["schemas"]["SeriesConsoleInfo"][];
+            games: components["schemas"]["SeriesGameResponse"][];
             heroUrl: string;
             id: string;
             /** Format: int64 */
@@ -7744,7 +7744,7 @@ export interface components {
              */
             readonly $schema?: string;
             cheatsEnabled: boolean;
-            enabledIndices: number[] | null;
+            enabledIndices: number[];
         };
         SessionSaveData: {
             /**
@@ -7836,7 +7836,7 @@ export interface components {
              */
             readonly $schema?: string;
             /** @description Ordered list of server health checks. */
-            checks: components["schemas"]["DiagnosticCheck"][] | null;
+            checks: components["schemas"]["DiagnosticCheck"][];
         };
         SetupStatusResponse: {
             /**
@@ -7896,7 +7896,7 @@ export interface components {
             id: string;
             /** Format: int64 */
             memberCount: number;
-            members: components["schemas"]["SharedSessionMemberResponse"][] | null;
+            members: components["schemas"]["SharedSessionMemberResponse"][];
             name: string;
             ownerId: string;
             ownerUsername: string;
@@ -8077,7 +8077,7 @@ export interface components {
             originalFileName: string;
             /** Format: int64 */
             players: number;
-            possibleConsoles: components["schemas"]["PossibleConsoleResponse"][] | null;
+            possibleConsoles: components["schemas"]["PossibleConsoleResponse"][];
             publisher: string;
             releaseDate: string;
             status: string;
@@ -8110,7 +8110,7 @@ export interface components {
              * @example https://example.com/api/schemas/StorageUsageResponse.json
              */
             readonly $schema?: string;
-            byConsole: components["schemas"]["SessionStorageConsoleBreakdown"][] | null;
+            byConsole: components["schemas"]["SessionStorageConsoleBreakdown"][];
             /** Format: int64 */
             quotaBytes: number;
             /** Format: int64 */
@@ -8158,7 +8158,7 @@ export interface components {
              * @example https://example.com/api/schemas/SystemEventTypesResponse.json
              */
             readonly $schema?: string;
-            types: components["schemas"]["SystemEventTypeInfo"][] | null;
+            types: components["schemas"]["SystemEventTypeInfo"][];
         };
         SystemEventsListResponse: {
             /**
@@ -8167,7 +8167,7 @@ export interface components {
              * @example https://example.com/api/schemas/SystemEventsListResponse.json
              */
             readonly $schema?: string;
-            data: components["schemas"]["SystemEventResponse"][] | null;
+            data: components["schemas"]["SystemEventResponse"][];
             /** Format: int64 */
             page: number;
             /** Format: int64 */
@@ -8199,9 +8199,9 @@ export interface components {
              * @example https://example.com/api/schemas/TasteProfileResponse.json
              */
             readonly $schema?: string;
-            genres: components["schemas"]["TasteProfileGenre"][] | null;
-            themes: components["schemas"]["TasteProfileTheme"][] | null;
-            topConsoles: components["schemas"]["TasteProfileConsole"][] | null;
+            genres: components["schemas"]["TasteProfileGenre"][];
+            themes: components["schemas"]["TasteProfileTheme"][];
+            topConsoles: components["schemas"]["TasteProfileConsole"][];
             /** Format: int64 */
             totalPlayTime: number;
         };
@@ -8241,7 +8241,7 @@ export interface components {
             name: string;
         };
         TimelineEntry: {
-            games: components["schemas"]["TimelineGame"][] | null;
+            games: components["schemas"]["TimelineGame"][];
             /** Format: int64 */
             year: number;
         };
@@ -8285,7 +8285,7 @@ export interface components {
              * @example https://example.com/api/schemas/TrendingResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["TrendingGameResponse"][] | null;
+            games: components["schemas"]["TrendingGameResponse"][];
         };
         UnlockedAchievementsResponse: {
             /**
@@ -8294,7 +8294,7 @@ export interface components {
              * @example https://example.com/api/schemas/UnlockedAchievementsResponse.json
              */
             readonly $schema?: string;
-            achievements: components["schemas"]["RAUnlockedAchievementResponse"][] | null;
+            achievements: components["schemas"]["RAUnlockedAchievementResponse"][];
         };
         UpdateChallengeRequest: {
             /**
@@ -8456,7 +8456,7 @@ export interface components {
              */
             readonly $schema?: string;
             cheatsEnabled: boolean;
-            enabledIndices: number[] | null;
+            enabledIndices: number[];
         };
         UpdateSessionPlayTimeRequest: {
             /**
@@ -8536,7 +8536,7 @@ export interface components {
                 [key: string]: string;
             };
             defaultSecondScreenPage: string;
-            preferredRegions: string[] | null;
+            preferredRegions: string[];
             raHardcoreEnabled: boolean;
             raLinked: boolean;
             raUsername: string;
@@ -8619,7 +8619,7 @@ export interface components {
              * @example https://example.com/api/schemas/WizardResponse.json
              */
             readonly $schema?: string;
-            steps: components["schemas"]["WizardStep"][] | null;
+            steps: components["schemas"]["WizardStep"][];
         };
         WizardResultsResponse: {
             /**
@@ -8628,11 +8628,11 @@ export interface components {
              * @example https://example.com/api/schemas/WizardResultsResponse.json
              */
             readonly $schema?: string;
-            games: components["schemas"]["GameResponse"][] | null;
+            games: components["schemas"]["GameResponse"][];
             title: string;
         };
         WizardStep: {
-            options: components["schemas"]["WizardOption"][] | null;
+            options: components["schemas"]["WizardOption"][];
             /** Format: int64 */
             step: number;
             title: string;
@@ -9210,7 +9210,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["IGDBSearchResult"][] | null;
+                    "application/json": components["schemas"]["IGDBSearchResult"][];
                 };
             };
             /** @description Error */
@@ -9802,7 +9802,7 @@ export interface operations {
                 /** @description Set to 'true' to include dismissed events. */
                 dismissed?: string;
                 /** @description Filter by one or more event types (repeatable). */
-                eventType?: string[] | null;
+                eventType?: string[];
                 /** @description Case-insensitive username substring filter. */
                 username?: string;
                 /** @description IP address prefix filter (IPv4/IPv6). */
@@ -9851,7 +9851,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SystemEventCategoryResponse"][] | null;
+                    "application/json": components["schemas"]["SystemEventCategoryResponse"][];
                 };
             };
             /** @description Error */
@@ -9973,7 +9973,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["StagedUploadResponse"][] | null;
+                    "application/json": components["schemas"]["StagedUploadResponse"][];
                 };
             };
             /** @description Error */
@@ -10008,7 +10008,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["StagedUploadResponse"][] | null;
+                    "application/json": components["schemas"]["StagedUploadResponse"][];
                 };
             };
             /** @description Error */
@@ -10130,7 +10130,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["StagedUploadResponse"][] | null;
+                    "application/json": components["schemas"]["StagedUploadResponse"][];
                 };
             };
             /** @description Error */
@@ -10320,7 +10320,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UserResponse"][] | null;
+                    "application/json": components["schemas"]["UserResponse"][];
                 };
             };
             /** @description Error */
@@ -10382,7 +10382,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DeletedUserResponse"][] | null;
+                    "application/json": components["schemas"]["DeletedUserResponse"][];
                 };
             };
             /** @description Error */
@@ -10482,7 +10482,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DeviceResponse"][] | null;
+                    "application/json": components["schemas"]["DeviceResponse"][];
                 };
             };
             /** @description Error */
@@ -11098,7 +11098,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ChallengeAttemptResponse"][] | null;
+                    "application/json": components["schemas"]["ChallengeAttemptResponse"][];
                 };
             };
             /** @description Error */
@@ -11599,7 +11599,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ConsoleResponse"][] | null;
+                    "application/json": components["schemas"]["ConsoleResponse"][];
                 };
             };
             /** @description Error */
@@ -11802,7 +11802,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["LongestGameResponse"][] | null;
+                    "application/json": components["schemas"]["LongestGameResponse"][];
                 };
             };
             /** @description Error */
@@ -11834,7 +11834,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TopListGameResponse"][] | null;
+                    "application/json": components["schemas"]["TopListGameResponse"][];
                 };
             };
             /** @description Error */
@@ -11866,7 +11866,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TopListGameResponse"][] | null;
+                    "application/json": components["schemas"]["TopListGameResponse"][];
                 };
             };
             /** @description Error */
@@ -11898,7 +11898,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TopRatedGameResponse"][] | null;
+                    "application/json": components["schemas"]["TopRatedGameResponse"][];
                 };
             };
             /** @description Error */
@@ -11927,7 +11927,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["Core"][] | null;
+                    "application/json": components["schemas"]["Core"][];
                 };
             };
             /** @description Error */
@@ -12497,7 +12497,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FeaturedGameResponse"][] | null;
+                    "application/json": components["schemas"]["FeaturedGameResponse"][];
                 };
             };
             /** @description Error */
@@ -12620,7 +12620,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GameResponse"][] | null;
+                    "application/json": components["schemas"]["GameResponse"][];
                 };
             };
             /** @description Error */
@@ -12650,7 +12650,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["MoodResponse"][] | null;
+                    "application/json": components["schemas"]["MoodResponse"][];
                 };
             };
             /** @description Error */
@@ -12872,7 +12872,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FeaturedSeriesResponse"][] | null;
+                    "application/json": components["schemas"]["FeaturedSeriesResponse"][];
                 };
             };
             /** @description Error */
@@ -13065,7 +13065,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["FranchiseResponse"][] | null;
+                    "application/json": components["schemas"]["FranchiseResponse"][];
                 };
             };
             /** @description Error */
@@ -13483,7 +13483,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GameCheatResponse"][] | null;
+                    "application/json": components["schemas"]["GameCheatResponse"][];
                 };
             };
             /** @description Error */
@@ -13547,7 +13547,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DeveloperGameResponse"][] | null;
+                    "application/json": components["schemas"]["DeveloperGameResponse"][];
                 };
             };
             /** @description Error */
@@ -13684,7 +13684,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GameFranchiseResponse"][] | null;
+                    "application/json": components["schemas"]["GameFranchiseResponse"][];
                 };
             };
             /** @description Error */
@@ -13985,7 +13985,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GameSeriesResponse"][] | null;
+                    "application/json": components["schemas"]["GameSeriesResponse"][];
                 };
             };
             /** @description Error */
@@ -14017,7 +14017,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GameSessionResponse"][] | null;
+                    "application/json": components["schemas"]["GameSessionResponse"][];
                 };
             };
             /** @description Error */
@@ -14270,7 +14270,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SharedSessionResponse"][] | null;
+                    "application/json": components["schemas"]["SharedSessionResponse"][];
                 };
             };
             /** @description Error */
@@ -14302,7 +14302,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SimilarGameResponse"][] | null;
+                    "application/json": components["schemas"]["SimilarGameResponse"][];
                 };
             };
             /** @description Error */
@@ -14395,7 +14395,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["KeywordResponse"][] | null;
+                    "application/json": components["schemas"]["KeywordResponse"][];
                 };
             };
             /** @description Error */
@@ -14461,7 +14461,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["MakerDetailResponse"][] | null;
+                    "application/json": components["schemas"]["MakerDetailResponse"][];
                 };
             };
             /** @description Error */
@@ -14811,7 +14811,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["NetplayInviteResponse"][] | null;
+                    "application/json": components["schemas"]["NetplayInviteResponse"][];
                 };
             };
             /** @description Error */
@@ -14978,7 +14978,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SeriesListResponse"][] | null;
+                    "application/json": components["schemas"]["SeriesListResponse"][];
                 };
             };
             /** @description Error */
@@ -15314,7 +15314,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SessionSaveResponse"][] | null;
+                    "application/json": components["schemas"]["SessionSaveResponse"][];
                 };
             };
             /** @description Error */
@@ -15595,7 +15595,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SessionSaveResponse"][] | null;
+                    "application/json": components["schemas"]["SessionSaveResponse"][];
                 };
             };
             /** @description Error */
@@ -15829,7 +15829,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SharedSessionResponse"][] | null;
+                    "application/json": components["schemas"]["SharedSessionResponse"][];
                 };
             };
             /** @description Error */
@@ -16160,7 +16160,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SharedSessionSaveResponse"][] | null;
+                    "application/json": components["schemas"]["SharedSessionSaveResponse"][];
                 };
             };
             /** @description Error */
@@ -16574,7 +16574,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ThemeResponse"][] | null;
+                    "application/json": components["schemas"]["ThemeResponse"][];
                 };
             };
             /** @description Error */
@@ -16640,7 +16640,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["LongestGameResponse"][] | null;
+                    "application/json": components["schemas"]["LongestGameResponse"][];
                 };
             };
             /** @description Error */
@@ -16669,7 +16669,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TopListGameResponse"][] | null;
+                    "application/json": components["schemas"]["TopListGameResponse"][];
                 };
             };
             /** @description Error */
@@ -16698,7 +16698,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TopListGameResponse"][] | null;
+                    "application/json": components["schemas"]["TopListGameResponse"][];
                 };
             };
             /** @description Error */
@@ -16727,7 +16727,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["TopRatedGameResponse"][] | null;
+                    "application/json": components["schemas"]["TopRatedGameResponse"][];
                 };
             };
             /** @description Error */
@@ -16785,7 +16785,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ShowcaseEntryResponse"][] | null;
+                    "application/json": components["schemas"]["ShowcaseEntryResponse"][];
                 };
             };
             /** @description Error */
@@ -16808,7 +16808,7 @@ export interface operations {
         };
         requestBody: {
             content: {
-                "application/json": components["schemas"]["ShowcaseEntryInput"][] | null;
+                "application/json": components["schemas"]["ShowcaseEntryInput"][];
             };
         };
         responses: {
@@ -16818,7 +16818,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ShowcaseEntryResponse"][] | null;
+                    "application/json": components["schemas"]["ShowcaseEntryResponse"][];
                 };
             };
             /** @description Error */
@@ -16939,7 +16939,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["DeviceResponse"][] | null;
+                    "application/json": components["schemas"]["DeviceResponse"][];
                 };
             };
             /** @description Error */
@@ -17166,7 +17166,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GameResponse"][] | null;
+                    "application/json": components["schemas"]["GameResponse"][];
                 };
             };
             /** @description Error */
@@ -17395,7 +17395,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HeatmapEntry"][] | null;
+                    "application/json": components["schemas"]["HeatmapEntry"][];
                 };
             };
             /** @description Error */
@@ -17424,7 +17424,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GameResponse"][] | null;
+                    "application/json": components["schemas"]["GameResponse"][];
                 };
             };
             /** @description Error */
@@ -17550,7 +17550,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["PlayStatsEntry"][] | null;
+                    "application/json": components["schemas"]["PlayStatsEntry"][];
                 };
             };
             /** @description Error */
@@ -17858,7 +17858,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["GameResponse"][] | null;
+                    "application/json": components["schemas"]["GameResponse"][];
                 };
             };
             /** @description Error */
@@ -17887,7 +17887,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SavedSearchResponse"][] | null;
+                    "application/json": components["schemas"]["SavedSearchResponse"][];
                 };
             };
             /** @description Error */
@@ -18010,7 +18010,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["SharedSessionInviteResponse"][] | null;
+                    "application/json": components["schemas"]["SharedSessionInviteResponse"][];
                 };
             };
             /** @description Error */
@@ -18219,7 +18219,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["UserSearchResult"][] | null;
+                    "application/json": components["schemas"]["UserSearchResult"][];
                 };
             };
             /** @description Error */
@@ -18287,7 +18287,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["ShowcaseEntryResponse"][] | null;
+                    "application/json": components["schemas"]["ShowcaseEntryResponse"][];
                 };
             };
             /** @description Error */
@@ -18319,7 +18319,7 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
-                    "application/json": components["schemas"]["HeatmapEntry"][] | null;
+                    "application/json": components["schemas"]["HeatmapEntry"][];
                 };
             };
             /** @description Error */

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -89,10 +89,7 @@
             "items": {
               "$ref": "#/components/schemas/RALeaderboardEntryResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "raGameId": {
             "format": "int64",
@@ -139,10 +136,7 @@
             "items": {
               "$ref": "#/components/schemas/RATimelineEntryResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "totalAchievements": {
             "format": "int64",
@@ -189,10 +183,7 @@
             "items": {
               "$ref": "#/components/schemas/ExploreChallengeResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -238,10 +229,7 @@
             "items": {
               "$ref": "#/components/schemas/ActiveNowItem"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -586,10 +574,7 @@
             "items": {
               "$ref": "#/components/schemas/AlmostDoneGame"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -613,10 +598,7 @@
             "items": {
               "$ref": "#/components/schemas/AnniversaryItem"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -681,10 +663,7 @@
             "items": {
               "$ref": "#/components/schemas/ArtworkItem"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -996,10 +975,7 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "year": {
             "format": "int64",
@@ -1121,19 +1097,13 @@
             "items": {
               "$ref": "#/components/schemas/ConsoleBiosStatus"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "files": {
             "items": {
               "$ref": "#/components/schemas/BiosFileResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -1505,10 +1475,7 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "id": {
             "type": "string"
@@ -1648,10 +1615,7 @@
             "items": {
               "$ref": "#/components/schemas/CommunityTopGame"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -1766,10 +1730,7 @@
             "items": {
               "$ref": "#/components/schemas/CompletionistConsole"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "overallPct": {
             "format": "int64",
@@ -1808,10 +1769,7 @@
             "items": {
               "$ref": "#/components/schemas/ConsoleFileStatus"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "optionalPresent": {
             "format": "int64",
@@ -1931,10 +1889,7 @@
             "items": {
               "$ref": "#/components/schemas/ConsoleHighlight"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -1994,10 +1949,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "gameCount": {
             "format": "int64",
@@ -2106,55 +2058,37 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "genreBreakdown": {
             "items": {
               "$ref": "#/components/schemas/GenreCount"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "hiddenGems": {
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "recentlyAdded": {
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "recentlyPlayed": {
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "topDevelopers": {
             "items": {
               "$ref": "#/components/schemas/DeveloperSummary"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -2269,10 +2203,7 @@
             "items": {
               "$ref": "#/components/schemas/CoreCompatibilityEntry"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -2296,10 +2227,7 @@
             "items": {
               "$ref": "#/components/schemas/CoverItem"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -2541,10 +2469,7 @@
             "items": {
               "$ref": "#/components/schemas/CultClassicGame"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -2571,10 +2496,7 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "label": {
             "type": "string"
@@ -2672,10 +2594,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "gameCount": {
             "format": "int64",
@@ -2685,19 +2604,13 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "genreBreakdown": {
             "items": {
               "$ref": "#/components/schemas/GenreCount"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "heroUrl": {
             "type": "string"
@@ -2709,10 +2622,7 @@
             "items": {
               "$ref": "#/components/schemas/PlatformCount"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "primaryGenre": {
             "type": "string"
@@ -2721,10 +2631,7 @@
             "items": {
               "$ref": "#/components/schemas/NameCount"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "ratingDistribution": {
             "$ref": "#/components/schemas/RatingDistribution"
@@ -2733,28 +2640,19 @@
             "items": {
               "$ref": "#/components/schemas/RelatedDeveloper"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "timeline": {
             "items": {
               "$ref": "#/components/schemas/TimelineEntry"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "topGames": {
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "userStats": {
             "$ref": "#/components/schemas/EntityUserStats"
@@ -2817,10 +2715,7 @@
             "items": {
               "$ref": "#/components/schemas/DeveloperSummary"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -2848,10 +2743,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "gameCount": {
             "format": "int64",
@@ -2867,10 +2759,7 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -2894,10 +2783,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "gameCount": {
             "format": "int64",
@@ -3163,10 +3049,7 @@
             "items": {
               "$ref": "#/components/schemas/AchievementGameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -3350,10 +3233,7 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "id": {
             "type": "string"
@@ -3385,10 +3265,7 @@
             "items": {
               "$ref": "#/components/schemas/ExploreRowResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -3450,10 +3327,7 @@
             "items": {
               "$ref": "#/components/schemas/ExplorerBadge"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -3569,10 +3443,7 @@
             "items": {
               "$ref": "#/components/schemas/ForYouRowResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -3587,10 +3458,7 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "genre": {
             "type": "string"
@@ -3655,19 +3523,13 @@
             "items": {
               "$ref": "#/components/schemas/SeriesConsoleInfo"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "games": {
             "items": {
               "$ref": "#/components/schemas/SeriesGameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "heroUrl": {
             "type": "string"
@@ -3766,10 +3628,7 @@
             "items": {
               "$ref": "#/components/schemas/FreshChallengeGame"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -3793,10 +3652,7 @@
             "items": {
               "$ref": "#/components/schemas/RAProgressEntry"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "raGameId": {
             "format": "int64",
@@ -3827,10 +3683,7 @@
             "items": {
               "$ref": "#/components/schemas/Achievement"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "raGameId": {
             "description": "RetroAchievements game ID (0 when unknown).",
@@ -3949,10 +3802,7 @@
             "items": {
               "$ref": "#/components/schemas/CoverOption"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -4006,10 +3856,7 @@
             "items": {
               "$ref": "#/components/schemas/HeroOption"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -4123,10 +3970,7 @@
             "items": {
               "$ref": "#/components/schemas/AgeRatingResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "averageRating": {
             "format": "double",
@@ -4169,10 +4013,7 @@
             "items": {
               "$ref": "#/components/schemas/DiscResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "fileName": {
             "type": "string"
@@ -4221,10 +4062,7 @@
             "items": {
               "$ref": "#/components/schemas/LanguageSupportResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "lastPlayedAt": {
             "format": "date-time",
@@ -4266,10 +4104,7 @@
             "items": {
               "$ref": "#/components/schemas/ReleaseDateResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "revision": {
             "type": "string"
@@ -4278,10 +4113,7 @@
             "items": {
               "$ref": "#/components/schemas/RomHackGameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "scrapeAttempts": {
             "format": "int64",
@@ -4294,10 +4126,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "storyline": {
             "type": "string"
@@ -4351,10 +4180,7 @@
             "items": {
               "$ref": "#/components/schemas/VariantResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "verificationStatus": {
             "type": "string"
@@ -4366,10 +4192,7 @@
             "items": {
               "$ref": "#/components/schemas/VideoResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -4516,10 +4339,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "memberCount": {
             "format": "int64",
@@ -4529,10 +4349,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "name": {
             "type": "string"
@@ -4609,10 +4426,7 @@
             "items": {
               "$ref": "#/components/schemas/GameStatsTopPlayer"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "totalPlayTime": {
             "format": "int64",
@@ -4689,10 +4503,7 @@
             "items": {
               "$ref": "#/components/schemas/AchievementGameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -5056,10 +4867,7 @@
             "items": {
               "$ref": "#/components/schemas/NetplayInviteResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "total": {
             "format": "int64",
@@ -5143,10 +4951,7 @@
             "items": {
               "$ref": "#/components/schemas/ConsoleResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "name": {
             "type": "string"
@@ -5234,28 +5039,19 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "unscraped": {
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "unverified": {
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -5275,10 +5071,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "icon": {
             "type": "string"
@@ -5315,10 +5108,7 @@
             "items": {
               "$ref": "#/components/schemas/ActivePlayerEntry"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -5364,10 +5154,7 @@
             "items": {
               "$ref": "#/components/schemas/MostPlayedEntry"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -5627,10 +5414,7 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -5703,10 +5487,7 @@
             "items": {
               "$ref": "#/components/schemas/OnlineUserResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -5730,10 +5511,7 @@
             "items": {
               "$ref": "#/components/schemas/ActivityEventResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -5772,10 +5550,7 @@
             "items": {
               "$ref": "#/components/schemas/ChallengeLeaderboardEntry"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -5814,10 +5589,7 @@
             "items": {
               "$ref": "#/components/schemas/ChallengeResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -5856,10 +5628,7 @@
             "items": {
               "$ref": "#/components/schemas/CollectionResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -5898,10 +5667,7 @@
             "items": {
               "$ref": "#/components/schemas/GameRatingResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -5940,10 +5706,7 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -5982,10 +5745,7 @@
             "items": {
               "$ref": "#/components/schemas/NetplaySessionResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -6024,10 +5784,7 @@
             "items": {
               "$ref": "#/components/schemas/SharedSaveResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -6066,10 +5823,7 @@
             "items": {
               "$ref": "#/components/schemas/UserSearchResult"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -6194,10 +5948,7 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "similarUsersCount": {
             "format": "int64",
@@ -6277,10 +6028,7 @@
             "items": {
               "$ref": "#/components/schemas/PublicProfileGame"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "gamesPlayed": {
             "format": "int64",
@@ -6300,19 +6048,13 @@
             "items": {
               "$ref": "#/components/schemas/PublicProfileGame"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "topGames": {
             "items": {
               "$ref": "#/components/schemas/PublicProfileGame"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "totalPlayTime": {
             "format": "int64",
@@ -6363,19 +6105,13 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "developers": {
             "items": {
               "$ref": "#/components/schemas/NameCount"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "gameCount": {
             "format": "int64",
@@ -6385,19 +6121,13 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "genreBreakdown": {
             "items": {
               "$ref": "#/components/schemas/GenreCount"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "heroUrl": {
             "type": "string"
@@ -6409,10 +6139,7 @@
             "items": {
               "$ref": "#/components/schemas/PlatformCount"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "primaryGenre": {
             "type": "string"
@@ -6424,28 +6151,19 @@
             "items": {
               "$ref": "#/components/schemas/RelatedPublisher"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "timeline": {
             "items": {
               "$ref": "#/components/schemas/TimelineEntry"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "topGames": {
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "userStats": {
             "$ref": "#/components/schemas/EntityUserStats"
@@ -6871,10 +6589,7 @@
             "items": {
               "$ref": "#/components/schemas/RARecentAchievementResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -6928,10 +6643,7 @@
             "items": {
               "$ref": "#/components/schemas/RecentReviewItem"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -7002,10 +6714,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -7029,10 +6738,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -7096,10 +6802,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -7426,10 +7129,7 @@
             "items": {
               "$ref": "#/components/schemas/ScraperSourceResultResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -7563,10 +7263,7 @@
             "items": {
               "$ref": "#/components/schemas/ScreenshotItem"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "totalCount": {
             "format": "int64",
@@ -7624,10 +7321,7 @@
             "items": {
               "$ref": "#/components/schemas/SearchCollectionResult"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "total": {
             "format": "int64",
@@ -7647,10 +7341,7 @@
             "items": {
               "$ref": "#/components/schemas/SearchCompanyResult"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "total": {
             "format": "int64",
@@ -7670,10 +7361,7 @@
             "items": {
               "$ref": "#/components/schemas/SearchConsoleResult"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "total": {
             "format": "int64",
@@ -7693,10 +7381,7 @@
             "items": {
               "$ref": "#/components/schemas/SearchFranchiseResult"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "total": {
             "format": "int64",
@@ -7716,10 +7401,7 @@
             "items": {
               "$ref": "#/components/schemas/SearchGameResult"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "total": {
             "format": "int64",
@@ -7739,10 +7421,7 @@
             "items": {
               "$ref": "#/components/schemas/SearchSeriesResult"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "total": {
             "format": "int64",
@@ -8014,19 +7693,13 @@
             "items": {
               "$ref": "#/components/schemas/SeriesConsoleInfo"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "games": {
             "items": {
               "$ref": "#/components/schemas/SeriesGameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "heroUrl": {
             "type": "string"
@@ -8173,10 +7846,7 @@
               "format": "int64",
               "type": "integer"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -8420,10 +8090,7 @@
             "items": {
               "$ref": "#/components/schemas/DiagnosticCheck"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -8579,10 +8246,7 @@
             "items": {
               "$ref": "#/components/schemas/SharedSessionMemberResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "name": {
             "type": "string"
@@ -9152,10 +8816,7 @@
             "items": {
               "$ref": "#/components/schemas/PossibleConsoleResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "publisher": {
             "type": "string"
@@ -9260,10 +8921,7 @@
             "items": {
               "$ref": "#/components/schemas/SessionStorageConsoleBreakdown"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "quotaBytes": {
             "format": "int64",
@@ -9411,10 +9069,7 @@
             "items": {
               "$ref": "#/components/schemas/SystemEventTypeInfo"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -9438,10 +9093,7 @@
             "items": {
               "$ref": "#/components/schemas/SystemEventResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "page": {
             "format": "int64",
@@ -9533,28 +9185,19 @@
             "items": {
               "$ref": "#/components/schemas/TasteProfileGenre"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "themes": {
             "items": {
               "$ref": "#/components/schemas/TasteProfileTheme"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "topConsoles": {
             "items": {
               "$ref": "#/components/schemas/TasteProfileConsole"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "totalPlayTime": {
             "format": "int64",
@@ -9670,10 +9313,7 @@
             "items": {
               "$ref": "#/components/schemas/TimelineGame"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "year": {
             "format": "int64",
@@ -9819,10 +9459,7 @@
             "items": {
               "$ref": "#/components/schemas/TrendingGameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -9846,10 +9483,7 @@
             "items": {
               "$ref": "#/components/schemas/RAUnlockedAchievementResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -10214,10 +9848,7 @@
               "format": "int64",
               "type": "integer"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -10393,10 +10024,7 @@
             "items": {
               "type": "string"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "raHardcoreEnabled": {
             "type": "boolean"
@@ -10668,10 +10296,7 @@
             "items": {
               "$ref": "#/components/schemas/WizardStep"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           }
         },
         "required": [
@@ -10695,10 +10320,7 @@
             "items": {
               "$ref": "#/components/schemas/GameResponse"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "title": {
             "type": "string"
@@ -10717,10 +10339,7 @@
             "items": {
               "$ref": "#/components/schemas/WizardOption"
             },
-            "type": [
-              "array",
-              "null"
-            ]
+            "type": "array"
           },
           "step": {
             "format": "int64",
@@ -11577,10 +11196,7 @@
                   "items": {
                     "$ref": "#/components/schemas/IGDBSearchResult"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -12527,10 +12143,7 @@
               "items": {
                 "type": "string"
               },
-              "type": [
-                "array",
-                "null"
-              ]
+              "type": "array"
             }
           },
           {
@@ -12609,10 +12222,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SystemEventCategoryResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -12826,10 +12436,7 @@
                   "items": {
                     "$ref": "#/components/schemas/StagedUploadResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -12893,10 +12500,7 @@
                   "items": {
                     "$ref": "#/components/schemas/StagedUploadResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -13018,10 +12622,7 @@
                   "items": {
                     "$ref": "#/components/schemas/StagedUploadResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -13304,10 +12905,7 @@
                   "items": {
                     "$ref": "#/components/schemas/UserResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -13392,10 +12990,7 @@
                   "items": {
                     "$ref": "#/components/schemas/DeletedUserResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -13553,10 +13148,7 @@
                   "items": {
                     "$ref": "#/components/schemas/DeviceResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -14517,10 +14109,7 @@
                   "items": {
                     "$ref": "#/components/schemas/ChallengeAttemptResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -15340,10 +14929,7 @@
                   "items": {
                     "$ref": "#/components/schemas/ConsoleResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -15711,10 +15297,7 @@
                   "items": {
                     "$ref": "#/components/schemas/LongestGameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -15766,10 +15349,7 @@
                   "items": {
                     "$ref": "#/components/schemas/TopListGameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -15821,10 +15401,7 @@
                   "items": {
                     "$ref": "#/components/schemas/TopListGameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -15876,10 +15453,7 @@
                   "items": {
                     "$ref": "#/components/schemas/TopRatedGameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -15919,10 +15493,7 @@
                   "items": {
                     "$ref": "#/components/schemas/Core"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -16828,10 +16399,7 @@
                   "items": {
                     "$ref": "#/components/schemas/FeaturedGameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -17022,10 +16590,7 @@
                   "items": {
                     "$ref": "#/components/schemas/GameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -17072,10 +16637,7 @@
                   "items": {
                     "$ref": "#/components/schemas/MoodResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -17442,10 +17004,7 @@
                   "items": {
                     "$ref": "#/components/schemas/FeaturedSeriesResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -17776,10 +17335,7 @@
                   "items": {
                     "$ref": "#/components/schemas/FranchiseResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -18658,10 +18214,7 @@
                   "items": {
                     "$ref": "#/components/schemas/GameCheatResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -18762,10 +18315,7 @@
                   "items": {
                     "$ref": "#/components/schemas/DeveloperGameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -19001,10 +18551,7 @@
                   "items": {
                     "$ref": "#/components/schemas/GameFranchiseResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -19484,10 +19031,7 @@
                   "items": {
                     "$ref": "#/components/schemas/GameSeriesResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -19539,10 +19083,7 @@
                   "items": {
                     "$ref": "#/components/schemas/GameSessionResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -19983,10 +19524,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SharedSessionResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -20038,10 +19576,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SimilarGameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -20175,10 +19710,7 @@
                   "items": {
                     "$ref": "#/components/schemas/KeywordResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -20289,10 +19821,7 @@
                   "items": {
                     "$ref": "#/components/schemas/MakerDetailResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -20817,10 +20346,7 @@
                   "items": {
                     "$ref": "#/components/schemas/NetplayInviteResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -21085,10 +20611,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SeriesListResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -21659,10 +21182,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SessionSaveResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -22100,10 +21620,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SessionSaveResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -22463,10 +21980,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SharedSessionResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -22981,10 +22495,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SharedSessionSaveResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -23651,10 +23162,7 @@
                   "items": {
                     "$ref": "#/components/schemas/ThemeResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -23765,10 +23273,7 @@
                   "items": {
                     "$ref": "#/components/schemas/LongestGameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -23808,10 +23313,7 @@
                   "items": {
                     "$ref": "#/components/schemas/TopListGameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -23851,10 +23353,7 @@
                   "items": {
                     "$ref": "#/components/schemas/TopListGameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -23894,10 +23393,7 @@
                   "items": {
                     "$ref": "#/components/schemas/TopRatedGameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -23974,10 +23470,7 @@
                   "items": {
                     "$ref": "#/components/schemas/ShowcaseEntryResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -24014,10 +23507,7 @@
                 "items": {
                   "$ref": "#/components/schemas/ShowcaseEntryInput"
                 },
-                "type": [
-                  "array",
-                  "null"
-                ]
+                "type": "array"
               }
             }
           },
@@ -24031,10 +23521,7 @@
                   "items": {
                     "$ref": "#/components/schemas/ShowcaseEntryResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -24209,10 +23696,7 @@
                   "items": {
                     "$ref": "#/components/schemas/DeviceResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -24546,10 +24030,7 @@
                   "items": {
                     "$ref": "#/components/schemas/GameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -24896,10 +24377,7 @@
                   "items": {
                     "$ref": "#/components/schemas/HeatmapEntry"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -24940,10 +24418,7 @@
                   "items": {
                     "$ref": "#/components/schemas/GameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -25126,10 +24601,7 @@
                   "items": {
                     "$ref": "#/components/schemas/PlayStatsEntry"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -25548,10 +25020,7 @@
                   "items": {
                     "$ref": "#/components/schemas/GameResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -25591,10 +25060,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SavedSearchResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -25765,10 +25231,7 @@
                   "items": {
                     "$ref": "#/components/schemas/SharedSessionInviteResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -26054,10 +25517,7 @@
                   "items": {
                     "$ref": "#/components/schemas/UserSearchResult"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -26180,10 +25640,7 @@
                   "items": {
                     "$ref": "#/components/schemas/ShowcaseEntryResponse"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },
@@ -26235,10 +25692,7 @@
                   "items": {
                     "$ref": "#/components/schemas/HeatmapEntry"
                   },
-                  "type": [
-                    "array",
-                    "null"
-                  ]
+                  "type": "array"
                 }
               }
             },

--- a/web/src/lib/api-client.ts
+++ b/web/src/lib/api-client.ts
@@ -205,19 +205,12 @@ export function multipart(formData: FormData): {
 // value, throwing ApiError on failure. Hook call sites wrap their typedApi
 // calls in unwrap() so errors bubble through react-query's onError / try-
 // catch paths like a throwing fetcher.
-//
-// Special case: huma serialises Go nil slices as JSON `null`, so flat-list
-// endpoints (e.g. GET /api/consoles, /api/themes) come back typed as
-// `T[] | null` from openapi-fetch. We coerce a top-level `null` body to
-// `undefined` so consumers get a single absence sentinel — every list-based
-// query already treats `data == null/undefined` as "no data yet". This avoids
-// pushing `?? []` boilerplate to every page-level prop site.
 export async function unwrap<D, E>(
   promise: Promise<
     | { data: D; error?: never; response: Response }
     | { data?: never; error: E; response: Response }
   >,
-): Promise<Exclude<D, null>> {
+): Promise<D> {
   const { data, error, response } = await promise;
   if (error !== undefined) {
     const message =
@@ -227,7 +220,7 @@ export async function unwrap<D, E>(
     throw new ApiError(response.status, message);
   }
   if (response.status === 204) {
-    return undefined as Exclude<D, null>;
+    return undefined as D;
   }
-  return (data ?? undefined) as Exclude<D, null>;
+  return data as D;
 }


### PR DESCRIPTION
## Summary

Root-cause fix for the \`T[] | null\` propagation that earlier PRs worked around with a \`unwrap()\` null-coercion hack (#614).

**The one-line fix** in commit 1: \`huma.DefaultArrayNullable = false\`. Huma's default is to declare every Go slice field as JSON-schema-nullable (because Go nil slices marshal as JSON null), which propagates as \`T[] | null\` in openapi-typescript and \`List<T>?\` in openapi-generator Kotlin. Flipping the toggle emits \`\"type\": \"array\"\` instead.

The subsequent commits fix the Go contract that the flip now promises (no handler ships a nil slice), regenerate the clients, and remove the resulting scar tissue.

## Commits

1. **\`server: set huma.DefaultArrayNullable = false\`** — one-liner \`init()\` in \`huma_setup.go\`.

2. **\`server: ensure no huma handler ships a nil slice in a response Body\`** — 8 files. Audit of every flat-array Body + nested \`[]T\` in response structs. Big wins:
   - \`responses.go toGameResponseWithData\` (~40 endpoint callers) now initialises all 7 nested slice fields explicitly.
   - \`upload_handler.go\` \`PossibleConsoles\` init in every literal including the zip-bomb guard.
   - \`huma_bios.go\` / \`huma_profiles.go\`: \`var X []Y\` → \`make\`.
   - \`explore_handler_developer.go\`: 3 \`return nil\` → \`return []T{}\`.
   - \`explore_handler_test.go\`: 7 \`assert.Nil\` → \`assert.Empty\`.

3. **\`web: regenerate types; revert unwrap null-coercion workaround\`** — 5 files. Regenerated \`openapi.json\` + \`api.d.ts\` + \`schemas.ts\` (~500 \`T[] | null\` → \`T[]\`). \`unwrap()\` returns \`Promise<D>\` again. Search consumer scar tissue removed.

4. **\`player: regenerate Kotlin client; update test fixtures\`** — 92 files. \`List<T>?\` → \`List<T>\` across the shared-api model layer. Two test fixtures updated: \`GameRepositoryImplTest\` (\`null\` → \`emptyList()\`, one rename \`handlesNull\` → \`handlesEmpty\`), \`GameRepositoryOfflineTest\` (mock JSON \`null\` → \`[]\` for every array field).

## Verified
- Server: \`go test ./...\` passes. \`dump-openapi | grep -c '\"null\"'\` returns 39 (same as baseline; all remaining \`null\` is on pointer-nullable primitives/objects, not arrays).
- Web: \`tsc --noEmit\` + \`npm run build\` + \`vitest run\` all clean. 1495 tests pass.
- Kotlin: \`:shared-api:compileKotlinDesktop\` + \`:shared-api:compileDebugKotlinAndroid\` + \`:shared:compileKotlinDesktop\` + \`:shared:desktopTest\` all pass.

Code-reviewer subagent flagged the \`PossibleConsoles\` nil miss in the zip-bomb guard before this PR shipped — fixed in commit 2. The other flags (\`?? []\` / \`.orEmpty()\` scar tissue in web & Kotlin consumer code) are queued for follow-up PRs since they're separate from the root-cause fix.

## Test plan
- [ ] CI green