### PR TITLE
chore(#750): bump android-actions/setup-android to v4

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -22,7 +22,7 @@ jobs:
           java-version: 21
 
       - name: Set up Android SDK
-        uses: android-actions/setup-android@v3
+        uses: android-actions/setup-android@v4
 
       - name: Cache Gradle
         uses: actions/cache@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,7 @@ jobs:
         with:
           distribution: temurin
           java-version: 21
-      - uses: android-actions/setup-android@v3
+      - uses: android-actions/setup-android@v4
       - name: Cache Gradle
         uses: actions/cache@v5
         with:
@@ -365,7 +365,7 @@ jobs:
           distribution: jetbrains
           java-version: 21
           token: ${{ secrets.GITHUB_TOKEN }}
-      - uses: android-actions/setup-android@v3
+      - uses: android-actions/setup-android@v4
         with:
           packages: ''
       - name: Install dependencies


### PR DESCRIPTION
Closes #750.

Clears the Node.js 20 deprecation warning that's been showing on
release runs. v4.0.0 migrated the action to Node 24, which matches
what GitHub Actions runners now ship.

## Sites updated
- \`.github/workflows/android-build.yml:25\`
- \`.github/workflows/release.yml:128\`
- \`.github/workflows/release.yml:368\`

## Behaviour change to flag

v4 defaults \`cmdline-tools\` to **20.0** (was 11.0 in v3.0.0). None of
our three call sites pin a specific cmdline-tools version, so they
all get the new default. Should be invisible to the build — none of
our Gradle scripts pin a cmdline-tools version either — but worth
eyeballing the next release run to confirm.

## Test plan
- [ ] Watch the next CI run / next release tag for the deprecation
      warning to disappear and Android APK to still build clean