### PR TITLE
fix(#762): resolve ScummVM gameid BEFORE the parallel scrape block

### DIFF
--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -81,6 +81,15 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 		return nil
 	}
 
+	// --- ScummVM gameid pre-resolution ---
+	// Must run BEFORE the parallel scrape block: SteamGridDB and IGDB both
+	// read game.Title to query their respective APIs, and the gameid (e.g.
+	// "woodruff") is meaningless on either service. Resolve to the canonical
+	// title here so all parallel sources see the right name.
+	if console.Abbreviation == "SCUMMVM" {
+		resolveScummvmTitleFromMarker(game)
+	}
+
 	// --- Scrape all sources in parallel ---
 	// IGDB, LibRetro, and SteamGridDB are independent external services.
 	// Run them concurrently, collect outcomes, then write results to DB.
@@ -218,6 +227,41 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 	return nil
 }
 
+// resolveScummvmTitleFromMarker resolves a ScummVM game's title from the
+// marker filename (`<gameid>.scummvm`) using the curated gameid → canonical
+// title map. When the gameid is in the map (e.g. "woodruff" → "The Bizarre
+// Adventures of Woodruff and the Schnibble"), [game.Title] is overwritten
+// with the canonical title. When the gameid isn't in the map, [game.Title]
+// is left untouched (covers descriptively-named folders like "The Secret of
+// Monkey Island (CD DOS VGA)" where the gameid pattern wouldn't match the
+// regex anyway).
+//
+// Must be called BEFORE the parallel scrape block in ScrapeGame because
+// IGDB and SteamGridDB both query their respective APIs by [game.Title], and
+// the gameid alone is meaningless on either service.
+//
+// The marker filename is the canonical source of the gameid, NOT
+// [game.Title] — Title can be overwritten by a previous bad IGDB match
+// (e.g. "Dig It!" for the gameid "dig"). The filename is immutable.
+func resolveScummvmTitleFromMarker(game *db.Game) {
+	fn := game.FileName
+	if !strings.HasSuffix(strings.ToLower(fn), ".scummvm") {
+		return
+	}
+	gameid := strings.TrimSuffix(fn, ".scummvm")
+	gameid = strings.TrimSuffix(gameid, ".SCUMMVM")
+	canonical := igdb.LookupScummvmGameTitle(gameid)
+	if canonical == "" {
+		return
+	}
+	if canonical == game.Title {
+		return
+	}
+	slog.Info("ScummVM gameid resolved to canonical title",
+		"gameid", gameid, "title", canonical, "previousTitle", game.Title)
+	game.Title = canonical
+}
+
 // scrapeIGDB searches IGDB for game metadata and downloads images.
 func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string) error {
 	// SCUMMVM uses a hint-aware resolver because games originally shipped on
@@ -228,37 +272,14 @@ func (s *Scraper) scrapeIGDB(game *db.Game, console db.Console, gameIDStr string
 		return fmt.Errorf("no IGDB platform ID for console %s", console.Abbreviation)
 	}
 
-	// ScummVM games are folder-based; the FileName ("monkey.scummvm") is the
-	// engine's gameid marker, not a meaningful search term — but its
-	// stripped form ("monkey") IS the canonical ScummVM gameid by
-	// convention. That's our source of truth.
-	//
-	// Resolve the gameid → canonical title BEFORE the IGDB search every
-	// time, derived from the marker filename rather than game.Title. This
-	// means a re-scrape always uses the right title even when a previous
-	// scrape overwrote game.Title with a bad IGDB match (e.g. "Dig It!"
-	// for the gameid "dig"). When the gameid isn't in our curated map we
-	// fall back to game.Title — covers descriptively-named folders like
-	// "The Secret of Monkey Island (CD DOS VGA)".
+	// For ScummVM, the gameid → canonical-title resolution already happened
+	// in ScrapeGame's pre-flight (see resolveScummvmTitleFromMarker). game.Title
+	// is now either the canonical title from the map, or the folder-derived
+	// title (when the gameid isn't in the map). Either way, that's the right
+	// thing to search IGDB by. Other consoles use FileName-derived behaviour.
 	searchSource := game.FileName
-	if console.Abbreviation == "SCUMMVM" {
-		canonical := ""
-		gameid := ""
-		if strings.HasSuffix(strings.ToLower(game.FileName), ".scummvm") {
-			gameid = strings.TrimSuffix(game.FileName, ".scummvm")
-			gameid = strings.TrimSuffix(gameid, ".SCUMMVM")
-			canonical = igdb.LookupScummvmGameTitle(gameid)
-		}
-		switch {
-		case canonical != "":
-			slog.Info("ScummVM gameid resolved to canonical title",
-				"gameid", gameid, "title", canonical, "previousTitle", game.Title)
-			searchSource = canonical
-			game.Title = canonical
-		case game.Title != "":
-			// Gameid not in the map — fall back to the folder-derived title.
-			searchSource = game.Title
-		}
+	if console.Abbreviation == "SCUMMVM" && game.Title != "" {
+		searchSource = game.Title
 	}
 	cleanName := igdb.CleanGameName(searchSource)
 	if cleanName == "" {


### PR DESCRIPTION
Closes #762.

## Symptom

For ScummVM games whose folder is named after just the gameid (e.g.
\`woodruff\`), SteamGridDB artwork didn't match the right game — the
game ended up with correct IGDB metadata but **wrong cover/hero/grid
art** from SteamGridDB.

## Root cause

\`ScrapeGame\` runs IGDB and SteamGridDB in **parallel goroutines**.
The ScummVM gameid → canonical-title resolver was inside
\`scrapeIGDB\`, so SteamGridDB queried its API with the raw gameid
(\"woodruff\") before — or while racing with — the IGDB goroutine
mutating \`game.Title\`. SteamGridDB has no idea what \"woodruff\" is.

## Fix

Pull the resolver out of \`scrapeIGDB\` into a free function
\`resolveScummvmTitleFromMarker\` and call it from \`ScrapeGame\`
BEFORE the parallel block fires. Both sources then see the canonical
title.

## Verified locally

Created \`testdata/roms/scummvm/woodruff/woodruff.scummvm\`, scanned,
scraped end-to-end:

| Field | Value |
| --- | --- |
| title | The Bizarre Adventures of Woodruff and the Schnibble |
| scraper_id | igdb:2226 |
| description | 490 chars |
| developer | Coktel Vision |
| **steam_grid_db_id** | **5254681** |
| hero_url | \`SCUMMVM/183/artwork-hero.jpg\` |

Both IGDB and SteamGridDB now hit the correct game.

## Test plan
- [x] go build clean
- [x] Manual end-to-end with woodruff fixture, all artwork sources
      resolve to the right game
- [ ] After merge: rescrape \`woodruff.scummvm\` on user's server,
      confirm hero/grid/logo/icon artwork updates to the correct game