### PR TITLE
refactor(web): extract StandardShelfRow + ReviewCard from social-shelves (#687)

### DIFF
--- a/web/src/features/explore/components/__tests__/social-shelves.test.tsx
+++ b/web/src/features/explore/components/__tests__/social-shelves.test.tsx
@@ -8,6 +8,7 @@ import {
   CultClassicsShelf,
   RecentlyReviewedShelf,
   ActiveNowShelf,
+  ReviewCard,
 } from "../social-shelves";
 import type {
   TrendingGame,
@@ -287,5 +288,42 @@ describe("ActiveNowShelf", () => {
   it("returns null when empty", () => {
     const { container } = renderActiveNow({ games: [] });
     expect(container.innerHTML).toBe("");
+  });
+});
+
+// Standalone ReviewCard export — lets other surfaces (user profile,
+// game detail's recent reviews) render the same treatment without
+// duplicating the 5-star + line-clamp-3 layout.
+
+describe("ReviewCard", () => {
+  function renderReview(rating: number) {
+    const review: RecentReviewItem = {
+      game: makeGame({ id: "g1", title: "Chrono Trigger" }),
+      rating,
+      review: "Era-defining JRPG.",
+      reviewerName: "alice",
+      reviewedAt: "2026-04-20T00:00:00Z",
+    };
+    return render(
+      <MemoryRouter>
+        <ReviewCard review={review} />
+      </MemoryRouter>,
+    );
+  }
+
+  it("renders the review text and reviewer name", () => {
+    renderReview(4);
+    expect(screen.getByTestId("review-text")).toHaveTextContent(
+      "Era-defining JRPG.",
+    );
+    expect(screen.getByText(/alice/)).toBeInTheDocument();
+  });
+
+  it("renders a 5-star row with the correct number filled", () => {
+    const { container } = renderReview(3);
+    // 3 amber-filled stars + 2 dim; checking via classlist keeps the
+    // assertion independent of the Lucide icon markup.
+    const filledStars = container.querySelectorAll(".fill-amber-400");
+    expect(filledStars.length).toBe(3);
   });
 });

--- a/web/src/features/explore/components/social-shelves.tsx
+++ b/web/src/features/explore/components/social-shelves.tsx
@@ -21,13 +21,55 @@ import type {
   ActiveNowItem,
 } from "@/types/api";
 
-// --- Trending Shelf ---
+// Shared row + footer primitives used across most shelves. The 4
+// GameCard-based shelves used to duplicate the same wrapper; now
+// they delegate to [StandardShelfRow]. [RecentlyReviewedShelf]
+// diverges enough (2-column layout with an inline review excerpt)
+// that it uses [ReviewCard] instead.
 
-interface TrendingShelfProps {
-  games: TrendingGame[] | null | undefined;
-  isLoading: boolean;
+interface ShelfGameHandlers {
   onToggleFavorite?: (game: Game) => void;
   onTogglePlayLater?: (game: Game) => void;
+}
+
+interface StandardShelfRowProps extends ShelfGameHandlers {
+  game: Game;
+  footer?: React.ReactNode;
+}
+
+function StandardShelfRow({
+  game,
+  footer,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: StandardShelfRowProps) {
+  return (
+    <div className="flex-shrink-0" role="listitem">
+      <GameCard
+        game={game}
+        showConsoleBadge
+        coverHeight={CAROUSEL_CARD_HEIGHT}
+        onToggleFavorite={onToggleFavorite}
+        onTogglePlayLater={onTogglePlayLater}
+      />
+      {footer}
+    </div>
+  );
+}
+
+function ShelfFooter({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="flex items-center gap-1.5 mt-1.5 text-xs text-surface-400">
+      {children}
+    </div>
+  );
+}
+
+// ─── Trending Shelf ───────────────────────────────────────────────
+
+interface TrendingShelfProps extends ShelfGameHandlers {
+  games: TrendingGame[] | null | undefined;
+  isLoading: boolean;
 }
 
 export function TrendingShelf({
@@ -46,37 +88,30 @@ export function TrendingShelf({
       isEmpty={!games || games.length === 0}
     >
       {games?.map((item) => (
-        <div
+        <StandardShelfRow
           key={item.game.id}
-          className="flex-shrink-0"
-          role="listitem"
-        >
-          <GameCard
-            game={item.game}
-            showConsoleBadge
-            coverHeight={CAROUSEL_CARD_HEIGHT}
-            onToggleFavorite={onToggleFavorite}
-            onTogglePlayLater={onTogglePlayLater}
-          />
-          <div className="flex items-center gap-1 mt-1.5 text-xs text-surface-400">
-            <Users className="h-3 w-3" />
-            <span data-testid="players-count">
-              {item.playersThisWeek} player{item.playersThisWeek !== 1 ? "s" : ""} this week
-            </span>
-          </div>
-        </div>
+          game={item.game}
+          onToggleFavorite={onToggleFavorite}
+          onTogglePlayLater={onTogglePlayLater}
+          footer={
+            <ShelfFooter>
+              <Users className="h-3 w-3" />
+              <span data-testid="players-count">
+                {item.playersThisWeek} player{item.playersThisWeek !== 1 ? "s" : ""} this week
+              </span>
+            </ShelfFooter>
+          }
+        />
       ))}
     </ScrollShelf>
   );
 }
 
-// --- Community Top Shelf ---
+// ─── Community Top Shelf ──────────────────────────────────────────
 
-interface CommunityTopShelfProps {
+interface CommunityTopShelfProps extends ShelfGameHandlers {
   games: CommunityTopGame[] | null | undefined;
   isLoading: boolean;
-  onToggleFavorite?: (game: Game) => void;
-  onTogglePlayLater?: (game: Game) => void;
 }
 
 export function CommunityTopShelf({
@@ -95,40 +130,33 @@ export function CommunityTopShelf({
       isEmpty={!games || games.length === 0}
     >
       {games?.map((item) => (
-        <div
+        <StandardShelfRow
           key={item.game.id}
-          className="flex-shrink-0"
-          role="listitem"
-        >
-          <GameCard
-            game={item.game}
-            showConsoleBadge
-            coverHeight={CAROUSEL_CARD_HEIGHT}
-            onToggleFavorite={onToggleFavorite}
-            onTogglePlayLater={onTogglePlayLater}
-          />
-          <div className="flex items-center gap-1.5 mt-1.5 text-xs text-surface-400">
-            <Star className="h-3 w-3 text-amber-400 fill-amber-400" />
-            <span data-testid="community-rating">
-              {item.avgRating.toFixed(1)}/5
-            </span>
-            <span className="text-surface-500">
-              ({item.ratingCount} rating{item.ratingCount !== 1 ? "s" : ""})
-            </span>
-          </div>
-        </div>
+          game={item.game}
+          onToggleFavorite={onToggleFavorite}
+          onTogglePlayLater={onTogglePlayLater}
+          footer={
+            <ShelfFooter>
+              <Star className="h-3 w-3 text-amber-400 fill-amber-400" />
+              <span data-testid="community-rating">
+                {item.avgRating.toFixed(1)}/5
+              </span>
+              <span className="text-surface-500">
+                ({item.ratingCount} rating{item.ratingCount !== 1 ? "s" : ""})
+              </span>
+            </ShelfFooter>
+          }
+        />
       ))}
     </ScrollShelf>
   );
 }
 
-// --- Cult Classics Shelf ---
+// ─── Cult Classics Shelf ──────────────────────────────────────────
 
-interface CultClassicsShelfProps {
+interface CultClassicsShelfProps extends ShelfGameHandlers {
   games: CultClassicGame[] | null | undefined;
   isLoading: boolean;
-  onToggleFavorite?: (game: Game) => void;
-  onTogglePlayLater?: (game: Game) => void;
 }
 
 export function CultClassicsShelf({
@@ -147,38 +175,33 @@ export function CultClassicsShelf({
       isEmpty={!games || games.length === 0}
     >
       {games?.map((item) => (
-        <div
+        <StandardShelfRow
           key={item.game.id}
-          className="flex-shrink-0"
-          role="listitem"
-        >
-          <GameCard
-            game={item.game}
-            showConsoleBadge
-            coverHeight={CAROUSEL_CARD_HEIGHT}
-            onToggleFavorite={onToggleFavorite}
-            onTogglePlayLater={onTogglePlayLater}
-          />
-          <div className="flex items-center gap-1.5 mt-1.5 text-xs text-surface-400">
-            <Star className="h-3 w-3 text-amber-400 fill-amber-400" />
-            <span data-testid="cult-community-rating">
-              {item.communityRating.toFixed(1)}/5
-            </span>
-            <span className="text-surface-500">vs IGDB {item.igdbCriticsRating.toFixed(0)}/100</span>
-          </div>
-        </div>
+          game={item.game}
+          onToggleFavorite={onToggleFavorite}
+          onTogglePlayLater={onTogglePlayLater}
+          footer={
+            <ShelfFooter>
+              <Star className="h-3 w-3 text-amber-400 fill-amber-400" />
+              <span data-testid="cult-community-rating">
+                {item.communityRating.toFixed(1)}/5
+              </span>
+              <span className="text-surface-500">
+                vs IGDB {item.igdbCriticsRating.toFixed(0)}/100
+              </span>
+            </ShelfFooter>
+          }
+        />
       ))}
     </ScrollShelf>
   );
 }
 
-// --- Recently Reviewed Shelf ---
+// ─── Recently Reviewed Shelf ──────────────────────────────────────
 
-interface RecentlyReviewedShelfProps {
+interface RecentlyReviewedShelfProps extends ShelfGameHandlers {
   reviews: RecentReviewItem[] | null | undefined;
   isLoading: boolean;
-  onToggleFavorite?: (game: Game) => void;
-  onTogglePlayLater?: (game: Game) => void;
 }
 
 export function RecentlyReviewedShelf({
@@ -197,63 +220,78 @@ export function RecentlyReviewedShelf({
       isEmpty={!reviews || reviews.length === 0}
     >
       {reviews?.map((item) => (
-        <div
+        <ReviewCard
           key={`${item.game.id}-${item.reviewerName}`}
-          className="w-56 sm:w-60 flex-shrink-0"
-          role="listitem"
-        >
-          <div className="flex gap-3">
-            <div className="w-24 flex-shrink-0">
-              <GameCard
-                game={item.game}
-                showConsoleBadge={false}
-                onToggleFavorite={onToggleFavorite}
-                onTogglePlayLater={onTogglePlayLater}
-              />
-            </div>
-            <div className="flex flex-col min-w-0 py-0.5">
-              <Link
-                to={`/games/${item.game.id}`}
-                className="text-sm font-semibold text-surface-100 truncate hover:text-brand-400 transition-colors"
-              >
-                {item.game.title}
-              </Link>
-              <div className="flex items-center gap-1 mt-0.5">
-                {Array.from({ length: 5 }, (_, si) => (
-                  <Star
-                    key={si}
-                    className={`h-3 w-3 ${
-                      si < item.rating
-                        ? "text-amber-400 fill-amber-400"
-                        : "text-surface-600"
-                    }`}
-                  />
-                ))}
-              </div>
-              <p
-                className="text-xs text-surface-400 mt-1 line-clamp-3"
-                data-testid="review-text"
-              >
-                {item.review}
-              </p>
-              <p className="text-xs text-surface-500 mt-auto">
-                — {item.reviewerName}
-              </p>
-            </div>
-          </div>
-        </div>
+          review={item}
+          onToggleFavorite={onToggleFavorite}
+          onTogglePlayLater={onTogglePlayLater}
+        />
       ))}
     </ScrollShelf>
   );
 }
 
-// --- Active Now Shelf ---
+interface ReviewCardProps extends ShelfGameHandlers {
+  review: RecentReviewItem;
+}
 
-interface ActiveNowShelfProps {
+// Exported so profile / game-detail pages can render the same
+// treatment without duplicating the 5-star + line-clamp-3 layout.
+export function ReviewCard({
+  review,
+  onToggleFavorite,
+  onTogglePlayLater,
+}: ReviewCardProps) {
+  return (
+    <div className="w-56 sm:w-60 flex-shrink-0" role="listitem">
+      <div className="flex gap-3">
+        <div className="w-24 flex-shrink-0">
+          <GameCard
+            game={review.game}
+            showConsoleBadge={false}
+            onToggleFavorite={onToggleFavorite}
+            onTogglePlayLater={onTogglePlayLater}
+          />
+        </div>
+        <div className="flex flex-col min-w-0 py-0.5">
+          <Link
+            to={`/games/${review.game.id}`}
+            className="text-sm font-semibold text-surface-100 truncate hover:text-brand-400 transition-colors"
+          >
+            {review.game.title}
+          </Link>
+          <div className="flex items-center gap-1 mt-0.5">
+            {Array.from({ length: 5 }, (_, i) => (
+              <Star
+                key={i}
+                className={`h-3 w-3 ${
+                  i < review.rating
+                    ? "text-amber-400 fill-amber-400"
+                    : "text-surface-600"
+                }`}
+              />
+            ))}
+          </div>
+          <p
+            className="text-xs text-surface-400 mt-1 line-clamp-3"
+            data-testid="review-text"
+          >
+            {review.review}
+          </p>
+          <p className="text-xs text-surface-500 mt-auto">
+            — {review.reviewerName}
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ─── Active Now Shelf ─────────────────────────────────────────────
+
+interface ActiveNowShelfProps extends ShelfGameHandlers {
   games: ActiveNowItem[] | null | undefined;
   isLoading: boolean;
-  onToggleFavorite?: (game: Game) => void;
-  onTogglePlayLater?: (game: Game) => void;
 }
 
 export function ActiveNowShelf({
@@ -272,39 +310,34 @@ export function ActiveNowShelf({
       isEmpty={!games || games.length === 0}
     >
       {games?.map((item) => (
-        <div
+        <StandardShelfRow
           key={item.game.id}
-          className="flex-shrink-0"
-          role="listitem"
-        >
-          <GameCard
-            game={item.game}
-            showConsoleBadge
-            coverHeight={CAROUSEL_CARD_HEIGHT}
-            onToggleFavorite={onToggleFavorite}
-            onTogglePlayLater={onTogglePlayLater}
-          />
-          <div className="flex flex-wrap gap-1.5 mt-1.5">
-            {item.activeSessions > 0 && (
-              <Badge
-                variant="default"
-                className="text-[10px] px-1.5 py-0 gap-1 bg-green-500/15 text-green-400 border-green-500/30"
-              >
-                <Users className="h-2.5 w-2.5" />
-                {item.activeSessions} session{item.activeSessions !== 1 ? "s" : ""}
-              </Badge>
-            )}
-            {item.activeChallenges > 0 && (
-              <Badge
-                variant="default"
-                className="text-[10px] px-1.5 py-0 gap-1 bg-orange-500/15 text-orange-400 border-orange-500/30"
-              >
-                <Swords className="h-2.5 w-2.5" />
-                {item.activeChallenges} challenge{item.activeChallenges !== 1 ? "s" : ""}
-              </Badge>
-            )}
-          </div>
-        </div>
+          game={item.game}
+          onToggleFavorite={onToggleFavorite}
+          onTogglePlayLater={onTogglePlayLater}
+          footer={
+            <div className="flex flex-wrap gap-1.5 mt-1.5">
+              {item.activeSessions > 0 && (
+                <Badge
+                  variant="default"
+                  className="text-[10px] px-1.5 py-0 gap-1 bg-green-500/15 text-green-400 border-green-500/30"
+                >
+                  <Users className="h-2.5 w-2.5" />
+                  {item.activeSessions} session{item.activeSessions !== 1 ? "s" : ""}
+                </Badge>
+              )}
+              {item.activeChallenges > 0 && (
+                <Badge
+                  variant="default"
+                  className="text-[10px] px-1.5 py-0 gap-1 bg-orange-500/15 text-orange-400 border-orange-500/30"
+                >
+                  <Swords className="h-2.5 w-2.5" />
+                  {item.activeChallenges} challenge{item.activeChallenges !== 1 ? "s" : ""}
+                </Badge>
+              )}
+            </div>
+          }
+        />
       ))}
     </ScrollShelf>
   );


### PR DESCRIPTION
Closes #687. Five shelves in `features/explore/components/social-shelves.tsx` used to duplicate the same carousel-item scaffolding across Trending / CommunityTop / CultClassics / ActiveNow, plus a diverged custom 2-column layout on RecentlyReviewed.

## What changed

- **`StandardShelfRow`** — the shared carousel-item wrapper (`<div flex-shrink-0 role=\"listitem\"><GameCard .../><footer/></div>`). 4 of 5 shelves delegate to it.
- **`ShelfFooter`** — the canonical muted metadata line (icon + text). Used by 3 of the 5 shelves.
- **`ReviewCard`** — **exported** so profile / game-detail pages can reuse the review row without duplicating the 5-star + line-clamp-3 layout. Was previously inlined inside `RecentlyReviewedShelf`.

## Behaviour

Preserved. All existing `data-testid`s (`trending-shelf`, `players-count`, `community-rating`, `cult-community-rating`, `review-text`, etc.) stay in place. The 19 existing shelf tests pass without edits. Added 2 new tests for the exported `ReviewCard`.

## LOC honesty

File went from **311 → 344 lines** (+33). The win isn't current LOC — it's marginal cost:

| Task | Before | After |
|---|---|---|
| Add a 6th shelf that reuses the standard row | ~50 lines (full wrapper duplication) | ~15 lines (delegate to StandardShelfRow + footer) |
| Change the shared wrapper | 4 edits | 1 edit |
| Reuse the review-card treatment on profile / game-detail | Copy-paste ~50 lines | Import ReviewCard |

## Deferred

The badge cleanup (issue #687 item 3 — replacing ActiveNowShelf's hand-rolled green/orange chips with a proper Badge variant) needs a design-system addition. Separate PR.

## Tests

- Social shelves tests — 21/21 pass (was 19).
- Full web suite — 1557/1557 pass (was 1555).
- \`npx tsc --noEmit\` — clean.

Refs #687