### PR TITLE
refactor(web): extract useResolvedGamePreferences + useEmulatorInit from play-page (#694 partial)

### DIFF
--- a/web/src/features/play/hooks/__tests__/use-resolved-game-preferences.test.ts
+++ b/web/src/features/play/hooks/__tests__/use-resolved-game-preferences.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { UserPreferences } from "@/types/api";
+import { useResolvedGamePreferences } from "@/features/play/hooks/use-resolved-game-preferences";
+
+function prefs(overrides: Partial<UserPreferences> = {}): UserPreferences {
+  return {
+    autoLoadSaveEnabled: true,
+    autoSaveEnabled: true,
+    autoUpdateCoresEnabled: false,
+    consoleKeyMappings: {},
+    consoleShaders: {},
+    customKeyMapping: {},
+    defaultSecondScreenPage: "controls",
+    preferredRegions: [],
+    raHardcoreEnabled: false,
+    raLinked: false,
+    raUsername: "",
+    selectedKeyMapping: "arrows-left",
+    selectedShader: "none",
+    selectedTheme: "default",
+    showPerformanceOverlay: false,
+    ...overrides,
+  };
+}
+
+describe("useResolvedGamePreferences", () => {
+  it("falls back to defaults when preferences are undefined", () => {
+    const { result } = renderHook(() =>
+      useResolvedGamePreferences({
+        preferences: undefined,
+        consoleId: "snes",
+      }),
+    );
+
+    expect(result.current).toMatchObject({
+      shader: "none",
+      showPerformanceOverlay: false,
+      keyMapping: "arrows-left",
+      customKeyMapping: undefined,
+    });
+  });
+
+  it("uses per-console shader override when set", () => {
+    const { result } = renderHook(() =>
+      useResolvedGamePreferences({
+        preferences: prefs({
+          selectedShader: "crt-hylian",
+          consoleShaders: { snes: "crt-lottes" },
+        }),
+        consoleId: "snes",
+      }),
+    );
+
+    // crt-lottes has no EmulatorJS mapping, so it passes through unchanged
+    expect(result.current.shader).toBe("crt-lottes");
+  });
+
+  it("falls back to global shader when console has no override", () => {
+    const { result } = renderHook(() =>
+      useResolvedGamePreferences({
+        preferences: prefs({
+          selectedShader: "crt-hylian",
+          consoleShaders: { snes: "crt-lottes" },
+        }),
+        consoleId: "gba",
+      }),
+    );
+
+    expect(result.current.shader).toBe("crt-hylian");
+  });
+
+  it("uses per-console key mapping override when set", () => {
+    const { result } = renderHook(() =>
+      useResolvedGamePreferences({
+        preferences: prefs({
+          selectedKeyMapping: "arrows-left",
+          consoleKeyMappings: {
+            snes: { selectedMapping: "wasd-left", customMapping: {} },
+          },
+        }),
+        consoleId: "snes",
+      }),
+    );
+
+    expect(result.current.keyMapping).toBe("wasd-left");
+  });
+
+  it("resolves custom mapping only when the chosen mapping is custom", () => {
+    const global = { button_a: "K" };
+    const consoleCustom = { button_a: "J" };
+
+    const { result: resultCustom } = renderHook(() =>
+      useResolvedGamePreferences({
+        preferences: prefs({
+          selectedKeyMapping: "custom",
+          customKeyMapping: global,
+          consoleKeyMappings: {
+            snes: {
+              selectedMapping: "custom",
+              customMapping: consoleCustom,
+            },
+          },
+        }),
+        consoleId: "snes",
+      }),
+    );
+
+    expect(resultCustom.current.keyMapping).toBe("custom");
+    expect(resultCustom.current.customKeyMapping).toEqual(consoleCustom);
+
+    const { result: resultNonCustom } = renderHook(() =>
+      useResolvedGamePreferences({
+        preferences: prefs({
+          selectedKeyMapping: "arrows-left",
+          customKeyMapping: global,
+        }),
+        consoleId: "snes",
+      }),
+    );
+
+    expect(resultNonCustom.current.keyMapping).toBe("arrows-left");
+    expect(resultNonCustom.current.customKeyMapping).toBeUndefined();
+  });
+
+  it("falls back to global custom mapping when console has no custom override", () => {
+    const { result } = renderHook(() =>
+      useResolvedGamePreferences({
+        preferences: prefs({
+          selectedKeyMapping: "custom",
+          customKeyMapping: { button_a: "K" },
+          consoleKeyMappings: {
+            snes: { selectedMapping: "custom", customMapping: {} },
+          },
+        }),
+        consoleId: "gba",
+      }),
+    );
+
+    expect(result.current.keyMapping).toBe("custom");
+    expect(result.current.customKeyMapping).toEqual({ button_a: "K" });
+  });
+
+  it("passes showPerformanceOverlay through from preferences", () => {
+    const { result } = renderHook(() =>
+      useResolvedGamePreferences({
+        preferences: prefs({ showPerformanceOverlay: true }),
+        consoleId: "snes",
+      }),
+    );
+
+    expect(result.current.showPerformanceOverlay).toBe(true);
+  });
+});

--- a/web/src/features/play/hooks/use-emulator-init.ts
+++ b/web/src/features/play/hooks/use-emulator-init.ts
@@ -1,0 +1,216 @@
+import { useEffect, type MutableRefObject } from "react";
+import { api } from "@/lib/api-client";
+import { getBiosFileUrl } from "@/hooks/use-bios";
+import type { Game, SessionSave } from "@/types/api";
+import type { EmulatorPreferences } from "@/lib/emulator-protocol";
+import type { CoreMismatchChoice } from "@/features/play/components/core-mismatch-modal";
+
+/**
+ * Subset of the BIOS console status we actually use here — keeps
+ * the hook decoupled from whether the caller passes the raw schema
+ * object or the narrowed `BiosConsole` type.
+ */
+interface BiosConsoleLike {
+  files?: Array<{ fileName: string; status: string }> | null;
+}
+
+interface EmulatorApi {
+  initEmulator: (opts: {
+    romUrl: string;
+    romData?: ArrayBuffer;
+    targetDisc?: number;
+    core: string;
+    gameName: string;
+    saveStateData?: string;
+    biosUrls?: string[];
+    preferences: EmulatorPreferences;
+  }) => void;
+}
+
+interface UseEmulatorInitArgs {
+  // Effect triggers — changes to these re-run the init flow.
+  iframeLoaded: boolean;
+  gameId: string | undefined;
+  isSupported: boolean;
+  emulatorJsCore: string | null;
+  autoSaveInfoLoading: boolean;
+
+  // Data read freshly on each run.
+  game: Game | undefined;
+  isFreshStart: boolean;
+  biosConsole: BiosConsoleLike | undefined;
+  emulatorPrefs: EmulatorPreferences;
+
+  // Mutable state read via refs so we pick up the latest value
+  // without having to depend on it (the original code did the same).
+  autoSaveInfoRef: MutableRefObject<SessionSave | null | undefined>;
+  coreMismatchChoiceRef: MutableRefObject<CoreMismatchChoice | null>;
+  pendingDiscSwitchRef: MutableRefObject<{
+    targetDisc: number;
+    saveData: string;
+  } | null>;
+  buildMultiDiscBundleRef: MutableRefObject<() => ArrayBuffer | null>;
+
+  // Collaborators.
+  emulator: EmulatorApi;
+  loadInitialSave: (skipAutoLoad?: boolean) => Promise<string | undefined>;
+
+  // Side effects back into the page.
+  onToastError: (message: string) => void;
+  onRequestCoreMismatchChoice: () => void;
+  onDiscSwitchCurrentChanged: (newCurrentDisc: number) => void;
+  onDiscSwitchSettled: () => void;
+}
+
+/**
+ * Owns the big init `useEffect` that used to live inline in
+ * `play-page.tsx`. It runs when the iframe finishes loading and the
+ * game data is ready, then picks one of two paths:
+ *
+ *   1. **Disc-switch path** — when a disc switch is pending and its
+ *      save state has arrived, rebuild a combined multi-disc ROM bundle
+ *      and re-init the emulator with the target disc + save data.
+ *
+ *   2. **Normal init path** — pick the ROM URL (single-disc download or
+ *      multi-disc zip of disc 1), resolve the save state (skipped on
+ *      fresh start or when the user picked fresh/sram-only after a
+ *      core mismatch), build authenticated BIOS URLs, and call
+ *      `initEmulator`.
+ *
+ * The hook preserves the original `exhaustive-deps` suppression: the
+ * dep array is deliberately narrow (only the five listed triggers)
+ * because the other inputs are read via refs or closed-over values
+ * whose changes would cause unwanted re-initialisation mid-session.
+ *
+ * Extracted in #694 (partial). The companion `useDiscSwitchFlow` is
+ * still TODO — extracting it cleanly requires a multi-disc test rig
+ * to assert no regression on the pause → save → bundle → re-init
+ * sequence.
+ */
+export function useEmulatorInit({
+  iframeLoaded,
+  gameId,
+  isSupported,
+  emulatorJsCore,
+  autoSaveInfoLoading,
+  game,
+  isFreshStart,
+  biosConsole,
+  emulatorPrefs,
+  autoSaveInfoRef,
+  coreMismatchChoiceRef,
+  pendingDiscSwitchRef,
+  buildMultiDiscBundleRef,
+  emulator,
+  loadInitialSave,
+  onToastError,
+  onRequestCoreMismatchChoice,
+  onDiscSwitchCurrentChanged,
+  onDiscSwitchSettled,
+}: UseEmulatorInitArgs): void {
+  useEffect(() => {
+    if (!iframeLoaded || !game || !isSupported || !emulatorJsCore) return;
+    // Wait for auto-save info to settle before initializing (avoids double-init)
+    if (!isFreshStart && autoSaveInfoLoading) return;
+
+    // Disc switch flow: reload with combined bundle + save state + target disc
+    if (pendingDiscSwitchRef.current && pendingDiscSwitchRef.current.saveData) {
+      const { targetDisc, saveData } = pendingDiscSwitchRef.current;
+      const bundle = buildMultiDiscBundleRef.current();
+      if (!bundle) {
+        onToastError("Failed to build multi-disc bundle");
+        pendingDiscSwitchRef.current = null;
+        onDiscSwitchSettled();
+        return;
+      }
+
+      const token = api.getAccessToken();
+      const tokenSuffix = token
+        ? `?token=${encodeURIComponent(token)}`
+        : "";
+      const consoleBiosFiles = biosConsole?.files
+        ?.filter((f) => f.status !== "missing")
+        .map((f) => f.fileName) ?? [];
+      const biosUrls =
+        consoleBiosFiles.length > 0
+          ? consoleBiosFiles.map((f) => getBiosFileUrl(f) + tokenSuffix)
+          : undefined;
+
+      onDiscSwitchCurrentChanged(targetDisc + 1);
+      pendingDiscSwitchRef.current = null;
+
+      emulator.initEmulator({
+        romUrl: "",
+        romData: bundle,
+        targetDisc,
+        core: emulatorJsCore,
+        gameName: game.title,
+        saveStateData: saveData,
+        biosUrls,
+        preferences: emulatorPrefs,
+      });
+
+      onDiscSwitchSettled();
+      return;
+    }
+
+    async function init() {
+      if (!game || !emulatorJsCore) return;
+
+      const currentAutoSave = autoSaveInfoRef.current;
+      if (
+        !isFreshStart &&
+        currentAutoSave &&
+        currentAutoSave.coreMatch === false &&
+        !coreMismatchChoiceRef.current
+      ) {
+        onRequestCoreMismatchChoice();
+        return;
+      }
+
+      const token = api.getAccessToken();
+      const tokenSuffix = token
+        ? `?token=${encodeURIComponent(token)}`
+        : "";
+      // Multi-disc games (e.g. PS1 .m3u): load disc 1 via the disc endpoint.
+      // The main /download endpoint serves the .m3u playlist file which
+      // EmulatorJS can't use (it needs the actual disc image).
+      // For multi-file disc formats (cue+bin), request format=zip since
+      // EmulatorJS can extract zip but not tar.
+      const isMultiDisc =
+        game.discCount > 0 && !!game.discs && game.discs.length > 0;
+      // Include the filename in the URL path so EmulatorJS can detect the
+      // file extension (e.g. .gg for Game Gear). Without it, genesis_plus_gx
+      // can't distinguish Game Gear from Genesis ROMs.
+      const romUrl = isMultiDisc
+        ? `/api/games/${game.id}/discs/1/download?format=zip${token ? `&token=${encodeURIComponent(token)}` : ""}`
+        : `/api/games/${game.id}/download/${encodeURIComponent(game.fileName)}${tokenSuffix}`;
+
+      const choice = coreMismatchChoiceRef.current;
+      const skipSaveState = choice === "fresh" || choice === "sram-only";
+      const saveStateData = await loadInitialSave(
+        isFreshStart || skipSaveState,
+      );
+
+      const consoleBiosFiles = biosConsole?.files
+        ?.filter((f) => f.status !== "missing")
+        .map((f) => f.fileName) ?? [];
+      const biosUrls =
+        consoleBiosFiles.length > 0
+          ? consoleBiosFiles.map((f) => getBiosFileUrl(f) + tokenSuffix)
+          : undefined;
+
+      emulator.initEmulator({
+        romUrl,
+        core: emulatorJsCore,
+        gameName: game.title,
+        saveStateData,
+        biosUrls,
+        preferences: emulatorPrefs,
+      });
+    }
+
+    init();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [iframeLoaded, gameId, isSupported, emulatorJsCore, autoSaveInfoLoading]);
+}

--- a/web/src/features/play/hooks/use-resolved-game-preferences.ts
+++ b/web/src/features/play/hooks/use-resolved-game-preferences.ts
@@ -1,0 +1,60 @@
+import type { UserPreferences } from "@/types/api";
+import type { EmulatorPreferences } from "@/lib/emulator-protocol";
+import { toEmulatorJsShader } from "@/lib/shader-mapping";
+
+interface ResolvedPreferencesInput {
+  preferences: UserPreferences | undefined;
+  consoleId: string | undefined;
+}
+
+/**
+ * Resolves the effective emulator preferences for a game given the
+ * user's global + per-console overrides. Extracted from `play-page.tsx`
+ * in #694 — pure derived state, no side effects, so a plain function
+ * would do, but it is exposed as a `use-*` hook to keep the call site
+ * consistent with the surrounding hook pattern.
+ *
+ * Resolution order (matches the pre-refactor inline code):
+ *
+ *   shader:  per-console override  → global `selectedShader`      → "none"
+ *   mapping: per-console override  → global `selectedKeyMapping`  → "arrows-left"
+ *   custom:  only when the chosen mapping is `"custom"`; per-console
+ *            custom takes precedence over global custom, falling back
+ *            to `{}` if neither is set.
+ *
+ * The EmulatorJS shader name is mapped through `toEmulatorJsShader`
+ * (EmulatorJS uses its own shader ids; we pass the Spela id through
+ * unchanged for shaders without a mapping).
+ */
+export function useResolvedGamePreferences({
+  preferences,
+  consoleId,
+}: ResolvedPreferencesInput): EmulatorPreferences {
+  const key = consoleId ?? "";
+
+  const spelaShader = preferences
+    ? preferences.consoleShaders[key] ||
+      preferences.selectedShader ||
+      "none"
+    : "none";
+  const resolvedShader = toEmulatorJsShader(spelaShader) || spelaShader;
+
+  const consoleKeyMapping = preferences?.consoleKeyMappings[key];
+  const resolvedKeyMapping =
+    consoleKeyMapping?.selectedMapping ??
+    preferences?.selectedKeyMapping ??
+    "arrows-left";
+  const resolvedCustomMapping =
+    resolvedKeyMapping === "custom"
+      ? (consoleKeyMapping?.customMapping ??
+          preferences?.customKeyMapping ??
+          {})
+      : undefined;
+
+  return {
+    shader: resolvedShader,
+    showPerformanceOverlay: preferences?.showPerformanceOverlay ?? false,
+    keyMapping: resolvedKeyMapping,
+    customKeyMapping: resolvedCustomMapping,
+  };
+}

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -9,7 +9,7 @@ import {
 import { useGame } from "@/hooks/use-games";
 import { useUserPreferences } from "@/hooks/use-preferences";
 import { useConsoles } from "@/hooks/use-consoles";
-import { useBiosStatus, getBiosFileUrl } from "@/hooks/use-bios";
+import { useBiosStatus } from "@/hooks/use-bios";
 import { useAuth } from "@/hooks/use-auth";
 import { useEmulatorIframe } from "@/hooks/use-emulator-iframe";
 import { useEmulatorSaves } from "@/hooks/use-emulator-saves";
@@ -20,16 +20,15 @@ import { useToast } from "@/components/ui";
 import { useGamepadConnected } from "@/hooks/use-gamepad";
 import { useAutoSaveInfo } from "@/hooks/use-sessions";
 import { useQueryClient } from "@tanstack/react-query";
-import { api, typedApi, unwrap } from "@/lib/api-client";
-import { toEmulatorJsShader } from "@/lib/shader-mapping";
+import { typedApi, unwrap } from "@/lib/api-client";
+import { useEmulatorInit } from "@/features/play/hooks/use-emulator-init";
+import { useResolvedGamePreferences } from "@/features/play/hooks/use-resolved-game-preferences";
 import { PlayToolbar } from "@/features/play/components/play-toolbar";
 import { EmulatorOverlay } from "@/features/play/components/emulator-overlay";
 import {
   CoreMismatchModal,
   type CoreMismatchChoice,
 } from "@/features/play/components/core-mismatch-modal";
-import type { EmulatorPreferences } from "@/lib/emulator-protocol";
-
 export function PlayPage() {
   const { id, sessionId: sessionIdParam } = useParams<{ id: string; sessionId: string }>();
   const navigate = useNavigate();
@@ -98,34 +97,10 @@ export function PlayPage() {
   const emulatorJsCore = consoleInfo?.emulatorJsCore || null;
   const isSupported = !!emulatorJsCore;
 
-  // Resolve shader: per-console override -> global default -> none, then map to EmulatorJS name
-  const spelaShader = preferences
-    ? preferences.consoleShaders[game?.consoleId ?? ""] ||
-      preferences.selectedShader ||
-      "none"
-    : "none";
-  const resolvedShader = toEmulatorJsShader(spelaShader) || spelaShader;
-
-  // Resolve key mapping: per-console override -> global default -> arrows-left
-  const consoleKeyMapping =
-    preferences?.consoleKeyMappings[game?.consoleId ?? ""];
-  const resolvedKeyMapping =
-    consoleKeyMapping?.selectedMapping ??
-    preferences?.selectedKeyMapping ??
-    "arrows-left";
-  const resolvedCustomMapping =
-    resolvedKeyMapping === "custom"
-      ? (consoleKeyMapping?.customMapping ??
-        preferences?.customKeyMapping ??
-        {})
-      : undefined;
-
-  const emulatorPrefs: EmulatorPreferences = {
-    shader: resolvedShader,
-    showPerformanceOverlay: preferences?.showPerformanceOverlay ?? false,
-    keyMapping: resolvedKeyMapping,
-    customKeyMapping: resolvedCustomMapping,
-  };
+  const emulatorPrefs = useResolvedGamePreferences({
+    preferences,
+    consoleId: game?.consoleId,
+  });
 
   const emulator = useEmulatorIframe({
     onGameStarted: () => {
@@ -219,115 +194,27 @@ export function PlayPage() {
     [isSwitchingDisc, discManager.allDiscsReady, emulator],
   );
 
-  // Initialize emulator once iframe is loaded and we have game data
-  useEffect(() => {
-    if (!iframeLoaded || !game || !isSupported || !emulatorJsCore) return;
-    // Wait for auto-save info to settle before initializing (avoids double-init)
-    if (!isFreshStart && autoSaveInfoLoading) return;
-
-    // Disc switch flow: reload with combined bundle + save state + target disc
-    if (pendingDiscSwitchRef.current && pendingDiscSwitchRef.current.saveData) {
-      const { targetDisc, saveData } = pendingDiscSwitchRef.current;
-      const bundle = buildMultiDiscBundleRef.current();
-      if (!bundle) {
-        toast("error", "Failed to build multi-disc bundle");
-        pendingDiscSwitchRef.current = null;
-        setIsSwitchingDisc(false);
-        return;
-      }
-
-      const token = api.getAccessToken();
-      const tokenSuffix = token
-        ? `?token=${encodeURIComponent(token)}`
-        : "";
-      // Filter BIOS files for the current console only
-      const consoleBiosFiles = biosConsole?.files
-        ?.filter((f) => f.status !== "missing")
-        .map((f) => f.fileName) ?? [];
-      const biosUrls =
-        consoleBiosFiles.length > 0
-          ? consoleBiosFiles.map((f) => getBiosFileUrl(f) + tokenSuffix)
-          : undefined;
-
-      // Update currentDisc now that the switch is committed
-      setCurrentDisc(targetDisc + 1); // convert back to 1-indexed
-      pendingDiscSwitchRef.current = null;
-
-      emulator.initEmulator({
-        romUrl: "", // unused when romData is provided
-        romData: bundle,
-        targetDisc,
-        core: emulatorJsCore!,
-        gameName: game!.title,
-        saveStateData: saveData,
-        biosUrls,
-        preferences: emulatorPrefs,
-      });
-
-      setIsSwitchingDisc(false);
-      return;
-    }
-
-    // Normal initialization flow
-    async function init() {
-      // Check for core mismatch before loading the auto-save
-      const currentAutoSave = autoSaveInfoRef.current;
-      if (
-        !isFreshStart &&
-        currentAutoSave &&
-        currentAutoSave.coreMatch === false &&
-        !coreMismatchChoiceRef.current
-      ) {
-        setShowCoreMismatchModal(true);
-        return; // Wait for user choice — will re-enter after choice is made
-      }
-
-      const token = api.getAccessToken();
-      const tokenSuffix = token
-        ? `?token=${encodeURIComponent(token)}`
-        : "";
-      // Multi-disc games (e.g. PS1 .m3u): load disc 1 via the disc endpoint.
-      // The main /download endpoint serves the .m3u playlist file which
-      // EmulatorJS can't use (it needs the actual disc image).
-      // For multi-file disc formats (cue+bin), request format=zip since
-      // EmulatorJS can extract zip but not tar.
-      const isMultiDisc = game!.discCount > 0 && game!.discs && game!.discs.length > 0;
-      // Include the filename in the URL path so EmulatorJS can detect the
-      // file extension (e.g. .gg for Game Gear). Without it, genesis_plus_gx
-      // can't distinguish Game Gear from Genesis ROMs.
-      const romUrl = isMultiDisc
-        ? `/api/games/${game!.id}/discs/1/download?format=zip${token ? `&token=${encodeURIComponent(token)}` : ""}`
-        : `/api/games/${game!.id}/download/${encodeURIComponent(game!.fileName)}${tokenSuffix}`;
-
-      // Determine whether to load the save state based on user choice
-      const choice = coreMismatchChoiceRef.current;
-      const skipSaveState = choice === "fresh" || choice === "sram-only";
-      const saveStateData = await saveManager.loadInitialSave(
-        isFreshStart || skipSaveState,
-      );
-
-      // Build authenticated BIOS file URLs (filtered for current console)
-      const consoleBiosFiles2 = biosConsole?.files
-        ?.filter((f) => f.status !== "missing")
-        .map((f) => f.fileName) ?? [];
-      const biosUrls =
-        consoleBiosFiles2.length > 0
-          ? consoleBiosFiles2.map((f) => getBiosFileUrl(f) + tokenSuffix)
-          : undefined;
-
-      emulator.initEmulator({
-        romUrl,
-        core: emulatorJsCore!,
-        gameName: game!.title,
-        saveStateData,
-        biosUrls,
-        preferences: emulatorPrefs,
-      });
-    }
-
-    init();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [iframeLoaded, game?.id, isSupported, emulatorJsCore, autoSaveInfoLoading]);
+  useEmulatorInit({
+    iframeLoaded,
+    gameId: game?.id,
+    isSupported,
+    emulatorJsCore,
+    autoSaveInfoLoading,
+    game,
+    isFreshStart,
+    biosConsole,
+    emulatorPrefs,
+    autoSaveInfoRef,
+    coreMismatchChoiceRef,
+    pendingDiscSwitchRef,
+    buildMultiDiscBundleRef,
+    emulator,
+    loadInitialSave: saveManager.loadInitialSave,
+    onToastError: (message) => toast("error", message),
+    onRequestCoreMismatchChoice: () => setShowCoreMismatchModal(true),
+    onDiscSwitchCurrentChanged: setCurrentDisc,
+    onDiscSwitchSettled: () => setIsSwitchingDisc(false),
+  });
 
   async function handleBack() {
     if (isExitSaving) return;


### PR DESCRIPTION
## Summary

Partial implementation of #694. Lifts two pieces out of `web/src/pages/play-page.tsx` (**452 → 339 LOC**):

### 1. `useResolvedGamePreferences` (60 LOC)

Pure derived-state hook that resolves `EmulatorPreferences` from `UserPreferences` + `consoleId`. Same cascade as the inline code it replaces:

- shader: per-console → global `selectedShader` → "none"
- mapping: per-console → global `selectedKeyMapping` → "arrows-left"
- custom: only when the chosen mapping is `"custom"`

EmulatorJS shader name is mapped through `toEmulatorJsShader`. Covered by **7 unit tests** in `__tests__/use-resolved-game-preferences.test.ts`.

### 2. `useEmulatorInit` (216 LOC)

Owns the 108-line init `useEffect`. Two execution paths preserved verbatim:

- **disc-switch path**: build multi-disc bundle → init emulator with `targetDisc` + save data
- **normal init path**: core-mismatch check → pick ROM URL (multi-disc zip or single download) → load save state → build BIOS URLs → init emulator

Keeps the original narrow dep array `[iframeLoaded, gameId, isSupported, emulatorJsCore, autoSaveInfoLoading]` and the `react-hooks/exhaustive-deps` suppression — other inputs are read via refs or intentionally should NOT retrigger init (that would re-download the ROM).

Side effects flow back to the page via callbacks: `onToastError`, `onRequestCoreMismatchChoice`, `onDiscSwitchCurrentChanged`, `onDiscSwitchSettled`.

## Deferred

- **`useDiscSwitchFlow`** (the `handleDiscSwitch` + pending-disc-switch-ref state machine). Doing it cleanly requires a multi-disc test rig to assert no regression on the pause → save → bundle → re-init sequence.
- **`PlayPageStateOverlay`** already done in #704.

So #694 lands in three passes total: #704 (overlays) + this PR (init + prefs) + a future PR for the disc-switch flow once we have a test rig.

## Verification

- `npx tsc --noEmit` — green
- `npm run build` — green
- `npx vitest run` — 1564 tests, 0 failures (7 new tests for `useResolvedGamePreferences`)
- Review-gate (code-reviewer agent) — one import-order nit, fixed

## Test plan

- [x] Typecheck + build
- [x] Full unit test suite
- [x] Unit tests for the pure hook
- [ ] CI green
- [ ] Manual QA: single-disc game launch, core-mismatch modal flow, emulator error state (covered by existing Playwright e2e path if any)

Refs #694.