### PR TITLE
fix(#766): recognise Amiga floppy disk sets as multi-disc games

### DIFF
--- a/server/internal/scanner/scanner.go
+++ b/server/internal/scanner/scanner.go
@@ -325,6 +325,17 @@ var directoryConsoleMap = map[string]string{
 // discPattern matches disc/disk/cd markers in filenames, e.g. "(Disc 1)", "[Disk 2]", "(CD 3)".
 var discPattern = regexp.MustCompile(`(?i)[\(\[]\s*(?:disc|disk|cd)\s*(\d+)\s*[\)\]]`)
 
+// amigaDiscPattern matches the Amiga floppy convention where each disk is
+// suffixed with a single uppercase letter — e.g. "Odyssey (Alcatraz) A.adf",
+// "Batman Movie (Ocean) B.adf". The letter sits between a space and the
+// extension, so we anchor on `<space><LETTER><end>` (the extension is
+// stripped before this is matched). Captures the letter in group 1.
+//
+// Only checked for .adf / .ipf files (Amiga floppy formats); other
+// consoles' ROM names occasionally end in a letter for legitimate
+// non-disc reasons.
+var amigaDiscPattern = regexp.MustCompile(`\s([A-Z])$`)
+
 // trackPattern matches CD audio track markers in filenames, e.g. "(Track 06)", "(Track 1)".
 // These are companion files referenced by .cue sheets and should not be scanned as standalone games.
 var trackPattern = regexp.MustCompile(`(?i)\(Track\s*\d+\)`)
@@ -620,6 +631,22 @@ func generateM3U(dir, baseName string, discFiles []string) (string, error) {
 // stripDiscMarker removes the disc marker from a filename to get the base title.
 func stripDiscMarker(filename string) string {
 	return strings.TrimSpace(discPattern.ReplaceAllString(filename, ""))
+}
+
+// stripAmigaDiscMarker removes the Amiga letter-suffix disc marker from a
+// filename (extension already stripped). "Odyssey (Alcatraz) A" → "Odyssey
+// (Alcatraz)". Pass-through if no match.
+func stripAmigaDiscMarker(nameNoExt string) string {
+	return strings.TrimSpace(amigaDiscPattern.ReplaceAllString(nameNoExt, ""))
+}
+
+// amigaDiscNumber converts a single uppercase letter to a 1-indexed disc
+// number ("A" → 1, "B" → 2, "E" → 5). Used for sorting Amiga disk sets.
+func amigaDiscNumber(letter string) int {
+	if len(letter) != 1 || letter[0] < 'A' || letter[0] > 'Z' {
+		return 0
+	}
+	return int(letter[0]-'A') + 1
 }
 
 // discGroupKey returns a key for grouping disc files: (parentDir, baseTitle).
@@ -944,6 +971,13 @@ func (s *Scanner) scanMultiDisc(dir string, consoleMap map[string]*db.Console, f
 			parentDir := filepath.Dir(path)
 			nameNoExt := strings.TrimSuffix(info.Name(), filepath.Ext(info.Name()))
 			baseTitle := stripDiscMarker(nameNoExt)
+			key := discGroupKey{Dir: parentDir, Title: baseTitle}
+			discGroups[key] = append(discGroups[key], path)
+		} else if (ext == ".adf" || ext == ".ipf") && amigaDiscPattern.MatchString(strings.TrimSuffix(info.Name(), ext)) {
+			// Amiga floppy convention: "Title (Pub) A.adf" / "Title (Pub) B.adf" — letter suffix.
+			parentDir := filepath.Dir(path)
+			nameNoExt := strings.TrimSuffix(info.Name(), filepath.Ext(info.Name()))
+			baseTitle := stripAmigaDiscMarker(nameNoExt)
 			key := discGroupKey{Dir: parentDir, Title: baseTitle}
 			discGroups[key] = append(discGroups[key], path)
 		}

--- a/server/internal/scanner/scanner_test.go
+++ b/server/internal/scanner/scanner_test.go
@@ -406,6 +406,55 @@ func TestDiscPattern(t *testing.T) {
 	}
 }
 
+func TestAmigaDiscPattern(t *testing.T) {
+	// Pattern matches the Amiga floppy convention `<space><LETTER>` at end
+	// of the name-without-extension. Caller is responsible for stripping
+	// the extension first and limiting to .adf/.ipf files.
+	tests := []struct {
+		nameNoExt string
+		matches   bool
+		stripped  string
+	}{
+		{"Odyssey (Alcatraz) A", true, "Odyssey (Alcatraz)"},
+		{"Batman Movie (Ocean) B", true, "Batman Movie (Ocean)"},
+		{"Impossible Mission 2025 (MicroProse) A", true, "Impossible Mission 2025 (MicroProse)"},
+		{"World of Commodore (Sanity)", false, "World of Commodore (Sanity)"},
+		{"2nd Demo (Hypnotic) [1991]", false, "2nd Demo (Hypnotic) [1991]"},
+		// Lowercase letters don't match (Amiga convention is uppercase)
+		{"Title (Pub) a", false, "Title (Pub) a"},
+		// Multi-letter doesn't match
+		{"Title (Pub) AB", false, "Title (Pub) AB"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.nameNoExt, func(t *testing.T) {
+			assert.Equal(t, tt.matches, amigaDiscPattern.MatchString(tt.nameNoExt))
+			assert.Equal(t, tt.stripped, stripAmigaDiscMarker(tt.nameNoExt))
+		})
+	}
+}
+
+func TestAmigaDiscNumber(t *testing.T) {
+	tests := []struct {
+		letter string
+		want   int
+	}{
+		{"A", 1},
+		{"B", 2},
+		{"C", 3},
+		{"E", 5},
+		{"Z", 26},
+		{"a", 0}, // lowercase rejected
+		{"AB", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.letter, func(t *testing.T) {
+			assert.Equal(t, tt.want, amigaDiscNumber(tt.letter))
+		})
+	}
+}
+
 func TestDiscCompanionFiles_CueBin(t *testing.T) {
 	dir := t.TempDir()
 	binPath := filepath.Join(dir, "game.bin")


### PR DESCRIPTION
Closes #766.

Amiga ROMs distributed as multi-disk floppy sets (e.g. \`Batman Movie
(Ocean) A.adf\`, \`B.adf\`) scanned as **separate one-disk game entries**.
Big Amiga demos like Odyssey by Alcatraz — 5 disks A through E —
showed up as 5 separate games. The scanner's multi-disc grouping
recognised CD-format conventions (\`(Disc N)\`, \`(Disk N)\`, \`(CD N)\`)
but missed the Amiga floppy convention of a single uppercase letter
suffix.

## Fix

\`amigaDiscPattern\` matches \`<space><LETTER>\` at end of the name-
without-extension. Anchored on whitespace + single uppercase letter,
so unrelated suffixes don't false-match. Only checked for \`.adf\`/
\`.ipf\` files (Amiga floppy formats); other consoles' ROM filenames
occasionally end in a letter for legitimate non-disc reasons.

Hooks into the existing \`scanMultiDisc\` flow alongside the CD-format
pattern — same downstream path: group by basename + parent dir,
auto-generate an \`.m3u\` bundle file, create one Game with N GameDisc
records.

## Verified end-to-end on testdata

| game | discCount | bundled file |
| --- | --- | --- |
| Odyssey | **5** | \`Odyssey (Alcatraz).m3u\` |
| Batman Movie | **2** | \`Batman Movie (Ocean).m3u\` |
| HypeRace | **2** | \`HypeRace (Impact).m3u\` |
| Impossible Mission 2025 | **2** | \`Impossible Mission 2025 (MicroProse).m3u\` |
| 2nd Demo (Hypnotic) | 0 | \`2nd Demo (Hypnotic) [1991].adf\` |
| World of Commodore | 0 | \`World of Commodore (Sanity).adf\` |

Single-disk games stay as single files; multi-disk sets auto-bundle.

## Tests
- \`TestAmigaDiscPattern\` — positive matches for Odyssey/Batman/IM
  multi-disk fixtures + negatives (single-disk World of Commodore,
  lowercase letters, multi-letter tags, region tags).
- \`TestAmigaDiscNumber\` — letter → 1-indexed number (A=1..Z=26),
  with rejection of lowercase, multi-letter, and empty inputs.
- All existing \`TestDiscPattern\` cases still pass.