### PR TITLE
feat(#672): crash sentinel + dialog port + settings copy (PR 3c.iii/5)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/CoreMismatchDialogTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/components/CoreMismatchDialogTest.kt
@@ -1,0 +1,119 @@
+package com.spela.player.desktop.components
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.runComposeUiTest
+import com.spela.player.presentation.ui.feature.ingame.CoreMismatchDialog
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * Post-port coverage for [CoreMismatchDialog] — the post-load save
+ * state mismatch dialog, ported from a raw `Box + Scrim + clickable +
+ * SurfaceElevated` pattern to [SpDecisionSheet] in #672 PR 3c.iii.
+ * Pins the new tone-aligned copy (no "warning", no "corruption") and
+ * the three-action routing.
+ */
+@OptIn(ExperimentalTestApi::class)
+class CoreMismatchDialogTest {
+
+    @Test
+    fun rendersRefreshedCopyWithCoreNames() = runComposeUiTest {
+        setContent {
+            CoreMismatchDialog(
+                saveCoreName = "snes9x",
+                currentCoreName = "nestopia",
+                onTryAnyway = {},
+                onGameSaveOnly = {},
+                onStartFresh = {},
+            )
+        }
+
+        onNodeWithTag("core-mismatch-dialog").assertIsDisplayed()
+        onNodeWithText("We couldn't load that save state").assertIsDisplayed()
+        onNodeWithText(
+            "This save was made with snes9x — we're now running nestopia. " +
+                "Loading might still work, but you can also start from your " +
+                "in-game save or begin a fresh run.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun fallsBackToGenericCoreLabelsWhenNamesAreEmpty() = runComposeUiTest {
+        // Defensive: if the VM couldn't resolve one of the core names,
+        // the dialog must still produce a readable body — "the
+        // original core" / "the current core" placeholders.
+        setContent {
+            CoreMismatchDialog(
+                saveCoreName = "",
+                currentCoreName = "",
+                onTryAnyway = {},
+                onGameSaveOnly = {},
+                onStartFresh = {},
+            )
+        }
+
+        onNodeWithText(
+            "This save was made with the original core — we're now running " +
+                "the current core. Loading might still work, but you can also " +
+                "start from your in-game save or begin a fresh run.",
+        ).assertIsDisplayed()
+    }
+
+    @Test
+    fun primaryFiresOnTryAnyway() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            CoreMismatchDialog(
+                saveCoreName = "snes9x",
+                currentCoreName = "nestopia",
+                onTryAnyway = { clicks++ },
+                onGameSaveOnly = {},
+                onStartFresh = {},
+            )
+        }
+
+        onNodeWithText("Try loading anyway").assertIsDisplayed()
+        onNodeWithTag("sp-decision-primary").performClick()
+        assertEquals(1, clicks)
+    }
+
+    @Test
+    fun secondaryFiresOnGameSaveOnly() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            CoreMismatchDialog(
+                saveCoreName = "snes9x",
+                currentCoreName = "nestopia",
+                onTryAnyway = {},
+                onGameSaveOnly = { clicks++ },
+                onStartFresh = {},
+            )
+        }
+
+        onNodeWithText("Start with game save only").assertIsDisplayed()
+        onNodeWithTag("sp-decision-secondary").performClick()
+        assertEquals(1, clicks)
+    }
+
+    @Test
+    fun tertiaryFiresOnStartFresh() = runComposeUiTest {
+        var clicks = 0
+        setContent {
+            CoreMismatchDialog(
+                saveCoreName = "snes9x",
+                currentCoreName = "nestopia",
+                onTryAnyway = {},
+                onGameSaveOnly = {},
+                onStartFresh = { clicks++ },
+            )
+        }
+
+        onNodeWithText("Start fresh").assertIsDisplayed()
+        onNodeWithTag("sp-decision-tertiary").performClick()
+        assertEquals(1, clicks)
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/CoreMismatchDialog.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/CoreMismatchDialog.kt
@@ -1,115 +1,58 @@
 package com.spela.player.presentation.ui.feature.ingame
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.buildAnnotatedString
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.withStyle
-import com.spela.player.presentation.ui.components.SpButton
-import com.spela.player.presentation.ui.components.SpSecondaryButton
-import com.spela.player.presentation.ui.components.SpButtonStyle
-import com.spela.player.presentation.ui.theme.SpColor
-import com.spela.player.presentation.ui.theme.SpSpacing
-import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.presentation.ui.components.SpDecisionAction
+import com.spela.player.presentation.ui.components.SpDecisionActionStyle
+import com.spela.player.presentation.ui.components.SpDecisionSheet
 
 /**
- * Dialog shown when auto-load detects that the last save point was created
- * with a different emulator core than the one currently in use.
- * Presents three options to the user.
+ * Post-load core mismatch dialog. Fires when auto-load successfully
+ * downloaded a save state but `retro_unserialize` rejected it because
+ * the save was made with a different core. Distinct from the #672
+ * pre-load decision flow (Sheets A–D) which runs *before* the core is
+ * loaded — this one runs *after* a load attempt fails.
+ *
+ * Ported from the raw `Box + Scrim + clickable + SurfaceElevated`
+ * pattern to [SpDecisionSheet] in #672 PR 3c.iii. Copy was refreshed
+ * to match the spec's no-warning / no-corruption tone (`design-proposals/
+ * core-upgrade-decision-spec.md` §"Tone rules").
  */
 @Composable
-internal fun CoreMismatchDialog(
+fun CoreMismatchDialog(
     saveCoreName: String,
     currentCoreName: String,
     onTryAnyway: () -> Unit,
     onGameSaveOnly: () -> Unit,
     onStartFresh: () -> Unit,
 ) {
-    Box(
-        modifier = Modifier
-            .fillMaxSize()
-            .background(SpColor.Scrim)
-            .clickable(
-                interactionSource = remember { MutableInteractionSource() },
-                indication = null,
-                onClick = {}, // Block click-through
-            ),
-        contentAlignment = Alignment.Center,
-    ) {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth(0.75f)
-                .clip(RoundedCornerShape(SpSpacing.RadiusXLarge))
-                .background(SpColor.SurfaceElevated)
-                .clickable(
-                    interactionSource = remember { MutableInteractionSource() },
-                    indication = null,
-                    onClick = {}, // Prevent click-through
-                )
-                .padding(SpSpacing.XLarge),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            Text(
-                text = "Save State Compatibility Warning",
-                style = SpTypography.HeadlineMedium,
-                color = SpColor.Warning,
-            )
-            Spacer(Modifier.height(SpSpacing.Small))
+    val saveLabel = saveCoreName.ifEmpty { "the original core" }
+    val currentLabel = currentCoreName.ifEmpty { "the current core" }
+    val body = "This save was made with $saveLabel — we're now running " +
+        "$currentLabel. Loading might still work, but you can also start " +
+        "from your in-game save or begin a fresh run."
 
-            val bodyText = buildAnnotatedString {
-                val boldStyle = SpanStyle(fontWeight = FontWeight.Bold, color = SpColor.OnBackground)
-                append("Your last save state was created with a different emulator configuration (")
-                withStyle(boldStyle) { append(saveCoreName) }
-                append(" vs current ")
-                withStyle(boldStyle) { append(currentCoreName) }
-                append("). It may not load correctly on this platform.")
-            }
-            Text(
-                text = bodyText,
-                style = SpTypography.BodyMedium,
-                color = SpColor.OnBackgroundSecondary,
-                textAlign = TextAlign.Center,
-            )
-            Spacer(Modifier.height(SpSpacing.XLarge))
-            Column(
-                modifier = Modifier.fillMaxWidth(),
-                verticalArrangement = Arrangement.spacedBy(SpSpacing.Small),
-            ) {
-                SpButton(
-                    text = "Try Loading Anyway",
-                    onClick = onTryAnyway,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                SpSecondaryButton(
-                    text = "Start with Game Save Only",
-                    onClick = onGameSaveOnly,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-                SpButton(
-                    text = "Start Fresh",
-                    onClick = onStartFresh,
-                    style = SpButtonStyle.Ghost,
-                    modifier = Modifier.fillMaxWidth(),
-                )
-            }
-        }
-    }
+    SpDecisionSheet(
+        title = "We couldn't load that save state",
+        body = body,
+        primary = SpDecisionAction(
+            label = "Try loading anyway",
+            onClick = onTryAnyway,
+            style = SpDecisionActionStyle.Primary,
+        ),
+        secondary = SpDecisionAction(
+            label = "Start with game save only",
+            onClick = onGameSaveOnly,
+            style = SpDecisionActionStyle.Secondary,
+        ),
+        tertiary = SpDecisionAction(
+            label = "Start fresh",
+            onClick = onStartFresh,
+            style = SpDecisionActionStyle.Ghost,
+        ),
+        // Back-button maps to the safest non-destructive choice —
+        // "game save only" preserves the user's progress without
+        // attempting the risky save-state load.
+        onDismiss = onGameSaveOnly,
+        testTagName = "core-mismatch-dialog",
+    )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsCategoryContent.kt
@@ -202,8 +202,12 @@ private fun androidx.compose.foundation.lazy.LazyListScope.emulationContent(
                 )
                 SettingsDivider()
                 SettingsToggle(
-                    title = "Auto Update Cores",
-                    subtitle = "Silently re-download emulator cores when the server has a newer build. Turn off to keep the locally cached version until you manually refresh.",
+                    // #672 spec keys core_upd.settings.auto_update_label /
+                    // _desc — the previous copy was technical and didn't
+                    // make clear what "off" meant; the new copy aligns
+                    // with the rest of the core-upgrade decision tone.
+                    title = "Automatically update cores",
+                    subtitle = "When off, we'll only switch cores when you say so.",
                     isChecked = state.autoUpdateCoresEnabled,
                     onToggle = { viewModel.onIntent(SettingsIntent.ToggleAutoUpdateCores) },
                 )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -350,8 +350,24 @@ class EmulationViewModel(
                     )
                 }
             EmulationIntent.RehearsalCrashStartFresh -> rehearsalCrashStartFresh()
-            EmulationIntent.RehearsalCrashDismiss ->
-                _state.update { it.copy(coreDecision = null) }
+            EmulationIntent.RehearsalCrashDismiss -> rehearsalCrashDismiss()
+        }
+    }
+
+    /**
+     * Sheet D more-options — "Just go back — I'll try again later".
+     * Closes the sheet without changing core-mode or auto-load state.
+     * Clears the crash-recovery sentinel because the user explicitly
+     * acknowledged the crash here; leaving it set would re-route them
+     * to Sheet D on the next launch, which contradicts the "try again
+     * later" intent.
+     */
+    private fun rehearsalCrashDismiss() {
+        saveManager.rehearsalMode = false
+        val sessionId = _state.value.sessionId
+        _state.update { it.copy(coreDecision = null) }
+        scope.launch(dispatchers.io) {
+            saveManager.setSessionRehearsalCrashPending(sessionId, pending = false)
         }
     }
 
@@ -361,14 +377,22 @@ class EmulationViewModel(
      * pin itself is not written here; `Phase 3` pin-advancement fires
      * on the first successful save-write on the new core, matching
      * Sheet A's "Keep the new version anyway" behaviour.
+     *
+     * Also clears the #672 crash-recovery sentinel — the run reached a
+     * clean resolution without the process dying, so the next launch
+     * must not route to Sheet D.
      */
     private fun rehearsalKeepNew() {
         saveManager.rehearsalMode = false
+        val sessionId = _state.value.sessionId
         _state.update {
             it.copy(
                 coreDecision = null,
                 showRehearsalConfirmSheet = false,
             )
+        }
+        scope.launch(dispatchers.io) {
+            saveManager.setSessionRehearsalCrashPending(sessionId, pending = false)
         }
     }
 
@@ -413,6 +437,11 @@ class EmulationViewModel(
             }
             // Write succeeded — now safe to exit rehearsal + relaunch.
             saveManager.rehearsalMode = false
+            // Clear the crash-recovery sentinel: the user resolved the
+            // rehearsal cleanly. Losing the clear would cause the next
+            // launch to spuriously route to Sheet D, so we fire-and-
+            // continue (best effort) but don't block the relaunch.
+            saveManager.setSessionRehearsalCrashPending(sessionId, pending = false)
             withContext(dispatchers.main) {
                 _state.update { it.copy(coreDecision = null) }
                 // skipCoreDecisionPrompt=true is defence in depth —
@@ -455,6 +484,10 @@ class EmulationViewModel(
             } else {
                 true // no session — nothing to persist
             }
+            // Clear the crash-recovery sentinel: the user resolved the
+            // rehearsal cleanly (even if through a crash), so we don't
+            // want the next launch to re-route to Sheet D.
+            saveManager.setSessionRehearsalCrashPending(sessionId, pending = false)
             if (!persisted) {
                 withContext(dispatchers.main) {
                     _state.update {
@@ -509,6 +542,15 @@ class EmulationViewModel(
             when (entry) {
                 RehearsalEntry.Try -> {
                     saveManager.rehearsalMode = true
+                    // #672 PR 3c.iii — set the crash-recovery sentinel
+                    // BEFORE the new core gets a chance to crash. If
+                    // the player process dies mid-rehearsal, this flag
+                    // surviving on the server tells the next launch to
+                    // route the user to Sheet D. Failure to write is
+                    // logged but doesn't block the rehearsal — losing
+                    // the sentinel only degrades crash-recovery, not
+                    // the active session.
+                    saveManager.setSessionRehearsalCrashPending(pending.sessionId, pending = true)
                     // Build a RehearsalPrompt from whatever Sheet A was
                     // showing so the banner renders the same core name
                     // the user just acknowledged. UpgradeAvailable →

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -239,6 +239,31 @@ class SaveManager(
     }
 
     /**
+     * Writes `rehearsalCrashPending` on [sessionId]. Called immediately
+     * before entering rehearsal mode (with [pending] = true) and after
+     * a clean Sheet C / Sheet D resolution (with [pending] = false).
+     * Surviving the app process means the previous run crashed mid-
+     * rehearsal — on next session restore the player checks this flag
+     * and routes the user directly to Sheet D so they can recover.
+     *
+     * Returns `true` on success, `false` if the write failed; callers
+     * may proceed with the local rehearsal anyway because losing the
+     * sentinel only degrades crash-recovery, not the current session.
+     * See #672 spec §"Crash recovery" / PR 3c.iii.
+     */
+    suspend fun setSessionRehearsalCrashPending(sessionId: String?, pending: Boolean): Boolean {
+        if (sessionId.isNullOrEmpty()) return false
+        return try {
+            sessionRepository.updateSessionCoreFlags(
+                sessionId,
+                rehearsalCrashPending = pending,
+            ).isSuccess
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    /**
      * Load SRAM (save data) before starting emulation.
      * Downloads from session SRAM endpoint.
      * If the data starts with ZIP magic bytes, it's a directory-based save (e.g. Dolphin)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelRehearsalTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelRehearsalTest.kt
@@ -5,6 +5,7 @@ import com.spela.player.presentation.state.CoreDecision
 import com.spela.player.presentation.viewmodel.emulation.EmulationViewModelTestBuilder
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -166,6 +167,60 @@ class EmulationViewModelRehearsalTest {
         )
         assertEquals(0, builder.sessionRepository.updateSessionCoreFlagsCalls.size,
             "CrashDismiss must not write any server flags — it's a 'try again later' close",
+        )
+    }
+
+    // ── Crash-recovery sentinel lifecycle (PR 3c.iii) ────────────
+
+    @Test
+    fun keepNewClearsCrashSentinel() = runTest {
+        val vm = builder.build()
+        builder.mutableState.update { it.copy(sessionId = "s1") }
+
+        vm.onIntent(EmulationIntent.RehearsalCompletedKeepNew)
+        builder.advanceTimeBy(100)
+
+        val clearCalls = builder.sessionRepository.updateSessionCoreFlagsCalls
+            .filter { it.rehearsalCrashPending == false }
+        assertEquals(1, clearCalls.size,
+            "KeepNew must clear rehearsalCrashPending so the next launch doesn't re-route to Sheet D",
+        )
+        assertEquals("s1", clearCalls.single().sessionId)
+    }
+
+    @Test
+    fun crashDismissClearsCrashSentinelAndExitsRehearsal() = runTest {
+        val vm = builder.build()
+        builder.mutableState.update { it.copy(sessionId = "s1") }
+        builder.saveManager.rehearsalMode = true
+
+        vm.onIntent(EmulationIntent.RehearsalCrashed("nestopia", "Nestopia UE"))
+        builder.advanceTimeBy(50)
+        vm.onIntent(EmulationIntent.RehearsalCrashDismiss)
+        builder.advanceTimeBy(100)
+
+        assertFalse(builder.saveManager.rehearsalMode,
+            "CrashDismiss must exit rehearsal mode — the user explicitly acknowledged the crash",
+        )
+        val clearCalls = builder.sessionRepository.updateSessionCoreFlagsCalls
+            .filter { it.rehearsalCrashPending == false }
+        assertEquals(1, clearCalls.size,
+            "CrashDismiss must clear rehearsalCrashPending so the next launch doesn't re-route to Sheet D",
+        )
+    }
+
+    @Test
+    fun crashDismissWithoutSessionIsNoOp() = runTest {
+        val vm = builder.build()
+        // No session bound on state — defensive path. Must not crash
+        // and must not write any server flags.
+        vm.onIntent(EmulationIntent.RehearsalCrashed("nestopia", "Nestopia UE"))
+        builder.advanceTimeBy(50)
+        vm.onIntent(EmulationIntent.RehearsalCrashDismiss)
+        builder.advanceTimeBy(100)
+
+        assertEquals(0, builder.sessionRepository.updateSessionCoreFlagsCalls.size,
+            "CrashDismiss with no sessionId must not attempt a flag write",
         )
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -585,6 +585,14 @@ class EmulationViewModelTestBuilder {
      */
     lateinit var saveManager: SaveManager
 
+    /**
+     * Exposed so VM tests can seed state fields (e.g. `sessionId`)
+     * without walking the full StartGame pipeline. Most tests should
+     * prefer intents over direct state pokes — use this sparingly and
+     * only when driving a specific branch is impractical otherwise.
+     */
+    lateinit var mutableState: MutableStateFlow<EmulationState>
+
     /** Advance the VM's virtual clock by [ms] milliseconds and process pending tasks. */
     fun advanceTimeBy(ms: Long) {
         vmScheduler.advanceTimeBy(ms)
@@ -597,14 +605,15 @@ class EmulationViewModelTestBuilder {
         connectivityMonitor = ConnectivityMonitor(apiClient, dispatchers, vmScope)
         presenceService = PresenceService(apiClient, StubMockEngineFactory, dispatchers, vmScope)
         val gamepadPortManager = GamepadPortManager(keyMappingRepository)
-        val mutableState = MutableStateFlow(EmulationState())
+        mutableState = MutableStateFlow(EmulationState())
+        val mutableStateLocal = mutableState
 
         val saveManagerLocal = SaveManager(
             saveDataRepository = saveDataRepository,
             connectivityMonitor = connectivityMonitor,
             libretroController = libretroController,
             screenshotCapture = screenshotCapture,
-            _state = mutableState,
+            _state = mutableStateLocal,
             dispatchers = dispatchers,
             scope = vmScope,
             sessionRepository = sessionRepository,
@@ -614,7 +623,7 @@ class EmulationViewModelTestBuilder {
             challengeRepository = challengeRepository,
             libretroController = libretroController,
             screenshotCapture = screenshotCapture,
-            _state = mutableState,
+            _state = mutableStateLocal,
             dispatchers = dispatchers,
             scope = vmScope,
         )
@@ -623,7 +632,7 @@ class EmulationViewModelTestBuilder {
             libretroController = libretroController,
             apiClient = apiClient,
             engineFactory = StubMockEngineFactory,
-            _state = mutableState,
+            _state = mutableStateLocal,
             dispatchers = dispatchers,
             scope = vmScope,
         )
@@ -644,7 +653,7 @@ class EmulationViewModelTestBuilder {
             saveManager = saveManagerLocal,
             challengeManager = challengeManager,
             netplayManager = netplayManager,
-            _state = mutableState,
+            _state = mutableStateLocal,
             dispatchers = dispatchers,
             scope = vmScope,
             biosRepository = biosRepository,


### PR DESCRIPTION
PR 3c.iii in the #672 *informed core-upgrade decision* series. Wraps up the player-side scope with three independent cleanups. Builds on #678 (rehearsal Sheets C/D + banner).

## Behaviour

### 1. Crash-recovery sentinel
`SaveManager.setSessionRehearsalCrashPending(sessionId, pending)` writes the server-side `rehearsalCrashPending` flag. The VM:
- Sets the flag in `resolveCoreDecision`'s Try branch (before the new core gets a chance to crash).
- Clears it on every clean Sheet C / Sheet D resolution: `rehearsalKeepNew`, `rehearsalLockOld` (on success only), `rehearsalCrashStartFresh`, and the new `rehearsalCrashDismiss` path.

Surviving the app process means a previous run crashed mid-rehearsal. Relaunch routing to Sheet D lives in a follow-up — this PR persists the signal so it's available when the routing lands.

### 2. CoreMismatchDialog ported to SpDecisionSheet
- Was: raw `Box + Scrim + clickable + SurfaceElevated` with a red `SpColor.Warning` title and the word "Warning" in the heading.
- Now: `SpDecisionSheet` with refreshed copy matching spec tone — no "warning", no "corruption", no red. Title `"We couldn't load that save state"` + a calm body. Three actions in primary/secondary/tertiary slots so all three are peer-visible (no "More options" expander).

This dialog runs **after** `retro_unserialize` rejects a downloaded save state — it's the post-load fallback path, distinct from the pre-load Sheets A–D.

### 3. Settings copy refresh
`autoUpdateCoresEnabled` toggle uses the spec's canonical `core_upd.settings.auto_update_label` / `_desc`: `"Automatically update cores"` + `"When off, we'll only switch cores when you say so."`

## Review-gate notes

Both `code-reviewer` and `ui-agent` ran in plan mode before push. UI agent: ship — minor flag for narrow-Android title-wrap visual check. Code-reviewer flagged a sentinel-cancellation concern in `rehearsalLockOld`; on inspection the sibling path `rehearsalCrashStartFresh` uses the same single-launch pattern and `vmScope` outlives `StartGame` — there's no race. No code change required.

## Tests

8 new test cases all green locally.

- `CoreMismatchDialogTest` — 5 cases (refreshed title/body, empty-name fallback to "the original/current core", primary/secondary/tertiary action routing).
- `EmulationViewModelRehearsalTest` — +3 sentinel cases (KeepNew clear, CrashDismiss clear+exit, no-session no-op).
- `EmulationTestStubs` — `mutableState` lateinit exposed so VM tests can seed `sessionId` without walking the full StartGame pipeline.

`./run-desktop-tests.sh` — 521 shared + 18 desktop component tests pass. Pre-existing flaky `FramerateRegressionTest` passes in isolation, unrelated to this PR.

`./gradlew :shared:detektMainDesktop :desktop:detektMainDesktop :android:detektDebugAndroid` — clean.

## Deferred

- Session restore-on-launch checking the sentinel and routing to Sheet D for the affected session.
- Wiring "Report this to the server admin" to a real endpoint.
- "Switch to older version for comparison" banner secondary action.
- **PR 4/5** — Android smoke test against real backend.
- **PR 5/5** — web session-detail "Core version" read-only row.

Refs #672, #555