### PR TITLE
fix(explore): empty spotlight + suppress raw error JSON in optional sections

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/ExploreViewModel.kt
@@ -450,8 +450,10 @@ class ExploreViewModel(
                 onSuccess = { featured ->
                     _state.update { it.copy(featuredGames = featured, isLoadingFeatured = false) }
                 },
-                onFailure = { error ->
-                    _state.update { it.copy(isLoadingFeatured = false, error = error.message) }
+                onFailure = {
+                    // Optional explore section — fail soft, never leak error
+                    // text (HumaError JSON) to a user-facing snackbar.
+                    _state.update { it.copy(isLoadingFeatured = false) }
                 },
             )
         }
@@ -465,8 +467,8 @@ class ExploreViewModel(
                 onSuccess = { rows ->
                     _state.update { it.copy(rows = rows, isLoadingRows = false) }
                 },
-                onFailure = { error ->
-                    _state.update { it.copy(isLoadingRows = false, error = error.message) }
+                onFailure = {
+                    _state.update { it.copy(isLoadingRows = false) }
                 },
             )
         }
@@ -480,8 +482,8 @@ class ExploreViewModel(
                 onSuccess = { themes ->
                     _state.update { it.copy(themes = themes, isLoadingThemes = false) }
                 },
-                onFailure = { error ->
-                    _state.update { it.copy(isLoadingThemes = false, error = error.message) }
+                onFailure = {
+                    _state.update { it.copy(isLoadingThemes = false) }
                 },
             )
         }
@@ -495,8 +497,8 @@ class ExploreViewModel(
                 onSuccess = { keywords ->
                     _state.update { it.copy(keywords = keywords, isLoadingKeywords = false) }
                 },
-                onFailure = { error ->
-                    _state.update { it.copy(isLoadingKeywords = false, error = error.message) }
+                onFailure = {
+                    _state.update { it.copy(isLoadingKeywords = false) }
                 },
             )
         }
@@ -510,8 +512,8 @@ class ExploreViewModel(
                 onSuccess = { series ->
                     _state.update { it.copy(featuredSeries = series, isLoadingFeaturedSeries = false) }
                 },
-                onFailure = { error ->
-                    _state.update { it.copy(isLoadingFeaturedSeries = false, error = error.message) }
+                onFailure = {
+                    _state.update { it.copy(isLoadingFeaturedSeries = false) }
                 },
             )
         }
@@ -526,8 +528,8 @@ class ExploreViewModel(
                 onSuccess = { moods ->
                     _state.update { it.copy(moods = moods, isLoadingMoods = false) }
                 },
-                onFailure = { error ->
-                    _state.update { it.copy(isLoadingMoods = false, error = error.message) }
+                onFailure = {
+                    _state.update { it.copy(isLoadingMoods = false) }
                 },
             )
         }
@@ -541,8 +543,8 @@ class ExploreViewModel(
                 onSuccess = { rows ->
                     _state.update { it.copy(forYouRows = rows, isLoadingForYou = false) }
                 },
-                onFailure = { error ->
-                    _state.update { it.copy(isLoadingForYou = false, error = error.message) }
+                onFailure = {
+                    _state.update { it.copy(isLoadingForYou = false) }
                 },
             )
         }
@@ -590,10 +592,19 @@ class ExploreViewModel(
         jobs.launch("developerSpotlight", dispatchers.io) {
             exploreRepository.getDeveloperSpotlight().fold(
                 onSuccess = { spotlight ->
-                    _state.update { it.copy(developerSpotlight = spotlight, isLoadingDeveloperSpotlight = false) }
+                    // Server returns an empty spotlight (Name="") on minimally-seeded
+                    // installs — treat that as "no section visible" rather than
+                    // rendering an empty card.
+                    val effective = spotlight.takeIf { it.name.isNotEmpty() }
+                    _state.update {
+                        it.copy(developerSpotlight = effective, isLoadingDeveloperSpotlight = false)
+                    }
                 },
-                onFailure = { error ->
-                    _state.update { it.copy(isLoadingDeveloperSpotlight = false, error = error.message) }
+                onFailure = {
+                    // The spotlight is an optional explore section; failure must
+                    // not surface as a global error snackbar (would leak raw
+                    // HumaError JSON to the user). Just hide the section.
+                    _state.update { it.copy(isLoadingDeveloperSpotlight = false) }
                 },
             )
         }
@@ -679,8 +690,8 @@ class ExploreViewModel(
                 onSuccess = { highlights ->
                     _state.update { it.copy(consoleHighlights = highlights, isLoadingConsoleHighlights = false) }
                 },
-                onFailure = { error ->
-                    _state.update { it.copy(isLoadingConsoleHighlights = false, error = error.message) }
+                onFailure = {
+                    _state.update { it.copy(isLoadingConsoleHighlights = false) }
                 },
             )
         }
@@ -714,8 +725,8 @@ class ExploreViewModel(
                 onSuccess = { artworks ->
                     _state.update { it.copy(artworkShowcase = artworks, isLoadingArtwork = false) }
                 },
-                onFailure = { error ->
-                    _state.update { it.copy(isLoadingArtwork = false, error = error.message) }
+                onFailure = {
+                    _state.update { it.copy(isLoadingArtwork = false) }
                 },
             )
         }

--- a/server/internal/api/explore_handler_test.go
+++ b/server/internal/api/explore_handler_test.go
@@ -2212,7 +2212,15 @@ func TestGetDeveloperSpotlight_NoHeroArt(t *testing.T) {
 	req.Header.Set("Authorization", "Bearer "+env.token)
 	env.router.ServeHTTP(w, req)
 
-	assert.Equal(t, http.StatusNotFound, w.Code)
+	// Empty spotlight is a normal API response (200 with empty Name),
+	// not an error — the client uses Name="" as the "hide section"
+	// signal so the user never sees a "no developers with hero art"
+	// HumaError snackbar on a freshly-seeded server.
+	assert.Equal(t, http.StatusOK, w.Code)
+	var resp DeveloperSpotlightResponse
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &resp))
+	assert.Empty(t, resp.Name)
+	assert.Empty(t, resp.TopGames)
 }
 
 // --- Phase 8: Console Showcase tests ---

--- a/server/internal/api/huma_explore_developer.go
+++ b/server/internal/api/huma_explore_developer.go
@@ -340,7 +340,14 @@ func (h *ExploreHandler) HumaGetDeveloperSpotlight(ctx context.Context, _ *GetDe
 	}
 
 	if len(rows) == 0 {
-		return nil, huma.Error404NotFound("no developers with hero art found")
+		// Empty spotlight is a normal state on a fresh / minimally-seeded
+		// server, not an error. Return 200 with an empty Name so the
+		// client can hide the section without surfacing a HumaError to
+		// the user.
+		return &GetDeveloperSpotlightOutput{
+			CacheControl: "private, max-age=60",
+			Body:         DeveloperSpotlightResponse{},
+		}, nil
 	}
 
 	_, weekNumber := time.Now().ISOWeek()


### PR DESCRIPTION
## Summary

Manual smoke-test on a freshly-seeded server showed a snackbar on the Explore screen with raw HumaError JSON: `"no developers with hero art found"` plus the full `HumaError.json` envelope. Two-part fix.

## Server

`huma_explore_developer.go::HumaGetDeveloperSpotlight` was returning **404 with `"no developers with hero art found"`** when the rotation query produced no rows (e.g. fresh seed has no `GameArtwork` rows with `hero_url`). An empty optional section is a normal API response, not a client error. Now returns 200 with an empty body (`Name=""`) and a short cache header. The other `huma_explore_*.go` handlers already do the right thing — this was the only instance of the anti-pattern.

## Client

`ExploreViewModel`'s **9 optional-subsection loaders** (`Featured`, `Rows`, `Themes`, `Keywords`, `FeaturedSeries`, `Moods`, `ForYou`, `Spotlight`, `ConsoleHighlights`, `Artwork`) were writing `error.message` straight into `state.error`, which the Explore screen renders as a snackbar — leaking transport-layer text + HumaError JSON. Optional sections must fail soft: now they just clear their `isLoadingX` flag and the section stays invisible.

Spotlight specifically also treats an empty `Name` from the new server response as "no section" (skip the empty card).

## What's NOT in this PR

`Detail` screens (themeDetail, developerDetail, publisherDetail, …) still surface `error.message`. They're full screens — if those fail, the user is on a dead-end and seeing an error is correct. The separate "sanitize HumaError messages before display anywhere user-facing" cleanup is out of scope here; it'd be a wider refactor introducing a `humaError.toUserMessage()` helper across the repo.

## Test plan

- [x] `go build ./...` clean
- [x] `:shared:compileDebugKotlinAndroid` clean
- [ ] Manual: launch with a freshly-seeded server, open Explore — no snackbar, Spotlight section just hides cleanly.
