### PR TITLE
refactor(player): group root-level side effects into SpelaAppEffects (#693 PR 4/4)

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaApp.kt
@@ -63,7 +63,6 @@ import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpSnackbar
 import com.spela.player.presentation.ui.components.SpSnackbarData
 import com.spela.player.presentation.ui.components.SpSnackbarType
-import com.spela.player.presentation.navigation.NavigationEvent
 import com.spela.player.presentation.ui.feature.ingame.DsPrimaryTouchOverlay
 import com.spela.player.presentation.ui.screen.InGameOverlay
 import com.spela.player.presentation.ui.feature.ingame.PlatformEmulationSurface
@@ -78,7 +77,6 @@ import com.spela.player.presentation.ui.gamepad.LocalIsForwardNavigation
 import com.spela.player.presentation.ui.gamepad.LocalIsTabSwitch
 import com.spela.player.presentation.ui.gamepad.LocalInputMode
 import com.spela.player.presentation.ui.components.LocalScrapeService
-import com.spela.player.presentation.ui.components.ScrapeUpdates
 import com.spela.player.presentation.ui.theme.SpelaTheme
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.input.pointer.PointerEventPass
@@ -94,13 +92,6 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
         LocalScrapeService provides scrapeService,
         LocalInputMode provides (gamepadPortManager?.inputMode?.collectAsState()?.value ?: InputMode.TOUCH),
     ) {
-        // Observe scrape completions and update cover art reactively
-        LaunchedEffect(scrapeService) {
-            scrapeService?.scrapedCovers?.collect { (gameId, coverUrl) ->
-                ScrapeUpdates.onCoverUpdated(gameId, coverUrl)
-            }
-        }
-
         val navState by navigationViewModel.state.collectAsState()
 
         // Input mode detection: TOUCH shows tab bar, GAMEPAD shows section indicator
@@ -138,28 +129,16 @@ fun SpelaApp(deps: SpelaAppDependencies) = with(deps) {
             return@CompositionLocalProvider
         }
 
-        // Connect/disconnect WebSocket presence based on authentication state
         val isAuthenticated = navState.currentScreen !is SpScreen.ServerConnection &&
                 navState.currentScreen !is SpScreen.Login
-        LaunchedEffect(isAuthenticated) {
-            if (isAuthenticated) {
-                presenceService.connect()
-            } else {
-                presenceService.disconnect()
-            }
-        }
 
-        // Collect desktop gamepad navigation events
-        if (navigationEventBus != null) {
-            LaunchedEffect(navigationEventBus) {
-                navigationEventBus.events.collect { event ->
-                    when (event) {
-                        NavigationEvent.NextSection -> navigationViewModel.onIntent(NavigationIntent.NextSection)
-                        NavigationEvent.PreviousSection -> navigationViewModel.onIntent(NavigationIntent.PreviousSection)
-                    }
-                }
-            }
-        }
+        SpelaAppEffects(
+            scrapeService = scrapeService,
+            presenceService = presenceService,
+            isAuthenticated = isAuthenticated,
+            navigationEventBus = navigationEventBus,
+            navigationViewModel = navigationViewModel,
+        )
 
         val isGamepadScreen = navState.currentScreen !is SpScreen.ServerConnection &&
                 navState.currentScreen !is SpScreen.Login

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaAppEffects.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/SpelaAppEffects.kt
@@ -1,0 +1,63 @@
+package com.spela.player.presentation.ui
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import com.spela.player.data.remote.PresenceService
+import com.spela.player.data.remote.ScrapeService
+import com.spela.player.presentation.ui.components.ScrapeUpdates
+import com.spela.player.presentation.navigation.NavigationEvent
+import com.spela.player.presentation.navigation.NavigationEventBus
+import com.spela.player.presentation.navigation.NavigationIntent
+import com.spela.player.presentation.navigation.NavigationViewModel
+
+/**
+ * Root-level side effects that used to be three interleaved
+ * `LaunchedEffect` blocks scattered through the `SpelaApp` body.
+ * Grouped here in #693 PR D so the main composable reads as a layout
+ * description rather than a mix of layout and wire-up.
+ *
+ * Each effect keeps its own key, so reactivity is identical to the
+ * pre-refactor code:
+ *
+ * - `scrapeService` — re-subscribes if the service reference changes
+ *   (practically once, since it comes from DI).
+ * - `isAuthenticated` — flips between connect/disconnect whenever the
+ *   navigation state crosses the login / server-connection screens.
+ * - `navigationEventBus` — registers once if the bus is present (null
+ *   on Android; desktop wires it up for gamepad nav).
+ */
+@Composable
+fun SpelaAppEffects(
+    scrapeService: ScrapeService?,
+    presenceService: PresenceService,
+    isAuthenticated: Boolean,
+    navigationEventBus: NavigationEventBus?,
+    navigationViewModel: NavigationViewModel,
+) {
+    LaunchedEffect(scrapeService) {
+        scrapeService?.scrapedCovers?.collect { (gameId, coverUrl) ->
+            ScrapeUpdates.onCoverUpdated(gameId, coverUrl)
+        }
+    }
+
+    LaunchedEffect(isAuthenticated) {
+        if (isAuthenticated) {
+            presenceService.connect()
+        } else {
+            presenceService.disconnect()
+        }
+    }
+
+    if (navigationEventBus != null) {
+        LaunchedEffect(navigationEventBus) {
+            navigationEventBus.events.collect { event ->
+                when (event) {
+                    NavigationEvent.NextSection ->
+                        navigationViewModel.onIntent(NavigationIntent.NextSection)
+                    NavigationEvent.PreviousSection ->
+                        navigationViewModel.onIntent(NavigationIntent.PreviousSection)
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Moves the three root-level `LaunchedEffect`s (scrape completions, presence connect/disconnect, desktop gamepad nav events) into a single helper composable, `SpelaAppEffects`. Each effect keeps its own key, so Compose reactivity (cancel/restart on key change) is unchanged.

**Positional change (safe):** the scrape-completion effect used to run before the `isRestoringSession` early-return gate and now runs after it — grouped with the two effects that were already gated. This is observationally a no-op:

- `scrapedCovers` is a `MutableSharedFlow` with no replay — with no subscriber there is nothing to miss.
- The scrape WebSocket isn't opened until `PresenceService.connect()` — also gated behind the same restore return — so no events can arrive during the restore window.

`SpelaApp.kt` drops two now-unused imports (`NavigationEvent`, `ScrapeUpdates`).

## Closes #693

Four-PR split complete:

- PR A — `SpelaAppDependencies` bag: #705 (merged)
- PR B — `ScreenRouter` extraction: #706 (merged)
- PR C — `ConnectionStateOverlay`: #707 (merged)
- **PR D — this** — `SpelaAppEffects` grouping

SpelaApp.kt journey: **1715 LOC → ~470 LOC**, now dominated by the visible layout tree rather than a mix of wire-up, routing, connection-cascade logic, and side-effect plumbing.

## Verification

- `./gradlew :shared:compileKotlinDesktop :shared:compileDebugKotlinAndroid` — green
- `./gradlew :shared:detektMainDesktop` — clean on touched files
- `./run-desktop-tests.sh` — 1285 testcases across shared + desktop, 0 failure files in `<test-results>/**/TEST-*.xml`

## Test plan

- [x] Both compile targets
- [x] detekt clean
- [x] Full desktop test suite
- [ ] CI green

Refs #693.