### PR TITLE
refactor(web): extract PlayPage state placeholders (#694 partial)

### DIFF
--- a/web/src/features/play/components/play-page-state.tsx
+++ b/web/src/features/play/components/play-page-state.tsx
@@ -1,0 +1,100 @@
+import { AlertTriangle } from "lucide-react";
+import { Button, Skeleton } from "@/components/ui";
+
+// Full-screen placeholders used by `play-page.tsx` while the page is
+// not yet showing the emulator. Each shape used to be an inline
+// early-return block in the page body; extracted for readability
+// and to let the page body focus on the happy path.
+
+interface PlayPageLoadingProps {
+  // intentionally empty — renders a fixed skeleton
+}
+
+/** Top-bar + blank stage skeleton while game / consoles are loading. */
+export function PlayPageLoading(_props: PlayPageLoadingProps = {}) {
+  return (
+    <div className="flex flex-col h-screen">
+      <div className="flex items-center justify-between px-4 py-2 border-b border-surface-800 bg-surface-950/80">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-5 w-16" />
+          <Skeleton className="h-5 w-40" />
+        </div>
+        <div className="flex items-center gap-2">
+          <Skeleton className="h-8 w-8 rounded" />
+          <Skeleton className="h-8 w-8 rounded" />
+          <Skeleton className="h-8 w-8 rounded" />
+        </div>
+      </div>
+      <div className="flex-1 bg-surface-950" />
+    </div>
+  );
+}
+
+interface PlayPageNotFoundProps {
+  onBack: () => void;
+}
+
+export function PlayPageNotFound({ onBack }: PlayPageNotFoundProps) {
+  return (
+    <div className="text-center py-20">
+      <p className="text-surface-400">Game not found</p>
+      <Button variant="ghost" onClick={onBack} className="mt-4">
+        Go back
+      </Button>
+    </div>
+  );
+}
+
+interface PlayPageUnsupportedProps {
+  consoleName: string;
+  onBack: () => void;
+}
+
+export function PlayPageUnsupported({
+  consoleName,
+  onBack,
+}: PlayPageUnsupportedProps) {
+  return (
+    <div className="text-center py-20 space-y-4">
+      <AlertTriangle className="h-12 w-12 text-warning-500 mx-auto" />
+      <h2 className="text-xl font-bold text-surface-100">
+        Browser Play Not Available
+      </h2>
+      <p className="text-surface-400 max-w-md mx-auto">
+        {consoleName} is not yet supported for browser play. Use the Spela
+        player app to play this game.
+      </p>
+      <Button variant="secondary" onClick={onBack}>
+        Back to Game Details
+      </Button>
+    </div>
+  );
+}
+
+interface PlayPageErrorProps {
+  error: string | null | undefined;
+  onBack: () => void;
+  onRetry: () => void;
+}
+
+export function PlayPageError({
+  error,
+  onBack,
+  onRetry,
+}: PlayPageErrorProps) {
+  return (
+    <div className="text-center py-20 space-y-4">
+      <AlertTriangle className="h-12 w-12 text-danger-500 mx-auto" />
+      <h2 className="text-xl font-bold text-surface-100">Emulation Error</h2>
+      <p className="text-surface-400 max-w-md mx-auto">
+        {error || "The emulator encountered an unexpected error."}
+      </p>
+      <div className="flex items-center justify-center gap-3 pt-2">
+        <Button variant="secondary" onClick={onBack}>
+          Back to Game Details
+        </Button>
+        <Button onClick={onRetry}>Try Again</Button>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -1,7 +1,11 @@
 import { useParams, useNavigate } from "react-router-dom";
 import { useState, useEffect, useRef, useCallback } from "react";
-import { AlertTriangle } from "lucide-react";
-import { Button, Skeleton } from "@/components/ui";
+import {
+  PlayPageError,
+  PlayPageLoading,
+  PlayPageNotFound,
+  PlayPageUnsupported,
+} from "@/features/play/components/play-page-state";
 import { useGame } from "@/hooks/use-games";
 import { useUserPreferences } from "@/hooks/use-preferences";
 import { useConsoles } from "@/hooks/use-consoles";
@@ -356,80 +360,27 @@ export function PlayPage() {
     [emulator.iframeRef],
   );
 
-  // ── Loading state ─────────────────────────────────────────────────
+  // ── Loading / terminal states ─────────────────────────────────────
+  // Each full-screen placeholder lives in `features/play/components`
+  // so the main page body below can focus on the happy-path layout.
 
-  if (gameLoading || consolesLoading) {
-    return (
-      <div className="flex flex-col h-screen">
-        <div className="flex items-center justify-between px-4 py-2 border-b border-surface-800 bg-surface-950/80">
-          <div className="flex items-center gap-3">
-            <Skeleton className="h-5 w-16" />
-            <Skeleton className="h-5 w-40" />
-          </div>
-          <div className="flex items-center gap-2">
-            <Skeleton className="h-8 w-8 rounded" />
-            <Skeleton className="h-8 w-8 rounded" />
-            <Skeleton className="h-8 w-8 rounded" />
-          </div>
-        </div>
-        <div className="flex-1 bg-surface-950" />
-      </div>
-    );
-  }
-
-  if (!game) {
-    return (
-      <div className="text-center py-20">
-        <p className="text-surface-400">Game not found</p>
-        <Button variant="ghost" onClick={() => navigate(-1)} className="mt-4">
-          Go back
-        </Button>
-      </div>
-    );
-  }
-
+  if (gameLoading || consolesLoading) return <PlayPageLoading />;
+  if (!game) return <PlayPageNotFound onBack={() => navigate(-1)} />;
   if (!isSupported) {
     return (
-      <div className="text-center py-20 space-y-4">
-        <AlertTriangle className="h-12 w-12 text-warning-500 mx-auto" />
-        <h2 className="text-xl font-bold text-surface-100">
-          Browser Play Not Available
-        </h2>
-        <p className="text-surface-400 max-w-md mx-auto">
-          {game.consoleName} is not yet supported for browser play. Use the
-          Spela player app to play this game.
-        </p>
-        <Button variant="secondary" onClick={() => navigate(`/games/${id}`)}>
-          Back to Game Details
-        </Button>
-      </div>
+      <PlayPageUnsupported
+        consoleName={game.consoleName}
+        onBack={() => navigate(`/games/${id}`)}
+      />
     );
   }
-
-  // ── Error state ──────────────────────────────────────────────────
-
   if (emulator.status === "error") {
     return (
-      <div className="text-center py-20 space-y-4">
-        <AlertTriangle className="h-12 w-12 text-danger-500 mx-auto" />
-        <h2 className="text-xl font-bold text-surface-100">
-          Emulation Error
-        </h2>
-        <p className="text-surface-400 max-w-md mx-auto">
-          {emulator.error || "The emulator encountered an unexpected error."}
-        </p>
-        <div className="flex items-center justify-center gap-3 pt-2">
-          <Button
-            variant="secondary"
-            onClick={() => navigate(`/games/${id}`)}
-          >
-            Back to Game Details
-          </Button>
-          <Button onClick={() => window.location.reload()}>
-            Try Again
-          </Button>
-        </div>
-      </div>
+      <PlayPageError
+        error={emulator.error}
+        onBack={() => navigate(`/games/${id}`)}
+        onRetry={() => window.location.reload()}
+      />
     );
   }
 


### PR DESCRIPTION
Partial close of #694. `play-page.tsx` had four full-screen early-return states — each 10–25 lines of bespoke Tailwind for a distinct UX (loading skeleton, game-not-found, unsupported console, emulator error). Extracted to `features/play/components/play-page-state.tsx`.

## What changed

Four named exports, each with just the props it actually uses:

- `PlayPageLoading` — top-bar + blank stage skeleton.
- `PlayPageNotFound({ onBack })` — "Game not found" + Go back button.
- `PlayPageUnsupported({ consoleName, onBack })` — warning + back-to-game button.
- `PlayPageError({ error, onBack, onRetry })` — error message + two actions.

No prop-bag (`state: "loading" | "not-found" | …` + every field optional) that would force every caller to pass every field. The page body swaps ~75 lines of inline JSX for 15 lines of guarded early-returns.

## Scope — `useDiscSwitchFlow` NOT included

#694 also proposed a `useDiscSwitchFlow` hook to untangle the 5 refs + 108-line init `useEffect` that coordinate the multi-disc save-request → reload → rebuild-bundle chain. **Skipped here.** That logic is the most fragile in the page (the audit rated it high effort / high risk) and verifying it cleanly needs a multi-disc game on a live backend with end-to-end save-switch testing. Leaving the `useDiscSwitchFlow` piece of #694 open for a focused follow-up PR with proper test infrastructure.

## Numbers

- `play-page.tsx`: **501 → 452 LOC** (-49)
- `play-page-state.tsx`: 100 LOC (new)
- Net: +51 LOC of signatures / file headers for 4 separate components, but each state is now testable in isolation and reusable if other emulator surfaces appear.

## Tests

- All 1557 web tests pass — no behaviour regression.
- `npx tsc --noEmit` clean.
- Visual verification skipped (would need each of the 4 error states reproduced live — the happy path doesn't exercise them).

Refs #694