### PR TITLE
fix(player): challenge-create flow + reliable game-start detection

### DIFF
--- a/player/android/src/androidTest/java/com/spela/player/android/ChallengeAttemptTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/ChallengeAttemptTest.kt
@@ -47,9 +47,12 @@ class ChallengeAttemptTest : BaseE2ETest() {
         // Start attempt
         rule.tapOn("Attempt Challenge")
 
-        // Wait for the game to load. The core running indicator confirms the
-        // EmulationViewModel has set isRunning=true.
-        rule.waitForContentDescription("Core running", timeout = 30_000)
+        // Wait for the game to load. UiAutomator's "Core running"
+        // marker can sit on the wrong physical display on Thor's
+        // multi-display setup, and Compose's semantic-tree fetch can
+        // throw AppNotIdleException during the 60fps render loop —
+        // fall back to logcat markers we know fire on real start.
+        rule.waitForGameRunning(timeout = 30_000)
 
         // Wait for touch controls. If the in-game overlay opened unexpectedly
         // (e.g., after a previous test's state leaked), dismiss it first.

--- a/player/android/src/androidTest/java/com/spela/player/android/ChallengeCreationTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/ChallengeCreationTest.kt
@@ -3,6 +3,7 @@ package com.spela.player.android
 import androidx.compose.ui.test.assertIsNotEnabled
 import androidx.compose.ui.test.hasSetTextAction
 import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.onAllNodesWithText
 import androidx.compose.ui.test.onNodeWithText
 import androidx.compose.ui.test.performTextInput
 import org.junit.Test
@@ -108,23 +109,38 @@ class ChallengeCreationTest : BaseE2ETest() {
         rule.tapOn("Challenge")
         rule.waitForText("Create Challenge", timeout = 5_000)
 
-        // Fill in the form
-        rule.clearTextField("Title")
-        rule.onNode(hasText("Title") and hasSetTextAction())
-            .performTextInput("E2E Test Challenge")
+        // All form interaction goes through UiAutomator: Compose's
+        // performTextInput / performClick block on Espresso idle
+        // during the 60fps emulation render loop.
+        val device = androidx.test.uiautomator.UiDevice.getInstance(
+            androidx.test.platform.app.InstrumentationRegistry.getInstrumentation()
+        )
+        val deadline = System.currentTimeMillis() + 5_000L
+        var titleField = device.findObject(
+            androidx.test.uiautomator.UiSelector().className("android.widget.EditText").instance(0)
+        )
+        while (!titleField.exists() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(200)
+            titleField = device.findObject(
+                androidx.test.uiautomator.UiSelector().className("android.widget.EditText").instance(0)
+            )
+        }
+        check(titleField.exists()) { "Title field not found" }
+        titleField.clearTextField()
+        titleField.setText("E2E Test Challenge")
 
-        // Submit
-        rule.tapOn("Create")
+        device.findObject(androidx.test.uiautomator.UiSelector().text("Create")).click()
 
-        // US-1 AC: toast "Challenge created!", game resumes
+        // US-1 AC: toast "Challenge created!", game resumes.
         rule.waitForText("Challenge created!", timeout = 8_000)
 
-        // Overlay should be dismissed, game running
-        rule.assertTextNotVisible("Create Challenge")
-        rule.assertTextNotVisible("Exit Game")
+        // Toast auto-dismisses 2s after success; afterwards the
+        // panel + overlay are gone and the game is running.
+        rule.waitForTextNotVisible("Create Challenge", timeout = 5_000)
+        rule.waitForTextNotVisible("Exit Game", timeout = 3_000)
 
         // Game still running
-        rule.waitForVisible("Game running", timeout = 5_000)
+        rule.waitForVisible("Game running", timeout = 10_000)
 
         rule.openOverlayAndExit()
     }
@@ -139,17 +155,25 @@ class ChallengeCreationTest : BaseE2ETest() {
         rule.tapOn("Challenge")
         rule.waitForText("Create Challenge", timeout = 5_000)
 
-        // Type and difficulty chips are always visible — tap the desired one directly
-        rule.tapOn("Speedrun")
-        rule.tapOn("Hard")
+        // Drive the panel via UiAutomator: Compose's performClick /
+        // performTextInput block on Espresso idle during the 60fps
+        // emulation render loop.
+        val device = androidx.test.uiautomator.UiDevice.getInstance(
+            androidx.test.platform.app.InstrumentationRegistry.getInstrumentation()
+        )
+        device.findObject(androidx.test.uiautomator.UiSelector().text("Speedrun")).click()
+        device.findObject(androidx.test.uiautomator.UiSelector().text("Hard")).click()
 
-        // Fill title
-        rule.clearTextField("Title")
-        rule.onNode(hasText("Title") and hasSetTextAction())
-            .performTextInput("Hard Speedrun Challenge")
+        // Fill title — first EditText
+        val titleField = device.findObject(
+            androidx.test.uiautomator.UiSelector().className("android.widget.EditText").instance(0)
+        )
+        check(titleField.exists()) { "Title field not found" }
+        titleField.clearTextField()
+        titleField.setText("Hard Speedrun Challenge")
 
         // Submit
-        rule.tapOn("Create")
+        device.findObject(androidx.test.uiautomator.UiSelector().text("Create")).click()
         rule.waitForText("Challenge created!", timeout = 8_000)
 
         rule.openOverlayAndExit()
@@ -165,16 +189,38 @@ class ChallengeCreationTest : BaseE2ETest() {
         rule.tapOn("Challenge")
         rule.waitForText("Create Challenge", timeout = 5_000)
 
-        // Fill title
-        rule.clearTextField("Title")
-        rule.onNode(hasText("Title") and hasSetTextAction())
-            .performTextInput("Described Challenge")
+        // All form interaction goes through UiAutomator: Compose's
+        // performTextInput / performClick block on Espresso idle
+        // during the 60fps emulation render loop.
+        val device = androidx.test.uiautomator.UiDevice.getInstance(
+            androidx.test.platform.app.InstrumentationRegistry.getInstrumentation()
+        )
 
-        // Fill optional description — label is "Description (optional)"
-        rule.onNode(hasText("Description", substring = true) and hasSetTextAction())
-            .performTextInput("Beat the first boss without taking damage")
+        // Fill title — first EditText on the panel. Poll briefly so
+        // we don't race the Compose accessibility tree.
+        val deadline = System.currentTimeMillis() + 5_000L
+        var titleField = device.findObject(
+            androidx.test.uiautomator.UiSelector().className("android.widget.EditText").instance(0)
+        )
+        while (!titleField.exists() && System.currentTimeMillis() < deadline) {
+            Thread.sleep(200)
+            titleField = device.findObject(
+                androidx.test.uiautomator.UiSelector().className("android.widget.EditText").instance(0)
+            )
+        }
+        check(titleField.exists()) { "Title field not found" }
+        titleField.clearTextField()
+        titleField.setText("Described Challenge")
 
-        rule.tapOn("Create")
+        // Fill optional description — second EditText.
+        val descField = device.findObject(
+            androidx.test.uiautomator.UiSelector().className("android.widget.EditText").instance(1)
+        )
+        check(descField.exists()) { "Description field not found" }
+        descField.setText("Beat the first boss without taking damage")
+
+        // Click Create.
+        device.findObject(androidx.test.uiautomator.UiSelector().text("Create")).click()
         rule.waitForText("Challenge created!", timeout = 8_000)
 
         rule.openOverlayAndExit()
@@ -190,8 +236,12 @@ class ChallengeCreationTest : BaseE2ETest() {
         rule.tapOn("Challenge")
         rule.waitForText("Create Challenge", timeout = 5_000)
 
-        // Tap Cancel button to dismiss creation panel
-        rule.tapOn("Cancel")
+        // Tap Cancel via the panel's stable testTag. The tag-based
+        // helper invokes the OnClick semantic action directly, which
+        // bypasses both Espresso idle (blocked by the 60fps render
+        // loop) and the touch-dispatch ambiguity of clicking a Text
+        // child of SpSecondaryButton.
+        rule.tapOnTag("challenge_create_cancel_button")
 
         // Creation panel should be dismissed
         rule.waitForTextNotVisible("Create Challenge")
@@ -218,21 +268,27 @@ class ChallengeCreationTest : BaseE2ETest() {
     @Test
     fun createdChallengeVisibleInChallengeList() {
         setupGame()
-        rule.openOverlay()
 
-        rule.tapOn("Challenge")
-        rule.waitForText("Create Challenge", timeout = 5_000)
+        // Use the shared helper — it does the overlay open, panel
+        // wait, EditText polling and UiAutomator-based Create click
+        // (Compose's tapOn blocks on Espresso idle during the 60fps
+        // emulation render loop).
+        rule.createChallengeFromOverlay("My Created Challenge")
 
-        rule.clearTextField("Title")
-        rule.onNode(hasText("Title") and hasSetTextAction())
-            .performTextInput("My Created Challenge")
-
-        rule.tapOn("Create")
-        rule.waitForText("Challenge created!", timeout = 8_000)
-
-        // Exit game to go back to game detail
+        // Exit game to go back to game detail. The CTA depends on
+        // download + auto-save state — after playing once the
+        // primary action is "Resume" or "Play", not "Download".
         rule.openOverlayAndExit()
-        rule.waitForText("Download", timeout = 8_000)
+        rule.pollUntil(timeoutMillis = 8_000L) {
+            try {
+                rule.onAllNodesWithText("Resume", substring = false)
+                    .fetchSemanticsNodes().isNotEmpty() ||
+                    rule.onAllNodesWithText("Play", substring = false)
+                        .fetchSemanticsNodes().isNotEmpty() ||
+                    rule.onAllNodesWithText("Download", substring = false)
+                        .fetchSemanticsNodes().isNotEmpty()
+            } catch (_: Exception) { false }
+        }
 
         // Navigate to challenge list via "View Challenges" button
         rule.navigateToChallengeList()

--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -1279,17 +1279,60 @@ fun ComposeRule.navigateToGameByTitle(gameTitle: String) {
     val device = uiDevice()
     val tag = "E2E_NAV"
 
-    // Navigate to Consoles tab
+    // Navigate to Consoles tab. Don't wait on a generic
+    // "Nintendo Entertainment System" content description — that
+    // string also appears on Home game cards. Also, the bottom-nav
+    // tab preserves its stack, so a previous test could have left
+    // the per-console screen (screen_console) on top of the Consoles
+    // tab. Pop back to the consoles list root before tapping NES.
     android.util.Log.d(tag, "Step 1: Tapping Consoles tab")
     tapOn("Consoles")
-    android.util.Log.d(tag, "Step 2: Waiting for NES content description")
-    waitForContentDescription("Nintendo Entertainment System", TIMEOUT_EXTRA_LONG)
-    android.util.Log.d(tag, "Step 2: NES found")
+    val consolesDeadline = System.currentTimeMillis() + TIMEOUT_EXTRA_LONG
+    while (System.currentTimeMillis() < consolesDeadline) {
+        val onConsolesList = try {
+            onAllNodesWithTag("consoles-list", useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        } catch (_: Exception) { false }
+        if (onConsolesList) break
+        // If we're stranded on the per-console screen, press back
+        // until the consoles list is visible.
+        val onPerConsole = try {
+            onAllNodesWithContentDescription("screen_console", substring = false)
+                .fetchSemanticsNodes().isNotEmpty()
+        } catch (_: Exception) { false }
+        if (onPerConsole) {
+            android.util.Log.d(tag, "Step 2: stranded on screen_console, pressing back")
+            pressBack()
+            Thread.sleep(500)
+        } else {
+            Thread.sleep(250)
+        }
+    }
+    android.util.Log.d(tag, "Step 2: Consoles screen confirmed")
 
-    // Tap the NES console card. With isTestMode=true, Compose APIs are fast.
-    // Use the compound matcher to find the card with both "NES" and "games".
-    android.util.Log.d(tag, "Step 3: Tapping NES card")
-    scrollToAndTapMatchingBoth("Nintendo Entertainment System", "games")
+    // Tap the NES console card via its stable testTag — robust
+    // against card layout/copy changes (a recent UI tweak broke the
+    // old "Nintendo Entertainment System" + "games" pair matcher).
+    android.util.Log.d(tag, "Step 3: Tapping NES card (testTag console_card_nes)")
+    val nesCardTag = com.spela.player.presentation.ui.TestTags.consoleCard("nes")
+    // Poll for the tag — Compose's accessibility tree can briefly be
+    // unavailable right after a tab switch (AppNotIdleException).
+    val tagDeadline = System.currentTimeMillis() + 8_000
+    var tagPresent = false
+    while (System.currentTimeMillis() < tagDeadline) {
+        tagPresent = try {
+            onAllNodesWithTag(nesCardTag, useUnmergedTree = true)
+                .fetchSemanticsNodes().isNotEmpty()
+        } catch (_: Exception) { false }
+        if (tagPresent) break
+        Thread.sleep(250)
+    }
+    if (tagPresent) {
+        scrollToAndTapTag(nesCardTag, maxSwipes = 10)
+    } else {
+        android.util.Log.d(tag, "Step 3: NES tag not found, falling back to text-pair matcher")
+        scrollToAndTapMatchingBoth("Nintendo Entertainment System", "games")
+    }
     android.util.Log.d(tag, "Step 3: NES card tapped, waiting for console screen")
 
     // Verify we navigated to the console screen
@@ -1821,40 +1864,72 @@ fun ComposeRule.startGameAndWait() {
 
     // Wait for emulation to start using multiple signals
     val device = uiDevice()
-    // 20s is enough for download + extract + core init on a real device.
-    // First-time runs that need to fetch a fresh core from libretro
-    // buildbot may take longer; bump only if a passing test starts
-    // failing here, NOT to mask a hanging emulation pipeline.
+    // 20s is plenty: a cached core + ROM starts in well under a
+    // second. If this trips, the emulation pipeline is wedged or the
+    // detection markers are missing — investigate that instead of
+    // bumping the timeout.
     val deadline = System.currentTimeMillis() + 20_000
+    var iter = 0
     while (System.currentTimeMillis() < deadline) {
+        iter++
         // Signal 1: Compose "Game running" marker
         try {
-            if (onAllNodesWithContentDescription("Game running", substring = false)
-                    .fetchSemanticsNodes().isNotEmpty()) {
+            val composeCount = onAllNodesWithContentDescription("Game running", substring = false)
+                .fetchSemanticsNodes().size
+            android.util.Log.d("E2E_GAMEPLAY", "iter=$iter compose 'Game running' nodes=$composeCount")
+            if (composeCount > 0) {
                 android.util.Log.d("E2E_GAMEPLAY", "Game started! Compose 'Game running' marker")
                 Thread.sleep(2_000)
                 return
             }
-        } catch (_: Exception) {}
+        } catch (e: Exception) {
+            android.util.Log.d("E2E_GAMEPLAY", "iter=$iter compose check error: ${e.message?.take(80)}")
+        }
 
         // Signal 2: UiAutomator "Core running" marker
-        if (device.findObject(UiSelector().descriptionContains("Core running")).exists()) {
+        val uiAutomatorRunning = device.findObject(UiSelector().descriptionContains("Core running")).exists()
+        android.util.Log.d("E2E_GAMEPLAY", "iter=$iter uiautomator 'Core running' exists=$uiAutomatorRunning")
+        if (uiAutomatorRunning) {
             android.util.Log.d("E2E_GAMEPLAY", "Game started! UiAutomator 'Core running' marker")
             return
         }
 
-        // Signal 3: Logcat core messages
+        // Signal 3: Logcat core messages — match the actual Spela
+        // logs emitted by EmulationViewModel + LibretroController.
+        // `executeShellCommand` runs a single binary (no pipes), so
+        // we filter by tag at the logcat level and then do the
+        // pattern match in Kotlin. The two tags between them carry
+        // every "game-started" hint we need.
         try {
-            val logOutput = device.executeShellCommand("logcat -d -t 30 | grep -i 'retro_run\\|nativeRun\\|Core running\\|emulation started'")
-            if (logOutput.isNotEmpty()) {
-                android.util.Log.d("E2E_GAMEPLAY", "Game started! Logcat: ${logOutput.take(100)}")
+            val raw = device.executeShellCommand("logcat -d -s System.out:I SpelaLibretro:I -t 500")
+            val hit = raw.lineSequence().firstOrNull { line ->
+                line.contains("Game loaded:") ||
+                    line.contains("libretroController.start() returned")
+            }
+            if (hit != null) {
+                android.util.Log.d("E2E_GAMEPLAY", "iter=$iter logcat hit: ${hit.take(160)}")
+                android.util.Log.d("E2E_GAMEPLAY", "Game started! Logcat marker found")
                 Thread.sleep(2_000)
                 return
+            } else {
+                android.util.Log.d("E2E_GAMEPLAY", "iter=$iter logcat: no match yet (raw=${raw.length} bytes)")
             }
-        } catch (_: Exception) {}
+        } catch (e: Exception) {
+            android.util.Log.d("E2E_GAMEPLAY", "iter=$iter logcat error: ${e.message?.take(80)}")
+        }
 
         Thread.sleep(2_000)
     }
+    // Dump some context about what content descriptions WERE visible
+    // when we gave up so the next debug session has data to work with.
+    val lastDesc = try {
+        onAllNodesWithContentDescription("", substring = true).fetchSemanticsNodes()
+            .mapNotNull {
+                it.config.find { p -> p.key.name == "ContentDescription" }?.value as? List<*>
+            }
+            .flatten().filterIsInstance<String>().take(20)
+    } catch (_: Exception) { emptyList() }
+    android.util.Log.d("E2E_GAMEPLAY", "Game did not start. Visible contentDescriptions sample: $lastDesc")
     throw IllegalStateException("Game did not start within 20 seconds")
 }
 
@@ -2425,31 +2500,40 @@ fun ComposeRule.createChallengeFromOverlay(title: String = "E2E Test Challenge")
     tapOn("Challenge")
     waitForText("Create Challenge", timeout = 5_000)
 
-    // During emulation, Compose test performTextInput/performClick block on idle.
-    // Use UiAutomator for text input and button click.
+    // During emulation, Compose test performTextInput/performClick
+    // can block on Espresso idle (the 60fps render loop never goes
+    // idle), so use UiAutomator. Compose's accessibility tree often
+    // needs a moment to publish the EditText after the panel renders
+    // — poll for it instead of failing on the first miss.
     val device = UiDevice.getInstance(InstrumentationRegistry.getInstrumentation())
-    val titleField = device.findObject(UiSelector().textContains("Title").className("android.widget.EditText"))
-    if (!titleField.exists()) {
-        // Fallback: find by resource ID or any editable field
-        val anyField = device.findObject(UiSelector().className("android.widget.EditText"))
-        check(anyField.exists()) { "createChallengeFromOverlay: no text field found" }
-        anyField.clearTextField()
-        anyField.setText(title)
-    } else {
-        titleField.clearTextField()
-        titleField.setText(title)
+    val deadline = System.currentTimeMillis() + 5_000L
+    var titleField = device.findObject(UiSelector().className("android.widget.EditText"))
+    while (!titleField.exists() && System.currentTimeMillis() < deadline) {
+        Thread.sleep(200)
+        titleField = device.findObject(UiSelector().className("android.widget.EditText"))
     }
+    check(titleField.exists()) { "createChallengeFromOverlay: no Title text field found" }
+    titleField.clearTextField()
+    titleField.setText(title)
 
-    // Tap the "Create" button. tapOn would substring-match and could
-    // hit the "Create Challenge" dialog title first; tapLastWithText
-    // uses UiSelector.text() (exact match) so only the actual button
-    // qualifies, and `last` ensures we get the bottom one if the
-    // panel is ever rendered with multiple "Create" exact matches.
-    tapLastWithText("Create")
+    // Tap the "Create" button via UiAutomator directly. tapLastWithText
+    // tries Compose performClick first when "Core running" content
+    // description isn't detected — but the overlay/panel can hide
+    // that signal mid-flow, sending the click into Espresso's idle
+    // wait, which never completes during 60fps emulation.
+    var createIdx = 0
+    while (device.findObject(UiSelector().text("Create").instance(createIdx + 1)).exists()) {
+        createIdx++
+    }
+    val createBtn = device.findObject(UiSelector().text("Create").instance(createIdx))
+    check(createBtn.exists()) { "createChallengeFromOverlay: no Create button found" }
+    createBtn.click()
     waitForText("Challenge created!", timeout = 15_000)
 
-    // Game resumes after toast
-    waitForVisible("Game running", timeout = 5_000)
+    // Game resumes after the success toast auto-dismisses (~2s delay
+    // in InGameOverlay) plus another frame for emulation to restart.
+    // The 1dp "Game running" semantic marker is the canonical signal.
+    waitForVisible("Game running", timeout = 10_000)
 }
 
 /**

--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -381,6 +381,53 @@ fun ComposeRule.waitForContentDescription(desc: String, timeout: Long = TIMEOUT_
     throw IllegalStateException("waitForContentDescription('$desc'): not found within ${timeout}ms")
 }
 
+/**
+ * Wait for the libretro core to have actually started running.
+ *
+ * Uses three independent signals so the wait survives:
+ * - Thor multi-display routing (UiAutomator sees display 0, marker
+ *   may be on display 4)
+ * - the 60fps render loop that defeats Compose semantic-tree fetches
+ *   with AppNotIdleException
+ * - any one signal missing in a particular state transition
+ *
+ * Signals: Compose `Game running` content description, UiAutomator
+ * `Core running` description, and Spela's own logcat lines
+ * (`Game loaded:`, `libretroController.start() returned`).
+ */
+fun ComposeRule.waitForGameRunning(timeout: Long = TIMEOUT_LONG) {
+    val device = uiDevice()
+    val deadline = System.currentTimeMillis() + timeout
+    var iter = 0
+    while (System.currentTimeMillis() < deadline) {
+        iter++
+        try {
+            if (onAllNodesWithContentDescription("Game running", substring = false)
+                    .fetchSemanticsNodes().isNotEmpty()) {
+                android.util.Log.d("E2E_GAMEPLAY", "waitForGameRunning iter=$iter: Compose marker hit")
+                return
+            }
+        } catch (_: Exception) { /* AppNotIdle or tree unavailable */ }
+        if (device.findObject(UiSelector().descriptionContains("Core running")).exists()) {
+            android.util.Log.d("E2E_GAMEPLAY", "waitForGameRunning iter=$iter: UiAutomator marker hit")
+            return
+        }
+        try {
+            val raw = device.executeShellCommand("logcat -d -s System.out:I SpelaLibretro:I -t 500")
+            val hit = raw.lineSequence().firstOrNull { line ->
+                line.contains("Game loaded:") ||
+                    line.contains("libretroController.start() returned")
+            }
+            if (hit != null) {
+                android.util.Log.d("E2E_GAMEPLAY", "waitForGameRunning iter=$iter: logcat hit: ${hit.take(160)}")
+                return
+            }
+        } catch (_: Exception) {}
+        Thread.sleep(500)
+    }
+    throw IllegalStateException("waitForGameRunning: no signal within ${timeout}ms")
+}
+
 fun ComposeRule.waitForTextNotVisible(text: String, timeout: Long = TIMEOUT_SHORT) {
     val obj = uiDevice().findObject(UiSelector().textContains(text))
     if (obj.exists()) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/challenge/ChallengeCreationPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/challenge/ChallengeCreationPanel.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.semantics.heading
 import androidx.compose.ui.semantics.semantics
 import com.spela.player.domain.model.ChallengeDifficulty
@@ -90,7 +91,9 @@ fun ChallengeCreationPanel(
                 onValueChange = { name = it },
                 label = "Title",
                 singleLine = true,
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .testTag("challenge_create_title_field"),
             )
 
             Spacer(Modifier.height(SpSpacing.Medium))
@@ -165,7 +168,7 @@ fun ChallengeCreationPanel(
                     text = "Cancel",
                     onClick = onDismiss,
                     enabled = !isSubmitting,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f).testTag("challenge_create_cancel_button"),
                 )
                 SpButton(
                     text = if (isSubmitting) "Creating..." else "Create",
@@ -175,7 +178,7 @@ fun ChallengeCreationPanel(
                         }
                     },
                     enabled = name.isNotBlank() && !isSubmitting,
-                    modifier = Modifier.weight(1f),
+                    modifier = Modifier.weight(1f).testTag("challenge_create_submit_button"),
                 )
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameDetailSections.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameDetailSections.kt
@@ -124,7 +124,11 @@ fun ChallengesSection(
     onViewAll: () -> Unit,
     onCreateChallenge: (() -> Unit)? = null,
 ) {
-    SpTitledSection(title = "Challenges", icon = Icons.Outlined.Flag) {
+    SpTitledSection(
+        title = "Challenges",
+        icon = Icons.Outlined.Flag,
+        modifier = Modifier.testTag("challenges_section"),
+    ) {
         Text(
             text = "Compete on community-created challenges for $gameTitle",
             style = SpTypography.BodyMedium,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ChallengeManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ChallengeManager.kt
@@ -231,8 +231,21 @@ class ChallengeManager(
     fun dismissChallengeCreation(resumeGame: () -> Unit) {
         challengeCreationSaveData = null
         challengeCreationScreenshot = null
-        _state.update { it.copy(showChallengeCreation = false, challengeCreationSuccess = false) }
-        resumeGame()
+        // Cancel returns the user to the in-game overlay (where they
+        // started before tapping Challenge), not directly back to the
+        // running game. The overlay was hidden on init so the panel
+        // could take its place; restore it now. The success path
+        // (after a real submit) closes the overlay too — that's
+        // handled by submitChallenge's own state update.
+        val wasSuccess = _state.value.challengeCreationSuccess
+        _state.update {
+            it.copy(
+                showChallengeCreation = false,
+                challengeCreationSuccess = false,
+                showOverlay = if (wasSuccess) false else true,
+            )
+        }
+        if (wasSuccess) resumeGame()
     }
 
     /**

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/ChallengeManagerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/ChallengeManagerTest.kt
@@ -224,15 +224,43 @@ class ChallengeManagerTest {
     }
 
     @Test
-    fun dismissChallengeCreationClearsFlagsAndResumes() = runTest(testDispatcher) {
-        state.update { it.copy(showChallengeCreation = true) }
+    fun dismissChallengeCreationFromCancelRestoresOverlay() = runTest(testDispatcher) {
+        // Cancel path: user opened the panel (which hid the overlay)
+        // and tapped Cancel without submitting. Expected behaviour is
+        // to restore the overlay so the user can pick another action;
+        // do NOT resume the game.
+        state.update { it.copy(showChallengeCreation = true, showOverlay = false) }
 
         var resumeGameCalled = false
         manager.dismissChallengeCreation { resumeGameCalled = true }
 
-        assertTrue(resumeGameCalled)
+        assertEquals(false, resumeGameCalled)
         assertEquals(false, state.value.showChallengeCreation)
         assertEquals(false, state.value.challengeCreationSuccess)
+        assertEquals(true, state.value.showOverlay)
+    }
+
+    @Test
+    fun dismissChallengeCreationAfterSuccessResumesGame() = runTest(testDispatcher) {
+        // Auto-dismiss after a successful submit: the success-toast
+        // LaunchedEffect calls dismissChallengeCreation. Expected
+        // behaviour is to drop straight back into gameplay (no
+        // overlay), since the user already committed an action.
+        state.update {
+            it.copy(
+                showChallengeCreation = false,
+                challengeCreationSuccess = true,
+                showOverlay = false,
+            )
+        }
+
+        var resumeGameCalled = false
+        manager.dismissChallengeCreation { resumeGameCalled = true }
+
+        assertEquals(true, resumeGameCalled)
+        assertEquals(false, state.value.showChallengeCreation)
+        assertEquals(false, state.value.challengeCreationSuccess)
+        assertEquals(false, state.value.showOverlay)
     }
 
     @Test

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelChallengeTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModelChallengeTest.kt
@@ -235,7 +235,10 @@ class EmulationViewModelChallengeTest {
     }
 
     @Test
-    fun dismissChallengeCreationResumes() = runTest {
+    fun dismissChallengeCreationFromCancelKeepsGamePausedAndRestoresOverlay() = runTest {
+        // Cancel path: opening the panel hid the overlay; dismissing
+        // restores it. Game stays paused so the user can pick another
+        // overlay action without the game running underneath.
         val vm = builder.build()
         vm.onIntent(EmulationIntent.StartGame("game1"))
         builder.advanceTimeBy(100)
@@ -244,9 +247,11 @@ class EmulationViewModelChallengeTest {
         builder.advanceTimeBy(100)
         assertTrue(vm.state.value.showChallengeCreation)
         assertTrue(vm.state.value.isPaused)
+        assertFalse(vm.state.value.showOverlay)
 
         vm.onIntent(EmulationIntent.DismissChallengeCreation)
         assertFalse(vm.state.value.showChallengeCreation)
-        assertFalse(vm.state.value.isPaused)
+        assertTrue(vm.state.value.isPaused)
+        assertTrue(vm.state.value.showOverlay)
     }
 }


### PR DESCRIPTION
## Summary

Real product bug + Android E2E test infrastructure improvements.

### Product fix (ChallengeManager.dismissChallengeCreation)
Tapping **Challenge** from the in-game overlay hid the overlay so the creation panel could take its place; tapping **Cancel** on that panel went straight back into the running game instead of restoring the overlay. From the user's perspective Cancel should undo the "opened the panel" step, not the "opened the overlay" step — pull them back to the overlay so they can pick another action (Save, Exit Game, etc.) without re-opening it. The auto-dismiss path after a successful submit still resumes the game.

### Test infrastructure

- `startGameAndWait`: the logcat fallback used `logcat -d -t 30 | grep` which (a) interprets `-t 30` as 30 *lines* of recent log (~1 second of frames during emulation), and (b) the `|` pipe doesn't work through `executeShellCommand` (single-binary only). Filter at the logcat level by tag (System.out, SpelaLibretro) and pattern-match in Kotlin. Replace the obsolete `retro_run|nativeRun|Core running|emulation started` patterns with the real lines Spela emits today.
- `navigateToGameByTitle`: stop trusting a generic "Nintendo Entertainment System" content-description match — that string is also on Home game cards, so the wait would return before the Consoles screen had loaded. Wait for the `consoles-list` testTag instead, and pop back if we're stranded on `screen_console` from a previous test's stack. Prefer the stable `console_card_<id>` tag over the brittle text-pair matcher.
- New `waitForGameRunning` helper rotates through three independent signals so the wait survives Thor multi-display routing, AppNotIdleException during the 60fps render loop, and any one missing signal.
- `ChallengeCreationPanel` now exposes `challenge_create_title_field`, `challenge_create_submit_button`, `challenge_create_cancel_button` testTags.
- `createChallengeFromOverlay` polls the EditText for up to 5s and clicks Create via UiAutomator directly; the post-create wait for `Game running` is 10s.
- All form interactions in ChallengeCreationTest go through UiAutomator now — Compose `performClick` / `performTextInput` block on Espresso idle during the 60fps emulation render loop.
- Detailed per-iteration logging in `startGameAndWait` / `waitForGameRunning` so the next regression is easy to spot.

## Verified passing on AYN Thor

- SettingsTest 5/5
- EmulationTest 13/13
- EstablishSessionTest 1/1
- NavigationTest 2/2, ResetServerStateTest 1/1, CoreDecisionFlagsSmokeTest 1/1, CloneSessionSmokeTest 1/1
- ChallengeBrowsingTest 6/6
- ChallengeCreationTest 8/8

## Test plan

- [x] Manual smoke: sign in → open overlay → tap Challenge → tap Cancel → overlay still visible
- [x] `./run-e2e.sh com.spela.player.android.ChallengeBrowsingTest` 6/6
- [x] `./run-e2e.sh com.spela.player.android.ChallengeCreationTest` 8/8