### PR TITLE
fix(player): unblock desktop test compile (#631)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenArtPageTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SecondaryScreenArtPageTest.kt
@@ -31,6 +31,7 @@ class SecondaryScreenArtPageTest {
                 gameTitle = "Super Metroid",
                 sessionElapsedSeconds = 3600,
                 consoleId = "snes",
+                consoleName = "Super Nintendo",
                 consoleColorTheme = null,
                 gameDeveloper = "Nintendo R&D1",
                 gamePublisher = "Nintendo",
@@ -56,6 +57,7 @@ class SecondaryScreenArtPageTest {
                 gameTitle = "Unknown ROM",
                 sessionElapsedSeconds = 0,
                 consoleId = "nes",
+                consoleName = "Nintendo Entertainment System",
                 consoleColorTheme = null,
             )
         }
@@ -71,6 +73,7 @@ class SecondaryScreenArtPageTest {
                 gameTitle = "Chrono Trigger",
                 sessionElapsedSeconds = 120,
                 consoleId = "snes",
+                consoleName = "Super Nintendo",
                 consoleColorTheme = null,
                 gameDescription = "A classic JRPG about time travel and saving the world.",
             )
@@ -88,6 +91,7 @@ class SecondaryScreenArtPageTest {
                 gameTitle = "Final Fantasy VI",
                 sessionElapsedSeconds = 60,
                 consoleId = "snes",
+                consoleName = "Super Nintendo",
                 consoleColorTheme = null,
                 gameRating = 4.8,
             )
@@ -107,6 +111,7 @@ class SecondaryScreenArtPageTest {
                 gameTitle = "Street Fighter II",
                 sessionElapsedSeconds = 300,
                 consoleId = "snes",
+                consoleName = "Super Nintendo",
                 consoleColorTheme = null,
                 gamePlayers = 2,
             )
@@ -124,6 +129,7 @@ class SecondaryScreenArtPageTest {
                 gameTitle = "Mega Man X",
                 sessionElapsedSeconds = 180,
                 consoleId = "snes",
+                consoleName = "Super Nintendo",
                 consoleColorTheme = null,
                 gamePlayers = 1,
             )
@@ -199,6 +205,7 @@ class SecondaryScreenArtPageTest {
                 gameTitle = "Unknown ROM",
                 sessionElapsedSeconds = 0,
                 consoleId = "nes",
+                consoleName = "Nintendo Entertainment System",
                 consoleColorTheme = null,
                 gameDeveloper = "",
                 gamePublisher = "",
@@ -219,6 +226,7 @@ class SecondaryScreenArtPageTest {
                 gameTitle = "Super Metroid",
                 sessionElapsedSeconds = 120,
                 consoleId = "snes",
+                consoleName = "Super Nintendo",
                 consoleColorTheme = null,
             )
         }
@@ -237,6 +245,7 @@ class SecondaryScreenArtPageTest {
                 gameTitle = "Test Game",
                 sessionElapsedSeconds = 3661, // 1h 1m 1s
                 consoleId = "nes",
+                consoleName = "Nintendo Entertainment System",
                 consoleColorTheme = null,
             )
         }

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -147,6 +147,7 @@ class SpelaTestHarness(
         sharedSessionRepository = sharedSessionRepo,
         gameRepository = gameRepo,
         apiClient = fakeApiClient,
+        scrapeService = scrapeService,
         dispatchers = dispatchers,
         scope = scope,
         biosRepository = biosRepo,

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -749,7 +749,7 @@ class FakeSharedSessionRepository : SharedSessionRepository {
     var sharedSessionSaves: List<SharedSessionSave> = emptyList()
     var gameSharedSessions: List<SharedSession> = emptyList()
 
-    override suspend fun getMySharedSessions(page: Int, pageSize: Int): Result<List<SharedSession>> =
+    override suspend fun getMySharedSessions(): Result<List<SharedSession>> =
         Result.success(sharedSessions)
     override suspend fun getSharedSession(sharedSessionId: String): Result<SharedSessionDetail> =
         sharedSessionDetail?.let { Result.success(it) }
@@ -1184,7 +1184,7 @@ class FakeBiosRepository(
         syncCalled = true
     }
 
-    override suspend fun fetchBiosStatus(): com.spela.player.data.remote.dto.BiosStatusResponse? {
+    override suspend fun fetchBiosStatus(): com.spela.client.models.BiosListResponse? {
         fetchStatusCalled = true
         return null
     }
@@ -1428,7 +1428,7 @@ class FakeExploreRepository : ExploreRepository {
     var playersLikeYou: PlayersLikeYouResult? = null
     var developerSummaries: List<DeveloperSummary> = emptyList()
     var developerDetails: Map<String, DeveloperDetail> = emptyMap()
-    var publisherDetails: Map<String, DeveloperDetail> = emptyMap()
+    var publisherDetails: Map<String, PublisherDetail> = emptyMap()
     var developerSpotlightData: DeveloperSpotlight? = null
     var consoleShowcases: Map<String, ConsoleShowcase> = emptyMap()
     var consoleHighlightsList: List<ConsoleHighlight> = emptyList()
@@ -1554,7 +1554,7 @@ class FakeExploreRepository : ExploreRepository {
             else Result.failure(Exception("Developer not found"))
         }
 
-    override suspend fun getPublisherDetail(name: String): Result<DeveloperDetail> =
+    override suspend fun getPublisherDetail(name: String): Result<PublisherDetail> =
         if (shouldFail) Result.failure(Exception("Failed to load publisher detail"))
         else {
             val detail = publisherDetails[name]


### PR DESCRIPTION
## Summary

The desktop test sources had drifted from the production interfaces and no longer compiled. Five surgical fixes to the test fixtures restore compilation:

- **\`SecondaryScreenArtPageTest.kt\`** — \`SecondaryArtPage\` gained a required \`consoleName: String\` parameter. Nine call sites now pass it (using \"Super Nintendo\" for \`snes\`, \"Nintendo Entertainment System\" for \`nes\`).
- **\`SpelaTestHarness.kt\`** — \`GameDetailViewModel\` gained a required \`scrapeService\`. The harness already had a \`scrapeService\` instance available; now it passes it.
- **\`TestFakes.kt\` (FakeSharedSessionRepository)** — \`SharedSessionRepository.getMySharedSessions()\` no longer takes \`page\`/\`pageSize\`. The fake override now matches.
- **\`TestFakes.kt\` (FakeBiosRepository)** — \`BiosRepository.fetchBiosStatus()\` returns \`com.spela.client.models.BiosListResponse\` (not the old \`com.spela.player.data.remote.dto.BiosStatusResponse\`). Fixed.
- **\`TestFakes.kt\` (FakeExploreRepository)** — \`ExploreRepository.getPublisherDetail\` returns \`Result<PublisherDetail>\`, not \`Result<DeveloperDetail>\`. The var type and override signature now match.

## Test plan

- [x] \`./gradlew :desktop:desktopTestClasses\` — BUILD SUCCESSFUL.
- [x] \`./gradlew :desktop:desktopTest\` — runs. 594 / 707 tests pass. The 113 failing tests are runtime assertion/feature drift, not compile errors, and will be tackled per test file in separate PRs.

Closes #631.