### PR TITLE
test(player): game_detail_download_button testTag + adopt in tests

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameBrowsingAndSelectionTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameBrowsingAndSelectionTest.kt
@@ -103,7 +103,7 @@ class GameBrowsingAndSelectionTest {
         advance(harness)
 
         // Game is not cached, so Download should be shown
-        onNodeWithContentDescription("Download Castlevania").assertIsDisplayed()
+        onNodeWithTag("game_detail_download_button").assertIsDisplayed()
     }
 
     @Test

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailActionsMenuTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDetailActionsMenuTest.kt
@@ -39,7 +39,7 @@ class GameDetailActionsMenuTest {
         setContent { harness.App() }
         navigateToGameDetail(harness, "1")
 
-        onNodeWithContentDescription("Download Castlevania").assertIsDisplayed()
+        onNodeWithTag("game_detail_download_button").assertIsDisplayed()
     }
 
     @Test

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDownloadAndLaunchTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameDownloadAndLaunchTest.kt
@@ -31,14 +31,14 @@ class GameDownloadAndLaunchTest {
         advance(harness)
 
         // Should show Download button initially
-        onNodeWithContentDescription("Download Castlevania").assertIsDisplayed()
+        onNodeWithTag("game_detail_download_button").assertIsDisplayed()
 
         // Tap Download
-        onNodeWithContentDescription("Download Castlevania").performClick()
+        onNodeWithTag("game_detail_download_button").performClick()
         advance(harness)
 
         // After download completes, Play button should appear
-        onNodeWithContentDescription("Play Castlevania").assertIsDisplayed()
+        onNodeWithTag("game_detail_play_button").assertIsDisplayed()
     }
 
     @Test
@@ -58,7 +58,7 @@ class GameDownloadAndLaunchTest {
         advance(harness)
 
         // Tap Play
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Open overlay (hidden by default) and verify controls
@@ -84,7 +84,7 @@ class GameDownloadAndLaunchTest {
 
         advance(harness)
 
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Verify emulation actually started via the fake controller
@@ -107,7 +107,7 @@ class GameDownloadAndLaunchTest {
 
         advance(harness)
 
-        onNodeWithContentDescription("Play Castlevania").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advance(harness)
 
         // Open overlay to see game title

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -1000,6 +1000,7 @@ private fun GameHeroContent(
                 SpSplitButton(
                     text = if (isBusy) "Downloading..." else "Download",
                     onClick = onDownloadGame,
+                    modifier = Modifier.testTag("game_detail_download_button"),
                     isLoading = isBusy,
                     enabled = !isBusy,
                     menuItems = menuItems,


### PR DESCRIPTION
## Summary

Mirrors the Play-button fix from PR #647 for the Download CTA. The Download \`SpSplitButton\` on GameDetailScreen had no stable selector, and tests were keying on a \`Download Castlevania\` contentDescription that was never wired up.

- Add \`testTag(\"game_detail_download_button\")\` to the Download \`SpSplitButton\`.
- Adopt the new tag in three test files: GameDownloadAndLaunch, GameBrowsingAndSelection, GameDetailActionsMenu.
- GameDownloadAndLaunchTest also used \`Play Castlevania\` — migrated those to \`game_detail_play_button\` while in the file.

## Test plan

- [x] \`./gradlew :desktop:desktopTest --tests 'GameDownloadAndLaunchTest'\` — 4/4 pass.

Part of #631.