### PR TITLE
feat(web): Launch Games shelf on small-library consoles (#633)

### DIFF
--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -126,8 +126,11 @@ export function ConsoleDetailPage() {
           description="No games have been detected for this console yet."
         />
       ) : isSmallLibrary ? (
-        /* Small library: inline game grid */
+        /* Small library: inline game grid, with Launch Games above when
+           curated content exists. The shelf self-hides if the server
+           returns an empty list (#633). */
         <>
+          <ConsoleLaunchGames consoleId={id!} />
           <SearchInput
             placeholder={`Search ${consoleName} games...`}
             value={search}


### PR DESCRIPTION
## Summary

Small-library consoles (< 24 games) previously skipped every curated shelf in favour of a flat inline grid. Launch Games are the most editorially interesting shelf for exactly those consoles — Virtual Boy's 4 launch titles, N64's 2, FDS's 6 — so they are the first shelf worth surfacing there.

The shelf self-hides when the seed list has no matches in the user's library, so layering it above the inline grid costs nothing when absent.

Partial close for #633; rendering Essentials / Hidden Gems on small libraries is a plausible follow-up but the signal-to-noise ratio is lower, and I'd rather wait for user feedback before widening scope.

## Test plan

- [x] \`vitest run console-detail-page.test.tsx\` — 12 / 12 pass.
- [x] \`tsc --noEmit\` clean.

Partial: #633.