### PR TITLE
fix(#758): suppress rogue scrape progress after Cancel

### DIFF
--- a/server/internal/api/huma_scraper.go
+++ b/server/internal/api/huma_scraper.go
@@ -356,7 +356,7 @@ func (h *AdminHandler) HumaCancelScrape(ctx context.Context, _ *CancelScrapeInpu
 		return nil, huma.Error500InternalServerError("checking active job")
 	}
 	if job == nil {
-		return nil, huma.Error409Conflict("no scrape operation is running")
+		return nil, huma.Error409Conflict("No scrape operation is running")
 	}
 
 	if err := h.Scraper.Queue.CancelJob(job.ID); err != nil {

--- a/server/internal/scraper/worker.go
+++ b/server/internal/scraper/worker.go
@@ -174,6 +174,17 @@ func (w *ScrapeWorker) broadcastProgress(item *db.ScrapeQueueItem, game *db.Game
 			return
 		}
 
+		// Skip the progress broadcast when the job is no longer running —
+		// e.g. the admin clicked "Cancel scrape" while the worker had an
+		// item in flight. CancelJob marks pending items + the job as
+		// "cancelled", but the in-flight item keeps running until its
+		// scrape finishes; without this guard we emit a final
+		// EventScrapeProgress for that item that the UI mistakes for
+		// "the scrape is still going" right after Cancel was acked.
+		if job.Status != "running" {
+			return
+		}
+
 		w.hub.Broadcast(ws.Event{
 			Type: ws.EventScrapeProgress,
 			Payload: ScrapeProgress{


### PR DESCRIPTION
Closes #758.

## Symptom

1. Admin starts a scrape with several games queued.
2. After a couple complete, clicks **Cancel scrape**.
3. The cancel acks and the queue stops draining.
4. Briefly after, the UI flashes a new \"scrape progress\" update for
   the game that was in-flight at cancel time. UI thinks the scrape is
   still running. Clicking Cancel again returns a 409
   \"no scrape operation is running\".

## Root cause

\`HumaCancelScrape\` calls \`Queue.CancelJob(jobID)\` which marks the
pending queue items + the job itself as \`cancelled\`. But the worker
has an item already **in-flight** at that point — it doesn't know about
the cancel until it finishes the current scrape. When that scrape
finishes, the worker calls \`broadcastProgress\` unconditionally, which
fires \`EventScrapeProgress\` for the just-completed game. The UI
treats that event as \"scrape still going\".

\`server/internal/scraper/worker.go:166\` reads the parent job to compute
the progress payload but never checks \`job.Status\` before emitting.

## Fix

In \`broadcastProgress\`, return early when \`job.Status != \"running\"\`.
Suppresses the rogue progress event without touching the cancellation
flow (the cancel handler already broadcasts \`EventScrapeCancelled\`).

## Bonus nit

Capitalise the 409 error message \"no scrape operation is running\" →
\"No scrape operation is running\" — consistent with the rest of the
API's error message style.

## Test plan
- [x] go build clean
- [ ] Manual: start a scrape, cancel mid-flight, confirm no rogue
      progress event flashes in the UI and Cancel button returns to
      \"start scrape\" state cleanly. Verify after merge.