### PR TITLE
test(player): align SessionsUiTest with current SessionsSection

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionsUiTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SessionsUiTest.kt
@@ -53,7 +53,8 @@ class SessionsUiTest {
         scrollToSessions()
         onNodeWithTag("sessions_section").assertIsDisplayed()
         onNodeWithText("Sessions").assertIsDisplayed()
-        onNodeWithText("(1)").assertIsDisplayed()
+        // SessionsSection no longer renders a session count next to the
+        // title — verify the session item itself instead.
         onNodeWithTag("session_item_s1").assertIsDisplayed()
         onNodeWithText("My First Run").assertIsDisplayed()
     }
@@ -71,7 +72,7 @@ class SessionsUiTest {
         scrollToSessions()
         onNodeWithTag("sessions_section").assertIsDisplayed()
         onNodeWithTag("sessions_empty").assertIsDisplayed()
-        onNodeWithText("No sessions yet. Start a new playthrough to track your progress.")
+        onNodeWithText("No sessions yet. Press Play to start your first playthrough.")
             .assertIsDisplayed()
     }
 
@@ -88,8 +89,9 @@ class SessionsUiTest {
         onNodeWithTag("create_session_button").performClick()
         advanceQuick(harness)
 
-        // Dialog should appear with default name
-        onNodeWithText("New Session").assertIsDisplayed()
+        // Dialog should appear with its input field. "New Session" text
+        // appears on both the trigger button and the dialog title so we
+        // key on the input tag for the dialog-open assertion.
         onNodeWithTag("create_session_input").assertIsDisplayed()
 
         // Clear and type a custom name
@@ -191,7 +193,7 @@ class SessionsUiTest {
         navigateToGameDetail(harness, "1")
 
         scrollToSessions()
-        onNodeWithText("(3)").assertIsDisplayed()
+        // No session-count pill next to the title — assert item presence.
         onNodeWithTag("session_item_s1").assertIsDisplayed()
         onNodeWithTag("session_item_s2").assertIsDisplayed()
 
@@ -244,7 +246,9 @@ class SessionsUiTest {
         navigateToGameDetail(harness, "1")
 
         scrollToSessions()
-        onNodeWithText("(1)").assertIsDisplayed()
+        // The Castlevania session item exists and the Mario session (for
+        // a different game) does not — the count pill next to the title
+        // is no longer rendered.
         onNodeWithText("Castlevania Run").assertIsDisplayed()
         onNodeWithText("Mario Run").assertDoesNotExist()
     }
@@ -429,16 +433,14 @@ class SessionsUiTest {
 
         scrollToSessions()
         onNodeWithTag("session_item_s1").assertIsDisplayed()
-        onNodeWithText("(1)").assertIsDisplayed()
 
         // Click the duplicate button
         onNodeWithContentDescription("Duplicate session").performClick()
         advance(harness)
 
-        // A new session should appear in the list
+        // A new session should appear in the list.
         assertEquals(2, harness.sessionRepo.sessions.size)
         assertEquals("My Playthrough (Copy)", harness.sessionRepo.sessions[1].name)
-        onNodeWithText("(2)").assertIsDisplayed()
         onNodeWithText("My Playthrough (Copy)").assertIsDisplayed()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/SessionsSection.kt
@@ -75,6 +75,7 @@ internal fun SessionsSection(
             SpSecondaryButton(
                 text = "New Session",
                 onClick = { showCreateDialog = true },
+                modifier = Modifier.testTag("create_session_button"),
             )
         },
     ) {


### PR DESCRIPTION
## Summary

Clears 6 runtime failures in \`SessionsUiTest\` from the #631 backlog. One drift: \`SessionsSection\` was simplified to drop the \`(N)\` count pill next to the title and updated its empty-state wording.

Changes:

- Drop \`onNodeWithText(\"(1)\")\` / \`(2)\` / \`(3)\` assertions; key on session-item existence instead.
- Empty-state text matches current UI: \"No sessions yet. Press Play to start your first playthrough.\"
- \"New Session\" text appears on both the trigger button and the dialog title; the create-session test now keys on the input \`testTag\` for the \"dialog open\" assertion.
- Added \`testTag(\"create_session_button\")\` on the trigger button — the only production change, enabling unambiguous test selection.

## Test plan

- [x] \`./gradlew :desktop:desktopTest --tests 'SessionsUiTest'\` — 18/18 pass.

Part of #631.