### PR TITLE
feat(#752): auto-download MT-32 / CM-32L ROMs for ScummVM

### DIFF
--- a/server/internal/bios/registry.go
+++ b/server/internal/bios/registry.go
@@ -110,6 +110,23 @@ var registry = []Entry{
 	{ConsoleID: "cdi", FileName: "cdimono1.zip", Description: "CD-i Mono-I BIOS", MD5: "", Required: true, OverrideURL: "https://github.com/Abdess/retrobios/raw/main/bios/Philips/CD-i/cdimono1.zip", SubDir: "same_cdi/bios"},
 	{ConsoleID: "cdi", FileName: "cdimono2.zip", Description: "CD-i Mono-II BIOS", MD5: "", Required: false, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdimono2.zip", SubDir: "same_cdi/bios"},
 	{ConsoleID: "cdi", FileName: "cdibios.zip", Description: "CD-i BIOS (generic)", MD5: "", Required: false, OverrideURL: "https://archive.org/download/MAME208RomsOnlyMerged/cdibios.zip", SubDir: "same_cdi/bios"},
+
+	// ScummVM — Roland MT-32 / CM-32L MIDI ROMs. The libretro scummvm core
+	// hardcodes its "extrapath" to <system_dir>/scummvm/extra/, so that's
+	// where ScummVM picks up these ROMs to enable MT-32 sound emulation
+	// (vastly better than AdLib for late-80s/early-90s adventure games like
+	// Monkey Island, Indiana Jones, Loom, …). With auto music_driver
+	// (default), ScummVM prefers MT-32 over AdLib when ROMs are present;
+	// CM-32L is preferred over MT-32 when both are available.
+	//
+	// All four are Optional — most games sound fine on AdLib, and not every
+	// user wants the ROMs. Sources are archive.org's MAME-versioned dump.
+	// CM-32L's source filenames are MAME-style lowercase; FileName/SubDir
+	// rename them to ScummVM's expected uppercase target names on download.
+	{ConsoleID: "scummvm", FileName: "MT32_CONTROL.ROM", Description: "Roland MT-32 Control ROM (firmware v1.07)", MD5: "5626206284b22c2734f3e9efefcd2675", Required: false, SubDir: "scummvm/extra", OverrideURL: "https://archive.org/download/mame-versioned-roland-mt-32-and-cm-32l-rom-files/MT-32_v1.07_legacy_ROM_files.zip/MT32_CONTROL.ROM"},
+	{ConsoleID: "scummvm", FileName: "MT32_PCM.ROM", Description: "Roland MT-32 PCM ROM", MD5: "89e42e386e82e0cacb4a2704a03706ca", Required: false, SubDir: "scummvm/extra", OverrideURL: "https://archive.org/download/mame-versioned-roland-mt-32-and-cm-32l-rom-files/MT-32_v1.07_legacy_ROM_files.zip/MT32_PCM.ROM"},
+	{ConsoleID: "scummvm", FileName: "CM32L_CONTROL.ROM", Description: "Roland CM-32L Control ROM (v1.02) — preferred over MT-32 when present", MD5: "bfff32b6144c1d706109accb6e6b1113", Required: false, SubDir: "scummvm/extra", OverrideURL: "https://archive.org/download/mame-versioned-roland-mt-32-and-cm-32l-rom-files/MT-32_and_CM-32L_MAME-Versioned_ROM_files..zip/cm32l_ctrl_1_02.rom"},
+	{ConsoleID: "scummvm", FileName: "CM32L_PCM.ROM", Description: "Roland CM-32L PCM ROM (1MB, expanded sample bank)", MD5: "08cdcfa0ed93e9cb16afa76e6ac5f0a4", Required: false, SubDir: "scummvm/extra", OverrideURL: "https://archive.org/download/mame-versioned-roland-mt-32-and-cm-32l-rom-files/MT-32_and_CM-32L_MAME-Versioned_ROM_files..zip/cm32l_pcm.rom"},
 }
 
 // repoFolders maps console IDs to their folder path in the


### PR DESCRIPTION
Closes #752.

Adds four optional BIOS entries for the SCUMMVM console — the Roland
MT-32 and CM-32L MIDI ROMs that the libretro scummvm core picks up
automatically when present in its extrapath.

## Why

Early-90s adventure games (Monkey Island, Loom, Indy Crusade, Sam &
Max, Day of the Tentacle, …) were composed for the Roland MT-32. AdLib
is a strict downgrade. ScummVM's \`music_driver = auto\` (default)
prefers MT-32 over AdLib whenever the ROMs are findable, and prefers
CM-32L over MT-32 (CM-32L is a superset with extra rhythm samples).

The libretro scummvm core hardcodes its \`extrapath\` to
\`<system_dir>/scummvm/extra/\` (per
\`libretro-os-utils.cpp:194-196\`). Spela already sets the libretro
\`system_directory\` to the BIOS dir
(\`AndroidLibretroController.kt:118\`), so files at
\`<bios_dir>/scummvm/extra/\` are picked up automatically with no
client changes.

## Implementation

Four entries in \`server/internal/bios/registry.go\` with
\`ConsoleID: \"scummvm\"\` and \`SubDir: \"scummvm/extra\"\`. The registry
already supports nested SubDirs — \`cdi\` uses \`same_cdi/bios\`.

All four are \`Required: false\`. Most ScummVM games sound fine on
AdLib, so we don't want the BIOS UI to flag SCUMMVM as \"missing
required\" for users who don't care about MIDI fidelity.

## Source

archive.org's \`mame-versioned-roland-mt-32-and-cm-32l-rom-files\`
item — the same approach Saturn / NeoGeo / CD-i BIOSes already use:
- MT-32 pair comes from the legacy zip (ScummVM-style filenames
  already match — direct passthrough)
- CM-32L pair comes from the MAME-versioned zip (lowercase MAME-style
  names like \`cm32l_pcm.rom\`); \`OverrideURL\` points at the source while
  \`FileName\` is set to the uppercase ScummVM target on disk
  (\`CM32L_PCM.ROM\`). The downloader's existing \`entry.FilePath(biosDir)\`
  honours \`FileName\` independently of the URL, so renames are free.

MD5 hashes were verified by downloading each file once and computing
locally:
| File | MD5 | Size |
| --- | --- | --- |
| \`MT32_CONTROL.ROM\` | \`5626206284b22c2734f3e9efefcd2675\` | 64 KB |
| \`MT32_PCM.ROM\` | \`89e42e386e82e0cacb4a2704a03706ca\` | 512 KB |
| \`CM32L_CONTROL.ROM\` | \`bfff32b6144c1d706109accb6e6b1113\` | 64 KB |
| \`CM32L_PCM.ROM\` | \`08cdcfa0ed93e9cb16afa76e6ac5f0a4\` | 1 MB |

## How it surfaces in the UI

\`bios.ConsoleIDs()\` derives the list from registry entries, so SCUMMVM
will appear in the BIOS panel automatically once these entries land —
admin can hit \"Auto-download\" and the ROMs land in the right
subdirectory; clients (player app + EmulatorJS) sync them on next
launch.

## Test plan
- [x] go build clean
- [x] \`go test ./internal/bios/ ./internal/api/ -run Bios\` — green
- [ ] After merge: hit \"Auto-download BIOSes\" on the admin BIOS page
      with a fresh server, confirm \`scummvm/extra/\` appears under the
      bios dir with the four ROMs and matching MD5 hashes
- [ ] Smoke: launch Monkey Island in EmulatorJS / player app, listen
      for the rich MT-32 score (vs the AdLib bleeps you get without
      the ROMs)