### PR TITLE
feat(#633): surface curated shelves on small-library consoles

### DIFF
--- a/web/src/pages/__tests__/console-detail-page.test.tsx
+++ b/web/src/pages/__tests__/console-detail-page.test.tsx
@@ -44,7 +44,7 @@ vi.mock("@/components/ui", async () => {
 });
 
 vi.mock("@/hooks/use-explore", () => ({
-  useConsoleShowcase: () => ({ data: undefined }),
+  useConsoleShowcase: vi.fn(() => ({ data: undefined })),
 }));
 
 vi.mock("@/hooks/use-auto-scrape", () => ({
@@ -53,10 +53,12 @@ vi.mock("@/hooks/use-auto-scrape", () => ({
 
 import { useConsoles } from "@/hooks/use-consoles";
 import { useGames } from "@/hooks/use-games";
+import { useConsoleShowcase } from "@/hooks/use-explore";
 import { makeGame, makeConsole } from "@/test-utils/fixtures";
 
 const mockUseConsoles = useConsoles as ReturnType<typeof vi.fn>;
 const mockUseGames = useGames as ReturnType<typeof vi.fn>;
+const mockUseConsoleShowcase = useConsoleShowcase as ReturnType<typeof vi.fn>;
 
 
 
@@ -214,6 +216,56 @@ describe("ConsoleDetailPage", () => {
       ).toBeInTheDocument();
       // Should not show empty state or game cards
       expect(screen.queryByText("No games found")).not.toBeInTheDocument();
+    });
+
+    // #633 — curated shelves should render above the inline grid on
+    // small libraries when the server provides matching content. The
+    // previous behaviour hid them entirely, which hurt small libraries
+    // the most (a user with 6 Virtual Boy games never saw the Launch
+    // Games shelf). Each shelf self-hides on empty, so no visual
+    // noise for libraries where the curated lists are empty.
+
+    it("renders Essentials, Launch Games, and Hidden Gems shelves when the showcase returns content", () => {
+      mockUseConsoleShowcase.mockReturnValue({
+        data: {
+          console: makeConsole({ id: "snes", name: "Super Nintendo" }),
+          essentials: [makeGame({ id: "10", title: "Mega Man X" })],
+          launchGames: [makeGame({ id: "11", title: "Super Mario World" })],
+          hiddenGems: [makeGame({ id: "12", title: "Terranigma" })],
+          recentlyPlayed: [],
+          recentlyAdded: [],
+          genreBreakdown: [],
+          topDevelopers: [],
+        },
+      });
+      renderPage();
+
+      expect(screen.getByText("Essentials")).toBeInTheDocument();
+      expect(screen.getByText("Launch Games")).toBeInTheDocument();
+      expect(screen.getByText("Hidden Gems")).toBeInTheDocument();
+    });
+
+    it("hides lower-priority curated shelves on small libraries even when populated", () => {
+      // Genre Breakdown / Top Developers / Recently Added are intentionally
+      // omitted from the small-library branch — they lose signal when the
+      // game pool is small. The ticket explicitly scopes them out.
+      mockUseConsoleShowcase.mockReturnValue({
+        data: {
+          console: makeConsole({ id: "snes", name: "Super Nintendo" }),
+          essentials: [],
+          launchGames: [],
+          hiddenGems: [],
+          recentlyPlayed: [],
+          recentlyAdded: [makeGame({ id: "20", title: "Just Added" })],
+          genreBreakdown: [{ name: "Platformer", gameCount: 3 }],
+          topDevelopers: [{ id: "dev1", name: "Nintendo EAD", gameCount: 5 }],
+        },
+      });
+      renderPage();
+
+      expect(screen.queryByTestId("genre-breakdown")).not.toBeInTheDocument();
+      expect(screen.queryByText(/top developers/i)).not.toBeInTheDocument();
+      expect(screen.queryByText("Just Added")).not.toBeInTheDocument();
     });
   });
 

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -126,11 +126,18 @@ export function ConsoleDetailPage() {
           description="No games have been detected for this console yet."
         />
       ) : isSmallLibrary ? (
-        /* Small library: inline game grid, with Launch Games above when
-           curated content exists. The shelf self-hides if the server
-           returns an empty list (#633). */
+        /* Small library: inline game grid, with curated shelves above
+           when content exists. Each shelf self-hides if the server
+           returns an empty list (#633). Essentials, Launch Games, and
+           Hidden Gems are most valuable on small libraries — they
+           help a user with 6 Virtual Boy games discover the
+           curated picks. Top Developers and Genre Breakdown stay
+           hidden on small libraries because their signal degrades
+           with a small pool. */
         <>
+          <ConsoleEssentials consoleId={id!} />
           <ConsoleLaunchGames consoleId={id!} />
+          <ConsoleHiddenGems consoleId={id!} />
           <SearchInput
             placeholder={`Search ${consoleName} games...`}
             value={search}


### PR DESCRIPTION
Closes #633. The small-library branch of `ConsoleDetailPage` (gameCount ≤ 24) now renders three curated shelves above the inline game grid — Essentials, Launch Games, Hidden Gems — where previously only Launch Games was shown.

## Rationale

A user with 6 Virtual Boy games never saw the curated Launch Games shelf (_Mario's Tennis, Red Alarm, Galactic Pinball, Teleroboxer_), even though it would be **maximally** interesting there. A user with 18 N64 games never saw the launch pair (_Super Mario 64, Pilotwings 64_) curated out, despite that being ~10% of their library. Small libraries benefit *more* from curated shelves, not less.

## Scope

Per the ticket:

| Shelf | Small library | Large library |
|---|---|---|
| Essentials | ✅ new | ✅ |
| Launch Games | ✅ (was already there) | ✅ |
| Hidden Gems | ✅ new | ✅ |
| Recently Added | — (signal too weak on <24 games) | ✅ |
| Genre Breakdown | — | ✅ |
| Top Developers | — | ✅ |
| Recently Played | — | ✅ |

Each shelf self-hides on empty via the existing `(showcase.X ?? []).length === 0` guard in `console-showcase-sections.tsx`, so libraries without qualifying games see no visual noise.

Shelf ordering on the small-library branch matches the relative ordering on the large-library branch — a library that crosses the threshold doesn't reorder its shelves.

## Verification

Playwright on NES (19 games, under threshold):
- ✅ Essentials shelf rendering
- ✅ Launch Games shelf rendering
- Hidden Gems self-hides (seed data has no curated hidden-gems for NES — expected)

Tests:
- All 141 existing web test files + 1555 tests pass (baseline 1553, +2 new).
- New case: populated curated shelves render on small libraries when the showcase returns matching content.
- New case: the three scoped-out shelves stay hidden on small libraries even when populated — guards against accidental re-addition to the branch.

`npx tsc --noEmit` clean. `npx vitest run src/pages/__tests__/console-detail-page.test.tsx` — 14 tests pass.

## Player app

The player app (`ConsoleScreen.kt`) already renders Essentials, Launch Games, and Hidden Gems unconditionally — no threshold gating there. No changes needed.

Refs #633