### PR TITLE
feat(#672): launch-time crash recovery wiring

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/usecase/EmulationUseCases.kt
@@ -30,6 +30,16 @@ enum class DecisionKind {
     PinPruned,
 
     /**
+     * The previous run on this session entered rehearsal mode and the
+     * player process died before reaching a clean Sheet C/D resolution.
+     * Surfaces Sheet D on the next launch so the user can recover. The
+     * sentinel write happens around rehearsal entry / clean exit; see
+     * `SaveManager.setSessionRehearsalCrashPending` and the spec's
+     * §"Crash recovery" for the full lifecycle.
+     */
+    RehearsalCrashed,
+
+    /**
      * The core name was substituted for platform compatibility (macOS
      * Metal, Android variant names). The resulting sha mismatch is
      * legitimate, not an upgrade — the VM must not show Sheet A for
@@ -134,6 +144,7 @@ class PrepareGameUseCase(
         userLockedCoreVersion: Boolean = false,
         sessionHasSaves: Boolean = false,
         skipCoreDecisionPrompt: Boolean = false,
+        rehearsalCrashPending: Boolean = false,
     ): Result<PrepareGameResult> {
         val gamePath = downloadRepository.getLocalGamePath(gameId)
             ?: return Result.failure(IllegalStateException("Game not downloaded"))
@@ -165,6 +176,31 @@ class PrepareGameUseCase(
         // constructed from the substituted name.
         val downloadUrl = if (coreName != core.name) null else core.downloadUrl
         val platformSubstituted = coreName != core.name
+
+        // #672 PR — launch-time crash recovery. If the previous run on
+        // this session entered rehearsal and the player process died
+        // before reaching a clean Sheet C/D resolution, route the user
+        // to Sheet D for that session BEFORE doing any other detection
+        // — the user explicitly needs to acknowledge the crash before
+        // we either retry the new core or fall back to the pinned one.
+        // skipCoreDecisionPrompt is honoured so the resolution
+        // re-launches don't loop back into Sheet D.
+        if (rehearsalCrashPending && !skipCoreDecisionPrompt) {
+            return Result.success(
+                PrepareGameResult(
+                    gamePath = gamePath,
+                    // corePath stays empty — the VM intercepts before
+                    // loadCore is called, and Sheet D's resolution
+                    // re-fires StartGame which re-runs this use case
+                    // with the appropriate skipCoreDecisionPrompt /
+                    // skipAutoLoad flags.
+                    corePath = "",
+                    decisionKind = DecisionKind.RehearsalCrashed,
+                    coreName = coreName,
+                    coreDisplayName = core.displayName.ifEmpty { coreName },
+                ),
+            )
+        }
 
         // #672 core-upgrade decision detection. Runs BEFORE the
         // pinned-core download path so we can give the VM a chance to

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -361,13 +361,27 @@ class EmulationViewModel(
      * acknowledged the crash here; leaving it set would re-route them
      * to Sheet D on the next launch, which contradicts the "try again
      * later" intent.
+     *
+     * For the launch-time intercept path (sentinel detected before
+     * loadCore was called), there is no running emulator surface to
+     * "go back to" — set [EmulationState.requestExit] so the
+     * EmulationScreen observer navigates away instead of leaving the
+     * user on a blank screen. For the in-session live-crash path the
+     * emulator surface is still visible (just stopped) and the user
+     * can quit normally, so we don't force-exit there.
      */
     private fun rehearsalCrashDismiss() {
         saveManager.rehearsalMode = false
-        val sessionId = _state.value.sessionId
-        _state.update { it.copy(coreDecision = null) }
+        val snapshot = _state.value
+        val isLaunchTimeIntercept = !snapshot.isRunning
+        _state.update {
+            it.copy(
+                coreDecision = null,
+                requestExit = it.requestExit || isLaunchTimeIntercept,
+            )
+        }
         scope.launch(dispatchers.io) {
-            saveManager.setSessionRehearsalCrashPending(sessionId, pending = false)
+            saveManager.setSessionRehearsalCrashPending(snapshot.sessionId, pending = false)
         }
     }
 
@@ -814,6 +828,7 @@ class EmulationViewModel(
             val flags = saveManager.coreDecisionFlagsFor(saveManager.currentSessionId)
             val pinnedSha = flags?.pinnedCoreSha256
             val userLocked = flags?.userLockedCoreVersion ?: false
+            val crashPending = flags?.rehearsalCrashPending ?: false
             val hasSaves = saveManager.sessionSaveCount(saveManager.currentSessionId) > 0
             prepareGameUseCase(
                 gameId,
@@ -822,6 +837,7 @@ class EmulationViewModel(
                 userLockedCoreVersion = userLocked,
                 sessionHasSaves = hasSaves,
                 skipCoreDecisionPrompt = skipCoreDecisionPrompt,
+                rehearsalCrashPending = crashPending,
             ).fold(
                 onSuccess = { prepared ->
                     val gamePath = prepared.gamePath
@@ -842,6 +858,45 @@ class EmulationViewModel(
                         netplaySessionId != null
                             || sharedSessionId != null
                             || challengeId != null
+                    // #672 launch-time crash recovery — Sheet D fires
+                    // BEFORE Sheets A/B because the user explicitly
+                    // needs to acknowledge the crash before any other
+                    // upgrade/lock decision applies. The existing
+                    // `rehearsalCrashStartFresh` / `rehearsalLockOld` /
+                    // `rehearsalCrashDismiss` handlers in this VM
+                    // already clear the sentinel and re-fire StartGame
+                    // with the right skipAutoLoad / skipCoreDecisionPrompt.
+                    if (prepared.decisionKind == com.spela.player.domain.usecase.DecisionKind.RehearsalCrashed
+                        && !suppressForSpecialMode
+                    ) {
+                        pendingCoreDecisionStart = EmulationIntent.StartGame(
+                            gameId = gameId,
+                            sharedSessionId = sharedSessionId,
+                            turnToken = turnToken,
+                            netplaySessionId = netplaySessionId,
+                            netplayLocalPort = netplayLocalPort,
+                            netplayInputDelay = netplayInputDelay,
+                            netplayIsHost = netplayIsHost,
+                            challengeId = challengeId,
+                            challengeSaveData = challengeSaveDataArg,
+                            skipAutoLoad = skipAutoLoad,
+                            forceNewSession = forceNewSession,
+                            sessionId = saveManager.currentSessionId,
+                        )
+                        withContext(dispatchers.main) {
+                            _state.update {
+                                it.copy(
+                                    isLoading = false,
+                                    showCoreMismatchDialog = false,
+                                    coreDecision = com.spela.player.presentation.state.CoreDecision.RehearsalCrashed(
+                                        coreName = prepared.coreName,
+                                        coreDisplayName = prepared.coreDisplayName.ifEmpty { prepared.coreName },
+                                    ),
+                                )
+                            }
+                        }
+                        return@fold
+                    }
                     if (prepared.decisionKind == com.spela.player.domain.usecase.DecisionKind.PinPruned
                         && !suppressForSpecialMode
                     ) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -63,6 +63,14 @@ data class RehearsalSaveBlocked(val kind: RehearsalSaveKind)
 data class CoreDecisionFlags(
     val pinnedCoreSha256: String?,
     val userLockedCoreVersion: Boolean,
+    /**
+     * When true, the previous run on this session entered rehearsal
+     * mode and the player process didn't reach a clean Sheet C/D
+     * resolution before dying. The next launch must route the user to
+     * Sheet D so they can recover (lock to old / start fresh /
+     * dismiss). Cleared by all of the rehearsal exit handlers.
+     */
+    val rehearsalCrashPending: Boolean = false,
 )
 
 /**
@@ -179,6 +187,7 @@ class SaveManager(
             CoreDecisionFlags(
                 pinnedCoreSha256 = session.pinnedCoreSha256,
                 userLockedCoreVersion = session.userLockedCoreVersion,
+                rehearsalCrashPending = session.rehearsalCrashPending,
             )
         } catch (_: Exception) {
             null

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/PrepareGameUseCaseTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/domain/usecase/PrepareGameUseCaseTest.kt
@@ -258,6 +258,83 @@ class PrepareGameUseCaseTest {
             "skipCoreDecisionPrompt must short-circuit the detection block on re-entry")
     }
 
+    // ── Launch-time RehearsalCrashed — sentinel from a prior crash ──
+
+    @Test
+    fun signalsRehearsalCrashedWhenSentinelIsSet() = runTest {
+        // Previous rehearsal run died before reaching a clean Sheet
+        // C/D resolution. Next launch must surface Sheet D BEFORE any
+        // other detection — even if the sha hasn't changed and the
+        // session isn't locked.
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = true,
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            rehearsalCrashPending = true,
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.RehearsalCrashed, result.decisionKind,
+            "rehearsalCrashPending=true must surface Sheet D regardless of pin/lock state",
+        )
+        // VM intercepts before loadCore — corePath isn't used on this
+        // branch, so it stays empty.
+        assertEquals("", result.corePath)
+    }
+
+    @Test
+    fun rehearsalCrashedTakesPriorityOverUpgradeAvailable() = runTest {
+        // A user who locked + crashed is still locked — but the crash
+        // recovery prompt must come first because the user explicitly
+        // needs to acknowledge the crash. UpgradeAvailable detection
+        // requires `!userLockedCoreVersion`, but RehearsalCrashed must
+        // fire even when the lock IS set (different concern entirely).
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = false,
+            serverSha = "bb".repeat(32),
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            pinnedCoreSha256 = "aa".repeat(32),
+            sessionHasSaves = true,
+            autoUpdateCoresEnabled = false,
+            rehearsalCrashPending = true,
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.RehearsalCrashed, result.decisionKind,
+            "crash recovery must precede upgrade detection — user must acknowledge the crash first",
+        )
+    }
+
+    @Test
+    fun rehearsalCrashedRespectsSkipFlagForResolutionRefires() = runTest {
+        // After Sheet D resolution the VM re-fires StartGame with
+        // skipCoreDecisionPrompt=true. Detection must short-circuit
+        // even though the sentinel is still true on the server (the
+        // resolution handlers clear it asynchronously).
+        val core = FakeCoreRepository(
+            local = "/local/core.so",
+            isCurrent = true,
+        )
+        val useCase = PrepareGameUseCase(FakeDownloadRepository(), core)
+
+        val result = useCase.invoke(
+            gameId = "g1",
+            rehearsalCrashPending = true,
+            skipCoreDecisionPrompt = true,
+        ).getOrThrow()
+
+        assertEquals(DecisionKind.None, result.decisionKind,
+            "skipCoreDecisionPrompt must short-circuit RehearsalCrashed on re-entry",
+        )
+    }
+
     // ── PinPruned detection — pinned binary rotated out of server retention ──
 
     @Test

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelRehearsalTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelRehearsalTest.kt
@@ -154,7 +154,12 @@ class EmulationViewModelRehearsalTest {
     }
 
     @Test
-    fun crashDismissClosesSheetDWithoutTouchingServerFlags() = runTest {
+    fun crashDismissWithoutSessionClearsSheetAndSkipsServerWrite() = runTest {
+        // Defensive path: the rehearsal flow shouldn't enter without a
+        // session, but if RehearsalCrashed somehow fires from a
+        // session-less context, dismissing must still clear the sheet
+        // — and the SaveManager helper short-circuits at the null
+        // sessionId guard, so no flag write is attempted.
         val vm = builder.build()
         vm.onIntent(EmulationIntent.RehearsalCrashed("nestopia", "Nestopia UE"))
         builder.advanceTimeBy(50)
@@ -163,10 +168,80 @@ class EmulationViewModelRehearsalTest {
         builder.advanceTimeBy(50)
 
         assertNull(vm.state.value.coreDecision,
-            "CrashDismiss must clear the sheet so the user lands on the (crashed) emulator and can quit normally",
+            "CrashDismiss must clear the sheet so the in-game surface is reachable",
         )
         assertEquals(0, builder.sessionRepository.updateSessionCoreFlagsCalls.size,
-            "CrashDismiss must not write any server flags — it's a 'try again later' close",
+            "Without a sessionId the SaveManager helper short-circuits — no flag write reaches the server",
+        )
+    }
+
+    // ── Launch-time crash recovery (rehearsalCrashPending intercept) ──
+
+    @Test
+    fun launchTimeCrashDismissNavigatesAwayInsteadOfStrandingTheUser() = runTest {
+        // Launch-time intercept: sentinel is true, Sheet D shows, the
+        // user picks "Just go back". There's no running emulator to
+        // resume — we must signal navigation via requestExit so the
+        // user doesn't end up on a blank EmulationScreen with no
+        // affordance to leave.
+        builder.sessionRepository.existingSessions = listOf(
+            com.spela.player.domain.model.GameSession(
+                id = "s1",
+                gameId = "g1",
+                name = "Crashed run",
+                rehearsalCrashPending = true,
+            ),
+        )
+
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame(gameId = "g1", sessionId = "s1"))
+        builder.advanceTimeBy(500)
+        // Precondition — Sheet D is visible, game never ran.
+        assertTrue(
+            vm.state.value.coreDecision is com.spela.player.presentation.state.CoreDecision.RehearsalCrashed,
+        )
+        assertFalse(vm.state.value.isRunning,
+            "the game never reached the running state — this is the launch-time intercept path",
+        )
+
+        vm.onIntent(EmulationIntent.RehearsalCrashDismiss)
+        builder.advanceTimeBy(100)
+
+        assertNull(vm.state.value.coreDecision)
+        assertTrue(vm.state.value.requestExit,
+            "launch-time CrashDismiss must request an exit so the user navigates back instead of being stranded",
+        )
+    }
+
+    @Test
+    fun launchTimeCrashSentinelInterceptsStartGameAndShowsSheetD() = runTest {
+        // Simulate a previous rehearsal run that died — the server
+        // session record carries rehearsalCrashPending=true. When the
+        // user taps Play, the VM must intercept BEFORE loadCore and
+        // surface CoreDecision.RehearsalCrashed so the UI renders
+        // Sheet D.
+        builder.sessionRepository.existingSessions = listOf(
+            com.spela.player.domain.model.GameSession(
+                id = "s1",
+                gameId = "g1",
+                name = "Crashed run",
+                rehearsalCrashPending = true,
+            ),
+        )
+
+        val vm = builder.build()
+        vm.onIntent(EmulationIntent.StartGame(gameId = "g1", sessionId = "s1"))
+        builder.advanceTimeBy(500)
+
+        val decision = vm.state.value.coreDecision
+        assertTrue(decision is com.spela.player.presentation.state.CoreDecision.RehearsalCrashed,
+            "Launch with rehearsalCrashPending=true must surface Sheet D — got ${decision?.let { it::class.simpleName }}",
+        )
+        assertFalse(vm.state.value.isLoading,
+            "Sheet D must clear the loading state so the user sees the prompt, not a spinner",
+        )
+        assertEquals(0, builder.libretroController.loadCoreCallCount,
+            "VM must intercept BEFORE loadCore — the previous run might have crashed inside the core",
         )
     }
 

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -360,7 +360,19 @@ class StubSessionRepository : SessionRepository {
     var existingSessions: List<GameSession> = emptyList()
 
     override suspend fun getSessionsForGame(gameId: String) = Result.success(existingSessions)
-    override suspend fun getSession(sessionId: String) = Result.failure<GameSession>(Exception("stub"))
+
+    /**
+     * Test hook for [getSession] — set to a function that returns the
+     * desired session for a given id. Defaults to looking the id up in
+     * [existingSessions] so seed-and-go tests work without explicit
+     * wiring. VM tests that need a specific failure path can override.
+     */
+    var lookupSession: (String) -> Result<GameSession> = { id ->
+        existingSessions.firstOrNull { it.id == id }
+            ?.let { Result.success(it) }
+            ?: Result.failure(Exception("stub: session $id not found"))
+    }
+    override suspend fun getSession(sessionId: String): Result<GameSession> = lookupSession(sessionId)
     override suspend fun createSession(gameId: String, name: String): Result<GameSession> {
         createSessionCallCount++
         lastCreatedSessionName = name


### PR DESCRIPTION
Follow-up to the now-merged #672 series. Closes the rehearsal crash-recovery loop that PR #679 left half-built — the `rehearsalCrashPending` sentinel was being written on rehearsal entry / cleared on clean resolution, but **nothing was reading it back on the next launch**. A mid-rehearsal process crash would silently leave the user on the new core with no chance to lock to the old one.

## What this PR adds

1. **`SaveManager.CoreDecisionFlags`** gains `rehearsalCrashPending`; existing `coreDecisionFlagsFor()` populates it from the session record.

2. **`PrepareGameUseCase`** gains a `rehearsalCrashPending` parameter. When true (and `skipCoreDecisionPrompt=false`), returns `DecisionKind.RehearsalCrashed` BEFORE any other detection. The user must explicitly acknowledge the crash before pin-mismatch or upgrade detection applies.

3. **`EmulationViewModel.startGame`** reads the flag, passes it to the use case, and intercepts on `RehearsalCrashed`: stashes the `StartGame` intent, surfaces `CoreDecision.RehearsalCrashed` via state, returns BEFORE `loadCore`. Existing `rehearsalLockOld` / `rehearsalCrashStartFresh` / `rehearsalCrashDismiss` handlers from PR #679 already clear the sentinel and re-fire `StartGame` with the right flags — they work unchanged for this launch-time path because they read `state.gameId/sessionId` which `startGame`'s bulk reset populates before the intercept.

## Review-gate fix applied

`rehearsalCrashDismiss` now sets `requestExit` when called from the launch-time intercept context (`!state.isRunning`). Without this, dismissing Sheet D at launch would leave the user on a blank `EmulationScreen` with no affordance to navigate away. The in-game crash path doesn't have this issue because the emulator surface is still mounted (just stopped).

Also fixed a misleading test from PR 3c.iii (`crashDismissClosesSheetDWithoutTouchingServerFlags`) that asserted the sentinel write doesn't happen — actually it does. The test was passing accidentally because no `sessionId` was seeded. Renamed and re-scoped.

## Tests

5 new cases:
- `PrepareGameUseCaseTest` ×3: sentinel set → RehearsalCrashed; takes priority over UpgradeAvailable; respects `skipCoreDecisionPrompt` re-entry.
- `EmulationViewModelRehearsalTest` ×2: launch-time intercept shows Sheet D and skips `loadCore`; launch-time dismiss requests exit.

525 shared tests + all desktop component tests pass. Same pre-existing `FramerateRegressionTest` flake (passes in isolation, unrelated).

`./gradlew :shared:detektMainDesktop :desktop:detektMainDesktop :android:detektDebugAndroid` — clean.

Refs #672, #555