### PR TITLE
fix: #663 cloneSession null body + master CI unused imports

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1577,11 +1577,12 @@ class SpelaApiClient(
         name: String? = null,
         saveId: Long? = null,
     ): com.spela.client.models.GameSessionResponse {
-        val request = if (name != null) {
-            com.spela.client.models.DuplicateSessionRequest(name = name)
-        } else {
-            null
-        }
+        // Always send a DuplicateSessionRequest — the model's `name` field
+        // is nullable server-side, so passing name=null through the DTO
+        // sends `{"name": null}` which huma accepts. Sending the Kotlin
+        // value `null` itself would cause Ktor to serialize the body as
+        // the JSON literal `null`, which huma rejects with 422. See #663.
+        val request = com.spela.client.models.DuplicateSessionRequest(name = name)
         return sessionsApi.cloneSession(sessionId, saveId, request).body()
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SharedSessionDetailScreen.kt
@@ -18,7 +18,6 @@ import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -52,7 +51,6 @@ import com.spela.player.presentation.ui.components.SpTopBar
 import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
-import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
 import com.spela.player.presentation.viewmodel.SharedSessionDetailViewModel

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SpelaApiClientCloneSessionTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/remote/SpelaApiClientCloneSessionTest.kt
@@ -1,0 +1,180 @@
+package com.spela.player.data.remote
+
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.engine.mock.toByteArray
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+/**
+ * Regression guard for #663.
+ *
+ * Before the fix, `SpelaApiClient.cloneSession(sessionId, name = null,
+ * saveId = null)` passed a Kotlin `null` to the generated `cloneSession`
+ * API call. Ktor then serialised that null as the JSON literal `"null"`
+ * (4 bytes), which the server's huma validator rejected with a 422. The
+ * bug was invisible to the desktop suite (fake repositories) and only
+ * surfaced on the Android smoke run.
+ *
+ * These tests pin the body shape that actually leaves the client.
+ */
+class SpelaApiClientCloneSessionTest {
+
+    private class CapturingMockEngineFactory(
+        private val fakeResponseJson: String,
+    ) : HttpClientEngineFactory<MockEngineConfig> {
+        var lastRequestBody: String = ""
+            private set
+
+        override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine =
+            MockEngine(MockEngineConfig().apply {
+                addHandler { request ->
+                    lastRequestBody = request.body.toByteArray().decodeToString()
+                    respond(
+                        fakeResponseJson,
+                        HttpStatusCode.Created,
+                        headersOf(HttpHeaders.ContentType, "application/json"),
+                    )
+                }
+                block()
+            })
+    }
+
+    // The smallest GameSessionResponse the generated model will deserialise.
+    // kotlinx-serialization strict mode rejects missing required fields, so
+    // every @Required field must be present here. Keep in sync with the
+    // model under test.
+    private val fakeSessionJson = """
+        {
+          "id": "new-session",
+          "ownerId": "u1",
+          "ownerUsername": "alice",
+          "gameId": "g1",
+          "name": "My Run (Copy)",
+          "totalPlayTime": 0,
+          "cheatsEnabled": false,
+          "isSharedSession": false,
+          "coreName": "",
+          "memberCount": 1,
+          "memberAvatars": [],
+          "memberUsernames": [],
+          "saveCount": 0,
+          "screenshotUrl": "",
+          "pinnedCoreSha256": "",
+          "createdAt": "2026-04-21T00:00:00Z",
+          "updatedAt": "2026-04-21T00:00:00Z",
+          "lastPlayedAt": null,
+          "lastPlayedBy": null,
+          "lastPlayedByUsername": null,
+          "sharedSessionId": null
+        }
+    """.trimIndent()
+
+    @Test
+    fun cloneSessionWithNullNameSendsObjectNotNullLiteral() = runTest {
+        val engineFactory = CapturingMockEngineFactory(fakeSessionJson)
+        val tokenManager = TokenManager().also {
+            it.setTokens("test-access", "test-refresh")
+        }
+        val apiClient = SpelaApiClient(engineFactory, tokenManager)
+        apiClient.setBaseUrl("http://localhost:8080")
+
+        apiClient.cloneSession(sessionId = "src-1", name = null, saveId = null)
+
+        val body = engineFactory.lastRequestBody
+        assertNotEquals(
+            "null",
+            body,
+            "#663: cloneSession(name=null) must not send the JSON literal 'null' — " +
+                "huma rejects it with 422. Expected an object literal like " +
+                "{\"name\":null}.",
+        )
+        assertTrue(
+            body.startsWith("{") && body.endsWith("}"),
+            "expected JSON object body, got: $body",
+        )
+        assertTrue(
+            body.contains("\"name\""),
+            "expected the body to include the name field, got: $body",
+        )
+    }
+
+    @Test
+    fun cloneSessionWithNonNullNameSendsThatName() = runTest {
+        val engineFactory = CapturingMockEngineFactory(fakeSessionJson)
+        val tokenManager = TokenManager().also {
+            it.setTokens("test-access", "test-refresh")
+        }
+        val apiClient = SpelaApiClient(engineFactory, tokenManager)
+        apiClient.setBaseUrl("http://localhost:8080")
+
+        apiClient.cloneSession(sessionId = "src-1", name = "My Copy", saveId = null)
+
+        val body = engineFactory.lastRequestBody
+        assertTrue(
+            body.contains("\"name\":\"My Copy\"") || body.contains("\"name\": \"My Copy\""),
+            "expected body to contain name=\"My Copy\", got: $body",
+        )
+    }
+
+    @Test
+    fun cloneSessionWithSaveIdStillSendsValidObjectBody() = runTest {
+        val engineFactory = CapturingMockEngineFactory(fakeSessionJson)
+        val tokenManager = TokenManager().also {
+            it.setTokens("test-access", "test-refresh")
+        }
+        val apiClient = SpelaApiClient(engineFactory, tokenManager)
+        apiClient.setBaseUrl("http://localhost:8080")
+
+        apiClient.cloneSession(sessionId = "src-1", name = null, saveId = 42L)
+
+        // saveId travels as a query parameter, not in the body. The body
+        // should still be an object with the name field (null or absent),
+        // never the JSON literal null.
+        val body = engineFactory.lastRequestBody
+        assertNotEquals("null", body)
+        assertTrue(
+            body.startsWith("{") && body.endsWith("}"),
+            "expected JSON object body, got: $body",
+        )
+    }
+
+    @Test
+    fun cloneSessionTargetsCloneNotDuplicatePath() = runTest {
+        var lastPath = ""
+        val engineFactory = object : HttpClientEngineFactory<MockEngineConfig> {
+            override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine =
+                MockEngine(MockEngineConfig().apply {
+                    addHandler { request ->
+                        lastPath = request.url.encodedPath
+                        respond(
+                            fakeSessionJson,
+                            HttpStatusCode.Created,
+                            headersOf(HttpHeaders.ContentType, "application/json"),
+                        )
+                    }
+                    block()
+                })
+        }
+        val tokenManager = TokenManager().also {
+            it.setTokens("test-access", "test-refresh")
+        }
+        val apiClient = SpelaApiClient(engineFactory, tokenManager)
+        apiClient.setBaseUrl("http://localhost:8080")
+
+        apiClient.cloneSession(sessionId = "src-1", name = "Any", saveId = null)
+
+        assertEquals("/api/sessions/src-1/clone", lastPath)
+    }
+}


### PR DESCRIPTION
## Summary

Two related fixes shipped together so master goes back to green and the bug that #664 introduced for the player app is closed.

### 1. Closes #663 — `cloneSession(name=null)` sent JSON literal `"null"`, server 422'd

The shared Kotlin client previously did:

```kotlin
if (name != null) sessionsApi.cloneSession(id, saveId, DuplicateSessionRequest(name))
else              sessionsApi.cloneSession(id, saveId, null)
```

Ktor serialises a Kotlin `null` body as the literal 4-byte JSON token `null`, which huma's request validator rejects with HTTP 422. Always constructing a `DuplicateSessionRequest(name = name)` produces `{"name": null}` instead, which huma accepts (the field is server-side nullable).

Why this was invisible to the desktop suite: the desktop tests use fake repositories and never exercise the real Ktor pipeline. The bug only surfaced on the Android smoke run against a real backend.

A new `SpelaApiClientCloneSessionTest` pins the wire-format body shape using a `MockEngine`-backed `HttpClientEngineFactory` that captures the outgoing request body. Three positive cases + one path-targeting check.

### 2. Refs #664 — master CI broke on the merge commit (player unit tests / detekt)

The SpIconButton migration in #664 left three unused imports behind that detekt's `style:UnusedImport` rule rejected:

- `SessionDetailScreen.kt` — `material3.IconButton`
- `SharedSessionDetailScreen.kt` — `material3.IconButton`
- `SharedSessionDetailScreen.kt` — `theme.SpColor` (the `tint = SpColor.OnBackground` parameter was dropped during the migration)

## Test plan

- [x] `./gradlew :shared:desktopTest` — all green, including 4 new `SpelaApiClientCloneSessionTest` cases
- [x] `./gradlew :shared:detektMainDesktop :android:detektDebugAndroid :desktop:detektMainDesktop` — 0 findings
- [ ] CI green on this PR before merge