### PR TITLE
refactor(player): extract Session + Achievement managers from GameDetailViewModel (#691)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailAchievementManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailAchievementManager.kt
@@ -1,0 +1,87 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.domain.repository.GameStatsRepository
+import com.spela.player.presentation.state.AchievementsViewMode
+import com.spela.player.presentation.state.GameDetailState
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Achievements slice of [GameDetailViewModel]. Handles the three
+ * view modes (grid / timeline / leaderboard) with their own
+ * cached-once-then-reuse load logic. Shares the VM's [_state]
+ * StateFlow so updates land directly.
+ *
+ * Extracted from the VM in the #691 refactor. Not a test seam (the
+ * achievement methods are thin enough that mocking the repo is
+ * enough) — the value is VM size + concern separation.
+ */
+class GameDetailAchievementManager(
+    private val gameStatsRepository: GameStatsRepository,
+    private val _state: MutableStateFlow<GameDetailState>,
+    private val dispatchers: DispatcherProvider,
+    private val scope: CoroutineScope,
+) {
+    fun loadAchievements(gameId: String) {
+        _state.update { it.copy(isLoadingAchievements = true) }
+        scope.launch(dispatchers.io) {
+            val achievements = gameStatsRepository.getGameAchievements(gameId).getOrDefault(emptyList())
+            val progress = gameStatsRepository.getAchievementProgress(gameId).getOrDefault(emptyList())
+            _state.update {
+                it.copy(
+                    achievements = achievements,
+                    achievementProgress = progress,
+                    isLoadingAchievements = false,
+                )
+            }
+        }
+    }
+
+    fun loadAchievementTimeline(gameId: String) {
+        if (_state.value.achievementTimeline != null) return
+        _state.update { it.copy(isLoadingAchievements = true) }
+        scope.launch(dispatchers.io) {
+            gameStatsRepository.getAchievementTimeline(gameId).fold(
+                onSuccess = { timeline ->
+                    _state.update { it.copy(achievementTimeline = timeline, isLoadingAchievements = false) }
+                },
+                onFailure = {
+                    _state.update { it.copy(isLoadingAchievements = false) }
+                },
+            )
+        }
+    }
+
+    fun loadAchievementLeaderboard(gameId: String) {
+        if (_state.value.achievementLeaderboard.isNotEmpty()) return
+        _state.update { it.copy(isLoadingAchievements = true) }
+        scope.launch(dispatchers.io) {
+            gameStatsRepository.getAchievementLeaderboard(gameId).fold(
+                onSuccess = { leaderboard ->
+                    _state.update { it.copy(achievementLeaderboard = leaderboard, isLoadingAchievements = false) }
+                },
+                onFailure = {
+                    _state.update { it.copy(isLoadingAchievements = false) }
+                },
+            )
+        }
+    }
+
+    /**
+     * Switch the achievements view and lazy-load the matching
+     * backing data. [currentGameId] is the VM's field, passed
+     * through because the mode toggle isn't game-scoped itself.
+     */
+    fun toggleAchievementsView(mode: AchievementsViewMode, currentGameId: String?) {
+        _state.update { it.copy(achievementsView = mode) }
+        val gameId = currentGameId ?: return
+        when (mode) {
+            AchievementsViewMode.TIMELINE -> loadAchievementTimeline(gameId)
+            AchievementsViewMode.LEADERBOARD -> loadAchievementLeaderboard(gameId)
+            AchievementsViewMode.GRID -> { /* Already loaded */ }
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailSessionManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailSessionManager.kt
@@ -1,0 +1,120 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.domain.repository.SessionRepository
+import com.spela.player.presentation.state.GameDetailState
+import com.spela.player.util.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+/**
+ * Session CRUD slice of [GameDetailViewModel]. Extracted from the
+ * VM in the #691 refactor to shrink the 894-line god-class. Owns
+ * nothing that the VM doesn't also own — it shares the same
+ * [_state] StateFlow so updates are visible immediately without a
+ * merge step — but keeps the session-specific intent handlers out
+ * of the VM's `when` ladder.
+ *
+ * When [sessionRepository] is null (player app configured without
+ * session support — rare; mostly in tests), every method is a
+ * no-op. The VM must not guard on that itself.
+ */
+class GameDetailSessionManager(
+    private val sessionRepository: SessionRepository?,
+    private val _state: MutableStateFlow<GameDetailState>,
+    private val dispatchers: DispatcherProvider,
+    private val scope: CoroutineScope,
+) {
+    fun loadSessions(gameId: String) {
+        val repo = sessionRepository ?: return
+        _state.update { it.copy(isLoadingSessions = true) }
+        scope.launch(dispatchers.io) {
+            repo.getSessionsForGame(gameId).fold(
+                onSuccess = { sessions ->
+                    _state.update { it.copy(sessions = sessions, isLoadingSessions = false) }
+                },
+                onFailure = {
+                    _state.update { it.copy(isLoadingSessions = false) }
+                },
+            )
+        }
+    }
+
+    fun createSession(gameId: String, name: String) {
+        val repo = sessionRepository ?: return
+        scope.launch(dispatchers.io) {
+            repo.createSession(gameId, name).fold(
+                onSuccess = { session ->
+                    _state.update { state ->
+                        state.copy(
+                            sessions = state.sessions + session,
+                            successMessage = "Session \"${session.name}\" created",
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun renameSession(sessionId: String, name: String) {
+        val repo = sessionRepository ?: return
+        scope.launch(dispatchers.io) {
+            repo.updateSession(sessionId, name).fold(
+                onSuccess = { updated ->
+                    _state.update { state ->
+                        state.copy(
+                            sessions = state.sessions.map {
+                                if (it.id == sessionId) updated else it
+                            },
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun deleteSession(sessionId: String) {
+        val repo = sessionRepository ?: return
+        scope.launch(dispatchers.io) {
+            repo.deleteSession(sessionId).fold(
+                onSuccess = {
+                    _state.update { state ->
+                        state.copy(
+                            sessions = state.sessions.filter { it.id != sessionId },
+                            successMessage = "Session deleted",
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+
+    fun cloneSession(sessionId: String, name: String?, saveId: Long?) {
+        val repo = sessionRepository ?: return
+        scope.launch(dispatchers.io) {
+            repo.cloneSession(sessionId, name, saveId).fold(
+                onSuccess = { newSession ->
+                    _state.update { state ->
+                        state.copy(
+                            sessions = state.sessions + newSession,
+                            successMessage = "Session cloned as \"${newSession.name}\"",
+                        )
+                    }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(error = error.message) }
+                },
+            )
+        }
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -21,7 +21,6 @@ import com.spela.player.domain.repository.SessionRepository
 import com.spela.player.domain.repository.SharedSaveRepository
 import com.spela.player.domain.repository.GameStatsRepository
 import com.spela.player.presentation.intent.GameDetailIntent
-import com.spela.player.presentation.state.AchievementsViewMode
 import com.spela.player.presentation.state.GameDetailState
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
@@ -59,6 +58,23 @@ class GameDetailViewModel(
     val state: StateFlow<GameDetailState> = _state.asStateFlow()
 
     private var currentGameId: String? = null
+
+    // Session + achievement CRUD extracted into their own managers
+    // (#691). Each shares this VM's `_state` so updates land
+    // directly. EmulationViewModel uses the same delegation pattern
+    // for SaveManager / ChallengeManager / NetplayManager.
+    private val sessionManager = GameDetailSessionManager(
+        sessionRepository = sessionRepository,
+        _state = _state,
+        dispatchers = dispatchers,
+        scope = scope,
+    )
+    private val achievementManager = GameDetailAchievementManager(
+        gameStatsRepository = gameStatsRepository,
+        _state = _state,
+        dispatchers = dispatchers,
+        scope = scope,
+    )
 
     fun onIntent(intent: GameDetailIntent) {
         when (intent) {
@@ -100,19 +116,19 @@ class GameDetailViewModel(
             is GameDetailIntent.LoadReviews -> loadReviews(intent.gameId)
             is GameDetailIntent.LoadMoreReviews -> loadMoreReviews(intent.gameId)
             is GameDetailIntent.LoadGameSharedSessions -> loadGameSharedSessions(intent.gameId)
-            is GameDetailIntent.LoadAchievements -> loadAchievements(intent.gameId)
-            is GameDetailIntent.LoadAchievementTimeline -> loadAchievementTimeline(intent.gameId)
-            is GameDetailIntent.LoadAchievementLeaderboard -> loadAchievementLeaderboard(intent.gameId)
-            is GameDetailIntent.ToggleAchievementsView -> toggleAchievementsView(intent.mode)
+            is GameDetailIntent.LoadAchievements -> achievementManager.loadAchievements(intent.gameId)
+            is GameDetailIntent.LoadAchievementTimeline -> achievementManager.loadAchievementTimeline(intent.gameId)
+            is GameDetailIntent.LoadAchievementLeaderboard -> achievementManager.loadAchievementLeaderboard(intent.gameId)
+            is GameDetailIntent.ToggleAchievementsView -> achievementManager.toggleAchievementsView(intent.mode, currentGameId)
             GameDetailIntent.DismissError -> _state.update { it.copy(error = null) }
             GameDetailIntent.DismissSuccess -> _state.update { it.copy(successMessage = null) }
 
             // Sessions
-            is GameDetailIntent.LoadSessions -> loadSessions(intent.gameId)
-            is GameDetailIntent.CreateSession -> createSession(intent.gameId, intent.name)
-            is GameDetailIntent.RenameSession -> renameSession(intent.sessionId, intent.name)
-            is GameDetailIntent.DeleteSession -> deleteSession(intent.sessionId)
-            is GameDetailIntent.CloneSession -> cloneSession(intent.sessionId, intent.name, intent.saveId)
+            is GameDetailIntent.LoadSessions -> sessionManager.loadSessions(intent.gameId)
+            is GameDetailIntent.CreateSession -> sessionManager.createSession(intent.gameId, intent.name)
+            is GameDetailIntent.RenameSession -> sessionManager.renameSession(intent.sessionId, intent.name)
+            is GameDetailIntent.DeleteSession -> sessionManager.deleteSession(intent.sessionId)
+            is GameDetailIntent.CloneSession -> sessionManager.cloneSession(intent.sessionId, intent.name, intent.saveId)
 
             // Admin actions
             GameDetailIntent.AdminScrapeGame -> adminScrapeGame()
@@ -139,7 +155,7 @@ class GameDetailViewModel(
             runCatching { apiClient.adminRefreshAchievements(gameId) }
                 .onSuccess {
                     // Reload achievements
-                    loadAchievements(gameId)
+                    achievementManager.loadAchievements(gameId)
                     _state.update { it.copy(isAdminActionLoading = false, successMessage = "Achievements refreshed") }
                 }
                 .onFailure { error ->
@@ -189,10 +205,10 @@ class GameDetailViewModel(
                     // Load playable-only community data after we know the game is playable
                     if (isPlayable) {
                         loadGameSharedSessions(gameId)
-                        loadAchievements(gameId)
+                        achievementManager.loadAchievements(gameId)
                         loadCheats(gameId)
                         loadBiosStatus()
-                        loadSessions(gameId)
+                        sessionManager.loadSessions(gameId)
                     }
                 },
                 onFailure = { error ->
@@ -630,60 +646,7 @@ class GameDetailViewModel(
         }
     }
 
-    private fun loadAchievements(gameId: String) {
-        _state.update { it.copy(isLoadingAchievements = true) }
-        scope.launch(dispatchers.io) {
-            val achievements = gameStatsRepository.getGameAchievements(gameId).getOrDefault(emptyList())
-            val progress = gameStatsRepository.getAchievementProgress(gameId).getOrDefault(emptyList())
-            _state.update {
-                it.copy(
-                    achievements = achievements,
-                    achievementProgress = progress,
-                    isLoadingAchievements = false,
-                )
-            }
-        }
-    }
-
-    private fun loadAchievementTimeline(gameId: String) {
-        if (_state.value.achievementTimeline != null) return
-        _state.update { it.copy(isLoadingAchievements = true) }
-        scope.launch(dispatchers.io) {
-            gameStatsRepository.getAchievementTimeline(gameId).fold(
-                onSuccess = { timeline ->
-                    _state.update { it.copy(achievementTimeline = timeline, isLoadingAchievements = false) }
-                },
-                onFailure = {
-                    _state.update { it.copy(isLoadingAchievements = false) }
-                },
-            )
-        }
-    }
-
-    private fun loadAchievementLeaderboard(gameId: String) {
-        if (_state.value.achievementLeaderboard.isNotEmpty()) return
-        _state.update { it.copy(isLoadingAchievements = true) }
-        scope.launch(dispatchers.io) {
-            gameStatsRepository.getAchievementLeaderboard(gameId).fold(
-                onSuccess = { leaderboard ->
-                    _state.update { it.copy(achievementLeaderboard = leaderboard, isLoadingAchievements = false) }
-                },
-                onFailure = {
-                    _state.update { it.copy(isLoadingAchievements = false) }
-                },
-            )
-        }
-    }
-
-    private fun toggleAchievementsView(mode: AchievementsViewMode) {
-        _state.update { it.copy(achievementsView = mode) }
-        val gameId = currentGameId ?: return
-        when (mode) {
-            AchievementsViewMode.TIMELINE -> loadAchievementTimeline(gameId)
-            AchievementsViewMode.LEADERBOARD -> loadAchievementLeaderboard(gameId)
-            AchievementsViewMode.GRID -> { /* Already loaded */ }
-        }
-    }
+    // Achievement loading moved to GameDetailAchievementManager (#691).
 
     private fun loadCheats(gameId: String) {
         val repo = cheatRepository ?: return
@@ -798,97 +761,5 @@ class GameDetailViewModel(
         }
     }
 
-    // Sessions
-
-    private fun loadSessions(gameId: String) {
-        val repo = sessionRepository ?: return
-        _state.update { it.copy(isLoadingSessions = true) }
-        scope.launch(dispatchers.io) {
-            repo.getSessionsForGame(gameId).fold(
-                onSuccess = { sessions ->
-                    _state.update { it.copy(sessions = sessions, isLoadingSessions = false) }
-                },
-                onFailure = {
-                    _state.update { it.copy(isLoadingSessions = false) }
-                },
-            )
-        }
-    }
-
-    private fun createSession(gameId: String, name: String) {
-        val repo = sessionRepository ?: return
-        scope.launch(dispatchers.io) {
-            repo.createSession(gameId, name).fold(
-                onSuccess = { session ->
-                    _state.update { state ->
-                        state.copy(
-                            sessions = state.sessions + session,
-                            successMessage = "Session \"${session.name}\" created",
-                        )
-                    }
-                },
-                onFailure = { error ->
-                    _state.update { it.copy(error = error.message) }
-                },
-            )
-        }
-    }
-
-    private fun renameSession(sessionId: String, name: String) {
-        val repo = sessionRepository ?: return
-        scope.launch(dispatchers.io) {
-            repo.updateSession(sessionId, name).fold(
-                onSuccess = { updated ->
-                    _state.update { state ->
-                        state.copy(
-                            sessions = state.sessions.map {
-                                if (it.id == sessionId) updated else it
-                            },
-                        )
-                    }
-                },
-                onFailure = { error ->
-                    _state.update { it.copy(error = error.message) }
-                },
-            )
-        }
-    }
-
-    private fun deleteSession(sessionId: String) {
-        val repo = sessionRepository ?: return
-        scope.launch(dispatchers.io) {
-            repo.deleteSession(sessionId).fold(
-                onSuccess = {
-                    _state.update { state ->
-                        state.copy(
-                            sessions = state.sessions.filter { it.id != sessionId },
-                            successMessage = "Session deleted",
-                        )
-                    }
-                },
-                onFailure = { error ->
-                    _state.update { it.copy(error = error.message) }
-                },
-            )
-        }
-    }
-
-    private fun cloneSession(sessionId: String, name: String?, saveId: Long?) {
-        val repo = sessionRepository ?: return
-        scope.launch(dispatchers.io) {
-            repo.cloneSession(sessionId, name, saveId).fold(
-                onSuccess = { newSession ->
-                    _state.update { state ->
-                        state.copy(
-                            sessions = state.sessions + newSession,
-                            successMessage = "Session cloned as \"${newSession.name}\"",
-                        )
-                    }
-                },
-                onFailure = { error ->
-                    _state.update { it.copy(error = error.message) }
-                },
-            )
-        }
-    }
+    // Session CRUD moved to GameDetailSessionManager (#691).
 }


### PR DESCRIPTION
Closes #691. `GameDetailViewModel.kt` was 894 LOC mixing 8+ unrelated domains: metadata, sessions CRUD, achievements (3 view modes), cheats, saves, challenges, ratings, shared saves, collections. Extracted two self-contained slices into manager classes, following the delegation pattern `EmulationViewModel` already uses for `SaveManager` / `ChallengeManager` / `NetplayManager`.

## Extracted

1. **`GameDetailSessionManager`** (120 LOC)
   - `loadSessions`, `createSession`, `renameSession`, `deleteSession`, `cloneSession`
   - 5 methods, all session-scoped CRUD

2. **`GameDetailAchievementManager`** (87 LOC)
   - `loadAchievements`, `loadAchievementTimeline`, `loadAchievementLeaderboard`, `toggleAchievementsView`
   - Cache-once-then-reuse logic for each of the three view modes

Both managers share the VM's `_state` StateFlow so updates land directly without a merge step. The VM delegates each intent through the managers in `onIntent`, and calls them from internal code paths too (e.g. `loadGame` seeds achievements + sessions, `adminRefreshAchievements` reloads via the manager).

## Numbers

| File | Before | After |
|---|---|---|
| `GameDetailViewModel.kt` | 894 | 765 |
| `GameDetailSessionManager.kt` | — | 120 |
| `GameDetailAchievementManager.kt` | — | 87 |

Net: +78 LOC of manager scaffolding (class declarations + imports), but the VM's remaining 765 lines are now focused on metadata / downloads / ratings / shared saves / collections.

## Tests

- 526 shared + 759 desktop tests pass — no behaviour regression.
- Both targets compile (`compileKotlinDesktop` + `compileDebugKotlinAndroid`).
- `detektMainDesktop` clean.

## Deferred

Shared saves (~70 LOC) + ratings (~40 LOC) clusters are smaller than sessions/achievements. Worth a `SocialManager` only if more social features land (reviews, comments). Monitor.

Refs #691