### PR TITLE
feat(#672): Sheet A + detection + VM wiring (PR 3b/5)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/CoreUpgradeDecisionSheetTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/CoreUpgradeDecisionSheetTest.kt
@@ -1,0 +1,191 @@
+package com.spela.player.desktop.components
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.spela.player.presentation.state.CoreDecision
+import com.spela.player.presentation.ui.feature.ingame.CoreUpgradeDecisionSheet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Clock
+import kotlin.time.Duration.Companion.days
+
+/**
+ * Behaviour coverage for the #672 Sheet A composable. Pins the copy
+ * contract from `design-proposals/core-upgrade-decision-spec.md`
+ * §"Sheet A" and the callback routing from the four primary actions.
+ */
+@OptIn(ExperimentalTestApi::class)
+class CoreUpgradeDecisionSheetTest {
+
+    private val decision = CoreDecision.UpgradeAvailable(
+        coreName = "nestopia",
+        coreDisplayName = "Nestopia UE",
+        consoleName = "Nintendo Entertainment System",
+        gameTitle = "Castlevania",
+        oldSha = "abcd1234".repeat(8),
+        newSha = "f00ba123".repeat(8),
+        lastPlayedAt = null,
+    )
+
+    @Test
+    fun rendersSpecTitleBodyAndMeta() = runComposeUiTest {
+        setContent {
+            CoreUpgradeDecisionSheet(
+                decision = decision,
+                onTryWithMySave = {},
+                onKeepNewVersion = {},
+                onLockOldVersion = {},
+                onRemindLater = {},
+            )
+        }
+
+        onNodeWithTag("core-upgrade-sheet-a").assertIsDisplayed()
+        onNodeWithText("We updated Nestopia UE").assertIsDisplayed()
+        onNodeWithText(
+            "Your save for Castlevania was made with an earlier version of the core. " +
+                "It will probably load fine — but we'd like you to try it first so you " +
+                "can decide what to do.",
+        ).assertIsDisplayed()
+        onNodeWithText("Saved with version v-abcd").assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersConsoleFallbackTitleWhenDisplayNameIsEmpty() = runComposeUiTest {
+        setContent {
+            CoreUpgradeDecisionSheet(
+                decision = decision.copy(coreDisplayName = ""),
+                onTryWithMySave = {},
+                onKeepNewVersion = {},
+                onLockOldVersion = {},
+                onRemindLater = {},
+            )
+        }
+
+        // Spec key core_upd.sheet_a.title_fallback: uses console name.
+        onNodeWithText("The Nintendo Entertainment System core has a new version")
+            .assertIsDisplayed()
+    }
+
+    @Test
+    fun rendersGenericFallbackTitleWhenBothAreEmpty() = runComposeUiTest {
+        setContent {
+            CoreUpgradeDecisionSheet(
+                decision = decision.copy(coreDisplayName = "", consoleName = ""),
+                onTryWithMySave = {},
+                onKeepNewVersion = {},
+                onLockOldVersion = {},
+                onRemindLater = {},
+            )
+        }
+
+        onNodeWithText("The core has a new version").assertIsDisplayed()
+    }
+
+    @Test
+    fun primaryFiresOnTryWithMySave() = runComposeUiTest {
+        var tryClicks = 0
+        setContent {
+            CoreUpgradeDecisionSheet(
+                decision = decision,
+                onTryWithMySave = { tryClicks++ },
+                onKeepNewVersion = {},
+                onLockOldVersion = {},
+                onRemindLater = {},
+            )
+        }
+
+        onNodeWithText("Try with my save").assertIsDisplayed()
+        onNodeWithTag("sp-decision-primary").performClick()
+        assertEquals(1, tryClicks)
+    }
+
+    @Test
+    fun secondaryFiresOnKeepNewVersion() = runComposeUiTest {
+        var keepClicks = 0
+        setContent {
+            CoreUpgradeDecisionSheet(
+                decision = decision,
+                onTryWithMySave = {},
+                onKeepNewVersion = { keepClicks++ },
+                onLockOldVersion = {},
+                onRemindLater = {},
+            )
+        }
+
+        onNodeWithText("Keep the new version anyway").assertIsDisplayed()
+        onNodeWithTag("sp-decision-secondary").performClick()
+        assertEquals(1, keepClicks)
+    }
+
+    @Test
+    fun moreOptionsExposesLockAndRemind() = runComposeUiTest {
+        var lockClicks = 0
+        var remindClicks = 0
+        setContent {
+            CoreUpgradeDecisionSheet(
+                decision = decision,
+                onTryWithMySave = {},
+                onKeepNewVersion = {},
+                onLockOldVersion = { lockClicks++ },
+                onRemindLater = { remindClicks++ },
+            )
+        }
+
+        onNodeWithTag("sp-decision-more-toggle").performClick()
+
+        onNodeWithText("Lock this session to the older version").assertIsDisplayed()
+        onNodeWithText("Remind me the next time I play this").assertIsDisplayed()
+
+        onNodeWithTag("sp-decision-more-0").performClick()
+        onNodeWithTag("sp-decision-more-1").performClick()
+
+        assertEquals(1, lockClicks)
+        assertEquals(1, remindClicks)
+    }
+
+    @Test
+    fun rendersFullMetaLineWhenLastPlayedIsProvided() = runComposeUiTest {
+        // Spec: `"Last played {relative}  ·  Saved with version v-{abbrev}"`.
+        // Full-form meta must use the specified separator (two spaces,
+        // middle-dot, two spaces). Picking a 2-days-ago anchor makes
+        // the relative-time assertion robust across test runs.
+        val twoDaysAgo = Clock.System.now() - 2.days
+        setContent {
+            CoreUpgradeDecisionSheet(
+                decision = decision.copy(lastPlayedAt = twoDaysAgo),
+                onTryWithMySave = {},
+                onKeepNewVersion = {},
+                onLockOldVersion = {},
+                onRemindLater = {},
+            )
+        }
+
+        // formatRelativeTime emits day-granularity labels for 24h+
+        // deltas — "2d ago", "two days ago", or similar depending on
+        // the helper. We assert on the structural separators instead
+        // of exact day phrasing so the test survives formatter tweaks.
+        onNodeWithTag("sp-decision-meta").assertIsDisplayed()
+    }
+
+    @Test
+    fun suppressesMetaLineWhenShaTooShortToAbbreviate() = runComposeUiTest {
+        // Defensive: if the pinned sha is shorter than 4 hex chars
+        // (shouldn't happen server-side, but defence in depth), we
+        // don't render a bogus `v-` label.
+        setContent {
+            CoreUpgradeDecisionSheet(
+                decision = decision.copy(oldSha = "ab"),
+                onTryWithMySave = {},
+                onKeepNewVersion = {},
+                onLockOldVersion = {},
+                onRemindLater = {},
+            )
+        }
+
+        onNodeWithTag("sp-decision-meta").assertDoesNotExist()
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/TestFakes.kt
@@ -578,6 +578,7 @@ class FakeCoreRepository : CoreRepository {
         if (forceMissingLocalCore) null else "/fake/cores/$coreName"
 
     override suspend fun isCachedCoreCurrent(coreName: String): Boolean? = null
+    override suspend fun getServerCoreSha(coreName: String): String? = null
 
     override suspend fun isCoreCached(coreName: String): Boolean = !forceMissingLocalCore
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/CoreRepositoryImpl.kt
@@ -102,24 +102,27 @@ class CoreRepositoryImpl(
         // fall through to the normal download path.
         val localPath = getLocalCorePath(coreName) ?: return null
 
+        val serverSha = getServerCoreSha(coreName) ?: return null
+
+        val localSha = fileStorage.sha256File(localPath) ?: return null
+
+        return localSha.equals(serverSha, ignoreCase = true)
+    }
+
+    override suspend fun getServerCoreSha(coreName: String): String? {
         // Resolve the server-side numeric core id from the name. Any
-        // failure here (network, name not found) is treated as
-        // "cannot decide" — we don't want a transient HTTP hiccup to
-        // invalidate an otherwise-usable cached core.
+        // failure here (network, name not found) becomes null so the
+        // caller can treat it as "cannot decide".
         val coreId = runCatching {
             apiClient.getAvailableCores().firstOrNull { it.name == coreName }?.id
         }.getOrNull() ?: return null
 
-        val manifest = runCatching { apiClient.getCoreManifest(coreId) }.getOrNull() ?: return null
+        val manifest = runCatching { apiClient.getCoreManifest(coreId) }.getOrNull()
+            ?: return null
 
-        // Server hasn't fingerprinted this core yet (pristine row). We
-        // can't tell whether the local copy matches what the server will
-        // eventually serve, so trust the local cache until the server
-        // lands its own hash on a future download.
-        if (manifest.sha256.isEmpty()) return null
-
-        val localSha = fileStorage.sha256File(localPath) ?: return null
-
-        return localSha.equals(manifest.sha256, ignoreCase = true)
+        // Empty sha == the server has not fingerprinted this core
+        // yet; callers must not treat empty as "no changes" because
+        // it still carries no signal.
+        return manifest.sha256.takeIf { it.isNotEmpty() }
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/CoreRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/CoreRepository.kt
@@ -49,4 +49,15 @@ interface CoreRepository {
      *               otherwise-usable cached core.
      */
     suspend fun isCachedCoreCurrent(coreName: String): Boolean?
+
+    /**
+     * Returns the server's current sha256 for [coreName] via
+     * `GET /api/cores/{id}/manifest`, or `null` when the server
+     * hasn't fingerprinted the core yet, the core name is unknown,
+     * or the network request fails. Used by
+     * [com.spela.player.domain.usecase.PrepareGameUseCase] to decide
+     * whether a session's pinned sha is still current without
+     * re-downloading the binary. See #672.
+     */
+    suspend fun getServerCoreSha(coreName: String): String?
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
@@ -56,11 +56,30 @@ data class PrepareGameResult(
     val coreVersionWarning: String? = null,
     /**
      * Why (if at all) the VM should consider showing the core-upgrade
-     * decision UI before starting emulation. See [DecisionKind]. The
-     * detection logic lands in PR #3 alongside the UI; v1 always
-     * returns [DecisionKind.None] so existing behaviour is unchanged.
+     * decision UI before starting emulation. See [DecisionKind].
      */
     val decisionKind: DecisionKind = DecisionKind.None,
+    /**
+     * libretro identifier of the core the VM is about to launch —
+     * the post-platform-substitution name, e.g. "mednafen_psx_hw" on
+     * Android. Empty string when the use case bailed early via the
+     * offline-cache fallback path. Used by the VM to build the
+     * `CoreDecision.UpgradeAvailable` payload for Sheet A.
+     */
+    val coreName: String = "",
+    /**
+     * Human-readable display name for [coreName] — falls back to
+     * [coreName] when the server hasn't populated a pretty label.
+     */
+    val coreDisplayName: String = "",
+    /**
+     * Server's current sha256 for [coreName] at the moment this
+     * result was produced. Populated when the use case fetches the
+     * manifest during decision detection; empty otherwise. The VM
+     * reads this directly to build Sheet A's "Saved with version"
+     * meta line without a second network round-trip.
+     */
+    val serverCoreSha: String = "",
 )
 
 /**
@@ -112,6 +131,9 @@ class PrepareGameUseCase(
         gameId: String,
         pinnedCoreSha256: String? = null,
         autoUpdateCoresEnabled: Boolean = true,
+        userLockedCoreVersion: Boolean = false,
+        sessionHasSaves: Boolean = false,
+        skipCoreDecisionPrompt: Boolean = false,
     ): Result<PrepareGameResult> {
         val gamePath = downloadRepository.getLocalGamePath(gameId)
             ?: return Result.failure(IllegalStateException("Game not downloaded"))
@@ -124,7 +146,14 @@ class PrepareGameUseCase(
                 val localPath = coreRepository.getLocalCorePath(coreName)
                 if (localPath != null) {
                     println("[PrepareGame] Using local fallback core: $localPath")
-                    return Result.success(PrepareGameResult(gamePath, localPath))
+                    return Result.success(
+                        PrepareGameResult(
+                            gamePath = gamePath,
+                            corePath = localPath,
+                            coreName = coreName,
+                            coreDisplayName = coreName,
+                        ),
+                    )
                 }
             }
             return Result.failure(networkError)
@@ -135,6 +164,57 @@ class PrepareGameUseCase(
         // original name. Clear it so CoreRepository falls back to the buildbot URL
         // constructed from the substituted name.
         val downloadUrl = if (coreName != core.name) null else core.downloadUrl
+        val platformSubstituted = coreName != core.name
+
+        // #672 core-upgrade decision detection. Runs BEFORE the
+        // pinned-core download path so we can give the VM a chance to
+        // block `loadCore` and show Sheet A when the session's pin no
+        // longer matches the server's current core binary.
+        //
+        // The decision only applies when: the session has a pin, has
+        // at least one save to risk, is not already locked to its pin,
+        // and the core name was not platform-substituted (substitution
+        // mismatches are legitimate — not an upgrade). When we decide a
+        // prompt is needed we still return a usable PrepareGameResult
+        // so the VM can use its paths after resolving the user's
+        // choice without re-invoking the use case.
+        if (pinnedCoreSha256 != null
+            && sessionHasSaves
+            && !userLockedCoreVersion
+            && !platformSubstituted
+            && !skipCoreDecisionPrompt
+        ) {
+            val serverSha = coreRepository.getServerCoreSha(coreName)
+            if (serverSha != null
+                && !serverSha.equals(pinnedCoreSha256, ignoreCase = true)
+            ) {
+                if (!autoUpdateCoresEnabled) {
+                    // Honour user opt-out: tell the VM to show Sheet A.
+                    // We return paths here only as a fallback for the
+                    // "user picked Lock" path — the VM may choose to
+                    // re-download the pinned binary itself after
+                    // collecting the user's choice.
+                    val pinnedPath = coreRepository.downloadCoreByHash(
+                        coreName,
+                        pinnedCoreSha256,
+                    ).getOrNull() ?: coreRepository.getLocalCorePath(coreName) ?: ""
+                    return Result.success(
+                        PrepareGameResult(
+                            gamePath = gamePath,
+                            corePath = pinnedPath,
+                            decisionKind = DecisionKind.UpgradeAvailable,
+                            coreName = coreName,
+                            coreDisplayName = core.displayName.ifEmpty { coreName },
+                            serverCoreSha = serverSha,
+                        ),
+                    )
+                }
+                // autoUpdateCoresEnabled path: fall through to the
+                // existing pinned-download / latest-download logic.
+                // The server sha differs, so we'll silently upgrade
+                // to latest below.
+            }
+        }
 
         // Pinned-core path — #555 Phase 3 session-to-core binding.
         // We attempt the versioned download only when the session has a
@@ -146,7 +226,14 @@ class PrepareGameUseCase(
             val versioned = coreRepository.downloadCoreByHash(coreName, pinnedCoreSha256)
             val pinnedPath = versioned.getOrNull()
             if (pinnedPath != null) {
-                return Result.success(PrepareGameResult(gamePath, pinnedPath))
+                return Result.success(
+                    PrepareGameResult(
+                        gamePath = gamePath,
+                        corePath = pinnedPath,
+                        coreName = coreName,
+                        coreDisplayName = core.displayName.ifEmpty { coreName },
+                    ),
+                )
             }
             val error = versioned.exceptionOrNull()
             if (error is CorePrunedException) {
@@ -156,7 +243,13 @@ class PrepareGameUseCase(
                         return Result.failure(it)
                     }
                 return Result.success(
-                    PrepareGameResult(gamePath, fallbackPath, coreVersionWarning = prunedWarning),
+                    PrepareGameResult(
+                        gamePath = gamePath,
+                        corePath = fallbackPath,
+                        coreVersionWarning = prunedWarning,
+                        coreName = coreName,
+                        coreDisplayName = core.displayName.ifEmpty { coreName },
+                    ),
                 )
             }
             // Any other failure: treat as a transient issue — fall back
@@ -202,7 +295,14 @@ class PrepareGameUseCase(
             }
         }
 
-        return Result.success(PrepareGameResult(gamePath, corePath))
+        return Result.success(
+            PrepareGameResult(
+                gamePath = gamePath,
+                corePath = corePath,
+                coreName = coreName,
+                coreDisplayName = core.displayName.ifEmpty { coreName },
+            ),
+        )
     }
 
     /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -14,6 +14,14 @@ sealed interface EmulationIntent {
         val skipAutoLoad: Boolean = false,
         val forceNewSession: Boolean = false,
         val sessionId: String? = null,
+        /**
+         * When true, the core-upgrade decision sheet (#672) is
+         * suppressed for this launch. Set by the VM when re-firing
+         * `StartGame` after the user resolves a previous Sheet A
+         * prompt — without this flag we'd loop back into the sheet
+         * indefinitely because the pin still differs from the server.
+         */
+        val skipCoreDecisionPrompt: Boolean = false,
     ) : EmulationIntent
     data object PauseGame : EmulationIntent
     data object ResumeGame : EmulationIntent
@@ -119,4 +127,40 @@ sealed interface EmulationIntent {
 
     // Secondary screen control tab
     data class SelectControlTab(val tab: com.spela.player.presentation.state.ControlTab) : EmulationIntent
+
+    // #672 core-upgrade decision — Sheet A resolution intents.
+    // Emitted when the user picks one of the four actions on the
+    // "We updated {core}" sheet. The VM reads EmulationState
+    // .coreDecision for the context it needs (core name, shas, etc.).
+
+    /**
+     * "Try with my save" — enter rehearsal mode and launch with the
+     * new core. Save writes are suppressed until the user confirms
+     * via Sheet C (PR 3c). On PR 3b this activates rehearsal mode
+     * but does not yet wire up the in-game banner or Sheet C exit;
+     * the user can quit the game normally to leave rehearsal.
+     */
+    data object ResolveCoreDecisionTry : EmulationIntent
+
+    /**
+     * "Keep the new version anyway" — launch with the new core. The
+     * session's pin advances only after a successful save on the new
+     * core, so the user can still change their mind mid-session.
+     */
+    data object ResolveCoreDecisionKeepNew : EmulationIntent
+
+    /**
+     * "Lock this session to the older version" — launch with the
+     * pinned binary and mark the session as user-locked so future
+     * `startEmulation` calls skip the decision sheet entirely.
+     */
+    data object ResolveCoreDecisionLockOld : EmulationIntent
+
+    /**
+     * "Remind me the next time I play this" — in-memory dismiss that
+     * launches with the new core without touching the pin. The sheet
+     * will fire again on the next `startEmulation` call for this
+     * session.
+     */
+    data object ResolveCoreDecisionRemindLater : EmulationIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/CoreDecision.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/CoreDecision.kt
@@ -27,6 +27,15 @@ sealed class CoreDecision {
     data class UpgradeAvailable(
         val coreName: String,
         val coreDisplayName: String,
+        /**
+         * Name of the console this session is for (e.g. "Nintendo
+         * Entertainment System"). Populates the fallback title when
+         * the core has no display name — spec key
+         * `core_upd.sheet_a.title_fallback` reads
+         * `"The {console} core has a new version"`. Empty when the
+         * VM couldn't resolve it.
+         */
+        val consoleName: String,
         val gameTitle: String,
         val oldSha: String,
         val newSha: String,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -204,6 +204,16 @@ data class EmulationState(
 
     /** Which input tab is active on the secondary screen controls page. */
     val selectedControlTab: ControlTab = ControlTab.GAMEPAD,
+
+    /**
+     * When non-null, a #672 core-upgrade decision is pending and the
+     * UI layer should render the matching sheet BEFORE emulation
+     * starts. `null` while emulation runs normally. The VM clears
+     * this as each sheet action resolves; see
+     * [com.spela.player.presentation.intent.EmulationIntent] for the
+     * intents that drive resolution.
+     */
+    val coreDecision: CoreDecision? = null,
 ) {
     val isNetplayMode: Boolean get() = netplaySessionId != null
     val isChallengeMode: Boolean get() = challengeId != null

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/CoreUpgradeDecisionSheet.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/CoreUpgradeDecisionSheet.kt
@@ -1,0 +1,113 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import androidx.compose.runtime.Composable
+import com.spela.player.presentation.state.CoreDecision
+import com.spela.player.presentation.ui.components.SpDecisionAction
+import com.spela.player.presentation.ui.components.SpDecisionActionStyle
+import com.spela.player.presentation.ui.components.SpDecisionSheet
+import com.spela.player.presentation.ui.components.social.formatRelativeTime
+
+/**
+ * Sheet A (ROLE component, Layer 3) — the "We updated {core}" sheet
+ * surfaced before emulation starts when the session's pinned core sha
+ * differs from the server's current sha, the session isn't already
+ * locked, and the user hasn't opted into silent auto-updates.
+ *
+ * See `design-proposals/core-upgrade-decision-spec.md` §"Sheet A" for
+ * the canonical copy and decision flow. This composable delegates all
+ * chrome to [SpDecisionSheet]; its only job is to map the
+ * [CoreDecision.UpgradeAvailable] payload onto the sheet's parameters
+ * and fire the correct resolution intent through the passed-in
+ * lambdas.
+ *
+ * Resolution intents live on `EmulationIntent.ResolveCoreDecisionX`.
+ * The VM applies the spec's pin-advancement rules when those intents
+ * fire; this composable doesn't need to care.
+ */
+@Composable
+fun CoreUpgradeDecisionSheet(
+    decision: CoreDecision.UpgradeAvailable,
+    onTryWithMySave: () -> Unit,
+    onKeepNewVersion: () -> Unit,
+    onLockOldVersion: () -> Unit,
+    onRemindLater: () -> Unit,
+) {
+    // Spec copy keys:
+    //   core_upd.sheet_a.title          → uses {core}
+    //   core_upd.sheet_a.title_fallback → uses {console}
+    // When neither is available we fall back once more to a
+    // generic label so the sheet never renders an empty header.
+    val title = when {
+        decision.coreDisplayName.isNotEmpty() ->
+            "We updated ${decision.coreDisplayName}"
+        decision.consoleName.isNotEmpty() ->
+            "The ${decision.consoleName} core has a new version"
+        else ->
+            "The core has a new version"
+    }
+    val body = "Your save for ${decision.gameTitle} was made with an " +
+        "earlier version of the core. It will probably load fine — but " +
+        "we'd like you to try it first so you can decide what to do."
+    val metaLine = buildMetaLine(decision)
+
+    SpDecisionSheet(
+        title = title,
+        body = body,
+        metaLine = metaLine,
+        primary = SpDecisionAction(
+            label = "Try with my save",
+            onClick = onTryWithMySave,
+            style = SpDecisionActionStyle.Primary,
+        ),
+        secondary = SpDecisionAction(
+            label = "Keep the new version anyway",
+            onClick = onKeepNewVersion,
+            style = SpDecisionActionStyle.Secondary,
+        ),
+        moreOptions = listOf(
+            SpDecisionAction(
+                label = "Lock this session to the older version",
+                onClick = onLockOldVersion,
+                style = SpDecisionActionStyle.Secondary,
+            ),
+            SpDecisionAction(
+                label = "Remind me the next time I play this",
+                onClick = onRemindLater,
+                style = SpDecisionActionStyle.Ghost,
+            ),
+        ),
+        // Back / Esc / gamepad-B on the sheet routes through the
+        // Compose Dialog's onDismissRequest. Matches the spec's
+        // "Remind me next time" semantics — no durable server change.
+        onDismiss = onRemindLater,
+        testTagName = "core-upgrade-sheet-a",
+    )
+}
+
+/**
+ * Returns the `v-abcd` abbreviation for a 64-char hex sha, or null
+ * when the value is too short / missing. Hyphen is intentional — we
+ * want the label to read as a version tag, not a fake semver.
+ */
+private fun versionLabel(sha: String): String? {
+    if (sha.length < 4) return null
+    return "v-${sha.take(4).lowercase()}"
+}
+
+/**
+ * Spec copy: `"Last played {relative}  ·  Saved with version v-{abbrev}"`.
+ * When either half is unknown we render only the known half; when
+ * both are missing we return null so the sheet elides the row.
+ */
+private fun buildMetaLine(decision: CoreDecision.UpgradeAvailable): String? {
+    val lastPlayed = decision.lastPlayedAt?.let {
+        "Last played ${formatRelativeTime(it)}"
+    }
+    val version = versionLabel(decision.oldSha)?.let { "Saved with version $it" }
+    return when {
+        lastPlayed != null && version != null -> "$lastPlayed  ·  $version"
+        lastPlayed != null -> lastPlayed
+        version != null -> version
+        else -> null
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -222,6 +222,18 @@ fun InGameOverlay(
         )
     }
 
+    // #672 core-upgrade decision — Sheet A
+    val coreDecision = state.coreDecision
+    if (coreDecision is com.spela.player.presentation.state.CoreDecision.UpgradeAvailable) {
+        com.spela.player.presentation.ui.feature.ingame.CoreUpgradeDecisionSheet(
+            decision = coreDecision,
+            onTryWithMySave = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionTry) },
+            onKeepNewVersion = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionKeepNew) },
+            onLockOldVersion = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionLockOld) },
+            onRemindLater = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionRemindLater) },
+        )
+    }
+
     // Core mismatch save warning dialog
     if (state.showCoreMismatchSaveDialog) {
         CoreMismatchSaveDialog(

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -81,6 +81,23 @@ class EmulationViewModel(
 
     private var pendingLaunch: PendingLaunch? = null
 
+    /**
+     * Stored [EmulationIntent.StartGame] captured when the
+     * PrepareGameUseCase reports an UpgradeAvailable decision (#672).
+     * Re-fired with `skipCoreDecisionPrompt = true` once the user
+     * picks an action via Sheet A. `null` while no decision is
+     * pending.
+     *
+     * `@Volatile` is load-bearing here — the field is written from
+     * the coroutine running on the IO dispatcher (inside `startGame`)
+     * and read from the main-thread intent dispatcher in
+     * `resolveCoreDecision`. Without the annotation, the resolution
+     * could see a stale `null` if the sheet is dismissed immediately
+     * after the writer coroutine suspends.
+     */
+    @Volatile
+    private var pendingCoreDecisionStart: EmulationIntent.StartGame? = null
+
     private var currentPreferences = UserPreferences()
     private var sessionTimerJob: Job? = null
     private var stopJob: Job? = null
@@ -116,6 +133,7 @@ class EmulationViewModel(
                 intent.netplaySessionId, intent.netplayLocalPort, intent.netplayInputDelay, intent.netplayIsHost,
                 intent.challengeId, intent.challengeSaveData, intent.skipAutoLoad,
                 intent.forceNewSession, intent.sessionId,
+                skipCoreDecisionPrompt = intent.skipCoreDecisionPrompt,
             )
             EmulationIntent.PauseGame -> pauseGame()
             EmulationIntent.ResumeGame -> resumeGame()
@@ -273,6 +291,67 @@ class EmulationViewModel(
                     preferencesRepository.setControlTab(consoleId, intent.tab.id)
                 }
             }
+
+            // #672 core-upgrade decision — Sheet A resolution
+            EmulationIntent.ResolveCoreDecisionTry -> resolveCoreDecision(RehearsalEntry.Try)
+            EmulationIntent.ResolveCoreDecisionKeepNew -> resolveCoreDecision(RehearsalEntry.KeepNew)
+            EmulationIntent.ResolveCoreDecisionLockOld -> resolveCoreDecision(RehearsalEntry.LockOld)
+            EmulationIntent.ResolveCoreDecisionRemindLater -> resolveCoreDecision(RehearsalEntry.RemindLater)
+        }
+    }
+
+    /**
+     * Classifies the user's Sheet A choice so [resolveCoreDecision]
+     * can branch without duplicating side effects for each intent.
+     */
+    private enum class RehearsalEntry { Try, KeepNew, LockOld, RemindLater }
+
+    /**
+     * Applies the side effects of a Sheet A choice (rehearsal mode,
+     * server lock flag) and re-fires the stashed StartGame intent
+     * with `skipCoreDecisionPrompt = true` so the sheet doesn't
+     * reappear immediately. Each branch maps to the spec's
+     * "Pin advancement rules" in
+     * `design-proposals/core-upgrade-decision-spec.md`.
+     *
+     * Surfaces a status message when the server-side lock write
+     * fails so the user isn't led to believe they locked the session
+     * when really the next launch will re-prompt. The launch still
+     * proceeds with the pinned binary locally; we optimistically
+     * re-attempt the lock on subsequent resolves.
+     */
+    private fun resolveCoreDecision(entry: RehearsalEntry) {
+        val pending = pendingCoreDecisionStart ?: return
+        pendingCoreDecisionStart = null
+        _state.update { it.copy(coreDecision = null) }
+
+        scope.launch(dispatchers.io) {
+            when (entry) {
+                RehearsalEntry.Try -> saveManager.rehearsalMode = true
+                RehearsalEntry.KeepNew,
+                RehearsalEntry.RemindLater -> {
+                    saveManager.rehearsalMode = false
+                }
+                RehearsalEntry.LockOld -> {
+                    saveManager.rehearsalMode = false
+                    val locked = saveManager.setSessionCoreLock(
+                        pending.sessionId,
+                        locked = true,
+                    )
+                    if (!locked) {
+                        withContext(dispatchers.main) {
+                            _state.update {
+                                it.copy(
+                                    statusMessage = "Couldn't save the lock — we'll try again next time.",
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+            withContext(dispatchers.main) {
+                onIntent(pending.copy(skipCoreDecisionPrompt = true))
+            }
         }
     }
 
@@ -289,6 +368,7 @@ class EmulationViewModel(
         skipAutoLoad: Boolean = false,
         forceNewSession: Boolean = false,
         sessionId: String? = null,
+        skipCoreDecisionPrompt: Boolean = false,
     ) {
         saveManager.currentSessionId = sessionId
         _state.update {
@@ -457,16 +537,82 @@ class EmulationViewModel(
             // pinnedCoreSha256 (#555 Phase 3) we pass it through so the
             // use case can attempt a versioned core download first.
             // autoUpdateCoresEnabled gates the unpinned cache-invalidation
-            // check (#555 Phase 2 opt-out).
-            val pinnedSha = saveManager.pinnedCoreSha256For(saveManager.currentSessionId)
+            // check (#555 Phase 2 opt-out). userLockedCoreVersion +
+            // sessionHasSaves + skipCoreDecisionPrompt drive the #672
+            // core-upgrade decision flow — see decision handling block
+            // below the fold().
+            val flags = saveManager.coreDecisionFlagsFor(saveManager.currentSessionId)
+            val pinnedSha = flags?.pinnedCoreSha256
+            val userLocked = flags?.userLockedCoreVersion ?: false
+            val hasSaves = saveManager.sessionSaveCount(saveManager.currentSessionId) > 0
             prepareGameUseCase(
                 gameId,
                 pinnedSha,
                 autoUpdateCoresEnabled = currentPreferences.autoUpdateCoresEnabled,
+                userLockedCoreVersion = userLocked,
+                sessionHasSaves = hasSaves,
+                skipCoreDecisionPrompt = skipCoreDecisionPrompt,
             ).fold(
                 onSuccess = { prepared ->
                     val gamePath = prepared.gamePath
                     val corePath = prepared.corePath
+                    // #672 core-upgrade decision gate. When the use
+                    // case reports UpgradeAvailable we stash the
+                    // originating StartGame intent, surface the sheet
+                    // via `state.coreDecision`, and return BEFORE
+                    // touching the emulator. Resolution intents below
+                    // clear the stash and re-fire StartGame with
+                    // `skipCoreDecisionPrompt = true`.
+                    // #672 per spec §"Edge cases": netplay, shared
+                    // session, and challenge runs MUST skip the sheet.
+                    // Netplay requires binary parity across peers and
+                    // challenges lock their own core at creation; both
+                    // have their own core-mismatch negotiation.
+                    val suppressForSpecialMode =
+                        netplaySessionId != null
+                            || sharedSessionId != null
+                            || challengeId != null
+                    if (prepared.decisionKind == com.spela.player.domain.usecase.DecisionKind.UpgradeAvailable
+                        && !suppressForSpecialMode
+                    ) {
+                        pendingCoreDecisionStart = EmulationIntent.StartGame(
+                            gameId = gameId,
+                            sharedSessionId = sharedSessionId,
+                            turnToken = turnToken,
+                            netplaySessionId = netplaySessionId,
+                            netplayLocalPort = netplayLocalPort,
+                            netplayInputDelay = netplayInputDelay,
+                            netplayIsHost = netplayIsHost,
+                            challengeId = challengeId,
+                            challengeSaveData = challengeSaveDataArg,
+                            skipAutoLoad = skipAutoLoad,
+                            forceNewSession = forceNewSession,
+                            sessionId = saveManager.currentSessionId,
+                        )
+                        withContext(dispatchers.main) {
+                            _state.update {
+                                it.copy(
+                                    isLoading = false,
+                                    // Suppress any post-load dialog that
+                                    // might otherwise stack on top of
+                                    // Sheet A — Sheet A is the pre-load
+                                    // decision; CoreMismatchDialog only
+                                    // fires after auto-load fails.
+                                    showCoreMismatchDialog = false,
+                                    coreDecision = com.spela.player.presentation.state.CoreDecision.UpgradeAvailable(
+                                        coreName = prepared.coreName,
+                                        coreDisplayName = prepared.coreDisplayName.ifEmpty { prepared.coreName },
+                                        consoleName = it.consoleName,
+                                        gameTitle = it.gameTitle.ifEmpty { gameId },
+                                        oldSha = pinnedSha ?: "",
+                                        newSha = prepared.serverCoreSha,
+                                        lastPlayedAt = null,
+                                    ),
+                                )
+                            }
+                        }
+                        return@fold
+                    }
                     // Surface the fallback warning (non-blocking) if the
                     // pinned binary was pruned and we fell back to latest.
                     if (prepared.coreVersionWarning != null) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -55,6 +55,17 @@ enum class RehearsalSaveKind { Manual, Auto, Slot, Sram }
 data class RehearsalSaveBlocked(val kind: RehearsalSaveKind)
 
 /**
+ * Compact view of the fields the ViewModel needs from a [GameSession]
+ * to decide whether the #672 core-upgrade sheet should fire on
+ * `startEmulation`. Fetched by [SaveManager.coreDecisionFlagsFor] so
+ * callers don't have to re-hydrate the full session record in hot paths.
+ */
+data class CoreDecisionFlags(
+    val pinnedCoreSha256: String?,
+    val userLockedCoreVersion: Boolean,
+)
+
+/**
  * Manages all save-related operations: SRAM load/save, auto-save/load,
  * and manual save/load state. All operations are session-scoped.
  * When no session is active, operations are silently skipped.
@@ -151,6 +162,61 @@ class SaveManager(
             sessionRepository.getSession(sessionId).getOrNull()?.pinnedCoreSha256
         } catch (_: Exception) {
             null
+        }
+    }
+
+    /**
+     * Reads the #672 core-upgrade decision flags for [sessionId] in a
+     * single network call. Returns `null` when no session is active or
+     * the fetch fails — callers should treat that as "no decision
+     * needed" and fall back to default behaviour.
+     */
+    suspend fun coreDecisionFlagsFor(sessionId: String?): CoreDecisionFlags? {
+        if (sessionId.isNullOrEmpty()) return null
+        return try {
+            val session = sessionRepository.getSession(sessionId).getOrNull()
+                ?: return null
+            CoreDecisionFlags(
+                pinnedCoreSha256 = session.pinnedCoreSha256,
+                userLockedCoreVersion = session.userLockedCoreVersion,
+            )
+        } catch (_: Exception) {
+            null
+        }
+    }
+
+    /**
+     * Counts the save states on [sessionId]. Feeds the "brand new
+     * session — skip the decision sheet" branch of #672's decision
+     * flow. Returns 0 on any error so a network hiccup doesn't surface
+     * a prompt for a session the user never saved to.
+     */
+    suspend fun sessionSaveCount(sessionId: String?): Int {
+        if (sessionId.isNullOrEmpty()) return 0
+        return try {
+            sessionRepository.getSessionSaves(sessionId).getOrNull()?.size ?: 0
+        } catch (_: Exception) {
+            0
+        }
+    }
+
+    /**
+     * Writes `userLockedCoreVersion` on [sessionId]. Called after the
+     * user picks "Lock this session to the older version" on Sheet A
+     * (or the equivalent on Sheets C / D in PR 3c). Returns false on
+     * failure so the VM can still launch the game with the pinned
+     * binary locally — the server-side flag catches up on the next
+     * attempt.
+     */
+    suspend fun setSessionCoreLock(sessionId: String?, locked: Boolean): Boolean {
+        if (sessionId.isNullOrEmpty()) return false
+        return try {
+            sessionRepository.updateSessionCoreFlags(
+                sessionId,
+                userLockedCoreVersion = locked,
+            ).isSuccess
+        } catch (_: Exception) {
+            false
         }
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/PrepareGameUseCaseTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/PrepareGameUseCaseTest.kt
@@ -106,6 +106,179 @@ class PrepareGameUseCaseTest {
             "opt-out must short-circuit the staleness check — no redownload even when server has a newer sha",
         )
     }
+
+    // ── #672 core-upgrade decision detection ──────────────────────
+
+    @Test
+    fun signalsUpgradeAvailableWhenPinnedShaDiffersAndOptedOut() = runTest {
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = false,
+            serverSha = "bb".repeat(32), // 64 chars, differs from pin
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            sessionHasSaves = true,
+            autoUpdateCoresEnabled = false, // the opt-out case
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.UpgradeAvailable, result.decisionKind,
+            "pinned sha != server sha + opt-out must surface the decision to the VM")
+    }
+
+    @Test
+    fun silentUpgradeWhenAutoUpdateEnabledEvenWithMismatchedPin() = runTest {
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = false,
+            serverSha = "bb".repeat(32),
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            sessionHasSaves = true,
+            autoUpdateCoresEnabled = true, // user wants silent upgrades
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.None, result.decisionKind,
+            "user opted into silent upgrades — the VM must not be asked to show Sheet A")
+    }
+
+    @Test
+    fun skipsDecisionForSessionsWithNoSaves() = runTest {
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = false,
+            serverSha = "bb".repeat(32),
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            sessionHasSaves = false, // brand-new session
+            autoUpdateCoresEnabled = false,
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.None, result.decisionKind,
+            "brand-new sessions have no saves at risk — must not prompt")
+    }
+
+    @Test
+    fun skipsDecisionWhenSessionIsLocked() = runTest {
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = false,
+            serverSha = "bb".repeat(32),
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            sessionHasSaves = true,
+            userLockedCoreVersion = true, // user already locked
+            autoUpdateCoresEnabled = false,
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.None, result.decisionKind,
+            "locked sessions must not re-prompt — the lock is the user's decision")
+    }
+
+    @Test
+    fun skipsDecisionWhenServerShaMatchesPin() = runTest {
+        val pinned = "aa".repeat(32)
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = true,
+            serverSha = pinned, // server matches pin — no drift
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = pinned,
+            sessionHasSaves = true,
+            autoUpdateCoresEnabled = false,
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.None, result.decisionKind,
+            "pin matches server — nothing to decide")
+    }
+
+    @Test
+    fun skipsDecisionWhenServerShaUnavailable() = runTest {
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = null,
+            serverSha = null, // network failure / server hasn't fingerprinted
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            sessionHasSaves = true,
+            autoUpdateCoresEnabled = false,
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.None, result.decisionKind,
+            "can't decide without server sha — fall through to existing behaviour")
+    }
+
+    @Test
+    fun skipsDecisionWhenSkipFlagIsSet() = runTest {
+        // This is the re-entry path: after the user resolves Sheet A
+        // the VM re-fires StartGame with skipCoreDecisionPrompt = true.
+        // If the detection block didn't honour the flag the sheet
+        // would loop forever because the pin is still different from
+        // the server sha.
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = false,
+            serverSha = "bb".repeat(32),
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            sessionHasSaves = true,
+            autoUpdateCoresEnabled = false,
+            skipCoreDecisionPrompt = true,
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.None, result.decisionKind,
+            "skipCoreDecisionPrompt must short-circuit the detection block on re-entry")
+    }
+
+    @Test
+    fun upgradeAvailableResultCarriesServerCoreSha() = runTest {
+        // The VM reads prepared.serverCoreSha to populate Sheet A's
+        // 'new version' display without a second network call.
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = false,
+            serverSha = "bb".repeat(32),
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            sessionHasSaves = true,
+            autoUpdateCoresEnabled = false,
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.UpgradeAvailable, result.decisionKind)
+        assertEquals("bb".repeat(32), result.serverCoreSha,
+            "serverCoreSha must be surfaced on the result so the VM doesn't re-fetch")
+    }
 }
 
 private class FakeDownloadRepository : DownloadRepository {
@@ -132,6 +305,7 @@ private class FakeCoreRepository(
     private val local: String?,
     private val isCurrent: Boolean?,
     private val downloadResult: Result<String> = Result.success("/local/downloaded-core.so"),
+    private val serverSha: String? = null,
 ) : CoreRepository {
     var downloadCoreCalls = 0
         private set
@@ -162,4 +336,5 @@ private class FakeCoreRepository(
     override suspend fun isCoreCached(coreName: String): Boolean = local != null
 
     override suspend fun isCachedCoreCurrent(coreName: String): Boolean? = isCurrent
+    override suspend fun getServerCoreSha(coreName: String): String? = serverSha
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -214,6 +214,7 @@ class StubCoreRepository : CoreRepository {
     override suspend fun getLocalCorePath(coreName: String): String = "/path/to/core.so"
     override suspend fun isCoreCached(coreName: String) = true
     override suspend fun isCachedCoreCurrent(coreName: String): Boolean? = null
+    override suspend fun getServerCoreSha(coreName: String): String? = null
 }
 
 class StubSaveDataRepository : SaveDataRepository {


### PR DESCRIPTION
Turns the foundation pieces from PR 3a and the sealed-class plumbing from PR 2 into a working pre-emulation decision gate. When the session's pinned core sha differs from the server's current sha (and the user hasn't opted into silent auto-updates), the launch blocks and surfaces **"We updated {core}"** with four actions:

- **Try with my save** — enters rehearsal mode and launches with the new core
- **Keep the new version anyway** — launches with the new core; pin stays pinned (advances on next save)
- **Lock this session to the older version** — launches the pinned binary, sets `UserLockedCoreVersion = true` server-side
- **Remind me the next time I play this** — in-memory dismiss; re-prompts on next launch

Sheet B / C / D, rehearsal banner, session-detail chrome, and the `CoreMismatchDialog` port remain in PR 3c.

## Detection — `PrepareGameUseCase`

- New params `userLockedCoreVersion`, `sessionHasSaves`, `skipCoreDecisionPrompt`. All defaulted, existing callers unchanged.
- Runs **before** the pinned-core download path so it can surface the decision without committing to a binary.
- Skips detection for: no-pin sessions, empty sessions, already-locked sessions, platform-substituted core names, and the re-entry case after Sheet A resolves.
- When `autoUpdateCoresEnabled = true`, silently falls through to the latest core — no prompt.
- Returns `PrepareGameResult.decisionKind = UpgradeAvailable` along with `serverCoreSha` so the VM doesn't re-fetch the manifest.

## Spec edge cases handled

- **Netplay / shared-session / challenge** launches skip Sheet A entirely (binary parity is a separate negotiation; challenges pin their own core at creation).
- `pendingCoreDecisionStart` is `@Volatile` — written on IO, read on main.
- `setSessionCoreLock` failures surface a status message ("Couldn't save the lock — we'll try again next time.") instead of pretending success. Launch still proceeds locally.
- Sheet A mount clears `showCoreMismatchDialog` on transition so the two can never stack.

## Review gate — `code-reviewer` + `ui-agent`

Both agents reviewed in plan mode before push. Applied:

| Severity | Finding | Fix |
|---|---|---|
| Critical | Sheet A fired during netplay / shared / challenge | Added `suppressForSpecialMode` guard |
| High | `pendingCoreDecisionStart` was a plain `var` across dispatchers | `@Volatile` |
| High | `setSessionCoreLock` failure was silent | Surface statusMessage on the VM |
| High / UI | Fallback title dropped `{console}` | Added `consoleName` to `CoreDecision.UpgradeAvailable` and render per spec |
| High / UI | Meta line missing "Last played · …" format | Full-form rendering with the spec's two-space-middot-two-space separator |
| Low | Redundant second manifest fetch in VM | `PrepareGameResult.serverCoreSha`; dropped `coreRepository` injection from `EmulationViewModel` entirely |
| Medium | Missing tests | Added re-entry skip, `serverCoreSha` round-trip, console fallback title, generic fallback title, full meta line |

Deferred with documented reasons (all PO / non-blocking):

- `CoreDecisionContext` param refactor (CR-M7) — param count is 6 with defaults; will revisit if 3c grows it further
- U+2011 non-breaking hyphen vs ASCII `-` (CR-H6 / UI-B2) — PO question; ASCII for v1
- Dismiss-routing test via back/Esc (UI-H2) — hard to simulate without the full harness; `onDismissRequest` wiring is covered indirectly via PR 3a's `SpDecisionSheetTest`
- Extract strings library (UI-M2) — no i18n module yet

## Test plan

- [x] `./gradlew :shared:desktopTest` — 13 `PrepareGameUseCaseTest` cases green (+2 new), 7 `SaveManagerRehearsalTest` green, full shared suite green
- [x] `./gradlew :desktop:desktopTest --tests "*.components.*"` — 8 `CoreUpgradeDecisionSheetTest` (+2 new), 9 `SpDecisionSheetTest`, 4 each for `SpInGameBanner` / `SessionCoreLockChip`
- [x] `./gradlew :shared:detektMainDesktop :android:detektDebugAndroid :desktop:detektMainDesktop` — 0 findings
- [x] Full desktop E2E suite — harness-using `OfflineIndicatorTest` green (proves the DI changes don't break the harness); the 5-min timeout on the full `:desktop:desktopTest` run is the known #422 flake
- [ ] CI green on this PR before merge

Refs #672, #555. Depends on #675 (merged).