### PR TITLE
feat(#555): persist per-save coreSha256 on SessionSaveState (Phase 3)

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SessionsApi.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/apis/SessionsApi.kt
@@ -791,19 +791,21 @@ open class SessionsApi : ApiClient {
      * Stores an auto-save for the session and returns the resulting save record. Older auto-saves beyond the retention limit are pruned. Optionally attaches a screenshot.
      * @param id Session ID.
      * @param coreName Identifier of the libretro core that produced the save. (optional)
+     * @param coreSha256 Hex sha256 of the core binary that produced this save state. Optional — the server records it alongside the save for diagnostics and future rollback UX. Invalid values (not 64 hex chars) are silently dropped. See #555 Phase 3. (optional)
      * @param name Display name for the save (defaults to the uploaded filename). (optional)
      * @param save Save state file. Required. (optional)
      * @param screenshot Optional screenshot to attach to the save (typically PNG/JPEG). (optional)
      * @return SessionSaveResponse
      */
     @Suppress("UNCHECKED_CAST")
-    open suspend fun uploadAutoSave(id: kotlin.String, coreName: kotlin.String? = null, name: kotlin.String? = null, save: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null, screenshot: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null): HttpResponse<SessionSaveResponse> {
+    open suspend fun uploadAutoSave(id: kotlin.String, coreName: kotlin.String? = null, coreSha256: kotlin.String? = null, name: kotlin.String? = null, save: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null, screenshot: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null): HttpResponse<SessionSaveResponse> {
 
         val localVariableAuthNames = listOf<String>()
 
         val localVariableBody = 
             formData {
                 coreName?.apply { append("coreName", coreName) }
+                coreSha256?.apply { append("coreSha256", coreSha256) }
                 name?.apply { append("name", name) }
                 save?.apply { append(save) }
                 screenshot?.apply { append(screenshot) }
@@ -869,19 +871,21 @@ open class SessionsApi : ApiClient {
      * Stores a manual save state for the session and returns the resulting save record. Optionally attaches a screenshot.
      * @param id Session ID.
      * @param coreName Identifier of the libretro core that produced the save. (optional)
+     * @param coreSha256 Hex sha256 of the core binary that produced this save state. Optional — the server records it alongside the save for diagnostics and future rollback UX. Invalid values (not 64 hex chars) are silently dropped. See #555 Phase 3. (optional)
      * @param name Display name for the save (defaults to the uploaded filename). (optional)
      * @param save Save state file. Required. (optional)
      * @param screenshot Optional screenshot to attach to the save (typically PNG/JPEG). (optional)
      * @return SessionSaveResponse
      */
     @Suppress("UNCHECKED_CAST")
-    open suspend fun uploadSessionSave(id: kotlin.String, coreName: kotlin.String? = null, name: kotlin.String? = null, save: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null, screenshot: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null): HttpResponse<SessionSaveResponse> {
+    open suspend fun uploadSessionSave(id: kotlin.String, coreName: kotlin.String? = null, coreSha256: kotlin.String? = null, name: kotlin.String? = null, save: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null, screenshot: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null): HttpResponse<SessionSaveResponse> {
 
         val localVariableAuthNames = listOf<String>()
 
         val localVariableBody = 
             formData {
                 coreName?.apply { append("coreName", coreName) }
+                coreSha256?.apply { append("coreSha256", coreSha256) }
                 name?.apply { append("name", name) }
                 save?.apply { append(save) }
                 screenshot?.apply { append(screenshot) }
@@ -912,19 +916,21 @@ open class SessionsApi : ApiClient {
      * @param id Session ID.
      * @param slot Slot number 1-10.
      * @param coreName Identifier of the libretro core that produced the save. (optional)
+     * @param coreSha256 Hex sha256 of the core binary that produced this save state. Optional — the server records it alongside the save for diagnostics and future rollback UX. Invalid values (not 64 hex chars) are silently dropped. See #555 Phase 3. (optional)
      * @param name Display name for the save (defaults to the uploaded filename). (optional)
      * @param save Save state file. Required. (optional)
      * @param screenshot Optional screenshot to attach to the save (typically PNG/JPEG). (optional)
      * @return SessionSaveResponse
      */
     @Suppress("UNCHECKED_CAST")
-    open suspend fun upsertSlotSave(id: kotlin.String, slot: kotlin.String, coreName: kotlin.String? = null, name: kotlin.String? = null, save: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null, screenshot: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null): HttpResponse<SessionSaveResponse> {
+    open suspend fun upsertSlotSave(id: kotlin.String, slot: kotlin.String, coreName: kotlin.String? = null, coreSha256: kotlin.String? = null, name: kotlin.String? = null, save: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null, screenshot: io.ktor.client.request.forms.FormPart<io.ktor.client.request.forms.InputProvider>? = null): HttpResponse<SessionSaveResponse> {
 
         val localVariableAuthNames = listOf<String>()
 
         val localVariableBody = 
             formData {
                 coreName?.apply { append("coreName", coreName) }
+                coreSha256?.apply { append("coreSha256", coreSha256) }
                 name?.apply { append("name", name) }
                 save?.apply { append(save) }
                 screenshot?.apply { append(screenshot) }

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionSaveResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/SessionSaveResponse.kt
@@ -25,6 +25,7 @@ import kotlinx.serialization.encoding.*
  *
  * @param coreMatch 
  * @param coreName 
+ * @param coreSha256 
  * @param createdAt 
  * @param currentCore 
  * @param fileSize 
@@ -48,6 +49,8 @@ data class SessionSaveResponse (
     @SerialName(value = "coreMatch") @Required val coreMatch: kotlin.Boolean?,
 
     @SerialName(value = "coreName") @Required val coreName: kotlin.String,
+
+    @SerialName(value = "coreSha256") @Required val coreSha256: kotlin.String,
 
     @SerialName(value = "createdAt") @Required val createdAt: kotlinx.datetime.Instant,
 

--- a/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/data/repository/GameRepositoryImplTest.kt
@@ -512,6 +512,7 @@ class GameRepositoryImplTest {
             updatedAt = now,
             coreMatch = false,
             coreName = "",
+            coreSha256 = "",
             currentCore = "",
             notes = "",
             screenshotUrl = "",

--- a/server/internal/api/huma_session_uploads.go
+++ b/server/internal/api/huma_session_uploads.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/danielgtaylor/huma/v2"
@@ -24,6 +25,7 @@ type SessionSaveUploadBody struct {
 	Screenshot huma.FormFile `form:"screenshot" required:"false" contentType:"application/octet-stream" doc:"Optional screenshot to attach to the save (typically PNG/JPEG)."`
 	Name       string        `form:"name" required:"false" doc:"Display name for the save (defaults to the uploaded filename)."`
 	CoreName   string        `form:"coreName" required:"false" doc:"Identifier of the libretro core that produced the save."`
+	CoreSha256 string        `form:"coreSha256" required:"false" doc:"Hex sha256 of the core binary that produced this save state. Optional — the server records it alongside the save for diagnostics and future rollback UX. Invalid values (not 64 hex chars) are silently dropped. See #555 Phase 3."`
 }
 
 // SessionSaveUploadInput wraps the path parameter and multipart body for
@@ -210,6 +212,7 @@ func (h *SessionHandler) HumaUploadSessionSave(ctx context.Context, in *SessionS
 		FileSize:      size,
 		ScreenshotURL: screenshotURL,
 		CoreName:      body.CoreName,
+		CoreSha256:    sanitizeCoreSha256(body.CoreSha256),
 		IsAuto:        false,
 	}
 	if err := h.DB.Create(&rec).Error; err != nil {
@@ -264,6 +267,7 @@ func (h *SessionHandler) HumaUploadAutoSave(ctx context.Context, in *SessionAuto
 		FileSize:      size,
 		ScreenshotURL: screenshotURL,
 		CoreName:      body.CoreName,
+		CoreSha256:    sanitizeCoreSha256(body.CoreSha256),
 		IsAuto:        true,
 		IsCurrent:     true,
 	}
@@ -337,6 +341,7 @@ func (h *SessionHandler) HumaUpsertSlotSave(ctx context.Context, in *SessionSlot
 			FileSize:      size,
 			ScreenshotURL: screenshotURL,
 			CoreName:      body.CoreName,
+			CoreSha256:    sanitizeCoreSha256(body.CoreSha256),
 			IsAuto:        false,
 			Slot:          &slotNum,
 		}
@@ -346,6 +351,7 @@ func (h *SessionHandler) HumaUpsertSlotSave(ctx context.Context, in *SessionSlot
 		rec.FileSize = size
 		rec.ScreenshotURL = screenshotURL
 		rec.CoreName = body.CoreName
+		rec.CoreSha256 = sanitizeCoreSha256(body.CoreSha256)
 		h.DB.Save(&rec)
 	}
 
@@ -451,6 +457,19 @@ func (h *SessionHandler) touchSessionAfterUpload(session db.GameSession, uid uin
 		updates["pinned_core_sha256"] = sha
 	}
 	h.DB.Model(&session).Updates(updates)
+}
+
+// sanitizeCoreSha256 accepts the raw coreSha256 string from a save
+// upload body and returns the lowercase hex form if it's a valid
+// 64-char hex sha256. Anything malformed (wrong length, non-hex
+// characters, whitespace) is silently dropped to "" — the field is
+// diagnostic metadata, so we prefer "no value" over a 400 that would
+// reject the whole save. See #555 Phase 3.
+func sanitizeCoreSha256(raw string) string {
+	if !isValidSha256Hex(raw) {
+		return ""
+	}
+	return strings.ToLower(raw)
 }
 
 // pinSessionCoreSha256 returns the sha256 to persist into

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -996,6 +996,11 @@ type SessionSaveResponse struct {
 	IsAuto        bool      `json:"isAuto"`
 	IsCurrent     bool      `json:"isCurrent"`
 	CoreName      string    `json:"coreName"`
+	// Hex sha256 of the core binary that produced this save state.
+	// Empty when the player didn't supply one. Used for diagnostics
+	// (matching a failing load to the exact core binary that wrote
+	// the save) and future rollback UX. See #555 Phase 3.
+	CoreSha256    string    `json:"coreSha256"`
 	CoreMatch     *bool     `json:"coreMatch"`
 	CurrentCore   string    `json:"currentCore"`
 	Notes         string    `json:"notes"`

--- a/server/internal/api/session_handler.go
+++ b/server/internal/api/session_handler.go
@@ -137,6 +137,7 @@ func (h *SessionHandler) toSaveResponse(s db.SessionSaveState, currentCore strin
 		IsAuto:        s.IsAuto,
 		IsCurrent:     s.IsCurrent,
 		CoreName:      s.CoreName,
+		CoreSha256:    s.CoreSha256,
 		Notes:         s.Notes,
 		Slot:          s.Slot,
 		CreatedAt:     s.CreatedAt,

--- a/server/internal/api/session_handler_test.go
+++ b/server/internal/api/session_handler_test.go
@@ -1397,6 +1397,84 @@ func uploadSessionSaveWithCore(t *testing.T, router http.Handler, token, session
 	return resp
 }
 
+// uploadSessionSaveWithCoreAndSha drives the save-upload endpoint with
+// both coreName and coreSha256 fields, used by the #555 Phase 3 tests
+// that pin the save→core fingerprint wire contract.
+func uploadSessionSaveWithCoreAndSha(t *testing.T, router http.Handler, token, sessionID, name, coreName, coreSha256 string, data []byte) map[string]interface{} {
+	t.Helper()
+	var buf bytes.Buffer
+	writer := multipart.NewWriter(&buf)
+	writer.WriteField("name", name)
+	if coreName != "" {
+		writer.WriteField("coreName", coreName)
+	}
+	if coreSha256 != "" {
+		writer.WriteField("coreSha256", coreSha256)
+	}
+	part, _ := writer.CreateFormFile("save", "state.sav")
+	part.Write(data)
+	writer.Close()
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("POST", "/api/sessions/"+sessionID+"/saves", &buf)
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusCreated, w.Code, "upload save failed: %s", w.Body.String())
+
+	var resp map[string]interface{}
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	return resp
+}
+
+// TestSaveUpload_CoreSha256Roundtrip verifies that a client-supplied
+// coreSha256 is persisted on the SessionSaveState row and surfaced on
+// the upload response — the full wire round-trip the player will rely
+// on for future rollback UX. See #555 Phase 3.
+func TestSaveUpload_CoreSha256Roundtrip(t *testing.T) {
+	env := setupSessionTestEnv(t)
+	created := createGameSession(t, env.router, env.token, env.gameID, "Roundtrip")
+	sessionID := created["id"].(string)
+
+	// Valid lowercase 64-char hex sha → must be persisted as-is.
+	const sha = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+	resp := uploadSessionSaveWithCoreAndSha(t, env.router, env.token, sessionID, "Pinned", "nestopia", sha, []byte("data"))
+	assert.Equal(t, sha, resp["coreSha256"])
+}
+
+// TestSaveUpload_CoreSha256UppercaseNormalized verifies that a valid
+// sha256 supplied in uppercase hex is normalised to lowercase before
+// persistence. The spec calls for lowercase; normalising defensively
+// means a player with a MessageDigest.toHex-style helper doesn't
+// silently produce mismatches against the lower-case history-path
+// layout on disk.
+func TestSaveUpload_CoreSha256UppercaseNormalized(t *testing.T) {
+	env := setupSessionTestEnv(t)
+	created := createGameSession(t, env.router, env.token, env.gameID, "UpperCase")
+	sessionID := created["id"].(string)
+
+	upper := "ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789ABCDEF0123456789"
+	lower := "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789"
+	resp := uploadSessionSaveWithCoreAndSha(t, env.router, env.token, sessionID, "Mixed", "nestopia", upper, []byte("data"))
+	assert.Equal(t, lower, resp["coreSha256"])
+}
+
+// TestSaveUpload_CoreSha256InvalidDropped verifies that malformed
+// coreSha256 values (wrong length, non-hex characters, whitespace) are
+// silently dropped to the empty string rather than failing the whole
+// upload. The field is diagnostic metadata — we'd rather lose the tag
+// than reject a save the user just wrote.
+func TestSaveUpload_CoreSha256InvalidDropped(t *testing.T) {
+	env := setupSessionTestEnv(t)
+	created := createGameSession(t, env.router, env.token, env.gameID, "Invalid")
+	sessionID := created["id"].(string)
+
+	for _, bad := range []string{"", "not-hex-at-all", "short", "  abcdef0123456789abcdef0123456789abcdef0123456789abcdef012345  "} {
+		resp := uploadSessionSaveWithCoreAndSha(t, env.router, env.token, sessionID, "Bad", "nestopia", bad, []byte("x"))
+		assert.Empty(t, resp["coreSha256"], "invalid coreSha256 %q must be dropped to empty", bad)
+	}
+}
+
 func TestSaveResponse_CoreMatch_Matching(t *testing.T) {
 	env := setupSessionTestEnv(t)
 

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -854,6 +854,13 @@ type SessionSaveState struct {
 	IsAuto        bool           `gorm:"default:false" json:"isAuto"`
 	IsCurrent     bool           `gorm:"default:false" json:"isCurrent"`
 	CoreName      string         `gorm:"size:128" json:"coreName"`
+	// CoreSha256 is the hex sha256 of the core binary that produced
+	// this save state. Populated by the player at save-upload time when
+	// available. Used for diagnostics (matching a failing load against
+	// the specific binary that wrote the save) and — eventually — for
+	// rollback UX that offers the exact core version the save was made
+	// with. Empty when the player didn't supply one. See #555 Phase 3.
+	CoreSha256    string         `gorm:"size:64" json:"coreSha256"`
 	Notes         string         `gorm:"type:text" json:"notes"`
 	Slot          *int           `json:"slot"`
 }

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -7893,6 +7893,7 @@ export interface components {
             readonly $schema?: string;
             coreMatch: boolean | null;
             coreName: string;
+            coreSha256: string;
             /** Format: date-time */
             createdAt: string;
             currentCore: string;
@@ -15576,6 +15577,8 @@ export interface operations {
                 "multipart/form-data": {
                     /** @description Identifier of the libretro core that produced the save. */
                     coreName?: string;
+                    /** @description Hex sha256 of the core binary that produced this save state. Optional — the server records it alongside the save for diagnostics and future rollback UX. Invalid values (not 64 hex chars) are silently dropped. See #555 Phase 3. */
+                    coreSha256?: string;
                     /** @description Display name for the save (defaults to the uploaded filename). */
                     name?: string;
                     /**
@@ -15689,6 +15692,8 @@ export interface operations {
                 "multipart/form-data": {
                     /** @description Identifier of the libretro core that produced the save. */
                     coreName?: string;
+                    /** @description Hex sha256 of the core binary that produced this save state. Optional — the server records it alongside the save for diagnostics and future rollback UX. Invalid values (not 64 hex chars) are silently dropped. See #555 Phase 3. */
+                    coreSha256?: string;
                     /** @description Display name for the save (defaults to the uploaded filename). */
                     name?: string;
                     /**
@@ -15774,6 +15779,8 @@ export interface operations {
                 "multipart/form-data": {
                     /** @description Identifier of the libretro core that produced the save. */
                     coreName?: string;
+                    /** @description Hex sha256 of the core binary that produced this save state. Optional — the server records it alongside the save for diagnostics and future rollback UX. Invalid values (not 64 hex chars) are silently dropped. See #555 Phase 3. */
+                    coreSha256?: string;
                     /** @description Display name for the save (defaults to the uploaded filename). */
                     name?: string;
                     /**

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -8054,6 +8054,9 @@
           "coreName": {
             "type": "string"
           },
+          "coreSha256": {
+            "type": "string"
+          },
           "createdAt": {
             "format": "date-time",
             "type": "string"
@@ -8115,6 +8118,7 @@
           "isAuto",
           "isCurrent",
           "coreName",
+          "coreSha256",
           "coreMatch",
           "currentCore",
           "notes",
@@ -21577,6 +21581,9 @@
                 "coreName": {
                   "contentType": "text/plain"
                 },
+                "coreSha256": {
+                  "contentType": "text/plain"
+                },
                 "name": {
                   "contentType": "text/plain"
                 },
@@ -21591,6 +21598,10 @@
                 "properties": {
                   "coreName": {
                     "description": "Identifier of the libretro core that produced the save.",
+                    "type": "string"
+                  },
+                  "coreSha256": {
+                    "description": "Hex sha256 of the core binary that produced this save state. Optional — the server records it alongside the save for diagnostics and future rollback UX. Invalid values (not 64 hex chars) are silently dropped. See #555 Phase 3.",
                     "type": "string"
                   },
                   "name": {
@@ -21713,6 +21724,9 @@
                 "coreName": {
                   "contentType": "text/plain"
                 },
+                "coreSha256": {
+                  "contentType": "text/plain"
+                },
                 "name": {
                   "contentType": "text/plain"
                 },
@@ -21727,6 +21741,10 @@
                 "properties": {
                   "coreName": {
                     "description": "Identifier of the libretro core that produced the save.",
+                    "type": "string"
+                  },
+                  "coreSha256": {
+                    "description": "Hex sha256 of the core binary that produced this save state. Optional — the server records it alongside the save for diagnostics and future rollback UX. Invalid values (not 64 hex chars) are silently dropped. See #555 Phase 3.",
                     "type": "string"
                   },
                   "name": {
@@ -21869,6 +21887,9 @@
                 "coreName": {
                   "contentType": "text/plain"
                 },
+                "coreSha256": {
+                  "contentType": "text/plain"
+                },
                 "name": {
                   "contentType": "text/plain"
                 },
@@ -21883,6 +21904,10 @@
                 "properties": {
                   "coreName": {
                     "description": "Identifier of the libretro core that produced the save.",
+                    "type": "string"
+                  },
+                  "coreSha256": {
+                    "description": "Hex sha256 of the core binary that produced this save state. Optional — the server records it alongside the save for diagnostics and future rollback UX. Invalid values (not 64 hex chars) are silently dropped. See #555 Phase 3.",
                     "type": "string"
                   },
                   "name": {


### PR DESCRIPTION
## Summary

Phase 3 leftover #664 deferred. `GameSession.PinnedCoreSha256` captures the session's *expected* core version, but there was no way to tell which specific save was made with which core binary. That matters for:

- **Diagnosis** — "save won't load" reports. The row's `coreSha256` tells us whether the user is loading against the same binary that wrote the save, independent of the session pin.
- **Future rollback UX** — if a load fails, we'll be able to offer the *exact* historical binary the save was made with, served from the existing `CoreDir/history/{sha}/` snapshot the Phase 3 retention already keeps around.

## Server

- `SessionSaveState` gains a `CoreSha256 string` column (size:64).
- `SessionSaveUploadBody` accepts an optional `coreSha256` multipart field.
- `sanitizeCoreSha256()` (sitting next to the existing `isValidSha256Hex` guard) validates the 64-char hex shape and lowercases it, silently dropping anything malformed so a garbled value never rejects the whole save.
- All three save-upload paths (manual, auto, slot upsert) capture it alongside `CoreName`.
- `SessionSaveResponse + toSaveResponse` expose the stored value. Empty string when the player didn't supply one — matches the `CoreName` "unknown provenance" convention.

## Tests

- `TestSaveUpload_CoreSha256Roundtrip` pins the wire contract for a valid lowercase sha.
- `TestSaveUpload_CoreSha256UppercaseNormalized` verifies uppercase input is lowercased on the way in — prevents subtle mismatches against the lowercase `CoreDir/history/` layout later.
- `TestSaveUpload_CoreSha256InvalidDropped` covers empty / non-hex / wrong-length / whitespace-padded values, asserting the invalid tag is dropped without failing the upload.

## Regen

Web TS + Kotlin clients pick up `SessionSaveResponse.coreSha256` and the new multipart field.

## Test plan

- [x] `go test ./internal/api/ ./internal/db/` — green (3 new cases)
- [x] `cd web && npx tsc --noEmit && npx vitest run` — 1549 tests green
- [x] Player compile-check — `./gradlew :shared:compileKotlinDesktop` clean
- [ ] CI green on this PR before merge

## Follow-up (not in scope)

- **Player write path**: hash the currently loaded core on save and include the sha in the multipart body. The `sha256File(path)` utility + `LoadedCoreInfo` scaffolding from Phase 2a makes this a small diff. I'd do it in a separate PR so this one stays a narrow "server accepts + persists" chunk.
- **Rollback UX**: when a load fails, look up the save's `coreSha256`, check if the server still has it under `history/{sha}/`, offer a one-click "retry with the original core".

Refs #555 (Phase 3 save-level core fingerprint)