### PR TITLE
chore: clear Kotlin compile warnings in player code

### DIFF
--- a/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/DesktopAudioPlayerTest.kt
+++ b/player/desktop/src/desktopTest/kotlin/com/spela/player/desktop/e2e/DesktopAudioPlayerTest.kt
@@ -69,7 +69,7 @@ class DesktopAudioPlayerTest {
         val buffer = controller.getAudioBuffer()
 
         assertTrue(buffer != null, "Audio buffer should not be null")
-        assertTrue(buffer!!.isNotEmpty(), "Audio buffer should contain samples")
+        assertTrue(buffer.isNotEmpty(), "Audio buffer should contain samples")
         assertEquals(1024, buffer.size, "Audio buffer should have 1024 samples")
     }
 
@@ -129,7 +129,7 @@ class DesktopAudioPlayerTest {
 
         val buffer = controller.getAudioBuffer()
         assertTrue(buffer != null, "Empty buffer should not be null")
-        assertTrue(buffer!!.isEmpty(), "Empty buffer should have size 0")
+        assertTrue(buffer.isEmpty(), "Empty buffer should have size 0")
     }
 
     @Test

--- a/player/shared/src/androidMain/kotlin/com/spela/player/platform/secondarydisplay/SecondaryDisplayPresentation.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/platform/secondarydisplay/SecondaryDisplayPresentation.kt
@@ -86,6 +86,7 @@ class SecondaryDisplayPresentation(
         return super.dispatchTouchEvent(ev)
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onBackPressed() {
         // Suppress back button (gamepad B mapped to KEYCODE_BACK) so it doesn't
         // dismiss the secondary display during gameplay. The presentation is

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/ExploreRepositoryImpl.kt
@@ -275,7 +275,7 @@ class ExploreRepositoryImpl(
                 iconUrl = apiClient.resolveUrl(dto.iconUrl) ?: "",
                 logoUrl = apiClient.resolveUrl(dto.logoUrl) ?: "",
                 topGame = topGameDto?.takeIf { it.id.isNotEmpty() }?.toDomain()?.copy(
-                    coverUrl = apiClient.resolveUrl(topGameDto?.coverUrl ?: ""),
+                    coverUrl = apiClient.resolveUrl(topGameDto.coverUrl),
                 ),
             )
         }


### PR DESCRIPTION
Clears the four project-code Kotlin warnings I noticed during yesterday's
builds. Mechanical, no behavior change.

## Changes
- `ExploreRepositoryImpl.kt:278` — drop redundant safe call and elvis
  on \`topGameDto.coverUrl\`. The DTO smart-casts non-null inside the
  surrounding \`?.copy(...)\` chain, and \`coverUrl\` is
  \`@Required val coverUrl: String\` in the generated DTO.
- \`SecondaryDisplayPresentation.kt:89\` — add
  \`@Deprecated(\"Deprecated in Java\")\` to the \`onBackPressed()\`
  override. \`Activity.onBackPressed\` was deprecated upstream; we
  still need the override to suppress back-button dismissal during
  gameplay, so the annotation just acknowledges the upstream
  deprecation.
- \`DesktopAudioPlayerTest.kt:72,132\` — drop unnecessary \`!!\` after
  \`assertTrue(buffer != null)\` smart-casts the local \`val buffer\`.

## Out of scope
\`shared-api/HttpBasicAuth.kt\` has a \`String.encodeBase64()\`
deprecation warning, but that file is openapi-generator output —
patching it directly would be undone on the next regen. Needs a
template-level fix in the codegen pipeline, separate change.

## Test plan
- [x] \`:shared:compileKotlinDesktop\` — clean (no \`w:\` lines)
- [x] \`:shared:compileDebugKotlinAndroid\` — clean
- [x] \`:desktop:compileTestKotlinDesktop\` — clean
- [x] \`DesktopAudioPlayerTest\` — pass