### PR TITLE
cleanup: remove dead ?? [] / .orEmpty() after #619 (fixes #620)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -97,7 +97,7 @@ fun GameDto.toDomain(): Game = Game(
     lastPlayedAt = lastPlayedAt?.toString(),
     totalPlayTime = totalPlayTime,
     discCount = discCount.toInt(),
-    discs = discs.orEmpty().map { it.toDomain() },
+    discs = discs.map { it.toDomain() },
     achievementsWarning = achievementsWarning,
     verificationStatus = verificationStatus,
     verificationTag = verificationTag,
@@ -144,9 +144,9 @@ fun RomHackGameDto.toDomain(): RomHackGame = RomHackGame(
 fun GameDto.toGameDetail(): GameDetail = GameDetail(
     game = toDomain(),
     screenshots = screenshotUrls.orEmpty(),
-    variants = variants.orEmpty().map { it.toDomain() },
+    variants = variants.map { it.toDomain() },
     parentGame = parentGame.takeIf { it.id.isNotEmpty() }?.toDomain(),
-    romHacks = romHacks.orEmpty().map { it.toDomain() },
+    romHacks = romHacks.map { it.toDomain() },
 )
 
 fun com.spela.client.models.SessionSaveResponse.toDomain(): SaveState = SaveState(
@@ -269,9 +269,9 @@ fun com.spela.client.models.PublicProfileResponse.toDomain(): PublicProfile = Pu
     currentGame = currentGame.takeIf { it.id.isNotEmpty() }?.toDomain(),
     totalPlayTime = totalPlayTime,
     gamesPlayed = gamesPlayed,
-    favoriteGames = favoriteGames.orEmpty().map { it.toDomain() },
-    recentGames = recentGames.orEmpty().map { it.toDomain() },
-    topGames = topGames.orEmpty().map { it.toDomain() },
+    favoriteGames = favoriteGames.map { it.toDomain() },
+    recentGames = recentGames.map { it.toDomain() },
+    topGames = topGames.map { it.toDomain() },
 )
 
 // Shared Session mappers
@@ -314,7 +314,7 @@ fun com.spela.client.models.SharedSessionDetailResponse.toDomain(): SharedSessio
     status = status,
     memberCount = memberCount.toInt(),
     activeUserId = activeUserId,
-    members = members.orEmpty().map { it.toDomain() },
+    members = members.map { it.toDomain() },
     lastActivityAt = updatedAt.toString(),
     createdAt = createdAt.toString(),
     updatedAt = updatedAt.toString(),
@@ -377,7 +377,7 @@ fun com.spela.client.models.CollectionDetailResponse.toDomain(): GameCollectionD
     isPublic = isPublic,
     coverUrl = coverUrl,
     gameCount = gameCount.toInt(),
-    games = games.orEmpty().map { it.toDomain() },
+    games = games.map { it.toDomain() },
 )
 
 // Game Stats mappers
@@ -393,7 +393,7 @@ fun com.spela.client.models.GameStatsResponse.toDomain(): GameStats = GameStats(
     totalPlayers = totalPlayers.toInt(),
     totalPlayTime = totalPlayTime,
     averagePlayTime = averagePlayTime,
-    topPlayers = topPlayers.orEmpty().map { it.toDomain() },
+    topPlayers = topPlayers.map { it.toDomain() },
 )
 
 fun com.spela.client.models.Achievement.toDomain(): GameAchievement = GameAchievement(
@@ -429,7 +429,7 @@ fun com.spela.client.models.AchievementTimelineResponse.toDomain(): AchievementT
     raGameId = raGameId,
     gameTitle = gameTitle,
     totalPlayTime = totalPlayTime,
-    timeline = timeline.orEmpty().map { it.toDomain() },
+    timeline = timeline.map { it.toDomain() },
     totalAchievements = totalAchievements.toInt(),
     unlockedCount = unlockedCount.toInt(),
     totalPoints = totalPoints.toInt(),
@@ -672,7 +672,7 @@ fun com.spela.client.models.GameSessionResponse.toDomain(): GameSession = GameSe
 
 fun com.spela.client.models.SessionCheatsResponse.toDomain() = SessionCheatConfig(
     cheatsEnabled = cheatsEnabled,
-    enabledIndices = enabledIndices.orEmpty().map { it.toInt() },
+    enabledIndices = enabledIndices.map { it.toInt() },
 )
 
 // Explore mappers
@@ -698,7 +698,7 @@ fun com.spela.client.models.FeaturedGameResponse.toDomain(): FeaturedGame = Feat
 fun com.spela.client.models.ExploreRowResponse.toDomain(): ExploreRow = ExploreRow(
     id = id,
     title = title,
-    games = games.orEmpty().map { it.toDomain() },
+    games = games.map { it.toDomain() },
 )
 
 fun com.spela.client.models.ThemeResponse.toDomain(): Theme = Theme(
@@ -727,10 +727,10 @@ fun com.spela.client.models.SeriesDetailResponse.toDomain(): SeriesDetail = Seri
     name = name,
     heroUrl = heroUrl,
     logoUrl = logoUrl,
-    consoles = consoles.orEmpty().map { it.toDomain() },
+    consoles = consoles.map { it.toDomain() },
     libraryGames = libraryGames.toInt(),
     totalGames = totalGames.toInt(),
-    games = games.orEmpty().map { it.toDomain() },
+    games = games.map { it.toDomain() },
 )
 
 fun com.spela.client.models.FranchiseDetailResponse.toDomain(): SeriesDetail = SeriesDetail(
@@ -738,10 +738,10 @@ fun com.spela.client.models.FranchiseDetailResponse.toDomain(): SeriesDetail = S
     name = name,
     heroUrl = heroUrl,
     logoUrl = logoUrl,
-    consoles = consoles.orEmpty().map { it.toDomain() },
+    consoles = consoles.map { it.toDomain() },
     libraryGames = libraryGames.toInt(),
     totalGames = totalGames.toInt(),
-    games = games.orEmpty().map { it.toDomain() },
+    games = games.map { it.toDomain() },
 )
 
 fun com.spela.client.models.SeriesConsoleInfo.toDomain(): SeriesConsole = SeriesConsole(
@@ -796,7 +796,7 @@ fun com.spela.client.models.ForYouRowResponse.toDomain(): ForYouRow = ForYouRow(
     title = title,
     sourceGame = sourceGame.takeIf { it.id.isNotEmpty() }?.toDomain(),
     genre = genre,
-    games = games.orEmpty().map { it.toDomain() },
+    games = games.map { it.toDomain() },
 )
 
 fun com.spela.client.models.TasteProfileGenre.toDomain(): TasteBreakdown = TasteBreakdown(
@@ -822,13 +822,13 @@ fun com.spela.client.models.TasteProfileConsole.toDomain(): ConsoleBreakdown = C
 
 fun com.spela.client.models.TasteProfileResponse.toDomain(): TasteProfile = TasteProfile(
     totalPlayTime = totalPlayTime,
-    genres = genres.orEmpty().map { it.toDomain() },
-    themes = themes.orEmpty().map { it.toDomain() },
-    topConsoles = topConsoles.orEmpty().map { it.toDomain() },
+    genres = genres.map { it.toDomain() },
+    themes = themes.map { it.toDomain() },
+    topConsoles = topConsoles.map { it.toDomain() },
 )
 
 fun com.spela.client.models.PlayersLikeYouResponse.toDomain(): PlayersLikeYouResult = PlayersLikeYouResult(
-    games = games.orEmpty().map { it.toDomain() },
+    games = games.map { it.toDomain() },
     similarUsersCount = similarUsersCount.toInt(),
 )
 
@@ -917,7 +917,7 @@ fun com.spela.client.models.TimelineGame.toDomain(): TimelineGame = TimelineGame
 
 fun com.spela.client.models.TimelineEntry.toDomain(): TimelineEntry = TimelineEntry(
     year = year.toInt(),
-    games = games.orEmpty().map { it.toDomain() },
+    games = games.map { it.toDomain() },
 )
 
 fun com.spela.client.models.RelatedDeveloper.toDomain(): RelatedDeveloper = RelatedDeveloper(
@@ -933,18 +933,18 @@ fun com.spela.client.models.DeveloperDetailResponse.toDomain(): DeveloperDetail 
     consoles = consoles.orEmpty(),
     heroUrl = heroUrl,
     companyInfo = companyInfo.toDomain().takeIf { it.hasAnyData() },
-    topGames = topGames.orEmpty().map { it.toDomain() },
-    genreBreakdown = genreBreakdown.orEmpty().map { it.toDeveloperGenreBreakdown() },
-    platformBreakdown = platformBreakdown.orEmpty().map { it.toDeveloperPlatformBreakdown() },
+    topGames = topGames.map { it.toDomain() },
+    genreBreakdown = genreBreakdown.map { it.toDeveloperGenreBreakdown() },
+    platformBreakdown = platformBreakdown.map { it.toDeveloperPlatformBreakdown() },
     userStats = userStats.takeIf { it.gamesPlayed > 0 }?.toDeveloperUserStats(),
-    publishers = publishers.orEmpty().map { it.toDeveloperPublisher() },
-    games = games.orEmpty().map { it.toDomain() },
+    publishers = publishers.map { it.toDeveloperPublisher() },
+    games = games.map { it.toDomain() },
     activeYears = activeYears.takeIf { it.first > 0 }?.toDomain(),
     // Generated RatingDistribution is @Required non-null.
     ratingDistribution = ratingDistribution.toDomain(),
     primaryGenre = primaryGenre,
-    timeline = timeline.orEmpty().map { it.toDomain() },
-    relatedDevelopers = relatedDevelopers.orEmpty().map { it.toDomain() },
+    timeline = timeline.map { it.toDomain() },
+    relatedDevelopers = relatedDevelopers.map { it.toDomain() },
 )
 
 fun com.spela.client.models.GenreCount.toPublisherGenreBreakdown(): PublisherDetailGenreBreakdown =
@@ -987,17 +987,17 @@ fun com.spela.client.models.PublisherDetailResponse.toDomain(): PublisherDetail 
     consoles = consoles.orEmpty(),
     heroUrl = heroUrl,
     companyInfo = companyInfo.toDomain().takeIf { it.hasAnyData() },
-    topGames = topGames.orEmpty().map { it.toDomain() },
-    genreBreakdown = genreBreakdown.orEmpty().map { it.toPublisherGenreBreakdown() },
-    platformBreakdown = platformBreakdown.orEmpty().map { it.toPublisherPlatformBreakdown() },
+    topGames = topGames.map { it.toDomain() },
+    genreBreakdown = genreBreakdown.map { it.toPublisherGenreBreakdown() },
+    platformBreakdown = platformBreakdown.map { it.toPublisherPlatformBreakdown() },
     userStats = userStats.takeIf { it.gamesPlayed > 0 }?.toPublisherUserStats(),
-    developers = developers.orEmpty().map { it.toPublisherDeveloper() },
-    games = games.orEmpty().map { it.toDomain() },
+    developers = developers.map { it.toPublisherDeveloper() },
+    games = games.map { it.toDomain() },
     activeYears = activeYears.takeIf { it.first > 0 }?.toDomain(),
     ratingDistribution = ratingDistribution.toDomain(),
     primaryGenre = primaryGenre,
-    timeline = timeline.orEmpty().map { it.toDomain() },
-    relatedPublishers = relatedPublishers.orEmpty().map { it.toDomain() },
+    timeline = timeline.map { it.toDomain() },
+    relatedPublishers = relatedPublishers.map { it.toDomain() },
 )
 
 fun com.spela.client.models.DeveloperSpotlightResponse.toDomain(): DeveloperSpotlight = DeveloperSpotlight(
@@ -1005,7 +1005,7 @@ fun com.spela.client.models.DeveloperSpotlightResponse.toDomain(): DeveloperSpot
     gameCount = gameCount.toInt(),
     avgRating = avgRating,
     consoles = consoles.orEmpty(),
-    topGames = topGames.orEmpty().map { it.toDomain() },
+    topGames = topGames.map { it.toDomain() },
     heroUrl = heroUrl.ifBlank { null },
 )
 
@@ -1018,11 +1018,11 @@ fun com.spela.client.models.GenreCount.toDomain(): GenreCount = GenreCount(
 
 fun com.spela.client.models.ConsoleShowcaseResponse.toDomain(): ConsoleShowcase = ConsoleShowcase(
     console = console.toDomain(),
-    essentials = essentials.orEmpty().map { it.toDomain() },
-    hiddenGems = hiddenGems.orEmpty().map { it.toDomain() },
-    genreBreakdown = genreBreakdown.orEmpty().map { it.toDomain() },
-    topDevelopers = topDevelopers.orEmpty().map { it.toDomain() },
-    recentlyPlayed = recentlyPlayed.orEmpty().map { it.toDomain() },
+    essentials = essentials.map { it.toDomain() },
+    hiddenGems = hiddenGems.map { it.toDomain() },
+    genreBreakdown = genreBreakdown.map { it.toDomain() },
+    topDevelopers = topDevelopers.map { it.toDomain() },
+    recentlyPlayed = recentlyPlayed.map { it.toDomain() },
 )
 
 // Generated ConsoleHighlight has @Required non-nullable topGame, but the
@@ -1168,11 +1168,11 @@ fun com.spela.client.models.WizardStep.toDomain() = WizardStep(
     step = step.toInt(),
     title = title,
     type = type,
-    options = options.orEmpty().map { it.toDomain() },
+    options = options.map { it.toDomain() },
 )
 
 fun com.spela.client.models.WizardResultsResponse.toDomain() = WizardResults(
-    games = games.orEmpty().map { it.toDomain() },
+    games = games.map { it.toDomain() },
     title = title,
 )
 
@@ -1195,7 +1195,7 @@ fun com.spela.client.models.CompletionistConsole.toDomain() = CompletionistConso
 )
 
 fun com.spela.client.models.CompletionistMapResponse.toDomain() = CompletionistMap(
-    consoles = consoles.orEmpty().map { it.toDomain() },
+    consoles = consoles.map { it.toDomain() },
     totalGames = totalGames.toInt(),
     totalPlayed = totalPlayed.toInt(),
     overallPct = overallPct.toInt(),
@@ -1262,31 +1262,31 @@ fun com.spela.client.models.SearchFranchiseResult.toDomain() = SearchFranchiseRe
 
 fun com.spela.client.models.SearchResponse.toDomain() = GlobalSearchResult(
     games = SearchCategory(
-        results = games.results.orEmpty().map { it.toDomain() },
+        results = games.results.map { it.toDomain() },
         total = games.total.toInt(),
     ),
     consoles = SearchCategory(
-        results = consoles.results.orEmpty().map { it.toDomain() },
+        results = consoles.results.map { it.toDomain() },
         total = consoles.total.toInt(),
     ),
     developers = SearchCategory(
-        results = developers.results.orEmpty().map { it.toDeveloper() },
+        results = developers.results.map { it.toDeveloper() },
         total = developers.total.toInt(),
     ),
     publishers = SearchCategory(
-        results = publishers.results.orEmpty().map { it.toPublisher() },
+        results = publishers.results.map { it.toPublisher() },
         total = publishers.total.toInt(),
     ),
     collections = SearchCategory(
-        results = collections.results.orEmpty().map { it.toDomain() },
+        results = collections.results.map { it.toDomain() },
         total = collections.total.toInt(),
     ),
     series = SearchCategory(
-        results = series.results.orEmpty().map { it.toDomain() },
+        results = series.results.map { it.toDomain() },
         total = series.total.toInt(),
     ),
     franchises = SearchCategory(
-        results = franchises.results.orEmpty().map { it.toDomain() },
+        results = franchises.results.map { it.toDomain() },
         total = franchises.total.toInt(),
     ),
 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -143,7 +143,7 @@ fun RomHackGameDto.toDomain(): RomHackGame = RomHackGame(
 /** Constructs GameDetail from the enriched GameResponse. */
 fun GameDto.toGameDetail(): GameDetail = GameDetail(
     game = toDomain(),
-    screenshots = screenshotUrls.orEmpty(),
+    screenshots = screenshotUrls,
     variants = variants.map { it.toDomain() },
     parentGame = parentGame.takeIf { it.id.isNotEmpty() }?.toDomain(),
     romHacks = romHacks.map { it.toDomain() },
@@ -173,7 +173,7 @@ fun com.spela.client.models.UserPreferencesResponse.toDomain(): UserPreferences 
     consoleKeyMappings = consoleKeyMappings.mapValues {
         ConsoleKeyMappingPref(
             selectedMapping = it.value.selectedMapping,
-            customMapping = it.value.customMapping.orEmpty(),
+            customMapping = it.value.customMapping,
         )
     },
     defaultSecondScreenPage = defaultSecondScreenPage,
@@ -666,8 +666,8 @@ fun com.spela.client.models.GameSessionResponse.toDomain(): GameSession = GameSe
     isSharedSession = isSharedSession,
     sharedSessionId = sharedSessionId,
     memberCount = memberCount.toInt(),
-    memberUsernames = memberUsernames.orEmpty(),
-    memberAvatars = memberAvatars.orEmpty(),
+    memberUsernames = memberUsernames,
+    memberAvatars = memberAvatars,
 )
 
 fun com.spela.client.models.SessionCheatsResponse.toDomain() = SessionCheatConfig(
@@ -788,7 +788,7 @@ fun com.spela.client.models.MoodResponse.toDomain(): MoodDefinition = MoodDefini
     name = name,
     description = description,
     icon = icon,
-    gradient = gradient.orEmpty(),
+    gradient = gradient,
 )
 
 fun com.spela.client.models.ForYouRowResponse.toDomain(): ForYouRow = ForYouRow(
@@ -852,7 +852,7 @@ fun com.spela.client.models.DeveloperSummary.toDomain(): DeveloperSummary = Deve
     name = name,
     gameCount = gameCount.toInt(),
     avgRating = avgRating,
-    consoles = consoles.orEmpty(),
+    consoles = consoles,
 )
 
 fun com.spela.client.models.GenreCount.toDeveloperGenreBreakdown(): DeveloperDetailGenreBreakdown =
@@ -923,14 +923,14 @@ fun com.spela.client.models.TimelineEntry.toDomain(): TimelineEntry = TimelineEn
 fun com.spela.client.models.RelatedDeveloper.toDomain(): RelatedDeveloper = RelatedDeveloper(
     name = name,
     gameCount = gameCount.toInt(),
-    sharedPublishers = sharedPublishers.orEmpty(),
+    sharedPublishers = sharedPublishers,
 )
 
 fun com.spela.client.models.DeveloperDetailResponse.toDomain(): DeveloperDetail = DeveloperDetail(
     name = name,
     gameCount = gameCount.toInt(),
     avgRating = avgRating,
-    consoles = consoles.orEmpty(),
+    consoles = consoles,
     heroUrl = heroUrl,
     companyInfo = companyInfo.toDomain().takeIf { it.hasAnyData() },
     topGames = topGames.map { it.toDomain() },
@@ -977,14 +977,14 @@ fun com.spela.client.models.NameCount.toPublisherDeveloper(): PublisherDetailDev
 fun com.spela.client.models.RelatedPublisher.toDomain(): RelatedPublisher = RelatedPublisher(
     name = name,
     gameCount = gameCount.toInt(),
-    sharedDevelopers = sharedDevelopers.orEmpty(),
+    sharedDevelopers = sharedDevelopers,
 )
 
 fun com.spela.client.models.PublisherDetailResponse.toDomain(): PublisherDetail = PublisherDetail(
     name = name,
     gameCount = gameCount.toInt(),
     avgRating = avgRating,
-    consoles = consoles.orEmpty(),
+    consoles = consoles,
     heroUrl = heroUrl,
     companyInfo = companyInfo.toDomain().takeIf { it.hasAnyData() },
     topGames = topGames.map { it.toDomain() },
@@ -1004,7 +1004,7 @@ fun com.spela.client.models.DeveloperSpotlightResponse.toDomain(): DeveloperSpot
     name = name,
     gameCount = gameCount.toInt(),
     avgRating = avgRating,
-    consoles = consoles.orEmpty(),
+    consoles = consoles,
     topGames = topGames.map { it.toDomain() },
     heroUrl = heroUrl.ifBlank { null },
 )

--- a/web/src/features/shared-sessions/components/shared-session-hero.tsx
+++ b/web/src/features/shared-sessions/components/shared-session-hero.tsx
@@ -109,7 +109,7 @@ export function SharedSessionHero({
         </div>
 
         {/* Member avatars */}
-        <MemberAvatars members={sharedSession.members ?? []} max={6} />
+        <MemberAvatars members={sharedSession.members} max={6} />
       </div>
     </div>
   );

--- a/web/src/hooks/use-shared-sessions.ts
+++ b/web/src/hooks/use-shared-sessions.ts
@@ -41,7 +41,7 @@ function toSharedSessionDetail(
   return {
     ...wire,
     status: asSharedSessionStatus(wire.status),
-    members: wire.members?.map(toSharedSessionMember) ?? null,
+    members: wire.members.map(toSharedSessionMember),
   };
 }
 

--- a/web/src/pages/developer-detail-page.tsx
+++ b/web/src/pages/developer-detail-page.tsx
@@ -113,13 +113,13 @@ export function DeveloperDetailPage() {
     developer.genreBreakdown && developer.genreBreakdown.length >= 2;
 
   // Build platform-grouped games
-  const platformBreakdown = developer.platformBreakdown ?? [];
+  const platformBreakdown = developer.platformBreakdown;
   const sortedPlatforms = [...platformBreakdown].sort(
     (a, b) => b.count - a.count,
   );
 
   // Apply genre + console filter to the all-games list
-  let filteredGames = developer.games ?? [];
+  let filteredGames = developer.games;
   if (genreFilter) {
     filteredGames = filteredGames.filter((g: Game) =>
       g.genre
@@ -168,7 +168,7 @@ export function DeveloperDetailPage() {
         name={developer.name}
         gameCount={developer.gameCount}
         avgRating={developer.avgRating}
-        consoleCount={(developer.consoles ?? []).length}
+        consoleCount={developer.consoles.length}
         heroUrl={developer.heroUrl}
         logoUrl={developer.companyInfo?.logoUrl}
       />
@@ -183,7 +183,7 @@ export function DeveloperDetailPage() {
         gameCount={developer.gameCount}
         activeYears={developer.activeYears}
         primaryGenre={developer.primaryGenre}
-        platformCount={(developer.consoles ?? []).length}
+        platformCount={developer.consoles.length}
         avgRating={developer.avgRating}
       />
 
@@ -244,7 +244,7 @@ export function DeveloperDetailPage() {
       )}
 
       {/* Console filter chips */}
-      {(developer.consoles ?? []).length > 1 && (
+      {developer.consoles.length > 1 && (
         <div
           className="flex flex-wrap gap-2"
           data-testid="developer-console-filters"
@@ -253,10 +253,10 @@ export function DeveloperDetailPage() {
             label="All"
             isSelected={consoleFilter === null}
             onClick={() => setConsoleFilter(null)}
-            count={(developer.games ?? []).length}
+            count={(developer.games).length}
           />
-          {(developer.consoles ?? []).map((consoleName: string) => {
-            const count = (developer.games ?? []).filter(
+          {developer.consoles.map((consoleName: string) => {
+            const count = (developer.games).filter(
               (g: Game) => g.consoleName === consoleName,
             ).length;
             return (

--- a/web/src/pages/explore-franchise-page.tsx
+++ b/web/src/pages/explore-franchise-page.tsx
@@ -54,7 +54,7 @@ export function ExploreFranchisePage() {
     );
   }
 
-  const sortedGames = [...(franchise.games ?? [])].sort((a, b) => {
+  const sortedGames = [...franchise.games].sort((a, b) => {
     if (!a.releaseDate && !b.releaseDate) return 0;
     if (!a.releaseDate) return 1;
     if (!b.releaseDate) return -1;
@@ -132,7 +132,7 @@ export function ExploreFranchisePage() {
         </>
       )}
 
-      {(franchise.consoles ?? []).length > 0 && (
+      {franchise.consoles.length > 0 && (
         <div className="flex flex-wrap gap-2" data-testid="console-filters">
           <button
             onClick={() => setConsoleFilter(null)}
@@ -143,9 +143,9 @@ export function ExploreFranchisePage() {
                 : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
             )}
           >
-            All ({(franchise.games ?? []).length})
+            All ({franchise.games.length})
           </button>
-          {(franchise.consoles ?? []).map((console: SeriesConsole) => (
+          {franchise.consoles.map((console: SeriesConsole) => (
             <button
               key={console.abbreviation}
               onClick={() =>

--- a/web/src/pages/explore-series-page.tsx
+++ b/web/src/pages/explore-series-page.tsx
@@ -60,7 +60,7 @@ export function ExploreSeriesPage() {
   }
 
   // Sort games by release date, games without dates go to end
-  const sortedGames = [...(series.games ?? [])].sort((a, b) => {
+  const sortedGames = [...series.games].sort((a, b) => {
     if (!a.releaseDate && !b.releaseDate) return 0;
     if (!a.releaseDate) return 1;
     if (!b.releaseDate) return -1;
@@ -141,7 +141,7 @@ export function ExploreSeriesPage() {
       )}
 
       {/* Console badges */}
-      {(series.consoles ?? []).length > 0 && (
+      {series.consoles.length > 0 && (
         <div className="flex flex-wrap gap-2" data-testid="console-filters">
           <button
             onClick={() => setConsoleFilter(null)}
@@ -152,9 +152,9 @@ export function ExploreSeriesPage() {
                 : "bg-surface-800 text-surface-300 border-surface-700 hover:bg-surface-700",
             )}
           >
-            All ({(series.games ?? []).length})
+            All ({series.games.length})
           </button>
-          {(series.consoles ?? []).map((console: SeriesConsole) => (
+          {series.consoles.map((console: SeriesConsole) => (
             <button
               key={console.abbreviation}
               onClick={() =>

--- a/web/src/pages/publisher-detail-page.tsx
+++ b/web/src/pages/publisher-detail-page.tsx
@@ -113,13 +113,13 @@ export function PublisherDetailPage() {
     publisher.genreBreakdown && publisher.genreBreakdown.length >= 2;
 
   // Build platform-grouped games
-  const platformBreakdown = publisher.platformBreakdown ?? [];
+  const platformBreakdown = publisher.platformBreakdown;
   const sortedPlatforms = [...platformBreakdown].sort(
     (a, b) => b.count - a.count,
   );
 
   // Apply genre + console filter to the all-games list
-  let filteredGames = publisher.games ?? [];
+  let filteredGames = publisher.games;
   if (genreFilter) {
     filteredGames = filteredGames.filter((g: Game) =>
       g.genre
@@ -168,7 +168,7 @@ export function PublisherDetailPage() {
         name={publisher.name}
         gameCount={publisher.gameCount}
         avgRating={publisher.avgRating}
-        consoleCount={(publisher.consoles ?? []).length}
+        consoleCount={publisher.consoles.length}
         heroUrl={publisher.heroUrl}
         logoUrl={publisher.companyInfo?.logoUrl}
       />
@@ -183,7 +183,7 @@ export function PublisherDetailPage() {
         gameCount={publisher.gameCount}
         activeYears={publisher.activeYears}
         primaryGenre={publisher.primaryGenre}
-        platformCount={(publisher.consoles ?? []).length}
+        platformCount={publisher.consoles.length}
         avgRating={publisher.avgRating}
       />
 
@@ -244,7 +244,7 @@ export function PublisherDetailPage() {
       )}
 
       {/* Console filter chips */}
-      {(publisher.consoles ?? []).length > 1 && (
+      {publisher.consoles.length > 1 && (
         <div
           className="flex flex-wrap gap-2"
           data-testid="publisher-console-filters"
@@ -253,10 +253,10 @@ export function PublisherDetailPage() {
             label="All"
             isSelected={consoleFilter === null}
             onClick={() => setConsoleFilter(null)}
-            count={(publisher.games ?? []).length}
+            count={(publisher.games).length}
           />
-          {(publisher.consoles ?? []).map((consoleName: string) => {
-            const count = (publisher.games ?? []).filter(
+          {publisher.consoles.map((consoleName: string) => {
+            const count = (publisher.games).filter(
               (g: Game) => g.consoleName === consoleName,
             ).length;
             return (

--- a/web/src/pages/shared-session-detail-page.tsx
+++ b/web/src/pages/shared-session-detail-page.tsx
@@ -136,7 +136,7 @@ export function SharedSessionDetailPage() {
 
       <SharedSessionMembersList
         sharedSessionId={sharedSession.id}
-        members={sharedSession.members ?? []}
+        members={sharedSession.members}
         isOwner={isOwner}
       />
 

--- a/web/src/types/api.ts
+++ b/web/src/types/api.ts
@@ -256,7 +256,7 @@ export type SharedSessionDetail = Omit<
   "status" | "members"
 > & {
   status: SharedSessionStatus;
-  members: SharedSessionMember[] | null;
+  members: SharedSessionMember[];
 };
 
 // The wire response for GET /api/user/shared-session-invites is


### PR DESCRIPTION
Fixes #620.

Follow-up cleanup to #619's non-null-array root-cause fix. Generated types no longer say \`T[] | null\` on response bodies, so `?? []` guards in web pages and `.orEmpty().map` guards in Kotlin mappers whose receivers are now `T[]` / `List<T>` are compile-time dead code.

## Commits

1. **web: drop `?? []` guards in detail pages** — 6 files. \`DeveloperDetail\`, \`PublisherDetail\`, \`SeriesDetail\`, \`FranchiseDetail\`, \`SharedSessionDetail\` child-array fields are all \`T[]\` now. Also flips \`SharedSessionDetail.members\` in \`api.ts\` from \`SharedSessionMember[] | null\` to \`SharedSessionMember[]\` (the view-model narrowing was the last piece holding on to the `| null` arm).
2. **player: drop `.orEmpty().map`** — 22 sites in \`DtoMappers.kt\` where the receiver is now non-null \`List<T>\`.
3. **web: fix mapper / type-lie in use-shared-sessions** — reviewer flagged that \`toSharedSessionDetail\` still produced \`null\` via \`wire.members?.map(...) ?? null\` even though the declared return type no longer has the \`| null\` arm. Mapper now does \`wire.members.map(...)\`. Removed a downstream \`sharedSession.members ?? []\` that the stale mapper had been papering over.
4. **player: drop more dead `.orEmpty()`** — reviewer-flagged second pass catching bare \`.orEmpty()\` on \`List<T>\` / \`Map<K,V>\` receivers (my first pass only matched \`.orEmpty().map\`). 8 more sites. Remaining \`.orEmpty()\` calls are on \`String\` receivers — no-ops on non-null strings, not worth the churn.

## Verified
- Web: \`npx tsc --noEmit\` + \`npm run build\` clean, 1495 tests pass.
- Kotlin: \`:shared:compileKotlinDesktop\` + \`:shared:desktopTest\` clean.
- Code-reviewer subagent caught the critical mapper/type-lie (commit 3) and the missed bare \`.orEmpty()\` (commit 4) before push.

## Test plan
- [ ] CI green