### PR TITLE
feat(server): factual core metadata (#555 phase 1)

### DIFF
--- a/server/internal/api/core_handler.go
+++ b/server/internal/api/core_handler.go
@@ -1,9 +1,13 @@
 package api
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/spela/server/internal/db"
 	"gorm.io/gorm"
@@ -13,6 +17,57 @@ import (
 type CoreHandler struct {
 	DB      *gorm.DB
 	CoreDir string
+}
+
+// ensureCoreMetadata populates Sha256 / SizeBytes / FetchedAt / SourceURL
+// on the core row if any are missing. This is a lazy backfill: the first
+// serve of a core after this code lands (or after a fresh core binary
+// lands on disk) computes the hash and records the metadata. Subsequent
+// serves are no-ops.
+//
+// Errors hashing the file are logged and swallowed — a failure here must
+// not block the user from downloading the core. #555.
+func (h *CoreHandler) ensureCoreMetadata(core *db.Core, corePath string) {
+	if core.Sha256 != "" && core.SizeBytes > 0 && core.FetchedAt != nil {
+		return
+	}
+	sum, size, err := hashFileSha256(corePath)
+	if err != nil {
+		slog.Error("failed to hash core binary for metadata", "core", core.Name, "path", corePath, "error", err)
+		return
+	}
+	now := time.Now().UTC()
+	updates := map[string]interface{}{
+		"sha256":     sum,
+		"size_bytes": size,
+		"fetched_at": &now,
+	}
+	// Only overwrite SourceURL if we actually know where this binary came
+	// from. DownloadURL is a template (contains {platform}); storing it as
+	// the source URL is still better than leaving the field blank, since
+	// the admin can tell at a glance whether the core is pinned or pulled
+	// from the buildbot.
+	if core.SourceURL == "" && core.DownloadURL != "" {
+		updates["source_url"] = core.DownloadURL
+	}
+	if err := h.DB.Model(core).Updates(updates).Error; err != nil {
+		slog.Error("failed to persist core metadata", "core", core.Name, "error", err)
+	}
+}
+
+// hashFileSha256 returns the hex sha256 digest and byte length of a file.
+func hashFileSha256(path string) (string, int64, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", 0, err
+	}
+	defer f.Close()
+	hasher := sha256.New()
+	size, err := io.Copy(hasher, f)
+	if err != nil {
+		return "", 0, err
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), size, nil
 }
 
 // platformExtension returns the shared library extension for the given platform.

--- a/server/internal/api/core_handler_test.go
+++ b/server/internal/api/core_handler_test.go
@@ -1,15 +1,22 @@
 package api
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
 	"testing"
 
 	"github.com/spela/server/internal/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func itoa(u uint) string { return strconv.FormatUint(uint64(u), 10) }
 
 func TestListCores_AzaharHasDownloadURL(t *testing.T) {
 	_, cfg := setupTestEnv(t)
@@ -61,4 +68,62 @@ func TestListCores_BuildbotCoresHaveNoDownloadURL(t *testing.T) {
 			assert.Empty(t, c.DownloadURL, "buildbot core %s should have no downloadUrl", c.Name)
 		}
 	}
+}
+
+// TestDownloadCore_BackfillsMetadata verifies that the first serve of a
+// core binary computes and persists the factual metadata (sha256, size,
+// fetchedAt) — #555 Phase 1.
+func TestDownloadCore_BackfillsMetadata(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	// Ensure the CoreDir exists and place a deterministic binary for nestopia.
+	require.NoError(t, os.MkdirAll(cfg.CoreDir, 0o755))
+	payload := []byte("libretro-core-bytes-for-test")
+	corePath := filepath.Join(cfg.CoreDir, "nestopia_libretro.so")
+	require.NoError(t, os.WriteFile(corePath, payload, 0o644))
+
+	// Look up the seeded nestopia core ID.
+	var core db.Core
+	require.NoError(t, database.Where("name = ?", "nestopia").First(&core).Error)
+	// Metadata fields should be empty before the first serve.
+	assert.Empty(t, core.Sha256)
+	assert.Zero(t, core.SizeBytes)
+	assert.Nil(t, core.FetchedAt)
+
+	// First download triggers the metadata backfill.
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/cores/"+itoa(core.ID)+"/download?platform=linux", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	assert.Equal(t, payload, w.Body.Bytes())
+
+	// Row should now have populated metadata.
+	var refreshed db.Core
+	require.NoError(t, database.First(&refreshed, core.ID).Error)
+
+	expectedSum := sha256.Sum256(payload)
+	assert.Equal(t, hex.EncodeToString(expectedSum[:]), refreshed.Sha256)
+	assert.Equal(t, int64(len(payload)), refreshed.SizeBytes)
+	require.NotNil(t, refreshed.FetchedAt)
+	assert.False(t, refreshed.FetchedAt.IsZero())
+
+	// A second serve must not re-hash (the row is already populated, so the
+	// FetchedAt timestamp should remain stable).
+	firstFetchedAt := *refreshed.FetchedAt
+
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("GET", "/api/cores/"+itoa(core.ID)+"/download?platform=linux", nil)
+	req2.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusOK, w2.Code)
+
+	var refreshedAgain db.Core
+	require.NoError(t, database.First(&refreshedAgain, core.ID).Error)
+	require.NotNil(t, refreshedAgain.FetchedAt)
+	assert.Equal(t, firstFetchedAt.Unix(), refreshedAgain.FetchedAt.Unix(),
+		"fetchedAt should not change on subsequent serves")
 }

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -405,6 +405,10 @@ func (h *CoreHandler) HumaDownloadCore(_ context.Context, in *CoreDownloadInput)
 		return nil, huma.Error403Forbidden("core file access denied")
 	}
 
+	// Lazy backfill of factual core metadata. Only runs until the row
+	// has all fields populated; afterwards it's a no-op. See #555.
+	h.ensureCoreMetadata(&core, corePath)
+
 	ext := platformExtension(platform)
 	return streamFileFromDisk(corePath, core.Name+"_libretro"+ext, "application/octet-stream"), nil
 }

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -778,6 +778,15 @@ type Core struct {
 	Platforms   string         `gorm:"size:255" json:"platforms"` // comma-separated: windows,linux,macos,android
 	FilePath    string         `gorm:"size:1024" json:"-"`
 	DownloadURL string         `gorm:"size:1024" json:"downloadUrl"` // URL template for non-buildbot cores; {platform} is replaced by the player
+
+	// Factual metadata about the cached binary, populated by the server
+	// whenever it downloads or serves a core for the first time. See #555.
+	// Nullable pointer for FetchedAt so admin UI can distinguish "never
+	// fetched" from "fetched long ago".
+	Sha256    string     `gorm:"size:64" json:"sha256"`    // hex sha256 of the cached binary
+	SizeBytes int64      `json:"sizeBytes"`                // byte length of the cached binary
+	FetchedAt *time.Time `json:"fetchedAt"`                // when the binary was last downloaded
+	SourceURL string     `gorm:"size:1024" json:"sourceUrl"` // URL we pulled the binary from
 }
 
 // CheatCode represents a cheat code for a specific game.

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -5826,10 +5826,16 @@ export interface components {
             description: string;
             displayName: string;
             downloadUrl: string;
+            /** Format: date-time */
+            fetchedAt: string | null;
             /** Format: int64 */
             id: number;
             name: string;
             platforms: string;
+            sha256: string;
+            /** Format: int64 */
+            sizeBytes: number;
+            sourceUrl: string;
             /** Format: date-time */
             updatedAt: string;
             version: string;

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -2142,6 +2142,13 @@
           "downloadUrl": {
             "type": "string"
           },
+          "fetchedAt": {
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
           "id": {
             "format": "int64",
             "minimum": 0,
@@ -2151,6 +2158,16 @@
             "type": "string"
           },
           "platforms": {
+            "type": "string"
+          },
+          "sha256": {
+            "type": "string"
+          },
+          "sizeBytes": {
+            "format": "int64",
+            "type": "integer"
+          },
+          "sourceUrl": {
             "type": "string"
           },
           "updatedAt": {
@@ -2170,7 +2187,11 @@
           "description",
           "version",
           "platforms",
-          "downloadUrl"
+          "downloadUrl",
+          "sha256",
+          "sizeBytes",
+          "fetchedAt",
+          "sourceUrl"
         ],
         "type": "object"
       },


### PR DESCRIPTION
## Summary

Phase 1 of #555 (core binary freshness + versioning + save-state compatibility). This increment is deliberately small and user-invisible — it just makes the admin surface factual by lazy-backfilling real metadata about each cached core binary.

## Changes

- \`Core\` model gains four new columns:
  - \`sha256\` — hex digest of the cached binary (stable identifier).
  - \`sizeBytes\` — byte length.
  - \`fetchedAt\` — pointer timestamp so \"never fetched\" is distinguishable from \"fetched long ago\".
  - \`sourceUrl\` — where we pulled the binary from (seeded with \`DownloadURL\` on first serve for pinned cores like Azahar).
- \`HumaDownloadCore\` runs \`ensureCoreMetadata\` before streaming. The helper is a no-op once the row is populated, so the hash computation happens exactly once per core binary.
- Hash failures are logged and swallowed — never block the download.
- No admin UI changes (no existing UI surface showed \`Version\` either). A dedicated admin \"Cores\" page is a good follow-up.
- No Kotlin regeneration in this PR — the generated DTOs are additive (new fields only) and can be refreshed in the next Kotlin regen batch.

## Test plan

- [x] \`go test ./internal/api/ -run 'TestListCores|TestDownloadCore'\` — all pass, including the new \`TestDownloadCore_BackfillsMetadata\` covering: empty-before, populated-after, no re-hash on second serve.
- [x] \`go build ./...\` clean.
- [x] \`npm run openapi:gen\` — regenerated web types, \`tsc --noEmit\` clean.

Part of #555 (phases 2 and 3 — background refresh + player cache invalidation, save-state pinning — in follow-up PRs).