### PR TITLE
feat(web): stamp every component with data-comp for DevTools visibility

### DIFF
--- a/web/scripts/add-data-comp.mjs
+++ b/web/scripts/add-data-comp.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+// Add data-comp="<ComponentName>" to the outermost JSX HTML element
+// returned by every top-level exported React component in web/src.
+//
+// "Component" here = an exported function or const-arrow declaration whose
+// name starts with an uppercase letter and whose body returns JSX.
+// We only stamp HTML elements (lowercase tag name), not custom components
+// (uppercase) — those have their own data-comp on whatever HTML they render.
+// JSX fragments (<>...</>) are skipped (can't carry attributes).
+// Existing data-comp attributes are left untouched.
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import ts from "typescript";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const SRC = join(__dirname, "..", "src");
+
+const SKIP_DIR_NAMES = new Set([
+  "__tests__",
+  "__test__",
+  "generated",
+  "node_modules",
+]);
+
+function walk(dir, out) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      if (SKIP_DIR_NAMES.has(entry)) continue;
+      walk(full, out);
+    } else if (st.isFile() && full.endsWith(".tsx")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const files = walk(SRC, []);
+
+let totalEdits = 0;
+let touchedFiles = 0;
+
+for (const file of files) {
+  const source = readFileSync(file, "utf8");
+  const sf = ts.createSourceFile(file, source, ts.ScriptTarget.ESNext, true, ts.ScriptKind.TSX);
+
+  /** @type {Array<{ pos: number; insert: string }>} */
+  const edits = [];
+
+  function addAttribute(jsxOpening, name, expr) {
+    for (const attr of jsxOpening.attributes.properties) {
+      if (ts.isJsxAttribute(attr) && attr.name && attr.name.getText(sf) === name) {
+        return false;
+      }
+    }
+    const pos = jsxOpening.tagName.getEnd();
+    edits.push({ pos, insert: ` ${name}="${expr}"` });
+    return true;
+  }
+
+  function isLowercaseTag(tagText) {
+    const c = tagText[0];
+    return c && c === c.toLowerCase() && c !== c.toUpperCase();
+  }
+
+  function findOutermostJsxOpening(returnedExpr) {
+    let e = returnedExpr;
+    while (e && ts.isParenthesizedExpression(e)) e = e.expression;
+    if (!e) return null;
+    if (ts.isJsxElement(e)) {
+      const tag = e.openingElement.tagName.getText(sf);
+      if (isLowercaseTag(tag)) return e.openingElement;
+      return null;
+    }
+    if (ts.isJsxSelfClosingElement(e)) {
+      const tag = e.tagName.getText(sf);
+      if (isLowercaseTag(tag)) return e;
+      return null;
+    }
+    return null;
+  }
+
+  function getReturnedJsx(fn) {
+    if (ts.isArrowFunction(fn) && !ts.isBlock(fn.body)) return fn.body;
+    if (!fn.body || !ts.isBlock(fn.body)) return null;
+    for (const stmt of fn.body.statements) {
+      if (ts.isReturnStatement(stmt) && stmt.expression) return stmt.expression;
+    }
+    return null;
+  }
+
+  function processComponent(name, fn) {
+    if (!/^[A-Z]/.test(name)) return;
+    const expr = getReturnedJsx(fn);
+    if (!expr) return;
+    const opening = findOutermostJsxOpening(expr);
+    if (!opening) return;
+    if (addAttribute(opening, "data-comp", name)) totalEdits++;
+  }
+
+  for (const stmt of sf.statements) {
+    if (ts.isFunctionDeclaration(stmt) && stmt.name) {
+      processComponent(stmt.name.text, stmt);
+    } else if (ts.isVariableStatement(stmt)) {
+      for (const decl of stmt.declarationList.declarations) {
+        if (
+          decl.name &&
+          ts.isIdentifier(decl.name) &&
+          decl.initializer &&
+          (ts.isArrowFunction(decl.initializer) || ts.isFunctionExpression(decl.initializer))
+        ) {
+          processComponent(decl.name.text, decl.initializer);
+        }
+      }
+    }
+  }
+
+  if (edits.length === 0) continue;
+
+  edits.sort((a, b) => b.pos - a.pos);
+  let out = source;
+  for (const { pos, insert } of edits) {
+    out = out.slice(0, pos) + insert + out.slice(pos);
+  }
+  writeFileSync(file, out);
+  touchedFiles++;
+}
+
+console.log(`added data-comp to ${totalEdits} components across ${touchedFiles} files`);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -76,7 +76,7 @@ function ThemeApplier({ children }: { children: React.ReactNode }) {
 // connection, so a heavy spinner would flash and feel worse than nothing.
 function RouteFallback() {
   return (
-    <div
+    <div data-comp="RouteFallback"
       data-testid="route-fallback"
       className="min-h-screen bg-surface-950"
       aria-hidden="true"

--- a/web/src/components/alphabet-bar.tsx
+++ b/web/src/components/alphabet-bar.tsx
@@ -44,7 +44,7 @@ export function AlphabetBar({
   const isVertical = orientation === "vertical";
 
   return (
-    <nav
+    <nav data-comp="AlphabetBar"
       aria-label="Alphabet quick-jump"
       className={cn(
         "flex gap-0.5",

--- a/web/src/components/app-layout.tsx
+++ b/web/src/components/app-layout.tsx
@@ -171,7 +171,7 @@ export function AppLayout() {
   ];
 
   return (
-    <div className="min-h-screen">
+    <div data-comp="AppLayout" className="min-h-screen">
       {/* Mobile header bar — visible below lg */}
       <header className="fixed top-0 left-0 right-0 z-30 flex items-center gap-3 h-14 px-4 bg-surface-950 border-b border-surface-800/50 lg:hidden">
         <button

--- a/web/src/components/auth-form-layout.tsx
+++ b/web/src/components/auth-form-layout.tsx
@@ -16,7 +16,7 @@ export function AuthFormLayout({
   footer,
 }: AuthFormLayoutProps) {
   return (
-    <div className="min-h-screen flex items-center justify-center px-4">
+    <div data-comp="AuthFormLayout" className="min-h-screen flex items-center justify-center px-4">
       {/* Background gradient */}
       <div className="fixed inset-0 bg-gradient-to-br from-brand-950/40 via-surface-950 to-surface-950" />
 

--- a/web/src/components/console-hero-banner.tsx
+++ b/web/src/components/console-hero-banner.tsx
@@ -22,7 +22,7 @@ export function ConsoleHeroBanner({
   const Icon = style.icon;
 
   return (
-    <div
+    <div data-comp="ConsoleHeroBanner"
       className={cn(
         "relative overflow-hidden rounded-2xl border border-white/[0.06]",
         "bg-gradient-to-br",

--- a/web/src/components/game-grid.tsx
+++ b/web/src/components/game-grid.tsx
@@ -4,5 +4,5 @@ export const GAME_GRID_CLASSES =
   "grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-5";
 
 export function GameGrid({ children }: { children: ReactNode }) {
-  return <div className={GAME_GRID_CLASSES}>{children}</div>;
+  return <div data-comp="GameGrid" className={GAME_GRID_CLASSES}>{children}</div>;
 }

--- a/web/src/components/game-picker.tsx
+++ b/web/src/components/game-picker.tsx
@@ -31,7 +31,7 @@ export function GamePicker({
   const showResults = gameSearch.length > 0 && !selectedGame;
 
   return (
-    <div className="space-y-1.5">
+    <div data-comp="GamePicker" className="space-y-1.5">
       <label className="block text-sm font-medium text-surface-300">
         Game
       </label>

--- a/web/src/components/invite-modal.tsx
+++ b/web/src/components/invite-modal.tsx
@@ -29,7 +29,7 @@ function UserAvatar({ user }: { user: UserSearchResult }) {
     );
   }
   return (
-    <div className="h-8 w-8 rounded-full bg-surface-600 flex items-center justify-center text-xs font-medium text-surface-300">
+    <div data-comp="UserAvatar" className="h-8 w-8 rounded-full bg-surface-600 flex items-center justify-center text-xs font-medium text-surface-300">
       {user.username[0]?.toUpperCase()}
     </div>
   );

--- a/web/src/components/library-layout.tsx
+++ b/web/src/components/library-layout.tsx
@@ -4,7 +4,7 @@ import { TabNav, TabItem } from "@/components/ui";
 
 export function LibraryLayout() {
   return (
-    <div>
+    <div data-comp="LibraryLayout">
       <TabNav className="mb-6">
         <TabItem to="/consoles" icon={Gamepad2} label="Consoles" />
         <TabItem to="/games" icon={Library} label="Games" />

--- a/web/src/components/meta-item.tsx
+++ b/web/src/components/meta-item.tsx
@@ -10,7 +10,7 @@ interface MetaItemProps {
 
 export function MetaItem({ icon: Icon, label, value, href }: MetaItemProps) {
   return (
-    <div className="flex items-start gap-2.5 text-sm">
+    <div data-comp="MetaItem" className="flex items-start gap-2.5 text-sm">
       <Icon className="h-4 w-4 text-surface-500 flex-shrink-0 mt-0.5" />
       <div className="flex flex-col">
         <span className="text-surface-500">{label}</span>

--- a/web/src/components/pagination.tsx
+++ b/web/src/components/pagination.tsx
@@ -57,7 +57,7 @@ export function Pagination({
   const pages = getPageNumbers(currentPage, pageCount);
 
   return (
-    <nav className="flex justify-center items-center gap-1.5 pt-4" aria-label="Pagination" data-testid="pagination">
+    <nav data-comp="Pagination" className="flex justify-center items-center gap-1.5 pt-4" aria-label="Pagination" data-testid="pagination">
       {/* Previous button */}
       <button
         onClick={() => onPageChange(currentPage - 1)}

--- a/web/src/components/play-heatmap.tsx
+++ b/web/src/components/play-heatmap.tsx
@@ -173,7 +173,7 @@ export function PlayHeatmap({ data, className }: PlayHeatmapProps) {
   const svgHeight = TOP_MARGIN + DAYS * (CELL_SIZE + CELL_GAP);
 
   return (
-    <div className={cn("relative", className)}>
+    <div data-comp="PlayHeatmap" className={cn("relative", className)}>
       <div className="overflow-x-auto">
         <svg
           width={svgWidth}

--- a/web/src/components/play-info.tsx
+++ b/web/src/components/play-info.tsx
@@ -14,7 +14,7 @@ export function PlayInfo({ gameId, className }: PlayInfoProps) {
   if (!entry) return null;
 
   return (
-    <span
+    <span data-comp="PlayInfo"
       className={`inline-flex items-center gap-3 text-xs text-surface-500 ${className ?? ""}`}
     >
       {entry.playTime > 0 && (

--- a/web/src/components/player-avatar.tsx
+++ b/web/src/components/player-avatar.tsx
@@ -29,7 +29,7 @@ export function PlayerAvatar({
   }
 
   return (
-    <div
+    <div data-comp="PlayerAvatar"
       className={`${classes} rounded-full bg-gradient-to-br from-brand-500 to-brand-700 flex items-center justify-center font-bold text-white`}
     >
       {username.charAt(0).toUpperCase()}

--- a/web/src/components/shader-preview-modal.tsx
+++ b/web/src/components/shader-preview-modal.tsx
@@ -37,7 +37,7 @@ export function ShaderPreviewModal({
   if (!open) return null;
 
   return (
-    <div
+    <div data-comp="ShaderPreviewModal"
       className="fixed inset-0 z-50 flex flex-col items-center justify-center"
       onClick={onClose}
     >

--- a/web/src/components/shader-preview.tsx
+++ b/web/src/components/shader-preview.tsx
@@ -144,7 +144,7 @@ export function ShaderPreview({
   }, []);
 
   return (
-    <div
+    <div data-comp="ShaderPreview"
       ref={containerRef}
       className={cn("relative", onClick && "cursor-pointer", className)}
       onClick={onClick}

--- a/web/src/components/ui/card.tsx
+++ b/web/src/components/ui/card.tsx
@@ -7,7 +7,7 @@ interface CardProps extends HTMLAttributes<HTMLDivElement> {
 
 export function Card({ className, hover, children, ...props }: CardProps) {
   return (
-    <div
+    <div data-comp="Card"
       className={cn(
         "rounded-2xl bg-surface-900/50 border border-surface-800/50 overflow-hidden",
         hover &&
@@ -27,7 +27,7 @@ export function CardHeader({
   ...props
 }: HTMLAttributes<HTMLDivElement>) {
   return (
-    <div className={cn("px-5 pt-5 pb-2", className)} {...props}>
+    <div data-comp="CardHeader" className={cn("px-5 pt-5 pb-2", className)} {...props}>
       {children}
     </div>
   );
@@ -39,7 +39,7 @@ export function CardContent({
   ...props
 }: HTMLAttributes<HTMLDivElement>) {
   return (
-    <div className={cn("px-5 pb-5", className)} {...props}>
+    <div data-comp="CardContent" className={cn("px-5 pb-5", className)} {...props}>
       {children}
     </div>
   );

--- a/web/src/components/ui/chip.tsx
+++ b/web/src/components/ui/chip.tsx
@@ -14,7 +14,7 @@ export interface ChipProps
 
 export function Chip({ selected, className, children, ...rest }: ChipProps) {
   return (
-    <button
+    <button data-comp="Chip"
       aria-pressed={selected}
       className={cn(
         "px-2.5 py-1 rounded-full text-xs font-medium transition-colors",
@@ -64,7 +64,7 @@ export function ChipPicker({
   const hasOverflow = options.length > initiallyVisible;
 
   return (
-    <div data-testid={testId}>
+    <div data-comp="ChipPicker" data-testid={testId}>
       <span
         id={labelId}
         className="block text-sm font-medium text-surface-300 mb-2"

--- a/web/src/components/ui/leaderboard-skeleton.tsx
+++ b/web/src/components/ui/leaderboard-skeleton.tsx
@@ -2,7 +2,7 @@ import { Skeleton } from "@/components/ui";
 
 export function LeaderboardSkeleton() {
   return (
-    <div className="space-y-2">
+    <div data-comp="LeaderboardSkeleton" className="space-y-2">
       {Array.from({ length: 5 }, (_, i) => (
         <div
           key={i}

--- a/web/src/components/ui/modal.tsx
+++ b/web/src/components/ui/modal.tsx
@@ -51,7 +51,7 @@ export function Modal({
   if (!open) return null;
 
   return (
-    <div
+    <div data-comp="Modal"
       ref={overlayRef}
       className="fixed inset-0 z-50 flex items-center justify-center p-4"
       onClick={(e) => {

--- a/web/src/components/ui/sidebar.tsx
+++ b/web/src/components/ui/sidebar.tsx
@@ -56,7 +56,7 @@ interface SidebarSectionProps {
 
 function SidebarSection({ title, children }: SidebarSectionProps) {
   return (
-    <div className="space-y-1">
+    <div data-comp="SidebarSection" className="space-y-1">
       {title && (
         <p className="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-surface-500">
           {title}

--- a/web/src/components/ui/skeleton.tsx
+++ b/web/src/components/ui/skeleton.tsx
@@ -7,7 +7,7 @@ interface SkeletonProps {
 
 export function Skeleton({ className, style }: SkeletonProps) {
   return (
-    <div
+    <div data-comp="Skeleton"
       className={cn("animate-pulse rounded-lg bg-surface-800/60", className)}
       style={style}
     />
@@ -22,7 +22,7 @@ export function GameCardSkeleton({
   coverHeight?: number;
 }) {
   return (
-    <div className={`space-y-3${coverHeight ? " flex-shrink-0" : ""}`}>
+    <div data-comp="GameCardSkeleton" className={`space-y-3${coverHeight ? " flex-shrink-0" : ""}`}>
       <Skeleton
         className="rounded-2xl"
         style={coverHeight ? { height: coverHeight, aspectRatio: aspectRatio ?? 3 / 4 } : { aspectRatio: aspectRatio ?? 3 / 4, width: "100%" }}
@@ -37,7 +37,7 @@ export function GameCardSkeleton({
 
 export function ConsoleCardSkeleton() {
   return (
-    <div className="space-y-3">
+    <div data-comp="ConsoleCardSkeleton" className="space-y-3">
       <Skeleton className="aspect-[16/10] w-full rounded-2xl" />
       <div className="space-y-2 px-1">
         <Skeleton className="h-5 w-2/3" />
@@ -53,7 +53,7 @@ export function GameDetailSkeleton({
   aspectRatio?: number;
 }) {
   return (
-    <div className="space-y-8">
+    <div data-comp="GameDetailSkeleton" className="space-y-8">
       <div className="flex flex-col items-center gap-6 md:flex-row md:items-start md:gap-8">
         <Skeleton
           className="w-48 md:w-64 rounded-2xl flex-shrink-0"
@@ -76,7 +76,7 @@ export function GameDetailSkeleton({
 
 export function GameListRowSkeleton() {
   return (
-    <div className="flex items-center gap-4 px-4 py-3 rounded-xl">
+    <div data-comp="GameListRowSkeleton" className="flex items-center gap-4 px-4 py-3 rounded-xl">
       <Skeleton className="h-12 w-9 rounded-lg flex-shrink-0" />
       <div className="flex-1 min-w-0 space-y-2">
         <Skeleton className="h-4 w-2/5" />
@@ -95,7 +95,7 @@ export function GameListRowSkeleton() {
 // resolved to real rows.
 export function TableRowSkeleton({ columns = 5 }: { columns?: number }) {
   return (
-    <tr>
+    <tr data-comp="TableRowSkeleton">
       {Array.from({ length: columns }, (_, i) => (
         <td key={i} className="px-5 py-3">
           <Skeleton className="h-4 w-full" />

--- a/web/src/features/admin/components/edit-user-modal.tsx
+++ b/web/src/features/admin/components/edit-user-modal.tsx
@@ -71,7 +71,7 @@ function EditUserForm({
   }
 
   return (
-    <div className="space-y-4">
+    <div data-comp="EditUserForm" className="space-y-4">
       <Input
         label="Email"
         type="email"

--- a/web/src/features/admin/components/igdb-warning-banner.tsx
+++ b/web/src/features/admin/components/igdb-warning-banner.tsx
@@ -12,7 +12,7 @@ export function IgdbWarningBanner({
   onDismiss,
 }: IgdbWarningBannerProps) {
   return (
-    <div
+    <div data-comp="IgdbWarningBanner"
       className="rounded-xl bg-warning-500/10 border border-warning-500/30 px-4 py-3 flex items-start gap-3"
       role="alert"
       data-testid="igdb-warning-banner"

--- a/web/src/features/admin/components/progress-bar.tsx
+++ b/web/src/features/admin/components/progress-bar.tsx
@@ -5,7 +5,7 @@
 export function ProgressBar({ value, max }: { value: number; max: number }) {
   const pct = max > 0 ? Math.round((value / max) * 100) : 0;
   return (
-    <div className="h-2 w-full rounded-full bg-surface-700">
+    <div data-comp="ProgressBar" className="h-2 w-full rounded-full bg-surface-700">
       <div
         className="h-2 rounded-full bg-brand-500 transition-all duration-300 ease-out"
         style={{ width: `${pct}%` }}

--- a/web/src/features/admin/components/scrape-status-card.tsx
+++ b/web/src/features/admin/components/scrape-status-card.tsx
@@ -42,7 +42,7 @@ function SourceSection({
   isPending,
 }: SourceSectionProps) {
   return (
-    <div className="space-y-2">
+    <div data-comp="SourceSection" className="space-y-2">
       <h3 className="text-sm font-semibold text-surface-200">
         {sourceLabel(counts.source)}
       </h3>

--- a/web/src/features/admin/components/system-event-detail-modal.tsx
+++ b/web/src/features/admin/components/system-event-detail-modal.tsx
@@ -122,7 +122,7 @@ export function SystemEventDetailModal({
 }
 
 function DetailGrid({ children }: { children: React.ReactNode }) {
-  return <dl className="grid grid-cols-1 gap-3 sm:grid-cols-2">{children}</dl>;
+  return <dl data-comp="DetailGrid" className="grid grid-cols-1 gap-3 sm:grid-cols-2">{children}</dl>;
 }
 
 interface DetailRowProps {
@@ -134,7 +134,7 @@ interface DetailRowProps {
 
 function DetailRow({ label, value, mono, secondary }: DetailRowProps) {
   return (
-    <div>
+    <div data-comp="DetailRow">
       <dt className="text-xs font-medium uppercase tracking-wider text-surface-500">
         {label}
       </dt>

--- a/web/src/features/admin/components/system-events-filters.tsx
+++ b/web/src/features/admin/components/system-events-filters.tsx
@@ -81,7 +81,7 @@ export function SystemEventsFilters({
     since !== DEFAULT_SYSTEM_EVENTS_SINCE;
 
   return (
-    <div className="space-y-4 rounded-2xl border border-surface-800/50 bg-surface-900/50 p-5">
+    <div data-comp="SystemEventsFilters" className="space-y-4 rounded-2xl border border-surface-800/50 bg-surface-900/50 p-5">
       <div className="flex items-center justify-between">
         <h2 className="text-sm font-semibold uppercase tracking-wider text-surface-400">
           Filters

--- a/web/src/features/admin/components/user-stats-grid.tsx
+++ b/web/src/features/admin/components/user-stats-grid.tsx
@@ -21,7 +21,7 @@ export function UserStatsGrid({ stats }: UserStatsGridProps) {
   ];
 
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+    <div data-comp="UserStatsGrid" className="grid grid-cols-2 md:grid-cols-4 gap-4">
       {items.map(({ icon: Icon, value, label }) => (
         <Section key={label}>
           <div className="px-5 pb-5 flex items-center gap-3 py-4">

--- a/web/src/features/bios/components/bios-upload-results.tsx
+++ b/web/src/features/bios/components/bios-upload-results.tsx
@@ -64,7 +64,7 @@ function UploadResultItem({ item }: { item: UploadResult }) {
   }
 
   return (
-    <div className="flex items-start gap-2.5 text-sm">
+    <div data-comp="UploadResultItem" className="flex items-start gap-2.5 text-sm">
       <HelpCircle className="h-4 w-4 text-surface-400 mt-0.5 flex-shrink-0" />
       <div>
         <span className="text-surface-200 font-mono text-xs">
@@ -86,7 +86,7 @@ export function BiosUploadResults({ results }: BiosUploadResultsProps) {
   if (results.length === 0) return null;
 
   return (
-    <div
+    <div data-comp="BiosUploadResults"
       className="rounded-xl bg-surface-800/50 p-4 space-y-3"
       data-testid="bios-upload-results"
     >

--- a/web/src/features/bios/components/bios-warning-banner.tsx
+++ b/web/src/features/bios/components/bios-warning-banner.tsx
@@ -16,7 +16,7 @@ export function BiosWarningBanner({
   missingFiles,
 }: BiosWarningBannerProps) {
   return (
-    <div
+    <div data-comp="BiosWarningBanner"
       className="rounded-xl bg-warning-500/10 border border-warning-500/30 px-4 py-3 flex items-start gap-3"
       role="alert"
       data-testid="bios-warning-banner"

--- a/web/src/features/challenges/components/challenge-leaderboard.tsx
+++ b/web/src/features/challenges/components/challenge-leaderboard.tsx
@@ -32,7 +32,7 @@ export function ChallengeLeaderboard({
   }
 
   return (
-    <section data-testid="challenge-leaderboard">
+    <section data-comp="ChallengeLeaderboard" data-testid="challenge-leaderboard">
       <h2 className="text-xl font-bold text-surface-100 flex items-center gap-2.5 mb-5">
         <Trophy className="h-5 w-5 text-brand-400" />
         Leaderboard

--- a/web/src/features/challenges/components/game-challenges.tsx
+++ b/web/src/features/challenges/components/game-challenges.tsx
@@ -13,7 +13,7 @@ interface GameChallengesProps {
 
 function ChallengesSkeleton() {
   return (
-    <div className="space-y-2">
+    <div data-comp="ChallengesSkeleton" className="space-y-2">
       {Array.from({ length: 3 }, (_, i) => (
         <div
           key={i}
@@ -35,7 +35,7 @@ export function GameChallenges({ gameId }: GameChallengesProps) {
   const { data, isLoading } = useGameChallenges(gameId);
 
   return (
-    <section data-testid="game-challenges">
+    <section data-comp="GameChallenges" data-testid="game-challenges">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2.5">
           <Flag className="h-5 w-5 text-brand-400" />

--- a/web/src/features/challenges/components/rank-badge.tsx
+++ b/web/src/features/challenges/components/rank-badge.tsx
@@ -43,7 +43,7 @@ export function RankBadge({ rank }: RankBadgeProps) {
   }
 
   return (
-    <span
+    <span data-comp="RankBadge"
       data-testid={`rank-badge-${rank}`}
       className="inline-flex items-center justify-center h-7 w-7 text-sm font-medium text-surface-500 flex-shrink-0"
     >

--- a/web/src/features/dashboard/components/top-rated-row.tsx
+++ b/web/src/features/dashboard/components/top-rated-row.tsx
@@ -9,7 +9,7 @@ import { TopRatedGameCard } from "./top-rated-game-card";
 
 function TopRatedSkeletonContent() {
   return (
-    <div className="flex gap-4 overflow-hidden">
+    <div data-comp="TopRatedSkeletonContent" className="flex gap-4 overflow-hidden">
       {Array.from({ length: 6 }, (_, i) => (
         <GameCardSkeleton key={i} coverHeight={CAROUSEL_CARD_HEIGHT} />
       ))}

--- a/web/src/features/explore/components/artwork-showcase.tsx
+++ b/web/src/features/explore/components/artwork-showcase.tsx
@@ -10,7 +10,7 @@ interface ArtworkShowcaseProps {
 
 function ArtworkSkeletonContent() {
   return (
-    <div className="flex gap-5 overflow-hidden">
+    <div data-comp="ArtworkSkeletonContent" className="flex gap-5 overflow-hidden">
       {Array.from({ length: 4 }, (_, i) => (
         <div key={i} className="w-80 sm:w-96 flex-shrink-0">
           <Skeleton className="w-full rounded-xl" style={{ aspectRatio: "16/9" }} />

--- a/web/src/features/explore/components/at-a-glance-row.tsx
+++ b/web/src/features/explore/components/at-a-glance-row.tsx
@@ -25,7 +25,7 @@ interface StatPillProps {
 
 function StatPill({ icon, label, value, testId }: StatPillProps) {
   return (
-    <div
+    <div data-comp="StatPill"
       className="flex items-center gap-2.5 rounded-xl border border-white/[0.06] bg-surface-900/60 px-4 py-2.5"
       data-testid={testId}
     >
@@ -103,7 +103,7 @@ export function AtAGlanceRow({
   if (pills.length === 0) return null;
 
   return (
-    <section data-testid="at-a-glance-row">
+    <section data-comp="AtAGlanceRow" data-testid="at-a-glance-row">
       <div className="flex flex-wrap gap-3">
         {pills.map((pill) => (
           <StatPill key={pill.testId} {...pill} />

--- a/web/src/features/explore/components/company-info-section.tsx
+++ b/web/src/features/explore/components/company-info-section.tsx
@@ -18,7 +18,7 @@ export function CompanyInfoSection({ companyInfo }: CompanyInfoSectionProps) {
   }
 
   return (
-    <section data-testid="company-info-section" className="space-y-3">
+    <section data-comp="CompanyInfoSection" data-testid="company-info-section" className="space-y-3">
       {/* Description */}
       {hasDescription && (
         <div data-testid="company-description">

--- a/web/src/features/explore/components/completionist-map.tsx
+++ b/web/src/features/explore/components/completionist-map.tsx
@@ -29,7 +29,7 @@ export function CompletionistMapSection({
   if (!data || (data.consoles ?? []).length === 0) return null;
 
   return (
-    <section data-testid="completionist-map">
+    <section data-comp="CompletionistMapSection" data-testid="completionist-map">
       <div className="flex items-center gap-2.5 mb-5">
         <Map className="h-5 w-5 text-brand-400" />
         <h2 className="text-xl font-bold text-surface-100">

--- a/web/src/features/explore/components/console-quick-jump.tsx
+++ b/web/src/features/explore/components/console-quick-jump.tsx
@@ -11,7 +11,7 @@ interface ConsoleQuickJumpProps {
 
 function ConsoleQuickJumpSkeleton() {
   return (
-    <section data-testid="console-quick-jump-skeleton">
+    <section data-comp="ConsoleQuickJumpSkeleton" data-testid="console-quick-jump-skeleton">
       <h2 className="text-xl font-bold text-surface-100 mb-5">
         Browse by Console
       </h2>
@@ -71,7 +71,7 @@ export function ConsoleQuickJump({
   }
 
   return (
-    <section
+    <section data-comp="ConsoleQuickJump"
       data-testid="console-quick-jump"
       className="group/console-jump relative"
     >

--- a/web/src/features/explore/components/console-showcase-sections.tsx
+++ b/web/src/features/explore/components/console-showcase-sections.tsx
@@ -29,7 +29,7 @@ export function ConsoleRecentlyPlayed({
   if (!showcase || (showcase.recentlyPlayed ?? []).length === 0) return null;
 
   return (
-    <div data-testid="recently-played-section">
+    <div data-comp="ConsoleRecentlyPlayed" data-testid="recently-played-section">
       <GameShelf
         title="Continue Playing"
         icon={Play}
@@ -113,7 +113,7 @@ export function ConsoleTopDevelopers({
   const colorTheme = showcase.console.colorTheme || "#6366f1";
 
   return (
-    <div data-testid="top-developers" aria-labelledby="top-developers-heading">
+    <div data-comp="ConsoleTopDevelopers" data-testid="top-developers" aria-labelledby="top-developers-heading">
       <TitledSection
         title="Studios That Defined This Console"
         icon={Building2}

--- a/web/src/features/explore/components/developer-hero-banner.tsx
+++ b/web/src/features/explore/components/developer-hero-banner.tsx
@@ -51,7 +51,7 @@ export function DeveloperHeroBanner({
   };
 
   return (
-    <div
+    <div data-comp="DeveloperHeroBanner"
       className="relative w-full rounded-2xl overflow-hidden"
       data-testid="developer-hero-banner"
     >

--- a/web/src/features/explore/components/developer-spotlight.tsx
+++ b/web/src/features/explore/components/developer-spotlight.tsx
@@ -15,7 +15,7 @@ interface DeveloperSpotlightProps {
 
 function DeveloperSpotlightSkeleton() {
   return (
-    <section data-testid="developer-spotlight-skeleton">
+    <section data-comp="DeveloperSpotlightSkeleton" data-testid="developer-spotlight-skeleton">
       <Skeleton className="w-full h-64 rounded-2xl" />
     </section>
   );
@@ -70,7 +70,7 @@ export function DeveloperSpotlight({
   }
 
   return (
-    <section
+    <section data-comp="DeveloperSpotlight"
       data-testid="developer-spotlight"
       className="group/spotlight relative"
     >

--- a/web/src/features/explore/components/developer-stats-card.tsx
+++ b/web/src/features/explore/components/developer-stats-card.tsx
@@ -13,7 +13,7 @@ export function DeveloperStatsCard({
   totalGames,
 }: DeveloperStatsCardProps) {
   return (
-    <section data-testid="developer-user-stats">
+    <section data-comp="DeveloperStatsCard" data-testid="developer-user-stats">
       <h2 className="text-xl font-bold text-surface-100 mb-4">Your Stats</h2>
       <div className="rounded-xl border border-white/[0.06] bg-surface-900/50 p-5">
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-4">

--- a/web/src/features/explore/components/explorer-badges.tsx
+++ b/web/src/features/explore/components/explorer-badges.tsx
@@ -44,7 +44,7 @@ export function ExplorerBadgesSection({
   if (!badges || badges.length === 0) return null;
 
   return (
-    <section data-testid="explorer-badges">
+    <section data-comp="ExplorerBadgesSection" data-testid="explorer-badges">
       <div className="flex items-center gap-2.5 mb-5">
         <Medal className="h-5 w-5 text-brand-400" />
         <h2 className="text-xl font-bold text-surface-100">Explorer Badges</h2>

--- a/web/src/features/explore/components/for-you-section.tsx
+++ b/web/src/features/explore/components/for-you-section.tsx
@@ -14,7 +14,7 @@ interface ForYouSectionProps {
 
 function ForYouSkeleton() {
   return (
-    <div data-testid="for-you-skeleton" className="space-y-10">
+    <div data-comp="ForYouSkeleton" data-testid="for-you-skeleton" className="space-y-10">
       {Array.from({ length: 3 }, (_, i) => (
         <section key={i}>
           <div className="h-7 w-64 rounded bg-surface-800 animate-pulse mb-5" />
@@ -81,7 +81,7 @@ function ForYouShelf({
   const testId = `for-you-row-${row.type}`;
 
   return (
-    <section data-testid={testId} className="group/shelf relative">
+    <section data-comp="ForYouShelf" data-testid={testId} className="group/shelf relative">
       <div className="flex items-center gap-3 mb-5">
         {/* Show source game thumbnail for "because_you_played" rows */}
         {row.type === "because_you_played" && row.sourceGame?.coverUrl && (
@@ -167,7 +167,7 @@ export function ForYouSection({
   }
 
   return (
-    <div data-testid="for-you-section" className="space-y-10">
+    <div data-comp="ForYouSection" data-testid="for-you-section" className="space-y-10">
       {rows.map((row, index) => (
         <ForYouShelf
           key={`${row.type}-${index}`}

--- a/web/src/features/explore/components/hero-carousel.tsx
+++ b/web/src/features/explore/components/hero-carousel.tsx
@@ -15,7 +15,7 @@ interface HeroCarouselProps {
 
 function HeroCarouselSkeleton() {
   return (
-    <div
+    <div data-comp="HeroCarouselSkeleton"
       className="relative w-full overflow-hidden rounded-2xl"
       data-testid="hero-carousel-skeleton"
     >
@@ -34,7 +34,7 @@ function NavigationDots({
   onSelect: (index: number) => void;
 }) {
   return (
-    <div
+    <div data-comp="NavigationDots"
       className="absolute bottom-4 left-1/2 -translate-x-1/2 flex items-center gap-2 z-10"
       role="tablist"
       aria-label="Carousel navigation"
@@ -68,7 +68,7 @@ function HeroSlide({
   const [imageError, setImageError] = useState(false);
 
   return (
-    <div
+    <div data-comp="HeroSlide"
       className={cn(
         "absolute inset-0 transition-opacity duration-700 ease-in-out",
         isActive ? "opacity-100 z-[1]" : "opacity-0 z-0",
@@ -218,7 +218,7 @@ export function HeroCarousel({ games, isLoading }: HeroCarouselProps) {
   }
 
   return (
-    <div
+    <div data-comp="HeroCarousel"
       ref={containerRef}
       className="relative w-full overflow-hidden rounded-2xl group aspect-[21/9]"
       onMouseEnter={() => setIsPaused(true)}

--- a/web/src/features/explore/components/keyword-chips.tsx
+++ b/web/src/features/explore/components/keyword-chips.tsx
@@ -11,7 +11,7 @@ interface KeywordChipsProps {
 
 function KeywordChipsSkeleton() {
   return (
-    <section data-testid="keyword-chips-skeleton">
+    <section data-comp="KeywordChipsSkeleton" data-testid="keyword-chips-skeleton">
       <h2 className="text-xl font-bold text-surface-100 mb-5">
         Popular Keywords
       </h2>
@@ -72,7 +72,7 @@ export function KeywordChips({ keywords, isLoading }: KeywordChipsProps) {
   }
 
   return (
-    <section data-testid="keyword-chips" className="group/keywords relative">
+    <section data-comp="KeywordChips" data-testid="keyword-chips" className="group/keywords relative">
       <h2 className="text-xl font-bold text-surface-100 mb-5">
         Popular Keywords
       </h2>

--- a/web/src/features/explore/components/mood-picker.tsx
+++ b/web/src/features/explore/components/mood-picker.tsx
@@ -10,7 +10,7 @@ interface MoodPickerProps {
 
 function MoodPickerSkeleton() {
   return (
-    <section data-testid="mood-picker-skeleton">
+    <section data-comp="MoodPickerSkeleton" data-testid="mood-picker-skeleton">
       <Skeleton className="w-72 h-7 mb-5" />
       <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
         {Array.from({ length: 6 }, (_, i) => (
@@ -31,7 +31,7 @@ export function MoodPicker({ moods, isLoading }: MoodPickerProps) {
   }
 
   return (
-    <section data-testid="mood-picker">
+    <section data-comp="MoodPicker" data-testid="mood-picker">
       <h2 className="text-xl font-bold text-surface-100 mb-5">
         What are you in the mood for?
       </h2>

--- a/web/src/features/explore/components/rating-distribution.tsx
+++ b/web/src/features/explore/components/rating-distribution.tsx
@@ -60,7 +60,7 @@ export function RatingDistribution({ distribution }: RatingDistributionProps) {
   const visibleBars = bars.filter((b) => b.count > 0);
 
   return (
-    <section data-testid="rating-distribution">
+    <section data-comp="RatingDistribution" data-testid="rating-distribution">
       <h2 className="text-lg font-bold text-surface-100 mb-4">
         Rating Distribution
       </h2>

--- a/web/src/features/explore/components/release-timeline.tsx
+++ b/web/src/features/explore/components/release-timeline.tsx
@@ -13,7 +13,7 @@ export function ReleaseTimeline({ timeline }: ReleaseTimelineProps) {
   const sorted = [...timeline].sort((a, b) => a.year - b.year);
 
   return (
-    <section data-testid="release-timeline">
+    <section data-comp="ReleaseTimeline" data-testid="release-timeline">
       <h2 className="text-lg font-bold text-surface-100 mb-4">
         Release Timeline
       </h2>
@@ -32,7 +32,7 @@ export function ReleaseTimeline({ timeline }: ReleaseTimelineProps) {
 
 function TimelineYearColumn({ entry }: { entry: TimelineEntry }) {
   return (
-    <div className="flex-shrink-0 min-w-[100px]" data-testid={`timeline-year-${entry.year}`}>
+    <div data-comp="TimelineYearColumn" className="flex-shrink-0 min-w-[100px]" data-testid={`timeline-year-${entry.year}`}>
       <p className="text-sm font-bold text-surface-200 mb-2">{entry.year}</p>
       <div className="flex flex-wrap gap-1.5" style={{ maxWidth: "120px" }}>
         {entry.games?.map((game) => (
@@ -51,7 +51,7 @@ function TimelineCover({
   const [showTooltip, setShowTooltip] = useState(false);
 
   return (
-    <div
+    <div data-comp="TimelineCover"
       className="relative"
       onMouseEnter={() => setShowTooltip(true)}
       onMouseLeave={() => setShowTooltip(false)}

--- a/web/src/features/explore/components/series-shelf.tsx
+++ b/web/src/features/explore/components/series-shelf.tsx
@@ -10,7 +10,7 @@ interface SeriesShelfProps {
 
 function SeriesSkeletonContent() {
   return (
-    <div className="flex gap-4 overflow-hidden">
+    <div data-comp="SeriesSkeletonContent" className="flex gap-4 overflow-hidden">
       {Array.from({ length: 5 }, (_, i) => (
         <Skeleton key={i} className="w-56 sm:w-60 lg:w-64 h-36 flex-shrink-0 rounded-2xl" />
       ))}

--- a/web/src/features/explore/components/social-shelves.tsx
+++ b/web/src/features/explore/components/social-shelves.tsx
@@ -44,7 +44,7 @@ function StandardShelfRow({
   onTogglePlayLater,
 }: StandardShelfRowProps) {
   return (
-    <div className="flex-shrink-0" role="listitem">
+    <div data-comp="StandardShelfRow" className="flex-shrink-0" role="listitem">
       <GameCard
         game={game}
         showConsoleBadge
@@ -59,7 +59,7 @@ function StandardShelfRow({
 
 function ShelfFooter({ children }: { children: React.ReactNode }) {
   return (
-    <div className="flex items-center gap-1.5 mt-1.5 text-xs text-surface-400">
+    <div data-comp="ShelfFooter" className="flex items-center gap-1.5 mt-1.5 text-xs text-surface-400">
       {children}
     </div>
   );
@@ -243,7 +243,7 @@ export function ReviewCard({
   onTogglePlayLater,
 }: ReviewCardProps) {
   return (
-    <div className="w-56 sm:w-60 flex-shrink-0" role="listitem">
+    <div data-comp="ReviewCard" className="w-56 sm:w-60 flex-shrink-0" role="listitem">
       <div className="flex gap-3">
         <div className="w-24 flex-shrink-0">
           <GameCard

--- a/web/src/features/explore/components/temporal-shelves.tsx
+++ b/web/src/features/explore/components/temporal-shelves.tsx
@@ -101,7 +101,7 @@ export function BestOfYearSection({
   if (!data?.games || data.games.length === 0) return null;
 
   return (
-    <section data-testid="best-of-year-section">
+    <section data-comp="BestOfYearSection" data-testid="best-of-year-section">
       <div className="flex items-center gap-2 mb-1">
         <Trophy className="h-5 w-5 text-brand-400" />
         <h2 className="text-xl font-bold text-surface-100">

--- a/web/src/features/explore/components/theme-grid.tsx
+++ b/web/src/features/explore/components/theme-grid.tsx
@@ -57,7 +57,7 @@ interface ThemeGridProps {
 
 function ThemeGridSkeleton() {
   return (
-    <section data-testid="theme-grid-skeleton">
+    <section data-comp="ThemeGridSkeleton" data-testid="theme-grid-skeleton">
       <h2 className="text-xl font-bold text-surface-100 mb-5">
         Browse by Theme
       </h2>
@@ -117,7 +117,7 @@ export function ThemeGrid({ themes, isLoading }: ThemeGridProps) {
   }
 
   return (
-    <section data-testid="theme-grid" className="group/themes relative">
+    <section data-comp="ThemeGrid" data-testid="theme-grid" className="group/themes relative">
       <h2 className="text-xl font-bold text-surface-100 mb-5">
         Browse by Theme
       </h2>

--- a/web/src/features/explore/components/wild-features.tsx
+++ b/web/src/features/explore/components/wild-features.tsx
@@ -37,7 +37,7 @@ function FeatureCard({
 }: FeatureCardProps) {
   const accent = accentClasses[colorAccent];
   return (
-    <div
+    <div data-comp="FeatureCard"
       data-testid={testId}
       className={cn(
         "flex items-start gap-4 rounded-xl border border-surface-800 bg-gradient-to-br p-6",
@@ -76,7 +76,7 @@ export function WildFeaturesSection() {
   }
 
   return (
-    <section data-testid="wild-features">
+    <section data-comp="WildFeaturesSection" data-testid="wild-features">
       <h2 className="text-xl font-bold text-surface-100 mb-5">
         Feeling Adventurous?
       </h2>
@@ -148,7 +148,7 @@ export function WildFeaturesSection() {
 
 export function WildFeaturesSkeleton() {
   return (
-    <section>
+    <section data-comp="WildFeaturesSkeleton">
       <Skeleton className="w-56 h-7 mb-5" />
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
         <Skeleton className="h-28 rounded-xl" />

--- a/web/src/features/game-detail/components/achievement-card.tsx
+++ b/web/src/features/game-detail/components/achievement-card.tsx
@@ -64,7 +64,7 @@ export function AchievementCard({
   const showRarityPercent = unlocked && rarity.tier !== "Common";
 
   return (
-    <div
+    <div data-comp="AchievementCard"
       className={cn(
         "flex items-start gap-3 rounded-lg border p-3",
         unlocked

--- a/web/src/features/game-detail/components/achievement-timeline.tsx
+++ b/web/src/features/game-detail/components/achievement-timeline.tsx
@@ -58,7 +58,7 @@ export function TimelineView({
   );
 
   return (
-    <div data-testid="timeline-view">
+    <div data-comp="TimelineView" data-testid="timeline-view">
       {/* Mini stat summary */}
       {timelineEntries.length > 0 && (
         <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
@@ -126,7 +126,7 @@ export function TimelineView({
 
 function TimelineEntryCard({ entry }: { entry: AchievementTimelineEntry }) {
   return (
-    <div className="relative flex items-start gap-3">
+    <div data-comp="TimelineEntryCard" className="relative flex items-start gap-3">
       {/* Node */}
       <div className="absolute -left-6 top-2 h-3 w-3 rounded-full bg-brand-400 border-2 border-surface-900" />
 
@@ -174,7 +174,7 @@ function TimelineEntryCard({ entry }: { entry: AchievementTimelineEntry }) {
 
 function LockedTimelineEntry({ achievement }: { achievement: Achievement }) {
   return (
-    <div className="relative flex items-start gap-3 opacity-40">
+    <div data-comp="LockedTimelineEntry" className="relative flex items-start gap-3 opacity-40">
       {/* Node */}
       <div className="absolute -left-6 top-2 h-3 w-3 rounded-full bg-surface-700 border-2 border-surface-900" />
 
@@ -208,7 +208,7 @@ function LockedTimelineEntry({ achievement }: { achievement: Achievement }) {
 
 function TimelineSkeleton() {
   return (
-    <div className="space-y-4" data-testid="timeline-skeleton">
+    <div data-comp="TimelineSkeleton" className="space-y-4" data-testid="timeline-skeleton">
       {Array.from({ length: 4 }, (_, i) => (
         <div key={i} className="flex items-start gap-3">
           <Skeleton className="h-3 w-3 rounded-full flex-shrink-0" />

--- a/web/src/features/game-detail/components/game-achievement-leaderboard.tsx
+++ b/web/src/features/game-detail/components/game-achievement-leaderboard.tsx
@@ -34,7 +34,7 @@ function RankBadge({ rank }: { rank: number }) {
   }
 
   return (
-    <span className="inline-flex items-center justify-center h-7 w-7 text-sm font-medium text-surface-500">
+    <span data-comp="RankBadge" className="inline-flex items-center justify-center h-7 w-7 text-sm font-medium text-surface-500">
       {rank}
     </span>
   );

--- a/web/src/features/game-detail/components/game-achievements.tsx
+++ b/web/src/features/game-detail/components/game-achievements.tsx
@@ -194,7 +194,7 @@ function ViewToggle({
   onChange: (mode: ViewMode) => void;
 }) {
   return (
-    <div
+    <div data-comp="ViewToggle"
       className="flex rounded-full bg-surface-800 p-0.5"
       data-testid="view-toggle"
     >

--- a/web/src/features/game-detail/components/game-community-stats.tsx
+++ b/web/src/features/game-detail/components/game-community-stats.tsx
@@ -14,7 +14,7 @@ interface GameCommunityStatsProps {
 
 function CommunityStatsSkeleton() {
   return (
-    <div className="space-y-5">
+    <div data-comp="CommunityStatsSkeleton" className="space-y-5">
       <div className="flex items-center gap-2.5">
         <Skeleton className="h-5 w-5" />
         <Skeleton className="h-6 w-32" />
@@ -80,7 +80,7 @@ export function GameCommunityStats({ gameId, game }: GameCommunityStatsProps) {
       : 1;
 
   return (
-    <section>
+    <section data-comp="GameCommunityStats">
       <h2 className="text-lg font-semibold text-surface-100 flex items-center gap-2.5 mb-5">
         <Activity className="h-5 w-5 text-brand-400" />
         Play Activity

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -168,7 +168,7 @@ export function GameHero({
   ];
 
   return (
-    <div className="relative">
+    <div className="relative" data-comp={"GameHero"}>
       {/* Hero banner background */}
       <div className="relative min-h-[320px] md:min-h-[400px] overflow-hidden">
         {heroImage ? (

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -359,7 +359,7 @@ function getRegionFlag(region: string): string | null {
 function RegionBadge({ region }: { region: string }) {
   const flag = getRegionFlag(region);
   return (
-    <span className="inline-flex items-center gap-1 rounded-md bg-black/30 backdrop-blur-sm px-2 py-0.5 text-xs font-medium text-white/80">
+    <span data-comp="RegionBadge" className="inline-flex items-center gap-1 rounded-md bg-black/30 backdrop-blur-sm px-2 py-0.5 text-xs font-medium text-white/80">
       {flag && <span>{flag}</span>}
       {region}
     </span>
@@ -373,7 +373,7 @@ function IgdbRatingStars({ rating }: { rating: number }) {
   const emptyStars = 5 - fullStars - (halfStar ? 1 : 0);
 
   return (
-    <div className="flex items-center gap-1.5">
+    <div data-comp="IgdbRatingStars" className="flex items-center gap-1.5">
       <div className="flex items-center">
         {Array.from({ length: fullStars }, (_, i) => (
           <Star

--- a/web/src/features/game-detail/components/game-reviews.tsx
+++ b/web/src/features/game-detail/components/game-reviews.tsx
@@ -8,7 +8,7 @@ import { useGameRatings } from "@/hooks/use-ratings";
 
 function ReviewsSkeleton() {
   return (
-    <div className="space-y-4">
+    <div data-comp="ReviewsSkeleton" className="space-y-4">
       {Array.from({ length: 3 }, (_, i) => (
         <div
           key={i}
@@ -38,7 +38,7 @@ export function GameReviews({ gameId }: GameReviewsProps) {
   const hasMore = data ? page * pageSize < data.total : false;
 
   return (
-    <div data-testid="game-reviews">
+    <div data-comp="GameReviews" data-testid="game-reviews">
       <div className="flex items-center gap-2.5 mb-4">
         <MessageSquare className="h-5 w-5 text-brand-400" />
         <h2 className="text-lg font-semibold text-surface-100">Reviews</h2>

--- a/web/src/features/game-detail/components/game-variants-section.tsx
+++ b/web/src/features/game-detail/components/game-variants-section.tsx
@@ -71,7 +71,7 @@ function CollapsibleVariantList({
   const panelId = `${testId}-panel`;
 
   return (
-    <div data-testid={testId}>
+    <div data-comp="CollapsibleVariantList" data-testid={testId}>
       <button
         onClick={() => setExpanded(!expanded)}
         className="flex items-center gap-2 w-full text-left group/toggle focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 rounded-md px-1 py-0.5 -mx-1 hover:bg-surface-800/30"
@@ -110,7 +110,7 @@ export function GameVariantsSection({ variants }: GameVariantsSectionProps) {
   if (versionVariants.length === 0 && hackVariants.length === 0) return null;
 
   return (
-    <section
+    <section data-comp="GameVariantsSection"
       className="space-y-4"
       data-testid="game-variants-section"
     >

--- a/web/src/features/game-detail/components/rating-summary.tsx
+++ b/web/src/features/game-detail/components/rating-summary.tsx
@@ -15,7 +15,7 @@ function DistributionBar({
   const percentage = maxCount > 0 ? (count / maxCount) * 100 : 0;
 
   return (
-    <div className="flex items-center gap-2">
+    <div data-comp="DistributionBar" className="flex items-center gap-2">
       <span className="text-xs text-surface-400 w-4 text-right">{star}</span>
       <Star className="h-3 w-3 text-amber-400 fill-amber-400 flex-shrink-0" />
       <div className="flex-1 h-2 rounded-full bg-surface-800 overflow-hidden">
@@ -31,7 +31,7 @@ function DistributionBar({
 
 function RatingSummarySkeleton() {
   return (
-    <div className="space-y-3">
+    <div data-comp="RatingSummarySkeleton" className="space-y-3">
       <div className="flex items-center gap-3">
         <Skeleton className="h-10 w-16" />
         <Skeleton className="h-5 w-28" />
@@ -87,7 +87,7 @@ export function RatingSummaryCard({ gameId }: RatingSummaryProps) {
   const maxCount = Math.max(...Object.values(summary.distribution));
 
   return (
-    <div data-testid="rating-summary">
+    <div data-comp="RatingSummaryCard" data-testid="rating-summary">
       <div className="flex items-center gap-2.5 mb-4">
         <Star className="h-5 w-5 text-brand-400" />
         <h2 className="text-lg font-semibold text-surface-100">Ratings</h2>

--- a/web/src/features/game-detail/components/replace-rom-modal.tsx
+++ b/web/src/features/game-detail/components/replace-rom-modal.tsx
@@ -227,7 +227,7 @@ function ResultView({
   onClose: () => void;
 }) {
   return (
-    <div className="space-y-4" data-testid="replace-result">
+    <div data-comp="ResultView" className="space-y-4" data-testid="replace-result">
       {result.verified ? (
         <div className="flex flex-col items-center gap-3 py-2">
           <CheckCircle2 className="h-12 w-12 text-success-500" />

--- a/web/src/features/game-detail/components/scrape-match-modal.tsx
+++ b/web/src/features/game-detail/components/scrape-match-modal.tsx
@@ -94,7 +94,7 @@ function ScrapeMatchContent({
     igdbStatus && igdbStatus.status !== "connected";
 
   return (
-    <div className="space-y-4">
+    <div data-comp="ScrapeMatchContent" className="space-y-4">
       {fileName && (
         <p className="text-sm text-surface-400 truncate" title={fileName}>
           ROM: <span className="text-surface-200 font-mono">{fileName}</span>
@@ -180,7 +180,7 @@ function IgdbResultItem({
   onSelect: () => void;
 }) {
   return (
-    <button
+    <button data-comp="IgdbResultItem"
       onClick={onSelect}
       disabled={isApplying || isCurrentMatch}
       data-testid={`igdb-result-${result.igdbId}`}

--- a/web/src/features/game-detail/components/screenshot-lightbox.tsx
+++ b/web/src/features/game-detail/components/screenshot-lightbox.tsx
@@ -58,7 +58,7 @@ export function ScreenshotLightbox({
   if (!open) return null;
 
   return (
-    <div
+    <div data-comp="ScreenshotLightbox"
       ref={dialogRef}
       role="dialog"
       aria-modal="true"

--- a/web/src/features/game-detail/components/shared-saves-list.tsx
+++ b/web/src/features/game-detail/components/shared-saves-list.tsx
@@ -14,7 +14,7 @@ import {
 
 function SharedSavesSkeleton() {
   return (
-    <div className="space-y-3">
+    <div data-comp="SharedSavesSkeleton" className="space-y-3">
       {Array.from({ length: 3 }, (_, i) => (
         <div
           key={i}
@@ -51,7 +51,7 @@ export function SharedSavesList({ gameId }: SharedSavesListProps) {
   const hasMore = data ? page * pageSize < data.total : false;
 
   return (
-    <section data-testid="shared-saves-list">
+    <section data-comp="SharedSavesList" data-testid="shared-saves-list">
       <div className="flex items-center gap-2.5 mb-4">
         <Share2 className="h-5 w-5 text-brand-400" />
         <h2 className="text-lg font-semibold text-surface-100">Community Saves</h2>

--- a/web/src/features/game-detail/components/star-rating.tsx
+++ b/web/src/features/game-detail/components/star-rating.tsx
@@ -27,7 +27,7 @@ export function StarRating({
   const interactive = !readonly && !!onChange;
 
   return (
-    <div
+    <div data-comp="StarRating"
       className="inline-flex items-center gap-0.5"
       onMouseLeave={() => interactive && setHovered(0)}
       data-testid="star-rating"

--- a/web/src/features/game-detail/components/user-rating.tsx
+++ b/web/src/features/game-detail/components/user-rating.tsx
@@ -43,7 +43,7 @@ export function UserRating({ gameId }: UserRatingProps) {
   };
 
   return (
-    <div className="rounded-xl bg-surface-800/30 p-4" data-testid="user-rating">
+    <div data-comp="UserRating" className="rounded-xl bg-surface-800/30 p-4" data-testid="user-rating">
       <div className="flex items-center gap-2.5 mb-3">
         <Star className="h-4 w-4 text-brand-400" />
         <h3 className="text-sm font-semibold text-surface-200">Your Rating</h3>

--- a/web/src/features/game-detail/components/verification-badge.tsx
+++ b/web/src/features/game-detail/components/verification-badge.tsx
@@ -94,7 +94,7 @@ export function VerificationBadge({ game, isAdmin }: VerificationBadgeProps) {
   const displayText = game.verificationTag || "Unverified";
 
   return (
-    <div className="relative">
+    <div data-comp="VerificationBadge" className="relative">
       <button
         type="button"
         onClick={() => setShowInfo(!showInfo)}

--- a/web/src/features/games/components/active-filter-pills.tsx
+++ b/web/src/features/games/components/active-filter-pills.tsx
@@ -206,7 +206,7 @@ export function ActiveFilterPills({
   };
 
   return (
-    <div className="flex flex-wrap items-center gap-2" data-testid="active-filter-pills">
+    <div data-comp="ActiveFilterPills" className="flex flex-wrap items-center gap-2" data-testid="active-filter-pills">
       {pills.map((pill) => (
         <button
           key={pill.key}

--- a/web/src/features/games/components/advanced-filter-panel.tsx
+++ b/web/src/features/games/components/advanced-filter-panel.tsx
@@ -43,7 +43,7 @@ function RangeInput({
   testId: string;
 }) {
   return (
-    <div data-testid={testId}>
+    <div data-comp="RangeInput" data-testid={testId}>
       <span className="block text-sm font-medium text-surface-300 mb-2">
         {label}
       </span>
@@ -90,7 +90,7 @@ function SavedSearchItem({
   onDelete: () => void;
 }) {
   return (
-    <div className="flex items-center gap-2 group" data-testid="saved-search-item">
+    <div data-comp="SavedSearchItem" className="flex items-center gap-2 group" data-testid="saved-search-item">
       <button
         onClick={onApply}
         className="flex-1 text-left px-3 py-2 rounded-lg bg-surface-800 hover:bg-surface-700 text-sm text-surface-200 transition-colors truncate"
@@ -181,7 +181,7 @@ export function AdvancedFilterPanel({
   };
 
   return (
-    <div data-testid="advanced-filter-panel">
+    <div data-comp="AdvancedFilterPanel" data-testid="advanced-filter-panel">
       {/* Toggle button */}
       <button
         onClick={onToggle}

--- a/web/src/features/games/components/best-versions-button.tsx
+++ b/web/src/features/games/components/best-versions-button.tsx
@@ -39,7 +39,7 @@ export function BestVersionsButton({
   };
 
   return (
-    <button
+    <button data-comp="BestVersionsButton"
       onClick={handleClick}
       className={cn(
         "inline-flex items-center gap-1.5 rounded-lg border px-3 py-2.5 text-sm font-medium transition-all",

--- a/web/src/features/games/components/games-filter-bar.tsx
+++ b/web/src/features/games/components/games-filter-bar.tsx
@@ -42,7 +42,7 @@ export function GamesFilterBar({
   ];
 
   return (
-    <div className="flex flex-wrap items-center gap-3">
+    <div data-comp="GamesFilterBar" className="flex flex-wrap items-center gap-3">
       <div className="flex-1 min-w-[240px] max-w-md">
         <SearchInput
           placeholder="Search games..."

--- a/web/src/features/netplay/components/netplay-invitations-section.tsx
+++ b/web/src/features/netplay/components/netplay-invitations-section.tsx
@@ -5,7 +5,7 @@ import { NetplayInviteCard } from "@/features/netplay/components/netplay-invite-
 
 function InvitationsSkeleton() {
   return (
-    <div className="space-y-3">
+    <div data-comp="InvitationsSkeleton" className="space-y-3">
       {Array.from({ length: 2 }, (_, i) => (
         <div
           key={i}
@@ -50,7 +50,7 @@ export function NetplayInvitationsSection() {
   }
 
   return (
-    <section>
+    <section data-comp="NetplayInvitationsSection">
       <div className="flex items-center gap-2.5 mb-4">
         <Mail className="h-5 w-5 text-brand-400" />
         <h2 className="text-xl font-bold text-surface-100">Invitations</h2>

--- a/web/src/features/netplay/components/netplay-invite-card.tsx
+++ b/web/src/features/netplay/components/netplay-invite-card.tsx
@@ -44,7 +44,7 @@ export function NetplayInviteCard({ invite }: NetplayInviteCardProps) {
   }
 
   return (
-    <div
+    <div data-comp="NetplayInviteCard"
       className="flex items-center gap-4 px-4 py-4 rounded-xl bg-surface-900/50"
       data-testid={`netplay-invite-${invite.id}`}
     >

--- a/web/src/features/netplay/components/netplay-player-list.tsx
+++ b/web/src/features/netplay/components/netplay-player-list.tsx
@@ -11,7 +11,7 @@ interface NetplayPlayerListProps {
 
 export function NetplayPlayerList({ session }: NetplayPlayerListProps) {
   return (
-    <section>
+    <section data-comp="NetplayPlayerList">
       <div className="flex items-center gap-2.5 mb-4">
         <Users className="h-5 w-5 text-brand-400" />
         <h2 className="text-xl font-bold text-surface-100">Players</h2>

--- a/web/src/features/netplay/components/netplay-player-slot.tsx
+++ b/web/src/features/netplay/components/netplay-player-slot.tsx
@@ -16,7 +16,7 @@ export function NetplayPlayerSlot({
   label,
 }: FilledSlotProps) {
   return (
-    <div
+    <div data-comp="NetplayPlayerSlot"
       className="flex items-center gap-4 px-4 py-3 rounded-xl bg-surface-900/50"
       data-testid={`netplay-player-slot-${label}`}
     >
@@ -44,7 +44,7 @@ export function NetplayPlayerSlot({
 
 export function NetplayEmptySlot() {
   return (
-    <div
+    <div data-comp="NetplayEmptySlot"
       className="flex items-center gap-4 px-4 py-3 rounded-xl bg-surface-900/50 border border-dashed border-surface-700"
       data-testid="netplay-player-slot-empty"
     >

--- a/web/src/features/netplay/components/netplay-session-invites.tsx
+++ b/web/src/features/netplay/components/netplay-session-invites.tsx
@@ -21,7 +21,7 @@ interface NetplaySessionInvitesProps {
 
 function InvitesSkeleton() {
   return (
-    <div className="space-y-2">
+    <div data-comp="InvitesSkeleton" className="space-y-2">
       {Array.from({ length: 2 }, (_, i) => (
         <div
           key={i}
@@ -61,7 +61,7 @@ export function NetplaySessionInvites({ sessionId }: NetplaySessionInvitesProps)
   }
 
   return (
-    <section>
+    <section data-comp="NetplaySessionInvites">
       <div className="flex items-center gap-2.5 mb-4">
         <Mail className="h-5 w-5 text-brand-400" />
         <h2 className="text-xl font-bold text-surface-100">

--- a/web/src/features/netplay/components/session-code.tsx
+++ b/web/src/features/netplay/components/session-code.tsx
@@ -20,7 +20,7 @@ export function SessionCode({ code }: SessionCodeProps) {
   }
 
   return (
-    <div className="flex items-center gap-4">
+    <div data-comp="SessionCode" className="flex items-center gap-4">
       <div className="px-5 py-3 rounded-xl bg-surface-900 border border-surface-700">
         <span className="font-mono text-3xl tracking-[0.3em] text-surface-100">
           {code}

--- a/web/src/features/play/components/play-page-state.tsx
+++ b/web/src/features/play/components/play-page-state.tsx
@@ -13,7 +13,7 @@ interface PlayPageLoadingProps {
 /** Top-bar + blank stage skeleton while game / consoles are loading. */
 export function PlayPageLoading(_props: PlayPageLoadingProps = {}) {
   return (
-    <div className="flex flex-col h-screen">
+    <div data-comp="PlayPageLoading" className="flex flex-col h-screen">
       <div className="flex items-center justify-between px-4 py-2 border-b border-surface-800 bg-surface-950/80">
         <div className="flex items-center gap-3">
           <Skeleton className="h-5 w-16" />
@@ -36,7 +36,7 @@ interface PlayPageNotFoundProps {
 
 export function PlayPageNotFound({ onBack }: PlayPageNotFoundProps) {
   return (
-    <div className="text-center py-20">
+    <div data-comp="PlayPageNotFound" className="text-center py-20">
       <p className="text-surface-400">Game not found</p>
       <Button variant="ghost" onClick={onBack} className="mt-4">
         Go back
@@ -55,7 +55,7 @@ export function PlayPageUnsupported({
   onBack,
 }: PlayPageUnsupportedProps) {
   return (
-    <div className="text-center py-20 space-y-4">
+    <div data-comp="PlayPageUnsupported" className="text-center py-20 space-y-4">
       <AlertTriangle className="h-12 w-12 text-warning-500 mx-auto" />
       <h2 className="text-xl font-bold text-surface-100">
         Browser Play Not Available
@@ -83,7 +83,7 @@ export function PlayPageError({
   onRetry,
 }: PlayPageErrorProps) {
   return (
-    <div className="text-center py-20 space-y-4">
+    <div data-comp="PlayPageError" className="text-center py-20 space-y-4">
       <AlertTriangle className="h-12 w-12 text-danger-500 mx-auto" />
       <h2 className="text-xl font-bold text-surface-100">Emulation Error</h2>
       <p className="text-surface-400 max-w-md mx-auto">

--- a/web/src/features/play/components/play-toolbar.tsx
+++ b/web/src/features/play/components/play-toolbar.tsx
@@ -37,7 +37,7 @@ export function PlayToolbar({
   onRetryDisc,
 }: PlayToolbarProps) {
   return (
-    <div className="flex items-center justify-between px-4 py-2 border-b border-surface-800 bg-surface-950/80">
+    <div data-comp="PlayToolbar" className="flex items-center justify-between px-4 py-2 border-b border-surface-800 bg-surface-950/80">
       <div className="flex items-center gap-3">
         <BackButton
           onClick={onBack}

--- a/web/src/features/preferences/components/controller-visual.tsx
+++ b/web/src/features/preferences/components/controller-visual.tsx
@@ -6,7 +6,7 @@ interface ControllerVisualProps {
 
 function KeyBadge({ label, keyName }: { label: string; keyName: string }) {
   return (
-    <div className="flex items-center gap-2">
+    <div data-comp="KeyBadge" className="flex items-center gap-2">
       <span className="text-xs text-surface-400 w-20 text-right">{label}</span>
       <span className="inline-flex items-center justify-center min-w-[2rem] px-1.5 py-0.5 rounded bg-surface-800 border border-surface-700 text-xs font-mono text-surface-200">
         {formatKeyName(keyName)}
@@ -17,7 +17,7 @@ function KeyBadge({ label, keyName }: { label: string; keyName: string }) {
 
 export function ControllerVisual({ mapping }: ControllerVisualProps) {
   return (
-    <div
+    <div data-comp="ControllerVisual"
       data-testid="controller-visual"
       className="bg-surface-900 border border-surface-800 rounded-xl p-5"
     >

--- a/web/src/features/preferences/components/custom-key-mapping-editor.tsx
+++ b/web/src/features/preferences/components/custom-key-mapping-editor.tsx
@@ -29,7 +29,7 @@ export function CustomKeyMappingEditor({
   }));
 
   return (
-    <div className="space-y-4">
+    <div data-comp="CustomKeyMappingEditor" className="space-y-4">
       {groups.map((group) => (
         <div key={group.label}>
           <p className="text-xs font-semibold uppercase tracking-wider text-surface-400 mb-2">

--- a/web/src/features/preferences/components/key-capture-button.tsx
+++ b/web/src/features/preferences/components/key-capture-button.tsx
@@ -29,7 +29,7 @@ export function KeyCaptureButton({ value, onChange }: KeyCaptureButtonProps) {
   }, [listening, onChange]);
 
   return (
-    <button
+    <button data-comp="KeyCaptureButton"
       ref={buttonRef}
       type="button"
       onClick={() => setListening(true)}

--- a/web/src/features/search/components/search-palette.tsx
+++ b/web/src/features/search/components/search-palette.tsx
@@ -95,7 +95,7 @@ export function SearchPalette() {
   if (!open) return null;
 
   return (
-    <div
+    <div data-comp="SearchPalette"
       ref={overlayRef}
       className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh] px-4"
       onClick={(e) => {

--- a/web/src/features/search/components/search-results.tsx
+++ b/web/src/features/search/components/search-results.tsx
@@ -186,7 +186,7 @@ export function SearchResultsDisplay({
   let globalIndex = 0;
 
   return (
-    <div ref={scrollRef} className="overflow-y-auto max-h-[60vh]">
+    <div data-comp="SearchResultsDisplay" ref={scrollRef} className="overflow-y-auto max-h-[60vh]">
       {sections.map((section) => (
         <div key={section.key} className="py-2">
           <div className="px-4 py-1.5 flex items-center justify-between">
@@ -244,7 +244,7 @@ function SearchResultRow({
   highlighted,
 }: SearchResultRowProps) {
   return (
-    <div
+    <div data-comp="SearchResultRow"
       className={cn(
         "flex items-center gap-3 rounded-lg px-2 py-1.5 transition-colors",
         highlighted ? "bg-surface-800" : "hover:bg-surface-800/50",
@@ -274,7 +274,7 @@ function IconBadge({
   icon: typeof Code;
 }) {
   return (
-    <div className="h-8 w-8 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0">
+    <div data-comp="IconBadge" className="h-8 w-8 rounded-lg bg-surface-800 flex items-center justify-center flex-shrink-0">
       <Icon className="h-4 w-4 text-surface-400" />
     </div>
   );
@@ -291,7 +291,7 @@ function GameCountWithRating({
   avgRating: number;
 }) {
   return (
-    <span className="text-xs text-surface-500 flex items-center gap-1.5">
+    <span data-comp="GameCountWithRating" className="text-xs text-surface-500 flex items-center gap-1.5">
       {gameCount} {gameCount === 1 ? "game" : "games"}
       {avgRating > 0 && (
         <>

--- a/web/src/features/sessions/components/game-sessions.tsx
+++ b/web/src/features/sessions/components/game-sessions.tsx
@@ -16,7 +16,7 @@ import type { GameSession } from "@/types/api";
 
 function SessionsSkeleton() {
   return (
-    <div className="space-y-2">
+    <div data-comp="SessionsSkeleton" className="space-y-2">
       {Array.from({ length: 2 }, (_, i) => (
         <div
           key={i}

--- a/web/src/features/sessions/components/session-cheat-selector.tsx
+++ b/web/src/features/sessions/components/session-cheat-selector.tsx
@@ -53,7 +53,7 @@ export function SessionCheatSelector({
   }
 
   return (
-    <div className="mt-4 space-y-3">
+    <div data-comp="SessionCheatSelector" className="mt-4 space-y-3">
       <div className="flex items-center gap-2">
         <div className="relative flex-1">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-surface-500" />

--- a/web/src/features/setup/components/complete-step.tsx
+++ b/web/src/features/setup/components/complete-step.tsx
@@ -14,7 +14,7 @@ export function CompleteStep({
   const navigate = useNavigate();
 
   return (
-    <div className="space-y-6 text-center">
+    <div data-comp="CompleteStep" className="space-y-6 text-center">
       <div className="flex justify-center">
         <div className="h-16 w-16 rounded-full bg-success-500/20 flex items-center justify-center">
           <CheckCircle2 className="h-8 w-8 text-success-500" />

--- a/web/src/features/setup/components/create-account-step.tsx
+++ b/web/src/features/setup/components/create-account-step.tsx
@@ -38,7 +38,7 @@ export function CreateAccountStep({ onNext }: CreateAccountStepProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <div data-comp="CreateAccountStep" className="space-y-6">
       <div>
         <h2 className="text-xl font-semibold text-surface-100">
           Create Owner Account

--- a/web/src/features/setup/components/game-scan-step.tsx
+++ b/web/src/features/setup/components/game-scan-step.tsx
@@ -48,7 +48,7 @@ export function GameScanStep({ onSkip, onComplete }: GameScanStepProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <div data-comp="GameScanStep" className="space-y-6">
       <div>
         <h2 className="text-xl font-semibold text-surface-100">
           Scan for Games

--- a/web/src/features/setup/components/igdb-step.tsx
+++ b/web/src/features/setup/components/igdb-step.tsx
@@ -96,7 +96,7 @@ export function IgdbStep({ onSkip, onSave }: IgdbStepProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <div data-comp="IgdbStep" className="space-y-6">
       <div>
         <h2 className="text-xl font-semibold text-surface-100">
           IGDB Metadata

--- a/web/src/features/setup/components/steamgriddb-step.tsx
+++ b/web/src/features/setup/components/steamgriddb-step.tsx
@@ -59,7 +59,7 @@ export function SteamGridDBStep({ onSkip, onSave }: SteamGridDBStepProps) {
   }
 
   return (
-    <div className="space-y-6">
+    <div data-comp="SteamGridDBStep" className="space-y-6">
       <div>
         <h2 className="text-xl font-semibold text-surface-100">
           SteamGridDB Artwork

--- a/web/src/features/setup/components/system-check-step.tsx
+++ b/web/src/features/setup/components/system-check-step.tsx
@@ -26,7 +26,7 @@ export function SystemCheckStep({ onNext }: SystemCheckStepProps) {
   const hasErrors = checks.some((c) => c.status === "error");
 
   return (
-    <div className="space-y-6">
+    <div data-comp="SystemCheckStep" className="space-y-6">
       <div>
         <h2 className="text-xl font-semibold text-surface-100">
           System Check

--- a/web/src/features/setup/components/wizard-layout.tsx
+++ b/web/src/features/setup/components/wizard-layout.tsx
@@ -10,7 +10,7 @@ interface WizardLayoutProps {
 
 export function WizardLayout({ currentStep, children }: WizardLayoutProps) {
   return (
-    <div className="min-h-screen flex flex-col items-center px-4 py-8">
+    <div data-comp="WizardLayout" className="min-h-screen flex flex-col items-center px-4 py-8">
       <div className="fixed inset-0 bg-gradient-to-br from-brand-950/40 via-surface-950 to-surface-950" />
 
       <div className="relative w-full max-w-2xl space-y-8">

--- a/web/src/features/shared-sessions/components/game-active-shared-sessions.tsx
+++ b/web/src/features/shared-sessions/components/game-active-shared-sessions.tsx
@@ -12,7 +12,7 @@ const statusVariant: Record<string, "success" | "warning" | "default"> = {
 
 function GameActiveSharedSessionsSkeleton() {
   return (
-    <div className="space-y-2">
+    <div data-comp="GameActiveSharedSessionsSkeleton" className="space-y-2">
       {Array.from({ length: 2 }, (_, i) => (
         <div
           key={i}

--- a/web/src/features/shared-sessions/components/member-avatars.tsx
+++ b/web/src/features/shared-sessions/components/member-avatars.tsx
@@ -11,7 +11,7 @@ export function MemberAvatars({ members, max = 4 }: MemberAvatarsProps) {
   const overflow = members.length - max;
 
   return (
-    <div className="flex -space-x-2">
+    <div data-comp="MemberAvatars" className="flex -space-x-2">
       {visible.map((member) => (
         <div
           key={member.username}

--- a/web/src/features/shared-sessions/components/shared-session-hero.tsx
+++ b/web/src/features/shared-sessions/components/shared-session-hero.tsx
@@ -39,7 +39,7 @@ export function SharedSessionHero({
   // provides no affordance about what would unblock it.
   const canClone = !!sharedSession.sessionId;
   return (
-    <div className="flex flex-col items-center gap-6 md:flex-row md:items-start md:gap-8">
+    <div data-comp="SharedSessionHero" className="flex flex-col items-center gap-6 md:flex-row md:items-start md:gap-8">
       {/* Cover art */}
       <div className="w-48 flex-shrink-0 md:w-64">
         <div className="aspect-[3/4] rounded-2xl overflow-hidden bg-surface-900 border border-surface-800 shadow-2xl">

--- a/web/src/features/shared-sessions/components/shared-session-members-list.tsx
+++ b/web/src/features/shared-sessions/components/shared-session-members-list.tsx
@@ -25,7 +25,7 @@ export function SharedSessionMembersList({
   const { user } = useAuth();
 
   return (
-    <section>
+    <section data-comp="SharedSessionMembersList">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2.5">
           <Users className="h-5 w-5 text-brand-400" />

--- a/web/src/features/shared-sessions/components/shared-session-saves-list.tsx
+++ b/web/src/features/shared-sessions/components/shared-session-saves-list.tsx
@@ -23,7 +23,7 @@ export function SharedSessionSavesList({
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null);
 
   return (
-    <section>
+    <section data-comp="SharedSessionSavesList">
       <div className="flex items-center gap-2.5 mb-4">
         <Save className="h-5 w-5 text-brand-400" />
         <h2 className="text-xl font-bold text-surface-100">Shared Session Saves</h2>

--- a/web/src/features/social/components/activity-event-item.tsx
+++ b/web/src/features/social/components/activity-event-item.tsx
@@ -129,7 +129,7 @@ interface ActivityEventItemProps {
 
 export function ActivityEventItem({ event, compact }: ActivityEventItemProps) {
   return (
-    <div
+    <div data-comp="ActivityEventItem"
       className="flex items-start gap-3 rounded-xl px-3 py-3 hover:bg-surface-800/50 transition-colors"
       data-testid={`activity-event-${event.id}`}
     >

--- a/web/src/features/social/components/activity-feed.tsx
+++ b/web/src/features/social/components/activity-feed.tsx
@@ -6,7 +6,7 @@ import { useActivityFeed, useActivityRealtime } from "@/hooks/use-social";
 
 function ActivityFeedSkeleton({ count = 5 }: { count?: number }) {
   return (
-    <div className="space-y-2">
+    <div data-comp="ActivityFeedSkeleton" className="space-y-2">
       {Array.from({ length: count }, (_, i) => (
         <div key={i} className="flex items-start gap-3 px-3 py-3">
           <Skeleton className="h-8 w-8 rounded-full flex-shrink-0" />
@@ -37,7 +37,7 @@ export function ActivityFeed({
   const events = maxItems ? data?.data?.slice(0, maxItems) : data?.data;
 
   return (
-    <div data-testid="activity-feed">
+    <div data-comp="ActivityFeed" data-testid="activity-feed">
       {showHeader && (
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2.5">

--- a/web/src/features/social/components/online-users.tsx
+++ b/web/src/features/social/components/online-users.tsx
@@ -6,7 +6,7 @@ import { useOnlineUsers } from "@/hooks/use-social";
 
 function OnlineUsersSkeleton() {
   return (
-    <div className="space-y-3">
+    <div data-comp="OnlineUsersSkeleton" className="space-y-3">
       {Array.from({ length: 3 }, (_, i) => (
         <div key={i} className="flex items-center gap-3 px-3 py-2">
           <Skeleton className="h-8 w-8 rounded-full" />
@@ -24,7 +24,7 @@ export function OnlineUsers() {
   const { data, isLoading } = useOnlineUsers();
 
   return (
-    <div data-testid="online-users-widget">
+    <div data-comp="OnlineUsers" data-testid="online-users-widget">
       <div className="flex items-center gap-2.5 mb-4">
         <Users className="h-5 w-5 text-brand-400" />
         <h2 className="text-lg font-bold text-surface-100">Online Now</h2>

--- a/web/src/features/storage/components/console-breakdown-table.tsx
+++ b/web/src/features/storage/components/console-breakdown-table.tsx
@@ -11,7 +11,7 @@ export function ConsoleBreakdownTable({
   const sorted = [...consoles].sort((a, b) => b.bytes - a.bytes);
 
   return (
-    <div className="overflow-x-auto">
+    <div data-comp="ConsoleBreakdownTable" className="overflow-x-auto">
       <table className="w-full text-left">
         <thead>
           <tr className="border-b border-surface-800/50">

--- a/web/src/features/storage/components/storage-bar.tsx
+++ b/web/src/features/storage/components/storage-bar.tsx
@@ -22,7 +22,7 @@ export function StorageBar({ usedBytes, quotaBytes }: StorageBarProps) {
   const clampedWidth = Math.min(percentage, 100);
 
   return (
-    <div>
+    <div data-comp="StorageBar">
       <div className="flex items-baseline justify-between mb-2">
         <p className="text-sm text-surface-300">
           <span className={getTextColor(percentage)}>

--- a/web/src/features/upload/components/console-selector.tsx
+++ b/web/src/features/upload/components/console-selector.tsx
@@ -21,7 +21,7 @@ export function ConsoleSelector({
   ];
 
   return (
-    <div className="flex items-center gap-2" data-testid="console-selector">
+    <div data-comp="ConsoleSelector" className="flex items-center gap-2" data-testid="console-selector">
       <Select
         options={options}
         value=""

--- a/web/src/features/upload/components/drop-zone.tsx
+++ b/web/src/features/upload/components/drop-zone.tsx
@@ -38,7 +38,7 @@ export function DropZone({ onFiles, isUploading }: DropZoneProps) {
   }
 
   return (
-    <div
+    <div data-comp="DropZone"
       className={`rounded-2xl border-2 border-dashed p-8 text-center transition-colors ${
         isDragOver
           ? "border-brand-500 bg-brand-500/5"

--- a/web/src/features/upload/components/upload-progress.tsx
+++ b/web/src/features/upload/components/upload-progress.tsx
@@ -19,7 +19,7 @@ export function UploadProgress({ files }: UploadProgressProps) {
   const total = files.length;
 
   return (
-    <div className="space-y-3" data-testid="upload-progress">
+    <div data-comp="UploadProgress" className="space-y-3" data-testid="upload-progress">
       <div className="flex items-center justify-between text-sm">
         <span className="text-surface-300">
           Uploaded {completed} of {total} files

--- a/web/src/features/user-profile/components/achievement-showcase.tsx
+++ b/web/src/features/user-profile/components/achievement-showcase.tsx
@@ -51,7 +51,7 @@ function ShowcaseCard({
   const pillClass = getRarityPillClass(rarity.tier);
 
   return (
-    <div className="flex flex-col items-center gap-2 w-36 flex-shrink-0">
+    <div data-comp="ShowcaseCard" className="flex flex-col items-center gap-2 w-36 flex-shrink-0">
       {/* Badge */}
       <div
         className={cn(
@@ -113,7 +113,7 @@ export function AchievementShowcase({ userId }: { userId: string }) {
   if (!hasShowcase && !isOwnProfile) return null;
 
   return (
-    <section>
+    <section data-comp="AchievementShowcase">
       <div className="flex items-center justify-between mb-4">
         <div className="flex items-center gap-2.5">
           <Trophy className="h-5 w-5 text-brand-400" />

--- a/web/src/features/user-profile/components/showcase-editor.tsx
+++ b/web/src/features/user-profile/components/showcase-editor.tsx
@@ -96,7 +96,7 @@ export function ShowcaseEditor({ onClose }: { onClose: () => void }) {
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
+    <div data-comp="ShowcaseEditor" className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
       <div className="bg-surface-900 rounded-2xl w-full max-w-lg mx-4 max-h-[80vh] flex flex-col">
         {/* Header */}
         <div className="flex items-center justify-between p-5 border-b border-surface-800">

--- a/web/src/pages/activity-page.tsx
+++ b/web/src/pages/activity-page.tsx
@@ -8,7 +8,7 @@ import { OnlineUsers } from "@/features/social/components/online-users";
 
 function ActivityPageSkeleton() {
   return (
-    <div className="space-y-2">
+    <div data-comp="ActivityPageSkeleton" className="space-y-2">
       {Array.from({ length: 10 }, (_, i) => (
         <div key={i} className="flex items-start gap-3 px-3 py-3">
           <Skeleton className="h-8 w-8 rounded-full flex-shrink-0" />

--- a/web/src/pages/admin/metadata-fix-page.tsx
+++ b/web/src/pages/admin/metadata-fix-page.tsx
@@ -34,7 +34,7 @@ function GameRow({
   const navigate = useNavigate();
 
   return (
-    <div
+    <div data-comp="GameRow"
       className="flex items-center gap-4 p-4 rounded-xl bg-surface-800/30 border border-surface-800 hover:border-surface-700 transition-colors cursor-pointer"
       onClick={() => navigate(`/games/${game.id}`)}
     >

--- a/web/src/pages/challenge-detail-page.tsx
+++ b/web/src/pages/challenge-detail-page.tsx
@@ -23,7 +23,7 @@ import {
 
 function DetailSkeleton() {
   return (
-    <div className="max-w-5xl space-y-8">
+    <div data-comp="DetailSkeleton" className="max-w-5xl space-y-8">
       <Skeleton className="h-8 w-24" />
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         <div className="lg:col-span-2">

--- a/web/src/pages/challenges-page.tsx
+++ b/web/src/pages/challenges-page.tsx
@@ -18,7 +18,7 @@ type Tab = "popular" | "recent" | "mine";
 
 function ChallengeCardSkeleton() {
   return (
-    <div className="space-y-3">
+    <div data-comp="ChallengeCardSkeleton" className="space-y-3">
       <Skeleton className="aspect-[16/10] rounded-2xl" />
       <div className="px-1 space-y-1.5">
         <Skeleton className="h-4 w-32" />
@@ -31,7 +31,7 @@ function ChallengeCardSkeleton() {
 
 function ChallengeGridSkeleton() {
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
+    <div data-comp="ChallengeGridSkeleton" className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-5">
       {Array.from({ length: 8 }, (_, i) => (
         <ChallengeCardSkeleton key={i} />
       ))}

--- a/web/src/pages/collection-detail-page.tsx
+++ b/web/src/pages/collection-detail-page.tsx
@@ -28,7 +28,7 @@ import type { Game } from "@/types/api";
 
 function CollectionDetailSkeleton() {
   return (
-    <div className="space-y-6">
+    <div data-comp="CollectionDetailSkeleton" className="space-y-6">
       <Skeleton className="h-5 w-16" />
       <div className="space-y-3">
         <Skeleton className="h-9 w-72" />

--- a/web/src/pages/console-detail-page.tsx
+++ b/web/src/pages/console-detail-page.tsx
@@ -201,7 +201,7 @@ function ScanButton({
   toast: ReturnType<typeof useToast>["toast"];
 }) {
   return (
-    <button
+    <button data-comp="ScanButton"
       className="inline-flex items-center gap-2 rounded-lg bg-white/10 backdrop-blur-sm px-4 py-2 text-sm font-medium text-white hover:bg-white/20 transition-colors disabled:opacity-50"
       disabled={scanLibrary.isPending}
       data-testid="scan-button"

--- a/web/src/pages/cover-gallery-page.tsx
+++ b/web/src/pages/cover-gallery-page.tsx
@@ -20,7 +20,7 @@ const zoomGridClasses: Record<ZoomLevel, string> = {
 
 function CoverGallerySkeleton() {
   return (
-    <div data-testid="cover-gallery-skeleton">
+    <div data-comp="CoverGallerySkeleton" data-testid="cover-gallery-skeleton">
       <div className="grid grid-cols-4 sm:grid-cols-6 md:grid-cols-8 lg:grid-cols-10 gap-3">
         {Array.from({ length: 20 }, (_, i) => (
           <Skeleton

--- a/web/src/pages/dashboard-page.tsx
+++ b/web/src/pages/dashboard-page.tsx
@@ -40,7 +40,7 @@ import type { RecentAchievement } from "@/types/api";
 
 function RecentAchievementsSkeleton() {
   return (
-    <div className="flex gap-4 overflow-x-auto pb-2">
+    <div data-comp="RecentAchievementsSkeleton" className="flex gap-4 overflow-x-auto pb-2">
       {Array.from({ length: 4 }, (_, i) => (
         <div
           key={i}
@@ -127,7 +127,7 @@ function RecentAchievementsSection() {
   }
 
   return (
-    <div data-testid="recent-achievements-section">
+    <div data-comp="RecentAchievementsSection" data-testid="recent-achievements-section">
       <TitledSection
         title="Recent Achievements"
         icon={Trophy}
@@ -190,7 +190,7 @@ function TrendingChallengesSection() {
   if (!data?.data || data.data.length === 0) return null;
 
   return (
-    <div data-testid="trending-challenges-section">
+    <div data-comp="TrendingChallengesSection" data-testid="trending-challenges-section">
       <TitledSection
         title="Trending Challenges"
         icon={Flag}

--- a/web/src/pages/developer-detail-page.tsx
+++ b/web/src/pages/developer-detail-page.tsx
@@ -18,7 +18,7 @@ import type { Game } from "@/types/api";
 
 function DeveloperPageSkeleton() {
   return (
-    <div className="space-y-8" data-testid="developer-detail-skeleton">
+    <div data-comp="DeveloperPageSkeleton" className="space-y-8" data-testid="developer-detail-skeleton">
       {/* Hero banner skeleton */}
       <Skeleton className="w-full h-48 rounded-2xl" />
 

--- a/web/src/pages/explore-franchise-page.tsx
+++ b/web/src/pages/explore-franchise-page.tsx
@@ -9,7 +9,7 @@ import type { SeriesConsole } from "@/types/api";
 
 function FranchisePageSkeleton() {
   return (
-    <div className="space-y-8" data-testid="franchise-detail-skeleton">
+    <div data-comp="FranchisePageSkeleton" className="space-y-8" data-testid="franchise-detail-skeleton">
       <Skeleton className="w-full h-64 sm:h-80 lg:h-96 rounded-2xl" />
       <Skeleton className="w-64 h-10" />
       <Skeleton className="w-full h-2 rounded-full" />

--- a/web/src/pages/explore-series-page.tsx
+++ b/web/src/pages/explore-series-page.tsx
@@ -9,7 +9,7 @@ import type { SeriesConsole } from "@/types/api";
 
 function SeriesPageSkeleton() {
   return (
-    <div className="space-y-8" data-testid="series-detail-skeleton">
+    <div data-comp="SeriesPageSkeleton" className="space-y-8" data-testid="series-detail-skeleton">
       {/* Hero skeleton */}
       <Skeleton className="w-full h-64 sm:h-80 lg:h-96 rounded-2xl" />
       {/* Title */}

--- a/web/src/pages/netplay-page.tsx
+++ b/web/src/pages/netplay-page.tsx
@@ -21,7 +21,7 @@ import { NetplayInvitationsSection } from "@/features/netplay/components/netplay
 
 function SessionListSkeleton() {
   return (
-    <div className="space-y-3">
+    <div data-comp="SessionListSkeleton" className="space-y-3">
       {Array.from({ length: 4 }, (_, i) => (
         <div
           key={i}

--- a/web/src/pages/netplay-session-page.tsx
+++ b/web/src/pages/netplay-session-page.tsx
@@ -31,7 +31,7 @@ import { formatDate } from "@/lib/format";
 
 function NetplaySessionSkeleton() {
   return (
-    <div className="max-w-5xl space-y-8">
+    <div data-comp="NetplaySessionSkeleton" className="max-w-5xl space-y-8">
       <Skeleton className="h-5 w-16" />
       <div className="flex flex-col gap-6 md:flex-row md:gap-8">
         <Skeleton className="w-48 md:w-64 aspect-[3/4] rounded-2xl" /> {/* Skeleton uses default 3:4, actual page uses session.coverAspectRatio */}

--- a/web/src/pages/play-later-page.tsx
+++ b/web/src/pages/play-later-page.tsx
@@ -12,7 +12,7 @@ import type { Game } from "@/types/api";
 
 function PlayLaterSkeleton() {
   return (
-    <div className="space-y-2">
+    <div data-comp="PlayLaterSkeleton" className="space-y-2">
       {Array.from({ length: 5 }, (_, i) => (
         <div
           key={i}

--- a/web/src/pages/play-page.tsx
+++ b/web/src/pages/play-page.tsx
@@ -253,7 +253,7 @@ export function PlayPage() {
   // ── Main emulator layout ──────────────────────────────────────────
 
   return (
-    <div className="flex flex-col h-screen">
+    <div data-comp="PlayPage" className="flex flex-col h-screen">
       <CoreMismatchModal
         open={showCoreMismatchModal}
         onChoice={handleCoreMismatchChoice}

--- a/web/src/pages/publisher-detail-page.tsx
+++ b/web/src/pages/publisher-detail-page.tsx
@@ -18,7 +18,7 @@ import type { Game } from "@/types/api";
 
 function PublisherPageSkeleton() {
   return (
-    <div className="space-y-8" data-testid="publisher-detail-skeleton">
+    <div data-comp="PublisherPageSkeleton" className="space-y-8" data-testid="publisher-detail-skeleton">
       {/* Hero banner skeleton */}
       <Skeleton className="w-full h-48 rounded-2xl" />
 

--- a/web/src/pages/screenshot-gallery-page.tsx
+++ b/web/src/pages/screenshot-gallery-page.tsx
@@ -10,7 +10,7 @@ import type { ScreenshotItem } from "@/types/api";
 
 function GallerySkeleton() {
   return (
-    <div data-testid="screenshot-gallery-skeleton">
+    <div data-comp="GallerySkeleton" data-testid="screenshot-gallery-skeleton">
       <div className="columns-2 md:columns-3 xl:columns-4 gap-4">
         {Array.from({ length: 12 }, (_, i) => (
           <div key={i} className="break-inside-avoid mb-4">
@@ -27,7 +27,7 @@ function GallerySkeleton() {
 
 function ScreenshotCard({ screenshot }: { screenshot: ScreenshotItem }) {
   return (
-    <div className="break-inside-avoid mb-4" role="listitem" data-testid="screenshot-card">
+    <div data-comp="ScreenshotCard" className="break-inside-avoid mb-4" role="listitem" data-testid="screenshot-card">
       <Link
         to={`/games/${screenshot.gameId}`}
         className="group relative block rounded-xl overflow-hidden"

--- a/web/src/pages/session-detail-page.tsx
+++ b/web/src/pages/session-detail-page.tsx
@@ -44,7 +44,7 @@ import { CloneSessionDialog } from "@/features/sessions/components/clone-session
 
 function SessionDetailSkeleton() {
   return (
-    <div className="max-w-4xl space-y-6">
+    <div data-comp="SessionDetailSkeleton" className="max-w-4xl space-y-6">
       <Skeleton className="h-6 w-32" />
       <Skeleton className="h-10 w-64" />
       <Skeleton className="h-48 w-full rounded-xl" />

--- a/web/src/pages/shared-session-detail-page.tsx
+++ b/web/src/pages/shared-session-detail-page.tsx
@@ -21,7 +21,7 @@ import { CloneSessionDialog } from "@/features/sessions/components/clone-session
 
 function SharedSessionDetailSkeleton() {
   return (
-    <div className="max-w-5xl space-y-8">
+    <div data-comp="SharedSessionDetailSkeleton" className="max-w-5xl space-y-8">
       <Skeleton className="h-5 w-16" />
       <div className="flex flex-col gap-6 md:flex-row md:gap-8">
         <Skeleton className="w-48 md:w-64 aspect-[3/4] rounded-2xl" />

--- a/web/src/pages/shared-sessions-page.tsx
+++ b/web/src/pages/shared-sessions-page.tsx
@@ -27,7 +27,7 @@ type Tab = "mine" | "invitations";
 
 function InvitationsSkeleton() {
   return (
-    <div className="space-y-3">
+    <div data-comp="InvitationsSkeleton" className="space-y-3">
       {Array.from({ length: 3 }, (_, i) => (
         <div
           key={i}

--- a/web/src/pages/stats-page.tsx
+++ b/web/src/pages/stats-page.tsx
@@ -51,7 +51,7 @@ function RankBadge({ rank }: { rank: number }) {
   }
 
   return (
-    <span className="inline-flex items-center justify-center h-7 w-7 text-sm font-medium text-surface-500">
+    <span data-comp="RankBadge" className="inline-flex items-center justify-center h-7 w-7 text-sm font-medium text-surface-500">
       {rank}
     </span>
   );
@@ -59,7 +59,7 @@ function RankBadge({ rank }: { rank: number }) {
 
 function MostPlayedSkeleton() {
   return (
-    <div className="space-y-2">
+    <div data-comp="MostPlayedSkeleton" className="space-y-2">
       {Array.from({ length: 10 }, (_, i) => (
         <div
           key={i}
@@ -81,7 +81,7 @@ function MostPlayedSkeleton() {
 
 function MostActiveSkeleton() {
   return (
-    <div className="space-y-2">
+    <div data-comp="MostActiveSkeleton" className="space-y-2">
       {Array.from({ length: 10 }, (_, i) => (
         <div
           key={i}

--- a/web/src/pages/storage-page.tsx
+++ b/web/src/pages/storage-page.tsx
@@ -14,7 +14,7 @@ import { ConsoleBreakdownTable } from "@/features/storage/components/console-bre
 
 function StorageSkeleton() {
   return (
-    <div className="space-y-6">
+    <div data-comp="StorageSkeleton" className="space-y-6">
       <Section>
         <div className="px-5 pt-5 pb-2">
           <Skeleton className="h-6 w-40" />

--- a/web/src/pages/top-lists-page.tsx
+++ b/web/src/pages/top-lists-page.tsx
@@ -51,7 +51,7 @@ function RankBadge({ rank }: { rank: number }) {
   }
 
   return (
-    <span className="inline-flex items-center justify-center h-7 w-7 text-sm font-medium text-surface-500">
+    <span data-comp="RankBadge" className="inline-flex items-center justify-center h-7 w-7 text-sm font-medium text-surface-500">
       {rank}
     </span>
   );
@@ -59,7 +59,7 @@ function RankBadge({ rank }: { rank: number }) {
 
 function ListSkeleton() {
   return (
-    <div className="space-y-2">
+    <div data-comp="ListSkeleton" className="space-y-2">
       {Array.from({ length: 10 }, (_, i) => (
         <div
           key={i}
@@ -94,7 +94,7 @@ function TopRatedList({ games }: { games: TopListGame[] }) {
   }
 
   return (
-    <div className="space-y-2">
+    <div data-comp="TopRatedList" className="space-y-2">
       {games.map((game) => (
         <Link
           key={game.gameId}
@@ -142,7 +142,7 @@ function LongestGamesList({ games }: { games: LongestGame[] }) {
   }
 
   return (
-    <div className="space-y-2">
+    <div data-comp="LongestGamesList" className="space-y-2">
       {games.map((game) => (
         <Link
           key={game.gameId}

--- a/web/src/pages/user-profile-page.tsx
+++ b/web/src/pages/user-profile-page.tsx
@@ -67,7 +67,7 @@ function ProfileSection({
   children: React.ReactNode;
 }) {
   return (
-    <div className="rounded-2xl bg-surface-900/50 p-5">
+    <div data-comp="ProfileSection" className="rounded-2xl bg-surface-900/50 p-5">
       <div className="flex items-center gap-2.5 mb-4">
         <Icon className="h-5 w-5 text-brand-400" />
         <h2 className="text-lg font-bold text-surface-100">{title}</h2>
@@ -79,7 +79,7 @@ function ProfileSection({
 
 function ProfileSkeleton() {
   return (
-    <div className="space-y-8">
+    <div data-comp="ProfileSkeleton" className="space-y-8">
       <div className="flex items-center gap-6">
         <Skeleton className="h-20 w-20 rounded-full" />
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
Two-commit series that adds `data-comp="<ComponentName>"` to the outermost HTML element of every exported React component in `web/src`, so each rendered component is identifiable in the Chrome DevTools Elements panel without React DevTools.

- **Commit 1** — hand-edited `game-hero.tsx` as the seed, plus `web/scripts/add-data-comp.mjs`: a TypeScript-compiler-API codemod that finds top-level PascalCase function/arrow components and inserts `data-comp` on their outermost HTML tag. Skips fragments, custom-component wrappers (capitalised tags), and existing `data-comp` attributes.
- **Commit 2** — result of running the codemod: 202 components across 137 files.

The codemod is idempotent (skips files that already have `data-comp`) so it's safe to re-run after future component changes.

## Why split into two commits?
The hand edit + codemod logic are interesting to read; the bulk codemod output is mechanical. Keeping them separate makes review possible — the bulk commit is `git show -- web/src/components/pagination.tsx` for spot-checking, the codemod commit is the part that actually needs reading.

Fixes #778

## Test plan
- [ ] tsc --noEmit clean.
- [ ] All 1558 unit tests pass.
- [ ] Open any page in dev mode and confirm components are visible by name in the Chrome DevTools Elements panel (e.g. `<div data-comp="GameHero">`).