### PR TITLE
refactor(player): SpelaAppDependencies data class (#693 PR A/4)

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/SpelaTestHarness.kt
@@ -11,6 +11,7 @@ import com.spela.player.domain.usecase.*
 import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.navigation.NavigationViewModel
 import com.spela.player.presentation.ui.SpelaApp
+import com.spela.player.presentation.ui.SpelaAppDependencies
 import com.spela.player.platform.secondarydisplay.DesktopSecondaryDisplay
 import com.spela.player.presentation.secondarydisplay.PlatformSecondaryDisplay
 import com.spela.player.presentation.state.EmulationState
@@ -368,34 +369,36 @@ class SpelaTestHarness(
             com.spela.player.presentation.ui.components.LocalAnimationsEnabled provides false,
         ) {
         SpelaApp(
-            navigationViewModel = navigationViewModel,
-            serverConnectionViewModel = serverConnectionViewModel,
-            loginViewModel = loginViewModel,
-            gameListViewModel = gameListViewModel,
-            gameDetailViewModel = gameDetailViewModel,
-            emulationViewModel = emulationViewModel,
-            libretroController = libretroController,
-            downloadsViewModel = downloadsViewModel,
-            settingsViewModel = settingsViewModel,
-            keyMappingViewModel = keyMappingViewModel,
-            gamepadConfigViewModel = gamepadConfigViewModel,
-            socialViewModel = socialViewModel,
-            sharedSessionsViewModel = sharedSessionsViewModel,
-            sharedSessionDetailViewModel = sharedSessionDetailViewModel,
-            netplayViewModel = netplayViewModel,
-            netplayLobbyViewModel = netplayLobbyViewModel,
-            statsViewModel = statsViewModel,
-            collectionsViewModel = collectionsViewModel,
-            challengeListViewModel = challengeListViewModel,
-            challengeDetailViewModel = challengeDetailViewModel,
-            secondaryDisplay = secondaryDisplay,
-            presenceService = presenceService,
-            connectivityMonitor = connectivityMonitor,
-            sessionDetailViewModel = sessionDetailViewModel,
-            topListsViewModel = topListsViewModel,
-            exploreViewModel = exploreViewModel,
-            gamepadPortManager = gamepadPortManager,
-            globalSearchViewModel = globalSearchViewModel,
+            SpelaAppDependencies(
+                navigationViewModel = navigationViewModel,
+                serverConnectionViewModel = serverConnectionViewModel,
+                loginViewModel = loginViewModel,
+                gameListViewModel = gameListViewModel,
+                gameDetailViewModel = gameDetailViewModel,
+                emulationViewModel = emulationViewModel,
+                libretroController = libretroController,
+                downloadsViewModel = downloadsViewModel,
+                settingsViewModel = settingsViewModel,
+                keyMappingViewModel = keyMappingViewModel,
+                gamepadConfigViewModel = gamepadConfigViewModel,
+                socialViewModel = socialViewModel,
+                sharedSessionsViewModel = sharedSessionsViewModel,
+                sharedSessionDetailViewModel = sharedSessionDetailViewModel,
+                netplayViewModel = netplayViewModel,
+                netplayLobbyViewModel = netplayLobbyViewModel,
+                statsViewModel = statsViewModel,
+                collectionsViewModel = collectionsViewModel,
+                challengeListViewModel = challengeListViewModel,
+                challengeDetailViewModel = challengeDetailViewModel,
+                secondaryDisplay = secondaryDisplay,
+                presenceService = presenceService,
+                connectivityMonitor = connectivityMonitor,
+                sessionDetailViewModel = sessionDetailViewModel,
+                topListsViewModel = topListsViewModel,
+                exploreViewModel = exploreViewModel,
+                gamepadPortManager = gamepadPortManager,
+                globalSearchViewModel = globalSearchViewModel,
+            ),
         )
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/App.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import com.spela.player.presentation.secondarydisplay.PlatformSecondaryDisplay
 import com.spela.player.presentation.navigation.NavigationViewModel
 import com.spela.player.presentation.ui.SpelaApp
+import com.spela.player.presentation.ui.SpelaAppDependencies
 import com.spela.player.presentation.viewmodel.DownloadsViewModel
 import com.spela.player.presentation.viewmodel.EmulationViewModel
 import com.spela.player.presentation.viewmodel.GameDetailViewModel
@@ -72,35 +73,37 @@ fun App() {
     val scrapeService: ScrapeService = koinInject()
 
     SpelaApp(
-        navigationViewModel = navigationViewModel,
-        serverConnectionViewModel = serverConnectionViewModel,
-        loginViewModel = loginViewModel,
-        gameListViewModel = gameListViewModel,
-        gameDetailViewModel = gameDetailViewModel,
-        emulationViewModel = emulationViewModel,
-        libretroController = libretroController,
-        downloadsViewModel = downloadsViewModel,
-        settingsViewModel = settingsViewModel,
-        keyMappingViewModel = keyMappingViewModel,
-        socialViewModel = socialViewModel,
-        sharedSessionsViewModel = sharedSessionsViewModel,
-        sharedSessionDetailViewModel = sharedSessionDetailViewModel,
-        netplayViewModel = netplayViewModel,
-        netplayLobbyViewModel = netplayLobbyViewModel,
-        statsViewModel = statsViewModel,
-        collectionsViewModel = collectionsViewModel,
-        challengeListViewModel = challengeListViewModel,
-        challengeDetailViewModel = challengeDetailViewModel,
-        secondaryDisplay = secondaryDisplay,
-        presenceService = presenceService,
-        connectivityMonitor = connectivityMonitor,
-        sessionDetailViewModel = sessionDetailViewModel,
-        navigationEventBus = navigationEventBus,
-        gamepadPortManager = gamepadPortManager,
-        globalSearchViewModel = globalSearchViewModel,
-        exploreViewModel = exploreViewModel,
-        topListsViewModel = topListsViewModel,
-        gamepadConfigViewModel = gamepadConfigViewModel,
-        scrapeService = scrapeService,
+        SpelaAppDependencies(
+            navigationViewModel = navigationViewModel,
+            serverConnectionViewModel = serverConnectionViewModel,
+            loginViewModel = loginViewModel,
+            gameListViewModel = gameListViewModel,
+            gameDetailViewModel = gameDetailViewModel,
+            emulationViewModel = emulationViewModel,
+            libretroController = libretroController,
+            downloadsViewModel = downloadsViewModel,
+            settingsViewModel = settingsViewModel,
+            keyMappingViewModel = keyMappingViewModel,
+            socialViewModel = socialViewModel,
+            sharedSessionsViewModel = sharedSessionsViewModel,
+            sharedSessionDetailViewModel = sharedSessionDetailViewModel,
+            netplayViewModel = netplayViewModel,
+            netplayLobbyViewModel = netplayLobbyViewModel,
+            statsViewModel = statsViewModel,
+            collectionsViewModel = collectionsViewModel,
+            challengeListViewModel = challengeListViewModel,
+            challengeDetailViewModel = challengeDetailViewModel,
+            secondaryDisplay = secondaryDisplay,
+            presenceService = presenceService,
+            connectivityMonitor = connectivityMonitor,
+            sessionDetailViewModel = sessionDetailViewModel,
+            navigationEventBus = navigationEventBus,
+            gamepadPortManager = gamepadPortManager,
+            globalSearchViewModel = globalSearchViewModel,
+            exploreViewModel = exploreViewModel,
+            topListsViewModel = topListsViewModel,
+            gamepadConfigViewModel = gamepadConfigViewModel,
+            scrapeService = scrapeService,
+        ),
     )
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -52,14 +52,12 @@ import androidx.compose.ui.semantics.contentDescription
 import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.input.pointer.pointerInput
-import com.spela.player.presentation.secondarydisplay.PlatformSecondaryDisplay
 import com.spela.player.domain.model.NetplaySessionStatus
 import com.spela.player.presentation.intent.EmulationIntent
 import com.spela.player.presentation.intent.GameDetailIntent
 import com.spela.player.presentation.intent.GameListIntent
 import com.spela.player.presentation.intent.NetplayIntent
 import com.spela.player.presentation.navigation.NavigationIntent
-import com.spela.player.presentation.navigation.NavigationViewModel
 import com.spela.player.presentation.navigation.SpScreen
 import com.spela.player.presentation.ui.components.BottomNavTab
 import com.spela.player.presentation.ui.components.PlatformBackHandler
@@ -75,9 +73,7 @@ import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
 import com.spela.player.data.remote.ConnectionState
-import com.spela.player.data.remote.ConnectivityMonitor
 import com.spela.player.presentation.navigation.NavigationEvent
-import com.spela.player.presentation.navigation.NavigationEventBus
 import com.spela.player.presentation.ui.feature.ingame.DsPrimaryTouchOverlay
 import com.spela.player.presentation.ui.screen.ConsoleGamesScreen
 import com.spela.player.presentation.ui.screen.DeveloperGamesScreen
@@ -136,70 +132,13 @@ import com.spela.player.presentation.ui.gamepad.LocalInputMode
 import com.spela.player.presentation.ui.components.LocalScrapeService
 import com.spela.player.presentation.ui.components.ScrapeUpdates
 import com.spela.player.presentation.ui.theme.SpelaTheme
-import com.spela.player.data.remote.ScrapeService
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.input.pointer.PointerEventPass
-import com.spela.player.presentation.viewmodel.DownloadsViewModel
-import com.spela.player.presentation.viewmodel.EmulationViewModel
-import com.spela.player.presentation.viewmodel.GameDetailViewModel
-import com.spela.player.presentation.viewmodel.GameListViewModel
-import com.spela.player.presentation.viewmodel.LibretroController
-import com.spela.player.presentation.viewmodel.LoginViewModel
-import com.spela.player.presentation.viewmodel.SharedSessionDetailViewModel
-import com.spela.player.presentation.viewmodel.SessionDetailViewModel
-import com.spela.player.presentation.viewmodel.SharedSessionsViewModel
-import com.spela.player.presentation.viewmodel.ServerConnectionViewModel
-import com.spela.player.presentation.viewmodel.KeyMappingViewModel
-import com.spela.player.presentation.viewmodel.SettingsViewModel
-import com.spela.player.data.remote.PresenceService
-import com.spela.player.presentation.viewmodel.NetplayLobbyViewModel
-import com.spela.player.presentation.viewmodel.NetplayViewModel
-import com.spela.player.presentation.viewmodel.ChallengeDetailViewModel
-import com.spela.player.presentation.viewmodel.ChallengeListViewModel
-import com.spela.player.presentation.viewmodel.ExploreViewModel
-import com.spela.player.presentation.viewmodel.GlobalSearchViewModel
-import com.spela.player.presentation.viewmodel.CollectionsViewModel
-import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
-import com.spela.player.presentation.viewmodel.SocialViewModel
-import com.spela.player.presentation.viewmodel.StatsViewModel
-import com.spela.player.presentation.viewmodel.TopListsViewModel
 import com.spela.player.libretro.ControllerStatusState
-import com.spela.player.libretro.GamepadPortManager
 import com.spela.player.presentation.ui.components.SpSectionIndicator
 
 @Composable
-fun SpelaApp(
-    navigationViewModel: NavigationViewModel,
-    serverConnectionViewModel: ServerConnectionViewModel,
-    loginViewModel: LoginViewModel,
-    gameListViewModel: GameListViewModel,
-    gameDetailViewModel: GameDetailViewModel,
-    emulationViewModel: EmulationViewModel,
-    libretroController: LibretroController,
-    downloadsViewModel: DownloadsViewModel,
-    settingsViewModel: SettingsViewModel,
-    keyMappingViewModel: KeyMappingViewModel,
-    gamepadConfigViewModel: GamepadConfigViewModel? = null,
-    socialViewModel: SocialViewModel,
-    sharedSessionsViewModel: SharedSessionsViewModel,
-    sharedSessionDetailViewModel: SharedSessionDetailViewModel,
-    netplayViewModel: NetplayViewModel,
-    netplayLobbyViewModel: NetplayLobbyViewModel,
-    statsViewModel: StatsViewModel,
-    collectionsViewModel: CollectionsViewModel,
-    challengeListViewModel: ChallengeListViewModel,
-    challengeDetailViewModel: ChallengeDetailViewModel,
-    secondaryDisplay: PlatformSecondaryDisplay,
-    presenceService: PresenceService,
-    connectivityMonitor: ConnectivityMonitor,
-    sessionDetailViewModel: SessionDetailViewModel? = null,
-    topListsViewModel: TopListsViewModel? = null,
-    exploreViewModel: ExploreViewModel? = null,
-    navigationEventBus: NavigationEventBus? = null,
-    gamepadPortManager: GamepadPortManager? = null,
-    globalSearchViewModel: GlobalSearchViewModel? = null,
-    scrapeService: ScrapeService? = null,
-) {
+fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
     val currentTheme by settingsViewModel.selectedTheme.collectAsState()
 
     SpelaTheme(theme = currentTheme) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaAppDependencies.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaAppDependencies.kt
@@ -1,0 +1,92 @@
+package com.spela.player.presentation.ui
+
+import com.spela.player.data.remote.ConnectivityMonitor
+import com.spela.player.data.remote.PresenceService
+import com.spela.player.data.remote.ScrapeService
+import com.spela.player.libretro.GamepadPortManager
+import com.spela.player.presentation.navigation.NavigationEventBus
+import com.spela.player.presentation.navigation.NavigationViewModel
+import com.spela.player.presentation.secondarydisplay.PlatformSecondaryDisplay
+import com.spela.player.presentation.viewmodel.ChallengeDetailViewModel
+import com.spela.player.presentation.viewmodel.ChallengeListViewModel
+import com.spela.player.presentation.viewmodel.CollectionsViewModel
+import com.spela.player.presentation.viewmodel.DownloadsViewModel
+import com.spela.player.presentation.viewmodel.EmulationViewModel
+import com.spela.player.presentation.viewmodel.ExploreViewModel
+import com.spela.player.presentation.viewmodel.GameDetailViewModel
+import com.spela.player.presentation.viewmodel.GameListViewModel
+import com.spela.player.presentation.viewmodel.GamepadConfigViewModel
+import com.spela.player.presentation.viewmodel.GlobalSearchViewModel
+import com.spela.player.presentation.viewmodel.KeyMappingViewModel
+import com.spela.player.presentation.viewmodel.LibretroController
+import com.spela.player.presentation.viewmodel.LoginViewModel
+import com.spela.player.presentation.viewmodel.NetplayLobbyViewModel
+import com.spela.player.presentation.viewmodel.NetplayViewModel
+import com.spela.player.presentation.viewmodel.ServerConnectionViewModel
+import com.spela.player.presentation.viewmodel.SessionDetailViewModel
+import com.spela.player.presentation.viewmodel.SettingsViewModel
+import com.spela.player.presentation.viewmodel.SharedSessionDetailViewModel
+import com.spela.player.presentation.viewmodel.SharedSessionsViewModel
+import com.spela.player.presentation.viewmodel.SocialViewModel
+import com.spela.player.presentation.viewmodel.StatsViewModel
+import com.spela.player.presentation.viewmodel.TopListsViewModel
+
+/**
+ * Dependency bag for [SpelaApp]. The composable root needs a lot of
+ * ViewModels + platform services to wire every screen in its
+ * `when (screen)` router, and the flat 30-parameter signature was
+ * making the call sites unreadable. Grouping them here gives a
+ * single place to add a new dependency and lets the two callers
+ * (`presentation/App.kt` and `desktopTest/SpelaTestHarness.kt`)
+ * both build the same shape without copy-pasting a long argument
+ * list.
+ *
+ * Nullability on the trailing fields matches the original
+ * parameter defaults — tests and the slim initial-boot path can
+ * omit services that aren't exercised. All non-nullable fields
+ * are genuinely required by the main run.
+ *
+ * Part of #693 — the first of a four-PR split. Subsequent PRs
+ * move the screen router, connection-state overlay, and init
+ * effect grouping.
+ */
+data class SpelaAppDependencies(
+    // ── ViewModels (always required) ─────────────────────────────
+    val navigationViewModel: NavigationViewModel,
+    val serverConnectionViewModel: ServerConnectionViewModel,
+    val loginViewModel: LoginViewModel,
+    val gameListViewModel: GameListViewModel,
+    val gameDetailViewModel: GameDetailViewModel,
+    val emulationViewModel: EmulationViewModel,
+    val libretroController: LibretroController,
+    val downloadsViewModel: DownloadsViewModel,
+    val settingsViewModel: SettingsViewModel,
+    val keyMappingViewModel: KeyMappingViewModel,
+    val socialViewModel: SocialViewModel,
+    val sharedSessionsViewModel: SharedSessionsViewModel,
+    val sharedSessionDetailViewModel: SharedSessionDetailViewModel,
+    val netplayViewModel: NetplayViewModel,
+    val netplayLobbyViewModel: NetplayLobbyViewModel,
+    val statsViewModel: StatsViewModel,
+    val collectionsViewModel: CollectionsViewModel,
+    val challengeListViewModel: ChallengeListViewModel,
+    val challengeDetailViewModel: ChallengeDetailViewModel,
+
+    // ── Platform / services (always required) ────────────────────
+    val secondaryDisplay: PlatformSecondaryDisplay,
+    val presenceService: PresenceService,
+    val connectivityMonitor: ConnectivityMonitor,
+
+    // ── Optional slots ──────────────────────────────────────────
+    // These matched `= null` defaults on the original `SpelaApp`
+    // signature. Keeping them nullable so tests + simpler host
+    // apps can omit services the scenario doesn't exercise.
+    val gamepadConfigViewModel: GamepadConfigViewModel? = null,
+    val sessionDetailViewModel: SessionDetailViewModel? = null,
+    val topListsViewModel: TopListsViewModel? = null,
+    val exploreViewModel: ExploreViewModel? = null,
+    val navigationEventBus: NavigationEventBus? = null,
+    val gamepadPortManager: GamepadPortManager? = null,
+    val globalSearchViewModel: GlobalSearchViewModel? = null,
+    val scrapeService: ScrapeService? = null,
+)


### PR DESCRIPTION
First of four planned PRs retiring the `SpelaApp` god file (#693).

## Problem

`SpelaApp` took **30 parameters** as a flat argument list — painful to extend, easy to mis-wire at the two call sites (`App.kt` + `SpelaTestHarness.kt`), and a smell that the function is doing too much. The param list alone was 30+ lines of the signature.

## What changed

- **`SpelaAppDependencies`** — new data class with 22 required + 8 nullable fields (matching the original defaults).
- **`SpelaApp(deps: SpelaAppDependencies)`** — swapped signature. Body wrapped in `with(deps) { … }` so every existing bare reference to `navigationViewModel`, `settingsViewModel`, etc. still resolves. No mechanical rename of 1700 lines of wiring.
- Both call sites wrap their existing named-arg calls in `SpelaAppDependencies(…)` — no named-arg changes, no new fields exposed yet.
- Dropped 30 ViewModel/service type imports from `SpelaApp.kt` that were only needed as parameter types. They now live in the Dependencies file.

## Why incremental

Later PRs in this series will slice the body into pieces that each take the deps they need. PR A establishes the type that those pieces consume. The big win *this* PR is signal, not LOC: the Dependencies bag makes the function's API a single type, which subsequent router / overlay extractions can reference.

## Numbers

| File | Before | After |
|---|---|---|
| `SpelaApp.kt` | 1776 | 1715 (-61) |
| `SpelaAppDependencies.kt` | — | 92 |

## Tests / checks

- **526 shared + 759 desktop tests pass.** One known-flaky `AppLaunchAndConnectionTest.addServerValidatesAndSavesOnSuccess` fires under parallel-fork contention; passes in isolation, unrelated (documented in #683).
- Both targets compile (`compileKotlinDesktop` + `compileDebugKotlinAndroid`).
- `detektMainDesktop` clean.

## Next

**PR B** — extract the ~900-line `when (screen)` router into `ScreenRouter.kt`, taking the Dependencies bag as input.
**PR C** — `ConnectionStateOverlay` (offline banner, auth-failed dialog, DB error screen).
**PR D** — group the five interleaved init `LaunchedEffect`s.

Refs #693