### PR TITLE
test(player): batch 4 singleton-failure drift fixes

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/DashboardWidgetsTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/DashboardWidgetsTest.kt
@@ -58,8 +58,10 @@ class DashboardWidgetsTest {
     @Test
     fun personalStatsHiddenWhenLibraryEmpty() = runComposeUiTest {
         val harness = createLoggedInHarness()
-        // Empty game list triggers the EmptyLibrary state, hiding all sections
+        // Empty library state requires clearing both games AND consoles —
+        // HomeScreen.isEmpty considers consoles too (see PR #656).
         harness.gameRepo.games = emptyList()
+        harness.gameRepo.consoles = emptyList()
 
         setContent { harness.App() }
         advance(harness)

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/EmulationVerificationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/EmulationVerificationTest.kt
@@ -146,7 +146,7 @@ class EmulationVerificationTest {
 
         // Play second game — needs extra advancement for the full
         // LaunchedEffect → StartGame → scope.launch chain to complete
-        onNodeWithContentDescription("Play Super Mario Bros.").performClick()
+        onNodeWithTag("game_detail_play_button").performClick()
         advanceFully(harness)
 
         assertTrue(harness.libretroController.isRunning)

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreScreenTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ExploreScreenTest.kt
@@ -147,9 +147,13 @@ class ExploreScreenTest {
         harness.navigationViewModel.onIntent(NavigationIntent.NavigateTo(SpScreen.Explore))
         advance(harness)
 
-        // Console name chip and genre chip should be visible for the active slide
-        onNodeWithText("Super Nintendo").assertExists()
-        onNodeWithText("Platformer").assertExists()
+        // The active slide renders a console chip. Genre is no longer
+        // shown in the carousel metadata row — assert on the console
+        // chip only. If genre returns, re-add the assertion.
+        onNodeWithTag("hero_carousel").assertIsDisplayed()
+        onAllNodesWithText("Super Nintendo").fetchSemanticsNodes().let {
+            assert(it.isNotEmpty()) { "Expected 'Super Nintendo' chip text" }
+        }
     }
 
     @Test

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameBrowsingAndSelectionTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GameBrowsingAndSelectionTest.kt
@@ -68,8 +68,11 @@ class GameBrowsingAndSelectionTest {
         onNodeWithContentDescription("Nintendo Entertainment System, 3 games").performClick()
         advance(harness)
 
-        // Should navigate to console screen and show the browse button
-        onNodeWithText("Browse All 3 Games").assertIsDisplayed()
+        // Should navigate to the console screen. The "Browse games" CTA
+        // on the hero only renders for large libraries (> 15 games);
+        // with 3 games the console screen shows the inline "All Games"
+        // section directly, which contains the NES titles.
+        onNodeWithText("Castlevania").assertExists()
     }
 
     @Test


### PR DESCRIPTION
## Summary

Four independent singleton test failures from the #631 backlog, each with its own small drift:

- **EmulationVerificationTest.multipleGamesCanBePlayedSequentially** — \`Play Super Mario Bros.\` contentDescription doesn't exist; switch to \`game_detail_play_button\` testTag.
- **GameBrowsingAndSelectionTest.tappingConsoleInConsolesScreenNavigatesToConsoleScreen** — \`Browse All 3 Games\` button was renamed to \`Browse games\` and only renders for >15-game libraries. Assert a game title on the inline All Games section instead.
- **DashboardWidgetsTest.personalStatsHiddenWhenLibraryEmpty** — same empty-library fixture drift as #656; clear consoles too.
- **ExploreScreenTest.heroCarouselShowsConsoleChipAndGenre** — genre chip was removed from the carousel metadata row; assertion now covers the carousel + console chip only.

## Test plan

- [x] All four test classes pass individually.

Part of #631.