### PR TITLE
fix(player): surface recentlyAdded in console showcase (#632)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreConsoleShowcaseTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreConsoleShowcaseTest.kt
@@ -66,6 +66,7 @@ class ExploreConsoleShowcaseTest {
         genreBreakdown = emptyList(),
         topDevelopers = emptyList(),
         recentlyPlayed = emptyList(),
+        recentlyAdded = emptyList(),
     )
 
     // --- Console highlights on Explore screen ---
@@ -147,5 +148,55 @@ class ExploreConsoleShowcaseTest {
         advance(harness)
 
         onNodeWithTag("console_launch_games_section").assertDoesNotExist()
+    }
+
+    // --- Recently Added shelf ---
+
+    private fun sampleAddedGame(id: String, title: String) = Game(
+        id = id,
+        title = title,
+        consoleId = "snes",
+        consoleName = "Super Nintendo",
+    )
+
+    @Test
+    fun consoleRecentlyAddedSectionRendersWhenPopulated() = runComposeUiTest {
+        val harness = createHarness()
+        // Use distinctive titles that don't collide with the fake gameRepo's
+        // default SNES game list — the console screen also renders those in
+        // an inline grid, so shared titles would satisfy the assertion from
+        // either location.
+        val showcase = sampleShowcase.copy(
+            recentlyAdded = listOf(
+                sampleAddedGame("ra-1", "Recently Added Alpha"),
+                sampleAddedGame("ra-2", "Recently Added Beta"),
+            ),
+        )
+        harness.exploreRepo.consoleShowcases = mapOf("snes" to showcase)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.Console("snes"))
+        )
+        advance(harness)
+
+        onNodeWithTag("console_recently_added_section").assertExists()
+        onNodeWithText("Recently Added").assertExists()
+        onNodeWithText("Recently Added Alpha").assertExists()
+        onNodeWithText("Recently Added Beta").assertExists()
+    }
+
+    @Test
+    fun consoleRecentlyAddedSectionHiddenWhenEmpty() = runComposeUiTest {
+        val harness = createHarness()
+        harness.exploreRepo.consoleShowcases = mapOf("snes" to sampleShowcase)
+
+        setContent { harness.App() }
+        harness.navigationViewModel.onIntent(
+            NavigationIntent.NavigateTo(SpScreen.Console("snes"))
+        )
+        advance(harness)
+
+        onNodeWithTag("console_recently_added_section").assertDoesNotExist()
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -1023,6 +1023,7 @@ fun com.spela.client.models.ConsoleShowcaseResponse.toDomain(): ConsoleShowcase 
     genreBreakdown = genreBreakdown.map { it.toDomain() },
     topDevelopers = topDevelopers.map { it.toDomain() },
     recentlyPlayed = recentlyPlayed.map { it.toDomain() },
+    recentlyAdded = recentlyAdded.map { it.toDomain() },
 )
 
 // Generated ConsoleHighlight has @Required non-nullable topGame, but the

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -258,6 +258,13 @@ class ExploreRepositoryImpl(
                     logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
                 )
             },
+            recentlyAdded = dto.recentlyAdded.map { gameDto ->
+                gameDto.toDomain().copy(
+                    coverUrl = apiClient.resolveUrl(gameDto.coverUrl),
+                    heroUrl = apiClient.resolveUrl(gameDto.heroUrl),
+                    logoUrl = apiClient.resolveUrl(gameDto.logoUrl),
+                )
+            },
         )
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/ExploreModels.kt
@@ -326,6 +326,7 @@ data class ConsoleShowcase(
     val genreBreakdown: List<GenreCount>,
     val topDevelopers: List<DeveloperSummary>,
     val recentlyPlayed: List<Game>,
+    val recentlyAdded: List<Game>,
 )
 
 data class ConsoleHighlight(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ConsoleShowcaseSections.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ConsoleShowcaseSections.kt
@@ -161,6 +161,29 @@ fun ConsoleRecentlyPlayed(
     }
 }
 
+@Composable
+fun ConsoleRecentlyAdded(
+    viewModel: ExploreViewModel,
+    onGameSelected: (String) -> Unit,
+) {
+    val state by viewModel.consoleShowcaseState.collectAsState()
+    val showcase = state.showcase ?: return
+    if (showcase.recentlyAdded.isEmpty()) return
+
+    SpTitledSection(
+        title = "Recently Added",
+        edgeToEdgeContent = true,
+        modifier = Modifier
+            .rememberFocus("section_recently_added")
+            .testTag("console_recently_added_section"),
+    ) {
+        GameShelf(
+            games = showcase.recentlyAdded,
+            onGameSelected = onGameSelected,
+        )
+    }
+}
+
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 internal fun GenreBreakdownChips(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/ConsoleScreen.kt
@@ -48,6 +48,7 @@ import com.spela.player.presentation.ui.components.SpTitledSection
 import com.spela.player.presentation.ui.feature.explore.ConsoleEssentials
 import com.spela.player.presentation.ui.feature.explore.ConsoleHiddenGems
 import com.spela.player.presentation.ui.feature.explore.ConsoleLaunchGames
+import com.spela.player.presentation.ui.feature.explore.ConsoleRecentlyAdded
 import com.spela.player.presentation.ui.feature.explore.ConsoleTopDevelopers
 import com.spela.player.presentation.ui.feature.home.ContinuePlayingRow
 import com.spela.player.presentation.ui.feature.home.TopRatedRow
@@ -163,6 +164,7 @@ fun ConsoleScreen(
                         ConsoleEssentials(exploreViewModel, onGameSelected)
                         ConsoleLaunchGames(exploreViewModel, onGameSelected)
                         ConsoleHiddenGems(exploreViewModel, onGameSelected)
+                        ConsoleRecentlyAdded(exploreViewModel, onGameSelected)
                     }
 
                     // Top Rated


### PR DESCRIPTION
## Summary

The server emits \`recentlyAdded\` in \`ConsoleShowcaseResponse\` and the generated Kotlin DTO already has the field — but the player app's domain \`ConsoleShowcase\` dropped it, the mapper didn't copy it, and the console screen never rendered it. Users saw their Recently Added games on web but never in the player app. Closes #632 (surfaced while reviewing #617).

## Changes

- **Domain** (\`ExploreModels.kt\`): \`ConsoleShowcase\` gains \`recentlyAdded: List<Game>\`.
- **DTO mapper** (\`DtoMappers.kt\`): maps the new field.
- **Repository** (\`ExploreRepositoryImpl.kt\`): resolves \`coverUrl\` / \`heroUrl\` / \`logoUrl\` on the \`recentlyAdded\` list, matching the other shelves.
- **UI** (\`ConsoleShowcaseSections.kt\`): new \`ConsoleRecentlyAdded\` composable, structurally identical to \`ConsoleRecentlyPlayed\` (SpTitledSection + GameShelf, \`rememberFocus(\"section_recently_added\")\`, test tag \`console_recently_added_section\`).
- **Screen** (\`ConsoleScreen.kt\`): renders the shelf after HiddenGems.
- **Tests**: \`sampleShowcase\` in \`ExploreConsoleShowcaseTest\` now passes \`recentlyAdded\`, plus two new desktop tests covering populated + hidden states.

## Test plan

- [x] \`./gradlew :shared:compileKotlinDesktop\` — clean.
- [x] \`./gradlew :desktop:desktopTest --tests 'ExploreConsoleShowcaseTest'\` — 6/6 pass.

Closes #632.