### PR TITLE
fix(#772): add missing IGDB platform IDs for 11 consoles

### DIFF
--- a/server/internal/igdb/client.go
+++ b/server/internal/igdb/client.go
@@ -90,6 +90,18 @@ var AbbreviationToIGDBPlatform = map[string][]int{
 	"PET":    {90},
 	"PLUS4":  {94},
 	"VIC20":  {71},
+	// Verified against IGDB platforms endpoint (2026-04):
+	"A800":    {65},  // Atari 8-bit family (400/800/XL/XE)
+	"ATARIST": {63},  // Atari ST/STE
+	"CHAF":    {127}, // Fairchild Channel F
+	"FDS":     {51},  // Family Computer Disk System
+	"GW":      {307}, // Nintendo Game & Watch
+	"INTV":    {67},  // Mattel Intellivision
+	"O2":      {133}, // Magnavox Odyssey 2 / Videopac G7000
+	"SG1K":    {84},  // Sega SG-1000
+	"SGX":     {128}, // NEC PC Engine SuperGrafx
+	"VEC":     {70},  // GCE Vectrex
+	"VITA":    {46},  // Sony PlayStation Vita
 }
 
 // IGDBPlatformsFor returns the IGDB platform IDs to constrain a search by


### PR DESCRIPTION
Closes #772.

User reported Vectrex (\`VEC\`) and Fairchild Channel F (\`CHAF\`) games
weren't being scraped. Audit found **14 of Spela's 71 console
abbreviations** had no IGDB platform mapping, and \`scrapeIGDB\`
short-circuited with \"no IGDB platform ID\" for each. 11 are real
consoles that need entries; the other 3 (\`ADEMO\`, \`DDEMO\`, \`SCUMMVM\`)
are correctly handled by special paths.

## Added (IDs verified against IGDB \`/v4/platforms\`)

| Spela abbr | Console | IGDB ID |
| --- | --- | --- |
| \`VEC\` | GCE Vectrex | 70 |
| \`CHAF\` | Fairchild Channel F | 127 |
| \`A800\` | Atari 8-bit family (400/800/XL/XE) | 65 |
| \`ATARIST\` | Atari ST/STE | 63 |
| \`FDS\` | Family Computer Disk System | 51 |
| \`GW\` | Nintendo Game & Watch | 307 |
| \`INTV\` | Mattel Intellivision | 67 |
| \`O2\` | Magnavox Odyssey 2 / Videopac G7000 | 133 |
| \`SG1K\` | Sega SG-1000 | 84 |
| \`SGX\` | NEC PC Engine SuperGrafx | 128 |
| \`VITA\` | Sony PlayStation Vita | 46 |

## Verified locally on user's testdata

**VEC** (5 games) — all matched:
- Mine Storm (GCE) → igdb:18769
- Mine Storm II → igdb:41987
- Mr. Boston Clean Sweep → igdb:72611
- Polar Rescue (GCE) → igdb:24453
- Pole Position (Namco) → igdb:5691

**CHAF** (4 games) — all matched:
- Videocart-12: Baseball → igdb:41210 (Fairchild Semiconductor)
- Videocart-19: Checkers → igdb:41225 (Fairchild Semiconductor)
- Videocart-21: Bowling → igdb:41231 (Fairchild Semiconductor)
- Videocart-25: Casino Poker → igdb:18603 (Zircon International)

## Test plan
- [x] go build clean, igdb tests pass
- [x] Manual end-to-end with user's testdata fixtures
- [ ] After merge: existing users with affected console games can
      rescrape (manual or scheduled) to backfill metadata