### PR TITLE
test(player): seed auto-save for Load-state tests (#658)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InGameOverlayTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/InGameOverlayTest.kt
@@ -73,8 +73,14 @@ class InGameOverlayTest {
     fun loadTriggersUnserialization() = runComposeUiTest {
         val harness = createHarnessWithGameReady()
 
-        // Pre-set serialized state so load succeeds
-        harness.libretroController.serializedState = ByteArray(64) { 42 }
+        // The Load button downloads the session's auto-save. Seed a
+        // session + auto-save so there's something to unserialize;
+        // mirrors the state "a prior play left an auto-save behind".
+        val sessionId = "session-1"
+        harness.sessionRepo.sessions.add(
+            com.spela.player.domain.model.GameSession(id = sessionId, gameId = "1", name = "Default"),
+        )
+        harness.sessionRepo.preSeedAutoSave(sessionId)
 
         startGame(harness)
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SaveLoadStateTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SaveLoadStateTest.kt
@@ -1,6 +1,7 @@
 package com.spela.player.desktop.e2e
 
 import androidx.compose.ui.test.*
+import com.spela.player.domain.model.GameSession
 import com.spela.player.presentation.intent.EmulationIntent
 import com.spela.player.presentation.navigation.NavigationIntent
 import com.spela.player.presentation.navigation.SpScreen
@@ -56,6 +57,17 @@ class SaveLoadStateTest {
     fun loadStateRestoresFromSaveRepository() = runComposeUiTest {
         val harness = createHarnessWithGameReady()
 
+        // The Load button downloads the session's *auto*-save (not the
+        // manual save that the Save button uploads — those go to a named
+        // slot). Seed a session + auto-save so Load has something to
+        // unserialize; models the "prior play left an auto-save behind"
+        // state that would be present in real use.
+        val sessionId = "session-1"
+        harness.sessionRepo.sessions.add(
+            GameSession(id = sessionId, gameId = "1", name = "Default"),
+        )
+        harness.sessionRepo.preSeedAutoSave(sessionId)
+
         setContent { harness.App() }
         advance(harness)
 
@@ -66,10 +78,6 @@ class SaveLoadStateTest {
         // Open overlay to access Save/Load buttons
         harness.emulationViewModel.onIntent(EmulationIntent.ToggleOverlay)
         advanceQuick(harness)
-
-        // First save, then load
-        onNodeWithContentDescription("Save").performClick()
-        advance(harness)
 
         val loadCountBefore = harness.libretroController.loadCallCount
 

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1228,6 +1228,17 @@ class FakeSessionRepository : SessionRepository {
     var sessions: MutableList<GameSession> = mutableListOf()
     private val sessionSaves = mutableMapOf<String, MutableList<SaveState>>()
     private val autoSaves = mutableMapOf<String, ByteArray>()
+
+    /**
+     * Test-only: seed an auto-save for [sessionId]. Used by SaveLoadStateTest
+     * and InGameOverlayTest to verify that clicking Load downloads and
+     * unserializes a pre-existing auto-save. In production, auto-saves are
+     * written by the periodic background saver; pre-seeding models the
+     * state "a prior play session left an auto-save behind".
+     */
+    fun preSeedAutoSave(sessionId: String, data: ByteArray = ByteArray(128) { it.toByte() }) {
+        autoSaves[sessionId] = data
+    }
     private val slotSaves = mutableMapOf<String, ByteArray>() // key: "$sessionId:$slot"
     private val sram = mutableMapOf<String, ByteArray>()
     private val sessionCheats = mutableMapOf<String, SessionCheatConfig>()


### PR DESCRIPTION
## Summary

Two tests in the #658 behaviour-dependent cluster asserted that clicking Load from the emulation overlay triggers \`libretroController.unserialize\` — but both failed. Root cause: the Save button uploads a *manual* save (named slot), while the Load button downloads the *auto*-save. Separate endpoints; the tests wrongly assumed Save→Load round-trips. In production, auto-saves are written by the periodic background saver, not by the manual Save action.

Fix by seeding a session + auto-save at test setup — models the \"prior play left an auto-save behind\" state that real users would have. New helper \`FakeSessionRepository.preSeedAutoSave(sessionId, data)\` makes this ergonomic.

Tests cleared:
- \`SaveLoadStateTest.loadStateRestoresFromSaveRepository\`
- \`InGameOverlayTest.loadTriggersUnserialization\`

## Test plan

- [x] \`./gradlew :desktop:desktopTest --tests 'SaveLoadStateTest' --tests 'InGameOverlayTest'\` — all pass.
- [x] Full suite: down to 2 remaining failures (both in #658: GamepadNavigation focus recovery + ScrollPosition preservation — unrelated to save/load wiring).

Part of #658.