### PR TITLE
test(player): retire removed copy-save tests + fix empty-state fixtures

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/DashboardSectionOrderTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/DashboardSectionOrderTest.kt
@@ -194,7 +194,10 @@ class DashboardSectionOrderTest {
     @Test
     fun emptyStateShownWhenAllSectionsEmpty() = runComposeUiTest {
         val harness = createLoggedInHarness()
+        // HomeScreen treats consoles as a "section" for empty-detection,
+        // so the fake's default two consoles must also be cleared.
         harness.gameRepo.games = emptyList()
+        harness.gameRepo.consoles = emptyList()
         // socialRepo defaults to empty
 
         setContent { harness.App() }
@@ -244,6 +247,7 @@ class DashboardSectionOrderTest {
         val harness = createLoggedInHarness()
         // No personal games, no social data — only top-rated discovery data
         harness.gameRepo.games = emptyList()
+        harness.gameRepo.consoles = emptyList()
         harness.gameRepo.globalTopRatedGames = listOf(
             TopRatedGame(rank = 1, name = "Chrono Trigger", rating = 96.0, localGameId = null),
         )

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SharedSessionFeaturesTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SharedSessionFeaturesTest.kt
@@ -454,81 +454,13 @@ class SharedSessionFeaturesTest {
     }
 
     // ---- Shared session detail: copy save to game ----
-
-    @Test
-    fun sharedSessionDetailScreenShowsCopyButtonOnSaves() = runComposeUiTest {
-        val harness = createLoggedInHarness()
-        harness.sharedSessionRepo.sharedSessionDetail = SharedSessionDetail(
-            id = "ss1",
-            name = "Test Session",
-            gameId = "1",
-            gameTitle = "Castlevania",
-            ownerId = "1",
-            ownerUsername = "player",
-            memberCount = 1,
-            members = emptyList(),
-        )
-        harness.sharedSessionRepo.sharedSessionSaves = listOf(
-            SharedSessionSave(
-                id = 1,
-                sharedSessionId = "ss1",
-                username = "player",
-                name = "Boss fight save",
-                fileSize = 4096,
-                isAuto = false,
-            ),
-        )
-
-        setContent { harness.App() }
-
-        harness.navigationViewModel.onIntent(
-            NavigationIntent.NavigateTo(SpScreen.SharedSessionDetail("ss1"))
-        )
-        advance(harness)
-
-        onNodeWithContentDescription("Copy Boss fight save to your library").assertExists()
-    }
-
-    @Test
-    fun sharedSessionDetailScreenCopySaveShowsSuccessMessage() = runComposeUiTest {
-        val harness = createLoggedInHarness()
-        harness.sharedSessionRepo.sharedSessionDetail = SharedSessionDetail(
-            id = "ss1",
-            name = "Test Session",
-            gameId = "1",
-            gameTitle = "Castlevania",
-            ownerId = "1",
-            ownerUsername = "player",
-            memberCount = 1,
-            members = emptyList(),
-        )
-        harness.sharedSessionRepo.sharedSessionSaves = listOf(
-            SharedSessionSave(
-                id = 1,
-                sharedSessionId = "ss1",
-                username = "player",
-                name = "Boss fight save",
-                fileSize = 4096,
-                isAuto = false,
-            ),
-        )
-
-        setContent { harness.App() }
-
-        harness.navigationViewModel.onIntent(
-            NavigationIntent.NavigateTo(SpScreen.SharedSessionDetail("ss1"))
-        )
-        advance(harness)
-
-        onNodeWithContentDescription("Copy Boss fight save to your library").assertExists()
-        onNodeWithContentDescription("Copy Boss fight save to your library").performClick()
-        // Advance test dispatcher only (not Compose clock) to process ViewModel coroutine
-        harness.testDispatcher.scheduler.advanceTimeBy(2_000)
-        harness.testDispatcher.scheduler.runCurrent()
-
-        val state = harness.sharedSessionDetailViewModel.state.value
-        assertEquals("Save copied to your library", state.successMessage)
-    }
+    //
+    // The "Copy save to your library" button was removed along with the
+    // game-scoped save model (commit 8b7bcb49). The replacement — session
+    // cloning — is tracked in #553 and will require fresh tests against
+    // the new UI. The two tests that lived here have been deleted rather
+    // than ported, since they exercised an endpoint/button that no longer
+    // exists in any form.
 
     // ---- Shared session detail: invite section ----
 


### PR DESCRIPTION
## Summary

Two small unrelated batches cleared from the #631 backlog:

1. **SharedSessionFeaturesTest (2 deletions)** — the \"Copy save to your library\" button was removed with the game-scoped save model (commit 8b7bcb49). Session cloning in #553 will need fresh tests. Deleted the stale tests.
2. **DashboardSectionOrderTest (2 fixes)** — \`HomeScreen.isEmpty\` checks consoles too, and the fake repo seeds two default consoles. Tests now clear consoles in addition to games to trigger the empty state.

## Test plan

- [x] \`./gradlew :desktop:desktopTest --tests 'SharedSessionFeaturesTest'\` — all remaining pass.
- [x] \`./gradlew :desktop:desktopTest --tests 'DashboardSectionOrderTest'\` — all pass.

Part of #631.