### PR TITLE
fix(emulation): poll first-frame-run instead of fixed 3s delay (#737) + add dev-login script

### DIFF
--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -1123,6 +1123,16 @@ JNI_FUNC(jlong, nativeSerializeSize)(JNIEnv *env, jobject thiz) {
     return (jlong)g_core.retro_serialize_size();
 }
 
+/* True once retro_run() has returned at least once for the currently
+ * loaded core. EmulationViewModel polls this after start() to gate
+ * post-launch operations (save-state probe, deferred auto-load) that
+ * are unsafe before the core has ticked one frame — replaces the
+ * conservative fixed delay that was tuned for Dolphin's worst case.
+ * See #737. */
+JNI_FUNC(jboolean, nativeFirstFrameRun)(JNIEnv *env, jobject thiz) {
+    return g_first_frame_run ? JNI_TRUE : JNI_FALSE;
+}
+
 JNI_FUNC(jbyteArray, nativeSerialize)(JNIEnv *env, jobject thiz) {
     if (!g_core.game_loaded) return NULL;
 
@@ -1653,6 +1663,12 @@ JNI_FUNC(jboolean, nativeGpuIsActive)(JNIEnv *env, jobject thiz) {
 
 JNI_FUNC(jboolean, nativeIsHwRenderEnabled)(JNIEnv *env, jobject thiz) {
     return g_core.hw_render_enabled ? JNI_TRUE : JNI_FALSE;
+}
+
+JNI_FUNC(jboolean, nativeIsVulkanHwRender)(JNIEnv *env, jobject thiz) {
+    return (g_core.hw_render_enabled &&
+            g_core.hw_render_callback.context_type == RETRO_HW_CONTEXT_VULKAN)
+        ? JNI_TRUE : JNI_FALSE;
 }
 
 JNI_FUNC(void, nativeGpuSetSourceRect)(JNIEnv *env, jobject thiz,

--- a/player/scripts/dev-login.sh
+++ b/player/scripts/dev-login.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+#
+# Drive the Spela Android player from any starting state (cold install,
+# logged-out, or already at Login) through to a logged-in Home screen.
+#
+# Useful for manual smoke testing on the AYN Thor when you don't want
+# to run the full ./run-e2e.sh suite. Reads the same .env file —
+# ADB_SERIAL is required; SPELA_USERNAME, SPELA_PASSWORD, SERVER_NAME,
+# SERVER_URL are optional (default: player / player123 / Local /
+# http://127.0.0.1:8080).
+#
+# Workarounds for the AYN Thor:
+# - Launches the activity on display 0 (Thor's secondary "Screen-2"
+#   presentation display otherwise eats it).
+# - Sets up `adb reverse tcp:8080 tcp:8080` so the app can reach a
+#   docker-compose backend on the host.
+# - Dismisses the soft keyboard between every text input. Gboard's
+#   landscape extract-editor mode otherwise stacks every typed char
+#   into whichever field was first tapped, ignoring subsequent taps.
+# - Clears each text field with KEYCODE_MOVE_END + repeated KEYCODE_DEL
+#   before typing, so re-running the script over a partially-filled
+#   form doesn't pile garbage onto existing content.
+#
+# Usage:
+#   ./player/scripts/dev-login.sh           # uses .env
+#   ./player/scripts/dev-login.sh <serial>  # override ADB_SERIAL
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PLAYER_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$PLAYER_DIR/.env"
+
+if [ -f "$ENV_FILE" ]; then
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+fi
+
+ADB_SERIAL="${1:-${ADB_SERIAL:-}}"
+SERVER_NAME="${SERVER_NAME:-Local}"
+SERVER_URL="${SERVER_URL:-http://127.0.0.1:8080}"
+SPELA_USERNAME="${SPELA_USERNAME:-player}"
+SPELA_PASSWORD="${SPELA_PASSWORD:-player123}"
+
+if [ -z "$ADB_SERIAL" ]; then
+  ADB_SERIAL="$(adb devices | awk 'NR>1 && $2=="device"{print $1; exit}')"
+fi
+if [ -z "$ADB_SERIAL" ]; then
+  echo "No device. Pass serial as arg or set ADB_SERIAL in $ENV_FILE." >&2
+  exit 1
+fi
+
+ADB="adb -s $ADB_SERIAL"
+DUMP=/sdcard/dev-login.dump.xml
+
+echo "── Device $ADB_SERIAL ──"
+$ADB shell input keyevent KEYCODE_WAKEUP >/dev/null
+sleep 0.3
+$ADB reverse tcp:8080 tcp:8080 >/dev/null
+
+# Force-launch on display 0. Thor caches the launch display per task,
+# so once the app has been launched on display 0, ActivityScenario
+# inherits it. Cheap to repeat each run.
+$ADB shell am force-stop com.spela.player >/dev/null 2>&1 || true
+sleep 0.4
+$ADB shell am start --display 0 -n com.spela.player/.android.MainActivity >/dev/null
+sleep 3
+
+# ── UI helpers ──
+
+LOCAL_DUMP="/tmp/dev-login.ui.xml"
+
+dump_ui() {
+  $ADB shell uiautomator dump "$DUMP" >/dev/null 2>&1 || true
+  $ADB shell cat "$DUMP" >"$LOCAL_DUMP" 2>/dev/null || true
+}
+
+# Returns center (x y) of the first node whose text or content-desc
+# CONTAINS the needle. Empty output if not found.
+#
+# Implementation note: previously used `cat | python3 - <<HEREDOC` —
+# but the heredoc and the pipe both redirect stdin and bash gives the
+# heredoc precedence, so python's sys.stdin returned the script body
+# rather than the XML. Now we dump to a host-side file and pass the
+# path as argv[1]; needle is argv[2].
+ui_center() {
+  dump_ui
+  python3 -c '
+import re, sys
+with open(sys.argv[1]) as f: data = f.read()
+needle = sys.argv[2]
+pattern = (
+    r"<node[^>]*?(?:text|content-desc)=\"([^\"]*" + re.escape(needle) +
+    r"[^\"]*)\"[^>]*?bounds=\"\[(\d+),(\d+)\]\[(\d+),(\d+)\]\""
+)
+m = re.search(pattern, data)
+if not m: sys.exit(0)
+x = (int(m.group(2)) + int(m.group(4))) // 2
+y = (int(m.group(3)) + int(m.group(5))) // 2
+print(f"{x} {y}")
+' "$LOCAL_DUMP" "$1"
+}
+
+ui_has() {
+  dump_ui
+  grep -q "$1" "$LOCAL_DUMP" 2>/dev/null
+}
+
+# Returns "x y" for the Nth (0-indexed) android.widget.EditText.
+edittext_center() {
+  local n=$1
+  dump_ui
+  python3 -c '
+import re, sys
+with open(sys.argv[1]) as f: data = f.read()
+n = int(sys.argv[2])
+matches = re.findall(
+    r"<node[^>]*?class=\"android\.widget\.EditText\"[^>]*?bounds=\"\[(\d+),(\d+)\]\[(\d+),(\d+)\]\"",
+    data,
+)
+if n >= len(matches): sys.exit(0)
+x1, y1, x2, y2 = map(int, matches[n])
+print(f"{(x1+x2)//2} {(y1+y2)//2}")
+' "$LOCAL_DUMP" "$n"
+}
+
+# Tap field at (x,y), clear, type, dismiss keyboard. Single-arg
+# coords to avoid quoting hell.
+tap_clear_type() {
+  local coords=$1 text=$2
+  read -r x y <<<"$coords"
+  $ADB shell input tap "$x" "$y"
+  sleep 0.7
+  $ADB shell input keyevent KEYCODE_MOVE_END >/dev/null
+  for _ in $(seq 1 50); do
+    $ADB shell input keyevent KEYCODE_DEL >/dev/null
+  done
+  sleep 0.2
+  $ADB shell input text "$(printf %s "$text" | sed 's/ /%s/g')"
+  sleep 0.4
+  # Dismiss the soft keyboard. KEYCODE_BACK while IME is up closes
+  # only the IME on Android, not the activity.
+  $ADB shell input keyevent KEYCODE_BACK >/dev/null
+  sleep 0.8
+}
+
+tap_node() {
+  local coords=$1
+  read -r x y <<<"$coords"
+  $ADB shell input tap "$x" "$y"
+}
+
+# ── Drive screens ──
+
+for attempt in $(seq 1 10); do
+  # Already on Home? Look for distinctive Home-screen markers.
+  if ui_has "Recently Added" || ui_has "Continue Playing" \
+      || ui_has "screen_home" || ui_has "Top Rated"; then
+    echo "✓ On Home — logged in"
+    exit 0
+  fi
+
+  # Add Server screen (cold install, no servers yet).
+  if ui_has "Server URL" && ui_has "Connect"; then
+    echo "── Add Server: $SERVER_NAME → $SERVER_URL ──"
+    name_field=$(edittext_center 0)
+    url_field=$(edittext_center 1)
+    [ -z "$name_field" ] || [ -z "$url_field" ] && {
+      echo "Couldn't locate server form fields"; exit 1; }
+    tap_clear_type "$name_field" "$SERVER_NAME"
+    tap_clear_type "$url_field" "$SERVER_URL"
+    connect=$(ui_center "Connect")
+    [ -z "$connect" ] && { echo "Connect button not found"; exit 1; }
+    tap_node "$connect"
+    sleep 3
+    continue
+  fi
+
+  # Server list (one or more saved servers, no active session).
+  # Distinguish from Add Server by presence of a server card (URL text)
+  # plus the persistent "Add Server" button below.
+  if ui_has "Add Server" && ui_has "$SERVER_URL"; then
+    echo "── Server list: tapping $SERVER_NAME ──"
+    card=$(ui_center "$SERVER_NAME")
+    [ -z "$card" ] && { echo "Server card not found"; exit 1; }
+    tap_node "$card"
+    sleep 3
+    continue
+  fi
+
+  # Login screen.
+  if ui_has "Username" && ui_has "Sign In"; then
+    echo "── Login: signing in as $SPELA_USERNAME ──"
+    user_field=$(edittext_center 0)
+    pass_field=$(edittext_center 1)
+    [ -z "$user_field" ] || [ -z "$pass_field" ] && {
+      echo "Couldn't locate login form fields"; exit 1; }
+    tap_clear_type "$user_field" "$SPELA_USERNAME"
+    tap_clear_type "$pass_field" "$SPELA_PASSWORD"
+    signin=$(ui_center "Sign In")
+    [ -z "$signin" ] && { echo "Sign In button not found"; exit 1; }
+    tap_node "$signin"
+    sleep 4
+    continue
+  fi
+
+  echo "Unknown screen state (attempt $attempt) — waiting…"
+  sleep 2
+done
+
+echo "Failed to reach Home after 10 attempts." >&2
+exit 1

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
@@ -238,6 +238,8 @@ class AndroidLibretroController(
     override fun supportsSaveStates(): Boolean =
         runOnEmulationThread { jni.nativeSerializeSize() > 0 } ?: true
 
+    override fun firstFrameRun(): Boolean = jni.nativeFirstFrameRun()
+
     override fun serialize(): ByteArray? =
         runOnEmulationThread { jni.nativeSerialize() }
 
@@ -314,6 +316,8 @@ class AndroidLibretroController(
     fun gpuIsActive(): Boolean = jni.nativeGpuIsActive()
     fun gpuSetSourceRect(x: Int, y: Int, w: Int, h: Int) = jni.nativeGpuSetSourceRect(x, y, w, h)
     override fun isHwRenderEnabled(): Boolean = jni.nativeIsHwRenderEnabled()
+
+    override fun isVulkanHwRender(): Boolean = jni.nativeIsVulkanHwRender()
 
     /**
      * Notify that physical controller input was received.

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
@@ -20,6 +20,10 @@ class LibretroJni {
     external fun nativeReset()
     external fun nativeUnloadGame()
     external fun nativeDeinit()
+    /** True once retro_run() has returned at least once for the
+     *  currently-loaded game. Used to gate post-launch operations
+     *  (save-state probe, deferred auto-load) — see #737. */
+    external fun nativeFirstFrameRun(): Boolean
 
     /* Save state */
     external fun nativeSerializeSize(): Long
@@ -77,6 +81,7 @@ class LibretroJni {
     external fun nativeGpuIsActive(): Boolean
     external fun nativeGpuSetSourceRect(x: Int, y: Int, w: Int, h: Int)
     external fun nativeIsHwRenderEnabled(): Boolean
+    external fun nativeIsVulkanHwRender(): Boolean
 
     /* Cheats */
     external fun nativeCheatReset()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -1080,13 +1080,22 @@ class EmulationViewModel(
                         // Populate save slot thumbnails for the secondary screen
                         saveManager.refreshSaveSlots()
 
-                        // Re-check save state support after core has run a few frames.
-                        // Skip for GL HW render cores (e.g. PPSSPP) — calling
-                        // nativeSerializeSize triggers GL calls that crash on the
-                        // IO dispatcher thread. Default of true (set above) is fine.
-                        println("[Emulation] Starting 3-second delay for HW render init")
-                        kotlinx.coroutines.delay(3000)
-                        println("[Emulation] 3-second delay completed, checking save state support")
+                        // Wait for the core to be ready for post-launch operations
+                        // (save-state probe, deferred auto-load). Most cores set
+                        // g_first_frame_run within 1-2 retro_run() calls (~16-32ms);
+                        // Vulkan HW cores like Dolphin spin up an additional GPU /
+                        // shader-compile thread that's not gated by first-frame, so
+                        // they get an extra pad. Replaces a fixed 3000ms delay
+                        // tuned for Dolphin's worst case (#737).
+                        val readinessDeadline = System.currentTimeMillis() + 1500L
+                        while (!libretroController.firstFrameRun() && System.currentTimeMillis() < readinessDeadline) {
+                            kotlinx.coroutines.delay(50)
+                        }
+                        if (libretroController.isVulkanHwRender()) {
+                            println("[Emulation] Vulkan HW core — extra 2s pad for GPU thread spin-up")
+                            kotlinx.coroutines.delay(2000)
+                        }
+                        println("[Emulation] Core ready, checking save state support")
                         val saveStatesSupported = if (hwRender) true else libretroController.supportsSaveStates()
                         println("[Emulation] saveStatesSupported=$saveStatesSupported")
                         withContext(dispatchers.main) {
@@ -1733,6 +1742,12 @@ interface LibretroController {
     fun setFastForward(enabled: Boolean)
     fun performanceStats(): kotlinx.coroutines.flow.Flow<Pair<Float, Float>>
 
+    /** True once retro_run() has returned at least one frame for the
+     *  currently loaded game. Replaces a fixed Dolphin-tuned wait
+     *  with a per-core readiness check — see #737. Default returns
+     *  true so platforms / fakes that don't track this don't block. */
+    fun firstFrameRun(): Boolean = true
+
     /** Set pointer/touch state for the given port (used for DS touch screen). */
     fun setPointer(port: Int, x: Int, y: Int, pressed: Boolean) {}
 
@@ -1753,6 +1768,14 @@ interface LibretroController {
 
     /** Returns true if the loaded core uses HW rendering (OpenGL/Vulkan). */
     fun isHwRenderEnabled(): Boolean = false
+
+    /** Returns true if the loaded core's HW render context is Vulkan
+     *  specifically (Dolphin, Beetle PSX HW, paraLLEl-RDP). Used by
+     *  the post-launch readiness wait — Vulkan HW cores spin up a
+     *  separate GPU/shader-compile thread that takes longer to reach
+     *  a state where retro_unserialize is safe, beyond the first
+     *  retro_run frame. See #737. */
+    fun isVulkanHwRender(): Boolean = false
 
     /**
      * Enter netplay lockstep mode. The emulation loop will synchronize inputs


### PR DESCRIPTION
## Summary

Two changes from the late-night session:

### #737 — first-frame readiness poll

`EmulationViewModel.startGame()` was hardcoded to `delay(3000)` after `libretroController.start()` before:
- probing `supportsSaveStates()` (calls `retro_serialize_size`)
- running deferred auto-load for HW render cores (`retro_unserialize`)

The 3s was tuned for Dolphin's worst case — its Vulkan GPU thread spins up async after the first `retro_run`. Every other core was ready in 1-2 retro_run ticks (~16-32ms). User-visible impact: post-launch resume on N64 jumped to the saved state ~3 seconds late, looking like a lag.

Replaces with:
- Poll `g_first_frame_run` (exposed via new JNI `nativeFirstFrameRun`) on a 50ms interval, with a 1.5s deadline as belt-and-suspenders.
- Extra 2s pad iff the loaded core uses Vulkan HW render (`RETRO_HW_CONTEXT_VULKAN` on `hw_render_callback.context_type`), exposed via new JNI `nativeIsVulkanHwRender`. Catches Dolphin / Beetle PSX HW / paraLLEl-RDP.

**Effect:** NES / SNES / GBA / N64 (mupen64plus_next, GLES) post-launch goes from ~3000ms to ~50-100ms. Dolphin still gets ~2s safety pad on top of first-frame.

Verified manually on AYN Thor: Super Mario 64 Resume now jumps back to saved state instantly. Confirmed by user.

Default `LibretroController` impl returns `firstFrameRun=true` and `isVulkanHwRender=false` so existing fakes / desktop tests continue without behavior change.

### `dev-login.sh`

Adds `player/scripts/dev-login.sh` — drives the Spela Android player from any starting state (cold install / logged-out / Login screen) to a logged-in Home. Idempotent; reads `player/.env`.

Fixes a stdin-redirect bug we hit during manual testing tonight: the original `cat XML | python3 - <<'PY' code PY` pattern put the heredoc on python's stdin, replacing the piped XML. Now writes the dump to a host-side file and passes the path as argv.

Handles AYN Thor IME quirks (Gboard landscape extract editor stacks input into whichever field was tapped first; clears each field with `KEYCODE_MOVE_END` + repeated `KEYCODE_DEL`; dismisses keyboard between fields).

## Test plan

- [x] Android build clean
- [x] Desktop tests pass (`./gradlew :shared:desktopTest`)
- [x] Manual on AYN Thor: N64 Super Mario 64 → Exit → Resume → instant restore (was ~3s)
- [x] Manual: NES baseline still works
- [x] dev-login.sh: cold install → Home, end-to-end
