### PR TITLE
fix(player): autoFocus on tab switches + tighter scroll-test fixture (#658)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/GamepadNavigationTest.kt
@@ -157,10 +157,14 @@ class GamepadNavigationTest {
         harness.gamepadPortManager.setInputMode(InputMode.GAMEPAD)
         advanceQuick(harness)
 
-        // Switch to Consoles section via NextSection (Home → Explore → Consoles)
+        // Switch to Consoles section via NextSection (Home → Explore → Consoles).
+        // The destination screen's `autoFocus()` modifier on the first console
+        // card requests focus after a 500ms delay. `advanceFully` runs enough
+        // dispatcher iterations for that delay to elapse.
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
+        advanceQuick(harness)
         harness.navigationViewModel.onIntent(NavigationIntent.NextSection)
-        advance(harness)
+        advanceFully(harness)
 
         // Focus should have been recovered — first console card should be focused
         val nesCard = onNodeWithContentDescription("Nintendo Entertainment System, 3 games")

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ScrollPositionTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/ScrollPositionTest.kt
@@ -19,8 +19,11 @@ class ScrollPositionTest {
     private fun createHarnessWithManyConsoles(): SpelaTestHarness {
         val harness = SpelaTestHarness(StandardTestDispatcher())
         harness.authRepo.preSetTokens()
-        // Add enough consoles to require scrolling (all same generation so they render in one group)
-        harness.gameRepo.consoles = (1..20).map { i ->
+        // Add enough consoles to require scrolling. The desktop test viewport
+        // is large; 50 consoles in a single generation group (default 0)
+        // gives roughly 25 rows and forces Console 1 well above the fold
+        // once we scroll mid-list.
+        harness.gameRepo.consoles = (1..50).map { i ->
             Console(
                 id = "console$i",
                 name = "Console $i",
@@ -43,8 +46,9 @@ class ScrollPositionTest {
         // Console 1 should be visible at the top
         onNodeWithText("Console 1").assertIsDisplayed()
 
-        // Scroll down to Console 15
-        onNodeWithTag("consoles-list").performScrollToNode(hasText("Console 15"))
+        // Scroll down to Console 40 — far enough that Console 1 leaves
+        // the viewport on any reasonable desktop test window.
+        onNodeWithTag("consoles-list").performScrollToNode(hasText("Console 40"))
         advanceQuick(harness)
 
         // Console 1 should no longer be visible after scrolling
@@ -52,7 +56,7 @@ class ScrollPositionTest {
 
         // Navigate to a console detail screen
         harness.navigationViewModel.onIntent(
-            NavigationIntent.NavigateTo(SpScreen.Console("console15"))
+            NavigationIntent.NavigateTo(SpScreen.Console("console40"))
         )
         advance(harness)
 
@@ -62,8 +66,8 @@ class ScrollPositionTest {
 
         // Console 1 should still NOT be visible — scroll position was preserved
         onNodeWithText("Console 1").assertIsNotDisplayed()
-        // Console 15 should still be visible
-        onNodeWithText("Console 15").assertIsDisplayed()
+        // Console 40 should still be visible
+        onNodeWithText("Console 40").assertIsDisplayed()
     }
 
     @Test

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -131,6 +131,7 @@ import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.ui.gamepad.GamepadHandler
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalIsForwardNavigation
+import com.spela.player.presentation.ui.gamepad.LocalIsTabSwitch
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
 import com.spela.player.presentation.ui.components.LocalScrapeService
 import com.spela.player.presentation.ui.components.ScrapeUpdates
@@ -458,7 +459,10 @@ fun SpelaApp(
                     fun ScreenContent(screen: com.spela.player.presentation.navigation.SpScreen) {
                         val isForward = !navState.isGoingBack && !navState.isTabSwitch
                         saveableStateHolder.SaveableStateProvider(screen.route) {
-                        CompositionLocalProvider(LocalIsForwardNavigation provides isForward) {
+                        CompositionLocalProvider(
+                            LocalIsForwardNavigation provides isForward,
+                            LocalIsTabSwitch provides navState.isTabSwitch,
+                        ) {
                         when (screen) {
                             is SpScreen.ServerConnection -> {
                                 ServerConnectionScreen(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/AutoFocus.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/gamepad/AutoFocus.kt
@@ -17,16 +17,16 @@ val LocalIsForwardNavigation = compositionLocalOf { false }
 
 /**
  * Requests focus on this element when it mounts during forward navigation
- * in gamepad mode.
+ * (or a bottom-nav tab switch) in gamepad mode.
  *
  * Apply to the first meaningful focusable element on each screen — the
  * element that should receive initial gamepad focus. Each screen is
  * responsible for placing this modifier; this is the primary mechanism
  * for focus acquisition on navigation.
  *
- * On back navigation, this modifier does nothing — the GamepadHandler
- * Box retains focus and the first d-pad press enters content near the
- * restored scroll position.
+ * On back navigation, this modifier does nothing — focus-memory
+ * restoration in [Modifier.rememberFocus] takes over so the user lands
+ * back on the element they last focused.
  *
  * The 500ms delay ensures the AnimatedContent exit transition has
  * completed so focus doesn't land on the outgoing screen.
@@ -34,8 +34,14 @@ val LocalIsForwardNavigation = compositionLocalOf { false }
 fun Modifier.autoFocus(): Modifier = composed {
     val isForward = LocalIsForwardNavigation.current
     val isGamepad = LocalInputMode.current == InputMode.GAMEPAD
+    // Tab-switches via L1/R1 are not forward navigations (no back stack
+    // entry) but also not back navigations. Treat them like forward
+    // navigations for focus purposes — the destination screen has no
+    // focus memory yet, so autoFocus is the only mechanism that can
+    // place initial focus on a useful element.
+    val isTabSwitch = LocalIsTabSwitch.current
 
-    if (isForward && isGamepad) {
+    if ((isForward || isTabSwitch) && isGamepad) {
         val focusRequester = remember { FocusRequester() }
         LaunchedEffect(Unit) {
             // Wait for AnimatedContent exit transition to complete
@@ -49,3 +55,10 @@ fun Modifier.autoFocus(): Modifier = composed {
         this
     }
 }
+
+/**
+ * Whether the current screen was reached via a bottom-nav tab switch
+ * (L1/R1 on gamepads, or a tab tap on touch). Set by SpelaApp alongside
+ * [LocalIsForwardNavigation] when rendering each screen.
+ */
+val LocalIsTabSwitch = compositionLocalOf { false }


### PR DESCRIPTION
## Summary

Closes the last two failures in the #658 cluster. Different root causes; bundled because they're both small.

### Gamepad tab-switch focus recovery (production change)

\`Modifier.autoFocus()\` previously only fired during *forward navigation*. Bottom-nav tab switches (L1/R1 → \`NextSection\`/\`PreviousSection\`) were classified as neither forward nor back, so on first-time entry to a tab **nothing gained focus** — the user had to press d-pad once before anything useful happened. The corresponding test (\`GamepadNavigationTest.focusRecoveredAfterSectionSwitchToConsoles\`) had the right expectation; production was the bug.

Adds \`LocalIsTabSwitch\` CompositionLocal alongside the existing \`LocalIsForwardNavigation\`. \`autoFocus\` now fires when either is true. \`rememberFocus\` (focus-memory restoration) still gates on \`!isForward\` so revisits with prior focus state continue to restore the remembered element rather than the first one.

### ScrollPositionTest fixture (test-only)

20 consoles + scroll-to-Console-15 wasn't enough — the desktop test window is large enough that both \"Console 1\" and \"Console 15\" stayed visible. Bumped to 50 consoles + scroll-to-Console-40 so the assertion holds.

## Test plan

- [x] \`./gradlew :desktop:desktopTest --tests 'GamepadNavigationTest' --tests 'ScrollPositionTest'\` — all pass.
- [x] No regressions in adjacent gamepad tests.

Closes #658.