### PR TITLE
feat(#672): web session-detail core-version row + preferences copy (PR 5/5)

### DIFF
--- a/web/src/features/preferences/components/emulation-settings-card.tsx
+++ b/web/src/features/preferences/components/emulation-settings-card.tsx
@@ -41,9 +41,13 @@ const TOGGLES: Array<{
   },
   {
     key: "autoUpdateCoresEnabled",
-    label: "Auto Update Cores",
-    description:
-      "Silently re-download emulator cores when the server has a newer build. Turn off to keep the locally cached version until you manually refresh.",
+    // Spec keys core_upd.settings.auto_update_label / _desc — aligned
+    // with the #672 core-upgrade decision tone (see
+    // design-proposals/core-upgrade-decision-spec.md §"Copy library").
+    // The old subtitle was technical; the new copy makes clear what
+    // "off" actually means for the user.
+    label: "Automatically update cores",
+    description: "When off, we'll only switch cores when you say so.",
   },
 ];
 

--- a/web/src/pages/__tests__/preferences-page.test.tsx
+++ b/web/src/pages/__tests__/preferences-page.test.tsx
@@ -197,7 +197,7 @@ describe("PreferencesPage", () => {
     expect(switches[1]).toHaveAttribute("aria-checked", "false");
     // Auto Load Save is true
     expect(switches[2]).toHaveAttribute("aria-checked", "true");
-    // Auto Update Cores is true (#555 Phase 2 opt-out preference)
+    // Automatically update cores is true (#555 Phase 2 opt-out preference)
     expect(switches[3]).toHaveAttribute("aria-checked", "true");
   });
 
@@ -216,7 +216,7 @@ describe("PreferencesPage", () => {
     renderPage();
     await userEvent.click(screen.getByRole("tab", { name: "Emulation" }));
     const switches = screen.getAllByRole("switch");
-    await userEvent.click(switches[3]); // Auto Update Cores (currently true)
+    await userEvent.click(switches[3]); // Automatically update cores (currently true)
     expect(mockMutate).toHaveBeenCalledWith(
       { autoUpdateCoresEnabled: false },
       expect.objectContaining({ onError: expect.any(Function) }),

--- a/web/src/pages/__tests__/session-detail-page.test.tsx
+++ b/web/src/pages/__tests__/session-detail-page.test.tsx
@@ -87,6 +87,15 @@ const mockSession = {
   memberAvatars: [],
   createdAt: "2026-01-01T00:00:00Z",
   updatedAt: "2026-02-01T10:00:00Z",
+  // #672 PR 5/5 — mirror the server's no-pin wire shape (empty string,
+  // not undefined). GameSessionResponse marks these as required:true,
+  // and the server always sends them. The core-version row must treat
+  // "" as hidden so brand-new sessions don't show a bogus "Core v-"
+  // label.
+  pinnedCoreSha256: "",
+  userLockedCoreVersion: false,
+  autoLoadSuppressed: false,
+  rehearsalCrashPending: false,
 };
 
 // Save IDs are stringified uints on the wire (see server response.go
@@ -360,5 +369,69 @@ describe("SessionDetailPage", () => {
     expect(
       screen.getByText(/Cheats are disabled for this session\. 3 cheats available\./i),
     ).toBeInTheDocument();
+  });
+
+  // ── #672 core-version read-only row ─────────────────────────────
+
+  describe("core version row (#672)", () => {
+    it("does not render when the session has no pinned sha", () => {
+      // Baseline: brand-new session, never saved. Row must stay hidden
+      // so the header doesn't show a nonsense "Core v-" label.
+      renderPage();
+      expect(
+        screen.queryByTestId("session-core-version"),
+      ).not.toBeInTheDocument();
+    });
+
+    it("shows 'Core v-{abbrev}' when the session has a pinned sha", () => {
+      mockUseSession.mockReturnValue({
+        data: {
+          ...mockSession,
+          pinnedCoreSha256: "a3f912b400000000000000000000000000000000000000000000000000000000",
+          coreName: "snes9x",
+        },
+        isLoading: false,
+      });
+      renderPage();
+      const row = screen.getByTestId("session-core-version");
+      expect(row).toBeInTheDocument();
+      // Abbreviation rule: first 4 hex chars, lowercased, real hyphen.
+      expect(row).toHaveTextContent("Core v-a3f9");
+      // Locked badge must NOT appear when the lock flag is off/absent.
+      expect(row).not.toHaveTextContent(/locked/i);
+    });
+
+    it("shows the Locked badge when userLockedCoreVersion is true", () => {
+      mockUseSession.mockReturnValue({
+        data: {
+          ...mockSession,
+          pinnedCoreSha256: "a3f912b400000000000000000000000000000000000000000000000000000000",
+          userLockedCoreVersion: true,
+          coreName: "snes9x",
+        },
+        isLoading: false,
+      });
+      renderPage();
+      const row = screen.getByTestId("session-core-version");
+      expect(row).toHaveTextContent("Core v-a3f9");
+      expect(row).toHaveTextContent(/locked/i);
+    });
+
+    it("lowercases uppercase hex in the abbreviation", () => {
+      // Server normally returns lowercase hex but the abbreviation
+      // must be defensive against uppercase input so the label is
+      // stable regardless of source.
+      mockUseSession.mockReturnValue({
+        data: {
+          ...mockSession,
+          pinnedCoreSha256: "ABCDEF0100000000000000000000000000000000000000000000000000000000",
+        },
+        isLoading: false,
+      });
+      renderPage();
+      expect(
+        screen.getByTestId("session-core-version"),
+      ).toHaveTextContent("Core v-abcd");
+    });
   });
 });

--- a/web/src/pages/session-detail-page.tsx
+++ b/web/src/pages/session-detail-page.tsx
@@ -10,6 +10,7 @@ import {
   Layers,
   Save,
   AlertTriangle,
+  Cpu,
   Copy,
 } from "lucide-react";
 import {
@@ -245,7 +246,7 @@ export function SessionDetailPage() {
               </Button>
             </h1>
           )}
-          <div className="flex items-center gap-3 mt-2 text-sm text-surface-400">
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-2 text-sm text-surface-400">
             {game && (
               <Link
                 to={`/games/${game.id}`}
@@ -266,6 +267,46 @@ export function SessionDetailPage() {
                 <Zap className="h-3.5 w-3.5" />
                 Cheats
               </span>
+            )}
+            {/*
+              #672 PR 5/5 — read-only "Core version" indicator. The web
+              doesn't drive the decision flow (that's player-app scope);
+              this is surfaced so users can see *which* historical core
+              their session is pinned to and whether the lock is active.
+              Abbreviation rule from the spec: v-{first 4 hex chars},
+              real hyphen. Hidden when the session has no pin yet.
+            */}
+            {session.pinnedCoreSha256 && (
+              (() => {
+                const abbrev = session.pinnedCoreSha256.slice(0, 4).toLowerCase();
+                const ariaLabel = session.coreName
+                  ? `Pinned core ${session.coreName} version v-${abbrev}${
+                      session.userLockedCoreVersion ? " (locked)" : ""
+                    }`
+                  : `Pinned core version v-${abbrev}${
+                      session.userLockedCoreVersion ? " (locked)" : ""
+                    }`;
+                return (
+                  <span
+                    className="flex items-center gap-1"
+                    data-testid="session-core-version"
+                    aria-label={ariaLabel}
+                    title={
+                      session.coreName
+                        ? `Pinned core: ${session.coreName} (sha256: ${session.pinnedCoreSha256})`
+                        : `Pinned sha256: ${session.pinnedCoreSha256}`
+                    }
+                  >
+                    <Cpu className="h-3.5 w-3.5" aria-hidden="true" />
+                    <span>Core v-{abbrev}</span>
+                    {session.userLockedCoreVersion && (
+                      <Badge variant="default" className="ml-1">
+                        Locked
+                      </Badge>
+                    )}
+                  </span>
+                );
+              })()
             )}
           </div>
         </div>


### PR DESCRIPTION
Final PR in the #672 *informed core-upgrade decision* series. Read-only web surfaces for the new flags + a copy refresh on the preferences toggle.

## Behaviour

### 1. Session detail "Core version" row
`web/src/pages/session-detail-page.tsx` — when a session has a pinned sha (set on first save per #555 Phase 3), the existing header metadata line now shows `Core v-{abbrev}` using the spec's first-4-hex-chars abbreviation. When `userLockedCoreVersion=true`, a `Locked` badge appears next to it. Hidden on fresh sessions with no pin yet.

Read-only by design — the decision flow itself (Sheets A–D, lock/unlock actions) is player-app scope. Web users get visibility into which historical core their session is pinned to via tooltip + abbreviation.

### 2. Preferences copy refresh
`web/src/features/preferences/components/emulation-settings-card.tsx` — `autoUpdateCoresEnabled` toggle now uses spec keys `core_upd.settings.auto_update_label` / `_desc`:
- Label: `"Automatically update cores"` (was: `"Auto Update Cores"`)
- Subtitle: `"When off, we'll only switch cores when you say so."` (was: a long technical sentence)

Visually verified via Playwright — copy renders cleanly, no wrap or alignment regressions on the toggle row.

## Review-gate fixes applied

Both `code-reviewer` and `ui-agent` ran in plan mode before push:

- `mockSession` fixture now carries `pinnedCoreSha256: ""` so the "row hidden" test exercises the real server wire shape (`""`, not `undefined`).
- `aria-label` on the core-version chip + `aria-hidden` on the icon so screen readers announce something meaningful instead of just the bare sha abbreviation.
- Header metadata row gains `flex-wrap + gap-y-1` so the new chip doesn't push items off-screen on narrow viewports (~768–1024px).
- Dropped the `Cpu`→`Lock` icon swap. The `Locked` badge is the cleaner signifier on its own — having both was redundant.
- Stale `"Auto Update Cores"` comments in `preferences-page.test.tsx` updated to match the new label.

## Tests

- 4 new session-detail cases (no pin → hidden, pinned → abbreviation visible, pinned + locked → Locked badge, uppercase hex → lowercase abbreviation).
- All 1553 existing web unit tests pass.
- `npx tsc --noEmit` clean.

## Closes the #672 series

This wraps up the player-app + web scope. Shipped across:

- #673 — server flags + storage
- #674 — player plumbing (SaveManager.rehearsalMode, CoreDecision sealed class, new repos)
- #675 — Sp* design-system components (`SpDecisionSheet`, `SpInGameBanner`, `SessionCoreLockChip`)
- #676 — Sheet A + detection + VM (PR 3b)
- #677 — Sheet B + session-detail lock chip (PR 3c.i)
- #678 — Sheets C/D + rehearsal banner + RehearsalSaveBlocked snackbar (PR 3c.ii)
- #679 — crash sentinel + `CoreMismatchDialog` ported + settings copy (PR 3c.iii)
- #680 — Android smoke test (PR 4/5)
- This PR — web read-only surfaces (PR 5/5)

Out of scope, deferred to follow-ups: session-restore-on-launch routing to Sheet D when the crash sentinel is set, "Switch to older version for comparison" banner secondary, "Report to server admin" wired to a real endpoint, and the post-3-dismissal "demote Sheet A to inline banner" behaviour.

Refs #672, #555