### PR TITLE
fix(#743): scrape ScummVM games via source-platform hint

### DIFF
--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -91,6 +91,63 @@ var AbbreviationToIGDBPlatform = map[string][]int{
 	"VIC20":  {71},
 }
 
+// IGDBPlatformsFor returns the IGDB platform IDs to constrain a search by
+// for [consoleAbbrev]. Most consoles are a direct lookup in
+// [AbbreviationToIGDBPlatform]; SCUMMVM is the exception.
+//
+// SCUMMVM games are runtime-emulated adventure games that originally
+// shipped on a mix of DOS, Mac, Amiga, Atari ST, and Apple II. IGDB has
+// no "ScummVM" platform, so we sniff the game title (e.g. "The Secret
+// of Monkey Island (CD DOS VGA)") for an explicit platform hint. When a
+// hint is present we narrow to that platform; otherwise we fall back to
+// searching across the four most common ScummVM source platforms — DOS,
+// Amiga, Mac, Atari ST. IGDB's `platforms = (X,Y,Z)` filter is an "any
+// of" match, so a wider set just improves recall.
+//
+// Returns an empty slice when the console has no IGDB mapping at all.
+func IGDBPlatformsFor(consoleAbbrev, hintText string) []int {
+	if consoleAbbrev == "SCUMMVM" {
+		return scummvmPlatformsFromHint(hintText)
+	}
+	return AbbreviationToIGDBPlatform[consoleAbbrev]
+}
+
+// scummvmPlatformsFromHint inspects [hint] (typically the game title or
+// folder name) for an explicit platform marker and returns matching IGDB
+// platform IDs. When no marker is found, returns the canonical
+// ScummVM-source platform set [DOS, Amiga, Mac, Atari ST].
+func scummvmPlatformsFromHint(hint string) []int {
+	const (
+		dosID     = 13
+		macID     = 14
+		amigaID   = 16
+		atariSTID = 63
+		appleIIID = 75
+	)
+	lower := strings.ToLower(hint)
+	switch {
+	case strings.Contains(lower, "dos"),
+		strings.Contains(lower, "vga"),
+		strings.Contains(lower, "ega"),
+		strings.Contains(lower, "(pc)"),
+		strings.Contains(lower, " pc "):
+		return []int{dosID}
+	case strings.Contains(lower, "amiga"):
+		return []int{amigaID}
+	case strings.Contains(lower, "macintosh"),
+		strings.Contains(lower, "(mac)"),
+		strings.Contains(lower, " mac "):
+		return []int{macID}
+	case strings.Contains(lower, "atari st"):
+		return []int{atariSTID}
+	case strings.Contains(lower, "apple ii"),
+		strings.Contains(lower, "iigs"):
+		return []int{appleIIID}
+	default:
+		return []int{dosID, amigaID, macID, atariSTID}
+	}
+}
+
 // formatPlatformList renders a list of platform IDs as an IGDB query tuple:
 // [19, 58] → "(19, 58)". This matches IGDB's syntax for matching a game
 // where any of the listed platforms is present.

--- a/server/internal/igdb/client_test.go
+++ b/server/internal/igdb/client_test.go
@@ -904,3 +904,74 @@ func TestPlatformMapping(t *testing.T) {
 	_, exists := AbbreviationToIGDBPlatform["UNKNOWN"]
 	assert.False(t, exists)
 }
+
+func TestIGDBPlatformsFor(t *testing.T) {
+	tests := []struct {
+		name          string
+		consoleAbbrev string
+		hint          string
+		want          []int
+	}{
+		{
+			name:          "non-scummvm console falls through to direct map lookup",
+			consoleAbbrev: "SNES",
+			hint:          "Super Mario World",
+			want:          []int{19, 58},
+		},
+		{
+			name:          "non-scummvm console with no map entry returns empty",
+			consoleAbbrev: "UNKNOWN",
+			hint:          "anything",
+			want:          nil,
+		},
+		{
+			name:          "scummvm DOS hint resolves to DOS only",
+			consoleAbbrev: "SCUMMVM",
+			hint:          "The Secret of Monkey Island (CD DOS VGA)",
+			want:          []int{13},
+		},
+		{
+			name:          "scummvm VGA hint resolves to DOS",
+			consoleAbbrev: "SCUMMVM",
+			hint:          "Loom (VGA)",
+			want:          []int{13},
+		},
+		{
+			name:          "scummvm Amiga hint resolves to Amiga",
+			consoleAbbrev: "SCUMMVM",
+			hint:          "Indiana Jones and the Last Crusade (Amiga)",
+			want:          []int{16},
+		},
+		{
+			name:          "scummvm Macintosh hint resolves to Mac",
+			consoleAbbrev: "SCUMMVM",
+			hint:          "The Secret of Monkey Island (Macintosh)",
+			want:          []int{14},
+		},
+		{
+			name:          "scummvm Atari ST hint resolves to Atari ST",
+			consoleAbbrev: "SCUMMVM",
+			hint:          "Zak McKracken (Atari ST)",
+			want:          []int{63},
+		},
+		{
+			name:          "scummvm Apple II hint resolves to Apple II",
+			consoleAbbrev: "SCUMMVM",
+			hint:          "Maniac Mansion (Apple IIgs)",
+			want:          []int{75},
+		},
+		{
+			name:          "scummvm with no hint searches multi-platform",
+			consoleAbbrev: "SCUMMVM",
+			hint:          "Day of the Tentacle",
+			want:          []int{13, 16, 14, 63},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := IGDBPlatformsFor(tt.consoleAbbrev, tt.hint)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -220,14 +220,26 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 
 // scrapeIGDB searches IGDB for game metadata and downloads images.
 func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string) error {
-	platformIDs, ok := igdb.AbbreviationToIGDBPlatform[console.Abbreviation]
-	if !ok {
+	// SCUMMVM uses a hint-aware resolver because games originally shipped on
+	// a mix of DOS/Amiga/Mac/Atari ST and IGDB has no "ScummVM" platform —
+	// see igdb.IGDBPlatformsFor.
+	platformIDs := igdb.IGDBPlatformsFor(console.Abbreviation, game.Title)
+	if len(platformIDs) == 0 {
 		return fmt.Errorf("no IGDB platform ID for console %s", console.Abbreviation)
 	}
 
-	cleanName := igdb.CleanGameName(game.FileName)
+	// ScummVM games are folder-based; the FileName ("monkey.scummvm") is just
+	// the engine's gameid marker, not a meaningful search term. The folder
+	// name lives in game.Title (set by the scanner). For ScummVM, search by
+	// the cleaned title; for everything else, the FileName-derived behaviour
+	// is preserved.
+	searchSource := game.FileName
+	if console.Abbreviation == "SCUMMVM" && game.Title != "" {
+		searchSource = game.Title
+	}
+	cleanName := igdb.CleanGameName(searchSource)
 	if cleanName == "" {
-		return fmt.Errorf("empty game name after cleaning: %s", game.FileName)
+		return fmt.Errorf("empty game name after cleaning: %s", searchSource)
 	}
 
 	// CRC-based identification: look up ROM in No-Intro DAT
@@ -400,7 +412,7 @@ func (s *Scraper) applyIGDBMatch(game *db.Game, console db.Console, match igdb.G
 	// Use platform-specific release date when available (e.g. SNES release of
 	// a game that originally launched on another platform), falling back to
 	// the global first release date.
-	platformIDs := igdb.AbbreviationToIGDBPlatform[console.Abbreviation]
+	platformIDs := igdb.IGDBPlatformsFor(console.Abbreviation, game.Title)
 	if rd := earliestPlatformReleaseDate(match.ReleaseDates, platformIDs); rd > 0 {
 		t := time.Unix(rd, 0)
 		game.ReleaseDate = t.Format("2006-01-02")


### PR DESCRIPTION
Closes #743.

ScummVM games never produced IGDB metadata (only the SteamGridDB hero
image came through). Two compounding bugs:

1. **No SCUMMVM → IGDB platform mapping.** \`scrapeIGDB\` short-circuited
   with \"no IGDB platform ID for console SCUMMVM\" before ever hitting
   the search.
2. **Wrong search term.** The scraper used \`game.FileName\`
   (\`monkey.scummvm\` — the engine's gameid marker), which cleans to
   \`\"monkey\"\` and matches Monkey Island 2 (or any other Monkey-something
   title) on IGDB.

## Fix

- New \`igdb.IGDBPlatformsFor(consoleAbbrev, hintText) []int\` resolves
  the platform IDs to constrain a search by. SCUMMVM is the special
  case: ScummVM is a runtime that targets games originally released on
  DOS, Mac, Amiga, Atari ST, and Apple II — IGDB has no \"ScummVM\"
  platform. The resolver sniffs the game title for a parenthesized
  platform hint and narrows when present:
  - \`(CD DOS VGA)\` / \`(VGA)\` / \`(EGA)\` / \`(PC)\` → DOS (id 13)
  - \`(Amiga)\` → Amiga (16)
  - \`(Macintosh)\` / \`(Mac)\` → Mac (14)
  - \`(Atari ST)\` → Atari ST (63)
  - \`(Apple IIgs)\` / \`Apple II\` → Apple II (75)
  - No hint → multi-platform fallback \`[DOS, Amiga, Mac, Atari ST]\`
    (IGDB's \`platforms = (X,Y,Z)\` is \"any of\", so wider recall comes
    free).
- For SCUMMVM, \`scrapeIGDB\` now searches by \`game.Title\` (the
  folder-derived display title) instead of the meaningless
  \`game.FileName\`. All other consoles keep their existing FileName
  behaviour.
- Both platform-lookup call sites in \`scraper_igdb.go\` (the search and
  the release-date narrowing on line 406) go through the new resolver,
  so the rest of the scrape stays consistent.

## Tests

- 9 table-driven tests for \`IGDBPlatformsFor\` — non-SCUMMVM
  passthrough, unknown console returns empty, all five platform-hint
  variants resolve to a single ID, no-hint case yields the multi-
  platform fallback.

## Manual verification

Reset and re-enqueued game id 176 in a local dev DB
(\`The Secret of Monkey Island (CD DOS VGA)\`):

| Field | Before | After |
| --- | --- | --- |
| title | \`(CD DOS VGA)\` suffix retained | \`The Secret of Monkey Island\` (correct, from IGDB) |
| scraper_id | \`libretro\` only | \`igdb:60\` (MI1, the right game) |
| description | empty | 778 chars |
| cover_url | empty | \`SCUMMVM/176/boxart-igdb.jpg\` |
| developer | empty | Lucasfilm Games |
| publisher | empty | Lucasfilm Games |
| release_date | empty | 1990-10-01 (DOS release) |
| genre | empty | Point-and-click, Puzzle, Adventure |

Note: previous bad-state runs matched MI2 (\`igdb:61\`) — the
search-source fix is what disambiguates.

## Test plan
- [x] go unit tests
- [x] manual rescrape of testdata game 176 verified end-to-end
- [ ] Bulk re-scrape of existing SCUMMVM games (out of scope for this
      PR — once merged, run \"scrape unscraped\" or clear scraper_id
      for SCUMMVM rows to backfill)