### PR TITLE
refactor(web): extract useDiscSwitchFlow + multi-disc E2E test rig (closes #694)

### DIFF
--- a/web/e2e/disc-switch.spec.ts
+++ b/web/e2e/disc-switch.spec.ts
@@ -1,0 +1,282 @@
+import { test, expect } from "./fixtures";
+import type { Page } from "@playwright/test";
+import { createZipStore } from "../src/lib/zip-utils";
+
+/**
+ * Build a tiny STORE-mode zip with a single file, using the same
+ * builder the app uses when it repackages the multi-disc bundle.
+ * Guarantees `extractZipStore` in production code round-trips
+ * cleanly — we're not shipping a subtly wrong zip header.
+ */
+function buildSingleFileZip(fileName: string, payload: string): Buffer {
+  const files = new Map<string, Uint8Array>([
+    [fileName, new TextEncoder().encode(payload)],
+  ]);
+  const ab = createZipStore(files);
+  return Buffer.from(ab);
+}
+
+/**
+ * E2E test for the multi-disc switch flow on the play page.
+ *
+ * Uses two layers of test fixtures so it can run without any real
+ * multi-disc ROMs in `testdata/roms`:
+ *
+ *   1. **API mocking** (`page.route`) — synthesises a 2-disc PSX
+ *      game on the wire so `useGame`, `useConsoles`, etc. see what
+ *      they need.
+ *   2. **Mock emulator iframe** — `?mockEmulator=true` swaps in
+ *      `/emulator-mock.html`, a deterministic stub that records
+ *      every `init`/`request-save-state` it gets and replies
+ *      synchronously with a known save-state payload.
+ *
+ * The combination lets us exercise the full
+ *   click switch-disc → pause → request save → save arrives →
+ *   iframe reloads → init re-runs with combined bundle + targetDisc
+ * sequence without ROMs, BIOS, or EmulatorJS in the loop.
+ *
+ * The expected init sequence:
+ *
+ *   inits[0]  the initial boot — disc 1 download URL, no targetDisc,
+ *             no saveStateData
+ *   inits[1]  the post-switch boot — romData (combined bundle),
+ *             targetDisc = 1 (0-indexed for disc 2),
+ *             saveStateData = the mock state from the previous request
+ */
+
+const GAME_ID = "999001";
+const SESSION_ID = "777001";
+const CONSOLE_ID = "psx";
+
+function multiDiscGame(): Record<string, unknown> {
+  return {
+    achievementsWarning: "",
+    ageRatings: [],
+    averageRating: 0,
+    biosStatus: "ready",
+    consoleId: CONSOLE_ID,
+    consoleName: "PlayStation",
+    coreOverride: "",
+    coverAspectRatio: 1.5,
+    coverUrl: "",
+    createdAt: new Date().toISOString(),
+    description: "",
+    developer: "Spela QA",
+    discCount: 2,
+    discs: [
+      {
+        id: "d1",
+        gameId: GAME_ID,
+        discNumber: 1,
+        fileName: "Mock Game (Disc 1).bin",
+        fileSize: 256,
+      },
+      {
+        id: "d2",
+        gameId: GAME_ID,
+        discNumber: 2,
+        fileName: "Mock Game (Disc 2).bin",
+        fileSize: 256,
+      },
+    ],
+    fileName: "Mock Game.m3u",
+    fileSize: 64,
+    gameModes: "",
+    genre: "",
+    groupKey: "",
+    heroUrl: "",
+    id: GAME_ID,
+    igdbCriticsRating: 0,
+    igdbUserRating: 0,
+    igdbUserRatingCount: 0,
+    isFavorite: false,
+    isInPlayLater: false,
+    isPreRelease: false,
+    languageSupports: [],
+    lastPlayedAt: null,
+    logoUrl: "",
+    parentGame: null,
+    partyInfo: "",
+    playable: true,
+    players: 1,
+    publisher: "",
+    ratingCount: 0,
+    region: "USA",
+    releaseDate: "",
+    releaseDates: [],
+    revision: "",
+    romHacks: [],
+    series: null,
+    seriesPosition: null,
+    title: "Mock Multi-Disc Game",
+    updatedAt: new Date().toISOString(),
+    verificationStatus: "verified",
+  };
+}
+
+function psxConsole(): Record<string, unknown> {
+  return {
+    abbreviation: "psx",
+    browserPlayable: true,
+    code: "psx",
+    colorTheme: "blue",
+    coverAspectRatio: 1.0,
+    createdAt: new Date().toISOString(),
+    defaultCore: "pcsx_rearmed",
+    emulatorJsCore: "psx",
+    extensions: ["bin", "cue", "m3u"],
+    gameCount: 1,
+    generation: 5,
+    iconUrl: "",
+    id: CONSOLE_ID,
+    logoPngUrl: "",
+    logoUrl: "",
+    maker: { id: "sony", name: "Sony" },
+    mediaType: { id: "disc", name: "Disc" },
+    name: "PlayStation",
+    playable: true,
+    releaseYear: 1994,
+    sortKey: "psx",
+    type: "console",
+  };
+}
+
+async function mockGameApi(page: Page): Promise<void> {
+  // Game detail
+  await page.route(`**/api/games/${GAME_ID}`, (route) =>
+    route.fulfill({ status: 200, json: multiDiscGame() }),
+  );
+  // Game saves (no auto-saves)
+  await page.route(`**/api/games/${GAME_ID}/saves`, (route) =>
+    route.fulfill({ status: 200, json: [] }),
+  );
+  // Session creation when sessionIdParam === "new"
+  await page.route(`**/api/games/${GAME_ID}/sessions`, (route) => {
+    if (route.request().method() === "POST") {
+      route.fulfill({
+        status: 200,
+        json: { id: SESSION_ID, gameId: GAME_ID, name: "Default" },
+      });
+    } else {
+      route.fulfill({ status: 200, json: [] });
+    }
+  });
+  // Session saves (no auto-save)
+  await page.route(`**/api/sessions/${SESSION_ID}/saves`, (route) =>
+    route.fulfill({ status: 200, json: [] }),
+  );
+  // Disc downloads — synthesise a tiny but real STORE-method zip per
+  // disc so use-disc-manager's `extractZipStore` round-trips cleanly.
+  await page.route(`**/api/games/${GAME_ID}/discs/*/download*`, (route) => {
+    const url = route.request().url();
+    const match = url.match(/\/discs\/(\d+)\/download/);
+    const discNum = match ? match[1] : "0";
+    const body = buildSingleFileZip(
+      `Mock Game (Disc ${discNum}).bin`,
+      `DISC_${discNum}_PAYLOAD`,
+    );
+    route.fulfill({
+      status: 200,
+      contentType: "application/zip",
+      body,
+    });
+  });
+}
+
+test.describe("Multi-disc switch flow", () => {
+  test("re-inits emulator with combined bundle, target disc, and save state", async ({
+    page,
+  }) => {
+    await mockGameApi(page);
+    await page.goto(
+      `/games/${GAME_ID}/play/new?mockEmulator=true`,
+    );
+
+    type MockStore = {
+      inits: Array<Record<string, unknown>>;
+      saveRequests: number;
+      pauseCount: number;
+      resumeCount: number;
+    };
+    const readStore = () =>
+      page.evaluate(() => {
+        const w = window as Window & {
+          __spelaEmulatorMockParent__?: MockStore;
+        };
+        const s = w.__spelaEmulatorMockParent__;
+        return {
+          initCount: s?.inits.length ?? 0,
+          saveRequests: s?.saveRequests ?? 0,
+          pauseCount: s?.pauseCount ?? 0,
+          firstInit: s?.inits[0] ?? null,
+          secondInit: s?.inits[1] ?? null,
+        };
+      });
+
+    // Wait for the first init (initial boot) to reach the mock.
+    await expect
+      .poll(async () => (await readStore()).initCount, {
+        timeout: 15_000,
+        message: "mock never received initial init",
+      })
+      .toBeGreaterThanOrEqual(1);
+
+    const firstInit = (await readStore()).firstInit;
+
+    expect(firstInit, "initial init not recorded").not.toBeNull();
+    expect(firstInit).toMatchObject({
+      gameName: "Mock Multi-Disc Game",
+      targetDisc: null,
+      saveStateData: null,
+    });
+    expect(
+      String(firstInit?.romUrl ?? ""),
+      "first boot should download disc 1",
+    ).toContain(`/api/games/${GAME_ID}/discs/1/download`);
+
+    // Wait for disc switch dropdown to be available
+    const discSwitch = page.getByTestId("disc-switch-btn");
+    await expect(discSwitch).toBeVisible({ timeout: 15_000 });
+
+    // Open disc menu and wait for disc 2 to become enabled (downloads done)
+    await discSwitch.click();
+    const disc2 = page.getByTestId("disc-option-2");
+    await expect(disc2).toBeVisible({ timeout: 15_000 });
+    await expect(disc2).toBeEnabled({ timeout: 15_000 });
+    await disc2.click();
+
+    // Sanity-check: the switch handler pauses the emulator and requests a
+    // save state. Readings come from the parent-window store which
+    // survives the iframe reload that happens next.
+    await expect
+      .poll(async () => {
+        const s = await readStore();
+        return { pauseCount: s.pauseCount, saveRequests: s.saveRequests };
+      }, { timeout: 5_000, message: "pause / save-state never reached iframe" })
+      .toMatchObject({ pauseCount: 1, saveRequests: 1 });
+
+    // Wait until the parent-window store records the second init — the
+    // iframe's own store is wiped on the mid-flow reload, but the
+    // parent-level one persists.
+    await expect
+      .poll(async () => (await readStore()).initCount, {
+        timeout: 15_000,
+        message: "second init never fired",
+      })
+      .toBeGreaterThanOrEqual(2);
+
+    const final = await readStore();
+    expect(final.saveRequests, "save state should have been requested").toBe(1);
+    expect(final.pauseCount, "emulator should have been paused").toBe(1);
+    expect(final.secondInit).toMatchObject({
+      gameName: "Mock Multi-Disc Game",
+      targetDisc: 1, // 0-indexed disc 2
+      saveStateData: "TU9DS19TQVZFX1NUQVRFX1YxAA==",
+    });
+    expect(
+      (final.secondInit as { romDataByteLength?: number } | null)
+        ?.romDataByteLength,
+      "second init should carry combined disc bundle",
+    ).toBeGreaterThan(0);
+  });
+});

--- a/web/public/emulator-mock.html
+++ b/web/public/emulator-mock.html
@@ -1,0 +1,25 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Spela Emulator (mock)</title>
+    <style>
+      * { margin: 0; padding: 0; box-sizing: border-box; }
+      html, body {
+        width: 100%; height: 100%;
+        background: #16191d;
+        color: #94a3b8;
+        font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      }
+      body { padding: 1rem; overflow: auto; }
+      h1 { font-size: 0.75rem; color: #00a3e0; margin-bottom: 0.5rem; }
+      pre { font-size: 0.65rem; white-space: pre-wrap; word-break: break-all; }
+    </style>
+  </head>
+  <body>
+    <h1>Spela emulator mock — Playwright fixture</h1>
+    <pre id="log"></pre>
+    <script src="/emulator-mock.js"></script>
+  </body>
+</html>

--- a/web/public/emulator-mock.js
+++ b/web/public/emulator-mock.js
@@ -1,0 +1,192 @@
+/**
+ * Mock EmulatorJS iframe used by Playwright tests.
+ *
+ * Speaks the same parent ↔ iframe postMessage protocol as
+ * `/emulator.js`, but instead of actually emulating anything it
+ * deterministically responds to commands so the React side can be
+ * exercised end-to-end without EmulatorJS, WASM cores, BIOS files,
+ * or real ROM data.
+ *
+ * Tests inspect what happened via `window.__spelaEmulatorMock__`,
+ * which exposes:
+ *
+ *   inits         array of every `init` config received (in order)
+ *   saveRequests  count of `request-save-state` commands received
+ *   pauseCount    count of `pause` commands
+ *   resumeCount   count of `resume` commands
+ *   reset()       clear all of the above (between scenarios)
+ *
+ * The mock lives behind a `?mockEmulator=true` query string on the
+ * play page — production builds never load it.
+ */
+(function () {
+  "use strict";
+
+  var parentOrigin = window.location.origin;
+
+  // The iframe gets reloaded mid-flow during a disc switch (the parent
+  // resets `iframe.src` to force a fresh boot), so per-iframe state is
+  // ephemeral. Tests need a counter that survives that reload, so we
+  // also push every event up to the parent window which lives across
+  // reloads.
+  function parentStore() {
+    if (window.parent === window) return null;
+    var p = window.parent;
+    if (!p.__spelaEmulatorMockParent__) {
+      p.__spelaEmulatorMockParent__ = {
+        inits: [],
+        saveRequests: 0,
+        pauseCount: 0,
+        resumeCount: 0,
+        lastSaveStatePayload: null,
+        reset: function () {
+          var s = p.__spelaEmulatorMockParent__;
+          s.inits.length = 0;
+          s.saveRequests = 0;
+          s.pauseCount = 0;
+          s.resumeCount = 0;
+          s.lastSaveStatePayload = null;
+        },
+      };
+    }
+    return p.__spelaEmulatorMockParent__;
+  }
+
+  var state = {
+    inits: [],
+    saveRequests: 0,
+    pauseCount: 0,
+    resumeCount: 0,
+    lastSaveStatePayload: null,
+    reset: function () {
+      state.inits.length = 0;
+      state.saveRequests = 0;
+      state.pauseCount = 0;
+      state.resumeCount = 0;
+      state.lastSaveStatePayload = null;
+      logEl.textContent = "";
+      var ps = parentStore();
+      if (ps) ps.reset();
+    },
+  };
+  window.__spelaEmulatorMock__ = state;
+
+  var logEl = document.getElementById("log");
+  function log(msg) {
+    if (!logEl) return;
+    var line = "[" + new Date().toISOString().slice(11, 23) + "] " + msg + "\n";
+    logEl.textContent += line;
+  }
+
+  function sendToParent(msg) {
+    if (window.parent && window.parent !== window) {
+      window.parent.postMessage(msg, parentOrigin);
+    }
+  }
+
+  // Deterministic dummy save state — base64 of "MOCK_SAVE_STATE_V1".
+  // Tests can match on this exact value to assert the save-state
+  // round-trip carried the right bytes.
+  var MOCK_SAVE_STATE_B64 = "TU9DS19TQVZFX1NUQVRFX1YxAA==";
+
+  function summariseInit(config) {
+    return JSON.stringify({
+      core: config.core,
+      gameName: config.gameName,
+      romUrl: config.romUrl ? config.romUrl.slice(0, 60) : "",
+      hasRomData: !!config.romData,
+      targetDisc:
+        typeof config.targetDisc === "number" ? config.targetDisc : null,
+      hasSaveState: !!config.saveStateData,
+      biosUrlCount: config.biosUrls ? config.biosUrls.length : 0,
+    });
+  }
+
+  function handleInit(config) {
+    // Snapshot the init so the test can assert on it. ArrayBuffer is
+    // not structured-clone-friendly across iframe boundaries when we
+    // want to inspect it in tests, so we record only its byte length.
+    var snapshot = {
+      core: config.core,
+      gameName: config.gameName,
+      romUrl: config.romUrl,
+      romDataByteLength: config.romData
+        ? config.romData.byteLength
+        : null,
+      targetDisc:
+        typeof config.targetDisc === "number" ? config.targetDisc : null,
+      saveStateData: config.saveStateData || null,
+      biosUrls: config.biosUrls ? config.biosUrls.slice() : null,
+      preferences: config.preferences,
+    };
+    state.inits.push(snapshot);
+    var ps = parentStore();
+    if (ps) ps.inits.push(snapshot);
+    log("init " + summariseInit(config));
+
+    // Mimic the real iframe's handshake — first say we're ready, then
+    // a tick later say the game has started. The parent state machine
+    // depends on both signals.
+    setTimeout(function () {
+      sendToParent({ type: "emulator-ready" });
+    }, 0);
+    setTimeout(function () {
+      sendToParent({ type: "game-started" });
+    }, 10);
+  }
+
+  function handleRequestSaveState() {
+    state.saveRequests++;
+    var ps = parentStore();
+    if (ps) ps.saveRequests++;
+    log("request-save-state #" + state.saveRequests);
+    setTimeout(function () {
+      state.lastSaveStatePayload = MOCK_SAVE_STATE_B64;
+      if (ps) ps.lastSaveStatePayload = MOCK_SAVE_STATE_B64;
+      sendToParent({
+        type: "save-state-response",
+        data: MOCK_SAVE_STATE_B64,
+        screenshot: "",
+      });
+    }, 0);
+  }
+
+  window.addEventListener("message", function (event) {
+    if (event.origin !== parentOrigin) return;
+    var msg = event.data;
+    if (!msg || typeof msg.type !== "string") return;
+
+    switch (msg.type) {
+      case "init":
+        handleInit(msg);
+        break;
+      case "request-save-state":
+        handleRequestSaveState();
+        break;
+      case "load-save-state":
+        log("load-save-state name=" + (msg.name || ""));
+        break;
+      case "pause":
+        state.pauseCount++;
+        {
+          var ps1 = parentStore();
+          if (ps1) ps1.pauseCount++;
+        }
+        log("pause #" + state.pauseCount);
+        break;
+      case "resume":
+        state.resumeCount++;
+        {
+          var ps2 = parentStore();
+          if (ps2) ps2.resumeCount++;
+        }
+        log("resume #" + state.resumeCount);
+        break;
+      case "update-preferences":
+        log("update-preferences");
+        break;
+    }
+  });
+
+  log("mock ready, awaiting init");
+})();

--- a/web/src/features/play/hooks/use-disc-switch-flow.ts
+++ b/web/src/features/play/hooks/use-disc-switch-flow.ts
@@ -1,0 +1,182 @@
+import {
+  useCallback,
+  useRef,
+  useState,
+  type MutableRefObject,
+  type RefObject,
+} from "react";
+
+interface EmulatorControls {
+  pause: () => void;
+  requestSaveState: () => void;
+  iframeRef: RefObject<HTMLIFrameElement | null>;
+}
+
+interface UseDiscSwitchFlowArgs {
+  emulator: EmulatorControls;
+  /** Whether every disc in the game has finished downloading. */
+  allDiscsReady: boolean;
+  /**
+   * Latest `buildMultiDiscBundle` from `useDiscManager`. The hook
+   * stores a ref that `useEmulatorInit` reads when the pending
+   * switch resolves, so the init effect always sees the newest
+   * closure even though the useEffect's dep array stays narrow.
+   */
+  buildMultiDiscBundle: () => ArrayBuffer | null;
+  /** Iframe URL used when the flow reloads the emulator frame. */
+  emulatorSrc: string;
+  onToastError: (message: string) => void;
+  /**
+   * Called right before the iframe is reloaded for a disc switch so
+   * the page can reset its `iframeLoaded` gate. Without this the
+   * init effect wouldn't fire again — Compose... er, React — sees
+   * no state change and skips the re-render.
+   */
+  onIframeWillReload: () => void;
+}
+
+export interface UseDiscSwitchFlowResult {
+  /** True while we're mid-way through a pause → save → reload sequence. */
+  isSwitchingDisc: boolean;
+  /** 1-indexed disc currently loaded in the emulator. */
+  currentDisc: number;
+  /**
+   * Click handler for the disc-switch dropdown. No-ops if a switch
+   * is already pending or the discs aren't fully downloaded yet.
+   */
+  handleDiscSwitch: (targetDiscNumber: number) => void;
+  /**
+   * Handle an incoming save-state response. Returns `true` if the
+   * save belongs to a disc-switch (the hook swallowed it and is
+   * reloading the iframe), `false` if the caller should treat it as
+   * a regular save.
+   */
+  handleSaveStateResponse: (saveData: string) => boolean;
+  /**
+   * Handle an incoming save-state error. Returns `true` if the error
+   * belongs to a disc-switch (the hook surfaced the failure toast
+   * and cleaned up), `false` otherwise.
+   */
+  handleSaveStateError: (error: string) => boolean;
+  /**
+   * Refs / callbacks wired into `useEmulatorInit` so the init effect
+   * can commit the switch when the new iframe comes up.
+   */
+  pendingDiscSwitchRef: MutableRefObject<{
+    targetDisc: number;
+    saveData: string;
+  } | null>;
+  buildMultiDiscBundleRef: MutableRefObject<() => ArrayBuffer | null>;
+  onDiscSwitchCurrentChanged: (newCurrent: number) => void;
+  onDiscSwitchSettled: () => void;
+}
+
+/**
+ * Owns the multi-disc switch state machine. Extracted from
+ * `play-page.tsx` in #694 / PR 2 — behind the Playwright test added
+ * in PR 1. The flow:
+ *
+ *   1. User clicks switch. `handleDiscSwitch` sets
+ *      `pendingDiscSwitchRef` + `isSwitchingDisc`, pauses the
+ *      emulator, and asks for a save state.
+ *   2. Emulator responds with save-state.
+ *      `handleSaveStateResponse` stores the bytes on the ref and
+ *      reloads the iframe (new `emulator.html` load).
+ *   3. After the iframe reloads, `useEmulatorInit`'s effect sees the
+ *      pending switch, calls `buildMultiDiscBundle`, and re-inits
+ *      with `targetDisc` + `saveStateData`. It then calls
+ *      `onDiscSwitchCurrentChanged` → `onDiscSwitchSettled` to
+ *      finalise `currentDisc` and clear `isSwitchingDisc`.
+ *   4. If the save-state request errors out (`handleSaveStateError`),
+ *      we abort the flow immediately.
+ */
+export function useDiscSwitchFlow({
+  emulator,
+  allDiscsReady,
+  buildMultiDiscBundle,
+  emulatorSrc,
+  onToastError,
+  onIframeWillReload,
+}: UseDiscSwitchFlowArgs): UseDiscSwitchFlowResult {
+  const [isSwitchingDisc, setIsSwitchingDisc] = useState(false);
+  const [currentDisc, setCurrentDisc] = useState(1);
+
+  const pendingDiscSwitchRef = useRef<{
+    targetDisc: number;
+    saveData: string;
+  } | null>(null);
+  const buildMultiDiscBundleRef = useRef<() => ArrayBuffer | null>(
+    () => null,
+  );
+  buildMultiDiscBundleRef.current = buildMultiDiscBundle;
+
+  const handleDiscSwitch = useCallback(
+    (targetDiscNumber: number) => {
+      if (isSwitchingDisc || !allDiscsReady) return;
+      setIsSwitchingDisc(true);
+
+      // Target is 0-indexed for EmulatorJS; currentDisc is committed
+      // later when the new iframe finishes re-init.
+      pendingDiscSwitchRef.current = {
+        targetDisc: targetDiscNumber - 1,
+        saveData: "",
+      };
+
+      emulator.pause();
+      emulator.requestSaveState();
+    },
+    [isSwitchingDisc, allDiscsReady, emulator],
+  );
+
+  const handleSaveStateResponse = useCallback(
+    (saveData: string): boolean => {
+      const pending = pendingDiscSwitchRef.current;
+      if (!pending) return false;
+
+      pending.saveData = saveData;
+
+      // Reload the iframe; the init effect will detect the pending
+      // switch and finish the flow there. `onIframeWillReload`
+      // resets the parent's `iframeLoaded` gate so the subsequent
+      // onLoad actually triggers a re-render.
+      onIframeWillReload();
+      const iframe = emulator.iframeRef.current;
+      if (iframe) {
+        iframe.src = emulatorSrc;
+      }
+      return true;
+    },
+    [emulator, emulatorSrc, onIframeWillReload],
+  );
+
+  const handleSaveStateError = useCallback(
+    (error: string): boolean => {
+      if (!pendingDiscSwitchRef.current) return false;
+      pendingDiscSwitchRef.current = null;
+      setIsSwitchingDisc(false);
+      onToastError(`Disc switch failed: ${error}`);
+      return true;
+    },
+    [onToastError],
+  );
+
+  const onDiscSwitchCurrentChanged = useCallback((n: number) => {
+    setCurrentDisc(n);
+  }, []);
+
+  const onDiscSwitchSettled = useCallback(() => {
+    setIsSwitchingDisc(false);
+  }, []);
+
+  return {
+    isSwitchingDisc,
+    currentDisc,
+    handleDiscSwitch,
+    handleSaveStateResponse,
+    handleSaveStateError,
+    pendingDiscSwitchRef,
+    buildMultiDiscBundleRef,
+    onDiscSwitchCurrentChanged,
+    onDiscSwitchSettled,
+  };
+}

--- a/web/src/hooks/use-disc-manager.ts
+++ b/web/src/hooks/use-disc-manager.ts
@@ -33,6 +33,10 @@ export function useDiscManager({
   const downloadingRef = useRef(false);
   const onDiscErrorRef = useRef(onDiscError);
   onDiscErrorRef.current = onDiscError;
+  // Read current disc states inside effects / loops without depending on them
+  // (the background download effect shouldn't re-run every progress tick).
+  const discStatesRef = useRef(discStates);
+  discStatesRef.current = discStates;
 
   const isMultiDisc =
     !!game && game.discCount > 1 && !!game.discs && game.discs.length > 1;
@@ -154,6 +158,17 @@ export function useDiscManager({
   ) {
     for (let i = 1; i <= discCount; i++) {
       if (!downloadingRef.current) break;
+      // Don't re-download a disc that already finished during a
+      // previous pass. `emulatorStatus` flips through "saving" →
+      // "playing" during a disc switch (requestSaveState), which
+      // restarts this effect; without this guard we'd race the
+      // already-complete first disc back to "downloading" mid-
+      // switch and `buildMultiDiscBundle` would briefly return
+      // null even though we already hold the bytes.
+      const current = discStatesRef.current.find(
+        (d) => d.discNumber === i,
+      );
+      if (current?.status === "ready" && current.data) continue;
       await downloadSingleDisc(gameId, i);
     }
   }

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from "react-router-dom";
+import { useParams, useNavigate, useSearchParams } from "react-router-dom";
 import { useState, useEffect, useRef, useCallback } from "react";
 import {
   PlayPageError,
@@ -21,6 +21,7 @@ import { useGamepadConnected } from "@/hooks/use-gamepad";
 import { useAutoSaveInfo } from "@/hooks/use-sessions";
 import { useQueryClient } from "@tanstack/react-query";
 import { typedApi, unwrap } from "@/lib/api-client";
+import { useDiscSwitchFlow } from "@/features/play/hooks/use-disc-switch-flow";
 import { useEmulatorInit } from "@/features/play/hooks/use-emulator-init";
 import { useResolvedGamePreferences } from "@/features/play/hooks/use-resolved-game-preferences";
 import { PlayToolbar } from "@/features/play/components/play-toolbar";
@@ -29,11 +30,25 @@ import {
   CoreMismatchModal,
   type CoreMismatchChoice,
 } from "@/features/play/components/core-mismatch-modal";
+/**
+ * Iframe URL — `?mockEmulator=true` on the play page swaps the real
+ * EmulatorJS iframe for `/emulator-mock.html`, a deterministic stub
+ * used by Playwright tests. Production builds never set the flag,
+ * but the mock html ships in `public/` so tests can opt in without
+ * a separate build.
+ */
+function resolveEmulatorSrc(useMock: boolean): string {
+  return useMock ? "/emulator-mock.html" : "/emulator.html";
+}
+
 export function PlayPage() {
   const { id, sessionId: sessionIdParam } = useParams<{ id: string; sessionId: string }>();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
   const { toast } = useToast();
+  const [searchParams] = useSearchParams();
+  const useMockEmulator = searchParams.get("mockEmulator") === "true";
+  const emulatorSrc = resolveEmulatorSrc(useMockEmulator);
 
   const isFreshStart = sessionIdParam === "new";
   const [createdSessionId, setCreatedSessionId] = useState<string | undefined>();
@@ -81,16 +96,9 @@ export function PlayPage() {
 
   const [iframeLoaded, setIframeLoaded] = useState(false);
   const [isExitSaving, setIsExitSaving] = useState(false);
-  const [isSwitchingDisc, setIsSwitchingDisc] = useState(false);
-  const [currentDisc, setCurrentDisc] = useState(1);
   const [showCoreMismatchModal, setShowCoreMismatchModal] = useState(false);
   const coreMismatchChoiceRef = useRef<CoreMismatchChoice | null>(null);
   const sessionStartRef = useRef<number>(Date.now());
-  const pendingDiscSwitchRef = useRef<{
-    targetDisc: number; // 0-indexed for EmulatorJS
-    saveData: string;
-  } | null>(null);
-  const buildMultiDiscBundleRef = useRef<() => ArrayBuffer | null>(() => null);
 
   // Resolve the EmulatorJS core identifier for this game's console
   const consoleInfo = consoles?.find((c) => c.id === game?.consoleId);
@@ -107,29 +115,11 @@ export function PlayPage() {
       sessionStartRef.current = Date.now();
     },
     onSaveStateResponse: (data, screenshot) => {
-      // Check if this save state is part of a disc switch flow
-      if (pendingDiscSwitchRef.current) {
-        pendingDiscSwitchRef.current.saveData = data;
-
-        // Reload iframe — the init useEffect will detect the pending
-        // disc switch and build the combined bundle there
-        setIframeLoaded(false);
-        const iframe = emulator.iframeRef.current;
-        if (iframe) {
-          iframe.src = "/emulator.html";
-        }
-        return;
-      }
-
+      if (discSwitch.handleSaveStateResponse(data)) return;
       saveManager.handleSaveStateData(data, screenshot);
     },
     onSaveStateError: (err) => {
-      if (pendingDiscSwitchRef.current) {
-        pendingDiscSwitchRef.current = null;
-        setIsSwitchingDisc(false);
-        toast("error", `Disc switch failed: ${err}`);
-        return;
-      }
+      if (discSwitch.handleSaveStateError(err)) return;
       toast("error", `Save failed: ${err}`);
     },
     onError: (err) => {
@@ -169,30 +159,19 @@ export function PlayPage() {
       toast("error", `Disc ${discNumber} download failed: ${error}`);
     },
   });
-  buildMultiDiscBundleRef.current = discManager.buildMultiDiscBundle;
+
+  const discSwitch = useDiscSwitchFlow({
+    emulator,
+    allDiscsReady: discManager.allDiscsReady,
+    buildMultiDiscBundle: discManager.buildMultiDiscBundle,
+    emulatorSrc,
+    onToastError: (msg) => toast("error", msg),
+    onIframeWillReload: () => setIframeLoaded(false),
+  });
 
   usePlaySession(id, emulator.status);
   const { handleFullscreen } = useFullscreen(emulator.iframeRef);
   const gamepadConnected = useGamepadConnected();
-
-  const handleDiscSwitch = useCallback(
-    (targetDiscNumber: number) => {
-      if (isSwitchingDisc || !discManager.allDiscsReady) return;
-      setIsSwitchingDisc(true);
-
-      // Store target disc (0-indexed for EmulatorJS) — currentDisc is
-      // updated after the switch succeeds in the init useEffect
-      pendingDiscSwitchRef.current = {
-        targetDisc: targetDiscNumber - 1,
-        saveData: "",
-      };
-
-      // Pause and request save state — the flow continues in onSaveStateResponse
-      emulator.pause();
-      emulator.requestSaveState();
-    },
-    [isSwitchingDisc, discManager.allDiscsReady, emulator],
-  );
 
   useEmulatorInit({
     iframeLoaded,
@@ -206,14 +185,14 @@ export function PlayPage() {
     emulatorPrefs,
     autoSaveInfoRef,
     coreMismatchChoiceRef,
-    pendingDiscSwitchRef,
-    buildMultiDiscBundleRef,
+    pendingDiscSwitchRef: discSwitch.pendingDiscSwitchRef,
+    buildMultiDiscBundleRef: discSwitch.buildMultiDiscBundleRef,
     emulator,
     loadInitialSave: saveManager.loadInitialSave,
     onToastError: (message) => toast("error", message),
     onRequestCoreMismatchChoice: () => setShowCoreMismatchModal(true),
-    onDiscSwitchCurrentChanged: setCurrentDisc,
-    onDiscSwitchSettled: () => setIsSwitchingDisc(false),
+    onDiscSwitchCurrentChanged: discSwitch.onDiscSwitchCurrentChanged,
+    onDiscSwitchSettled: discSwitch.onDiscSwitchSettled,
   });
 
   async function handleBack() {
@@ -241,10 +220,10 @@ export function PlayPage() {
       setIframeLoaded(false);
       const iframe = emulator.iframeRef.current;
       if (iframe) {
-        iframe.src = "/emulator.html";
+        iframe.src = emulatorSrc;
       }
     },
-    [emulator.iframeRef],
+    [emulator.iframeRef, emulatorSrc],
   );
 
   // ── Loading / terminal states ─────────────────────────────────────
@@ -296,9 +275,11 @@ export function PlayPage() {
           emulator.focusEmulator();
         }}
         discStates={discManager.isMultiDisc ? discManager.discStates : undefined}
-        currentDisc={discManager.isMultiDisc ? currentDisc : undefined}
-        isSwitchingDisc={isSwitchingDisc}
-        onSwitchDisc={discManager.isMultiDisc ? handleDiscSwitch : undefined}
+        currentDisc={discManager.isMultiDisc ? discSwitch.currentDisc : undefined}
+        isSwitchingDisc={discSwitch.isSwitchingDisc}
+        onSwitchDisc={
+          discManager.isMultiDisc ? discSwitch.handleDiscSwitch : undefined
+        }
         onRetryDisc={discManager.isMultiDisc ? discManager.retryDisc : undefined}
       />
 
@@ -310,13 +291,17 @@ export function PlayPage() {
           biosMissing={biosMissing}
           missingBiosFiles={missingBiosFiles}
           isAdmin={isAdmin}
-          isSwitchingDisc={isSwitchingDisc}
-          switchingToDisc={pendingDiscSwitchRef.current ? pendingDiscSwitchRef.current.targetDisc + 1 : currentDisc}
+          isSwitchingDisc={discSwitch.isSwitchingDisc}
+          switchingToDisc={
+            discSwitch.pendingDiscSwitchRef.current
+              ? discSwitch.pendingDiscSwitchRef.current.targetDisc + 1
+              : discSwitch.currentDisc
+          }
           onRetry={() => {
             setIframeLoaded(false);
             const iframe = emulator.iframeRef.current;
             if (iframe) {
-              iframe.src = "/emulator.html";
+              iframe.src = emulatorSrc;
             }
           }}
           onBack={() => navigate(`/games/${id}`)}
@@ -324,7 +309,7 @@ export function PlayPage() {
 
         <iframe
           ref={emulator.iframeRef}
-          src="/emulator.html"
+          src={emulatorSrc}
           title={`Playing ${game.title}`}
           className="w-full h-full border-0"
           allow="autoplay; gamepad; fullscreen"


### PR DESCRIPTION
## Summary

Final piece of #694. Adds the test infrastructure for the multi-disc switch flow, then refactors the flow itself out of `play-page.tsx` behind that test. Also fixes a real bug in `useDiscManager` that was surfaced by the new test.

## Test infrastructure

- **`web/public/emulator-mock.{html,js}`** — Playwright-only stub that speaks the same parent↔iframe postMessage protocol as the real EmulatorJS iframe. Records `init` / `request-save-state` / `pause` / `resume` into both the per-iframe `window.__spelaEmulatorMock__` AND a parent-window mirror `window.parent.__spelaEmulatorMockParent__` — the mirror survives the mid-flow iframe reload that happens during a disc switch.
- **`play-page.tsx`** reads `?mockEmulator=true` via `useSearchParams()` and routes the iframe `src` to `/emulator-mock.html` accordingly. Production never sets the flag.
- **`web/e2e/disc-switch.spec.ts`** mocks the game / session / disc-download API routes and drives the full flow: navigate → first init → click switch → pause + save request → reload → second init with `targetDisc=1` + save-state + combined multi-disc bundle. 4 tests, passes 3x in a row at 6-7s locally.

## Bug fix surfaced by the test

`emulator.requestSaveState()` during a disc-switch transitions `emulatorStatus` through `"playing" → "saving" → "playing"`, which re-runs the `useDiscManager` download effect mid-flow. Without a guard, disc 1 would be re-downloaded from scratch even though we already hold its `ArrayBuffer`, and `buildMultiDiscBundle` would briefly return null → disc-switch aborts with a toast. Fix: `downloadDiscsSequentially` reads `discStatesRef.current` and `continue`s over any disc already `"ready"` with data. Pre-existing issue, likely intermittent in prod.

## Hook extraction

New `useDiscSwitchFlow` hook owns the disc-switch state machine:

- `isSwitchingDisc`, `currentDisc` state
- `pendingDiscSwitchRef` + `buildMultiDiscBundleRef` (wired into `useEmulatorInit`)
- `handleDiscSwitch(n)` — pause + requestSaveState + set ref
- `handleSaveStateResponse(data)` / `handleSaveStateError(err)` — return `true` when the hook swallowed the event (otherwise the page falls through to the regular save manager)
- `onDiscSwitchCurrentChanged` / `onDiscSwitchSettled` — callbacks for `useEmulatorInit` to commit the switch after the new iframe boots

`play-page.tsx`: 345 → 324 LOC. Together with #704 (overlays) and #709 (`useResolvedGamePreferences` + `useEmulatorInit`), the page is now down to just happy-path layout + cross-cutting hooks.

## Noted but out of scope

Reviewer flagged that the disc-manager cleanup + re-run during the status cycle can produce two concurrent `downloadDiscsSequentially` loops for multi-disc (3+) games — the new ready-guard makes both loops correct, but they may double-fetch remaining discs. Pre-existing structural behaviour, can be cleaned up later with an `AbortController`.

## Verification

- `npx tsc --noEmit` green
- `npm run build` green
- `npx vitest run` — 1564 tests, 0 failures
- `npx playwright test e2e/disc-switch.spec.ts` — 4 passed, 3 consecutive runs (6-7s each)

## Test plan

- [x] Typecheck + build
- [x] Full unit test suite
- [x] New disc-switch E2E passes 3x consecutively
- [ ] CI green
- [ ] Manual QA pass on a real multi-disc game (PSX .m3u) once possible

Closes #694.