### PR TITLE
test(web): stabilise three flaky E2E specs (#565)

### DIFF
--- a/web/e2e/emulator-saves.spec.ts
+++ b/web/e2e/emulator-saves.spec.ts
@@ -448,16 +448,16 @@ test.describe("Emulator Save State Sync", () => {
 
       await simulatePlaying(page);
 
-      // Intercept fetch to capture FormData keys
+      // Intercept FormData.append to capture all appended keys. Capturing
+      // `window.fetch`'s body won't work — the openapi-fetch transport
+      // serialises the FormData to an ArrayBuffer via authedFetch
+      // (api-client.ts) before the global fetch sees it.
       await page.evaluate(() => {
-        const origFetch = window.fetch;
-        (window as unknown as Record<string, unknown>).__capturedFormDataKeys = [] as string[];
-        window.fetch = async function (...args: Parameters<typeof fetch>) {
-          const [, options] = args;
-          if (options?.body instanceof FormData) {
-            (window as unknown as Record<string, string[]>).__capturedFormDataKeys = Array.from(options.body.keys());
-          }
-          return origFetch.apply(this, args as [RequestInfo | URL, RequestInit?]);
+        const origAppend = FormData.prototype.append;
+        (window as unknown as Record<string, unknown>).__formDataKeys = [] as string[];
+        FormData.prototype.append = function (name: string, ...rest: unknown[]) {
+          (window as unknown as Record<string, string[]>).__formDataKeys.push(name);
+          return origAppend.call(this, name, ...rest);
         };
       });
 
@@ -478,7 +478,7 @@ test.describe("Emulator Save State Sync", () => {
       await page.waitForTimeout(3_000);
 
       const formDataKeys = await page.evaluate(
-        () => (window as unknown as Record<string, string[]>).__capturedFormDataKeys,
+        () => (window as unknown as Record<string, string[]>).__formDataKeys,
       );
       expect(formDataKeys).toContain("save");
       expect(formDataKeys).not.toContain("screenshot");

--- a/web/e2e/emulator.spec.ts
+++ b/web/e2e/emulator.spec.ts
@@ -277,8 +277,20 @@ test.describe("Emulator Page", () => {
       await page.getByPlaceholder(/search/i).fill("Castlevania");
       await page.keyboard.press("Enter");
 
-      await page.getByText("Castlevania", { exact: false }).first().click();
+      // Target the card's anchor specifically. `.getByText(...).first()`
+      // sometimes resolved to a heading inside the card whose click didn't
+      // reliably propagate to the wrapping link — intermittent #565 failure.
+      const firstCard = page.getByRole("link", { name: /Castlevania/ }).first();
+      await expect(firstCard).toBeVisible();
+      await firstCard.click();
       await expect(page).toHaveURL(/\/games\/\d+$/);
+      // Wait for the detail page's queries (game, consoles, saves, achievements)
+      // to settle. Without this the `play-in-browser-btn` locator races with
+      // the react-query cache warm-up and intermittently reports the button
+      // missing (#565). The mock intercepts /api/consoles to return
+      // emulatorJsCore=""; the button only appears once both the game and
+      // its console info have landed in the cache.
+      await page.waitForLoadState("networkidle");
 
       const playButton = page.getByTestId("play-in-browser-btn");
       await expect(playButton).toBeVisible();

--- a/web/e2e/play-later.spec.ts
+++ b/web/e2e/play-later.spec.ts
@@ -585,10 +585,10 @@ test.describe("Dashboard Play Later Section", () => {
     });
     await expect(playLaterHeading).toBeVisible({ timeout: 10_000 });
 
-    // Assert within the TitledSection div that contains the Play Later heading
-    const playLaterSection = page.locator('[data-comp="TitledSection"]', {
-      has: playLaterHeading,
-    });
+    // Scope the assertion to the Play Later shelf by its testId. The dashboard
+    // renders Play Later via `ScrollShelf` (not `TitledSection`), so the
+    // original [data-comp="TitledSection"] selector matched nothing.
+    const playLaterSection = page.getByTestId("shelf-play-later");
     await expect(
       playLaterSection.getByText("Super Mario Bros.", { exact: true }),
     ).toBeVisible();


### PR DESCRIPTION
## Summary

Fixes three intermittent failures from #565, identified and reproduced against the real E2E Docker Compose stack.

- **emulator-saves.spec.ts** — override `FormData.prototype.append` instead of `window.fetch`. `authedFetch` serialises FormData to an ArrayBuffer before the global fetch sees it, so the capture array was always empty.
- **emulator.spec.ts** — click the card anchor via `getByRole("link")` (not `getByText().first()`, which sometimes resolved to a non-clickable heading inside the card), and wait for `networkidle` so the `play-in-browser-btn` locator doesn't race the react-query cache warm-up for game / consoles / saves / achievements.
- **play-later.spec.ts** — scope the dashboard assertion to `shelf-play-later` (the testId rendered by `ScrollShelf`). The old `[data-comp="TitledSection"]` selector matched nothing because the dashboard renders Play Later via `ScrollShelf`, not `TitledSection`.

No production code touched. Root causes are documented inline in each diff.

Closes part of #565.

## Test plan

- [x] `emulator.spec.ts` — 5/5 runs pass
- [x] `emulator-saves.spec.ts` — 5/5 runs pass
- [x] `play-later.spec.ts` — 5/5 runs pass
- [x] All five previously-flaky spec files: 51/51 pass locally against `docker-compose.e2e.yml`