### PR TITLE
test(android): tolerate prior-test download in navigateToN64Game

### DIFF
--- a/player/android/src/androidTest/java/com/spela/player/android/HwRenderTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/HwRenderTest.kt
@@ -46,15 +46,21 @@ class HwRenderTest : BaseE2ETest() {
      * Verifies: exit returns to game detail, second session starts,
      * overlay shows correct controls after resume.
      *
-     * QUARANTINED — see issue #724. Restarting the mupen64plus_next
-     * core in the same process fails with `failed to initialize
-     * core (err=2)` because `nativeDeinit` skips `retro_deinit` for
-     * GL HW render cores (avoids Play! PS2 GL cleanup crash) and
-     * mupen64plus's internal state then refuses a second
-     * `retro_init`. This affects real users who exit an N64 game
-     * and click Resume — the same product bug, surfaced here.
+     * QUARANTINED — see #724 / #726. The original workaround that
+     * skips retro_deinit + dlclose for GL HW render cores was
+     * over-broad (catching mupen64plus alongside Play!). Narrowing
+     * the workaround to Play!-only (so mupen64plus retro_deinit
+     * runs) fixes the err=2 re-init failure exposed by this test —
+     * but lets a second crash through:
+     * `Scudo ERROR: invalid chunk state when deallocating` in
+     * `vkDestroySwapchainKHR`, surfaced from `nativeGpuDeinit`
+     * after `retro_deinit` returns. So mupen64plus's retro_deinit
+     * also corrupts heap state, just less visibly than Play!'s.
+     * Both cores need upstream verification before the workaround
+     * can be narrowed or removed. See #726 for the verification
+     * playbook.
      */
-    @Ignore("#724 — N64 mupen64plus_next core can't re-initialize after exit (HW-render retro_deinit skip leaves core in 'initialized' state)")
+    @Ignore("#724 / #726 — mupen64plus retro_deinit corrupts heap (Scudo abort in vkDestroySwapchainKHR); workaround stays in place core-wide until upstream verified")
     @Test
     fun n64ExitAndResume() {
         setupN64Game()

--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -1718,7 +1718,17 @@ fun ComposeRule.navigateToN64Game() {
         scrollToAndTapText("Banjo-Kazooie")
     }
 
-    waitForText("Download", TIMEOUT_LONG)
+    // Wait for the GameDetail primary CTA. The label depends on local
+    // state: "Download" pre-download, "Play" post-download with no save,
+    // "Resume" once a save exists. After a previous test already ran the
+    // game, "Download" is gone — accept any of the three.
+    pollUntil(timeoutMillis = TIMEOUT_LONG) {
+        try {
+            onAllNodesWithText("Download", substring = false).fetchSemanticsNodes().isNotEmpty() ||
+                onAllNodesWithText("Play", substring = false).fetchSemanticsNodes().isNotEmpty() ||
+                onAllNodesWithText("Resume", substring = false).fetchSemanticsNodes().isNotEmpty()
+        } catch (_: Exception) { false }
+    }
 }
 
 fun ComposeRule.navigateToN64GameAndPlay() {


### PR DESCRIPTION
## Summary

Two small improvements that came out of investigating #724:

1. **`navigateToN64Game` tolerates prior-test download state.** The helper waited for "Download" on the GameDetail page, which only exists pre-download. If a prior test in the same suite already downloaded Banjo-Kazooie, the helper would time out. Now accepts any of "Download" / "Play" / "Resume".
2. **Refresh the `@Ignore` comment on `n64ExitAndResume`** with what we now know: narrowing the workaround to Play!-only fixes the err=2 re-init failure but exposes a second crash (Scudo abort in `vkDestroySwapchainKHR` from `nativeGpuDeinit`), so mupen64plus's `retro_deinit` also has a teardown bug. Full investigation in #726.

## What's NOT in this PR

The native bridge change that narrowed the deinit-skip workaround to Play!-only. It's clean code-wise but exposes the second crash in mupen64plus, which needs upstream verification before we can land a real fix. See #726 for the playbook.

## Test plan

- [x] `./player/run-e2e.sh com.spela.player.android.HwRenderTest` — the helper change unblocks the path that runs `n64GameplayAndSaveLoad` after another N64 test (which is what surfaced this).

Refs: #724, #726.
