### PR TITLE
fix(#568): ConsoleResponse.maker and mediaType always non-null

### DIFF
--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -61,8 +61,8 @@ type ConsoleResponse struct {
 	UpdatedAt        time.Time              `json:"updatedAt"`
 	Name             string                 `json:"name"`
 	Abbreviation     string                 `json:"abbreviation"`
-	Maker            *HardwareMakerResponse `json:"maker"`
-	MediaType        *MediaTypeResponse     `json:"mediaType"`
+	Maker            HardwareMakerResponse  `json:"maker"`
+	MediaType        MediaTypeResponse      `json:"mediaType"`
 	ReleaseYear      *int                   `json:"releaseYear"`
 	UnitsSold        *int64                 `json:"unitsSold"`
 	Summary          *string                `json:"summary"`
@@ -231,17 +231,20 @@ func ToConsoleResponse(c db.Console) ConsoleResponse {
 		code = *c.Code
 	}
 
-	var maker *HardwareMakerResponse
+	// ConsoleResponse.maker and mediaType are always-present per the OpenAPI
+	// contract. Post-seed every console has both; rows that haven't been
+	// re-seeded fall back to the zero struct so the wire shape stays valid.
+	var maker HardwareMakerResponse
 	if c.HardwareMaker != nil {
-		maker = &HardwareMakerResponse{
+		maker = HardwareMakerResponse{
 			Code: c.HardwareMaker.Code,
 			Name: c.HardwareMaker.Name,
 		}
 	}
 
-	var mediaType *MediaTypeResponse
+	var mediaType MediaTypeResponse
 	if c.MediaType != nil {
-		mediaType = &MediaTypeResponse{
+		mediaType = MediaTypeResponse{
 			Code: c.MediaType.Code,
 			Name: c.MediaType.Name,
 			Category: MediaTypeCategoryResponse{

--- a/server/internal/db/seed_metadata.go
+++ b/server/internal/db/seed_metadata.go
@@ -111,6 +111,10 @@ func SeedHardwareMakers(db *gorm.DB) error {
 		{Code: "fairchild", Name: "Fairchild"},
 		{Code: "gce", Name: "GCE"},
 		{Code: "magnavox", Name: "Magnavox"},
+		// Umbrella maker for consoles that belong to no single manufacturer
+		// (Arcade, DOS Demos, ScummVM). Keeps ConsoleResponse.maker always
+		// non-null so the API contract matches the OpenAPI schema.
+		{Code: "various", Name: "Various"},
 	}
 
 	for _, m := range makers {
@@ -258,14 +262,14 @@ func SeedConsoleMetadata(db *gorm.DB) error {
 		{Abbreviation: "VIC20", Code: "vic20", MakerCode: "commodore", MediaCode: "cartridge", ReleaseYear: intPtr(1980), UnitsSold: int64Ptr(2500000), Summary: strPtr("The Commodore VIC-20 was one of the first computers to sell over a million units, priced affordably at under $300. While limited to 5KB of RAM, it introduced an entire generation to home computing and programming, serving as a stepping stone to the legendary Commodore 64.")},
 
 		// Arcade (generation = 101)
-		{Abbreviation: "ARCADE", Code: "arcade", MakerCode: "", MediaCode: "arcade-board", ReleaseYear: intPtr(1971), UnitsSold: nil, Summary: strPtr("Arcade games have been a cornerstone of the video game industry since Computer Space in 1971 and Pong in 1972. From the golden age of Space Invaders and Pac-Man to modern fighting and rhythm games, arcades pioneered nearly every major gaming genre and remain a vibrant part of gaming culture worldwide.")},
+		{Abbreviation: "ARCADE", Code: "arcade", MakerCode: "various", MediaCode: "arcade-board", ReleaseYear: intPtr(1971), UnitsSold: nil, Summary: strPtr("Arcade games have been a cornerstone of the video game industry since Computer Space in 1971 and Pong in 1972. From the golden age of Space Invaders and Pac-Man to modern fighting and rhythm games, arcades pioneered nearly every major gaming genre and remain a vibrant part of gaming culture worldwide.")},
 
 		// Demo scenes (generation = 100)
 		{Abbreviation: "ADEMO", Code: "ademo", MakerCode: "commodore", MediaCode: "floppy-disk", ReleaseYear: nil, UnitsSold: nil, Summary: strPtr("The Amiga demo scene was one of the most vibrant creative computing communities, pushing the Amiga's custom hardware to produce stunning audiovisual demonstrations. Originating in the late 1980s, it became a breeding ground for future game developers, digital artists, and musicians.")},
-		{Abbreviation: "DDEMO", Code: "ddemo", MakerCode: "", MediaCode: "digital", ReleaseYear: nil, UnitsSold: nil, Summary: strPtr("The DOS demo scene produced creative real-time audiovisual programs that showcased programming skill and artistic expression on IBM PC compatibles. Demos like Second Reality by Future Crew became legendary, and the scene continues to thrive at events like Assembly and Revision.")},
+		{Abbreviation: "DDEMO", Code: "ddemo", MakerCode: "various", MediaCode: "digital", ReleaseYear: nil, UnitsSold: nil, Summary: strPtr("The DOS demo scene produced creative real-time audiovisual programs that showcased programming skill and artistic expression on IBM PC compatibles. Demos like Second Reality by Future Crew became legendary, and the scene continues to thrive at events like Assembly and Revision.")},
 
 		// ScummVM (generation = 100)
-		{Abbreviation: "SCUMMVM", Code: "scummvm", MakerCode: "", MediaCode: "digital", ReleaseYear: nil, UnitsSold: nil, Summary: strPtr("ScummVM is a collection of game engine reimplementations that allows classic point-and-click adventure games to run on modern hardware. Originally created to run LucasArts SCUMM games like Monkey Island and Day of the Tentacle, it now supports hundreds of adventure games from numerous publishers.")},
+		{Abbreviation: "SCUMMVM", Code: "scummvm", MakerCode: "various", MediaCode: "digital", ReleaseYear: nil, UnitsSold: nil, Summary: strPtr("ScummVM is a collection of game engine reimplementations that allows classic point-and-click adventure games to run on modern hardware. Originally created to run LucasArts SCUMM games like Monkey Island and Day of the Tentacle, it now supports hundreds of adventure games from numerous publishers.")},
 	}
 
 	for _, m := range metadata {


### PR DESCRIPTION
## Summary

The reported #568 failure — Android E2E `scrollToAndTapMatchingBoth('Nintendo Entertainment System', 'games')` can't locate the NES card — was the downstream symptom of a silent API-contract violation.

**Real root cause:**
- OpenAPI declares `ConsoleResponse.maker` / `mediaType` as required, non-nullable `$ref`.
- The server returned `"maker": null` for three consoles whose seed had `MakerCode: ""`: **Arcade**, **DOS Demos**, **ScummVM**.
- Generated Kotlin model: `@Required val maker: HardwareMakerResponse` (non-null). kotlinx-serialization threw `JsonConvertException: Expected start of the object '{', but had 'n' instead at path: $[37].maker` on every `/api/consoles` fetch.
- `GameRepositoryImpl.getConsoles()` wraps the fetch in `runCatching { … }.recoverCatching { cache-or-throw }`. On fresh install, cache is empty → returns `Result.failure`. `GetConsolesUseCase().getOrDefault(emptyList())` then swallowed it, so `state.consoles = []` → Consoles tab renders "Your library is empty".
- The test's `waitForContentDescription("Nintendo Entertainment System", 8_000)` was waiting for a card that would never appear.

Captured the smoking-gun logcat line mid-debug:
```
[GameListVM] getConsoles FAILED: io.ktor.serialization.JsonConvertException: \
  Illegal input: Unexpected JSON token at offset 36347: Expected start of the \
  object '{', but had 'n' instead at path: $[37].maker
```

This has been silently breaking every fresh Android install since Arcade/DOS Demos landed in the seed. Only E2E noticed, and the symptom pointed at the test harness.

## Fix

Data fix, matching the `feedback_no_omitempty` rule ("use `*T` only for genuinely nullable"):

1. **Seed**: add a `Various` umbrella `HardwareMaker`. Assign it to `ARCADE`, `DDEMO`, `SCUMMVM`. The metadata seeder is already idempotent (`if mid != nil && different → update`), so existing installations pick up the new `HardwareMakerID` on next boot.
2. **Response**: drop the pointer from `ConsoleResponse.Maker` / `MediaType` (`*T → T`). These are genuinely always-present post-seed. The builder keeps a defensive zero-struct fallback so rows that somehow slipped through don't regress the wire shape to `null`.

Regen produced **no diff** for the generated TS/Kotlin clients — the schema already declared these fields non-nullable; only the server was lying.

## Test plan

- [x] `cd server && go test ./internal/api/... ./internal/db/...` — green
- [x] `cd web && npx vitest run` — 1539 tests green
- [x] `cd player && ./run-desktop-tests.sh` — 479 unit + 28 E2E green
- [x] Android smoke (`NavigationTest#backStackNavigation` on AYN Thor, serial 54071896) — now loads **41 consoles** into the dashboard and advances past the NES card tap. Logcat confirms: `[GameListVM] loadDashboard() result: consoles=41, recent=0, favorites=0, playLater=0` (was `consoles=0` before).
- [ ] CI green on this PR before merge

## Follow-up (not in scope)

A downstream failure surfaced once the Consoles tab started rendering: `tapOn("Super Mario Bros. 3")` on the NES console page fails. Separate issue — will file if it doesn't resolve with a retry. The `#568`-reported path is fixed.

Closes #568