### PR TITLE
fix(#769): wrap game-detail loading + not-found in PageLayout

### DIFF
--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -167,20 +167,22 @@ export function GameDetailPage() {
 
   if (isLoading) {
     return (
-      <div className="max-w-5xl">
+      <PageLayout backButtonVariant="floating">
         <GameDetailSkeleton aspectRatio={consoleInfo?.coverAspectRatio} />
-      </div>
+      </PageLayout>
     );
   }
 
   if (!game) {
     return (
-      <div className="text-center py-20">
-        <p className="text-surface-400">Game not found</p>
-        <Button variant="ghost" onClick={() => navigate(-1)} className="mt-4">
-          Go back
-        </Button>
-      </div>
+      <PageLayout backButtonVariant="floating">
+        <div className="text-center py-20">
+          <p className="text-surface-400">Game not found</p>
+          <Button variant="ghost" onClick={() => navigate(-1)} className="mt-4">
+            Go back
+          </Button>
+        </div>
+      </PageLayout>
     );
   }
 


### PR DESCRIPTION
Closes #769.

The game-detail page's \`isLoading\` branch returned a bare
\`<div className=\"max-w-5xl\">\` containing the skeleton — no padding,
not wrapped in \`PageLayout\`. The loaded state uses
\`<PageLayout backButtonVariant=\"floating\" ...>\` which provides the
standard \`p-6\` padding. So when loading completes, the content
shifted inward by ~24px causing a visible jitter.

The \"Game not found\" branch had the same issue.

Wrap both branches in \`<PageLayout>\` so they share the loaded
state's padding and back button.