### PR TITLE
feat(#555): admin Cores page — surface libretro-core fingerprints

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,6 +30,7 @@ const MetadataFixPage = lazy(() => import("@/pages/admin/metadata-fix-page"));
 const AdminCheatsPage = lazy(() => import("@/pages/admin/cheats-page"));
 const AdminBiosPage = lazy(() => import("@/pages/admin/bios-page"));
 const CoreCompatibilityPage = lazy(() => import("@/pages/admin/core-compatibility-page"));
+const AdminCoresPage = lazy(() => import("@/pages/admin/cores-page"));
 const AdminSystemEventsPage = lazy(() => import("@/pages/admin/system-events-page"));
 const UploadRomsPage = lazy(() => import("@/pages/admin/upload-roms-page"));
 const RomHacksPage = lazy(() => import("@/pages/admin/rom-hacks-page"));
@@ -273,6 +274,14 @@ export function App() {
                       element={
                         <ProtectedRoute requireAdmin>
                           <CoreCompatibilityPage />
+                        </ProtectedRoute>
+                      }
+                    />
+                    <Route
+                      path="admin/cores"
+                      element={
+                        <ProtectedRoute requireAdmin>
+                          <AdminCoresPage />
                         </ProtectedRoute>
                       }
                     />

--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -23,6 +23,7 @@ import {
   GitCompareArrows,
   Puzzle,
   ShieldAlert,
+  Binary,
 } from "lucide-react";
 import { Sidebar } from "@/components/ui";
 import { useAuth } from "@/hooks/use-auth";
@@ -147,6 +148,11 @@ export function AppLayout() {
                 icon: Settings,
                 label: "Settings",
                 warning: igdbNotConfigured,
+              },
+              {
+                to: "/admin/cores",
+                icon: Binary,
+                label: "Cores",
               },
               {
                 to: "/admin/core-compatibility",

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -482,3 +482,10 @@ export function useCoreCompatibility() {
     queryFn: () => unwrap(typedApi.GET("/api/admin/core-compatibility")),
   });
 }
+
+export function useAdminCores() {
+  return useQuery({
+    queryKey: ["admin", "cores"],
+    queryFn: () => unwrap(typedApi.GET("/api/cores")),
+  });
+}

--- a/web/src/pages/admin/__tests__/cores-page.test.tsx
+++ b/web/src/pages/admin/__tests__/cores-page.test.tsx
@@ -1,0 +1,150 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { CoresPage } from "../cores-page";
+
+vi.mock("@/hooks/use-admin", () => ({
+  useAdminCores: vi.fn(),
+}));
+
+import { useAdminCores } from "@/hooks/use-admin";
+const mockUseAdminCores = useAdminCores as ReturnType<typeof vi.fn>;
+
+function renderPage() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <MemoryRouter initialEntries={["/admin/cores"]}>
+        <CoresPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+const fetchedAt = "2026-04-20T12:00:00Z";
+
+const fingerprintedCore = {
+  id: 1,
+  name: "nestopia",
+  displayName: "Nestopia UE",
+  description: "Nintendo Entertainment System emulator",
+  version: "1.52",
+  platforms: "windows,linux,macos,android",
+  downloadUrl: "",
+  sha256: "ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12cd34ef56ab12",
+  sizeBytes: 4_400_000,
+  fetchedAt,
+  sourceUrl: "https://buildbot.libretro.com/nightly/linux/x86_64/latest/nestopia_libretro.so.zip",
+  createdAt: "2026-01-01T00:00:00Z",
+  updatedAt: "2026-04-20T12:00:00Z",
+};
+
+const pristineCore = {
+  ...fingerprintedCore,
+  id: 2,
+  name: "mednafen_psx_hw",
+  displayName: "Mednafen PSX HW",
+  sha256: "",
+  sizeBytes: 0,
+  fetchedAt: null,
+  sourceUrl: "",
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("CoresPage", () => {
+  it("renders the loading skeleton while data is pending", () => {
+    mockUseAdminCores.mockReturnValue({ data: undefined, isLoading: true, isError: false });
+    const { container } = renderPage();
+    const skeletons = container.querySelectorAll("[class*='animate-pulse']");
+    expect(skeletons.length).toBeGreaterThan(0);
+  });
+
+  it("renders fingerprint data for a fetched core", () => {
+    mockUseAdminCores.mockReturnValue({
+      data: [fingerprintedCore],
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+
+    const row = screen.getByTestId("cores-row-nestopia");
+    expect(row).toBeInTheDocument();
+    expect(row).toHaveTextContent("Nestopia UE");
+    expect(row).toHaveTextContent("nestopia");
+    // SHA prefix only, not full 64 chars, and a trailing ellipsis.
+    expect(row).toHaveTextContent("ab12cd34ef56…");
+    expect(row).not.toHaveTextContent(fingerprintedCore.sha256);
+    // File size formatted.
+    expect(row).toHaveTextContent(/4\.2 MB/);
+  });
+
+  it("shows the 'not fetched' placeholders for cores with no recorded hash", () => {
+    mockUseAdminCores.mockReturnValue({
+      data: [pristineCore],
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+
+    const row = screen.getByTestId("cores-row-mednafen_psx_hw");
+    expect(row).toHaveTextContent(/not fetched/);
+    expect(row).toHaveTextContent(/never/);
+  });
+
+  it("surfaces a banner when at least one core has not been fetched", () => {
+    mockUseAdminCores.mockReturnValue({
+      data: [fingerprintedCore, pristineCore],
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+
+    expect(
+      screen.getByTestId("cores-never-fetched-banner"),
+    ).toHaveTextContent(/1 core has no recorded hash/);
+  });
+
+  it("does not render the banner when every core has been fetched", () => {
+    mockUseAdminCores.mockReturnValue({
+      data: [fingerprintedCore],
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+
+    expect(
+      screen.queryByTestId("cores-never-fetched-banner"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows the error state when the API call fails", () => {
+    mockUseAdminCores.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      isError: true,
+    });
+    renderPage();
+
+    expect(screen.getByText(/Failed to load cores/i)).toBeInTheDocument();
+  });
+
+  it("shows the empty state when no cores are registered", () => {
+    mockUseAdminCores.mockReturnValue({
+      data: [],
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+
+    expect(
+      screen.getByText(/No cores registered/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/web/src/pages/admin/cores-page.tsx
+++ b/web/src/pages/admin/cores-page.tsx
@@ -1,0 +1,172 @@
+import { HardDrive, AlertCircle } from "lucide-react";
+import { PageLayout, SectionList } from "@/components/layout";
+import { Section, Skeleton } from "@/components/ui";
+import { useAdminCores } from "@/hooks/use-admin";
+import { formatFileSize, formatRelativeTime } from "@/lib/format";
+
+export function CoresPage() {
+  const { data, isLoading, isError } = useAdminCores();
+
+  if (isLoading) {
+    return (
+      <PageLayout>
+        <SectionList className="max-w-5xl">
+          <Skeleton className="h-8 w-48" />
+          <Skeleton className="h-64 w-full rounded-2xl" />
+        </SectionList>
+      </PageLayout>
+    );
+  }
+
+  const cores = data ?? [];
+  const neverFetched = cores.filter((c) => !c.fetchedAt).length;
+
+  return (
+    <PageLayout
+      title="Cores"
+      subtitle="Factual metadata for the libretro cores this server hosts. The hash and size are computed from the actual binary on disk, not from seed data — use them to confirm which version a player is downloading."
+    >
+      <SectionList className="max-w-5xl">
+        {neverFetched > 0 && (
+          <div
+            data-testid="cores-never-fetched-banner"
+            className="flex items-start gap-3 rounded-xl border border-surface-700 bg-surface-800/50 px-4 py-3"
+          >
+            <AlertCircle className="h-5 w-5 text-surface-400 flex-shrink-0 mt-0.5" />
+            <p className="text-sm text-surface-300">
+              {neverFetched} core{neverFetched !== 1 ? "s" : ""} ha
+              {neverFetched !== 1 ? "ve" : "s"} no recorded hash yet. The server
+              fingerprints each binary the first time a player downloads it, so
+              these rows will populate after the next download.
+            </p>
+          </div>
+        )}
+
+        <Section>
+          <div className="px-5 pt-5 pb-2">
+            <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2">
+              <HardDrive className="h-5 w-5 text-brand-400" />
+              Libretro Cores
+            </h2>
+          </div>
+          <div className="px-5 pb-5">
+            {isError ? (
+              <p className="text-sm text-danger-500">
+                Failed to load cores.
+              </p>
+            ) : cores.length === 0 ? (
+              <p className="text-sm text-surface-400">
+                No cores registered.
+              </p>
+            ) : (
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm" data-testid="cores-table">
+                  <thead>
+                    <tr className="border-b border-surface-800 text-left">
+                      <th className="py-2 pr-4 font-medium text-surface-400">
+                        Core
+                      </th>
+                      <th className="py-2 pr-4 font-medium text-surface-400">
+                        Platforms
+                      </th>
+                      <th className="py-2 pr-4 font-medium text-surface-400">
+                        SHA-256
+                      </th>
+                      <th className="py-2 pr-4 font-medium text-surface-400">
+                        Size
+                      </th>
+                      <th className="py-2 pr-4 font-medium text-surface-400">
+                        Last fetched
+                      </th>
+                      <th className="py-2 font-medium text-surface-400">
+                        Source
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {cores.map((core) => (
+                      <tr
+                        key={core.id}
+                        data-testid={`cores-row-${core.name}`}
+                        className="hover:bg-surface-800/30"
+                      >
+                        <td className="py-2.5 pr-4 text-surface-100">
+                          <div className="font-medium">
+                            {core.displayName || core.name}
+                          </div>
+                          <div className="text-xs text-surface-500 font-mono">
+                            {core.name}
+                          </div>
+                        </td>
+                        <td className="py-2.5 pr-4 text-surface-300 text-xs">
+                          {core.platforms || (
+                            <span className="text-surface-500 italic">
+                              all
+                            </span>
+                          )}
+                        </td>
+                        <td className="py-2.5 pr-4 font-mono text-xs">
+                          {core.sha256 ? (
+                            <span
+                              title={core.sha256}
+                              className="text-surface-300"
+                            >
+                              {core.sha256.slice(0, 12)}…
+                            </span>
+                          ) : (
+                            <span className="text-surface-500 italic">
+                              not fetched
+                            </span>
+                          )}
+                        </td>
+                        <td className="py-2.5 pr-4 text-surface-300 text-xs">
+                          {core.sizeBytes > 0 ? (
+                            formatFileSize(core.sizeBytes)
+                          ) : (
+                            <span className="text-surface-500 italic">—</span>
+                          )}
+                        </td>
+                        <td className="py-2.5 pr-4 text-surface-300 text-xs">
+                          {core.fetchedAt ? (
+                            <span title={new Date(core.fetchedAt).toISOString()}>
+                              {formatRelativeTime(core.fetchedAt)}
+                            </span>
+                          ) : (
+                            <span className="text-surface-500 italic">
+                              never
+                            </span>
+                          )}
+                        </td>
+                        <td className="py-2.5 text-surface-300 font-mono text-xs">
+                          {core.sourceUrl ? (
+                            <span
+                              title={core.sourceUrl}
+                              className="break-all"
+                            >
+                              {truncateUrl(core.sourceUrl)}
+                            </span>
+                          ) : (
+                            <span className="text-surface-500 italic">
+                              buildbot
+                            </span>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            )}
+          </div>
+        </Section>
+      </SectionList>
+    </PageLayout>
+  );
+}
+
+function truncateUrl(url: string): string {
+  if (url.length <= 48) return url;
+  return url.slice(0, 45) + "…";
+}
+
+export default CoresPage;


### PR DESCRIPTION
## Summary

Phase 1 of #555 already landed the server-side fingerprint pipeline: every libretro core row has `Sha256`, `SizeBytes`, `FetchedAt`, and `SourceURL`, populated on first serve by `CoreHandler.ensureCoreMetadata`. The piece the issue called for that hadn't been wired is the admin UI surface — until now admins had to query the DB to see what binary was actually being handed out.

## New page: `/admin/cores`

Lists every row with:
- display name + internal name
- supported platforms (or "all" when unset)
- SHA-256 prefix (12 chars + ellipsis, full hash in the title tooltip)
- human-readable size
- relative "last fetched" with absolute ISO timestamp on hover
- source URL (truncated when long; "buildbot" when empty)

Cores that haven't been fetched yet fall back to italic placeholders ("not fetched", "—", "never", "buildbot") and trigger a banner at the top explaining the lazy-fingerprint behaviour. This is the expected initial state on a fresh install; the table populates as players pull each core for the first time.

## Screenshot

Against the e2e seed (52 cores, none fingerprinted yet — so the banner fires and every row shows placeholders):

![admin cores page](https://private-user-images.githubusercontent.com/placeholder/placeholder.png)

(Screenshot captured locally at `/tmp/admin-cores.png` during development; GitHub CDN upload omitted.)

## No server changes

`GET /api/cores` already returns the full row with the Phase 1 fields via `HumaListCores`. This PR adds:
- `useAdminCores` hook (thin wrapper over the existing typed endpoint)
- `/admin/cores` route, gated with `requireAdmin`
- sidebar entry in the System section next to Core Compatibility, using the `Binary` lucide icon (`HardDrive` was already taken by the main nav's Storage link)

## Test plan

- [x] `cd web && npx vitest run` — 1546 tests green (7 new cases covering loading, fingerprinted row, pristine row, banner presence, banner absence, API error, empty list)
- [x] `cd web && npx tsc --noEmit` — clean
- [x] Loaded `/admin/cores` in a local Vite dev server against the docker-e2e backend logged in as admin; page renders, banner correctly reports 52/52 cores as "not yet fetched", sidebar link sits where expected
- [ ] CI green on this PR before merge

Refs #555 (Phase 1 UI)