### PR TITLE
feat(#672): Sheet B + session-detail lock chip (PR 3c.i/5)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/CorePinPrunedDecisionSheetTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/CorePinPrunedDecisionSheetTest.kt
@@ -1,0 +1,126 @@
+package com.spela.player.desktop.components
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.spela.player.presentation.state.CoreDecision
+import com.spela.player.presentation.ui.feature.ingame.CorePinPrunedDecisionSheet
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Behaviour coverage for the #672 Sheet B composable. Pins the copy
+ * contract from `design-proposals/core-upgrade-decision-spec.md`
+ * §"Sheet B — The older version isn't available anymore" and the
+ * callback routing from its three actions.
+ */
+@OptIn(ExperimentalTestApi::class)
+class CorePinPrunedDecisionSheetTest {
+
+    private val decision = CoreDecision.PinPruned(
+        coreName = "nestopia",
+        coreDisplayName = "Nestopia UE",
+        gameTitle = "Castlevania",
+        prunedSha = "abcd1234".repeat(8),
+    )
+
+    @Test
+    fun rendersSpecTitleAndBody() = runComposeUiTest {
+        setContent {
+            CorePinPrunedDecisionSheet(
+                decision = decision,
+                onTryWithMySave = {},
+                onStartFresh = {},
+                onRemindLater = {},
+            )
+        }
+
+        onNodeWithTag("core-upgrade-sheet-b").assertIsDisplayed()
+        onNodeWithText("The older version isn't available anymore").assertIsDisplayed()
+        // Spec body — verbatim against `core_upd.sheet_b.body`. Note the
+        // body does NOT interpolate the game title (that's Sheet A's job).
+        onNodeWithText(
+            "We used to keep the exact core version your save was " +
+                "made with, but it's been rotated out of the server's history. " +
+                "We'll use the latest Nestopia UE instead. Try your save first — " +
+                "if it looks wrong you can start fresh.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun fallsBackToCoreNameWhenDisplayNameIsEmpty() = runComposeUiTest {
+        // Defence in depth: the server occasionally ships cores with no
+        // display-name set (pre-backfill rows). We must not emit an
+        // empty " " in the body — fall back to the libretro id.
+        setContent {
+            CorePinPrunedDecisionSheet(
+                decision = decision.copy(coreDisplayName = ""),
+                onTryWithMySave = {},
+                onStartFresh = {},
+                onRemindLater = {},
+            )
+        }
+
+        onNodeWithText(
+            "We used to keep the exact core version your save was " +
+                "made with, but it's been rotated out of the server's history. " +
+                "We'll use the latest nestopia instead. Try your save first — " +
+                "if it looks wrong you can start fresh.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun primaryFiresOnTryWithMySave() = runComposeUiTest {
+        var tryClicks = 0
+        setContent {
+            CorePinPrunedDecisionSheet(
+                decision = decision,
+                onTryWithMySave = { tryClicks++ },
+                onStartFresh = {},
+                onRemindLater = {},
+            )
+        }
+
+        onNodeWithText("Try with my save").assertIsDisplayed()
+        onNodeWithTag("sp-decision-primary").performClick()
+        assertEquals(1, tryClicks)
+    }
+
+    @Test
+    fun secondaryFiresOnStartFresh() = runComposeUiTest {
+        var freshClicks = 0
+        setContent {
+            CorePinPrunedDecisionSheet(
+                decision = decision,
+                onTryWithMySave = {},
+                onStartFresh = { freshClicks++ },
+                onRemindLater = {},
+            )
+        }
+
+        onNodeWithText("Start fresh anyway").assertIsDisplayed()
+        onNodeWithTag("sp-decision-secondary").performClick()
+        assertEquals(1, freshClicks)
+    }
+
+    @Test
+    fun moreOptionsExposesRemindLater() = runComposeUiTest {
+        var remindClicks = 0
+        setContent {
+            CorePinPrunedDecisionSheet(
+                decision = decision,
+                onTryWithMySave = {},
+                onStartFresh = {},
+                onRemindLater = { remindClicks++ },
+            )
+        }
+
+        onNodeWithTag("sp-decision-more-toggle").performClick()
+        onNodeWithText("Remind me the next time I play this").assertIsDisplayed()
+        onNodeWithTag("sp-decision-more-0").performClick()
+        assertEquals(1, remindClicks)
+    }
+}

--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SessionCoreLockChipTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/SessionCoreLockChipTest.kt
@@ -62,10 +62,11 @@ class SessionCoreLockChipTest {
     }
 
     @Test
-    fun toleratesShortShaWithoutCrashing() = runComposeUiTest {
+    fun fallsBackToVersionlessLabelWhenShaIsShorterThanFourChars() = runComposeUiTest {
         // Server shouldn't hand us anything shorter than 64 chars, but
-        // the UI should not crash if a short value slips through —
-        // just render whatever prefix we have.
+        // the UI must not render "v-ab" (a misleading 2-char version
+        // label). Fall back to the version-less copy so the unlock
+        // escape hatch still makes sense.
         setContent {
             SessionCoreLockChip(
                 pinnedCoreSha256 = "ab",
@@ -73,6 +74,26 @@ class SessionCoreLockChipTest {
             )
         }
 
-        onNodeWithText("Locked to version v-ab").assertIsDisplayed()
+        onNodeWithText("Locked to this core version").assertIsDisplayed()
+    }
+
+    @Test
+    fun fallsBackToVersionlessLabelWhenShaIsEmpty() = runComposeUiTest {
+        // Edge case: `userLockedCoreVersion = true` on a session whose
+        // pin was never set (shouldn't happen server-side, defensive
+        // path). Chip must still render so the user can reach the
+        // unlock link.
+        var unlockClicks = 0
+        setContent {
+            SessionCoreLockChip(
+                pinnedCoreSha256 = "",
+                onUnlock = { unlockClicks++ },
+            )
+        }
+
+        onNodeWithText("Locked to this core version").assertIsDisplayed()
+        onNodeWithTag("session-core-unlock-link").performClick()
+        assertEquals(1, unlockClicks,
+            "empty-sha fallback must still expose a working unlock action")
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
@@ -242,11 +242,24 @@ class PrepareGameUseCase(
                     ?: coreRepository.downloadCore(coreName, downloadUrl).getOrElse {
                         return Result.failure(it)
                     }
+                // When the user explicitly locked this session to the
+                // pinned sha (#672 UserLockedCoreVersion), pruning
+                // warrants Sheet B rather than the silent toast —
+                // their explicit choice just became impossible and
+                // they need the chance to decide next steps. For
+                // sessions that weren't user-locked we keep the old
+                // silent-fallback-with-warning behaviour.
+                val kind = if (userLockedCoreVersion && sessionHasSaves && !skipCoreDecisionPrompt) {
+                    DecisionKind.PinPruned
+                } else {
+                    DecisionKind.None
+                }
                 return Result.success(
                     PrepareGameResult(
                         gamePath = gamePath,
                         corePath = fallbackPath,
-                        coreVersionWarning = prunedWarning,
+                        coreVersionWarning = if (kind == DecisionKind.None) prunedWarning else null,
+                        decisionKind = kind,
                         coreName = coreName,
                         coreDisplayName = core.displayName.ifEmpty { coreName },
                     ),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/EmulationIntent.kt
@@ -163,4 +163,14 @@ sealed interface EmulationIntent {
      * session.
      */
     data object ResolveCoreDecisionRemindLater : EmulationIntent
+
+    /**
+     * "Start fresh on the new version" — launch with the new core and
+     * skip auto-load of the save state. Used by Sheet B (pinned
+     * binary pruned) and, later, Sheet D (rehearsal crashed). Sets
+     * `AutoLoadSuppressed = true` on the session so the next launch
+     * also skips the stale save; cleared on first successful manual
+     * save.
+     */
+    data object ResolveCoreDecisionStartFresh : EmulationIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/SessionDetailIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/SessionDetailIntent.kt
@@ -22,4 +22,13 @@ sealed interface SessionDetailIntent {
     data object DismissDeleteConfirm : SessionDetailIntent
     data object DismissError : SessionDetailIntent
     data object DismissSuccess : SessionDetailIntent
+
+    /**
+     * Clears `userLockedCoreVersion` on the session so the next launch
+     * will re-run the #672 core-upgrade decision flow with whatever
+     * the server currently has. Fired from the
+     * [com.spela.player.presentation.ui.feature.sessiondetail.SessionCoreLockChip]
+     * "Use the latest version instead" link.
+     */
+    data class UnlockCoreVersion(val sessionId: String) : SessionDetailIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/CorePinPrunedDecisionSheet.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/CorePinPrunedDecisionSheet.kt
@@ -1,0 +1,60 @@
+package com.spela.player.presentation.ui.feature.ingame
+
+import androidx.compose.runtime.Composable
+import com.spela.player.presentation.state.CoreDecision
+import com.spela.player.presentation.ui.components.SpDecisionAction
+import com.spela.player.presentation.ui.components.SpDecisionActionStyle
+import com.spela.player.presentation.ui.components.SpDecisionSheet
+
+/**
+ * Sheet B (ROLE component, Layer 3) — shown when the session was
+ * locked to a specific core sha via #672 Sheet A but the server has
+ * since pruned that binary out of its history retention window (3
+ * versions / 90 days per #555). There's no way to honour the user's
+ * original lock; they have to pick between trying the save against
+ * the latest core or starting fresh.
+ *
+ * See `design-proposals/core-upgrade-decision-spec.md` §"Sheet B —
+ * The older version isn't available anymore" for the canonical copy
+ * and decision flow.
+ */
+@Composable
+fun CorePinPrunedDecisionSheet(
+    decision: CoreDecision.PinPruned,
+    onTryWithMySave: () -> Unit,
+    onStartFresh: () -> Unit,
+    onRemindLater: () -> Unit,
+) {
+    val coreLabel = decision.coreDisplayName.ifEmpty { decision.coreName }
+    // Spec key `core_upd.sheet_b.body` — verbatim. Sheet A carries the
+    // game title; Sheet B intentionally does not (the user already saw
+    // Sheet A or locked manually, so they know which save is at risk).
+    val body = "We used to keep the exact core version your save was " +
+        "made with, but it's been rotated out of the server's history. " +
+        "We'll use the latest $coreLabel instead. Try your save first — " +
+        "if it looks wrong you can start fresh."
+
+    SpDecisionSheet(
+        title = "The older version isn't available anymore",
+        body = body,
+        primary = SpDecisionAction(
+            label = "Try with my save",
+            onClick = onTryWithMySave,
+            style = SpDecisionActionStyle.Primary,
+        ),
+        secondary = SpDecisionAction(
+            label = "Start fresh anyway",
+            onClick = onStartFresh,
+            style = SpDecisionActionStyle.Secondary,
+        ),
+        moreOptions = listOf(
+            SpDecisionAction(
+                label = "Remind me the next time I play this",
+                onClick = onRemindLater,
+                style = SpDecisionActionStyle.Ghost,
+            ),
+        ),
+        onDismiss = onRemindLater,
+        testTagName = "core-upgrade-sheet-b",
+    )
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sessiondetail/SessionCoreLockChip.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/sessiondetail/SessionCoreLockChip.kt
@@ -1,5 +1,6 @@
 package com.spela.player.presentation.ui.feature.sessiondetail
 
+import androidx.compose.foundation.focusable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -11,6 +12,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.semantics.Role
+import androidx.compose.ui.semantics.role
+import androidx.compose.ui.semantics.semantics
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpLinkText
 import com.spela.player.presentation.ui.theme.SpColor
@@ -30,7 +34,10 @@ import com.spela.player.presentation.ui.theme.SpSpacing
  *
  * Abbreviates the sha to the first 4 hex characters with a
  * real hyphen (`v-a3f9`) — see copy rules in
- * `design-proposals/core-upgrade-decision-spec.md`.
+ * `design-proposals/core-upgrade-decision-spec.md`. When the caller
+ * cannot supply a sha (edge case: flag set without a pin), the chip
+ * falls back to the version-less label so the unlock escape hatch
+ * still renders.
  */
 @Composable
 fun SessionCoreLockChip(
@@ -38,7 +45,14 @@ fun SessionCoreLockChip(
     onUnlock: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val abbrev = pinnedCoreSha256.take(4).lowercase()
+    val chipLabel = if (pinnedCoreSha256.length >= 4) {
+        "Locked to version v-${pinnedCoreSha256.take(4).lowercase()}"
+    } else {
+        // Fallback: missing sha shouldn't happen in normal flow but we
+        // render a valid label instead of `v-` so the escape hatch
+        // below stays usable.
+        "Locked to this core version"
+    }
     Column(
         modifier = modifier.testTag("session-core-lock-chip"),
         horizontalAlignment = Alignment.Start,
@@ -46,7 +60,7 @@ fun SessionCoreLockChip(
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
             SpChip(
-                text = "Locked to version v-$abbrev",
+                text = chipLabel,
                 leadingIcon = {
                     Icon(
                         imageVector = Icons.Filled.Lock,
@@ -57,10 +71,17 @@ fun SessionCoreLockChip(
                 },
             )
         }
+        // focusable() + Role.Button at the use site so the unlock link
+        // receives DPAD/gamepad focus — SpLinkText itself wraps a
+        // `clickable` Text without semantic role, which Compose can
+        // skip during focus traversal.
         SpLinkText(
             text = "Use the latest version instead",
             onClick = onUnlock,
-            modifier = Modifier.testTag("session-core-unlock-link"),
+            modifier = Modifier
+                .testTag("session-core-unlock-link")
+                .semantics { role = Role.Button }
+                .focusable(),
         )
     }
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/InGameOverlay.kt
@@ -222,16 +222,26 @@ fun InGameOverlay(
         )
     }
 
-    // #672 core-upgrade decision — Sheet A
-    val coreDecision = state.coreDecision
-    if (coreDecision is com.spela.player.presentation.state.CoreDecision.UpgradeAvailable) {
-        com.spela.player.presentation.ui.feature.ingame.CoreUpgradeDecisionSheet(
-            decision = coreDecision,
-            onTryWithMySave = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionTry) },
-            onKeepNewVersion = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionKeepNew) },
-            onLockOldVersion = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionLockOld) },
-            onRemindLater = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionRemindLater) },
-        )
+    // #672 core-upgrade decision sheets
+    when (val coreDecision = state.coreDecision) {
+        is com.spela.player.presentation.state.CoreDecision.UpgradeAvailable ->
+            com.spela.player.presentation.ui.feature.ingame.CoreUpgradeDecisionSheet(
+                decision = coreDecision,
+                onTryWithMySave = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionTry) },
+                onKeepNewVersion = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionKeepNew) },
+                onLockOldVersion = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionLockOld) },
+                onRemindLater = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionRemindLater) },
+            )
+        is com.spela.player.presentation.state.CoreDecision.PinPruned ->
+            com.spela.player.presentation.ui.feature.ingame.CorePinPrunedDecisionSheet(
+                decision = coreDecision,
+                onTryWithMySave = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionTry) },
+                onStartFresh = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionStartFresh) },
+                onRemindLater = { viewModel.onIntent(EmulationIntent.ResolveCoreDecisionRemindLater) },
+            )
+        // RehearsalPrompt + RehearsalCrashed sheets land in PR 3c.ii.
+        null -> Unit
+        else -> Unit
     }
 
     // Core mismatch save warning dialog

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SessionDetailScreen.kt
@@ -71,6 +71,7 @@ import com.spela.player.presentation.ui.gamepad.InputMode
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
 import com.spela.player.presentation.ui.gamepad.autoFocus
 import com.spela.player.presentation.ui.feature.sessiondetail.SessionCheatsSection
+import com.spela.player.presentation.ui.feature.sessiondetail.SessionCoreLockChip
 import com.spela.player.presentation.ui.components.SpPlayInfo
 import com.spela.player.presentation.ui.components.social.formatRelativeTime
 import com.spela.player.presentation.ui.theme.SpColor
@@ -193,9 +194,16 @@ fun SessionDetailScreen(
                                 cheatsEnabled = state.cheatsEnabled,
                                 memberCount = session.memberCount,
                                 game = state.game,
+                                pinnedCoreSha256 = session.pinnedCoreSha256,
+                                userLockedCoreVersion = session.userLockedCoreVersion,
                                 onRename = { showRenameDialog = true },
                                 onPlay = { onPlay(session.gameId, session.id) },
                                 onClone = { showCloneDialog = true },
+                                onUnlockCoreVersion = {
+                                    viewModel.onIntent(
+                                        SessionDetailIntent.UnlockCoreVersion(sessionId),
+                                    )
+                                },
                                 modifier = Modifier.padding(horizontal = SpSpacing.ScreenHorizontal),
                             )
                             Spacer(Modifier.height(SpSpacing.XLarge))
@@ -510,9 +518,12 @@ private fun SessionDetailHeader(
     cheatsEnabled: Boolean,
     memberCount: Int,
     game: Game?,
+    pinnedCoreSha256: String?,
+    userLockedCoreVersion: Boolean,
     onRename: () -> Unit,
     onPlay: () -> Unit,
     onClone: () -> Unit,
+    onUnlockCoreVersion: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     var showMoreMenu by remember { mutableStateOf(false) }
@@ -561,6 +572,21 @@ private fun SessionDetailHeader(
                     }
                 }
             }
+        }
+
+        // Locked-to-version chip (#672). Rendered whenever the user has
+        // explicitly locked the session — even if the sha is missing,
+        // because otherwise the user can't see or clear an invisible lock
+        // (`userLockedCoreVersion = true` without a pin should be rare,
+        // but the chip must still appear so the "Use the latest version
+        // instead" escape hatch remains reachable). The chip itself
+        // handles the empty-sha render path gracefully.
+        if (userLockedCoreVersion) {
+            Spacer(Modifier.height(SpSpacing.Default))
+            SessionCoreLockChip(
+                pinnedCoreSha256 = pinnedCoreSha256.orEmpty(),
+                onUnlock = onUnlockCoreVersion,
+            )
         }
 
         // Last played info

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -292,19 +292,20 @@ class EmulationViewModel(
                 }
             }
 
-            // #672 core-upgrade decision — Sheet A resolution
+            // #672 core-upgrade decision — Sheet A/B resolution
             EmulationIntent.ResolveCoreDecisionTry -> resolveCoreDecision(RehearsalEntry.Try)
             EmulationIntent.ResolveCoreDecisionKeepNew -> resolveCoreDecision(RehearsalEntry.KeepNew)
             EmulationIntent.ResolveCoreDecisionLockOld -> resolveCoreDecision(RehearsalEntry.LockOld)
             EmulationIntent.ResolveCoreDecisionRemindLater -> resolveCoreDecision(RehearsalEntry.RemindLater)
+            EmulationIntent.ResolveCoreDecisionStartFresh -> resolveCoreDecision(RehearsalEntry.StartFresh)
         }
     }
 
     /**
-     * Classifies the user's Sheet A choice so [resolveCoreDecision]
+     * Classifies the user's Sheet A/B choice so [resolveCoreDecision]
      * can branch without duplicating side effects for each intent.
      */
-    private enum class RehearsalEntry { Try, KeepNew, LockOld, RemindLater }
+    private enum class RehearsalEntry { Try, KeepNew, LockOld, RemindLater, StartFresh }
 
     /**
      * Applies the side effects of a Sheet A choice (rehearsal mode,
@@ -326,6 +327,7 @@ class EmulationViewModel(
         _state.update { it.copy(coreDecision = null) }
 
         scope.launch(dispatchers.io) {
+            var refiredIntent = pending.copy(skipCoreDecisionPrompt = true)
             when (entry) {
                 RehearsalEntry.Try -> saveManager.rehearsalMode = true
                 RehearsalEntry.KeepNew,
@@ -348,9 +350,21 @@ class EmulationViewModel(
                         }
                     }
                 }
+                RehearsalEntry.StartFresh -> {
+                    saveManager.rehearsalMode = false
+                    saveManager.setSessionAutoLoadSuppressed(
+                        pending.sessionId,
+                        suppressed = true,
+                    )
+                    // Locally also skip the auto-load so this launch
+                    // doesn't try to restore the stale save state —
+                    // the server flag caught on next launch, this
+                    // one needs an immediate runtime override.
+                    refiredIntent = refiredIntent.copy(skipAutoLoad = true)
+                }
             }
             withContext(dispatchers.main) {
-                onIntent(pending.copy(skipCoreDecisionPrompt = true))
+                onIntent(refiredIntent)
             }
         }
     }
@@ -572,6 +586,39 @@ class EmulationViewModel(
                         netplaySessionId != null
                             || sharedSessionId != null
                             || challengeId != null
+                    if (prepared.decisionKind == com.spela.player.domain.usecase.DecisionKind.PinPruned
+                        && !suppressForSpecialMode
+                    ) {
+                        pendingCoreDecisionStart = EmulationIntent.StartGame(
+                            gameId = gameId,
+                            sharedSessionId = sharedSessionId,
+                            turnToken = turnToken,
+                            netplaySessionId = netplaySessionId,
+                            netplayLocalPort = netplayLocalPort,
+                            netplayInputDelay = netplayInputDelay,
+                            netplayIsHost = netplayIsHost,
+                            challengeId = challengeId,
+                            challengeSaveData = challengeSaveDataArg,
+                            skipAutoLoad = skipAutoLoad,
+                            forceNewSession = forceNewSession,
+                            sessionId = saveManager.currentSessionId,
+                        )
+                        withContext(dispatchers.main) {
+                            _state.update {
+                                it.copy(
+                                    isLoading = false,
+                                    showCoreMismatchDialog = false,
+                                    coreDecision = com.spela.player.presentation.state.CoreDecision.PinPruned(
+                                        coreName = prepared.coreName,
+                                        coreDisplayName = prepared.coreDisplayName.ifEmpty { prepared.coreName },
+                                        gameTitle = it.gameTitle.ifEmpty { gameId },
+                                        prunedSha = pinnedSha ?: "",
+                                    ),
+                                )
+                            }
+                        }
+                        return@fold
+                    }
                     if (prepared.decisionKind == com.spela.player.domain.usecase.DecisionKind.UpgradeAvailable
                         && !suppressForSpecialMode
                     ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -221,6 +221,24 @@ class SaveManager(
     }
 
     /**
+     * Writes `autoLoadSuppressed` on [sessionId]. Called after the
+     * user picks "Start fresh" on Sheet B / D — the next launch of
+     * the session must skip the stale save auto-load. Cleared by the
+     * session handler on the first successful manual save. See #672.
+     */
+    suspend fun setSessionAutoLoadSuppressed(sessionId: String?, suppressed: Boolean): Boolean {
+        if (sessionId.isNullOrEmpty()) return false
+        return try {
+            sessionRepository.updateSessionCoreFlags(
+                sessionId,
+                autoLoadSuppressed = suppressed,
+            ).isSuccess
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /**
      * Load SRAM (save data) before starting emulation.
      * Downloads from session SRAM endpoint.
      * If the data starts with ZIP magic bytes, it's a directory-based save (e.g. Dolphin)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModel.kt
@@ -40,6 +40,42 @@ class SessionDetailViewModel(
             SessionDetailIntent.DismissDeleteConfirm -> _state.update { it.copy(showDeleteConfirm = false) }
             SessionDetailIntent.DismissError -> _state.update { it.copy(error = null) }
             SessionDetailIntent.DismissSuccess -> _state.update { it.copy(successMessage = null) }
+            is SessionDetailIntent.UnlockCoreVersion -> unlockCoreVersion(intent.sessionId)
+        }
+    }
+
+    private fun unlockCoreVersion(sessionId: String) {
+        // Optimistic: flip the chip off immediately so the tap feels
+        // responsive on slow connections. Revert in onFailure — matches
+        // the pattern established by `toggleCheatsEnabled` below.
+        val previousSession = _state.value.session
+        if (previousSession != null && previousSession.id == sessionId) {
+            _state.update {
+                it.copy(session = previousSession.copy(userLockedCoreVersion = false))
+            }
+        }
+        scope.launch(dispatchers.io) {
+            sessionRepository.updateSessionCoreFlags(
+                sessionId = sessionId,
+                userLockedCoreVersion = false,
+            ).fold(
+                onSuccess = { updated ->
+                    _state.update {
+                        it.copy(
+                            session = updated,
+                            successMessage = "Lock cleared. We'll check for a newer core next time you play.",
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update {
+                        it.copy(
+                            session = previousSession,
+                            error = error.message,
+                        )
+                    }
+                },
+            )
         }
     }
 

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
@@ -1,0 +1,265 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.domain.model.GameSession
+import com.spela.player.domain.model.SaveState
+import com.spela.player.domain.model.SessionCheatConfig
+import com.spela.player.domain.repository.SessionRepository
+import com.spela.player.presentation.intent.SessionDetailIntent
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Covers the #672 UnlockCoreVersion intent wired up on the session
+ * detail screen. The lock chip's "Use the latest version instead" link
+ * dispatches this intent; the VM must clear `userLockedCoreVersion` on
+ * the server so the next launch re-enters the upgrade decision flow.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionDetailViewModelTest {
+
+    private val testDispatcher = StandardTestDispatcher()
+    private val testDispatchers = object : DispatcherProvider {
+        override val main: CoroutineDispatcher = testDispatcher
+        override val io: CoroutineDispatcher = testDispatcher
+        override val default: CoroutineDispatcher = testDispatcher
+    }
+
+    private lateinit var fakeRepo: FakeSessionRepo
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        fakeRepo = FakeSessionRepo()
+    }
+
+    @AfterTest
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    private fun createViewModel(): SessionDetailViewModel {
+        val scope = CoroutineScope(testDispatcher)
+        return SessionDetailViewModel(
+            sessionRepository = fakeRepo,
+            dispatchers = testDispatchers,
+            scope = scope,
+        )
+    }
+
+    @Test
+    fun unlockCoreVersionClearsFlagOnServerAndUpdatesStateOnSuccess() = runTest(testDispatcher) {
+        fakeRepo.sessions += GameSession(
+            id = "s1",
+            gameId = "g1",
+            name = "Run 1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            userLockedCoreVersion = true,
+        )
+        val vm = createViewModel()
+
+        vm.onIntent(SessionDetailIntent.UnlockCoreVersion("s1"))
+        advanceUntilIdle()
+
+        assertEquals(1, fakeRepo.updateCoreFlagsCalls.size,
+            "unlock must call updateSessionCoreFlags exactly once")
+        val call = fakeRepo.updateCoreFlagsCalls.single()
+        assertEquals("s1", call.sessionId)
+        assertEquals(false, call.userLockedCoreVersion,
+            "unlock must push userLockedCoreVersion=false so the server clears the flag")
+        assertNull(call.autoLoadSuppressed,
+            "unlock must not touch autoLoadSuppressed — that's Sheet B / D's job")
+        assertNull(call.rehearsalCrashPending,
+            "unlock must not touch rehearsalCrashPending — rehearsal is a separate flow")
+
+        val state = vm.state.value
+        val session = state.session
+        assertNotNull(session, "session must be present after the server returns the updated row")
+        assertFalse(session.userLockedCoreVersion,
+            "state's session must reflect the cleared lock")
+        assertEquals(
+            "Lock cleared. We'll check for a newer core next time you play.",
+            state.successMessage,
+            "success toast must match the spec copy so users see why the chip disappeared",
+        )
+        assertNull(state.error)
+    }
+
+    @Test
+    fun unlockCoreVersionRevertsOptimisticUpdateOnFailure() = runTest(testDispatcher) {
+        // Seed a session + LoadSession so the VM has a "previous"
+        // session to revert to — this test exercises the revert path
+        // on the optimistic-update happy/sad split.
+        fakeRepo.sessions += GameSession(
+            id = "s1",
+            gameId = "g1",
+            name = "Run 1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            userLockedCoreVersion = true,
+        )
+        fakeRepo.failUpdateCoreFlagsWith = RuntimeException("network down")
+        val vm = createViewModel()
+        vm.onIntent(SessionDetailIntent.LoadSession("s1"))
+        advanceUntilIdle()
+
+        vm.onIntent(SessionDetailIntent.UnlockCoreVersion("s1"))
+        advanceUntilIdle()
+
+        val state = vm.state.value
+        assertEquals("network down", state.error,
+            "failure must surface as a dismissable error so the user can retry")
+        val session = state.session
+        assertNotNull(session, "revert path must restore the session we optimistically flipped")
+        assertTrue(session.userLockedCoreVersion,
+            "failure must revert the optimistic unlock — the chip reappears so the user knows the action didn't stick",
+        )
+        assertNull(state.successMessage)
+    }
+
+    @Test
+    fun unlockingAnUnknownSessionReturnsErrorInsteadOfCrashing() = runTest(testDispatcher) {
+        // Rare race: user taps the link right as the session is being
+        // deleted on another device. The fake's "session not found"
+        // failure mirrors what the real server returns (404).
+        val vm = createViewModel()
+
+        vm.onIntent(SessionDetailIntent.UnlockCoreVersion("does-not-exist"))
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.error.orEmpty().isNotEmpty(),
+            "missing session must surface a user-visible error, not silently swallow")
+    }
+}
+
+/**
+ * Minimal SessionRepository stub scoped to what SessionDetailViewModelTest
+ * exercises. Records every call to [updateSessionCoreFlags] so the test
+ * can assert the exact flag payload that reached the server.
+ */
+private class FakeSessionRepo : SessionRepository {
+    val sessions: MutableList<GameSession> = mutableListOf()
+
+    data class UpdateCoreFlagsInvocation(
+        val sessionId: String,
+        val userLockedCoreVersion: Boolean?,
+        val autoLoadSuppressed: Boolean?,
+        val rehearsalCrashPending: Boolean?,
+    )
+    val updateCoreFlagsCalls: MutableList<UpdateCoreFlagsInvocation> = mutableListOf()
+
+    /** Test hook: when set, [updateSessionCoreFlags] fails with this error. */
+    var failUpdateCoreFlagsWith: Throwable? = null
+
+    override suspend fun getSessionsForGame(gameId: String): Result<List<GameSession>> =
+        Result.success(sessions.filter { it.gameId == gameId })
+
+    override suspend fun getSession(sessionId: String): Result<GameSession> {
+        val s = sessions.find { it.id == sessionId }
+            ?: return Result.failure(Exception("Session not found"))
+        return Result.success(s)
+    }
+
+    override suspend fun createSession(gameId: String, name: String): Result<GameSession> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun createSessionFromSharedSave(gameId: String, saveId: String): Result<GameSession> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun updateSession(sessionId: String, name: String?, coreName: String?): Result<GameSession> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun updateSessionCoreFlags(
+        sessionId: String,
+        userLockedCoreVersion: Boolean?,
+        autoLoadSuppressed: Boolean?,
+        rehearsalCrashPending: Boolean?,
+    ): Result<GameSession> {
+        updateCoreFlagsCalls += UpdateCoreFlagsInvocation(
+            sessionId = sessionId,
+            userLockedCoreVersion = userLockedCoreVersion,
+            autoLoadSuppressed = autoLoadSuppressed,
+            rehearsalCrashPending = rehearsalCrashPending,
+        )
+        failUpdateCoreFlagsWith?.let { return Result.failure(it) }
+        val idx = sessions.indexOfFirst { it.id == sessionId }
+        if (idx < 0) return Result.failure(Exception("Session not found"))
+        var updated = sessions[idx]
+        if (userLockedCoreVersion != null) updated = updated.copy(userLockedCoreVersion = userLockedCoreVersion)
+        if (autoLoadSuppressed != null) updated = updated.copy(autoLoadSuppressed = autoLoadSuppressed)
+        if (rehearsalCrashPending != null) updated = updated.copy(rehearsalCrashPending = rehearsalCrashPending)
+        sessions[idx] = updated
+        return Result.success(sessions[idx])
+    }
+
+    override suspend fun deleteSession(sessionId: String): Result<Unit> =
+        Result.success(Unit)
+
+    override suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>> =
+        Result.success(emptyList())
+
+    override suspend fun uploadSessionSave(
+        sessionId: String,
+        name: String,
+        data: ByteArray,
+        screenshot: ByteArray?,
+        coreName: String,
+    ): Result<SaveState> = Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun uploadSessionAutoSave(
+        sessionId: String,
+        data: ByteArray,
+        screenshot: ByteArray?,
+        coreName: String,
+    ): Result<Unit> = Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun uploadSlotSave(
+        sessionId: String,
+        slot: Int,
+        data: ByteArray,
+        screenshot: ByteArray?,
+        coreName: String,
+    ): Result<SaveState> = Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun downloadSlotSave(sessionId: String, slot: Int): Result<ByteArray> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String): Result<Unit> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun downloadSessionSram(sessionId: String): Result<ByteArray> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun getSessionCheats(sessionId: String): Result<SessionCheatConfig> =
+        Result.success(SessionCheatConfig(cheatsEnabled = false, enabledIndices = emptyList()))
+
+    override suspend fun updateSessionCheats(
+        sessionId: String,
+        cheatsEnabled: Boolean,
+        enabledIndices: List<Int>,
+    ): Result<SessionCheatConfig> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun cloneSession(sessionId: String, name: String?, saveId: Long?): Result<GameSession> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/PrepareGameUseCaseTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/PrepareGameUseCaseTest.kt
@@ -3,6 +3,7 @@ package com.spela.player.domain.usecase
 import com.spela.player.domain.model.DownloadProgress
 import com.spela.player.domain.model.DownloadedGame
 import com.spela.player.domain.model.LibretroCore
+import com.spela.player.domain.repository.CorePrunedException
 import com.spela.player.domain.repository.CoreRepository
 import com.spela.player.domain.repository.DownloadRepository
 import kotlinx.coroutines.flow.Flow
@@ -257,6 +258,90 @@ class PrepareGameUseCaseTest {
             "skipCoreDecisionPrompt must short-circuit the detection block on re-entry")
     }
 
+    // ── PinPruned detection — pinned binary rotated out of server retention ──
+
+    @Test
+    fun signalsPinPrunedWhenLockedSessionsPinnedBinaryIsGone() = runTest {
+        // Server fingerprinted the core but the *specific* pinned
+        // historical binary was rotated out. For a user-locked session
+        // with saves, the VM must surface Sheet B instead of silently
+        // falling through with a toast.
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = true,
+            // downloadCoreByHash returns CorePrunedException — the pinned
+            // binary is no longer in the server's history.
+            hashDownloadResult = Result.failure(CorePrunedException("aa".repeat(32))),
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            sessionHasSaves = true,
+            userLockedCoreVersion = true,
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.PinPruned, result.decisionKind,
+            "user-locked + pruned pin must surface Sheet B, not a silent toast")
+        assertEquals("/local/core.so", result.corePath,
+            "corePath still resolves to the fallback so Sheet B can preview with a working core")
+        assertNull(result.coreVersionWarning,
+            "Sheet B replaces the legacy toast — warning must be suppressed when decisionKind is PinPruned")
+    }
+
+    @Test
+    fun pinPrunedStaysSilentWhenSessionIsNotUserLocked() = runTest {
+        // Same pruning event, but the user never explicitly locked — the
+        // legacy silent-fallback-with-warning behaviour is preserved so
+        // we don't churn the pre-#672 UX for the common unpinned case.
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = true,
+            hashDownloadResult = Result.failure(CorePrunedException("aa".repeat(32))),
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            sessionHasSaves = true,
+            userLockedCoreVersion = false, // not locked — legacy path
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.None, result.decisionKind,
+            "non-locked sessions keep the legacy silent-fallback behaviour")
+        assertEquals(
+            "Original core version no longer available. The latest core may not load this save correctly.",
+            result.coreVersionWarning,
+            "legacy warning copy must still be shown when decisionKind is None",
+        )
+    }
+
+    @Test
+    fun pinPrunedSkipsWhenSkipFlagIsSet() = runTest {
+        // Re-entry after the user resolved Sheet B — the VM re-fires
+        // with skipCoreDecisionPrompt = true. Detection must not loop
+        // back into PinPruned on the same launch.
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = true,
+            hashDownloadResult = Result.failure(CorePrunedException("aa".repeat(32))),
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            sessionHasSaves = true,
+            userLockedCoreVersion = true,
+            skipCoreDecisionPrompt = true,
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.None, result.decisionKind,
+            "skipCoreDecisionPrompt must short-circuit PinPruned on re-entry")
+    }
+
     @Test
     fun upgradeAvailableResultCarriesServerCoreSha() = runTest {
         // The VM reads prepared.serverCoreSha to populate Sheet A's
@@ -306,6 +391,11 @@ private class FakeCoreRepository(
     private val isCurrent: Boolean?,
     private val downloadResult: Result<String> = Result.success("/local/downloaded-core.so"),
     private val serverSha: String? = null,
+    // PinPruned tests override this with Result.failure(CorePrunedException(...)).
+    // Default stays on the old "not exercised here" marker for the pre-3c tests.
+    private val hashDownloadResult: Result<String> = Result.failure(
+        UnsupportedOperationException("pinned path not exercised here"),
+    ),
 ) : CoreRepository {
     var downloadCoreCalls = 0
         private set
@@ -329,7 +419,7 @@ private class FakeCoreRepository(
         coreName: String,
         sha256: String,
         onProgress: (Float) -> Unit,
-    ): Result<String> = Result.failure(UnsupportedOperationException("pinned path not exercised here"))
+    ): Result<String> = hashDownloadResult
 
     override suspend fun getLocalCorePath(coreName: String): String? = local
 


### PR DESCRIPTION
PR 3c.i in the #672 *informed core-upgrade decision* series. Adds the second decision sheet (Sheet B — pinned binary pruned out of server retention) and mounts the session-detail "Locked to version" chip discovered on PR #675 into the session detail screen.

Builds on #673 (server flags), #674 (player plumbing), #675 (components), #676 (Sheet A + detection + VM).

## Behaviour

- **PinPruned detection** — `PrepareGameUseCase` now classifies pruned-pin events on user-locked sessions as `DecisionKind.PinPruned` instead of the silent `coreVersionWarning` toast. Non-locked sessions keep the legacy silent-fallback behaviour to avoid churning the pre-#672 UX.
- **Sheet B** — `CorePinPrunedDecisionSheet` (role component on `SpDecisionSheet`). Title "The older version isn't available anymore", primary "Try with my save", secondary "Start fresh anyway", more-options "Remind me the next time I play this". Body verbatim against spec key `core_upd.sheet_b.body`.
- **InGameOverlay routing** — switches between Sheet A and Sheet B based on the `CoreDecision` sealed variant.
- **Start Fresh handler** — new `EmulationIntent.ResolveCoreDecisionStartFresh` + `RehearsalEntry.StartFresh` in the VM; sets `AutoLoadSuppressed=true` on the session and re-fires `StartGame` with `skipAutoLoad=true`. Cleared on the first successful manual save.
- **Session-detail lock chip** — `SessionDetailScreen` now mounts `SessionCoreLockChip` whenever `userLockedCoreVersion=true`. The chip's "Use the latest version instead" link dispatches `SessionDetailIntent.UnlockCoreVersion`, which the VM handles by clearing the flag on the server (optimistic UI + revert on failure). Toast: `"Lock cleared. We'll check for a newer core next time you play."`

## Review-gate fixes

Both `code-reviewer` and `ui-agent` ran in plan mode before push. Fixes applied:

- Sheet B body: removed off-spec game-title interpolation (Sheet A carries the title; Sheet B is intentionally generic).
- Optimistic UI on unlock so slow-network taps feel responsive.
- Lock chip renders even when `pinnedCoreSha256` is empty (defence in depth — keeps the unlock escape hatch reachable in pathological data states).
- `Role.Button` + `focusable()` on the unlock link so DPAD/gamepad focus traversal lands on it.

## Tests

Total: 13 new test cases across 3 suites; all green locally.

- `PrepareGameUseCaseTest` — +3 PinPruned cases (locked + pruned, unlocked stays silent, skipFlag short-circuits).
- `CorePinPrunedDecisionSheetTest` — 5 cases (spec copy, display-name fallback, primary/secondary/more wiring).
- `SessionCoreLockChipTest` — +2 fallback cases (empty/short sha render `"Locked to this core version"` and the unlock link still fires).
- `SessionDetailViewModelTest` — 3 cases (success path with optimistic flip + spec toast, revert on network failure, missing-session 404).

`./run-desktop-tests.sh` — 509 shared + 18 desktop component tests pass. One unrelated flake in `AppLaunchAndConnectionTest.addServerValidatesAndSavesOnSuccess` (passes in isolation, doesn't touch any code in this PR).

`./gradlew :shared:detektMainDesktop :desktop:detektMainDesktop :android:detektDebugAndroid` — clean.

## What's next

- **PR 3c.ii** — Sheet C ("Did it work?"), Sheet D (rehearsal crashed), `SpInGameBanner` wiring during rehearsal, crash recovery sentinel.
- **PR 3c.iii** — port `CoreMismatchDialog` from raw `Box + Scrim` to `SpDecisionSheet`; refresh `autoUpdateCoresEnabled` settings copy.
- **PR 4/5** — Android smoke test against real backend.
- **PR 5/5** — web session-detail "Core version" read-only row.

Refs #672, #555