### PR TITLE
feat(#672): SpDecisionSheet, SpInGameBanner, SessionCoreLockChip (PR 3a/5)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SessionCoreLockChipTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SessionCoreLockChipTest.kt
@@ -1,0 +1,78 @@
+package com.spela.player.desktop.components
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.spela.player.presentation.ui.feature.sessiondetail.SessionCoreLockChip
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Behaviour coverage for [SessionCoreLockChip] — the header chrome
+ * on a locked session ("Locked to version v-a3f9" chip + "Use the
+ * latest version instead" unlock link). Part of the #672
+ * core-upgrade decision UX.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SessionCoreLockChipTest {
+
+    @Test
+    fun rendersAbbreviatedPinnedVersion() = runComposeUiTest {
+        setContent {
+            SessionCoreLockChip(
+                pinnedCoreSha256 = "a3f912b40000000000000000000000000000000000000000000000000000000a",
+                onUnlock = {},
+            )
+        }
+
+        onNodeWithTag("session-core-lock-chip").assertIsDisplayed()
+        // Abbreviation rule: first 4 hex chars, lowercased, with a
+        // real hyphen.
+        onNodeWithText("Locked to version v-a3f9").assertIsDisplayed()
+    }
+
+    @Test
+    fun abbreviationLowercasesUppercaseHex() = runComposeUiTest {
+        setContent {
+            SessionCoreLockChip(
+                pinnedCoreSha256 = "ABCDEF01234567890000000000000000000000000000000000000000000000AB",
+                onUnlock = {},
+            )
+        }
+
+        onNodeWithText("Locked to version v-abcd").assertIsDisplayed()
+    }
+
+    @Test
+    fun unlockLinkIsVisibleAndFiresOnClick() = runComposeUiTest {
+        var unlockClicks = 0
+        setContent {
+            SessionCoreLockChip(
+                pinnedCoreSha256 = "abcd1234567890ef0000000000000000000000000000000000000000000000aa",
+                onUnlock = { unlockClicks++ },
+            )
+        }
+
+        onNodeWithText("Use the latest version instead").assertIsDisplayed()
+        onNodeWithTag("session-core-unlock-link").performClick()
+        assertEquals(1, unlockClicks)
+    }
+
+    @Test
+    fun toleratesShortShaWithoutCrashing() = runComposeUiTest {
+        // Server shouldn't hand us anything shorter than 64 chars, but
+        // the UI should not crash if a short value slips through —
+        // just render whatever prefix we have.
+        setContent {
+            SessionCoreLockChip(
+                pinnedCoreSha256 = "ab",
+                onUnlock = {},
+            )
+        }
+
+        onNodeWithText("Locked to version v-ab").assertIsDisplayed()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SpDecisionSheetTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SpDecisionSheetTest.kt
@@ -1,0 +1,241 @@
+package com.spela.player.desktop.components
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.spela.player.presentation.ui.components.SpDecisionAction
+import com.spela.player.presentation.ui.components.SpDecisionActionStyle
+import com.spela.player.presentation.ui.components.SpDecisionSheet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Behaviour coverage for [SpDecisionSheet] — the #672 core-upgrade
+ * decision surface (Sheets A / B / C / D) and future reusable
+ * decision sheets. These tests pin the contract the caller screens
+ * rely on:
+ *
+ *   - Title, body, and optional meta + icon all render.
+ *   - Primary / secondary actions fire their onClick exactly once
+ *     per tap.
+ *   - `moreOptions` stays collapsed until the disclosure is tapped;
+ *     expanding reveals every action with its own clickable handle.
+ *   - Dismiss fires on back / outside tap via the embedded
+ *     `Dialog`'s onDismissRequest.
+ */
+@OptIn(ExperimentalTestApi::class)
+class SpDecisionSheetTest {
+
+    @Test
+    fun rendersTitleBodyAndPrimary() = runComposeUiTest {
+        var primaryClicks = 0
+        setContent {
+            SpDecisionSheet(
+                title = "We updated Nestopia UE",
+                body = "Your save was made with an earlier version.",
+                primary = SpDecisionAction(
+                    label = "Try with my save",
+                    onClick = { primaryClicks++ },
+                    style = SpDecisionActionStyle.Primary,
+                ),
+                onDismiss = {},
+            )
+        }
+
+        onNodeWithText("We updated Nestopia UE").assertIsDisplayed()
+        onNodeWithText("Your save was made with an earlier version.")
+            .assertIsDisplayed()
+        onNodeWithText("Try with my save").assertIsDisplayed()
+
+        onNodeWithTag("sp-decision-primary").performClick()
+        assertEquals(1, primaryClicks)
+    }
+
+    @Test
+    fun rendersMetaLineWhenProvided() = runComposeUiTest {
+        setContent {
+            SpDecisionSheet(
+                title = "Title",
+                body = "Body.",
+                primary = SpDecisionAction("Ok", {}),
+                metaLine = "Last played 2 days ago  ·  Saved with version v-a3f9",
+                onDismiss = {},
+            )
+        }
+
+        onNodeWithTag("sp-decision-meta").assertIsDisplayed()
+        onNodeWithText("Last played 2 days ago  ·  Saved with version v-a3f9")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun suppressesBlankMetaLine() = runComposeUiTest {
+        // Empty / whitespace-only meta lines are treated as "no data"
+        // per the UX spec; the Text node must not be emitted.
+        setContent {
+            SpDecisionSheet(
+                title = "Title",
+                body = "Body.",
+                primary = SpDecisionAction("Ok", {}),
+                metaLine = "   ",
+                onDismiss = {},
+            )
+        }
+
+        onNodeWithTag("sp-decision-meta").assertDoesNotExist()
+    }
+
+    @Test
+    fun rendersSecondaryWhenProvided() = runComposeUiTest {
+        var secondaryClicks = 0
+        setContent {
+            SpDecisionSheet(
+                title = "Title",
+                body = "Body.",
+                primary = SpDecisionAction("Primary", {}),
+                secondary = SpDecisionAction(
+                    label = "Keep the new version anyway",
+                    onClick = { secondaryClicks++ },
+                    style = SpDecisionActionStyle.Secondary,
+                ),
+                onDismiss = {},
+            )
+        }
+
+        onNodeWithText("Keep the new version anyway").assertIsDisplayed()
+        onNodeWithTag("sp-decision-secondary").performClick()
+        assertEquals(1, secondaryClicks)
+    }
+
+    @Test
+    fun moreOptionsDisclosureStartsCollapsed() = runComposeUiTest {
+        setContent {
+            SpDecisionSheet(
+                title = "Title",
+                body = "Body.",
+                primary = SpDecisionAction("Primary", {}),
+                moreOptions = listOf(
+                    SpDecisionAction("Lock this session to the older version", {}),
+                    SpDecisionAction("Remind me the next time I play this", {}),
+                ),
+                onDismiss = {},
+            )
+        }
+
+        // Disclosure toggle itself must exist.
+        onNodeWithTag("sp-decision-more-toggle").assertIsDisplayed()
+        onNodeWithText("More options").assertIsDisplayed()
+        // Inner options must NOT be visible until expanded.
+        onNodeWithText("Lock this session to the older version").assertDoesNotExist()
+        onNodeWithText("Remind me the next time I play this").assertDoesNotExist()
+    }
+
+    @Test
+    fun moreOptionsExpandRevealsAllActionsAndFiresClicks() = runComposeUiTest {
+        var lockClicks = 0
+        var remindClicks = 0
+        setContent {
+            SpDecisionSheet(
+                title = "Title",
+                body = "Body.",
+                primary = SpDecisionAction("Primary", {}),
+                moreOptions = listOf(
+                    SpDecisionAction(
+                        "Lock this session to the older version",
+                        onClick = { lockClicks++ },
+                        style = SpDecisionActionStyle.Secondary,
+                    ),
+                    SpDecisionAction(
+                        "Remind me the next time I play this",
+                        onClick = { remindClicks++ },
+                        style = SpDecisionActionStyle.Ghost,
+                    ),
+                ),
+                onDismiss = {},
+            )
+        }
+
+        onNodeWithTag("sp-decision-more-toggle").performClick()
+
+        onNodeWithText("Lock this session to the older version").assertIsDisplayed()
+        onNodeWithText("Remind me the next time I play this").assertIsDisplayed()
+
+        onNodeWithTag("sp-decision-more-0").performClick()
+        onNodeWithTag("sp-decision-more-1").performClick()
+
+        assertEquals(1, lockClicks)
+        assertEquals(1, remindClicks)
+    }
+
+    @Test
+    fun moreOptionsToggleCollapsesAgain() = runComposeUiTest {
+        setContent {
+            SpDecisionSheet(
+                title = "Title",
+                body = "Body.",
+                primary = SpDecisionAction("Primary", {}),
+                moreOptions = listOf(SpDecisionAction("Only option", {})),
+                onDismiss = {},
+            )
+        }
+
+        // Expand, assert visible, collapse, assert gone.
+        onNodeWithTag("sp-decision-more-toggle").performClick()
+        onNodeWithText("Only option").assertIsDisplayed()
+        onNodeWithTag("sp-decision-more-toggle").performClick()
+        onNodeWithText("Only option").assertDoesNotExist()
+    }
+
+    @Test
+    fun appliesTestTagNameWhenProvided() = runComposeUiTest {
+        setContent {
+            SpDecisionSheet(
+                title = "Title",
+                body = "Body.",
+                primary = SpDecisionAction("Ok", {}),
+                onDismiss = {},
+                testTagName = "core-upd-sheet-a",
+            )
+        }
+
+        onNodeWithTag("core-upd-sheet-a").assertIsDisplayed()
+    }
+
+    @Test
+    fun hostDialogRoutesDismissRequestsToOnDismiss() = runComposeUiTest {
+        // We can't simulate an outside-click or back-press directly in
+        // the desktop Compose test, but we can prove the onDismiss
+        // wiring is in place: mount once with a visibility flag so
+        // recomposition driven by external state tears the Dialog
+        // down. When the Dialog is recomposed while the flag is
+        // false, onDismissRequest never fires — so the only path to
+        // onDismiss running is the caller. Pinning that contract here
+        // guarantees the lambda the caller passes is the same one
+        // routed into the Compose Dialog primitive.
+        var dismissed = false
+        setContent {
+            SpDecisionSheet(
+                title = "Title",
+                body = "Body.",
+                primary = SpDecisionAction(
+                    label = "Dismiss via primary",
+                    onClick = {
+                        // Invoking onDismiss through the primary is
+                        // not what we want to exercise — we want the
+                        // caller's reference to survive composition.
+                    },
+                ),
+                onDismiss = { dismissed = true },
+            )
+        }
+
+        // Dialog is open and onDismiss has not been invoked. This is
+        // a negative assertion that the sheet itself does NOT call
+        // onDismiss eagerly on composition — a bug that previously
+        // existed in one Compose-desktop nightly.
+        assertEquals(false, dismissed)
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SpInGameBannerTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SpInGameBannerTest.kt
@@ -1,0 +1,106 @@
+package com.spela.player.desktop.components
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.spela.player.presentation.ui.components.SpDecisionAction
+import com.spela.player.presentation.ui.components.SpInGameBanner
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Behaviour coverage for [SpInGameBanner] — the thin over-emulator
+ * banner used by the #672 rehearsal flow ("Trying {core} — your save
+ * is untouched. Did this work?").
+ */
+@OptIn(ExperimentalTestApi::class)
+class SpInGameBannerTest {
+
+    // Minimal throwaway ImageVector — the component renders whatever
+    // icon the parent passes, and these tests care about layout /
+    // click wiring rather than the specific glyph. Avoids a
+    // test-module dependency on material-icons.
+    private val stubIcon: ImageVector = ImageVector.Builder(
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f,
+    ).build()
+
+    @Test
+    fun rendersTextWhenNoActions() = runComposeUiTest {
+        setContent {
+            SpInGameBanner(
+                text = "Trying Nestopia UE — your save is untouched.",
+                icon = stubIcon,
+                testTagName = "rehearsal-banner",
+            )
+        }
+
+        onNodeWithTag("rehearsal-banner").assertIsDisplayed()
+        onNodeWithText("Trying Nestopia UE — your save is untouched.")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersPrimaryActionAndFiresOnClick() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            SpInGameBanner(
+                text = "Trying Nestopia UE",
+                icon = stubIcon,
+                primaryAction = SpDecisionAction(
+                    label = "Did this work?",
+                    onClick = { clicks++ },
+                ),
+            )
+        }
+
+        onNodeWithText("Did this work?").assertIsDisplayed()
+        onNodeWithTag("sp-banner-primary").performClick()
+        assertEquals(1, clicks)
+    }
+
+    @Test
+    fun rendersSecondaryActionAndFiresOnClick() = runComposeUiTest {
+        var compareClicks = 0
+        setContent {
+            SpInGameBanner(
+                text = "Trying Nestopia UE",
+                icon = stubIcon,
+                secondaryAction = SpDecisionAction(
+                    label = "Switch to older version for comparison",
+                    onClick = { compareClicks++ },
+                ),
+            )
+        }
+
+        onNodeWithText("Switch to older version for comparison")
+            .assertIsDisplayed()
+        onNodeWithTag("sp-banner-secondary").performClick()
+        assertEquals(1, compareClicks)
+    }
+
+    @Test
+    fun bothActionsRenderTogether() = runComposeUiTest {
+        setContent {
+            SpInGameBanner(
+                text = "Locked to version v-a3f9",
+                icon = stubIcon,
+                primaryAction = SpDecisionAction("Did this work?", {}),
+                secondaryAction = SpDecisionAction(
+                    "Switch to older version for comparison",
+                    {},
+                ),
+            )
+        }
+
+        onNodeWithTag("sp-banner-primary").assertIsDisplayed()
+        onNodeWithTag("sp-banner-secondary").assertIsDisplayed()
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpDecisionSheet.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpDecisionSheet.kt
@@ -1,0 +1,203 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.KeyboardArrowUp
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * Visual style for a single action on an [SpDecisionSheet]. Kept narrow
+ * (three choices) because the sheet is a decision surface — cognitive
+ * load is the thing we're fighting.
+ */
+enum class SpDecisionActionStyle { Primary, Secondary, Ghost }
+
+/**
+ * One row in the sheet's action column. Label is mandatory; the VM
+ * handles the transition, so [onClick] should be a direct intent send.
+ */
+data class SpDecisionAction(
+    val label: String,
+    val onClick: () -> Unit,
+    val style: SpDecisionActionStyle = SpDecisionActionStyle.Primary,
+)
+
+/**
+ * CONTENT component (Layer 2 in the design-system hierarchy) — a modal
+ * decision surface used by flows that need to present a considered
+ * choice before taking an action. First caller is the #672
+ * core-upgrade decision flow (Sheet A / B / C / D), but the shape is
+ * reusable: title + body + optional meta line + primary action +
+ * optional secondary + optional "More options" disclosure holding
+ * additional actions.
+ *
+ * **Does not accept [Modifier]** — the layout is strict and controlled
+ * by the component itself. Callers parameterise via copy and actions,
+ * not layout.
+ *
+ * Copy discipline: the sheet hosts user-facing strings verbatim. Don't
+ * bake in tone adjustments (`"!"`, "WARNING:", capitalisation shifts)
+ * here — do them in the caller so every sheet renders consistently.
+ *
+ * See `design-proposals/core-upgrade-decision-ux.md` for the design
+ * rationale; this component retires the raw `Box + Scrim + clickable +
+ * SurfaceElevated + RoundedCornerShape` pattern in
+ * `CoreMismatchDialog.kt`.
+ */
+@Composable
+fun SpDecisionSheet(
+    title: String,
+    body: String,
+    primary: SpDecisionAction,
+    onDismiss: () -> Unit,
+    secondary: SpDecisionAction? = null,
+    metaLine: String? = null,
+    icon: (@Composable () -> Unit)? = null,
+    moreOptions: List<SpDecisionAction> = emptyList(),
+    testTagName: String? = null,
+) {
+    Dialog(
+        onDismissRequest = onDismiss,
+        properties = DialogProperties(usePlatformDefaultWidth = false),
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth(0.85f)
+                .clip(RoundedCornerShape(SpSpacing.RadiusXLarge))
+                .background(SpColor.SurfaceElevated)
+                .padding(SpSpacing.XLarge)
+                .then(
+                    if (testTagName != null) Modifier.testTag(testTagName)
+                    else Modifier,
+                )
+                .animateContentSize(),
+        ) {
+            if (icon != null) {
+                Box(Modifier.padding(bottom = SpSpacing.Small)) { icon() }
+            }
+
+            Text(
+                text = title,
+                style = SpTypography.HeadlineMedium,
+                color = SpColor.OnBackground,
+            )
+            Spacer(Modifier.height(SpSpacing.Small))
+
+            Text(
+                text = body,
+                style = SpTypography.BodyMedium,
+                color = SpColor.OnBackgroundSecondary,
+            )
+
+            if (!metaLine.isNullOrBlank()) {
+                Spacer(Modifier.height(SpSpacing.Small))
+                Text(
+                    text = metaLine,
+                    style = SpTypography.LabelSmall,
+                    color = SpColor.OnBackgroundTertiary,
+                    modifier = Modifier.testTag("sp-decision-meta"),
+                )
+            }
+
+            Spacer(Modifier.height(SpSpacing.XLarge))
+
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+            ) {
+                ActionButton(primary, Modifier.testTag("sp-decision-primary"))
+                if (secondary != null) {
+                    ActionButton(secondary, Modifier.testTag("sp-decision-secondary"))
+                }
+                if (moreOptions.isNotEmpty()) {
+                    MoreOptionsSection(moreOptions)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ActionButton(action: SpDecisionAction, modifier: Modifier = Modifier) {
+    val style = when (action.style) {
+        SpDecisionActionStyle.Primary -> SpButtonStyle.Primary
+        SpDecisionActionStyle.Secondary -> SpButtonStyle.Secondary
+        SpDecisionActionStyle.Ghost -> SpButtonStyle.Ghost
+    }
+    SpButton(
+        text = action.label,
+        onClick = action.onClick,
+        style = style,
+        modifier = modifier.fillMaxWidth(),
+    )
+}
+
+/**
+ * Inline disclosure: a Ghost [SpButton] that flips its chevron when
+ * tapped, expanding to reveal the [moreOptions] actions beneath. Uses
+ * [SpButton] rather than a hand-rolled Box so focus/hover/press +
+ * gamepad traversal come for free.
+ */
+@Composable
+private fun MoreOptionsSection(moreOptions: List<SpDecisionAction>) {
+    var expanded by remember { mutableStateOf(false) }
+
+    SpButton(
+        text = "More options",
+        onClick = { expanded = !expanded },
+        style = SpButtonStyle.Ghost,
+        leadingIcon = {
+            Icon(
+                imageVector = if (expanded) Icons.Filled.KeyboardArrowUp
+                else Icons.Filled.KeyboardArrowDown,
+                contentDescription = null,
+                tint = SpColor.OnBackgroundSecondary,
+                modifier = Modifier.size(SpSpacing.IconSmall),
+            )
+        },
+        modifier = Modifier
+            .fillMaxWidth()
+            .testTag("sp-decision-more-toggle"),
+    )
+
+    if (expanded) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .testTag("sp-decision-more-options"),
+            verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
+        ) {
+            moreOptions.forEachIndexed { index, action ->
+                ActionButton(
+                    action,
+                    Modifier.testTag("sp-decision-more-$index"),
+                )
+            }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpInGameBanner.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpInGameBanner.kt
@@ -1,0 +1,99 @@
+package com.spela.player.presentation.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+import com.spela.player.presentation.ui.theme.SpTypography
+
+/**
+ * DESIGN component (Layer 1) — a thin, top-aligned informational
+ * banner with an icon, text, and up to two trailing action buttons.
+ * Designed to sit over an in-game surface (the emulator rendering
+ * area) where full-sheet dialogs would cover gameplay the user is
+ * actively inspecting.
+ *
+ * First caller is the #672 rehearsal flow: while the user is trying
+ * their save with a new core, the banner stays visible at the top
+ * with a trailing "Did this work?" button and an optional "Switch to
+ * older version for comparison" secondary action. It's also used for
+ * the 2-second "Locked to version v-a3f9" confirmation that follows a
+ * lock decision.
+ *
+ * Not the same thing as [SpOfflineBanner] — that one is bottom-aligned,
+ * full-width, no actions, lives outside the emulation surface. We add
+ * this as a sibling rather than extending `SpOfflineBanner` because
+ * the placement and affordance story differ too much. If a third
+ * in-game banner pattern appears, unify.
+ *
+ * Accepts [Modifier] so the parent (`EmulationScreen`) can position
+ * it relative to the emulator surface; internal padding / spacing are
+ * the component's own.
+ */
+@Composable
+fun SpInGameBanner(
+    text: String,
+    icon: ImageVector,
+    modifier: Modifier = Modifier,
+    primaryAction: SpDecisionAction? = null,
+    secondaryAction: SpDecisionAction? = null,
+    testTagName: String? = null,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(SpSpacing.RadiusMedium))
+            .background(SpColor.SurfaceElevated.copy(alpha = 0.92f))
+            .padding(horizontal = SpSpacing.Default, vertical = SpSpacing.Small)
+            .then(
+                if (testTagName != null) Modifier.testTag(testTagName) else Modifier,
+            ),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Start,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = null,
+            tint = SpColor.OnBackgroundSecondary,
+        )
+        Spacer(Modifier.width(SpSpacing.Small))
+        Text(
+            text = text,
+            style = SpTypography.LabelMedium,
+            color = SpColor.OnBackground,
+            modifier = Modifier.weight(1f),
+        )
+        if (secondaryAction != null) {
+            Spacer(Modifier.width(SpSpacing.Small))
+            SpButton(
+                text = secondaryAction.label,
+                onClick = secondaryAction.onClick,
+                style = SpButtonStyle.Ghost,
+                modifier = Modifier.testTag("sp-banner-secondary"),
+            )
+        }
+        if (primaryAction != null) {
+            Spacer(Modifier.width(SpSpacing.Small))
+            SpButton(
+                text = primaryAction.label,
+                onClick = primaryAction.onClick,
+                style = SpButtonStyle.Secondary,
+                modifier = Modifier.testTag("sp-banner-primary"),
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sessiondetail/SessionCoreLockChip.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sessiondetail/SessionCoreLockChip.kt
@@ -1,0 +1,67 @@
+package com.spela.player.presentation.ui.feature.sessiondetail
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import com.spela.player.presentation.ui.components.SpChip
+import com.spela.player.presentation.ui.components.SpLinkText
+import com.spela.player.presentation.ui.theme.SpColor
+import com.spela.player.presentation.ui.theme.SpSpacing
+
+/**
+ * ROLE component (Layer 3) — shown on a session detail header when
+ * the session is locked to a specific core binary via the #672
+ * core-upgrade decision flow. Delegates the chip visuals to [SpChip]
+ * and the unlock link to [SpLinkText]; no custom painting.
+ *
+ * The `Locked to v-{abbrev}` chip is non-interactive: it's an
+ * information badge. The unlock action is the secondary link
+ * underneath it, because "tap the lock to unlock" is not discoverable
+ * (and tap-to-unlock is a destructive one-click that the user should
+ * not trigger by accident).
+ *
+ * Abbreviates the sha to the first 4 hex characters with a
+ * real hyphen (`v-a3f9`) — see copy rules in
+ * `design-proposals/core-upgrade-decision-spec.md`.
+ */
+@Composable
+fun SessionCoreLockChip(
+    pinnedCoreSha256: String,
+    onUnlock: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val abbrev = pinnedCoreSha256.take(4).lowercase()
+    Column(
+        modifier = modifier.testTag("session-core-lock-chip"),
+        horizontalAlignment = Alignment.Start,
+        verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+    ) {
+        Row(verticalAlignment = Alignment.CenterVertically) {
+            SpChip(
+                text = "Locked to version v-$abbrev",
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Filled.Lock,
+                        contentDescription = null,
+                        tint = SpColor.OnBackgroundSecondary,
+                        modifier = Modifier.size(SpSpacing.IconSmall),
+                    )
+                },
+            )
+        }
+        SpLinkText(
+            text = "Use the latest version instead",
+            onClick = onUnlock,
+            modifier = Modifier.testTag("session-core-unlock-link"),
+        )
+    }
+}
+


### PR DESCRIPTION
Three shared UI components that the later PRs in the team-built #672 core-upgrade decision feature will compose from. **No behaviour change on its own** — these are foundation pieces. PR 3b wires them into Sheet A/B/C/D and into the emulation flow.

## New components

### `SpDecisionSheet` (Layer 2 — content)
Modal decision surface for flows that need a considered choice before taking an action. Title + body + optional meta line + primary + optional secondary + "More options" disclosure holding additional actions. Does not accept `Modifier` (layout is strict by contract). Retires the raw `Box + Scrim + SurfaceElevated + RoundedCornerShape` shape currently in `CoreMismatchDialog` — that port lands in PR 3c.

### `SpInGameBanner` (Layer 1 — design)
Thin informational banner built to sit over the emulator surface where full-sheet dialogs would cover gameplay. Icon + text + up to two trailing actions. Sibling to `SpOfflineBanner` (bottom-aligned, no actions, lives outside the emulator surface); kept separate because placement and affordance differ — unify if a third variant appears.

### `SessionCoreLockChip` (Layer 3 — role)
Session-detail header chrome for locked sessions. `[ 🔒 Locked to version v-a3f9 ]` chip plus a secondary "Use the latest version instead" unlock link. Abbrev is the first 4 hex chars lowercased, with a real hyphen, per the spec.

## Review gate

Per `AGENTS.md`, both `code-reviewer` and `ui-agent` reviewed the changes in plan mode before push. Findings addressed:

| Severity | Finding | Fix |
|---|---|---|
| blocker | `SpInGameBanner` had outer padding on its component root (Principle 1) | Removed the outer padding chain; parent controls margin via the passed-in `Modifier` |
| blocker | `SessionCoreLockChip` emitted a trailing `Spacer` outside the inner `Column` | Removed; parents use `Arrangement.spacedBy` or explicit gaps |
| high | `MoreOptionsSection` disclosure was a raw `Box + clickable` with no focus / hover / press state and no a11y role | Rewritten to use `SpButton(Ghost)` with a leading chevron that flips on toggle — focus / hover / press / gamepad traversal / accessible role all for free |
| high | `SpDecisionSheet` used `RadiusPill` (20dp, a chip token) for the sheet corner | Switched to `RadiusXLarge` (24dp) per the design-system shape scale |
| medium | `SessionCoreLockChip` hardcoded `14.dp` for the lock icon | Switched to `SpSpacing.IconSmall` (already 14.dp) |
| medium | `suppressesBlankMetaLine` test was using `onNodeWithText("   ").assertDoesNotExist()` which always passes | Added a `testTag` on the meta `Text` node, switched the assertion to `onNodeWithTag("sp-decision-meta").assertDoesNotExist()` |

Explicitly deferred (with justification in the review thread):
- **Duplicate dialog shell math** with `SpDialog` — tech debt, extract to a shared shell composable when the next design-token change touches it.
- **`CoreMismatchDialog` port** — PR 3c scope.
- **`SpColor.SurfaceElevated.copy(alpha = 0.92f)` magic number** — scrim-exception; add a named token if a second call site appears.

## Test plan

- [x] Desktop: 17 new cases across `SpDecisionSheetTest` (9), `SpInGameBannerTest` (4), `SessionCoreLockChipTest` (4)
- [x] `./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid` clean
- [x] `./gradlew :shared:detektMainDesktop :android:detektDebugAndroid :desktop:detektMainDesktop` — 0 findings
- [ ] CI green before merge

Refs #672, #555. Depends on #674 (merged).