### PR TITLE
feat(#672): player-side plumbing for core-upgrade decision (PR 2/5)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -1327,6 +1327,22 @@ class FakeSessionRepository : SessionRepository {
         return Result.success(sessions[idx])
     }
 
+    override suspend fun updateSessionCoreFlags(
+        sessionId: String,
+        userLockedCoreVersion: Boolean?,
+        autoLoadSuppressed: Boolean?,
+        rehearsalCrashPending: Boolean?,
+    ): Result<GameSession> {
+        val idx = sessions.indexOfFirst { it.id == sessionId }
+        if (idx < 0) return Result.failure(Exception("Session not found"))
+        var updated = sessions[idx]
+        if (userLockedCoreVersion != null) updated = updated.copy(userLockedCoreVersion = userLockedCoreVersion)
+        if (autoLoadSuppressed != null) updated = updated.copy(autoLoadSuppressed = autoLoadSuppressed)
+        if (rehearsalCrashPending != null) updated = updated.copy(rehearsalCrashPending = rehearsalCrashPending)
+        sessions[idx] = updated
+        return Result.success(sessions[idx])
+    }
+
     override suspend fun deleteSession(sessionId: String): Result<Unit> {
         sessions.removeAll { it.id == sessionId }
         return Result.success(Unit)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1572,6 +1572,27 @@ class SpelaApiClient(
         ).body()
     }
 
+    /**
+     * Toggles the core-upgrade decision flags on a session. Each flag is
+     * optional — null fields are left untouched server-side, matching the
+     * partial-update semantics of PUT /api/sessions/{id}. See #672.
+     */
+    suspend fun updateSessionCoreFlags(
+        sessionId: String,
+        userLockedCoreVersion: Boolean? = null,
+        autoLoadSuppressed: Boolean? = null,
+        rehearsalCrashPending: Boolean? = null,
+    ): com.spela.client.models.GameSessionResponse {
+        return sessionsApi.updateSession(
+            sessionId,
+            com.spela.client.models.UpdateSessionRequest(
+                userLockedCoreVersion = userLockedCoreVersion,
+                autoLoadSuppressed = autoLoadSuppressed,
+                rehearsalCrashPending = rehearsalCrashPending,
+            ),
+        ).body()
+    }
+
     suspend fun deleteSession(sessionId: String) {
         sessionsApi.deleteSession(sessionId)
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/dto/DtoMappers.kt
@@ -672,6 +672,9 @@ fun com.spela.client.models.GameSessionResponse.toDomain(): GameSession = GameSe
     // Server serializes absent pin as empty string (field is non-optional on
     // the DTO); map empty → null so consumers can branch on presence.
     pinnedCoreSha256 = pinnedCoreSha256.takeIf { it.isNotEmpty() },
+    userLockedCoreVersion = userLockedCoreVersion,
+    autoLoadSuppressed = autoLoadSuppressed,
+    rehearsalCrashPending = rehearsalCrashPending,
 )
 
 fun com.spela.client.models.SessionCheatsResponse.toDomain() = SessionCheatConfig(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -31,6 +31,20 @@ class SessionRepositoryImpl(
         apiClient.updateSession(sessionId, name, coreName).toDomain()
     }
 
+    override suspend fun updateSessionCoreFlags(
+        sessionId: String,
+        userLockedCoreVersion: Boolean?,
+        autoLoadSuppressed: Boolean?,
+        rehearsalCrashPending: Boolean?,
+    ): Result<GameSession> = runCatching {
+        apiClient.updateSessionCoreFlags(
+            sessionId,
+            userLockedCoreVersion = userLockedCoreVersion,
+            autoLoadSuppressed = autoLoadSuppressed,
+            rehearsalCrashPending = rehearsalCrashPending,
+        ).toDomain()
+    }
+
     override suspend fun deleteSession(sessionId: String): Result<Unit> = runCatching {
         apiClient.deleteSession(sessionId)
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -770,6 +770,27 @@ data class GameSession(
      * it will be set on the first save.
      */
     val pinnedCoreSha256: String? = null,
+    /**
+     * True when the user explicitly locked this session to
+     * [pinnedCoreSha256] via the core-upgrade decision UI. The lock
+     * always beats the global auto-update preference and short-circuits
+     * the pre-play decision sheet on subsequent launches. See #672.
+     */
+    val userLockedCoreVersion: Boolean = false,
+    /**
+     * True when the next launch of this session should skip automatic
+     * save-state load (set after the user picked "Start fresh on the
+     * new version" on Sheet B / D). Cleared on first successful manual
+     * save. See #672.
+     */
+    val autoLoadSuppressed: Boolean = false,
+    /**
+     * Sentinel set by the player around the rehearsal flow. A `true`
+     * value surviving an app relaunch signals that the previous
+     * rehearsal ended in a crash so the UI can route the user to
+     * Sheet D after session restore. See #672.
+     */
+    val rehearsalCrashPending: Boolean = false,
 )
 
 data class SessionCheatConfig(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -10,6 +10,19 @@ interface SessionRepository {
     suspend fun createSession(gameId: String, name: String): Result<GameSession>
     suspend fun createSessionFromSharedSave(gameId: String, saveId: String): Result<GameSession>
     suspend fun updateSession(sessionId: String, name: String? = null, coreName: String? = null): Result<GameSession>
+
+    /**
+     * Toggles the core-upgrade decision flags on a session. Each field
+     * is tri-state: `null` leaves the flag untouched, `true` / `false`
+     * sets it. Matches PUT /api/sessions/{id}'s partial-update
+     * semantics. See #672.
+     */
+    suspend fun updateSessionCoreFlags(
+        sessionId: String,
+        userLockedCoreVersion: Boolean? = null,
+        autoLoadSuppressed: Boolean? = null,
+        rehearsalCrashPending: Boolean? = null,
+    ): Result<GameSession>
     suspend fun deleteSession(sessionId: String): Result<Unit>
     suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>>
     suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
@@ -6,9 +6,43 @@ import com.spela.player.domain.repository.DownloadRepository
 import com.spela.player.util.currentPlatform
 
 /**
- * Result of preparing a game for emulation. Carries both the resolved
- * file paths and an optional user-facing warning when we had to fall
- * back from a pinned core version.
+ * Classifies why (if at all) the player might want to surface a
+ * decision UI before loading the core. The actual decision UI lives in
+ * `EmulationViewModel` + presentation layer (see #672); this enum is
+ * the signal the use case hands the VM so the VM doesn't have to
+ * re-derive the reason from raw sha comparisons.
+ */
+enum class DecisionKind {
+    /** No decision needed — proceed straight to loadCore. */
+    None,
+
+    /**
+     * The session has a pinned sha that differs from the server's
+     * current sha for this core. The VM should consider showing Sheet A
+     * from the #672 decision flow.
+     */
+    UpgradeAvailable,
+
+    /**
+     * The session's pinned sha has been rotated out of server-side
+     * history retention. The VM should consider Sheet B.
+     */
+    PinPruned,
+
+    /**
+     * The core name was substituted for platform compatibility (macOS
+     * Metal, Android variant names). The resulting sha mismatch is
+     * legitimate, not an upgrade — the VM must not show Sheet A for
+     * this case.
+     */
+    PlatformSubstitution,
+}
+
+/**
+ * Result of preparing a game for emulation. Carries the resolved file
+ * paths, an optional user-facing warning when we had to fall back from
+ * a pinned core version, and a classification of whether the session
+ * warrants showing the core-upgrade decision UI (#672).
  */
 data class PrepareGameResult(
     val gamePath: String,
@@ -20,6 +54,13 @@ data class PrepareGameResult(
      * non-blocking warning. Null when no pin, or the pin was satisfied.
      */
     val coreVersionWarning: String? = null,
+    /**
+     * Why (if at all) the VM should consider showing the core-upgrade
+     * decision UI before starting emulation. See [DecisionKind]. The
+     * detection logic lands in PR #3 alongside the UI; v1 always
+     * returns [DecisionKind.None] so existing behaviour is unchanged.
+     */
+    val decisionKind: DecisionKind = DecisionKind.None,
 )
 
 /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/CoreDecision.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/CoreDecision.kt
@@ -1,0 +1,72 @@
+package com.spela.player.presentation.state
+
+import kotlin.time.Instant
+
+/**
+ * Models the "core version has changed since this session's saves were
+ * written" decision point from issue #672. Exposed on [EmulationState]
+ * as `coreDecision: CoreDecision?` so the UI can render Sheet A / B / C /
+ * D without re-deriving which situation applies.
+ *
+ * v1 ships with the sealed class defined but not emitted from the
+ * ViewModel — detection + emission lands in the core-upgrade decision
+ * PR alongside the UI that consumes it. This file is the data contract
+ * the UI PR will build against.
+ *
+ * See `design-proposals/core-upgrade-decision-spec.md` for the full
+ * decision flow this type backs.
+ */
+sealed class CoreDecision {
+
+    /**
+     * Sheet A. The session has a pinned sha and the server has a newer
+     * one for the same core; the session is not locked; `autoUpdateCoresEnabled`
+     * is false (or this was reached via session detail's "Check for
+     * core update"). User picks Try / Keep new / Lock old / Remind me.
+     */
+    data class UpgradeAvailable(
+        val coreName: String,
+        val coreDisplayName: String,
+        val gameTitle: String,
+        val oldSha: String,
+        val newSha: String,
+        val lastPlayedAt: Instant? = null,
+    ) : CoreDecision()
+
+    /**
+     * Sheet B. The session's pinned sha has been rotated out of
+     * server-side history retention. "Lock to old" is not offered.
+     */
+    data class PinPruned(
+        val coreName: String,
+        val coreDisplayName: String,
+        val gameTitle: String,
+        val prunedSha: String,
+    ) : CoreDecision()
+
+    /**
+     * Active during the "Try with my save" rehearsal run. Drives the
+     * [SpInGameBanner] overlay and the "Did this work?" affordance that
+     * opens Sheet C.
+     */
+    data class RehearsalPrompt(
+        val coreName: String,
+        val coreDisplayName: String,
+        /**
+         * True when the rehearsal is running the server's current (new)
+         * core binary, false when the user used the comparison escape
+         * hatch to re-run the rehearsal on the pinned (old) binary.
+         */
+        val usingNewSha: Boolean,
+    ) : CoreDecision()
+
+    /**
+     * Sheet D. The rehearsal emitter surfaces this after a core crash
+     * / failed `retro_unserialize`, or the app detects a previous
+     * rehearsal's `RehearsalCrashPending` sentinel on relaunch.
+     */
+    data class RehearsalCrashed(
+        val coreName: String,
+        val coreDisplayName: String,
+    ) : CoreDecision()
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -10,7 +10,10 @@ import com.spela.player.presentation.state.SecondaryToastData
 import com.spela.player.presentation.state.SecondaryToastType
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -36,6 +39,22 @@ sealed class AutoLoadResult {
 }
 
 /**
+ * Classifies a save attempt that was intercepted while the SaveManager
+ * was in rehearsal mode (#672 "Try with my save" flow). The UI
+ * subscribes to these events to surface the
+ * `core_upd.snack.rehearsal_save` snackbar.
+ */
+enum class RehearsalSaveKind { Manual, Auto, Slot, Sram }
+
+/**
+ * Event emitted every time [SaveManager] silently drops a save write
+ * because [SaveManager.rehearsalMode] is active. The UI shows the
+ * "You're in a trial run — saves are paused until you keep this
+ * version" snackbar in response.
+ */
+data class RehearsalSaveBlocked(val kind: RehearsalSaveKind)
+
+/**
  * Manages all save-related operations: SRAM load/save, auto-save/load,
  * and manual save/load state. All operations are session-scoped.
  * When no session is active, operations are silently skipped.
@@ -55,6 +74,40 @@ class SaveManager(
 
     /** The active session ID. When null, save/load operations are no-ops. */
     var currentSessionId: String? = null
+
+    /**
+     * When true, every save-upload path in this manager silently drops
+     * the write and emits a [RehearsalSaveBlocked] event on
+     * [rehearsalSaveBlocked]. Used by the #672 "Try with my save"
+     * rehearsal flow: the user tries the new core binary against an
+     * existing save without risking the durable save file on disk.
+     *
+     * Game-state save/load via the libretro controller is unaffected —
+     * only the server-upload side is suppressed. The emulator's RAM
+     * state continues normally for the rehearsal's lifetime.
+     */
+    var rehearsalMode: Boolean = false
+
+    private val _rehearsalSaveBlocked = MutableSharedFlow<RehearsalSaveBlocked>(
+        extraBufferCapacity = 8,
+    )
+
+    /**
+     * Stream of save-write events that were silently dropped because
+     * [rehearsalMode] was active. See #672.
+     */
+    val rehearsalSaveBlocked: SharedFlow<RehearsalSaveBlocked> =
+        _rehearsalSaveBlocked.asSharedFlow()
+
+    /**
+     * Called from every upload call site while [rehearsalMode] is true
+     * so the UI can surface the `core_upd.snack.rehearsal_save`
+     * snackbar. tryEmit is used (not emit) so the call site stays
+     * non-suspending from the save-state-save path.
+     */
+    private fun emitRehearsalBlocked(kind: RehearsalSaveKind) {
+        _rehearsalSaveBlocked.tryEmit(RehearsalSaveBlocked(kind))
+    }
 
     /**
      * Ensures a session exists for the given game. If sessionId is already set,
@@ -130,6 +183,10 @@ class SaveManager(
      * the save directory and uploading that instead.
      */
     suspend fun saveSramOnStop(gameId: String) {
+        if (rehearsalMode) {
+            emitRehearsalBlocked(RehearsalSaveKind.Sram)
+            return
+        }
         try {
             val sessionId = currentSessionId ?: return
 
@@ -220,6 +277,10 @@ class SaveManager(
      * Called from within an IO coroutine.
      */
     suspend fun autoSaveOnStop(gameId: String) {
+        if (rehearsalMode) {
+            emitRehearsalBlocked(RehearsalSaveKind.Auto)
+            return
+        }
         try {
             val saveData = libretroController.serialize()
             if (saveData != null) {
@@ -254,6 +315,10 @@ class SaveManager(
         if (_state.value.isChallengeMode) return
         if (_state.value.isHardcoreMode) {
             _state.update { it.copy(error = "Save states are disabled in hardcore mode") }
+            return
+        }
+        if (rehearsalMode) {
+            emitRehearsalBlocked(RehearsalSaveKind.Manual)
             return
         }
         scope.launch(dispatchers.io) {
@@ -299,6 +364,10 @@ class SaveManager(
         if (_state.value.isChallengeMode) return
         if (_state.value.isHardcoreMode) {
             _state.update { it.copy(error = "Save states are disabled in hardcore mode") }
+            return
+        }
+        if (rehearsalMode) {
+            emitRehearsalBlocked(RehearsalSaveKind.Slot)
             return
         }
         scope.launch(dispatchers.io) {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -171,6 +171,7 @@ private class FakePlayFromSharedSaveSessionRepository : SessionRepository {
         return Result.success(session)
     }
     override suspend fun updateSession(sessionId: String, name: String?, coreName: String?) = Result.failure<GameSession>(Exception("stub"))
+    override suspend fun updateSessionCoreFlags(sessionId: String, userLockedCoreVersion: Boolean?, autoLoadSuppressed: Boolean?, rehearsalCrashPending: Boolean?) = Result.failure<GameSession>(Exception("stub"))
     override suspend fun deleteSession(sessionId: String) = Result.success(Unit)
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
     override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String) =

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
@@ -1,0 +1,223 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.data.remote.ConnectivityMonitor
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import com.spela.player.presentation.state.EmulationState
+import com.spela.player.presentation.viewmodel.emulation.StubLibretroController
+import com.spela.player.presentation.viewmodel.emulation.StubMockEngineFactory
+import com.spela.player.presentation.viewmodel.emulation.StubSaveDataRepository
+import com.spela.player.presentation.viewmodel.emulation.StubSessionRepository
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Rehearsal-mode coverage for SaveManager (#672). Pins the contract:
+ *
+ *   - With `rehearsalMode = false` every save path uploads as normal.
+ *   - With `rehearsalMode = true` every save path silently drops the
+ *     upload and emits exactly one `RehearsalSaveBlocked` with the
+ *     right kind, so the UI can show the rehearsal snackbar.
+ *
+ * The sealed-class + SharedFlow surface is what the decision UI will
+ * subscribe to — if this contract slips, the "Try with my save" flow
+ * can write saves the user thought were paused.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SaveManagerRehearsalTest {
+
+    private fun testDispatchers(dispatcher: CoroutineDispatcher): DispatcherProvider =
+        object : DispatcherProvider {
+            override val main: CoroutineDispatcher = dispatcher
+            override val io: CoroutineDispatcher = dispatcher
+            override val default: CoroutineDispatcher = dispatcher
+        }
+
+    private fun makeManager(
+        scope: CoroutineScope,
+        dispatcher: CoroutineDispatcher,
+    ): Triple<SaveManager, StubSessionRepository, StubLibretroController> {
+        val dispatchers = testDispatchers(dispatcher)
+        val apiClient = SpelaApiClient(StubMockEngineFactory, TokenManager())
+        val connectivity = ConnectivityMonitor(apiClient, dispatchers, scope)
+        val sessionRepo = StubSessionRepository()
+        val libretro = StubLibretroController()
+        val state = MutableStateFlow(EmulationState())
+        val manager = SaveManager(
+            saveDataRepository = StubSaveDataRepository(),
+            connectivityMonitor = connectivity,
+            libretroController = libretro,
+            screenshotCapture = null,
+            _state = state,
+            dispatchers = dispatchers,
+            scope = scope,
+            sessionRepository = sessionRepo,
+        )
+        manager.currentSessionId = "s1"
+        manager.currentCoreName = "nestopia"
+        return Triple(manager, sessionRepo, libretro)
+    }
+
+    @Test
+    fun saveStateUploadsWhenNotRehearsing() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val (manager, sessionRepo, _) = makeManager(scope, dispatcher)
+
+        manager.rehearsalMode = false
+        manager.saveState()
+        advanceUntilIdle()
+
+        assertEquals(1, sessionRepo.uploadSessionSaveCallCount)
+    }
+
+    @Test
+    fun saveStateDropsAndEmitsRehearsalBlockedWhenRehearsing() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val (manager, sessionRepo, _) = makeManager(scope, dispatcher)
+
+        manager.rehearsalMode = true
+
+        val received = mutableListOf<RehearsalSaveBlocked>()
+        val collectJob = scope.launch {
+            manager.rehearsalSaveBlocked.collect { received += it }
+        }
+        advanceUntilIdle()
+
+        manager.saveState()
+        advanceUntilIdle()
+
+        assertEquals(0, sessionRepo.uploadSessionSaveCallCount,
+            "manual save must NOT upload while rehearsing")
+        assertEquals(1, received.size)
+        assertEquals(RehearsalSaveKind.Manual, received[0].kind)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun saveToSlotDropsAndEmitsRehearsalBlockedWhenRehearsing() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val (manager, _, _) = makeManager(scope, dispatcher)
+
+        manager.rehearsalMode = true
+        val received = mutableListOf<RehearsalSaveBlocked>()
+        val collectJob = scope.launch {
+            manager.rehearsalSaveBlocked.collect { received += it }
+        }
+        advanceUntilIdle()
+
+        manager.saveToSlot(3)
+        advanceUntilIdle()
+
+        assertEquals(1, received.size)
+        assertEquals(RehearsalSaveKind.Slot, received[0].kind)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun autoSaveOnStopDropsAndEmitsRehearsalBlockedWhenRehearsing() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val (manager, sessionRepo, libretro) = makeManager(scope, dispatcher)
+
+        manager.rehearsalMode = true
+        val received = mutableListOf<RehearsalSaveBlocked>()
+        val collectJob = scope.launch {
+            manager.rehearsalSaveBlocked.collect { received += it }
+        }
+        advanceUntilIdle()
+
+        manager.autoSaveOnStop("g1")
+
+        assertEquals(0, sessionRepo.uploadSessionAutoSaveCallCount,
+            "auto-save must NOT upload while rehearsing")
+        assertEquals(0, libretro.serializeCallCount,
+            "rehearsal mode must skip libretroController.serialize()")
+        assertEquals(1, received.size)
+        assertEquals(RehearsalSaveKind.Auto, received[0].kind)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun saveSramOnStopDropsAndEmitsRehearsalBlockedWhenRehearsing() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val (manager, sessionRepo, libretro) = makeManager(scope, dispatcher)
+
+        manager.rehearsalMode = true
+        val received = mutableListOf<RehearsalSaveBlocked>()
+        val collectJob = scope.launch {
+            manager.rehearsalSaveBlocked.collect { received += it }
+        }
+        advanceUntilIdle()
+
+        manager.saveSramOnStop("g1")
+
+        assertEquals(0, sessionRepo.uploadSessionSramCallCount,
+            "SRAM flush must NOT upload while rehearsing")
+        assertEquals(0, libretro.getSRAMCallCount,
+            "rehearsal mode must skip libretroController.getSRAM()")
+        assertEquals(1, received.size)
+        assertEquals(RehearsalSaveKind.Sram, received[0].kind)
+
+        collectJob.cancel()
+    }
+
+    @Test
+    fun togglingRehearsalModeOffReenablesUploads() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val (manager, sessionRepo, _) = makeManager(scope, dispatcher)
+
+        manager.rehearsalMode = true
+        manager.saveState()
+        advanceUntilIdle()
+        assertEquals(0, sessionRepo.uploadSessionSaveCallCount)
+
+        manager.rehearsalMode = false
+        manager.saveState()
+        advanceUntilIdle()
+        assertEquals(1, sessionRepo.uploadSessionSaveCallCount,
+            "upload must resume after rehearsal mode is cleared")
+    }
+
+    @Test
+    fun rehearsalModeEmitsOneEventPerBlockedSave() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val (manager, _, _) = makeManager(scope, dispatcher)
+
+        manager.rehearsalMode = true
+        val received = mutableListOf<RehearsalSaveBlocked>()
+        val collectJob = scope.launch {
+            manager.rehearsalSaveBlocked.collect { received += it }
+        }
+        advanceUntilIdle()
+
+        manager.saveState()
+        manager.saveState()
+        manager.saveState()
+        advanceUntilIdle()
+
+        assertEquals(3, received.size, "every blocked save must emit its own event")
+        assertTrue(received.all { it.kind == RehearsalSaveKind.Manual })
+
+        collectJob.cancel()
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -366,6 +366,7 @@ class StubSessionRepository : SessionRepository {
         return Result.success(GameSession(id = "auto-${createSessionCallCount}", gameId = gameId, name = name))
     }
     override suspend fun updateSession(sessionId: String, name: String?, coreName: String?) = Result.failure<GameSession>(Exception("stub"))
+    override suspend fun updateSessionCoreFlags(sessionId: String, userLockedCoreVersion: Boolean?, autoLoadSuppressed: Boolean?, rehearsalCrashPending: Boolean?) = Result.failure<GameSession>(Exception("stub"))
     override suspend fun deleteSession(sessionId: String) = Result.success(Unit)
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
     override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<SaveState> {


### PR DESCRIPTION
Pure plumbing for the team-built #672 feature. **No UI, no detection logic, no user-visible behaviour change** — PR #3 wires both on top of this. Keeping the refactor reviewable and letting unit tests pin the contract before the emulation flow gates on it.

## What lands

### `SaveManager.rehearsalMode`

New `var` guard at the head of every save-upload path (`saveState`, `saveToSlot`, `autoSaveOnStop`, `saveSramOnStop`). When `true`, the upload is silently skipped and a `RehearsalSaveBlocked(kind)` event fires on the new `rehearsalSaveBlocked: SharedFlow<RehearsalSaveBlocked>` so the UI can show the "you're in a trial run — saves are paused" snackbar.

**Game-state save/load via the libretro controller is unaffected** — only the *server-upload* side is suppressed. The emulator's RAM state continues normally for the rehearsal's lifetime; the user's existing save files on disk (and on the server) are the ones that are protected.

### `CoreDecision` sealed class

At `presentation/state/CoreDecision.kt`. Four variants:

| Variant | Drives |
|---|---|
| `UpgradeAvailable` | Sheet A — core version changed, session isn't locked |
| `PinPruned` | Sheet B — pinned historical binary aged out of server retention |
| `RehearsalPrompt` | In-game banner + "Did this work?" during rehearsal |
| `RehearsalCrashed` | Sheet D — core crashed or `retro_unserialize` failed |

Defined but not yet emitted on `EmulationState`. PR #3 adds the `coreDecision: CoreDecision?` field + the detection logic + subscribers.

### `PrepareGameResult.decisionKind`

`DecisionKind` enum (`None` / `UpgradeAvailable` / `PinPruned` / `PlatformSubstitution`) carried alongside the resolved paths. Defaults to `None`; actual computation lands in PR #3. The type is here now so PR #3 can change the use case's internals without touching any callers.

### `SessionRepository.updateSessionCoreFlags`

Repository method wrapping the new `PUT /api/sessions/{id}` flag fields from PR #1 (#673). Tri-state (`null` = unchanged, `true` / `false` = set) matches the server's partial-update semantics so PR #3 can flip one flag at a time without touching the others.

### `GameSession` domain model

Three new booleans (`userLockedCoreVersion`, `autoLoadSuppressed`, `rehearsalCrashPending`) mapped through from the server response via `GameSessionResponse.toDomain()`.

## Tests — `SaveManagerRehearsalTest`

Seven cases pinning the rehearsal guard:

- [x] `saveState` uploads normally when rehearsal is off.
- [x] `saveState` / `saveToSlot` / `autoSaveOnStop` / `saveSramOnStop` each drop their upload AND emit exactly one `RehearsalSaveBlocked` with the right `RehearsalSaveKind` when rehearsal is on.
- [x] `autoSaveOnStop` + `saveSramOnStop` additionally assert the libretro controller is NOT touched — rehearsal exit must be cheap.
- [x] Toggling `rehearsalMode` back to `false` re-enables uploads.
- [x] Three successive `saveState` calls while rehearsing emit three events (not one coalesced), so the UI can count attempts.

Existing `StubSessionRepository` / `FakeSessionRepository` / `FakePlayFromSharedSaveSessionRepository` test doubles got the new `updateSessionCoreFlags` override.

## Does not change user-visible behaviour

Everything in this PR is either net-new (`rehearsalMode`, `CoreDecision`, `updateSessionCoreFlags`, `decisionKind`) or a widened return-value shape. No existing call sites change their semantics. PR #3 is the first PR where a user would notice anything different.

## Test plan

- [x] `./gradlew :shared:desktopTest --tests "*.SaveManagerRehearsalTest"` — 7 new cases green
- [x] `./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid` — clean
- [x] `./gradlew :shared:detektMainDesktop :android:detektDebugAndroid :desktop:detektMainDesktop` — 0 findings
- [ ] CI green on this PR before merge

Refs #672, #555
Depends on: #673