### PR TITLE
test(player): settings tests navigate to 'Per-Console' category

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SettingsConsoleNavigationTest.kt
@@ -31,7 +31,10 @@ class SettingsConsoleNavigationTest {
     }
 
     private fun ComposeUiTest.navigateToControlsCategory(harness: SpelaTestHarness) {
-        onNodeWithContentDescription("Controls").performClick()
+        // The per-console list lives under the "Per-Console" category,
+        // not "Controls" — it was moved when the settings screen was
+        // split into categorised sub-pages.
+        onNodeWithContentDescription("Per-Console").performClick()
         advanceQuick(harness)
     }
 


### PR DESCRIPTION
## Summary

Clears 5 runtime failures in \`SettingsConsoleNavigationTest\` from the #631 backlog. All five tests clicked the \"Controls\" settings category expecting the per-console list — but that list lives under the separate \"Per-Console\" category (the settings screen was split into categorised sub-pages). One-line helper change.

## Test plan

- [x] \`./gradlew :desktop:desktopTest --tests 'SettingsConsoleNavigationTest'\` — 5/5 pass.

Part of #631.