### PR TITLE
fix(#712): normalize iNES header on game download (in-memory)

### DIFF
--- a/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
+++ b/player/android/src/androidTest/java/com/spela/player/android/TestHelpers.kt
@@ -2159,12 +2159,9 @@ fun ComposeRule.exitGame(coreIdleTimeout: Long = 10_000) {
  *
  * When [preferredGameTitle] is given, picks the card whose contentDescription
  * starts with that title. That makes the test deterministic — otherwise
- * we tap the first card in the tree, which depends on seeded game ordering
- * and can land on a ROM nestopia rejects (Super Mario Bros.nes in the
- * test fixtures fails retro_load_game, while Balloon Fight loads cleanly).
- * Balloon Fight is the known-good default; it's the first NES game in
- * Browse Games (alphabetical) and has been verified to start emulation
- * end-to-end on the nestopia Android core.
+ * we tap the first card in the tree, which depends on seeded game ordering.
+ * Balloon Fight is the default because it's a small ROM that boots quickly
+ * and is verified to start emulation end-to-end on the nestopia Android core.
  */
 fun ComposeRule.navigateToGameAndPlay(preferredGameTitle: String? = "Balloon Fight") {
     val device = uiDevice()

--- a/server/internal/api/game_handler_test.go
+++ b/server/internal/api/game_handler_test.go
@@ -211,3 +211,56 @@ func TestUpdatePlayTime_CreatesPlayHistory(t *testing.T) {
 	assert.Equal(t, int64(60), ph.PlayTime)
 	assert.False(t, ph.LastPlayed.IsZero(), "LastPlayed should be set")
 }
+
+// TestDownloadGame_NormalizesINESHeader verifies that .nes ROMs with a
+// dirty iNES 1.0 header (e.g. tool-provenance markers like "NI2.1" in
+// reserved bytes) are streamed with bytes 8-15 zeroed, but the on-disk
+// file is left untouched. Strict cores like nestopia reject the dirty
+// header at retro_load_game; #712.
+func TestDownloadGame_NormalizesINESHeader(t *testing.T) {
+	database, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	// Build an iNES 1.0 ROM whose reserved bytes 11-15 carry the
+	// "NI2.1" ASCII marker. PRG/CHR sizes are nominal — the body
+	// content past the header doesn't matter for this assertion.
+	header := []byte{0x4e, 0x45, 0x53, 0x1a, 0x02, 0x01, 0x01, 0x00, 0, 0, 0, 'N', 'I', '2', '.', '1'}
+	rom := append(header, bytes.Repeat([]byte{0xaa}, 64)...)
+	romPath := filepath.Join(cfg.GameDirs[0], "smb.nes")
+	require.NoError(t, os.WriteFile(romPath, rom, 0644))
+
+	var console db.Console
+	database.First(&console)
+	game := db.Game{
+		ConsoleID: console.ID,
+		Title:     "iNES Header Test",
+		FileName:  "smb.nes",
+		FilePath:  "smb.nes",
+		FileSize:  int64(len(rom)),
+	}
+	require.NoError(t, database.Create(&game).Error)
+
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", fmt.Sprintf("/api/games/%d/download", game.ID), nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	got := w.Body.Bytes()
+	require.Equal(t, len(rom), len(got), "response length should match on-disk ROM length")
+	// Header bytes 0-7 unchanged.
+	assert.Equal(t, rom[:8], got[:8])
+	// Reserved bytes 8-15 should now be zero in the response.
+	for i := 8; i < 16; i++ {
+		assert.Equal(t, byte(0), got[i], "byte %d should be normalized to zero", i)
+	}
+	// Body past the header is untouched.
+	assert.Equal(t, rom[16:], got[16:])
+
+	// On-disk file must NOT have been modified.
+	onDisk, err := os.ReadFile(romPath)
+	require.NoError(t, err)
+	assert.Equal(t, rom, onDisk, "on-disk ROM must be untouched by the download path")
+}

--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -761,6 +761,12 @@ func (h *GameHandler) HumaDownloadGame(_ context.Context, in *GameDownloadInput)
 
 	// Fallback: inline single file. Match the gin "inline" Content-Disposition
 	// (the file may be a ROM that the client renders inline rather than saves).
+	//
+	// For .nes ROMs, the first 16 bytes are normalized in memory so iNES 1.0
+	// headers polluted with tool-provenance markers (e.g. "DiskDude!", "NI2.1"
+	// from old GoodNES dumps) don't trip strict cores like nestopia. The
+	// on-disk file is never modified — only the bytes streamed to the client.
+	normalizeINES := strings.HasSuffix(lower, ".nes")
 	return &huma.StreamResponse{
 		Body: func(hctx huma.Context) {
 			f, err := os.Open(absPath)
@@ -771,7 +777,25 @@ func (h *GameHandler) HumaDownloadGame(_ context.Context, in *GameDownloadInput)
 			defer f.Close()
 			hctx.SetHeader("Content-Type", "application/octet-stream")
 			hctx.SetHeader("Content-Disposition", fmt.Sprintf("inline; filename=%q", game.FileName))
-			_, _ = io.Copy(hctx.BodyWriter(), f)
+			w := hctx.BodyWriter()
+			if normalizeINES {
+				var head [16]byte
+				n, _ := io.ReadFull(f, head[:])
+				if n == len(head) {
+					if scanner.NormalizeINESHeaderBytes(head[:]) {
+						slog.Info("normalized iNES header for download",
+							"game", game.Title, "file", game.FileName)
+					}
+					if _, err := w.Write(head[:]); err != nil {
+						return
+					}
+				} else if n > 0 {
+					if _, err := w.Write(head[:n]); err != nil {
+						return
+					}
+				}
+			}
+			_, _ = io.Copy(w, f)
 		},
 	}, nil
 }

--- a/server/internal/scanner/ines_memory.go
+++ b/server/internal/scanner/ines_memory.go
@@ -1,0 +1,43 @@
+package scanner
+
+// NormalizeINESHeaderBytes inspects the first 16 bytes of an iNES ROM
+// buffer and zeroes the reserved bytes (8-15) when they're polluted by
+// tool-provenance markers (e.g. "DiskDude!", "NI2.1"). Returns true if
+// any byte was modified.
+//
+// The on-disk file is never touched; this operates purely on the buffer
+// the caller provides. Use this on the serve path so strict cores like
+// nestopia accept ROMs whose dumpers wrote ASCII trailers into the
+// iNES 1.0 reserved bytes — without rewriting the user's ROM library.
+//
+// No-op cases (returns false, leaves buffer untouched):
+//   - buffer shorter than 16 bytes
+//   - bytes 0-3 are not the iNES magic ("NES\x1a")
+//   - byte 7 bits 2-3 == 0b10 (NES 2.0 — bytes 8-15 are meaningful)
+//   - bytes 8-15 are already all zero
+func NormalizeINESHeaderBytes(header []byte) bool {
+	if len(header) < iNESHeaderSize {
+		return false
+	}
+	if header[0] != iNESMagic[0] || header[1] != iNESMagic[1] ||
+		header[2] != iNESMagic[2] || header[3] != iNESMagic[3] {
+		return false
+	}
+	if header[7]&0x0C == 0x08 {
+		return false
+	}
+	dirty := false
+	for i := 8; i < 16; i++ {
+		if header[i] != 0 {
+			dirty = true
+			break
+		}
+	}
+	if !dirty {
+		return false
+	}
+	for i := 8; i < 16; i++ {
+		header[i] = 0
+	}
+	return true
+}

--- a/server/internal/scanner/ines_memory_test.go
+++ b/server/internal/scanner/ines_memory_test.go
@@ -1,0 +1,108 @@
+package scanner
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestNormalizeINESHeaderBytes(t *testing.T) {
+	// A canonical Super Mario Bros (USA) iNES 1.0 header with a tool-
+	// provenance "NI2.1" ASCII trailer in bytes 11-15. nestopia rejects
+	// this; lenient cores accept it.
+	smbDirty := func() []byte {
+		b := make([]byte, 16)
+		copy(b, []byte{0x4e, 0x45, 0x53, 0x1a, 0x02, 0x01, 0x01, 0x00})
+		copy(b[11:], []byte("NI2.1"))
+		return b
+	}
+	smbClean := func() []byte {
+		b := make([]byte, 16)
+		copy(b, []byte{0x4e, 0x45, 0x53, 0x1a, 0x02, 0x01, 0x01, 0x00})
+		return b
+	}
+
+	tests := []struct {
+		name     string
+		input    []byte
+		modified bool
+		want     []byte
+	}{
+		{
+			name:     "dirty SMB header is sanitized",
+			input:    smbDirty(),
+			modified: true,
+			want:     smbClean(),
+		},
+		{
+			name:     "already-clean header is unchanged",
+			input:    smbClean(),
+			modified: false,
+			want:     smbClean(),
+		},
+		{
+			name: "NES 2.0 header is left untouched",
+			input: func() []byte {
+				b := smbDirty()
+				b[7] = 0x08 // bits 2-3 = 0b10 marks NES 2.0
+				return b
+			}(),
+			modified: false,
+			want: func() []byte {
+				b := smbDirty()
+				b[7] = 0x08
+				return b
+			}(),
+		},
+		{
+			name:     "non-iNES buffer is left untouched",
+			input:    bytes.Repeat([]byte{0xff}, 16),
+			modified: false,
+			want:     bytes.Repeat([]byte{0xff}, 16),
+		},
+		{
+			name:     "buffer shorter than 16 bytes is a no-op",
+			input:    []byte{0x4e, 0x45, 0x53, 0x1a},
+			modified: false,
+			want:     []byte{0x4e, 0x45, 0x53, 0x1a},
+		},
+		{
+			name: "DiskDude! marker is sanitized",
+			input: func() []byte {
+				b := make([]byte, 16)
+				copy(b, []byte{0x4e, 0x45, 0x53, 0x1a, 0x02, 0x01, 0x01, 0x00})
+				copy(b[7:], []byte("DiskDude!"))
+				// byte 7 is overwritten by the copy above; reset it.
+				b[7] = 0x00
+				return b
+			}(),
+			modified: true,
+			want:     smbClean(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.modified
+			gotMod := NormalizeINESHeaderBytes(tt.input)
+			if gotMod != got {
+				t.Fatalf("modified: got=%v want=%v", gotMod, got)
+			}
+			if !bytes.Equal(tt.input, tt.want) {
+				t.Fatalf("buffer mismatch:\n got:  %x\n want: %x", tt.input, tt.want)
+			}
+		})
+	}
+}
+
+func TestNormalizeINESHeaderBytes_Idempotent(t *testing.T) {
+	b := make([]byte, 16)
+	copy(b, []byte{0x4e, 0x45, 0x53, 0x1a, 0x02, 0x01, 0x01, 0x00})
+	copy(b[11:], []byte("NI2.1"))
+
+	if !NormalizeINESHeaderBytes(b) {
+		t.Fatal("first call should report modified=true")
+	}
+	if NormalizeINESHeaderBytes(b) {
+		t.Fatal("second call on already-clean buffer should report modified=false")
+	}
+}


### PR DESCRIPTION
Closes #712.

Some NES dumpers (notably old GoodNES tooling and one widely-mirrored
Super Mario Bros dump in the wild) write a tool-provenance ASCII
marker into bytes 8-15 of the iNES header — e.g. `DiskDude!`, `NI2.1`.
Bytes 8-15 of an iNES 1.0 header are reserved and must be zero;
lenient cores ignore them, but **nestopia rejects the ROM at
`retro_load_game`**.

This patches the bytes only as they're streamed to the client. The
on-disk file is never touched. Both the player app and the web UI
(EmulatorJS) get a normalized first 16 bytes for free, with no
client-side logic.

## Why server-side, in-memory

- **One fix covers both clients.** No per-client shim duplicated
  between native libretro_bridge.c and the web/EmulatorJS code path.
- **No on-disk modification.** The user's ROM library is never
  rewritten — only the bytes streamed in the response.
- **Doesn't break hash-pinning.** Game ROMs aren't hashed for client
  verification (only cores are, per #555), so changing 5 reserved
  bytes on the wire has no compatibility cost.

## Scope of the normalizer (no-op in every other case)
- Buffer is at least 16 bytes
- Bytes 0-3 are the iNES magic (`NES\x1a`)
- Byte 7 bits 2-3 != `0b10` (this is iNES 1.0, not NES 2.0 — NES 2.0
  uses bytes 8-15 for extended fields and must not be touched)
- Any of bytes 8-15 are non-zero

## Implementation
- `scanner.NormalizeINESHeaderBytes([]byte) bool` — pure in-memory
  helper, mirrors the scope of the existing on-disk `SanitizeNESHeader`
  but never writes to disk. Idempotent.
- `HumaDownloadGame` inline-file path: when filename ends in `.nes`,
  read first 16 bytes, normalize in memory, write to body, then
  `io.Copy` the rest of the file.
- Updated comment in the Android E2E `navigateToGameAndPlay` helper —
  Balloon Fight stays the default (small ROM, fast boot) but the
  comment no longer claims SMB is rejected, since the server now
  serves a valid header.

## Tests
- 7 table-driven cases for the in-memory normalizer (dirty SMB,
  already-clean, NES 2.0 left untouched, non-iNES, short buffer,
  `DiskDude!` marker, idempotent re-run).
- Integration test on the download endpoint asserts:
  - Response bytes 8-15 are zero
  - Bytes 0-7 and the body past the header are unchanged
  - The on-disk ROM is byte-identical after the request

## Test plan
- [x] `go test ./internal/scanner/...` — 7 cases pass
- [x] `go test ./internal/api/...` — full suite green (incl. new
      integration test + existing `TestDownloadGame_NoPlayHistory`)
- [ ] Smoke: tap Super Mario Bros on Android with nestopia and
      confirm it boots end-to-end (the originally-broken fixture)