### PR TITLE
fix(#623): validate username/email/password on POST /api/admin/users

### DIFF
--- a/server/internal/api/admin_user_validation_test.go
+++ b/server/internal/api/admin_user_validation_test.go
@@ -1,0 +1,110 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestAdminCreateUser_ValidationBounds verifies the huma-level validation
+// tags on AdminCreateUserRequest — username/email/password length checks
+// run before the handler body, returning 422 with huma's error shape.
+//
+// The admin endpoint does NOT enforce the public self-signup pattern
+// (`^[a-zA-Z0-9]+$`) on username — admins need to be able to create
+// migrated / reserved / legacy usernames that don't match the strict
+// public regex. Length and password strength still apply.
+func TestAdminCreateUser_ValidationBounds(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	create := func(body map[string]string) int {
+		buf, _ := json.Marshal(body)
+		w := httptest.NewRecorder()
+		req := httptest.NewRequest("POST", "/api/admin/users", bytes.NewReader(buf))
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("Authorization", "Bearer "+token)
+		router.ServeHTTP(w, req)
+		return w.Code
+	}
+
+	cases := []struct {
+		name   string
+		body   map[string]string
+		expect int
+	}{
+		{
+			name: "valid request succeeds",
+			body: map[string]string{
+				"username": "valid_user_01",
+				"email":    "valid@example.com",
+				"password": "password123",
+				"role":     "user",
+			},
+			expect: http.StatusCreated,
+		},
+		{
+			name: "username too short (<3)",
+			body: map[string]string{
+				"username": "ab",
+				"email":    "x@example.com",
+				"password": "password123",
+				"role":     "user",
+			},
+			expect: http.StatusUnprocessableEntity,
+		},
+		{
+			name: "username too long (>64)",
+			body: map[string]string{
+				"username": "a234567890123456789012345678901234567890123456789012345678901234X",
+				"email":    "x@example.com",
+				"password": "password123",
+				"role":     "user",
+			},
+			expect: http.StatusUnprocessableEntity,
+		},
+		{
+			name: "password too short (<8)",
+			body: map[string]string{
+				"username": "new_user_pw",
+				"email":    "x@example.com",
+				"password": "short",
+				"role":     "user",
+			},
+			expect: http.StatusUnprocessableEntity,
+		},
+		{
+			name: "empty email",
+			body: map[string]string{
+				"username": "new_user_em",
+				"email":    "",
+				"password": "password123",
+				"role":     "user",
+			},
+			expect: http.StatusUnprocessableEntity,
+		},
+		{
+			name: "admin can create username with underscores (not allowed on public signup)",
+			body: map[string]string{
+				"username": "migrated_user_123",
+				"email":    "migrated@example.com",
+				"password": "password123",
+				"role":     "user",
+			},
+			expect: http.StatusCreated,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := create(tc.body)
+			assert.Equal(t, tc.expect, got, "body=%+v", tc.body)
+		})
+	}
+}

--- a/server/internal/api/requests.go
+++ b/server/internal/api/requests.go
@@ -49,10 +49,14 @@ type UpdateGameKeyMappingRequest struct {
 // --- Admin user management ---
 
 // AdminCreateUserRequest is the body for POST /api/admin/users.
+// Validation is lighter than AuthRegisterRequest (the self-signup endpoint):
+// admins can create users with usernames that the public pattern rejects
+// (e.g. containing underscores / dashes) to accommodate migration imports
+// and reserved-name allocation. Length and password strength still apply.
 type AdminCreateUserRequest struct {
-	Username string      `json:"username"`
-	Email    string      `json:"email"`
-	Password string      `json:"password"`
+	Username string      `json:"username" minLength:"3" maxLength:"64" doc:"New account username (3-64 characters)."`
+	Email    string      `json:"email" minLength:"1" doc:"New account email."`
+	Password string      `json:"password" minLength:"8" maxLength:"72" doc:"New account password (8-72 characters)."`
 	Role     db.UserRole `json:"role,omitempty"`
 }
 


### PR DESCRIPTION
Fixes #623. Depends on #624 (the dead-binding-tags cleanup). Based on that branch so diffs are clean.

## Problem
\`POST /api/admin/users\` accepted any username/email/password. The old \`binding:\"required,min=3,max=64\"\` / \`binding:\"required,email\"\` / \`binding:\"required,min=8,max=72\"\` tags were dead under huma — huma doesn't honour gin-era validator tags. The handler (\`HumaAdminCreateUser\`) has no fallback check, so admin could create a user with a 1-character username, empty email, or 3-character password.

Noticed during the #449 dead-tag audit that led to #624.

## Fix
Proper huma validation tags on \`AdminCreateUserRequest\`:

| Field | Bounds |
|---|---|
| username | \`minLength=3 maxLength=64\` — **no pattern**, unlike the public self-signup |
| email | \`minLength=1\` |
| password | \`minLength=8 maxLength=72\` |

**Why no pattern on username?** The public \`AuthRegisterRequest\` enforces \`^[a-zA-Z0-9]+$\` — reasonable for self-signup. The admin endpoint shouldn't: admins need to import legacy / migrated / underscored names that the strict public regex would reject. Existing test fixtures (\`createNonOwnerUser(\"cult_rater\", ...)\`) rely on this.

## New test
\`TestAdminCreateUser_ValidationBounds\` covers:
- happy path (201)
- username <3, username >64, password <8, empty email → 422
- admin can create an underscored username (explicitly locks in the different-from-public-signup contract)

## Behaviour change
Admin panel clients that previously sent invalid data will now get 422. Small blast radius — one admin endpoint — but explicit call-out here.

## Verified
- \`go test ./internal/api/...\` green (370s)

## Test plan
- [ ] CI green