### PR TITLE
feat(#655): restore ownership-progress on franchise/series pages

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/explore/ExploreGroupDetailContent.kt
@@ -44,6 +44,7 @@ import androidx.compose.ui.text.font.FontWeight
 import coil3.compose.SubcomposeAsyncImage
 import com.spela.player.presentation.ui.components.SpCard
 import com.spela.player.presentation.ui.components.SpGameGrid
+import com.spela.player.presentation.ui.components.SpProgressBar
 import com.spela.player.presentation.ui.components.SpGridGameCard
 import com.spela.player.presentation.ui.components.SpHeroBanner
 import com.spela.player.presentation.ui.components.SpChip
@@ -166,11 +167,28 @@ fun ExploreGroupDetailContent(
                                             color = Color.White,
                                         )
                                     }
-                                    Text(
-                                        text = "${detail.totalGames} games",
-                                        style = SpTypography.BodyMedium,
-                                        color = Color.White.copy(alpha = 0.7f),
-                                    )
+                                    if (detail.totalGames > 0) {
+                                        Column(
+                                            modifier = Modifier
+                                                .fillMaxWidth()
+                                                .padding(horizontal = SpSpacing.Large)
+                                                .testTag("${groupLabel}_ownership_progress"),
+                                            horizontalAlignment = Alignment.CenterHorizontally,
+                                        ) {
+                                            Text(
+                                                text = "You own ${detail.libraryGames} of ${detail.totalGames} games",
+                                                style = SpTypography.BodyMedium,
+                                                color = Color.White.copy(alpha = 0.7f),
+                                                modifier = Modifier.testTag("${groupLabel}_ownership_text"),
+                                            )
+                                            Spacer(Modifier.height(SpSpacing.XSmall))
+                                            SpProgressBar(
+                                                progress = detail.libraryGames.toFloat() / detail.totalGames.toFloat(),
+                                                height = 6.dp,
+                                                onGradient = true,
+                                            )
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -214,10 +232,28 @@ fun ExploreGroupDetailContent(
                                 SpGameGrid(
                                     items = filteredGames.map { game ->
                                         @Composable {
+                                            // Rebuild the SpGameCard's baked-in
+                                            // "$title, $subtitle" semantic contract
+                                            // here — SpGameCard's own semantics
+                                            // modifier clears any wrapping
+                                            // contentDescription, so the only
+                                            // stable place to surface "not in
+                                            // library" is via the card's own
+                                            // visible subtitle text. Concatenate
+                                            // the phrase into the subtitle so it
+                                            // renders on-screen AND flows into
+                                            // the card's contentDescription.
+                                            val subtitle = buildString {
+                                                append(game.consoleName ?: "")
+                                                if (!game.inLibrary) {
+                                                    if (isNotEmpty()) append(" \u00b7 ")
+                                                    append("not in library")
+                                                }
+                                            }
                                             Box(modifier = Modifier.alpha(if (game.inLibrary) 1f else 0.5f)) {
                                                 SpGridGameCard(
                                                     title = game.name,
-                                                    subtitle = game.consoleName ?: "",
+                                                    subtitle = subtitle,
                                                     coverUrl = game.coverUrl,
                                                     onClick = if (game.inLibrary && game.localGameId != null) {
                                                         { onGameSelected(game.localGameId) }

--- a/web/src/components/ui/index.ts
+++ b/web/src/components/ui/index.ts
@@ -29,3 +29,4 @@ export { ConfirmDeleteModal } from "./confirm-delete-modal";
 export { LeaderboardRow } from "./leaderboard-row";
 export { FilterChip } from "./filter-chip";
 export { Divider } from "./divider";
+export { ProgressBar } from "./progress-bar";

--- a/web/src/components/ui/progress-bar.test.tsx
+++ b/web/src/components/ui/progress-bar.test.tsx
@@ -1,0 +1,55 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { ProgressBar } from "./progress-bar";
+
+describe("ProgressBar", () => {
+  it("renders a progressbar element with the correct aria attributes", () => {
+    render(<ProgressBar value={3} max={10} ariaLabel="3 of 10 games owned" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar).toHaveAttribute("aria-valuenow", "3");
+    expect(bar).toHaveAttribute("aria-valuemin", "0");
+    expect(bar).toHaveAttribute("aria-valuemax", "10");
+    expect(bar).toHaveAttribute("aria-label", "3 of 10 games owned");
+  });
+
+  it("clamps value to [0, max]", () => {
+    render(<ProgressBar value={-5} max={10} ariaLabel="clamped low" />);
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "0");
+  });
+
+  it("clamps value above max down to max", () => {
+    render(<ProgressBar value={99} max={10} ariaLabel="clamped high" />);
+    expect(screen.getByRole("progressbar")).toHaveAttribute("aria-valuenow", "10");
+  });
+
+  it("handles max=0 without dividing by zero", () => {
+    render(<ProgressBar value={0} max={0} ariaLabel="empty" />);
+    const bar = screen.getByRole("progressbar");
+    // max=0 is treated as max=1 internally; value clamps to 0 → 0%
+    expect(bar).toHaveAttribute("aria-valuemax", "1");
+    expect(bar.getAttribute("style")).toContain("width: 0%");
+  });
+
+  it("renders the label and percentage when requested", () => {
+    render(
+      <ProgressBar
+        value={3}
+        max={10}
+        label="Progress"
+        showPercentage
+        ariaLabel="3 of 10"
+      />,
+    );
+    expect(screen.getByText("Progress")).toBeInTheDocument();
+    expect(screen.getByText("30%")).toBeInTheDocument();
+  });
+
+  it("applies the onHero tone when requested", () => {
+    const { container } = render(
+      <ProgressBar value={5} max={10} tone="onHero" ariaLabel="on hero" />,
+    );
+    // The track div should carry the onHero track class; the fill the onHero fill class.
+    expect(container.innerHTML).toContain("bg-white/20");
+    expect(container.innerHTML).toContain("bg-brand-400");
+  });
+});

--- a/web/src/components/ui/progress-bar.tsx
+++ b/web/src/components/ui/progress-bar.tsx
@@ -1,0 +1,72 @@
+import type { HTMLAttributes, ReactNode } from "react";
+import { cn } from "@/lib/cn";
+
+type ProgressBarTone = "default" | "onHero";
+type ProgressBarSize = "sm" | "md";
+
+interface ProgressBarProps extends Omit<HTMLAttributes<HTMLDivElement>, "role" | "aria-valuenow" | "aria-valuemin" | "aria-valuemax"> {
+  value: number;
+  max: number;
+  label?: ReactNode;
+  showPercentage?: boolean;
+  tone?: ProgressBarTone;
+  size?: ProgressBarSize;
+  ariaLabel?: string;
+}
+
+const toneStyles: Record<ProgressBarTone, { track: string; fill: string; label: string }> = {
+  default: {
+    track: "bg-surface-800",
+    fill: "bg-brand-500",
+    label: "text-surface-400",
+  },
+  onHero: {
+    track: "bg-white/20 backdrop-blur-sm",
+    fill: "bg-brand-400",
+    label: "text-white/80",
+  },
+};
+
+const sizeStyles: Record<ProgressBarSize, string> = {
+  sm: "h-1.5",
+  md: "h-2",
+};
+
+export function ProgressBar({
+  value,
+  max,
+  label,
+  showPercentage = false,
+  tone = "default",
+  size = "md",
+  ariaLabel,
+  className,
+  ...rest
+}: ProgressBarProps) {
+  const safeMax = max > 0 ? max : 1;
+  const clampedValue = Math.max(0, Math.min(value, safeMax));
+  const percent = Math.round((clampedValue / safeMax) * 100);
+  const styles = toneStyles[tone];
+
+  return (
+    <div data-comp="ProgressBar" className={cn("w-full", className)} {...rest}>
+      {(label || showPercentage) && (
+        <div className={cn("flex items-center justify-between gap-2 text-xs mb-1", styles.label)}>
+          {label && <span>{label}</span>}
+          {showPercentage && <span>{percent}%</span>}
+        </div>
+      )}
+      <div className={cn("w-full rounded-full overflow-hidden", sizeStyles[size], styles.track)}>
+        <div
+          className={cn("h-full rounded-full transition-all duration-500", styles.fill)}
+          style={{ width: `${percent}%` }}
+          role="progressbar"
+          aria-valuenow={clampedValue}
+          aria-valuemin={0}
+          aria-valuemax={safeMax}
+          aria-label={ariaLabel}
+        />
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/explore-franchise-page.tsx
+++ b/web/src/pages/explore-franchise-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams } from "react-router-dom";
-import { Skeleton } from "@/components/ui";
+import { ProgressBar, Skeleton } from "@/components/ui";
 import { PageLayout, SectionList } from "@/components/layout";
 import { useFranchiseDetail } from "@/hooks/use-explore";
 import { GameTimelineCard } from "@/features/explore/components/game-timeline-card";
@@ -65,70 +65,66 @@ export function ExploreFranchisePage() {
     ? sortedGames.filter((g) => g.consoleAbbreviation === consoleFilter)
     : sortedGames;
 
-  const progressPercent =
-    franchise.totalGames > 0
-      ? Math.round((franchise.libraryGames / franchise.totalGames) * 100)
-      : 0;
+  const ownershipLabel = `You own ${franchise.libraryGames} of ${franchise.totalGames} games`;
+  const ownershipAriaLabel = `${franchise.libraryGames} of ${franchise.totalGames} games owned`;
+  const showOwnership = franchise.totalGames > 0;
 
-  return (
-    <PageLayout backButtonVariant="standard" backTo="/explore" backLabel="Explore" data-testid="franchise-detail-page">
-      <SectionList>
-      {/* Full-width hero banner */}
-      {franchise.heroUrl ? (
-        <div className="relative w-full h-64 sm:h-80 lg:h-96 -mx-6">
-          <div className="relative w-full h-full rounded-2xl overflow-hidden">
-            <img
-              src={franchise.heroUrl}
-              alt=""
-              className="w-full h-full object-cover"
-            />
-            {/* Multi-layer gradient for depth */}
-            <div className="absolute inset-0 bg-gradient-to-t from-surface-950 via-surface-950/60 to-transparent" />
-            <div className="absolute inset-0 bg-gradient-to-r from-surface-950/40 via-transparent to-surface-950/40" />
+  const renderHero = franchise.heroUrl
+    ? () => (
+        <div className="relative w-full h-64 sm:h-80 lg:h-96 overflow-hidden">
+          <img
+            src={franchise.heroUrl!}
+            alt=""
+            className="w-full h-full object-cover"
+          />
+          {/* Multi-layer gradient for depth */}
+          <div className="absolute inset-0 bg-gradient-to-t from-surface-950 via-surface-950/60 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-r from-surface-950/40 via-transparent to-surface-950/40" />
 
-            {/* Title + progress overlaid at bottom */}
-            <div className="absolute bottom-0 left-0 right-0 p-6 sm:p-8">
-              <h1 className="text-4xl sm:text-5xl font-bold text-white drop-shadow-lg mb-3">
-                {franchise.name}
-              </h1>
+          {/* Title + progress overlaid at bottom */}
+          <div className="absolute bottom-0 left-0 right-0 p-6 sm:p-8">
+            <h1 className="text-4xl sm:text-5xl font-bold text-white drop-shadow-lg mb-3">
+              {franchise.name}
+            </h1>
+            {showOwnership && (
               <div className="flex items-center gap-4" data-testid="ownership-progress">
-                <p className="text-sm text-white/80">
-                  You own {franchise.libraryGames} of {franchise.totalGames} games
-                </p>
-                <div className="flex-1 max-w-xs h-2 bg-white/20 rounded-full overflow-hidden backdrop-blur-sm">
-                  <div
-                    className="h-full bg-brand-400 rounded-full transition-all duration-500"
-                    style={{ width: `${progressPercent}%` }}
-                    role="progressbar"
-                    aria-valuenow={franchise.libraryGames}
-                    aria-valuemin={0}
-                    aria-valuemax={franchise.totalGames}
-                    aria-label={`${franchise.libraryGames} of ${franchise.totalGames} games owned`}
-                  />
-                </div>
+                <p className="text-sm text-white/80 whitespace-nowrap">{ownershipLabel}</p>
+                <ProgressBar
+                  value={franchise.libraryGames}
+                  max={franchise.totalGames}
+                  tone="onHero"
+                  ariaLabel={ownershipAriaLabel}
+                  className="max-w-xs"
+                />
               </div>
-            </div>
+            )}
           </div>
         </div>
-      ) : (
+      )
+    : undefined;
+
+  return (
+    <PageLayout
+      backButtonVariant={franchise.heroUrl ? "floating" : "standard"}
+      backTo="/explore"
+      backLabel="Explore"
+      data-testid="franchise-detail-page"
+      renderHeader={renderHero}
+    >
+      <SectionList>
+      {!franchise.heroUrl && (
         <>
           <h1 className="text-4xl font-bold text-surface-100">{franchise.name}</h1>
-          <div data-testid="ownership-progress">
-            <p className="text-sm text-surface-400 mb-2">
-              You own {franchise.libraryGames} of {franchise.totalGames} games
-            </p>
-            <div className="w-full h-2 bg-surface-800 rounded-full overflow-hidden">
-              <div
-                className="h-full bg-brand-500 rounded-full transition-all duration-500"
-                style={{ width: `${progressPercent}%` }}
-                role="progressbar"
-                aria-valuenow={franchise.libraryGames}
-                aria-valuemin={0}
-                aria-valuemax={franchise.totalGames}
-                aria-label={`${franchise.libraryGames} of ${franchise.totalGames} games owned`}
+          {showOwnership && (
+            <div data-testid="ownership-progress">
+              <p className="text-sm text-surface-400 mb-2">{ownershipLabel}</p>
+              <ProgressBar
+                value={franchise.libraryGames}
+                max={franchise.totalGames}
+                ariaLabel={ownershipAriaLabel}
               />
             </div>
-          </div>
+          )}
         </>
       )}
 

--- a/web/src/pages/explore-series-page.tsx
+++ b/web/src/pages/explore-series-page.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams } from "react-router-dom";
-import { Skeleton } from "@/components/ui";
+import { ProgressBar, Skeleton } from "@/components/ui";
 import { PageLayout, SectionList } from "@/components/layout";
 import { useSeriesDetail } from "@/hooks/use-explore";
 import { GameTimelineCard } from "@/features/explore/components/game-timeline-card";
@@ -72,71 +72,66 @@ export function ExploreSeriesPage() {
     ? sortedGames.filter((g) => g.consoleAbbreviation === consoleFilter)
     : sortedGames;
 
-  const progressPercent =
-    series.totalGames > 0
-      ? Math.round((series.libraryGames / series.totalGames) * 100)
-      : 0;
+  const ownershipLabel = `You own ${series.libraryGames} of ${series.totalGames} games`;
+  const ownershipAriaLabel = `${series.libraryGames} of ${series.totalGames} games owned`;
+  const showOwnership = series.totalGames > 0;
 
-  return (
-    <PageLayout backButtonVariant="standard" backTo="/explore" backLabel="Explore" data-testid="series-detail-page">
-      <SectionList>
-      {/* Full-width hero banner */}
-      {series.heroUrl ? (
-        <div className="relative w-full h-64 sm:h-80 lg:h-96 -mx-6">
-          <div className="relative w-full h-full rounded-2xl overflow-hidden">
-            <img
-              src={series.heroUrl}
-              alt=""
-              className="w-full h-full object-cover"
-            />
-            {/* Multi-layer gradient for depth */}
-            <div className="absolute inset-0 bg-gradient-to-t from-surface-950 via-surface-950/60 to-transparent" />
-            <div className="absolute inset-0 bg-gradient-to-r from-surface-950/40 via-transparent to-surface-950/40" />
+  const renderHero = series.heroUrl
+    ? () => (
+        <div className="relative w-full h-64 sm:h-80 lg:h-96 overflow-hidden">
+          <img
+            src={series.heroUrl!}
+            alt=""
+            className="w-full h-full object-cover"
+          />
+          {/* Multi-layer gradient for depth */}
+          <div className="absolute inset-0 bg-gradient-to-t from-surface-950 via-surface-950/60 to-transparent" />
+          <div className="absolute inset-0 bg-gradient-to-r from-surface-950/40 via-transparent to-surface-950/40" />
 
-            {/* Title + progress overlaid at bottom */}
-            <div className="absolute bottom-0 left-0 right-0 p-6 sm:p-8">
-              <h1 className="text-4xl sm:text-5xl font-bold text-white drop-shadow-lg mb-3">
-                {series.name}
-              </h1>
+          {/* Title + progress overlaid at bottom */}
+          <div className="absolute bottom-0 left-0 right-0 p-6 sm:p-8">
+            <h1 className="text-4xl sm:text-5xl font-bold text-white drop-shadow-lg mb-3">
+              {series.name}
+            </h1>
+            {showOwnership && (
               <div className="flex items-center gap-4" data-testid="ownership-progress">
-                <p className="text-sm text-white/80">
-                  You own {series.libraryGames} of {series.totalGames} games
-                </p>
-                <div className="flex-1 max-w-xs h-2 bg-white/20 rounded-full overflow-hidden backdrop-blur-sm">
-                  <div
-                    className="h-full bg-brand-400 rounded-full transition-all duration-500"
-                    style={{ width: `${progressPercent}%` }}
-                    role="progressbar"
-                    aria-valuenow={series.libraryGames}
-                    aria-valuemin={0}
-                    aria-valuemax={series.totalGames}
-                    aria-label={`${series.libraryGames} of ${series.totalGames} games owned`}
-                  />
-                </div>
+                <p className="text-sm text-white/80 whitespace-nowrap">{ownershipLabel}</p>
+                <ProgressBar
+                  value={series.libraryGames}
+                  max={series.totalGames}
+                  tone="onHero"
+                  ariaLabel={ownershipAriaLabel}
+                  className="max-w-xs"
+                />
               </div>
-            </div>
+            )}
           </div>
         </div>
-      ) : (
+      )
+    : undefined;
+
+  return (
+    <PageLayout
+      backButtonVariant={series.heroUrl ? "floating" : "standard"}
+      backTo="/explore"
+      backLabel="Explore"
+      data-testid="series-detail-page"
+      renderHeader={renderHero}
+    >
+      <SectionList>
+      {!series.heroUrl && (
         <>
           <h1 className="text-4xl font-bold text-surface-100">{series.name}</h1>
-          {/* Ownership progress */}
-          <div data-testid="ownership-progress">
-            <p className="text-sm text-surface-400 mb-2">
-              You own {series.libraryGames} of {series.totalGames} games
-            </p>
-            <div className="w-full h-2 bg-surface-800 rounded-full overflow-hidden">
-              <div
-                className="h-full bg-brand-500 rounded-full transition-all duration-500"
-                style={{ width: `${progressPercent}%` }}
-                role="progressbar"
-                aria-valuenow={series.libraryGames}
-                aria-valuemin={0}
-                aria-valuemax={series.totalGames}
-                aria-label={`${series.libraryGames} of ${series.totalGames} games owned`}
+          {showOwnership && (
+            <div data-testid="ownership-progress">
+              <p className="text-sm text-surface-400 mb-2">{ownershipLabel}</p>
+              <ProgressBar
+                value={series.libraryGames}
+                max={series.totalGames}
+                ariaLabel={ownershipAriaLabel}
               />
             </div>
-          </div>
+          )}
         </>
       )}
 


### PR DESCRIPTION
## Summary

The \"You own N of M games\" progress widget was dropped from the franchise and series pages as collateral damage in commit a7d35f3d (the hero-banner refactor — the commit message talked about hero visuals, never about removing ownership progress). The tests were never updated and the four corresponding runtime failures were the last cluster blocked on product input (#655).

Restores the widget on **three surfaces**, all backed by **standardized shared UI components** per the requirement:

### Web

- **New** \`web/src/components/ui/progress-bar.tsx\` — reusable \`ProgressBar\` with API: \`value\`, \`max\`, \`label\`, \`showPercentage\`, \`tone\` (\`default\` | \`onHero\`), \`size\`, \`ariaLabel\`. Emits \`role=\"progressbar\"\` + aria-valuenow/min/max. Six unit tests cover aria, clamping both directions, max=0 safety, label/percentage rendering, and tone classes.
- **\`explore-franchise-page.tsx\` / \`explore-series-page.tsx\`** — replaced two hand-rolled progress bars each with the shared component. Restructured the hero layout to use \`PageLayout.renderHeader\` + \`backButtonVariant=\"floating\"\` so the previous \`-mx-6\` negative margin (strictly forbidden) is gone — the hero is now full-bleed via the established \`renderHeader\` hook. Guard the widget on \`totalGames > 0\` so a \"You own 0 of 0\" label never surfaces.

### Player app

- **\`ExploreGroupDetailContent.kt\`** — added an ownership row inside the hero banner using the existing \`SpProgressBar\` with \`onGradient=true\`. Tags: \`franchise_ownership_progress\` + \`franchise_ownership_text\` (same for series via the shared \`groupLabel\` prefix pattern).
- Non-library games now include \`· not in library\` in the card subtitle so the badge flows into the card's generated contentDescription; a Modifier-based semantics approach didn't work because \`SpGameCard\`'s own \`.semantics{}\` block clears parent semantics.

## Reviewer feedback addressed

Code-reviewer flagged that web rendered the ownership block unconditionally while the player guarded on \`totalGames > 0\`. Fixed — both surfaces now share the same \`showOwnership\` guard.

## Test plan

- [x] \`./gradlew :desktop:desktopTest --tests 'FranchiseDetailTest' --tests 'ExploreSeriesTest'\` — 19/19 pass (was 4 failing).
- [x] \`npx vitest run src/pages/__tests__/explore-franchise-page.test.tsx src/pages/__tests__/explore-series-page.test.tsx src/components/ui/progress-bar.test.tsx\` — 38/38 pass.
- [x] \`npx tsc --noEmit\` — clean.

Closes #655.