### PR TITLE
chore(server): core-metadata Phase 1 follow-up (#555)

### DIFF
--- a/server/internal/api/core_handler.go
+++ b/server/internal/api/core_handler.go
@@ -27,7 +27,18 @@ type CoreHandler struct {
 //
 // Errors hashing the file are logged and swallowed — a failure here must
 // not block the user from downloading the core. #555.
+//
+// Limitations tracked for #555 Phase 2:
+//   - Binary replacement staleness: if an admin replaces the on-disk
+//     binary after the row is populated, the recorded sha256 goes stale
+//     until a force-refresh admin endpoint lands.
+//   - Concurrent first-serves may both run the hash and issue
+//     identical UPDATEs — SQLite serialises writes so there's no
+//     corruption, but the second hash is wasted I/O.
 func (h *CoreHandler) ensureCoreMetadata(core *db.Core, corePath string) {
+	// The `SizeBytes > 0` check both skips populated rows and avoids a
+	// bogus skip on zero-byte files: `FetchedAt != nil` is the
+	// authoritative "already ran" marker.
 	if core.Sha256 != "" && core.SizeBytes > 0 && core.FetchedAt != nil {
 		return
 	}

--- a/server/internal/api/core_handler_test.go
+++ b/server/internal/api/core_handler_test.go
@@ -110,6 +110,11 @@ func TestDownloadCore_BackfillsMetadata(t *testing.T) {
 	assert.Equal(t, int64(len(payload)), refreshed.SizeBytes)
 	require.NotNil(t, refreshed.FetchedAt)
 	assert.False(t, refreshed.FetchedAt.IsZero())
+	// Nestopia is a buildbot core (DownloadURL is empty in the seed), so
+	// SourceURL must stay empty — the helper only copies a non-empty
+	// DownloadURL into SourceURL. An admin cores UI follow-up can assert
+	// the complementary path for pinned cores like azahar.
+	assert.Empty(t, refreshed.SourceURL)
 
 	// A second serve must not re-hash (the row is already populated, so the
 	// FetchedAt timestamp should remain stable).
@@ -126,4 +131,43 @@ func TestDownloadCore_BackfillsMetadata(t *testing.T) {
 	require.NotNil(t, refreshedAgain.FetchedAt)
 	assert.Equal(t, firstFetchedAt.Unix(), refreshedAgain.FetchedAt.Unix(),
 		"fetchedAt should not change on subsequent serves")
+}
+
+// TestDownloadCore_PinnedCoreCopiesDownloadURL verifies that a core with a
+// populated DownloadURL (pinned cores like azahar) has its DownloadURL
+// copied into SourceURL on the first-serve backfill.
+func TestDownloadCore_PinnedCoreCopiesDownloadURL(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	require.NoError(t, os.MkdirAll(cfg.CoreDir, 0o755))
+	payload := []byte("pinned-core-bytes")
+	corePath := filepath.Join(cfg.CoreDir, "azahar_libretro.so")
+	require.NoError(t, os.WriteFile(corePath, payload, 0o644))
+
+	var core db.Core
+	require.NoError(t, database.Where("name = ?", "azahar").First(&core).Error)
+	require.NotEmpty(t, core.DownloadURL, "seeded azahar core should have a DownloadURL template")
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/cores/"+itoa(core.ID)+"/download?platform=linux", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var refreshed db.Core
+	require.NoError(t, database.First(&refreshed, core.ID).Error)
+	assert.Equal(t, core.DownloadURL, refreshed.SourceURL,
+		"pinned core's DownloadURL template should be copied to SourceURL on first serve")
+}
+
+// TestHashFileSha256_Errors verifies that hashFileSha256 returns an error
+// for unreadable paths. This pins the contract that `ensureCoreMetadata`
+// relies on: a hash failure surfaces as a Go error, not a panic, which
+// lets the download path log-and-continue without blocking the user.
+func TestHashFileSha256_Errors(t *testing.T) {
+	_, _, err := hashFileSha256(filepath.Join(t.TempDir(), "does-not-exist"))
+	assert.Error(t, err, "hashing a missing file must return an error, not panic")
 }


### PR DESCRIPTION
## Summary

Follow-up to #639 addressing code-reviewer feedback on the Phase 1 core-metadata work. No production behavior change — just code comments and test coverage.

- **ensureCoreMetadata** now documents the two known limitations: binary-replacement staleness (Phase 2 concern) and concurrent first-serve write race (benign under SQLite).
- **SizeBytes > 0** guard is explained: it prevents a zero-byte on-disk binary from being treated as already-populated; \`FetchedAt != nil\` is the authoritative "already ran" marker.
- **TestDownloadCore_PinnedCoreCopiesDownloadURL**: verifies pinned cores (azahar) have their DownloadURL template copied into SourceURL on first serve.
- **TestHashFileSha256_Errors**: pins the "returns Go error, no panic" contract the download path relies on, so a hash failure can be log-and-continued without blocking the user.

## Test plan

- [x] \`go test ./internal/api -run 'TestDownloadCore|TestHashFileSha256'\` — all pass.
- [x] No production code changed — server behavior is identical.

Part of #555.