### PR TITLE
fix(#628): GameScanStep reads scan result from WebSocket, not mutation

### DIFF
--- a/web/src/features/setup/components/__tests__/game-scan-step.test.tsx
+++ b/web/src/features/setup/components/__tests__/game-scan-step.test.tsx
@@ -1,0 +1,140 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { GameScanStep } from "../game-scan-step";
+
+// Regression guard for the bug where GameScanStep used to render
+// "Scan complete — null games found" because it read the mutation's
+// immediate response (which is just `{ message: "scan started" }`) instead
+// of the `scan_complete` WebSocket payload. After the fix the result
+// comes from `useScanProgress`, which captures the async result.
+
+const mockMutate = vi.fn();
+
+vi.mock("@/hooks/use-admin", () => ({
+  useScanLibrary: () => ({
+    mutate: mockMutate,
+    isPending: false,
+  }),
+}));
+
+vi.mock("@/hooks/use-setup-diagnostics", () => ({
+  useSetupDiagnostics: () => ({ data: undefined }),
+}));
+
+const useScanProgressMock = vi.fn();
+vi.mock("@/hooks/use-scan-progress", () => ({
+  useScanProgress: () => useScanProgressMock(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  useScanProgressMock.mockReturnValue({
+    phase: "idle",
+    message: "",
+    current: 0,
+    total: 0,
+    result: null,
+    error: null,
+    dismiss: vi.fn(),
+  });
+});
+
+describe("GameScanStep", () => {
+  it("renders scan button initially", () => {
+    render(<GameScanStep onSkip={vi.fn()} onComplete={vi.fn()} />);
+    expect(
+      screen.getByRole("button", { name: /Scan for Games/ }),
+    ).toBeInTheDocument();
+  });
+
+  it("kicks off the scan via the mutation when clicked", async () => {
+    render(<GameScanStep onSkip={vi.fn()} onComplete={vi.fn()} />);
+    await userEvent.click(
+      screen.getByRole("button", { name: /Scan for Games/ }),
+    );
+    expect(mockMutate).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows in-progress state from the scan progress hook", () => {
+    useScanProgressMock.mockReturnValue({
+      phase: "active",
+      message: "Scanning /games...",
+      current: 10,
+      total: 50,
+      result: null,
+      error: null,
+      dismiss: vi.fn(),
+    });
+    render(<GameScanStep onSkip={vi.fn()} onComplete={vi.fn()} />);
+    // The in-progress pill only renders after the user has clicked scan,
+    // so this test documents that behaviour — a completed scan without
+    // a user kick doesn't render the progress pill.
+    expect(screen.queryByText(/Scanning \/games/)).not.toBeInTheDocument();
+  });
+
+  it("renders the completed summary when useScanProgress reports a result", () => {
+    useScanProgressMock.mockReturnValue({
+      phase: "complete",
+      message: "",
+      current: 0,
+      total: 0,
+      result: {
+        totalGames: 42,
+        newGames: 7,
+        updatedGames: 3,
+        removedGames: 1,
+      },
+      error: null,
+      dismiss: vi.fn(),
+    });
+    render(<GameScanStep onSkip={vi.fn()} onComplete={vi.fn()} />);
+
+    // The critical regression: must show the real total from the WS
+    // payload, not "null games found".
+    expect(
+      screen.getByText(/Scan complete — 42 games found/),
+    ).toBeInTheDocument();
+    expect(screen.getByText("New: 7")).toBeInTheDocument();
+    expect(screen.getByText("Updated: 3")).toBeInTheDocument();
+    expect(screen.getByText("Removed: 1")).toBeInTheDocument();
+  });
+
+  it("singularises `game` when exactly one was found", () => {
+    useScanProgressMock.mockReturnValue({
+      phase: "complete",
+      message: "",
+      current: 0,
+      total: 0,
+      result: {
+        totalGames: 1,
+        newGames: 1,
+        updatedGames: 0,
+        removedGames: 0,
+      },
+      error: null,
+      dismiss: vi.fn(),
+    });
+    render(<GameScanStep onSkip={vi.fn()} onComplete={vi.fn()} />);
+    expect(
+      screen.getByText(/Scan complete — 1 game found/),
+    ).toBeInTheDocument();
+    // Non-positive counts are suppressed.
+    expect(screen.queryByText(/Updated:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Removed:/)).not.toBeInTheDocument();
+  });
+
+  it("surfaces a scan_error payload", () => {
+    useScanProgressMock.mockReturnValue({
+      phase: "error",
+      message: "",
+      current: 0,
+      total: 0,
+      result: null,
+      error: "directory not readable",
+      dismiss: vi.fn(),
+    });
+    render(<GameScanStep onSkip={vi.fn()} onComplete={vi.fn()} />);
+    expect(screen.getByText(/directory not readable/)).toBeInTheDocument();
+  });
+});

--- a/web/src/features/setup/components/game-scan-step.tsx
+++ b/web/src/features/setup/components/game-scan-step.tsx
@@ -1,8 +1,9 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { FolderSearch, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui";
 import { useScanLibrary } from "@/hooks/use-admin";
 import { useSetupDiagnostics } from "@/hooks/use-setup-diagnostics";
+import { useScanProgress } from "@/hooks/use-scan-progress";
 
 interface GameScanStepProps {
   onSkip: () => void;
@@ -12,28 +13,39 @@ interface GameScanStepProps {
 export function GameScanStep({ onSkip, onComplete }: GameScanStepProps) {
   const { data: diagnostics } = useSetupDiagnostics();
   const scanMutation = useScanLibrary();
-  const [scanResult, setScanResult] = useState<Record<string, unknown> | null>(
-    null,
-  );
+  const scan = useScanProgress();
   const [scanError, setScanError] = useState("");
+  const [scanKicked, setScanKicked] = useState(false);
 
   const gameDirsCheck = diagnostics?.checks.find((c) => c.id === "game_dirs");
 
+  // The scan runs asynchronously on the server — the POST /api/admin/games/scan
+  // endpoint returns immediately with { message: "scan started" } and the
+  // result arrives via the scan_complete WebSocket event. useScanProgress
+  // captures that payload in `scan.result`.
+  const scanResult = scan.result;
+  const phase = scan.phase;
+  const scanInProgress =
+    scanKicked && (scanMutation.isPending || phase === "active");
+
+  // Surface scan errors coming from the WebSocket too.
+  useEffect(() => {
+    if (scan.error) setScanError(scan.error);
+  }, [scan.error]);
+
   function handleScan() {
     setScanError("");
+    setScanKicked(true);
     scanMutation.mutate(undefined, {
-      onSuccess: (data) => {
-        setScanResult(data ?? null);
-      },
       onError: (err) => {
         setScanError(err instanceof Error ? err.message : "Scan failed");
+        setScanKicked(false);
       },
     });
+    // Note: `scanKicked` stays true on the success path — no observable
+    // effect because the button row flips to "Continue" as soon as
+    // `scanResult` is non-null.
   }
-
-  const gamesFound = scanResult
-    ? ((scanResult.totalGames as number) ?? null)
-    : null;
 
   return (
     <div className="space-y-6">
@@ -68,42 +80,58 @@ export function GameScanStep({ onSkip, onComplete }: GameScanStepProps) {
         </div>
       )}
 
+      {scanInProgress && !scanResult && (
+        <div className="rounded-xl bg-surface-800/30 border border-surface-800/50 px-4 py-3 text-sm text-surface-300">
+          {scan.message || "Starting scan..."}
+          {scan.total > 0 && (
+            <span className="text-surface-500">
+              {" "}
+              ({scan.current}/{scan.total})
+            </span>
+          )}
+        </div>
+      )}
+
       {scanResult && (
         <div className="rounded-xl bg-success-500/10 border border-success-500/30 px-4 py-3">
           <div className="flex items-center gap-2">
             <CheckCircle2 className="h-4 w-4 text-success-500" />
             <span className="text-sm font-medium text-success-500">
-              Scan complete — {gamesFound}{" "}
-              {gamesFound === 1 ? "game" : "games"} found
+              Scan complete — {scanResult.totalGames}{" "}
+              {scanResult.totalGames === 1 ? "game" : "games"} found
             </span>
           </div>
           <div className="mt-2 ml-6 space-y-0.5">
-              {(scanResult.newGames as number) > 0 && (
-                <p className="text-xs text-surface-400">
-                  New: {scanResult.newGames as number}
-                </p>
-              )}
-              {(scanResult.updatedGames as number) > 0 && (
-                <p className="text-xs text-surface-400">
-                  Updated: {scanResult.updatedGames as number}
-                </p>
-              )}
-              {(scanResult.removedGames as number) > 0 && (
-                <p className="text-xs text-surface-400">
-                  Removed: {scanResult.removedGames as number}
-                </p>
-              )}
-            </div>
+            {scanResult.newGames > 0 && (
+              <p className="text-xs text-surface-400">
+                New: {scanResult.newGames}
+              </p>
+            )}
+            {scanResult.updatedGames > 0 && (
+              <p className="text-xs text-surface-400">
+                Updated: {scanResult.updatedGames}
+              </p>
+            )}
+            {scanResult.removedGames > 0 && (
+              <p className="text-xs text-surface-400">
+                Removed: {scanResult.removedGames}
+              </p>
+            )}
+          </div>
         </div>
       )}
 
       <div className="flex items-center justify-between pt-2">
         {!scanResult ? (
           <>
-            <Button variant="secondary" onClick={onSkip}>
+            <Button variant="secondary" onClick={onSkip} disabled={scanInProgress}>
               Skip
             </Button>
-            <Button onClick={handleScan} loading={scanMutation.isPending}>
+            <Button
+              onClick={handleScan}
+              loading={scanInProgress}
+              disabled={scanInProgress}
+            >
               Scan for Games
             </Button>
           </>


### PR DESCRIPTION
Fixes #628.

## The bug
Setup-wizard Scan step flashed **"Scan complete — null games found"** immediately after clicking Scan. Root cause:

- `POST /api/admin/games/scan` returns synchronously with just `{ message: "scan started in background" }`. The real result arrives over WebSocket as `scan_complete` with `{ totalGames, newGames, updatedGames, removedGames }`.
- `GameScanStep` was storing the mutation's HTTP response into `scanResult` and reading `scanResult.totalGames`. That's always `undefined`.
- Cast `as number ?? null` made it `null`. The UI then rendered "Scan complete — null games found" the moment the HTTP landed — before the scan had actually done anything.

The `useScanProgress` hook already captures the WebSocket payload correctly. It just wasn't wired to this component.

## Fix
- Swap local `scanResult` useState for `useScanProgress().result` (captures the WS `scan_complete` payload).
- Track a `scanKicked` flag so the Scan and Skip buttons disable during the async scan.
- Show an in-progress pill (`Scanning /games... (10/50)`) while the scan runs.
- Sync `scan_error` WS payloads into the existing `scanError` state.

## Tests
New `src/features/setup/components/__tests__/game-scan-step.test.tsx` — 6 cases. The critical regression guard asserts that the summary renders real numbers from the WS payload, so this bug can't silently come back.

## Verified
- `npm run build` clean
- 1501 unit tests pass (+6 new)
- Code-reviewer subagent verified the root-cause vs server handler + hook source before commit; no blockers, one minor latent-state comment added to the source.

## Test plan
- [ ] CI green
- [ ] Manual smoke in setup wizard
