### PR TITLE
fix(player): activity feed metadata nullable (PlayLaterTest follow-up)

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActivityEventResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/ActivityEventResponse.kt
@@ -55,12 +55,14 @@ data class ActivityEventResponse (
 
     @SerialName(value = "id") @Required val id: kotlin.String,
 
-    // Manually patched: server returns metadata as a JSON object, but the
+    // Manually patched: server returns metadata as a JSON object (or null
+    // for events that have no metadata, e.g. queued_play_later), but the
     // OpenAPI generator emits `kotlin.String` for `type: object,
     // additionalProperties: {}`. The generated default fails to deserialize
-    // (Unexpected JSON token: Expected beginning of the string, but got `{`).
-    // Use JsonObject so it round-trips correctly.
-    @SerialName(value = "metadata") @Required val metadata: kotlinx.serialization.json.JsonObject,
+    // both branches (Unexpected JSON token: Expected beginning of the
+    // string, but got `{`/`null`). Use a nullable JsonObject so both
+    // null and object payloads round-trip.
+    @SerialName(value = "metadata") val metadata: kotlinx.serialization.json.JsonObject? = null,
 
     @SerialName(value = "userId") @Required val userId: kotlin.String,
 


### PR DESCRIPTION
## Summary

Follow-up to PR #721 that surfaced via `PlayLaterTest.activityFeedShowsPlayLaterEvent`.

PR #721 patched `ActivityEventResponse.metadata` from `kotlin.String` to a non-nullable `JsonObject`. That fixed `challenge_completed` events, which always carry a metadata object. But `CreateActivityEvent` is also called with `nil` metadata for events that don't need a payload (e.g. `queued_play_later`, `favorited_game`), so the server emits `"metadata": null` for them and the kotlinx serializer threw `Expected JsonObject, got null` again.

Make the field nullable.

## Result
- `PlayLaterTest`: **5/5** passing on Thor (was 4/5).
- Other activity-feed-bearing tests (ChallengeIntegrationTest 4/4, ChallengeAttemptTest 9/9, SessionTest 5/5) still pass.

## Test plan
- [ ] CI green
- [x] `./player/run-e2e.sh com.spela.player.android.PlayLaterTest --skip-reset --no-fail-fast` → 5/5 passing