### PR TITLE
test(web): stabilise last two #565 flaky specs

### DIFF
--- a/web/e2e/admin-scan.spec.ts
+++ b/web/e2e/admin-scan.spec.ts
@@ -121,7 +121,15 @@ test.describe("Admin Scan Page", () => {
   test("shows scrape progress when scrape is active on page load", async ({
     page,
   }) => {
-    // Mock the scrape status endpoint to return active scrape
+    // Mock the scrape status endpoint to return active scrape.
+    //
+    // The real /api/admin/scrape/status response is counters-only
+    // (active/current/total/successes/failures/verified). The per-game
+    // identification fields (gameName, consoleName, gameId, consoleAbbr)
+    // only arrive on the WebSocket `scrape_progress` event — see
+    // web/src/hooks/use-scrape-progress.ts. So this test asserts only
+    // what polling can actually deliver. gameName-centric assertions
+    // belong in a separate test that simulates a WS message (#565).
     await page.route("**/api/admin/scrape/status", (route) => {
       route.fulfill({
         status: 200,
@@ -129,9 +137,12 @@ test.describe("Admin Scan Page", () => {
           active: true,
           current: 3,
           total: 10,
-          gameName: "Super Mario Bros.",
           successes: 2,
           failures: 1,
+          verified: 0,
+          jobId: 0,
+          mode: "",
+          startedAt: null,
         },
       });
     });
@@ -141,7 +152,6 @@ test.describe("Admin Scan Page", () => {
     await expect(page.getByText(/Scraping game 3 of 10/)).toBeVisible({
       timeout: 5_000,
     });
-    await expect(page.getByText("Super Mario Bros.")).toBeVisible();
     await expect(page.getByText("2 succeeded")).toBeVisible();
     await expect(page.getByText("1 failed")).toBeVisible();
   });

--- a/web/e2e/emulator-real.spec.ts
+++ b/web/e2e/emulator-real.spec.ts
@@ -131,11 +131,19 @@ test.describe("EmulatorJS Real Integration", () => {
     await page.keyboard.press("Enter");
 
     // Open game detail
-    await page.getByText("Castlevania", { exact: false }).first().click();
+    // Click the card's anchor — `getByText().first()` sometimes resolves to
+    // a non-clickable heading inside the card. Same fix as #565 applied
+    // to emulator.spec.ts.
+    await page.getByRole("link", { name: /Castlevania/ }).first().click();
     await expect(page).toHaveURL(/\/games\/\d+$/);
 
     const gameId = page.url().match(/\/games\/(\d+)$/)?.[1];
     expect(gameId).toBeTruthy();
+
+    // Wait for the detail page's queries to land before clicking the
+    // Play button — the react-query cache warm-up races the button's
+    // enabled state otherwise.
+    await page.waitForLoadState("networkidle");
 
     // Click Play in Browser
     await page.getByTestId("play-in-browser-btn").click();
@@ -227,11 +235,18 @@ test.describe("EmulatorJS Real Integration", () => {
     await page.getByPlaceholder(/search/i).fill("Castlevania");
     await page.keyboard.press("Enter");
 
-    await page.getByText("Castlevania", { exact: false }).first().click();
+    // Click the card's anchor — `getByText().first()` sometimes resolves to
+    // a non-clickable heading inside the card. Same fix as #565 applied
+    // to emulator.spec.ts.
+    await page.getByRole("link", { name: /Castlevania/ }).first().click();
     await expect(page).toHaveURL(/\/games\/\d+$/);
 
     const gameId = page.url().match(/\/games\/(\d+)$/)?.[1];
     expect(gameId).toBeTruthy();
+
+    // Wait for the detail page's queries to land so the Play button is
+    // fully enabled before we click it.
+    await page.waitForLoadState("networkidle");
 
     // Click Play in Browser
     await page.getByTestId("play-in-browser-btn").click();
@@ -314,7 +329,10 @@ test.describe("EmulatorJS Real Integration", () => {
     await page.getByPlaceholder(/search/i).fill("Castlevania");
     await page.keyboard.press("Enter");
 
-    await page.getByText("Castlevania", { exact: false }).first().click();
+    // Click the card's anchor — `getByText().first()` sometimes resolves to
+    // a non-clickable heading inside the card. Same fix as #565 applied
+    // to emulator.spec.ts.
+    await page.getByRole("link", { name: /Castlevania/ }).first().click();
     const gameId = page.url().match(/\/games\/(\d+)$/)?.[1];
     expect(gameId).toBeTruthy();
 


### PR DESCRIPTION
## Summary

Final round of #565 flaky-test fixes, covering the two failures that the first round did not touch:

- **emulator-real.spec.ts** (3 tests) — same root cause as the emulator.spec.ts fix (PR #630): \`getByText('Castlevania').first().click()\` sometimes resolved to a non-clickable heading. Switched to \`getByRole('link', { name: /Castlevania/ }).first()\`. Added \`waitForLoadState('networkidle')\` before clicking the Play button where the react-query cache warm-up races the button's enabled state.
- **admin-scan.spec.ts:121** — the test mocked \`/api/admin/scrape/status\` with a \`gameName\` field the real endpoint never exposes. The hook \`useScrapeProgress\` explicitly documents that per-game fields only arrive on the \`scrape_progress\` WebSocket event. Dropped the gameName assertion and aligned the mock payload with the real \`ScrapeStatusResponse\` shape. A gameName-focused test should be added separately, simulating a WS message.

## Test plan

- [x] \`E2E_SERVERS_RUNNING=1 npx playwright test admin-scan.spec.ts emulator-real.spec.ts --workers=1\` — **14 / 14 passed** (20s).
- [x] Full Playwright run earlier in the session: 201 passed, 2 failed (the two fixed here), 18 skipped. After this PR the expected result is 203 passed / 0 failed.

Closes the last items from #565.