### PR TITLE
fix(player): sign-out clears LoginViewModel state, fixes auto-redirect to Home

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/LoginIntent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/intent/LoginIntent.kt
@@ -8,4 +8,11 @@ sealed interface LoginIntent {
     data object ToggleRegisterMode : LoginIntent
     data object Submit : LoginIntent
     data object DismissError : LoginIntent
+    /**
+     * Wipe transient state (credentials, isLoggedIn) so the screen
+     * starts from a clean slate. Called when LoginScreen mounts so a
+     * stale `isLoggedIn = true` from a prior session can't auto-fire
+     * onLoginSuccess before the user has had a chance to log in.
+     */
+    data object Reset : LoginIntent
 }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/LoginScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/LoginScreen.kt
@@ -53,14 +53,26 @@ fun LoginScreen(
 ) {
     val state by viewModel.state.collectAsState()
 
+    // Wipe transient state on every fresh mount so the credentials
+    // and isLoggedIn flag from a prior session don't leak into the
+    // next login attempt. The LoginViewModel is held at activity
+    // scope, so without this Reset the screen comes up with stale
+    // values when the user signs out and revisits.
+    LaunchedEffect(Unit) {
+        viewModel.onIntent(LoginIntent.Reset)
+        viewModel.onIntent(LoginIntent.SetServerUrl(serverUrl))
+    }
+
     LaunchedEffect(serverUrl) {
         viewModel.onIntent(LoginIntent.SetServerUrl(serverUrl))
     }
 
-    LaunchedEffect(state.isLoggedIn) {
-        if (state.isLoggedIn) {
-            onLoginSuccess()
-        }
+    // Navigate on a one-shot SharedFlow event rather than the sticky
+    // `state.isLoggedIn` flag. The flow only emits when a submit
+    // succeeds; a stale `true` from an earlier session will not
+    // re-emit on screen mount, so the user actually sees the form.
+    LaunchedEffect(viewModel) {
+        viewModel.loginSucceeded.collect { onLoginSuccess() }
     }
 
     BoxWithConstraints(modifier = Modifier.fillMaxSize().testTag(TestTags.SCREEN_LOGIN)) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/SettingsScreen.kt
@@ -182,13 +182,16 @@ private fun SettingsDialogs(
             title = "Sign Out",
             message = "Are you sure you want to sign out? You'll need to re-enter your credentials.",
             onDismiss = { viewModel.onIntent(SettingsIntent.DismissLogoutConfirm) },
-            onConfirm = {
-                viewModel.onIntent(SettingsIntent.Logout)
-                onLogout()
-            },
+            onConfirm = { viewModel.onIntent(SettingsIntent.Logout) },
             confirmText = "Sign Out",
             isDestructive = true,
         )
+    }
+
+    // Logout fires onLogout only after tokens have been cleared so the
+    // post-logout navigation can't auto-login back into Home.
+    LaunchedEffect(state.loggedOut) {
+        if (state.loggedOut) onLogout()
     }
 
     if (state.showClearCacheConfirm) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/LoginViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/LoginViewModel.kt
@@ -6,8 +6,11 @@ import com.spela.player.presentation.intent.LoginIntent
 import com.spela.player.presentation.state.LoginState
 import com.spela.player.util.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -21,6 +24,17 @@ class LoginViewModel(
     private val _state = MutableStateFlow(LoginState())
     val state: StateFlow<LoginState> = _state.asStateFlow()
 
+    /**
+     * One-shot navigation event emitted when the user has just
+     * successfully signed in. Distinct from `state.isLoggedIn` —
+     * which is a sticky flag that survives navigation away from the
+     * Login screen — so a stale `true` from a prior session can no
+     * longer auto-navigate when the user revisits Login after signing
+     * out.
+     */
+    private val _loginSucceeded = MutableSharedFlow<Unit>(extraBufferCapacity = 1)
+    val loginSucceeded: SharedFlow<Unit> = _loginSucceeded.asSharedFlow()
+
     fun onIntent(intent: LoginIntent) {
         when (intent) {
             is LoginIntent.SetServerUrl -> _state.update { it.copy(serverUrl = intent.url) }
@@ -29,6 +43,12 @@ class LoginViewModel(
             is LoginIntent.SetPassword -> _state.update { it.copy(password = intent.password) }
             LoginIntent.ToggleRegisterMode -> _state.update { it.copy(isRegisterMode = !it.isRegisterMode) }
             LoginIntent.DismissError -> _state.update { it.copy(error = null) }
+            LoginIntent.Reset -> _state.update {
+                // Wipe credentials and the success flag so revisiting
+                // LoginScreen after a previous successful sign-in
+                // doesn't immediately auto-fire onLoginSuccess.
+                LoginState(serverUrl = it.serverUrl)
+            }
             LoginIntent.Submit -> submit()
         }
     }
@@ -56,6 +76,7 @@ class LoginViewModel(
             result.fold(
                 onSuccess = {
                     _state.update { it.copy(isLoading = false, isLoggedIn = true) }
+                    _loginSucceeded.tryEmit(Unit)
                 },
                 onFailure = { error ->
                     _state.update {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SettingsViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SettingsViewModel.kt
@@ -46,6 +46,14 @@ data class SettingsState(
     val deviceShaderOverrides: Map<String, ShaderPreset> = emptyMap(),
     val consoles: List<Console> = emptyList(),
     val showLogoutConfirm: Boolean = false,
+    /**
+     * Set to true after [SettingsIntent.Logout] has finished clearing
+     * the auth tokens. Consumers (the navigator) should observe this
+     * to navigate away from authenticated screens — navigating before
+     * tokens clear races against the in-memory cache and lets the next
+     * screen auto-login back into Home.
+     */
+    val loggedOut: Boolean = false,
     val showClearCacheConfirm: Boolean = false,
     val fullscreenPreviewConsoleId: String? = null,
     val raStatus: RAStatus? = null,
@@ -275,9 +283,14 @@ class SettingsViewModel(
     }
 
     private fun logout() {
+        // Hide the confirm dialog immediately so the UI doesn't look
+        // wedged while clearTokens runs.
+        _state.update { it.copy(showLogoutConfirm = false) }
         scope.launch(dispatchers.io) {
             authRepository.clearTokens()
-            _state.update { it.copy(showLogoutConfirm = false) }
+            // Tokens are gone — only now is it safe to navigate away
+            // from authenticated screens. Consumers observe loggedOut.
+            _state.update { it.copy(loggedOut = true) }
         }
     }
 


### PR DESCRIPTION
## Summary

Real product bug, surfaced by EstablishSessionTest.

After signing out and tapping a saved server again, the user landed back on Home instead of the login form. Two underlying causes:

1. **`SettingsViewModel.logout()` race** — fired `clearTokens()` on IO scope but the navigation away happened synchronously. The navigator could pop into an authenticated screen before tokens were actually cleared.
2. **`LoginViewModel.isLoggedIn` was sticky** — held at activity scope (`koinInject` in `App`), so its `isLoggedIn = true` from a prior successful submit survived navigation away. Revisiting Login after sign-out instantly fired `onLoginSuccess` from the `LaunchedEffect(state.isLoggedIn)` before the form rendered.

## Fixes

- `SettingsViewModel.logout`: split state updates so the navigation signal (`loggedOut = true`) only flips after `clearTokens()` completes; `SettingsScreen` observes that flag from a `LaunchedEffect` and only then calls `onLogout`.
- `LoginViewModel`: emit a one-shot `SharedFlow<Unit>` (`loginSucceeded`) on a successful submit. `LoginScreen` collects that event for navigation rather than reading the sticky `state.isLoggedIn` flag.
- `LoginIntent.Reset`: wipes credentials and `isLoggedIn` on every fresh mount of `LoginScreen` so the form starts clean.

## Test plan

- [x] `./run-e2e.sh com.spela.player.android.EstablishSessionTest` on AYN Thor — passes.
- [ ] Manual smoke: sign in → sign out → re-tap saved server → form appears and accepts credentials.