### PR TITLE
feat(#555): admin core force-refresh endpoint + UI button (Phase 2b)

### DIFF
--- a/server/internal/api/core_handler.go
+++ b/server/internal/api/core_handler.go
@@ -192,6 +192,101 @@ func platformExtension(platform string) string {
 	}
 }
 
+// CoreRefreshResult is what RefreshCoreMetadata returns to callers. It
+// exposes enough state for the admin UI to distinguish "already current"
+// from "replaced with a new binary" without having to diff before/after.
+type CoreRefreshResult struct {
+	Changed   bool       // true when the on-disk sha differs from the DB sha
+	OldSha256 string     // empty on first-ever fingerprint
+	NewSha256 string     // always populated after a successful refresh
+	SizeBytes int64      // size of the on-disk binary after refresh
+	FetchedAt *time.Time // timestamp persisted on the row after refresh
+	SourceURL string     // source URL persisted on the row after refresh
+}
+
+// RefreshCoreMetadata re-hashes the on-disk binary for [core], updates
+// the DB row if the hash differs, snapshots the new binary into history,
+// and emits a SystemEventCoreUpdated audit row when the hash actually
+// changed. Returns 404-worthy errors wrapped in gorm.ErrRecordNotFound
+// when the binary isn't on disk — callers decide how to surface that
+// over HTTP.
+//
+// Unlike ensureCoreMetadata (lazy, gated on missing fields), this always
+// re-hashes. Admins call it after dropping a newer core binary into
+// CoreDir manually so the Phase 1 stored hash doesn't go stale — the
+// limitation documented on ensureCoreMetadata. See #555 Phase 2.
+func (h *CoreHandler) RefreshCoreMetadata(core *db.Core, platform string) (CoreRefreshResult, error) {
+	corePath := h.resolveCorePath(*core, platform)
+	if corePath == "" {
+		return CoreRefreshResult{}, fmt.Errorf("refresh: binary not on disk: %w", gorm.ErrRecordNotFound)
+	}
+	sum, size, err := hashFileSha256(corePath)
+	if err != nil {
+		return CoreRefreshResult{}, fmt.Errorf("refresh: hashing %s: %w", corePath, err)
+	}
+	old := core.Sha256
+	now := time.Now().UTC()
+	updates := map[string]interface{}{
+		"sha256":     sum,
+		"size_bytes": size,
+		"fetched_at": &now,
+	}
+	if core.SourceURL == "" && core.DownloadURL != "" {
+		updates["source_url"] = core.DownloadURL
+	}
+	if err := h.DB.Model(core).Updates(updates).Error; err != nil {
+		return CoreRefreshResult{}, fmt.Errorf("refresh: persisting metadata: %w", err)
+	}
+	core.Sha256 = sum
+	core.SizeBytes = size
+	core.FetchedAt = &now
+	if core.SourceURL == "" && core.DownloadURL != "" {
+		core.SourceURL = core.DownloadURL
+	}
+
+	h.snapshotCoreToHistory(*core, corePath, sum)
+
+	changed := old != sum
+	if changed {
+		meta := map[string]interface{}{
+			"core":        core.Name,
+			"old_sha256":  old,
+			"new_sha256":  sum,
+			"size_bytes":  size,
+			"platform":    platform,
+			"source_url":  core.SourceURL,
+			"trigger":     "admin_refresh",
+		}
+		db.RecordOperationalEvent(h.DB, db.SystemEventInput{
+			EventType: db.SystemEventCoreUpdated,
+			Reason:    fmt.Sprintf("core %q binary replaced: %s → %s", core.Name, shortSha(old), shortSha(sum)),
+			Metadata:  meta,
+		})
+	}
+
+	return CoreRefreshResult{
+		Changed:   changed,
+		OldSha256: old,
+		NewSha256: sum,
+		SizeBytes: size,
+		FetchedAt: &now,
+		SourceURL: core.SourceURL,
+	}, nil
+}
+
+// shortSha renders the leading 12 chars of a sha256 string, or the
+// literal "(none)" when the input is empty. Used only for audit-log
+// reason strings so the full sha stays in the row's Metadata map.
+func shortSha(s string) string {
+	if s == "" {
+		return "(none)"
+	}
+	if len(s) < 12 {
+		return s
+	}
+	return s[:12]
+}
+
 // resolveCorePath finds the core binary file path, checking the database FilePath
 // first, then falling back to discovery by name in the CoreDir using standard
 // libretro naming conventions (e.g., nestopia_libretro.so).

--- a/server/internal/api/core_handler_test.go
+++ b/server/internal/api/core_handler_test.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"testing"
 
+	"github.com/spela/server/internal/auth"
 	"github.com/spela/server/internal/db"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -284,4 +285,172 @@ func TestGetCoreManifest_RequiresAuth(t *testing.T) {
 	req := httptest.NewRequest("GET", "/api/cores/"+itoa(core.ID)+"/manifest", nil)
 	router.ServeHTTP(w, req)
 	assert.Equal(t, http.StatusUnauthorized, w.Code)
+}
+
+// TestRefreshCore_PicksUpReplacedBinary is the canonical #555 Phase 2b
+// test: Phase 1 backfill is lazy and only runs when the row has missing
+// metadata. If an admin drops a newer core binary onto disk after the
+// row is populated, the stored sha256 goes stale. The refresh endpoint
+// must re-hash and update the row.
+func TestRefreshCore_PicksUpReplacedBinary(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	adminToken := registerAndGetToken(t, router)
+
+	require.NoError(t, os.MkdirAll(cfg.CoreDir, 0o755))
+	corePath := filepath.Join(cfg.CoreDir, "nestopia_libretro.so")
+	originalPayload := []byte("nestopia-v1-bytes")
+	require.NoError(t, os.WriteFile(corePath, originalPayload, 0o644))
+
+	var core db.Core
+	require.NoError(t, database.Where("name = ?", "nestopia").First(&core).Error)
+
+	// Prime metadata via a download — Phase 1 backfill records the
+	// original sha256.
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/cores/"+itoa(core.ID)+"/download?platform=linux", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var afterDownload db.Core
+	require.NoError(t, database.First(&afterDownload, core.ID).Error)
+	originalSum := sha256.Sum256(originalPayload)
+	require.Equal(t, hex.EncodeToString(originalSum[:]), afterDownload.Sha256)
+
+	// Simulate the admin replacing the binary out-of-band.
+	newPayload := []byte("nestopia-v2-newer-bytes-with-different-length")
+	require.NoError(t, os.WriteFile(corePath, newPayload, 0o644))
+
+	// POST the refresh. Stored sha should move to the new payload's
+	// digest and `changed` should be true.
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("POST", "/api/cores/"+itoa(core.ID)+"/refresh?platform=linux", nil)
+	req2.Header.Set("Authorization", "Bearer "+adminToken)
+	router.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusOK, w2.Code)
+
+	var resp struct {
+		Changed   bool   `json:"changed"`
+		OldSha256 string `json:"oldSha256"`
+		Sha256    string `json:"sha256"`
+		SizeBytes int64  `json:"sizeBytes"`
+	}
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+
+	newSum := sha256.Sum256(newPayload)
+	expectedNew := hex.EncodeToString(newSum[:])
+	expectedOld := hex.EncodeToString(originalSum[:])
+
+	assert.True(t, resp.Changed, "refresh must flag changed=true when sha differs")
+	assert.Equal(t, expectedOld, resp.OldSha256)
+	assert.Equal(t, expectedNew, resp.Sha256)
+	assert.Equal(t, int64(len(newPayload)), resp.SizeBytes)
+
+	// DB should reflect the new sha too.
+	var refreshed db.Core
+	require.NoError(t, database.First(&refreshed, core.ID).Error)
+	assert.Equal(t, expectedNew, refreshed.Sha256)
+	assert.Equal(t, int64(len(newPayload)), refreshed.SizeBytes)
+
+	// And a system event must have been recorded so admins can audit
+	// the replacement.
+	var events []db.SystemEvent
+	require.NoError(t, database.Where("event_type = ?", db.SystemEventCoreUpdated).Find(&events).Error)
+	require.Len(t, events, 1, "refresh must emit exactly one core_updated event")
+	assert.Contains(t, events[0].Metadata, expectedNew)
+	assert.Contains(t, events[0].Metadata, expectedOld)
+}
+
+// TestRefreshCore_UnchangedBinarySkipsSystemEvent verifies that
+// re-hashing the same bytes is a no-op at the audit level — we don't
+// want the system events feed spammed by idle admin-refresh clicks.
+func TestRefreshCore_UnchangedBinarySkipsSystemEvent(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	adminToken := registerAndGetToken(t, router)
+
+	require.NoError(t, os.MkdirAll(cfg.CoreDir, 0o755))
+	corePath := filepath.Join(cfg.CoreDir, "nestopia_libretro.so")
+	payload := []byte("unchanged-bytes")
+	require.NoError(t, os.WriteFile(corePath, payload, 0o644))
+
+	var core db.Core
+	require.NoError(t, database.Where("name = ?", "nestopia").First(&core).Error)
+
+	// Prime via download.
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/cores/"+itoa(core.ID)+"/download?platform=linux", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Refresh without touching the file.
+	w2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest("POST", "/api/cores/"+itoa(core.ID)+"/refresh?platform=linux", nil)
+	req2.Header.Set("Authorization", "Bearer "+adminToken)
+	router.ServeHTTP(w2, req2)
+	require.Equal(t, http.StatusOK, w2.Code)
+
+	var resp struct {
+		Changed bool `json:"changed"`
+	}
+	require.NoError(t, json.Unmarshal(w2.Body.Bytes(), &resp))
+	assert.False(t, resp.Changed, "refresh must flag changed=false when sha matches")
+
+	// No core_updated event.
+	var count int64
+	require.NoError(t, database.Model(&db.SystemEvent{}).Where("event_type = ?", db.SystemEventCoreUpdated).Count(&count).Error)
+	assert.Equal(t, int64(0), count, "refresh on identical bytes must not emit an audit event")
+}
+
+// TestRefreshCore_MissingBinaryReturns404 verifies the admin gets a
+// useful error when the on-disk binary is missing (e.g. the CoreDir
+// hasn't been populated yet for this platform).
+func TestRefreshCore_MissingBinaryReturns404(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	adminToken := registerAndGetToken(t, router)
+
+	var core db.Core
+	require.NoError(t, database.Where("name = ?", "nestopia").First(&core).Error)
+
+	// No binary on disk.
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/cores/"+itoa(core.ID)+"/refresh?platform=linux", nil)
+	req.Header.Set("Authorization", "Bearer "+adminToken)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusNotFound, w.Code)
+}
+
+// TestRefreshCore_RequiresAdmin verifies non-admin callers are rejected.
+// Refresh is a privileged mutation — it changes persistent server state
+// and emits an audit event — so it must sit behind RequireAdmin.
+func TestRefreshCore_RequiresAdmin(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+
+	// Direct DB insert — mirrors the pattern in admin_deleted_users_test.go.
+	user := db.User{
+		Username:     "regular-core",
+		Email:        "regular-core@test.com",
+		PasswordHash: "unused",
+		Role:         "user",
+	}
+	require.NoError(t, database.Create(&user).Error)
+	token, err := auth.GenerateAccessToken(user.ID, user.Username, string(user.Role), testJWTSecret)
+	require.NoError(t, err)
+
+	var core db.Core
+	require.NoError(t, database.Where("name = ?", "nestopia").First(&core).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/cores/"+itoa(core.ID)+"/refresh", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	assert.Equal(t, http.StatusForbidden, w.Code)
 }

--- a/server/internal/api/huma_core.go
+++ b/server/internal/api/huma_core.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -41,12 +42,39 @@ type CoreManifestOutput struct {
 	Body CoreManifestResponse
 }
 
-// RegisterCoreRoutes wires the core list + manifest endpoints into the huma
-// API. Other core endpoints (download) stay on raw gin for now — this
-// migration covers the read paths only.
+// RefreshCoreInput is the input for POST /api/cores/{id}/refresh.
+type RefreshCoreInput struct {
+	ID       uint   `path:"id" doc:"Core row ID (not core name)."`
+	Platform string `query:"platform" required:"false" doc:"Platform whose on-disk binary to re-hash (linux|macos|windows|android). Defaults to linux — the default server host platform."`
+}
+
+// RefreshCoreResponse is the admin-UI payload for the refresh mutation.
+// Mirrors CoreManifestResponse plus a `changed` boolean so the UI can
+// differentiate "already current" from "picked up a new sha" without
+// diffing before/after itself.
+type RefreshCoreResponse struct {
+	Changed   bool       `json:"changed" doc:"True when the on-disk sha256 differed from the previously persisted sha256."`
+	OldSha256 string     `json:"oldSha256" doc:"The sha256 stored before this refresh. Empty on the first-ever fingerprint."`
+	Sha256    string     `json:"sha256" doc:"Sha256 of the on-disk binary after the refresh."`
+	SizeBytes int64      `json:"sizeBytes" doc:"Size of the on-disk binary after the refresh."`
+	FetchedAt *time.Time `json:"fetchedAt" doc:"Timestamp persisted on the row after this refresh."`
+	SourceURL string     `json:"sourceUrl" doc:"Source URL persisted on the row. Empty for buildbot-default cores."`
+}
+
+// RefreshCoreOutput is the huma response envelope for the refresh
+// mutation.
+type RefreshCoreOutput struct {
+	Body RefreshCoreResponse
+}
+
+// RegisterCoreRoutes wires the core list + manifest + admin refresh
+// endpoints into the huma API. Other core endpoints (download) stay on
+// raw gin for now — this migration covers the read paths and the
+// refresh mutation only.
 func RegisterCoreRoutes(api huma.API, h *CoreHandler, jwtSecret string, database *gorm.DB, userLimiter *RateLimiter) {
 	requireAuth := RequireAuth(jwtSecret, database)
 	rateLimit := UserRateLimitMiddleware(userLimiter)
+	requireAdmin := RequireAdmin(api)
 
 	huma.Register(api, huma.Operation{
 		OperationID: "listCores",
@@ -69,6 +97,17 @@ func RegisterCoreRoutes(api huma.API, h *CoreHandler, jwtSecret string, database
 		Middlewares: huma.Middlewares{requireAuth, rateLimit},
 		Security:    []map[string][]string{{"bearer": {}}},
 	}, h.HumaGetCoreManifest)
+
+	huma.Register(api, huma.Operation{
+		OperationID: "refreshCore",
+		Method:      http.MethodPost,
+		Path:        "/api/cores/{id}/refresh",
+		Summary:     "Re-fingerprint a core binary (admin)",
+		Description: "Admin-only. Re-hashes the on-disk core binary, updates the DB metadata, snapshots the new binary into the history directory, and emits a core_updated system event when the sha256 actually changed. Use after manually swapping a core binary on disk so stored fingerprints don't go stale. Returns 404 when the binary isn't on disk for the requested platform.",
+		Tags:        []string{"cores"},
+		Middlewares: huma.Middlewares{requireAuth, rateLimit, requireAdmin},
+		Security:    []map[string][]string{{"bearer": {}}},
+	}, h.HumaRefreshCore)
 }
 
 // HumaListCores is the huma handler for GET /api/cores.
@@ -94,5 +133,40 @@ func (h *CoreHandler) HumaGetCoreManifest(_ context.Context, in *CoreManifestInp
 		SizeBytes: core.SizeBytes,
 		FetchedAt: core.FetchedAt,
 		SourceURL: core.SourceURL,
+	}}, nil
+}
+
+// HumaRefreshCore is the huma handler for POST /api/cores/{id}/refresh.
+// Admin-only. Re-hashes the on-disk binary, updates the DB row, and
+// emits an audit event when the sha256 changed.
+func (h *CoreHandler) HumaRefreshCore(_ context.Context, in *RefreshCoreInput) (*RefreshCoreOutput, error) {
+	var core db.Core
+	if err := h.DB.First(&core, in.ID).Error; err != nil {
+		if err == gorm.ErrRecordNotFound {
+			return nil, huma.Error404NotFound("core not found")
+		}
+		return nil, huma.Error500InternalServerError("failed to fetch core")
+	}
+	platform := in.Platform
+	if platform == "" {
+		platform = "linux"
+	}
+	result, err := h.RefreshCoreMetadata(&core, platform)
+	if err != nil {
+		// Binary isn't on disk for this platform — surface as 404 so
+		// the admin UI can show a useful message ("upload a binary
+		// for this platform first") instead of a 500.
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, huma.Error404NotFound("core binary not available on disk for platform " + platform)
+		}
+		return nil, huma.Error500InternalServerError("failed to refresh core: " + err.Error())
+	}
+	return &RefreshCoreOutput{Body: RefreshCoreResponse{
+		Changed:   result.Changed,
+		OldSha256: result.OldSha256,
+		Sha256:    result.NewSha256,
+		SizeBytes: result.SizeBytes,
+		FetchedAt: result.FetchedAt,
+		SourceURL: result.SourceURL,
 	}}, nil
 }

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -326,6 +326,11 @@ const (
 	SystemEventROMFileMissing          = "rom_file_missing"
 	SystemEventAPICredentialsInvalid   = "api_credentials_invalid"
 	SystemEventEmulatorJSLoadFailed    = "emulatorjs_load_failed"
+	// Emitted when the server observes a new sha256 for a core binary —
+	// either an admin-triggered force-refresh or (future) a background
+	// buildbot poll. Metadata carries old_sha256 and new_sha256 so the
+	// audit trail shows which version replaced which. See #555 Phase 2.
+	SystemEventCoreUpdated = "core_updated"
 )
 
 // AllSystemEventTypes is the canonical catalog of system event type strings.
@@ -346,6 +351,7 @@ var AllSystemEventTypes = []string{
 	SystemEventROMFileMissing,
 	SystemEventAPICredentialsInvalid,
 	SystemEventEmulatorJSLoadFailed,
+	SystemEventCoreUpdated,
 }
 
 // SystemEventTypeCategory maps each event type to its category code. Used by
@@ -366,6 +372,7 @@ var SystemEventTypeCategory = map[string]string{
 	SystemEventROMFileMissing:          CategoryOperational,
 	SystemEventAPICredentialsInvalid:   CategoryOperational,
 	SystemEventEmulatorJSLoadFailed:    CategoryOperational,
+	SystemEventCoreUpdated:             CategoryOperational,
 }
 
 // SystemEvent records an admin-only audit entry for an authentication,

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -1804,6 +1804,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/cores/{id}/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Re-fingerprint a core binary (admin)
+         * @description Admin-only. Re-hashes the on-disk core binary, updates the DB metadata, snapshots the new binary into the history directory, and emits a core_updated system event when the sha256 actually changed. Use after manually swapping a core binary on disk so stored fingerprints don't go stale. Returns 404 when the binary isn't on disk for the requested platform.
+         */
+        post: operations["refreshCore"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/emulator/error": {
         parameters: {
             query?: never;
@@ -7430,6 +7450,32 @@ export interface components {
             game: string;
             message: string;
         };
+        RefreshCoreResponse: {
+            /**
+             * Format: uri
+             * @description A URL to the JSON Schema for this object.
+             * @example https://example.com/api/schemas/RefreshCoreResponse.json
+             */
+            readonly $schema?: string;
+            /** @description True when the on-disk sha256 differed from the previously persisted sha256. */
+            changed: boolean;
+            /**
+             * Format: date-time
+             * @description Timestamp persisted on the row after this refresh.
+             */
+            fetchedAt: string | null;
+            /** @description The sha256 stored before this refresh. Empty on the first-ever fingerprint. */
+            oldSha256: string;
+            /** @description Sha256 of the on-disk binary after the refresh. */
+            sha256: string;
+            /**
+             * Format: int64
+             * @description Size of the on-disk binary after the refresh.
+             */
+            sizeBytes: number;
+            /** @description Source URL persisted on the row. Empty for buildbot-default cores. */
+            sourceUrl: string;
+        };
         RegisterDeviceRequest: {
             /**
              * Format: uri
@@ -12069,6 +12115,41 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["CoreManifestResponse"];
+                };
+            };
+            /** @description Error */
+            default: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HumaError"];
+                };
+            };
+        };
+    };
+    refreshCore: {
+        parameters: {
+            query?: {
+                /** @description Platform whose on-disk binary to re-hash (linux|macos|windows|android). Defaults to linux — the default server host platform. */
+                platform?: string;
+            };
+            header?: never;
+            path: {
+                /** @description Core row ID (not core name). */
+                id: number;
+            };
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description OK */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["RefreshCoreResponse"];
                 };
             };
             /** @description Error */

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -6758,6 +6758,58 @@
         ],
         "type": "object"
       },
+      "RefreshCoreResponse": {
+        "additionalProperties": false,
+        "properties": {
+          "$schema": {
+            "description": "A URL to the JSON Schema for this object.",
+            "examples": [
+              "https://example.com/api/schemas/RefreshCoreResponse.json"
+            ],
+            "format": "uri",
+            "readOnly": true,
+            "type": "string"
+          },
+          "changed": {
+            "description": "True when the on-disk sha256 differed from the previously persisted sha256.",
+            "type": "boolean"
+          },
+          "fetchedAt": {
+            "description": "Timestamp persisted on the row after this refresh.",
+            "format": "date-time",
+            "type": [
+              "string",
+              "null"
+            ]
+          },
+          "oldSha256": {
+            "description": "The sha256 stored before this refresh. Empty on the first-ever fingerprint.",
+            "type": "string"
+          },
+          "sha256": {
+            "description": "Sha256 of the on-disk binary after the refresh.",
+            "type": "string"
+          },
+          "sizeBytes": {
+            "description": "Size of the on-disk binary after the refresh.",
+            "format": "int64",
+            "type": "integer"
+          },
+          "sourceUrl": {
+            "description": "Source URL persisted on the row. Empty for buildbot-default cores.",
+            "type": "string"
+          }
+        },
+        "required": [
+          "changed",
+          "oldSha256",
+          "sha256",
+          "sizeBytes",
+          "fetchedAt",
+          "sourceUrl"
+        ],
+        "type": "object"
+      },
       "RegisterDeviceRequest": {
         "additionalProperties": false,
         "properties": {
@@ -15712,6 +15764,67 @@
           }
         ],
         "summary": "Get fingerprint for a core binary",
+        "tags": [
+          "cores"
+        ]
+      }
+    },
+    "/api/cores/{id}/refresh": {
+      "post": {
+        "description": "Admin-only. Re-hashes the on-disk core binary, updates the DB metadata, snapshots the new binary into the history directory, and emits a core_updated system event when the sha256 actually changed. Use after manually swapping a core binary on disk so stored fingerprints don't go stale. Returns 404 when the binary isn't on disk for the requested platform.",
+        "operationId": "refreshCore",
+        "parameters": [
+          {
+            "description": "Core row ID (not core name).",
+            "in": "path",
+            "name": "id",
+            "required": true,
+            "schema": {
+              "description": "Core row ID (not core name).",
+              "format": "int64",
+              "minimum": 0,
+              "type": "integer"
+            }
+          },
+          {
+            "description": "Platform whose on-disk binary to re-hash (linux|macos|windows|android). Defaults to linux — the default server host platform.",
+            "explode": false,
+            "in": "query",
+            "name": "platform",
+            "schema": {
+              "description": "Platform whose on-disk binary to re-hash (linux|macos|windows|android). Defaults to linux — the default server host platform.",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RefreshCoreResponse"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "default": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HumaError"
+                }
+              }
+            },
+            "description": "Error"
+          }
+        },
+        "security": [
+          {
+            "bearer": []
+          }
+        ],
+        "summary": "Re-fingerprint a core binary (admin)",
         "tags": [
           "cores"
         ]

--- a/web/src/generated/schemas.ts
+++ b/web/src/generated/schemas.ts
@@ -191,6 +191,7 @@ export type RecentAchievementsResponse = Schemas["RecentAchievementsResponse"];
 export type RecentReviewItem = Schemas["RecentReviewItem"];
 export type RecentlyReviewedResponse = Schemas["RecentlyReviewedResponse"];
 export type RefreshAchievementsResponse = Schemas["RefreshAchievementsResponse"];
+export type RefreshCoreResponse = Schemas["RefreshCoreResponse"];
 export type RegisterDeviceRequest = Schemas["RegisterDeviceRequest"];
 export type RelatedDeveloper = Schemas["RelatedDeveloper"];
 export type RelatedPublisher = Schemas["RelatedPublisher"];

--- a/web/src/hooks/use-admin.ts
+++ b/web/src/hooks/use-admin.ts
@@ -489,3 +489,21 @@ export function useAdminCores() {
     queryFn: () => unwrap(typedApi.GET("/api/cores")),
   });
 }
+
+export function useRefreshCore() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (params: { id: number; platform?: string }) =>
+      unwrap(
+        typedApi.POST("/api/cores/{id}/refresh", {
+          params: {
+            path: { id: params.id },
+            query: params.platform ? { platform: params.platform } : {},
+          },
+        }),
+      ),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin", "cores"] });
+    },
+  });
+}

--- a/web/src/pages/admin/__tests__/cores-page.test.tsx
+++ b/web/src/pages/admin/__tests__/cores-page.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter } from "react-router-dom";
@@ -7,10 +8,22 @@ import { CoresPage } from "../cores-page";
 
 vi.mock("@/hooks/use-admin", () => ({
   useAdminCores: vi.fn(),
+  useRefreshCore: vi.fn(),
 }));
 
-import { useAdminCores } from "@/hooks/use-admin";
+// `useToast` is used for the refresh success/error feedback. Stub it so
+// tests don't need to wrap in a real ToastProvider.
+vi.mock("@/components/ui", async () => {
+  const actual = await vi.importActual("@/components/ui");
+  return {
+    ...actual,
+    useToast: vi.fn(() => ({ toast: vi.fn() })),
+  };
+});
+
+import { useAdminCores, useRefreshCore } from "@/hooks/use-admin";
 const mockUseAdminCores = useAdminCores as ReturnType<typeof vi.fn>;
+const mockUseRefreshCore = useRefreshCore as ReturnType<typeof vi.fn>;
 
 function renderPage() {
   const queryClient = new QueryClient({
@@ -56,6 +69,11 @@ const pristineCore = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockUseRefreshCore.mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+    variables: undefined,
+  });
 });
 
 describe("CoresPage", () => {
@@ -146,5 +164,44 @@ describe("CoresPage", () => {
     expect(
       screen.getByText(/No cores registered/i),
     ).toBeInTheDocument();
+  });
+
+  it("calls the refresh mutation with the row's id when the button is clicked", async () => {
+    const mutate = vi.fn();
+    mockUseRefreshCore.mockReturnValue({
+      mutate,
+      isPending: false,
+      variables: undefined,
+    });
+    mockUseAdminCores.mockReturnValue({
+      data: [fingerprintedCore],
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+
+    await userEvent.click(screen.getByTestId("cores-refresh-nestopia"));
+
+    expect(mutate).toHaveBeenCalledTimes(1);
+    expect(mutate.mock.calls[0][0]).toEqual({ id: 1 });
+  });
+
+  it("disables only the refreshing row's button while the mutation is in flight", () => {
+    mockUseRefreshCore.mockReturnValue({
+      mutate: vi.fn(),
+      isPending: true,
+      variables: { id: 1 }, // refreshing nestopia
+    });
+    mockUseAdminCores.mockReturnValue({
+      data: [fingerprintedCore, pristineCore],
+      isLoading: false,
+      isError: false,
+    });
+    renderPage();
+
+    expect(screen.getByTestId("cores-refresh-nestopia")).toBeDisabled();
+    // The other row's button must remain interactive — users can queue
+    // manual refreshes for different cores in parallel.
+    expect(screen.getByTestId("cores-refresh-mednafen_psx_hw")).not.toBeDisabled();
   });
 });

--- a/web/src/pages/admin/cores-page.tsx
+++ b/web/src/pages/admin/cores-page.tsx
@@ -1,11 +1,37 @@
-import { HardDrive, AlertCircle } from "lucide-react";
+import { HardDrive, AlertCircle, RefreshCw } from "lucide-react";
 import { PageLayout, SectionList } from "@/components/layout";
-import { Section, Skeleton } from "@/components/ui";
-import { useAdminCores } from "@/hooks/use-admin";
+import { Section, Skeleton, Button, useToast } from "@/components/ui";
+import { useAdminCores, useRefreshCore } from "@/hooks/use-admin";
 import { formatFileSize, formatRelativeTime } from "@/lib/format";
 
 export function CoresPage() {
   const { data, isLoading, isError } = useAdminCores();
+  const { toast } = useToast();
+  const refresh = useRefreshCore();
+
+  const onRefresh = (id: number, coreLabel: string) => {
+    refresh.mutate(
+      { id },
+      {
+        onSuccess: (res) => {
+          if (res?.changed) {
+            toast(
+              "success",
+              `${coreLabel} updated to ${res.sha256.slice(0, 12)}…`,
+            );
+          } else {
+            toast("success", `${coreLabel} already current`);
+          }
+        },
+        onError: (err) => {
+          toast(
+            "error",
+            err instanceof Error ? err.message : "Refresh failed",
+          );
+        },
+      },
+    );
+  };
 
   if (isLoading) {
     return (
@@ -78,8 +104,11 @@ export function CoresPage() {
                       <th className="py-2 pr-4 font-medium text-surface-400">
                         Last fetched
                       </th>
-                      <th className="py-2 font-medium text-surface-400">
+                      <th className="py-2 pr-4 font-medium text-surface-400">
                         Source
+                      </th>
+                      <th className="py-2 font-medium text-surface-400 text-right">
+                        Actions
                       </th>
                     </tr>
                   </thead>
@@ -137,7 +166,7 @@ export function CoresPage() {
                             </span>
                           )}
                         </td>
-                        <td className="py-2.5 text-surface-300 font-mono text-xs">
+                        <td className="py-2.5 pr-4 text-surface-300 font-mono text-xs">
                           {core.sourceUrl ? (
                             <span
                               title={core.sourceUrl}
@@ -150,6 +179,31 @@ export function CoresPage() {
                               buildbot
                             </span>
                           )}
+                        </td>
+                        <td className="py-2.5 text-right">
+                          <Button
+                            variant="secondary"
+                            size="sm"
+                            data-testid={`cores-refresh-${core.name}`}
+                            disabled={
+                              refresh.isPending &&
+                              refresh.variables?.id === core.id
+                            }
+                            onClick={() =>
+                              onRefresh(core.id, core.displayName || core.name)
+                            }
+                            title="Re-hash the on-disk binary and update the recorded sha256"
+                          >
+                            <RefreshCw
+                              className={`h-3.5 w-3.5 ${
+                                refresh.isPending &&
+                                refresh.variables?.id === core.id
+                                  ? "animate-spin"
+                                  : ""
+                              }`}
+                            />
+                            <span className="ml-1.5">Refresh</span>
+                          </Button>
                         </td>
                       </tr>
                     ))}


### PR DESCRIPTION
## Summary

Phase 2b of #555. Fixes the known "admin swapped the .so, DB metadata is now stale" limitation that Phase 1's `ensureCoreMetadata` explicitly documented as a tracked issue.

## Server

- **`POST /api/cores/{id}/refresh`** (admin-only). Re-hashes the on-disk binary for the requested platform, persists updated `sha256` / `sizeBytes` / `fetchedAt`, snapshots the new binary into `{CoreDir}/history/{sha256}/…` so older session pins can still be served, and emits a `SystemEvent("core_updated")` with `old_sha256 / new_sha256` in metadata — **only when the hash actually changed**, so idle refresh clicks don't spam the audit feed.
- New `CoreHandler.RefreshCoreMetadata(core, platform)` helper (unconditional re-hash; contrasts with `ensureCoreMetadata`'s lazy missing-fields check).
- `404` when the binary isn't on disk for the requested platform so the admin UI can surface "upload a binary for this platform first" instead of a generic 500.

## SystemEvent plumbing

- `SystemEventCoreUpdated = "core_updated"` added to the operational event catalog and category map.

## Admin UI

- New **Refresh** button per row on `/admin/cores` (lucide `RefreshCw` icon, spins while the mutation for that row is in flight).
- Toast on completion: `<core> updated to <sha prefix>` on a changed hash, `<core> already current` on a no-op.
- `useRefreshCore` mutation hook invalidates `["admin","cores"]` on success so the row repaints with the new sha / size / fetchedAt.
- Only the refreshing row's button is disabled — other rows stay clickable so admins can queue refreshes for multiple cores in parallel.

## Regen

`web/src/generated/{openapi.json,api.d.ts,schemas.ts}` picks up `refreshCore` operation + `RefreshCoreResponse` shape.

## Test plan

- [x] Go: 4 new handler cases — `TestRefreshCore_PicksUpReplacedBinary` (changed=true, OldSha256, Sha256, SizeBytes in response AND DB AND exactly one `SystemEventCoreUpdated` row with both hashes in `Metadata`); `TestRefreshCore_UnchangedBinarySkipsSystemEvent` (no audit spam); `TestRefreshCore_MissingBinaryReturns404`; `TestRefreshCore_RequiresAdmin`.
- [x] Web vitest: 2 new page cases — click fires mutation with correct id; only the in-flight row's button is disabled. Pre-existing 7 cases updated with the new `useRefreshCore` mock.
- [x] Full suites still green: **1548** web tests, `server ./internal/api + ./internal/db`, **487** player desktop unit + **28** desktop E2E.
- [x] Visually verified: `/admin/cores` in a local Vite dev server now shows the Actions column with a Refresh button on every row (screenshot captured locally at `/tmp/admin-cores-phase2b.png`).
- [ ] CI green on this PR before merge

## Still out of scope for Phase 2

- Background cron polling buildbot for new nightlies. The server currently doesn't fetch cores itself — players do. Adding server-side fetching introduces a platform-specific-hosting question (which OS/arch to cache?) that deserves its own design pass.
- User opt-out preference on the preferences page.

Refs #555 (Phase 2b: admin force-refresh)