### PR TITLE
chore: ignore local dev artefacts + generated subproject builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,11 +27,32 @@ server/saves/
 
 # Dependencies (npm)
 web/node_modules/
+design-proposals/node_modules/
 
 # Build outputs
 web/dist/
 web/build/
 web/dummy-non-existing-folder/
+design-proposals/dist/
+
+# Server build artefacts (local test binaries and dev databases)
+server/spela-server
+server/server
+server/api.test
+server/dump-openapi
+server/spela.db-shm
+server/spela.db-wal
+server/.vite/
+
+# Player-app local dev artefacts
+player/desktop/spela.db
+player/openapitools.json
+
+# Root-level local test + tool output (not source)
+spela.db
+openapitools.json
+test-results/
+node_modules/
 
 # Environment
 .env


### PR DESCRIPTION
## Summary

Expands \`.gitignore\` to cover local artefacts that currently pollute \`git status\` — node_modules and dist under \`design-proposals/\`, compiled server binaries and SQLite journals, the player desktop DB, and a handful of root-level scratch files (\`test-results/\`, root \`node_modules/\`). None of these belong in the tree; they just accumulated as the tooling matrix grew. Zero code change.

## Test plan

- [x] \`git status\` on a working tree now shows only real changes.