### PR TITLE
fix(#768): mark Amiga / demos / ScummVM as verification-skip

### DIFF
--- a/server/internal/api/huma_admin_multipart.go
+++ b/server/internal/api/huma_admin_multipart.go
@@ -352,7 +352,7 @@ func (h *GameHandler) HumaReplaceROM(ctx context.Context, in *AdminReplaceROMInp
 
 	if h.Scraper != nil && h.Scraper.DATCache != nil {
 		consoleAbbrev := game.Console.Abbreviation
-		if scraper.DiscBasedSystems[consoleAbbrev] {
+		if scraper.VerificationSkipSystems[consoleAbbrev] {
 			newVerificationStatus = "not_applicable"
 			if idx, err := h.Scraper.DATCache.GetRedumpIndex(consoleAbbrev); err == nil && idx != nil {
 				if entry, ok := idx.LookupCRC(crc); ok {

--- a/server/internal/api/upload_handler.go
+++ b/server/internal/api/upload_handler.go
@@ -421,7 +421,7 @@ func (h *UploadHandler) tryIdentifyByDAT(filePath string, fileSize int64) (conso
 
 	// Try No-Intro DATs for cartridge-based systems
 	for abbrev := range scraper.AbbreviationToLibRetro {
-		if scraper.DiscBasedSystems[abbrev] {
+		if scraper.VerificationSkipSystems[abbrev] {
 			continue
 		}
 		maxSize, ok := scraper.MaxROMSize[abbrev]
@@ -508,8 +508,8 @@ func (h *UploadHandler) scrapeStaged(staged *db.StagedUpload) {
 		if staged.CanonicalName != "" {
 			staged.Title = scanner.GameTitle(staged.CanonicalName)
 		}
-	} else if scraper.DiscBasedSystems[console.Abbreviation] {
-		// Disc-based system: try Redump DAT verification if available
+	} else if scraper.VerificationSkipSystems[console.Abbreviation] {
+		// CRC verification skipped — try Redump DAT for disc-based consoles
 		staged.VerificationStatus = "not_applicable"
 		if h.Scraper != nil && h.Scraper.DATCache != nil {
 			if crc, err := scraper.ComputeFileCRC32(staged.FilePath); err == nil {

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -235,6 +235,22 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		slog.Warn("failed to ensure token_blacklists expires_at index", "error", err)
 	}
 
+	// One-time backfill: games on consoles where CRC verification doesn't
+	// apply (Amiga, demos, ScummVM) used to land with status "unverified"
+	// because the scraper's skip-list didn't cover them. Flip those to
+	// "not_applicable" so the verification badge stops showing on those
+	// game detail pages without forcing a full rescrape.
+	if err := db.Exec(`
+		UPDATE games SET verification_status = 'not_applicable'
+		WHERE verification_status = 'unverified'
+		  AND console_id IN (
+		    SELECT id FROM consoles WHERE abbreviation IN
+		      ('AMIGA','ACD32','ADEMO','DDEMO','SCUMMVM')
+		  )
+	`).Error; err != nil {
+		slog.Warn("verification_status backfill for skip-list consoles failed", "error", err)
+	}
+
 	// Promote the first user to owner if no owner exists (handles upgrades).
 	var ownerCount int64
 	db.Model(&User{}).Where("role = ?", RoleOwner).Count(&ownerCount)

--- a/server/internal/scraper/datcache.go
+++ b/server/internal/scraper/datcache.go
@@ -12,34 +12,64 @@ import (
 	"sync"
 )
 
-// DiscBasedSystems lists console abbreviations where CRC-based identification
-// is impractical — either disc images are too large, or No-Intro DATs don't
-// exist for the platform (arcade ROM sets, DOS, etc.).
-var DiscBasedSystems = map[string]bool{
-	"PSX":    true,
-	"SAT":    true,
-	"DC":     true,
-	"SCD":    true,
-	"PS2":    true,
-	"GC":     true,  // disc-based
-	"PCFX":   true,  // disc-based
-	"NEOGEO": true,  // arcade ROM sets, no No-Intro DAT
-	"ARCADE": true,  // MAME ROM sets, no No-Intro DAT
-	"DOS":    true,  // no No-Intro DAT
-	"PS3":    true,  // disc/pkg-based
-	"PS4":    true,  // disc/pkg-based
-	"PS5":    true,  // disc/pkg-based
-	"X360":   true,  // disc/xex-based
-	"XONE":   true,  // disc-based
-	"XSX":    true,  // disc-based
-	"WII":    true,  // disc-based
-	"WIIU":   true,  // disc-based
-	"NSW":    true,  // cartridge images, too large for CRC
+// VerificationSkipSystems lists console abbreviations where No-Intro CRC
+// verification is impractical or meaningless. Games on these consoles get
+// VerificationStatus = "not_applicable" instead of "unverified", so the
+// admin UI doesn't dangle a useless "unverified" badge on them.
+//
+// Three reasons a console belongs here:
+//
+//  1. Disc-based — the image is too large to CRC and No-Intro doesn't
+//     index disc media anyway. Redump may be tried separately.
+//  2. No DAT exists for this platform (arcade ROM sets, demoscene
+//     productions, ScummVM folders, …).
+//  3. The DAT exists but the dump format isn't bitwise-deterministic —
+//     e.g. Amiga ADF dumps vary by source tool / filesystem layout, so
+//     a "verified" hit is fragile and an "unverified" tag is just noise.
+var VerificationSkipSystems = map[string]bool{
+	// Disc-based consoles
+	"PSX":  true,
+	"SAT":  true,
+	"DC":   true,
+	"SCD":  true,
+	"PS2":  true,
+	"GC":   true,
+	"PCFX": true,
+	"PS3":  true, // disc/pkg-based
+	"PS4":  true, // disc/pkg-based
+	"PS5":  true, // disc/pkg-based
+	"X360": true, // disc/xex-based
+	"XONE": true,
+	"XSX":  true,
+	"WII":  true,
+	"WIIU": true,
+
+	// Cartridge images too large for practical CRC
+	"NSW": true,
+
+	// No No-Intro DAT for these platforms
+	"NEOGEO": true, // arcade ROM sets
+	"ARCADE": true, // MAME ROM sets
+	"DOS":    true,
+
+	// Demoscene productions — never indexed in any DAT
+	"ADEMO": true, // Amiga demos
+	"DDEMO": true, // DOS demos
+
+	// ScummVM games are folder-based, no concept of a verifiable hash
+	"SCUMMVM": true,
+
+	// Amiga commercial games: a Commodore - Amiga.dat exists but ADF
+	// dumps aren't bitwise-deterministic (filesystem layout varies),
+	// so "verified" is fragile and "unverified" is just confusing.
+	"AMIGA": true,
+	"ACD32": true,
 }
+
 
 // MaxROMSize defines conservative upper bounds (in bytes) per console abbreviation.
 // Used during auto-identification to skip consoles where the file is too large to be a ROM.
-// Consoles not in this map (and not in DiscBasedSystems) are skipped during auto-identification.
+// Consoles not in this map (and not in VerificationSkipSystems) are skipped during auto-identification.
 var MaxROMSize = map[string]int64{
 	"NES":  4 * 1024 * 1024,   // 4 MB
 	"SNES": 16 * 1024 * 1024,  // 16 MB
@@ -119,7 +149,7 @@ func (c *DATCache) Dir() string {
 // It loads and parses the bundled DAT file from disk if not already in memory.
 // Returns nil, nil for disc-based systems, unmapped systems, or if the file is missing.
 func (c *DATCache) GetIndex(consoleAbbrev string) (*DATIndex, error) {
-	if DiscBasedSystems[consoleAbbrev] {
+	if VerificationSkipSystems[consoleAbbrev] {
 		return nil, nil
 	}
 
@@ -198,7 +228,7 @@ func (c *DATCache) RefreshAll() {
 
 	var ok, failures int
 	for consoleAbbrev, systemName := range AbbreviationToLibRetro {
-		if DiscBasedSystems[consoleAbbrev] && !nameOnlyDATSystems[consoleAbbrev] {
+		if VerificationSkipSystems[consoleAbbrev] && !nameOnlyDATSystems[consoleAbbrev] {
 			continue
 		}
 

--- a/server/internal/scraper/scraper_igdb.go
+++ b/server/internal/scraper/scraper_igdb.go
@@ -60,7 +60,7 @@ func (s *Scraper) ScrapeGame(game *db.Game) error {
 	}
 
 	// Mark disc-based systems as not applicable for CRC verification
-	if DiscBasedSystems[console.Abbreviation] {
+	if VerificationSkipSystems[console.Abbreviation] {
 		game.VerificationStatus = "not_applicable"
 	}
 


### PR DESCRIPTION
Closes #768.

The game detail screen showed \"Unverified\" badges on consoles where
No-Intro CRC verification is meaningless or impractical:
- **Amiga (.adf)** isn't bitwise-deterministic — filesystem layout
  varies between dumps, so \"verified\" is fragile and \"unverified\"
  is just noise.
- **Demoscene productions** (\`ADEMO\` / \`DDEMO\`) are never indexed
  in any DAT.
- **ScummVM** games are folder-based; no verifiable hash.

## Changes

- Add \`AMIGA\`, \`ACD32\`, \`ADEMO\`, \`DDEMO\`, \`SCUMMVM\` to the existing
  skip-verification list. Games on these consoles now get
  \`verification_status = \"not_applicable\"\`, which the UI badge
  gates off.
- Rename \`DiscBasedSystems\` → \`VerificationSkipSystems\` across the
  9 call sites. The old name was already inaccurate (DOS, NEOGEO,
  ARCADE were in there too); the rename clarifies actual scope.
- One-time backfill on startup flips existing \`unverified\` rows on
  these consoles to \`not_applicable\` — users don't need to rescrape
  to see the badge disappear.

## Test plan
- [x] go build clean, full \`./internal/scraper\` + \`./internal/api\`
      tests pass
- [ ] After merge: visit an Amiga / demo / ScummVM game detail page,
      confirm no verification badge shows