### PR TITLE
fix(player): refresh Home and GameDetail data after returning from in-game overlay

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ScreenRouter.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/ScreenRouter.kt
@@ -195,6 +195,7 @@ fun ScreenRouter(
                                     },
                                     hasActiveDownloads = downloadsState.activeDownloads.isNotEmpty(),
                                     activeNetplaySessions = activeNetplaySessions,
+                                    overlayClosedTick = navState.overlayClosedTick,
                                 )
                             }
 
@@ -715,6 +716,7 @@ fun ScreenRouter(
                                             NavigationIntent.NavigateTo(SpScreen.GameAchievements(gameId))
                                         )
                                     },
+                                    overlayClosedTick = navState.overlayClosedTick,
                                 )
                             }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/GameDetailScreen.kt
@@ -77,13 +77,21 @@ fun GameDetailScreen(
     onPlaySession: ((gameId: String, sessionId: String) -> Unit)? = null,
     onPlaySessionFromTitleScreen: ((gameId: String, sessionId: String) -> Unit)? = null,
     onNavigateToSession: ((sessionId: String) -> Unit)? = null,
+    /** Bumps every time the in-game overlay hides — see
+     *  NavigationState.overlayClosedTick. Re-keys the data load below
+     *  so play history, sessions, save state info, and the cached/Resume
+     *  CTA refresh after the user finishes a play session and returns
+     *  to this screen. Prior to this, "Continue Playing" / Resume
+     *  / Last Played fields stayed frozen at the values fetched on
+     *  initial screen entry. */
+    overlayClosedTick: Int = 0,
 ) {
     PlatformBackHandler { onBack() }
 
     val state by viewModel.state.collectAsState()
     val keyMappingState = keyMappingViewModel?.state?.collectAsState()
 
-    LaunchedEffect(gameId) {
+    LaunchedEffect(gameId, overlayClosedTick) {
         viewModel.onIntent(GameDetailIntent.LoadGame(gameId))
     }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/HomeScreen.kt
@@ -116,6 +116,13 @@ fun HomeScreen(
     onSearchSelected: () -> Unit = {},
     hasActiveDownloads: Boolean = false,
     activeNetplaySessions: List<NetplaySession> = emptyList(),
+    /** Bumps every time the in-game overlay hides — see
+     *  NavigationState.overlayClosedTick. Re-keys the dashboard load
+     *  below so "Continue Playing", recent games, activity feed, and
+     *  the play-later section refresh after the user finishes a play
+     *  session — Home stays composed under the overlay so a plain
+     *  LaunchedEffect(Unit) wouldn't refire on its own. */
+    overlayClosedTick: Int = 0,
 ) {
     val state by viewModel.state.collectAsState()
     val socialState by socialViewModel.state.collectAsState()
@@ -127,8 +134,8 @@ fun HomeScreen(
     if (state.isLoading) sawLoading = true
     if (sawLoading && !state.isLoading) hasInitiallyLoaded = true
 
-    LaunchedEffect(Unit) {
-        println("[HomeScreen] LaunchedEffect(Unit) fired — loading dashboard")
+    LaunchedEffect(overlayClosedTick) {
+        println("[HomeScreen] LaunchedEffect fired — loading dashboard (overlayClosedTick=$overlayClosedTick)")
         viewModel.onIntent(GameListIntent.LoadDashboard)
         socialViewModel.onIntent(SocialIntent.RefreshAll)
         settingsViewModel?.onIntent(SettingsIntent.LoadSettings)


### PR DESCRIPTION
## Summary

Follow-up to #729 — same product bug pattern, but applied to two more screens that hit the same issue:

- **HomeScreen** — `LaunchedEffect(Unit)` loads the dashboard once. Real users finishing a play session and returning to Home would see stale "Continue Playing", recent games, activity feed, and play-later sections.
- **GameDetailScreen** — `LaunchedEffect(gameId)` loads game detail once. Real users exiting a game would see stale Resume-vs-Play CTA, sessions list, save state info, and play history until they navigated away and back.

Both screens now key on `(..., overlayClosedTick)` — the monotonic counter introduced in #729 — so closing the in-game overlay triggers a fresh fetch.

## Notes

- Default `overlayClosedTick = 0` keeps existing callers backwards-compatible.
- `ScreenRouter` passes `navState.overlayClosedTick` through to both screens.
- Confirmed evidence the bug bit users: `PlayLaterTest` has a literal `// Bounce tabs to force a dashboard refresh` workaround. That workaround stays in place for now — it covers a different bug (back-navigation refresh, no overlay involved), which is a separate problem.

## Test plan

- [x] `:shared:compileDebugKotlinAndroid` builds clean.
- [x] No desktop tests reference these screens directly (only `ScreenRouter` does, which isn't unit-tested).
- [ ] CI: desktop + player unit + Go all expected to pass — the change is parameter-only with default value 0.
