### PR TITLE
feat(server): expand Launch Games seed to 9 more consoles (#617)

### DIFF
--- a/server/internal/api/seed_launch_games.go
+++ b/server/internal/api/seed_launch_games.go
@@ -449,6 +449,102 @@ var launchGamesByConsole = map[string][]string{
 		"Tennis",
 		"Golf",
 	},
+
+	// ColecoVision — North America, 1982-08.
+	"cv": {
+		"Donkey Kong",
+		"Cosmic Avenger",
+		"Lady Bug",
+		"Mouse Trap",
+		"Smurf: Rescue in Gargamel's Castle",
+		"Venture",
+		"Zaxxon",
+		"Carnival",
+		"Cosmic Crisis",
+		"Head to Head Baseball",
+		"Head to Head Football",
+	},
+
+	// Mattel Intellivision — North America, 1979-12.
+	"intv": {
+		"Las Vegas Poker & Blackjack",
+		"Math Fun",
+		"Backgammon",
+		"Checkers",
+		"Electric Company Math Fun",
+		"Armor Battle",
+		"Auto Racing",
+		"Major League Baseball",
+		"NBA Basketball",
+		"NFL Football",
+		"NHL Hockey",
+	},
+
+	// Magnavox Odyssey 2 — North America, 1978.
+	"o2": {
+		"Speedway!",
+		"Spin-Out!",
+		"Crypto-Logic!",
+		"Math-A-Magic!",
+		"Echo!",
+		"Armored Encounter!",
+		"Sub Chase!",
+		"Las Vegas Blackjack!",
+	},
+
+	// Fairchild Channel F — North America, 1976-11.
+	"chaf": {
+		"Tic-Tac-Toe, Shooting Gallery, Doodle, and Quadra-Doodle",
+		"Desert Fox, Shooting Gallery",
+		"Video Blackjack",
+		"Spitfire",
+	},
+
+	// Atari 5200 — North America, 1982-11.
+	"a52": {
+		"Super Breakout",
+		"Missile Command",
+		"Pac-Man",
+		"Galaxian",
+		"Centipede",
+		"Defender",
+		"Star Raiders",
+		"Space Invaders",
+		"Realsports Football",
+		"Asteroids",
+	},
+
+	// GCE Vectrex — North America, 1982-11.
+	"vec": {
+		"Mine Storm",
+		"Star Trek: The Motion Picture",
+		"Scramble",
+		"Berzerk",
+		"Armor Attack",
+		"Rip Off",
+		"HeadsUp: Soccer/Football",
+		"Hyperchase",
+	},
+
+	// PC Engine SuperGrafx — Japan, 1989-12-08.
+	"sgx": {
+		"Battle Ace",
+		"Daimakaimura",
+	},
+
+	// PC-FX — Japan, 1994-12-23.
+	"pcfx": {
+		"Battle Heat",
+		"Team Innocent: The Point of No Return",
+	},
+
+	// TurboGrafx-CD / PC Engine CD — Japan, 1988-12-04.
+	"pcecd": {
+		"Fighting Street",
+		"No-Ri-Ko",
+		"Bikkuriman World",
+		"CD-ROM^2 System Card",
+	},
 }
 
 // launchGamesFor returns the curated launch-title list for a console, keyed


### PR DESCRIPTION
## Summary

Extends the curated Launch Games seed (landed in #634) to cover nine more consoles:

- ColecoVision (NA 1982-08)
- Intellivision (NA 1979-12)
- Magnavox Odyssey 2 (NA 1978)
- Fairchild Channel F (NA 1976-11)
- Atari 5200 (NA 1982-11)
- Vectrex (NA 1982-11)
- PC Engine SuperGrafx (JP 1989-12)
- PC-FX (JP 1994-12)
- TurboGrafx-CD (JP 1988-12)

Sourced from Wikipedia's "List of launch games for the ..." pages, same editorial approach as the initial 27. Total coverage is now **36 consoles**.

## Test plan

- [x] \`go build ./...\` clean.
- [x] \`go test ./internal/api -run 'TestGetConsoleShowcase_LaunchGames'\` — existing tests still pass. Matching is data-driven so no new assertions needed; an integration test with seeded games could verify each new console, but the titles follow the same normalization pipeline as the existing ones.

Part of #617.