### PR TITLE
fix(#760): derive ScummVM gameid from marker filename, not mutable Title

### DIFF
--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -228,26 +228,36 @@ func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string
 		return fmt.Errorf("no IGDB platform ID for console %s", console.Abbreviation)
 	}
 
-	// ScummVM games are folder-based; the FileName ("monkey.scummvm") is just
-	// the engine's gameid marker, not a meaningful search term. The folder
-	// name lives in game.Title (set by the scanner). For ScummVM, search by
-	// the cleaned title; for everything else, the FileName-derived behaviour
-	// is preserved.
+	// ScummVM games are folder-based; the FileName ("monkey.scummvm") is the
+	// engine's gameid marker, not a meaningful search term — but its
+	// stripped form ("monkey") IS the canonical ScummVM gameid by
+	// convention. That's our source of truth.
+	//
+	// Resolve the gameid → canonical title BEFORE the IGDB search every
+	// time, derived from the marker filename rather than game.Title. This
+	// means a re-scrape always uses the right title even when a previous
+	// scrape overwrote game.Title with a bad IGDB match (e.g. "Dig It!"
+	// for the gameid "dig"). When the gameid isn't in our curated map we
+	// fall back to game.Title — covers descriptively-named folders like
+	// "The Secret of Monkey Island (CD DOS VGA)".
 	searchSource := game.FileName
-	if console.Abbreviation == "SCUMMVM" && game.Title != "" {
-		searchSource = game.Title
-		// When the user dropped the game in a folder named after the
-		// ScummVM gameid (e.g. "gob1", "indy3", "ite") rather than a real
-		// descriptive title, the scanner-derived title is just that
-		// gameid. IGDB has no idea what "gob1" is. Look it up in the
-		// curated gameid → title map. When found, also write the
-		// canonical title back so the UI shows "Gobliiins" instead of
-		// "gob1" before the IGDB scrape lands.
-		if canonical := igdb.LookupScummvmGameTitle(game.Title); canonical != "" {
+	if console.Abbreviation == "SCUMMVM" {
+		canonical := ""
+		gameid := ""
+		if strings.HasSuffix(strings.ToLower(game.FileName), ".scummvm") {
+			gameid = strings.TrimSuffix(game.FileName, ".scummvm")
+			gameid = strings.TrimSuffix(gameid, ".SCUMMVM")
+			canonical = igdb.LookupScummvmGameTitle(gameid)
+		}
+		switch {
+		case canonical != "":
 			slog.Info("ScummVM gameid resolved to canonical title",
-				"gameid", game.Title, "title", canonical)
+				"gameid", gameid, "title", canonical, "previousTitle", game.Title)
 			searchSource = canonical
 			game.Title = canonical
+		case game.Title != "":
+			// Gameid not in the map — fall back to the folder-derived title.
+			searchSource = game.Title
 		}
 	}
 	cleanName := igdb.CleanGameName(searchSource)


### PR DESCRIPTION
Closes #760.

## Symptom

A ScummVM game that was scraped on a pre-#757 server got the wrong
IGDB title written to \`game.Title\` (e.g. gameid \`dig\` matched to
\"Dig It!\" igdb:14490 instead of \"The Dig\" igdb:207). After updating
to the gameid-resolver version, rescraping the game **kept producing
the same wrong match** — server logs showed the IGDB search was
still being run with \`name=\"Dig It!\"\`, not \`\"The Dig\"\`.

## Root cause

The resolver looked up \`game.Title\` in the gameid → canonical-title
map. On the **initial** scrape, \`game.Title\` was the folder name
(= the gameid \`dig\`), so the lookup hit. On a **re-scrape** after a
prior bad match, \`game.Title\` was \"Dig It!\" — not a gameid, so the
lookup missed, and IGDB was queried with the wrong string again.

The canonical source of the gameid is the marker filename
(\`<gameid>.scummvm\` per ScummVM convention), not the mutated
\`game.Title\` field.

## Fix

Always derive the gameid from \`game.FileName\` first (strip
\`.scummvm\`) and look that up in the map. Fall back to \`game.Title\`
only when the gameid isn't in the map — covers descriptively-named
folders like \"The Secret of Monkey Island (CD DOS VGA)\" where the
gameid pattern wouldn't match the regex anyway.

## Verified locally

Started from the exact reported bug state:
- \`title=\"Dig It!\"\`
- \`scraper_id=\"igdb:14490\"\`

Re-enqueued the rescrape. Recovered:
- \`title=\"The Dig\"\`
- \`scraper_id=\"igdb:207\"\`
- \`developer=\"LucasArts\"\`
- description 1668 chars

## Test plan
- [x] go build clean
- [x] Manual recovery from the exact bug state on local backend
- [ ] After merge: re-trigger rescrape on user's affected SCUMMVM
      games and confirm titles correct themselves