### PR TITLE
feat(#748): silence Amiga floppy drive sound in EmulatorJS by default

### DIFF
--- a/web/public/emulator.js
+++ b/web/public/emulator.js
@@ -230,6 +230,19 @@
       window.EJS_volume = prefs.volume;
     }
 
+    // Per-core libretro variable defaults. EmulatorJS exposes them in its
+    // settings menu; these override RetroArch's defaults at boot. Users
+    // can still flip them back via the gear menu.
+    //
+    // puae (Amiga): silence the floppy drive seek/click sample. The core's
+    // default volume is 80 (loud); value "100" is labelled "disabled" in
+    // the option (it's an attenuation %, where 100 = full silence).
+    if (config.core === "puae") {
+      if (window.EJS_defaultOptions["puae_floppy_sound"] === undefined) {
+        window.EJS_defaultOptions["puae_floppy_sound"] = "100";
+      }
+    }
+
     // Key mapping
     // EmulatorJS uses its own key name format (e.g., "up arrow" not "arrowup").
     // This map converts standard DOM KeyboardEvent.key names to EmulatorJS names.


### PR DESCRIPTION
Closes #748.

Sets the puae core option \`puae_floppy_sound\` to \`\"100\"\` (counter-
intuitively labelled \"disabled\" — it's an attenuation %, where 0 =
full volume and 100 = full silence) when initialising EmulatorJS for
an Amiga game. Users can still flip it back via the EmulatorJS
settings gear menu — we only seed the default when the option isn't
already set.

The puae core's default is 80 (loud), so without this every Amiga
game in the browser plays the classic floppy seek/click sample at
high volume through the speakers. Most users find that distracting.

## Out of scope

The player app (Android + desktop) needs the same default, but goes
via \`libretroController.setCoreVariable\` in
\`EmulationViewModel.kt\` (where the existing per-core variable block
already lives — desmume, mupen64plus, etc.). That'll be a tiny
follow-up.

## Test plan
- [x] go build clean (no server change)
- [x] Visual: load an Amiga game in the browser, confirm the floppy
      sample is silent. Open settings gear → confirm
      \"Floppy Sound Emulation\" reads \"disabled\"; flipping it to a
      non-disabled value re-enables the sound (so users keep control).