### PR TITLE
refactor(player): extract ConnectionStateOverlay (#693 PR 3/4)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ConnectionStateOverlay.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ConnectionStateOverlay.kt
@@ -1,0 +1,103 @@
+package com.spela.player.presentation.ui
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import com.spela.player.data.remote.ConnectionState
+import com.spela.player.data.remote.ConnectivityMonitor
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.NavigationViewModel
+import com.spela.player.presentation.navigation.SpScreen
+import com.spela.player.presentation.ui.components.SpAuthExpiredDialog
+import com.spela.player.presentation.ui.components.SpDatabaseErrorScreen
+import com.spela.player.presentation.ui.components.SpOfflineBanner
+import com.spela.player.presentation.ui.components.SpServerWarningCard
+
+/**
+ * Extracted in #693 PR C. Owns the cascade of non-happy connection
+ * states on top of whatever the app wants to show underneath:
+ *
+ *   DatabaseError  → full-screen takeover (content is hidden)
+ *   AuthFailed     → dialog on top of content
+ *   Offline        → muted banner above content
+ *   ServerUnreach. → dismissible warning card above content
+ *
+ * The priority (DatabaseError > AuthFailed > ServerUnreachable > Offline)
+ * matches the pre-refactor inline block in SpelaApp.
+ *
+ * Also keeps the two pieces of state that go with those UIs —
+ * `serverWarningDismissed` resets whenever the state leaves
+ * ServerUnreachable, and `hasBeenOffline` tracks the offline→online
+ * transition so we can fire exactly one "Back online" snackbar via
+ * the [onBackOnline] callback. SpelaApp chooses how to render that
+ * snackbar (it shares a Snackbar host with other events).
+ *
+ * Declared as a `ColumnScope` extension and taking a
+ * `ColumnScope.() -> Unit` content slot so the banner/card + the
+ * screen router underneath all render into the caller's Column and
+ * keep their `.weight(1f)` layout semantics.
+ */
+@Composable
+fun ColumnScope.ConnectionStateOverlay(
+    connectivityMonitor: ConnectivityMonitor,
+    navigationViewModel: NavigationViewModel,
+    onBackOnline: () -> Unit,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    val state by connectivityMonitor.connectionState.collectAsState()
+    var serverWarningDismissed by remember { mutableStateOf(false) }
+    var hasBeenOffline by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state) {
+        if (state is ConnectionState.Online) {
+            if (hasBeenOffline) onBackOnline()
+        } else if (!state.isConnected) {
+            hasBeenOffline = true
+        }
+        if (state !is ConnectionState.ServerUnreachable) {
+            serverWarningDismissed = false
+        }
+    }
+
+    if (state is ConnectionState.DatabaseError) {
+        SpDatabaseErrorScreen(
+            message = (state as ConnectionState.DatabaseError).message,
+            onResetApp = { navigationViewModel.resetDatabase() },
+        )
+        return
+    }
+
+    if (state is ConnectionState.AuthFailed) {
+        SpAuthExpiredDialog(
+            onSignIn = {
+                connectivityMonitor.clearAuthFailure()
+                navigationViewModel.onIntent(
+                    NavigationIntent.NavigateTo(SpScreen.Login)
+                )
+            },
+            onContinueOffline = {
+                connectivityMonitor.clearAuthFailure()
+            },
+        )
+    }
+
+    SpOfflineBanner(connectionState = state)
+
+    if (state is ConnectionState.ServerUnreachable && !serverWarningDismissed) {
+        SpServerWarningCard(
+            onCheckServerSettings = {
+                navigationViewModel.onIntent(
+                    NavigationIntent.NavigateTo(SpScreen.Settings)
+                )
+            },
+            onDismiss = { serverWarningDismissed = true },
+        )
+    }
+
+    content()
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -59,15 +59,10 @@ import com.spela.player.presentation.ui.components.PlatformBackHandler
 import com.spela.player.presentation.ui.components.NavigationLayoutMode
 import com.spela.player.presentation.ui.components.SpBottomNavBar
 import com.spela.player.presentation.ui.components.SpNavigationRail
-import com.spela.player.presentation.ui.components.SpAuthExpiredDialog
 import com.spela.player.presentation.ui.components.SpButton
-import com.spela.player.presentation.ui.components.SpDatabaseErrorScreen
-import com.spela.player.presentation.ui.components.SpOfflineBanner
-import com.spela.player.presentation.ui.components.SpServerWarningCard
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
-import com.spela.player.data.remote.ConnectionState
 import com.spela.player.presentation.navigation.NavigationEvent
 import com.spela.player.presentation.ui.feature.ingame.DsPrimaryTouchOverlay
 import com.spela.player.presentation.ui.screen.InGameOverlay
@@ -262,67 +257,19 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
             }
 
             Column(modifier = Modifier.weight(1f).fillMaxHeight()) {
-                // Connection state
-                val currentConnectionState by connectivityMonitor.connectionState.collectAsState()
-                var serverWarningDismissed by remember { mutableStateOf(false) }
                 var snackbarData by remember { mutableStateOf<SpSnackbarData?>(null) }
 
-                // "Back online" snackbar: fires only after a genuine offline→online transition
-                var hasBeenOffline by remember { mutableStateOf(false) }
-                LaunchedEffect(currentConnectionState) {
-                    if (currentConnectionState is ConnectionState.Online) {
-                        if (hasBeenOffline) {
-                            snackbarData = SpSnackbarData(
-                                message = "Back online",
-                                type = SpSnackbarType.Success,
-                                durationMs = 3000L,
-                            )
-                        }
-                    } else if (!currentConnectionState.isConnected) {
-                        hasBeenOffline = true
-                    }
-                    // Reset dismiss when state changes away from ServerUnreachable
-                    if (currentConnectionState !is ConnectionState.ServerUnreachable) {
-                        serverWarningDismissed = false
-                    }
-                }
-
-                // Priority: DatabaseError (full-screen) > AuthFailed (dialog) > ServerUnreachable (card) > Offline (banner)
-                if (currentConnectionState is ConnectionState.DatabaseError) {
-                    SpDatabaseErrorScreen(
-                        message = (currentConnectionState as ConnectionState.DatabaseError).message,
-                        onResetApp = { navigationViewModel.resetDatabase() },
-                    )
-                } else {
-
-                if (currentConnectionState is ConnectionState.AuthFailed) {
-                    SpAuthExpiredDialog(
-                        onSignIn = {
-                            connectivityMonitor.clearAuthFailure()
-                            navigationViewModel.onIntent(
-                                NavigationIntent.NavigateTo(SpScreen.Login)
-                            )
-                        },
-                        onContinueOffline = {
-                            connectivityMonitor.clearAuthFailure()
-                        },
-                    )
-                }
-
-                // Offline banner (muted grey)
-                SpOfflineBanner(connectionState = currentConnectionState)
-
-                // Server unreachable card (dismissible per-session)
-                if (currentConnectionState is ConnectionState.ServerUnreachable && !serverWarningDismissed) {
-                    SpServerWarningCard(
-                        onCheckServerSettings = {
-                            navigationViewModel.onIntent(
-                                NavigationIntent.NavigateTo(SpScreen.Settings)
-                            )
-                        },
-                        onDismiss = { serverWarningDismissed = true },
-                    )
-                }
+                ConnectionStateOverlay(
+                    connectivityMonitor = connectivityMonitor,
+                    navigationViewModel = navigationViewModel,
+                    onBackOnline = {
+                        snackbarData = SpSnackbarData(
+                            message = "Back online",
+                            type = SpSnackbarType.Success,
+                            durationMs = 3000L,
+                        )
+                    },
+                ) {
 
                 Box(modifier = Modifier.weight(1f)) {
                     val animationsEnabled = com.spela.player.presentation.ui.components.LocalAnimationsEnabled.current
@@ -577,7 +524,7 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
                         },
                     )
                 }
-                } // else (not DatabaseError)
+                } // ConnectionStateOverlay content slot
             } // Column (content + bottom bar)
             } // Row (side rail + content column)
 


### PR DESCRIPTION
## Summary

Lifts the ~60-line connection-state cascade out of `SpelaApp.kt` into a new `ColumnScope.ConnectionStateOverlay` composable. The overlay owns the priority chain `DatabaseError → AuthFailed → ServerUnreachable → Offline` and the two pieces of local state and the `LaunchedEffect` that go with it.

The new composable's contract:

- **Renders the cascade** — `DatabaseError` returns early (full-screen takeover, content not rendered); `AuthFailed` shows a dialog above content; `Offline` shows the muted banner; `ServerUnreachable` shows a dismissible card.
- **Owns the local state** — `serverWarningDismissed` (resets when state leaves ServerUnreachable) and `hasBeenOffline` (used to gate the "Back online" snackbar).
- **`onBackOnline` callback** — fires once on a genuine offline→online transition. SpelaApp uses it to set `snackbarData`, keeping the snackbar host inline (it's shared with other snackbar sources).

The `DatabaseError` early-return is now `if (...) { ...; return }` instead of an `else` block wrapping ~280 lines of unrelated content — semantically identical to the pre-refactor inline block (composable `return` terminates the subtree for this frame, matching the `else`-skipped path).

`SpelaApp.kt` drops 5 now-unused imports.

## Split plan for #693

- PR A — `SpelaAppDependencies` bag: #705 (merged)
- PR B — `ScreenRouter` extraction: #706 (merged)
- **PR C — this** — `ConnectionStateOverlay`
- PR D — group the 5 interleaved init `LaunchedEffect`s

## Verification

- `./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid` — green
- `./gradlew :shared:detektMainDesktop` — no UnusedImport findings on touched files
- `./run-desktop-tests.sh` — 757 tests, 0 failures, 0 errors, 1 skipped (skip is from a manually killed test runner, not a regression)

## Test plan

- [x] Desktop compile both targets
- [x] detekt clean
- [x] Full desktop test suite
- [ ] CI green

Refs #693.