### PR TITLE
test(player): SyncStatusTest opens 'Storage & Sync' category

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SyncStatusTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SyncStatusTest.kt
@@ -27,8 +27,10 @@ class SyncStatusTest {
         )
         advance(harness)
 
-        onNodeWithTag("settings_list")
-            .performScrollToNode(hasText("Sync"))
+        // Sync lives under the "Storage & Sync" category since the
+        // settings screen was split into categorised sub-pages.
+        onNodeWithContentDescription("Storage & Sync").performClick()
+        advanceQuick(harness)
     }
 
     @Test
@@ -48,8 +50,6 @@ class SyncStatusTest {
         setContent { harness.App() }
         navigateToSettingsAndScrollToSync(harness)
 
-        onNodeWithTag("settings_list")
-            .performScrollToNode(hasText("Sync Now"))
         onNodeWithText("Online").assertIsDisplayed()
     }
 
@@ -60,8 +60,6 @@ class SyncStatusTest {
         setContent { harness.App() }
         navigateToSettingsAndScrollToSync(harness)
 
-        onNodeWithTag("settings_list")
-            .performScrollToNode(hasText("Sync Now"))
         onNodeWithText("Sync Now").assertIsDisplayed()
     }
 }


### PR DESCRIPTION
## Summary

Clears 3 runtime failures in \`SyncStatusTest\`. Same drift as PR #650 — the Sync section moved into the categorised \"Storage & Sync\" sub-page when settings was refactored. Helper now opens that category and redundant inner \`performScrollToNode\` calls are removed.

## Test plan

- [x] \`./gradlew :desktop:desktopTest --tests 'SyncStatusTest'\` — 3/3 pass.

Part of #631.