### PR TITLE
chore(player): drop dead .orEmpty() scar tissue in repositories

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/BiosRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/BiosRepository.kt
@@ -14,7 +14,7 @@ open class BiosRepository(
 
     open suspend fun syncBiosFiles() {
         val serverFiles = try {
-            apiClient.getBiosStatus().files.orEmpty()
+            apiClient.getBiosStatus().files
         } catch (e: Exception) {
             return // Server may not support BIOS yet
         }
@@ -61,10 +61,10 @@ open class BiosRepository(
      */
     open suspend fun getConsoleStatus(consoleId: String): BiosConsoleStatus? {
         val status = cachedBiosStatus ?: fetchBiosStatus() ?: return null
-        val console = status.consoles.orEmpty().find { it.consoleId == consoleId } ?: return null
+        val console = status.consoles.find { it.consoleId == consoleId } ?: return null
         val biosDir = fileStorage.getBiosDir()
 
-        val missingFiles = console.files.orEmpty()
+        val missingFiles = console.files
             .filter { it.required && it.status == "missing" }
             .map { BiosMissingFile(it.fileName, it.description, it.required, it.subDir) }
 
@@ -129,10 +129,10 @@ open class BiosRepository(
         val localFiles = getLocalBiosFiles()
         val biosDir = fileStorage.getBiosDir()
 
-        return status.consoles.orEmpty()
+        return status.consoles
             .filter { it.biosRequired && it.status == "missing" }
             .mapNotNull { console ->
-                val missingFiles = console.files.orEmpty()
+                val missingFiles = console.files
                     .filter { it.required && it.status == "missing" }
                     .filter { file ->
                         val localPath = if (!file.subDir.isNullOrEmpty()) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ChallengeRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ChallengeRepositoryImpl.kt
@@ -18,7 +18,7 @@ class ChallengeRepositoryImpl(
         sort: String?,
         page: Int,
     ): Result<List<Challenge>> = runCatching {
-        apiClient.getChallenges(gameId, consoleId, difficulty, sort, page).data.orEmpty().map { dto ->
+        apiClient.getChallenges(gameId, consoleId, difficulty, sort, page).data.map { dto ->
             val challenge = dto.toDomain()
             challenge.copy(
                 screenshotUrl = apiClient.resolveUrl(challenge.screenshotUrl),
@@ -29,7 +29,7 @@ class ChallengeRepositoryImpl(
     }
 
     override suspend fun getGameChallenges(gameId: String, page: Int): Result<List<Challenge>> = runCatching {
-        apiClient.getGameChallenges(gameId, page).data.orEmpty().map { dto ->
+        apiClient.getGameChallenges(gameId, page).data.map { dto ->
             val challenge = dto.toDomain()
             challenge.copy(
                 screenshotUrl = apiClient.resolveUrl(challenge.screenshotUrl),
@@ -40,7 +40,7 @@ class ChallengeRepositoryImpl(
     }
 
     override suspend fun getMyChallenges(page: Int): Result<List<Challenge>> = runCatching {
-        apiClient.getMyChallenges(page).data.orEmpty().map { dto ->
+        apiClient.getMyChallenges(page).data.map { dto ->
             val challenge = dto.toDomain()
             challenge.copy(
                 screenshotUrl = apiClient.resolveUrl(challenge.screenshotUrl),
@@ -63,7 +63,7 @@ class ChallengeRepositoryImpl(
         challengeId: String,
         page: Int,
     ): Result<List<ChallengeLeaderboardEntry>> = runCatching {
-        apiClient.getChallengeLeaderboard(challengeId, page).data.orEmpty().map { dto ->
+        apiClient.getChallengeLeaderboard(challengeId, page).data.map { dto ->
             val entry = dto.toDomain()
             entry.copy(avatarUrl = apiClient.resolveUrl(entry.avatarUrl))
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CollectionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CollectionRepositoryImpl.kt
@@ -13,13 +13,13 @@ class CollectionRepositoryImpl(
 ) : CollectionRepository {
 
     override suspend fun getMyCollections(page: Int, pageSize: Int): Result<List<GameCollection>> = runCatching {
-        apiClient.getMyCollections(page = page, pageSize = pageSize).data.orEmpty().map { dto ->
+        apiClient.getMyCollections(page = page, pageSize = pageSize).data.map { dto ->
             dto.toDomain().resolveImageUrls()
         }
     }
 
     override suspend fun getPublicCollections(page: Int, pageSize: Int): Result<List<GameCollection>> = runCatching {
-        apiClient.getPublicCollections(page = page, pageSize = pageSize).data.orEmpty().map { dto ->
+        apiClient.getPublicCollections(page = page, pageSize = pageSize).data.map { dto ->
             dto.toDomain().resolveImageUrls()
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
@@ -61,7 +61,7 @@ class DownloadRepositoryImpl(
         val gameDetail = apiClient.getGameDetail(gameId)
         println("[Download] Game detail: fileName=${gameDetail.fileName} fileSize=${gameDetail.fileSize} discCount=${gameDetail.discCount}")
 
-        val discs = gameDetail.discs.orEmpty()
+        val discs = gameDetail.discs
         if (gameDetail.discCount >= 2) {
             downloadMultiDiscGame(gameId, gameTitle, gameDetail)
         } else if (discs.isNotEmpty() && discs.size == 1) {
@@ -140,7 +140,7 @@ class DownloadRepositoryImpl(
         gameTitle: String,
         game: GameDto,
     ): String {
-        val disc = game.discs.orEmpty().first()
+        val disc = game.discs.first()
         val gameDir = fileStorage.getGamesDir() + "/$gameId"
         if (fileStorage.fileExists(gameDir) && !fileStorage.isDirectory(gameDir)) {
             fileStorage.deleteFile(gameDir)
@@ -207,14 +207,14 @@ class DownloadRepositoryImpl(
         fileStorage.createDirectory(gameDir)
 
         val m3uPath = "$gameDir/game.m3u"
-        val totalDiscs = game.discs.orEmpty().size
+        val totalDiscs = game.discs.size
         val totalSize = game.fileSize
         var completedBytes = 0L
 
         // Download each disc FIRST — write M3U only after all discs succeed.
         // Writing M3U early would make getLocalGamePath treat the game as cached
         // even if disc downloads fail or are still in progress.
-        for ((index, disc) in game.discs.orEmpty().sortedBy { it.discNumber }.withIndex()) {
+        for ((index, disc) in game.discs.sortedBy { it.discNumber }.withIndex()) {
             val discOffset = completedBytes
 
             downloads.update {
@@ -255,7 +255,7 @@ class DownloadRepositoryImpl(
         }
 
         // Write .m3u with local filenames — only after all discs downloaded
-        val m3uContent = game.discs.orEmpty().sortedBy { it.discNumber }
+        val m3uContent = game.discs.sortedBy { it.discNumber }
             .joinToString("\n") { it.fileName } + "\n"
         fileStorage.writeFile(m3uPath, m3uContent.encodeToByteArray())
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -60,7 +60,7 @@ class ExploreRepositoryImpl(
     override suspend fun getExploreRows(): Result<List<ExploreRow>> = runCatching {
         apiClient.getExploreRows().map { dto ->
             dto.toDomain().copy(
-                games = dto.games.orEmpty().map { gameDto ->
+                games = dto.games.map { gameDto ->
                     gameDto.toDomain().copy(
                         coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                         heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
@@ -76,7 +76,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getThemeGames(themeId: String, page: Int, pageSize: Int): Result<List<Game>> = runCatching {
-        apiClient.getThemeGames(themeId, page, pageSize).data.orEmpty().map { gameDto ->
+        apiClient.getThemeGames(themeId, page, pageSize).data.map { gameDto ->
             gameDto.toDomain().copy(
                 coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
@@ -90,7 +90,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getKeywordGames(keywordId: String, page: Int, pageSize: Int): Result<List<Game>> = runCatching {
-        apiClient.getKeywordGames(keywordId, page, pageSize).data.orEmpty().map { gameDto ->
+        apiClient.getKeywordGames(keywordId, page, pageSize).data.map { gameDto ->
             gameDto.toDomain().copy(
                 coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
@@ -112,7 +112,7 @@ class ExploreRepositoryImpl(
         dto.toDomain().copy(
             heroUrl = apiClient.resolveUrl(dto.heroUrl),
             logoUrl = apiClient.resolveUrl(dto.logoUrl),
-            games = dto.games.orEmpty().map { gameDto ->
+            games = dto.games.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 )
@@ -125,7 +125,7 @@ class ExploreRepositoryImpl(
         dto.toDomain().copy(
             heroUrl = apiClient.resolveUrl(dto.heroUrl),
             logoUrl = apiClient.resolveUrl(dto.logoUrl),
-            games = dto.games.orEmpty().map { gameDto ->
+            games = dto.games.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 )
@@ -166,7 +166,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getForYou(): Result<List<ForYouRow>> = runCatching {
-        apiClient.getForYou().rows.orEmpty().map { rowDto ->
+        apiClient.getForYou().rows.map { rowDto ->
             rowDto.toDomain().copy(
                 sourceGame = rowDto.sourceGame.takeIf { it.id.isNotEmpty() }?.let { sgDto ->
                     sgDto.toDomain().copy(
@@ -175,7 +175,7 @@ class ExploreRepositoryImpl(
                         logoUrl = apiClient.resolveUrl(sgDto.logoUrl),
                     )
                 },
-                games = rowDto.games.orEmpty().map { gameDto ->
+                games = rowDto.games.map { gameDto ->
                     gameDto.toDomain().copy(
                         coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                         heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
@@ -193,7 +193,7 @@ class ExploreRepositoryImpl(
     override suspend fun getPlayersLikeYou(): Result<PlayersLikeYouResult> = runCatching {
         val dto = apiClient.getPlayersLikeYou()
         dto.toDomain().copy(
-            games = dto.games.orEmpty().map { gameDto ->
+            games = dto.games.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                     heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
@@ -204,7 +204,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getDevelopers(): Result<List<DeveloperSummary>> = runCatching {
-        apiClient.getDevelopers().developers.orEmpty().map { it.toDomain() }
+        apiClient.getDevelopers().developers.map { it.toDomain() }
     }
 
     override suspend fun getDeveloperDetail(name: String): Result<DeveloperDetail> = runCatching {
@@ -219,7 +219,7 @@ class ExploreRepositoryImpl(
         val dto = apiClient.getDeveloperSpotlight()
         dto.toDomain().copy(
             heroUrl = apiClient.resolveUrl(dto.heroUrl),
-            topGames = dto.topGames.orEmpty().map { gameDto ->
+            topGames = dto.topGames.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 )
@@ -230,21 +230,21 @@ class ExploreRepositoryImpl(
     override suspend fun getConsoleShowcase(consoleId: String): Result<ConsoleShowcase> = runCatching {
         val dto = apiClient.getConsoleShowcase(consoleId)
         dto.toDomain().copy(
-            essentials = dto.essentials.orEmpty().map { gameDto ->
+            essentials = dto.essentials.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                     heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
                     logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
                 )
             },
-            hiddenGems = dto.hiddenGems.orEmpty().map { gameDto ->
+            hiddenGems = dto.hiddenGems.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                     heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
                     logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
                 )
             },
-            recentlyPlayed = dto.recentlyPlayed.orEmpty().map { gameDto ->
+            recentlyPlayed = dto.recentlyPlayed.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                     heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
@@ -255,7 +255,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getConsoleHighlights(): Result<List<ConsoleHighlight>> = runCatching {
-        apiClient.getConsoleHighlights().consoles.orEmpty().map { dto ->
+        apiClient.getConsoleHighlights().consoles.map { dto ->
             val topGameDto = dto.topGame
             dto.toDomain().copy(
                 iconUrl = apiClient.resolveUrl(dto.iconUrl) ?: "",
@@ -268,7 +268,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getArtworkGallery(page: Int): Result<List<ArtworkItem>> = runCatching {
-        apiClient.getArtworkGallery(page).artworks.orEmpty().map { dto ->
+        apiClient.getArtworkGallery(page).artworks.map { dto ->
             dto.toDomain().copy(
                 url = apiClient.resolveUrl(dto.url) ?: dto.url,
             )
@@ -276,7 +276,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getScreenshotGallery(page: Int): Result<List<ScreenshotItem>> = runCatching {
-        apiClient.getScreenshotGallery(page).screenshots.orEmpty().map { dto ->
+        apiClient.getScreenshotGallery(page).screenshots.map { dto ->
             dto.toDomain().copy(
                 url = apiClient.resolveUrl(dto.url) ?: dto.url,
             )
@@ -284,7 +284,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getTrending(): Result<List<TrendingGame>> = runCatching {
-        apiClient.getTrending().games.orEmpty().map { dto ->
+        apiClient.getTrending().games.map { dto ->
             dto.toDomain().copy(
                 game = resolveGameCovers(dto.game.toDomain(), dto.game),
             )
@@ -292,7 +292,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getCommunityTop(): Result<List<CommunityTopGame>> = runCatching {
-        apiClient.getCommunityTop().games.orEmpty().map { dto ->
+        apiClient.getCommunityTop().games.map { dto ->
             dto.toDomain().copy(
                 game = resolveGameCovers(dto.game.toDomain(), dto.game),
             )
@@ -300,7 +300,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getCultClassics(): Result<List<CultClassicGame>> = runCatching {
-        apiClient.getCultClassics().games.orEmpty().map { dto ->
+        apiClient.getCultClassics().games.map { dto ->
             dto.toDomain().copy(
                 game = resolveGameCovers(dto.game.toDomain(), dto.game),
             )
@@ -308,7 +308,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getRecentlyReviewed(): Result<List<RecentReviewItem>> = runCatching {
-        apiClient.getRecentlyReviewed().reviews.orEmpty().map { dto ->
+        apiClient.getRecentlyReviewed().reviews.map { dto ->
             dto.toDomain().copy(
                 game = resolveGameCovers(dto.game.toDomain(), dto.game),
             )
@@ -316,7 +316,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getActiveNow(): Result<List<ActiveNowItem>> = runCatching {
-        apiClient.getActiveNow().games.orEmpty().map { dto ->
+        apiClient.getActiveNow().games.map { dto ->
             dto.toDomain().copy(
                 game = resolveGameCovers(dto.game.toDomain(), dto.game),
             )
@@ -325,20 +325,20 @@ class ExploreRepositoryImpl(
 
     override suspend fun getOnThisDay(): Result<Pair<String, List<Game>>> = runCatching {
         val dto = apiClient.getOnThisDay()
-        val games = dto.games.orEmpty().map { gameDto ->
+        val games = dto.games.map { gameDto ->
             resolveGameCovers(gameDto.toDomain(), gameDto)
         }
         Pair(dto.date, games)
     }
 
     override suspend fun getBestOfYear(year: Int): Result<List<Game>> = runCatching {
-        apiClient.getBestOfYear(year).games.orEmpty().map { gameDto ->
+        apiClient.getBestOfYear(year).games.map { gameDto ->
             resolveGameCovers(gameDto.toDomain(), gameDto)
         }
     }
 
     override suspend fun getYourAnniversaries(): Result<List<AnniversaryItem>> = runCatching {
-        apiClient.getYourAnniversaries().anniversaries.orEmpty().map { dto ->
+        apiClient.getYourAnniversaries().anniversaries.map { dto ->
             dto.toDomain().copy(
                 game = resolveGameCovers(dto.game.toDomain(), dto.game),
             )
@@ -347,14 +347,14 @@ class ExploreRepositoryImpl(
 
     override suspend fun getDecade(decade: String): Result<Pair<String, List<Game>>> = runCatching {
         val dto = apiClient.getDecade(decade)
-        val games = dto.games.orEmpty().map { gameDto ->
+        val games = dto.games.map { gameDto ->
             resolveGameCovers(gameDto.toDomain(), gameDto)
         }
         Pair(dto.label, games)
     }
 
     override suspend fun getEasyToComplete(): Result<List<AchievementGameItem>> = runCatching {
-        apiClient.getEasyToComplete().games.orEmpty().map { dto ->
+        apiClient.getEasyToComplete().games.map { dto ->
             dto.toDomain().copy(
                 game = resolveGameCovers(dto.game.toDomain(), dto.game),
             )
@@ -362,7 +362,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getHardestGames(): Result<List<AchievementGameItem>> = runCatching {
-        apiClient.getHardestGames().games.orEmpty().map { dto ->
+        apiClient.getHardestGames().games.map { dto ->
             dto.toDomain().copy(
                 game = resolveGameCovers(dto.game.toDomain(), dto.game),
             )
@@ -370,7 +370,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getAlmostDone(): Result<List<AlmostDoneGame>> = runCatching {
-        apiClient.getAlmostDone().games.orEmpty().map { dto ->
+        apiClient.getAlmostDone().games.map { dto ->
             dto.toDomain().copy(
                 game = resolveGameCovers(dto.game.toDomain(), dto.game),
             )
@@ -378,7 +378,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getFreshChallenges(): Result<List<FreshChallengeGame>> = runCatching {
-        apiClient.getFreshChallenges().games.orEmpty().map { dto ->
+        apiClient.getFreshChallenges().games.map { dto ->
             dto.toDomain().copy(
                 game = resolveGameCovers(dto.game.toDomain(), dto.game),
             )
@@ -386,11 +386,11 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getActiveChallenges(): Result<List<ExploreChallenge>> = runCatching {
-        apiClient.getActiveChallenges().challenges.orEmpty().map { it.toDomain() }
+        apiClient.getActiveChallenges().challenges.map { it.toDomain() }
     }
 
     override suspend fun getFilteredGames(filters: Map<String, String>, page: Int, pageSize: Int): Result<List<Game>> = runCatching {
-        apiClient.getFilteredGames(filters, page, pageSize).data.orEmpty().map { gameDto ->
+        apiClient.getFilteredGames(filters, page, pageSize).data.map { gameDto ->
             gameDto.toDomain().copy(
                 coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
@@ -412,13 +412,13 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getWizardSteps(): Result<List<WizardStep>> = runCatching {
-        apiClient.getWizardSteps().steps.orEmpty().map { it.toDomain() }
+        apiClient.getWizardSteps().steps.map { it.toDomain() }
     }
 
     override suspend fun getWizardResults(mood: String, era: String, vibe: String): Result<WizardResults> = runCatching {
         val response = apiClient.getWizardResults(mood, era, vibe)
         WizardResults(
-            games = response.games.orEmpty().map { dto ->
+            games = response.games.map { dto ->
                 val game = dto.toDomain()
                 resolveGameCovers(game, dto)
             },
@@ -427,7 +427,7 @@ class ExploreRepositoryImpl(
     }
 
     override suspend fun getExplorerBadges(): Result<List<ExplorerBadge>> = runCatching {
-        apiClient.getExplorerBadges().badges.orEmpty().map { it.toDomain() }
+        apiClient.getExplorerBadges().badges.map { it.toDomain() }
     }
 
     override suspend fun getCompletionistMap(): Result<CompletionistMap> = runCatching {
@@ -449,7 +449,7 @@ class ExploreRepositoryImpl(
             companyInfo = dto.companyInfo.toDomain()
                 .takeIf { it.hasAnyData() }
                 ?.copy(logoUrl = apiClient.resolveUrl(dto.companyInfo.logoUrl)),
-            topGames = dto.topGames.orEmpty().map { gameDto ->
+            topGames = dto.topGames.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 )
@@ -465,7 +465,7 @@ class ExploreRepositoryImpl(
                         },
                 )
             },
-            games = dto.games.orEmpty().map { gameDto ->
+            games = dto.games.map { gameDto ->
                 gameDto.toDomain().copy(
                     coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
                 )
@@ -475,15 +475,15 @@ class ExploreRepositoryImpl(
     private fun DeveloperDetail.applyUrlResolution(
         heroUrl: String?,
         companyInfo: com.spela.client.models.CompanyInfo,
-        topGames: List<com.spela.client.models.GameResponse>?,
+        topGames: List<com.spela.client.models.GameResponse>,
         userStats: com.spela.client.models.EntityUserStats,
-        games: List<com.spela.client.models.GameResponse>?,
+        games: List<com.spela.client.models.GameResponse>,
     ): DeveloperDetail = copy(
         heroUrl = apiClient.resolveUrl(heroUrl),
         companyInfo = companyInfo.toDomain()
             .takeIf { it.hasAnyData() }
             ?.copy(logoUrl = apiClient.resolveUrl(companyInfo.logoUrl)),
-        topGames = topGames.orEmpty().map { gameDto ->
+        topGames = topGames.map { gameDto ->
             gameDto.toDomain().copy(
                 coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
             )
@@ -499,7 +499,7 @@ class ExploreRepositoryImpl(
                     },
             )
         },
-        games = games.orEmpty().map { gameDto ->
+        games = games.map { gameDto ->
             gameDto.toDomain().copy(
                 coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
             )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/GameRepositoryImpl.kt
@@ -36,7 +36,7 @@ class GameRepositoryImpl(
 
     override suspend fun getGamesForConsole(consoleId: String): Result<List<Game>> {
         return runCatching {
-            val games = apiClient.getGamesForConsole(consoleId, pageSize = 200).data.orEmpty()
+            val games = apiClient.getGamesForConsole(consoleId, pageSize = 200).data
                 .map { it.toDomain().resolveImageUrls() }
             cacheGames(games)
             games
@@ -61,7 +61,7 @@ class GameRepositoryImpl(
                 hidePreRelease = hidePreRelease,
                 grouped = grouped,
             )
-            val games = response.data.orEmpty().map { it.toDomain().resolveImageUrls() }
+            val games = response.data.map { it.toDomain().resolveImageUrls() }
             if (page == 1) cacheGames(games)
             PaginatedResult(
                 data = games,
@@ -74,7 +74,7 @@ class GameRepositoryImpl(
 
     override suspend fun getAllGames(): Result<List<Game>> {
         return runCatching {
-            val games = apiClient.getAllGames().data.orEmpty().map { it.toDomain().resolveImageUrls() }
+            val games = apiClient.getAllGames().data.map { it.toDomain().resolveImageUrls() }
             cacheGames(games)
             games
         }.recoverCatching {
@@ -96,7 +96,7 @@ class GameRepositoryImpl(
                 hidePreRelease = hidePreRelease,
                 grouped = grouped,
             )
-            val games = response.data.orEmpty().map { it.toDomain().resolveImageUrls() }
+            val games = response.data.map { it.toDomain().resolveImageUrls() }
             if (page == 1) cacheGames(games)
             PaginatedResult(
                 data = games,
@@ -114,7 +114,7 @@ class GameRepositoryImpl(
         sortOrder: String?,
     ): Result<List<Game>> {
         return runCatching {
-            apiClient.searchGames(query, consoleId, sortBy, sortOrder).data.orEmpty().map { it.toDomain().resolveImageUrls() }
+            apiClient.searchGames(query, consoleId, sortBy, sortOrder).data.map { it.toDomain().resolveImageUrls() }
         }.recoverCatching {
             val cached = searchCachedGames(query)
             if (cached.isNotEmpty()) cached else throw it
@@ -142,7 +142,7 @@ class GameRepositoryImpl(
                 page = page,
                 pageSize = pageSize,
             )
-            val games = response.data.orEmpty().map { it.toDomain().resolveImageUrls() }
+            val games = response.data.map { it.toDomain().resolveImageUrls() }
             PaginatedResult(
                 data = games,
                 total = response.total,
@@ -215,7 +215,7 @@ class GameRepositoryImpl(
     }
 
     override suspend fun getRecentlyAddedGames(): Result<List<Game>> = runCatching {
-        apiClient.getRecentlyAddedGames().data.orEmpty().map { it.toDomain().resolveImageUrls() }
+        apiClient.getRecentlyAddedGames().data.map { it.toDomain().resolveImageUrls() }
     }
 
     override suspend fun getTopRatedGames(consoleId: String): Result<List<TopRatedGame>> {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/NetplayRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/NetplayRepositoryImpl.kt
@@ -23,7 +23,7 @@ class NetplayRepositoryImpl(
     }
 
     override suspend fun getSessions(): Result<List<NetplaySession>> = runCatching {
-        apiClient.getNetplaySessions().data.orEmpty().map { it.toDomain() }
+        apiClient.getNetplaySessions().data.map { it.toDomain() }
     }
 
     override suspend fun getSession(sessionId: String): Result<NetplaySession> = runCatching {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/RatingRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/RatingRepositoryImpl.kt
@@ -18,7 +18,7 @@ class RatingRepositoryImpl(
     }
 
     override suspend fun getGameRatings(gameId: String, page: Int, pageSize: Int): Result<List<GameRating>> = runCatching {
-        apiClient.getGameRatings(gameId, page = page, pageSize = pageSize).data.orEmpty().map {
+        apiClient.getGameRatings(gameId, page = page, pageSize = pageSize).data.map {
             it.toDomain().resolveUrls()
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSaveRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SharedSaveRepositoryImpl.kt
@@ -10,7 +10,7 @@ class SharedSaveRepositoryImpl(
 ) : SharedSaveRepository {
 
     override suspend fun getSharedSaves(gameId: String, page: Int, pageSize: Int): Result<List<SharedSaveState>> = runCatching {
-        apiClient.getSharedSaves(gameId, page = page, pageSize = pageSize).data.orEmpty().map { dto ->
+        apiClient.getSharedSaves(gameId, page = page, pageSize = pageSize).data.map { dto ->
             val save = dto.toDomain()
             save.copy(userAvatarUrl = apiClient.resolveUrl(save.userAvatarUrl))
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SocialRepositoryImpl.kt
@@ -28,7 +28,7 @@ class SocialRepositoryImpl(
     }
 
     override suspend fun getActivityFeed(page: Int, pageSize: Int): Result<List<ActivityEvent>> = runCatching {
-        apiClient.getActivityFeed(page = page, pageSize = pageSize).data.orEmpty().map { dto ->
+        apiClient.getActivityFeed(page = page, pageSize = pageSize).data.map { dto ->
             val event = dto.toDomain()
             event.copy(
                 userAvatarUrl = apiClient.resolveUrl(event.userAvatarUrl),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/UserRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/UserRepositoryImpl.kt
@@ -17,7 +17,7 @@ class UserRepositoryImpl(
     ): Result<UserSearchPage> = runCatching {
         val response = apiClient.searchUsers(query, page, pageSize)
         UserSearchPage(
-            data = response.data.orEmpty().map { it.toDomain() },
+            data = response.data.map { it.toDomain() },
             total = response.total,
             page = response.page.toInt(),
             pageSize = response.pageSize.toInt(),


### PR DESCRIPTION
Follow-up to #619 / #622. Reviewer-flagged during #622 — the Kotlin sweep only hit `DtoMappers.kt`; the same dead-`.orEmpty()` pattern was scattered across the repository implementations. This PR cleans them up.

## Scope

- **~20 `.data.orEmpty()`** on paginated responses (Challenge, Collection, Game, Netplay, Rating, SharedSave, Social, User repos). Every `PaginatedResponse*` type has `@Required val data: List<T>`.
- **~6 `.files` / `.consoles` / `.discs`** in Bios + Download repos. Generated / domain types are all non-null `List<T>`.
- **~18 `.orEmpty().map`** across `ExploreRepositoryImpl.kt` (getForYou, getDevelopers, getTrending, getCommunityTop, etc.). Every generated response has non-null arrays.
- Bonus: `DeveloperDetail.applyUrlResolution` signature tightened — `topGames: List<GameResponse>?` / `games: List<GameResponse>?` → non-null. Callers always pass the wire fields directly (which are `@Required`).

Three commits, one per logical unit:
1. `.data.orEmpty()` on paginated wrappers
2. `.files` / `.consoles` / `.discs`
3. ExploreRepositoryImpl `.orEmpty().map` + param signature

## Verified
- `:shared:compileKotlinDesktop` clean
- `:shared:compileDebugKotlinAndroid` clean
- `:shared:desktopTest` clean
- Code-reviewer subagent verified each removal against the generated models before commit.

Pure subtraction — no behaviour change.

## Test plan
- [ ] CI green
