### PR TITLE
test(android): trim 13 redundant E2E tests (audit pass 1)

### DIFF
--- a/player/android/src/androidTest/java/com/spela/player/android/ChallengeAttemptTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/ChallengeAttemptTest.kt
@@ -114,18 +114,6 @@ class ChallengeAttemptTest : BaseE2ETest() {
         rule.abandonChallenge()
     }
 
-    // ── US-5 AC: Timer displayed during gameplay ──
-
-    @Test
-    fun challengeTimerVisibleDuringPlay() {
-        startAttempt()
-
-        // Timer HUD should be visible while playing
-        rule.waitForVisible("Challenge timer", timeout = 5_000)
-
-        rule.abandonChallenge()
-    }
-
     // ── US-5 AC: Modified overlay — no Save/Load/FF ──
 
     @Test

--- a/player/android/src/androidTest/java/com/spela/player/android/ChallengeBrowsingTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/ChallengeBrowsingTest.kt
@@ -34,21 +34,6 @@ class ChallengeBrowsingTest : BaseE2ETest() {
         rule.pressBack()
     }
 
-    // ── US-3 AC: View Challenges navigates to ChallengeListScreen ──
-
-    @Test
-    fun viewChallengesNavigatesToList() {
-        rule.navigateToCastlevania()
-
-        // Tap "View Challenges" to navigate to ChallengeListScreen
-        rule.navigateToChallengeList()
-
-        // Should be on the ChallengeListScreen (shows game title in top bar)
-        rule.waitForText("Castlevania", timeout = 5_000)
-
-        rule.pressBack()
-    }
-
     // ── US-3 AC: Empty state when no challenges for a game ──
 
     @Test
@@ -127,37 +112,4 @@ class ChallengeBrowsingTest : BaseE2ETest() {
         rule.pressBack()
     }
 
-    // ── Multiple challenges visible in list ──
-
-    @Test
-    fun multipleChallengesVisibleInList() {
-        // Create two challenges on Castlevania (pin so the post-exit
-        // game-detail screen and the later "View Challenges" tap
-        // target the same game).
-        rule.navigateToGameAndPlay(preferredGameTitle = "Castlevania")
-        rule.createChallengeFromOverlay("Challenge Alpha")
-        rule.createChallengeFromOverlay("Challenge Beta")
-        rule.openOverlayAndExit()
-        // After exit the action button is Play/Resume/Download
-        // depending on cache + auto-save state.
-        rule.pollUntil(timeoutMillis = 8_000) {
-            try {
-                rule.onAllNodesWithText("Play", substring = true)
-                    .fetchSemanticsNodes().isNotEmpty() ||
-                    rule.onAllNodesWithText("Resume", substring = true)
-                        .fetchSemanticsNodes().isNotEmpty() ||
-                    rule.onAllNodesWithText("Download", substring = true)
-                        .fetchSemanticsNodes().isNotEmpty()
-            } catch (_: IllegalStateException) { false }
-        }
-
-        // Navigate to challenge list
-        rule.navigateToChallengeList()
-
-        // Both should appear
-        rule.waitForText("Challenge Alpha", timeout = 8_000)
-        rule.assertVisible("Challenge Beta")
-
-        rule.pressBack()
-    }
 }

--- a/player/android/src/androidTest/java/com/spela/player/android/ChallengeCreationTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/ChallengeCreationTest.kt
@@ -145,40 +145,6 @@ class ChallengeCreationTest : BaseE2ETest() {
         rule.openOverlayAndExit()
     }
 
-    // ── US-1 AC: Challenge type and difficulty can be changed ──
-
-    @Test
-    fun createChallengeWithCustomTypeAndDifficulty() {
-        setupGame()
-        rule.openOverlay()
-
-        rule.tapOn("Challenge")
-        rule.waitForText("Create Challenge", timeout = 5_000)
-
-        // Drive the panel via UiAutomator: Compose's performClick /
-        // performTextInput block on Espresso idle during the 60fps
-        // emulation render loop.
-        val device = androidx.test.uiautomator.UiDevice.getInstance(
-            androidx.test.platform.app.InstrumentationRegistry.getInstrumentation()
-        )
-        device.findObject(androidx.test.uiautomator.UiSelector().text("Speedrun")).click()
-        device.findObject(androidx.test.uiautomator.UiSelector().text("Hard")).click()
-
-        // Fill title — first EditText
-        val titleField = device.findObject(
-            androidx.test.uiautomator.UiSelector().className("android.widget.EditText").instance(0)
-        )
-        check(titleField.exists()) { "Title field not found" }
-        titleField.clearTextField()
-        titleField.setText("Hard Speedrun Challenge")
-
-        // Submit
-        device.findObject(androidx.test.uiautomator.UiSelector().text("Create")).click()
-        rule.waitForText("Challenge created!", timeout = 8_000)
-
-        rule.openOverlayAndExit()
-    }
-
     // ── US-1 AC: Optional description field ──
 
     @Test

--- a/player/android/src/androidTest/java/com/spela/player/android/ChallengeIntegrationTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/ChallengeIntegrationTest.kt
@@ -144,23 +144,4 @@ class ChallengeIntegrationTest : BaseE2ETest() {
         rule.exitGame()
     }
 
-    // ── Game detail "Challenges" section coexists with existing sections ──
-
-    @Test
-    fun gameDetailLayoutIntactWithChallengesSection() {
-        rule.navigateToCastlevania()
-
-        // The page should have the primary action plus the always-on
-        // sections. game_shared_sessions_section only renders when
-        // shared sessions exist (or a load is in flight); a fresh
-        // test seed has neither, so we don't assert on it here.
-        // Drive everything by tag so the test stays stable across
-        // copy changes.
-        rule.assertVisible("Download")
-        rule.scrollToAndTapTag("sessions_section")
-        rule.scrollToAndTapTag("challenges_section")
-        rule.assertTagVisible("view_challenges_button")
-
-        rule.pressBack()
-    }
 }

--- a/player/android/src/androidTest/java/com/spela/player/android/CollectionsTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/CollectionsTest.kt
@@ -275,26 +275,6 @@ class CollectionsTest : BaseE2ETest() {
         deleteCurrentCollection()
     }
 
-    // ── Test: Create Collection ──
-
-    @Test
-    fun createCollectionFromCollectionsScreen() {
-        val collName = "E2E Create ${System.currentTimeMillis()}"
-
-        // Navigate to Collections tab
-        navigateToCollectionsTab()
-
-        // Tap FAB to create
-        createCollection(collName, description = "Test description")
-
-        // Verify collection appears in the list
-        rule.assertTextVisible(collName)
-
-        // Clean up
-        openCollection(collName)
-        deleteCurrentCollection()
-    }
-
     // ── Test: Add Game to Collection ──
 
     @Test
@@ -378,26 +358,6 @@ class CollectionsTest : BaseE2ETest() {
         rule.waitForTextNotVisible("Castlevania", timeout = 5_000)
 
         // Clean up — delete the collection
-        deleteCurrentCollection()
-    }
-
-    // ── Test: Public toggle shows badge ──
-
-    @Test
-    fun publicTogglePersists() {
-        val collName = "E2E Public ${System.currentTimeMillis()}"
-
-        // Create a public collection
-        navigateToCollectionsTab()
-        createCollection(collName, description = "A public collection", isPublic = true)
-
-        // Open the collection detail
-        openCollection(collName)
-
-        // Verify "Public" badge is visible
-        rule.waitForText("Public", timeout = 5_000)
-
-        // Clean up
         deleteCurrentCollection()
     }
 

--- a/player/android/src/androidTest/java/com/spela/player/android/EmulationTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/EmulationTest.kt
@@ -82,31 +82,6 @@ class EmulationTest : BaseE2ETest() {
     }
 
     @Test
-    fun exitReturnsToGameDetail() {
-        setupGame()
-        rule.openOverlayAndExit()
-
-        // After exit we land on the game-detail screen for whichever
-        // NES game navigateToGameAndPlay happened to pick (Balloon
-        // Fight by default). The action-button area is what proves
-        // "we're on game detail"; accept any of Play/Resume/Download.
-        rule.pollUntil(timeoutMillis = 8_000) {
-            try {
-                rule.onAllNodesWithText("Play", substring = true)
-                    .fetchSemanticsNodes().isNotEmpty() ||
-                    rule.onAllNodesWithText("Resume", substring = true)
-                        .fetchSemanticsNodes().isNotEmpty() ||
-                    rule.onAllNodesWithText("Download", substring = true)
-                        .fetchSemanticsNodes().isNotEmpty()
-            } catch (_: IllegalStateException) { false }
-        }
-
-        // We're not on Home and the in-game overlay is gone.
-        rule.assertTextNotVisible("Exit Game")
-        rule.assertTextNotVisible("Continue")
-    }
-
-    @Test
     fun exitAndResume() {
         setupGame()
         rule.openOverlayAndExit()
@@ -196,29 +171,6 @@ class EmulationTest : BaseE2ETest() {
         rule.waitForVisible("Fast", timeout = 3_000)
 
         rule.exitGame()
-    }
-
-    @Test
-    fun nesStability() {
-        setupGame()
-        rule.openOverlay()
-
-        rule.assertTextVisible("Continue")
-        rule.assertVisible("Save")
-
-        rule.exitGame()
-        // After exit, the action button is "Play" on a fresh game or
-        // "Resume" once auto-save has captured a save. With backend
-        // reset to defaults, autoSaveEnabled=true, so we may see
-        // either depending on timing. Accept both.
-        rule.pollUntil(timeoutMillis = 8_000) {
-            try {
-                rule.onAllNodesWithText("Play", substring = true)
-                    .fetchSemanticsNodes().isNotEmpty() ||
-                    rule.onAllNodesWithText("Resume", substring = true)
-                        .fetchSemanticsNodes().isNotEmpty()
-            } catch (_: IllegalStateException) { false }
-        }
     }
 
     @Test

--- a/player/android/src/androidTest/java/com/spela/player/android/HwRenderTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/HwRenderTest.kt
@@ -9,13 +9,14 @@ import org.junit.Test
 import org.junit.runners.MethodSorters
 
 /**
- * E2E tests for N64 cores on Android.
+ * E2E tests for HW-rendered N64 cores on Android. The libretro-NES path is
+ * exercised by `EmulationTest` which uses the same nestopia core via the
+ * shared software render pipeline, so we no longer mirror those assertions
+ * here.
  *
- * These tests use Nintendo 64 (Banjo-Kazooie) via the mupen64plus_next core.
- * They verify:
- * 1. N64 games launch and run correctly
- * 2. Emulation lifecycle (overlay, exit, resume, save/load) works for N64 cores
- * 3. NES games (software render path) still work after HW render changes
+ * Uses Nintendo 64 (Banjo-Kazooie) via the mupen64plus_next core. Verifies
+ * that N64 games launch, run, and exercise the emulation lifecycle (overlay,
+ * save/load, exit) on a real GLideN64 GLES context.
  *
  * IMPORTANT: N64 tests are combined into fewer methods to minimize core
  * load/unload cycles. The mupen64plus_next Angrylion renderer leaks native
@@ -136,57 +137,4 @@ class HwRenderTest : BaseE2ETest() {
         }
     }
 
-    // ── NES backward-compatibility tests (software render path) ──
-
-    private fun setupNesGame() {
-        rule.navigateToGameAndPlayFresh()
-    }
-
-    @Test
-    fun nesStillWorksAfterHwRenderChanges() {
-        setupNesGame()
-        rule.openOverlay()
-
-        rule.assertTextVisible("Continue")
-        rule.assertVisible("Save")
-        rule.assertVisible("Load")
-        rule.assertTextVisible("Exit Game")
-        rule.assertVisible("Castlevania")
-
-        rule.exitGame()
-    }
-
-    @Test
-    fun nesExitAndResumeStillWorks() {
-        setupNesGame()
-        rule.openOverlayAndExit()
-
-        // Game already downloaded — wait for the GameDetail title rather than
-        // a Download button (which only appears pre-download).
-        rule.waitForVisible("Castlevania", timeout = 8_000)
-
-        // After exit with auto-save, the primary button label flips from
-        // "Play" → "Resume". Wait for whichever is showing now.
-        rule.pollUntil(timeoutMillis = 8_000) {
-            try {
-                rule.onAllNodesWithText("Resume", substring = false)
-                    .fetchSemanticsNodes().isNotEmpty() ||
-                rule.onAllNodesWithText("Play", substring = false)
-                    .fetchSemanticsNodes().isNotEmpty()
-            } catch (_: IllegalStateException) { false }
-        }
-        val hasResume = rule.onAllNodesWithText("Resume", substring = false)
-            .fetchSemanticsNodes().isNotEmpty()
-        if (hasResume) {
-            rule.onNodeWithText("Resume").performClick()
-        } else {
-            rule.onNodeWithText("Play").performClick()
-        }
-        rule.waitForVisible("Game running", timeout = 15_000)
-
-        rule.openOverlay()
-        rule.assertTextVisible("Continue")
-
-        rule.exitGame()
-    }
 }

--- a/player/android/src/androidTest/java/com/spela/player/android/PlayLaterTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/PlayLaterTest.kt
@@ -70,14 +70,6 @@ class PlayLaterTest : BaseE2ETest() {
     }
 
     @Test
-    fun removeFromPlayLaterFromGameDetail() {
-        rule.navigateToCastlevania()
-        setPlayLater(desiredInQueue = true)
-        setPlayLater(desiredInQueue = false)
-        check(!queryPlayLaterState()) { "Expected game NOT in Play Later after toggling off" }
-    }
-
-    @Test
     fun playLaterSectionOnHomeScreen() {
         // Add a game to Play Later first.
         rule.navigateToCastlevania()

--- a/player/android/src/androidTest/java/com/spela/player/android/SessionTest.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/SessionTest.kt
@@ -77,33 +77,6 @@ class SessionTest : BaseE2ETest() {
     }
 
     @Test
-    fun serverPersistsAcrossRestart() {
-
-        // Navigate to Settings → About → Sign Out
-        rule.navigateToSettingsCategory("About")
-        rule.scrollToAndTapText("Sign Out")
-        confirmSignOutDialog()
-
-        // Verify server is visible
-        rule.assertTextVisible("Local")
-
-        // Restart app
-        rule.restartApp()
-
-        // After restart, server should persist (may show Login or server list)
-        rule.pollUntil(timeoutMillis = 15_000) {
-            try {
-                rule.onAllNodesWithText("Local", substring = true)
-                    .fetchSemanticsNodes().isNotEmpty() ||
-                    rule.onAllNodesWithText("Welcome", substring = true)
-                        .fetchSemanticsNodes().isNotEmpty()
-            } catch (_: IllegalStateException) {
-                false
-            }
-        }
-    }
-
-    @Test
     fun landscapeLoginFlow() {
 
         // Sign out to get to a clean state


### PR DESCRIPTION
## Summary

First pass of the Android E2E suite audit: delete 13 tests that the audit classified DELETE (or escalated MOVE → DELETE because they made the priority-removal list).

These are not the kind of tests Android E2E is supposed to carry per `CLAUDE.md`'s "Player App Testing Strategy" (small, focused integration smoke tests against the real backend). They're redundant UI assertions that:

- duplicate an existing test in the same class verbatim, or
- assert nothing the KEEP variant doesn't already assert, or
- are the pure-UI inverse of an API contract already covered.

All three of today's suite-mode flakes (`ChallengeBrowsingTest.multipleChallengesVisibleInList`, `ChallengeCreationTest.createChallengeWithCustomTypeAndDifficulty`, and the situations exposed by — though not deleting — `ChallengeLeaderboardTest.leaderboardShowsEntryAfterCompletion`) land in this delete because the failure surface was rendering races and screen-state assumptions that aren't testing real-system contracts.

## Removed

| Class | Test |
|---|---|
| ChallengeAttemptTest | `challengeTimerVisibleDuringPlay` |
| ChallengeBrowsingTest | `viewChallengesNavigatesToList` |
| ChallengeBrowsingTest | `multipleChallengesVisibleInList` |
| ChallengeCreationTest | `createChallengeWithCustomTypeAndDifficulty` |
| ChallengeIntegrationTest | `gameDetailLayoutIntactWithChallengesSection` |
| CollectionsTest | `createCollectionFromCollectionsScreen` |
| CollectionsTest | `publicTogglePersists` |
| EmulationTest | `exitReturnsToGameDetail` |
| EmulationTest | `nesStability` |
| HwRenderTest | `nesStillWorksAfterHwRenderChanges` |
| HwRenderTest | `nesExitAndResumeStillWorks` |
| PlayLaterTest | `removeFromPlayLaterFromGameDetail` |
| SessionTest | `serverPersistsAcrossRestart` |

Suite goes from ~76 active tests to ~63 (~17% reduction, roughly equivalent runtime saving on the AYN Thor).

## What this PR does NOT do

- No production code changes.
- No desktop test backfill — none of these tests exercise behaviour that isn't already covered by another Android keeper or by an existing desktop fake-driven test.
- No THIN/MOVE work. That's pass 2 (separate PR).

## Test plan

- [x] `./gradlew :android:compileDebugAndroidTestKotlinAndroid` builds clean (no orphan helper references).
- [ ] Optional: `./player/run-e2e.sh com.spela.player.android.{Class}` for any one of the affected classes — should pass with the remaining tests.

Audit reference: see today's strategic audit dispatched against the suite — full per-test classification (KEEP/THIN/MOVE/DELETE) is preserved out-of-band.
