### PR TITLE
fix(#646): add game_detail_play_button testTag to Play CTA

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/BiosWarningTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/BiosWarningTest.kt
@@ -148,7 +148,7 @@ class BiosWarningTest {
         navigateToGameDetail(harness, gameId = "1")
 
         // The play button should be enabled
-        onNodeWithContentDescription("Play Castlevania").assertIsDisplayed()
+        onNodeWithTag("game_detail_play_button").assertIsDisplayed()
     }
 
     @Test

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ChallengeCreationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ChallengeCreationTest.kt
@@ -36,7 +36,7 @@ class ChallengeCreationTest {
         advance(harness)
 
         // Start game
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Open overlay
@@ -56,7 +56,7 @@ class ChallengeCreationTest {
         advance(harness)
 
         // Start game -> open overlay -> tap Challenge
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
         harness.emulationViewModel.onIntent(EmulationIntent.ToggleOverlay)
         advanceQuick(harness)
@@ -80,7 +80,7 @@ class ChallengeCreationTest {
         advance(harness)
 
         // Start game -> open overlay -> create challenge
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
         harness.emulationViewModel.onIntent(EmulationIntent.ToggleOverlay)
         advanceQuick(harness)
@@ -113,7 +113,7 @@ class ChallengeCreationTest {
         advance(harness)
 
         // Start game -> open overlay -> open creation form
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
         harness.emulationViewModel.onIntent(EmulationIntent.ToggleOverlay)
         advanceQuick(harness)
@@ -133,7 +133,7 @@ class ChallengeCreationTest {
         advance(harness)
 
         // Start game -> open overlay -> open challenge form -> cancel
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
         harness.emulationViewModel.onIntent(EmulationIntent.ToggleOverlay)
         advanceQuick(harness)

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/DesktopKeyboardMappingTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/DesktopKeyboardMappingTest.kt
@@ -44,7 +44,7 @@ class DesktopKeyboardMappingTest {
         advance(harness)
 
         // Start game (overlay hidden by default, game enters playing state)
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Verify the controller is ready for input

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/EmulationVerificationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/EmulationVerificationTest.kt
@@ -37,7 +37,7 @@ class EmulationVerificationTest {
         setContent { harness.App() }
         advance(harness)
 
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Verify the correct core was loaded
@@ -54,7 +54,7 @@ class EmulationVerificationTest {
         setContent { harness.App() }
         advance(harness)
 
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Verify emulation state
@@ -72,7 +72,7 @@ class EmulationVerificationTest {
         advance(harness)
 
         // Start game
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Game starts with overlay hidden; verify it's running
@@ -87,7 +87,7 @@ class EmulationVerificationTest {
         setContent { harness.App() }
         advance(harness)
 
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         assertTrue(harness.libretroController.isRunning)
@@ -124,7 +124,7 @@ class EmulationVerificationTest {
         advance(harness)
 
         // Play first game
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         assertTrue(harness.libretroController.isRunning)

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/EscapeKeyOverlayTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/EscapeKeyOverlayTest.kt
@@ -39,7 +39,7 @@ class EscapeKeyOverlayTest {
         advance(harness)
 
         // Start game from detail screen (overlay is hidden by default)
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
     }
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameBrowsingAndSelectionTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameBrowsingAndSelectionTest.kt
@@ -121,7 +121,7 @@ class GameBrowsingAndSelectionTest {
         advance(harness)
 
         // Game is cached, so Play should be shown
-        onNodeWithContentDescription("Play Castlevania").assertIsDisplayed()
+        onNodeWithTag("game_detail_play_button").assertIsDisplayed()
     }
 
     @Test

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailActionsMenuTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailActionsMenuTest.kt
@@ -29,7 +29,7 @@ class GameDetailActionsMenuTest {
         setContent { harness.App() }
         navigateToGameDetail(harness, "1")
 
-        onNodeWithContentDescription("Play Castlevania").assertIsDisplayed()
+        onNodeWithTag("game_detail_play_button").assertIsDisplayed()
     }
 
     @Test

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InGameOverlayTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InGameOverlayTest.kt
@@ -33,7 +33,7 @@ class InGameOverlayTest {
         advance(harness)
 
         // Start game
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Open overlay (hidden by default on game start)

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/PauseHintTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/PauseHintTest.kt
@@ -43,7 +43,7 @@ class PauseHintTest {
         advance(harness)
 
         // Start game
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Overlay should be hidden by default
@@ -65,7 +65,7 @@ class PauseHintTest {
         advance(harness)
 
         // Start game (overlay hidden by default)
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Game should be running, overlay hidden
@@ -81,7 +81,7 @@ class PauseHintTest {
         advance(harness)
 
         // Start game (overlay hidden by default)
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // The "Press Esc to pause" hint should be visible in the emulation surface.
@@ -104,7 +104,7 @@ class PauseHintTest {
         advance(harness)
 
         // Start game (overlay hidden by default)
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Toggle overlay to show it
@@ -128,7 +128,7 @@ class PauseHintTest {
         advance(harness)
 
         // Start game (overlay hidden by default, FPS HUD should be visible)
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // FPS HUD should be visible (the small badge in top-right)
@@ -148,7 +148,7 @@ class PauseHintTest {
         advance(harness)
 
         // Start game (overlay hidden by default, hint would show and fade)
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Open overlay via ViewModel

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SaveLoadStateTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SaveLoadStateTest.kt
@@ -34,7 +34,7 @@ class SaveLoadStateTest {
         advance(harness)
 
         // Start game
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Open overlay to access Save button
@@ -60,7 +60,7 @@ class SaveLoadStateTest {
         advance(harness)
 
         // Start game
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Open overlay to access Save/Load buttons
@@ -90,7 +90,7 @@ class SaveLoadStateTest {
         advance(harness)
 
         // Start game
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         val saveCountBefore = harness.libretroController.saveCallCount

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.text.font.FontWeight
@@ -972,7 +973,9 @@ private fun GameHeroContent(
                     SpSplitButton(
                         text = if (hasSaves) "Resume" else "Play",
                         onClick = { onPlay(gameId) },
-                        modifier = Modifier.autoFocus(),
+                        modifier = Modifier
+                            .autoFocus()
+                            .testTag("game_detail_play_button"),
                         enabled = !hasRequiredBiosMissing && !isSyncing,
                         isLoading = false,
                         menuItems = menuItems,


### PR DESCRIPTION
## Summary

Ten desktop test files clicked the GameDetail Play button via \`onNodeWithContentDescription(\"Play Castlevania\")\` — but no node with that contentDescription exists anywhere in shared code. A refactor at some point removed it. The Play click is a prerequisite for dozens of tests (PauseHint, InGameOverlay, EscapeKeyOverlay, EmulationVerification, BiosWarning, etc.), so this one change unblocks a large chunk of the #631 runtime backlog.

Changes:

- Add \`testTag(\"game_detail_play_button\")\` to the primary \`SpSplitButton\` CTA in \`GameDetailScreen\`. testTag is more stable than a dynamic contentDescription keyed on the current game title.
- Replace \`onNodeWithContentDescription(\"Play Castlevania\")\` → \`onNodeWithTag(\"game_detail_play_button\")\` across 10 test files.

## Test plan

- [x] \`./gradlew :desktop:desktopTest\` — failure count drops from **93 → 58** (~35 tests unblocked by this one change).
- [x] \`./gradlew :desktop:desktopTest --tests 'PauseHintTest'\` — 6/6 pass.

Closes #646. Part of #631.