### PR TITLE
chore(web): drop stale null guards after #619 (tail cleanup)

### DIFF
--- a/web/src/hooks/use-scan-progress.ts
+++ b/web/src/hooks/use-scan-progress.ts
@@ -50,9 +50,9 @@ export function useScanProgress(): ScanProgressState {
     if (!initialStatus) return;
     if (initialStatus.active) {
       setPhase("active");
-      setMessage(initialStatus.message ?? "Scanning...");
-      setCurrent(initialStatus.current ?? 0);
-      setTotal(initialStatus.total ?? 0);
+      setMessage(initialStatus.message || "Scanning...");
+      setCurrent(initialStatus.current);
+      setTotal(initialStatus.total);
     } else if (phase === "active") {
       // Status went from active to inactive — scan finished while we were polling
       setPhase("idle");

--- a/web/src/pages/developer-detail-page.tsx
+++ b/web/src/pages/developer-detail-page.tsx
@@ -191,7 +191,7 @@ export function DeveloperDetailPage() {
       {showTopRated && (
         <GameShelf
           title="Top Rated"
-          games={developer.topGames!}
+          games={developer.topGames}
           isLoading={false}
           onToggleFavorite={handleToggleFavorite}
           onTogglePlayLater={handleTogglePlayLater}
@@ -218,7 +218,7 @@ export function DeveloperDetailPage() {
               isSelected={genreFilter === null}
               onClick={() => setGenreFilter(null)}
             />
-            {developer.genreBreakdown!.map((genre) => (
+            {developer.genreBreakdown.map((genre) => (
               <FilterChip
                 key={genre.name}
                 label={genre.name}

--- a/web/src/pages/publisher-detail-page.tsx
+++ b/web/src/pages/publisher-detail-page.tsx
@@ -191,7 +191,7 @@ export function PublisherDetailPage() {
       {showTopRated && (
         <GameShelf
           title="Top Rated"
-          games={publisher.topGames!}
+          games={publisher.topGames}
           isLoading={false}
           onToggleFavorite={handleToggleFavorite}
           onTogglePlayLater={handleTogglePlayLater}
@@ -218,7 +218,7 @@ export function PublisherDetailPage() {
               isSelected={genreFilter === null}
               onClick={() => setGenreFilter(null)}
             />
-            {publisher.genreBreakdown!.map((genre) => (
+            {publisher.genreBreakdown.map((genre) => (
               <FilterChip
                 key={genre.name}
                 label={genre.name}


### PR DESCRIPTION
Small follow-up to #622. Reviewer-driven search surfaced 4 more scar-tissue sites the bulk sed missed in #622.

## Changes

- \`pages/developer-detail-page.tsx\`: \`developer.genreBreakdown!.map\` and \`developer.topGames!\` — both fields non-nullable \`T[]\` in the generated \`DeveloperDetailResponse\` post-#619.
- \`pages/publisher-detail-page.tsx\`: same two patterns on publisher.
- \`hooks/use-scan-progress.ts\`: \`initialStatus.current ?? 0\` / \`.total ?? 0\` / \`.message ?? \"Scanning...\"\` — generated \`ScanStatusResponse\` has all three as non-null. \`message\` uses \`||\` instead of direct access so the empty-string case still falls back to the \"Scanning...\" placeholder.

## Verified
- \`tsc --noEmit\` + \`npm run build\` clean
- All 1495 tests pass

Pure subtraction, no behaviour change.

## Test plan
- [ ] CI green