### PR TITLE
fix(achievements): backoff to break ra_fetch re-enqueue loop

### DIFF
--- a/server/internal/api/huma_achievements.go
+++ b/server/internal/api/huma_achievements.go
@@ -227,6 +227,14 @@ func (h *RAHandler) HumaGetGameAchievements(ctx context.Context, in *GetGameAchi
 	if h.Queue != nil && h.RAAPIKey != "" {
 		queued, _ := h.Queue.IsGameQueuedForType(game.ID, "ra_fetch")
 		if !queued {
+			// Don't re-enqueue if a fetch attempt completed or failed in the
+			// last 5 minutes. The achievements UI polls every 2s while the
+			// response is "pending"; without this backoff a transient RA
+			// failure would loop forever (re-enqueue → fail → re-enqueue).
+			recent, _ := h.Queue.WasGameRecentlyAttemptedForType(game.ID, "ra_fetch", 5*time.Minute)
+			if recent {
+				return empty(), nil
+			}
 			if err := h.Queue.EnqueueGameWithType(game.ID, nil, 100, "ra_fetch"); err != nil {
 				slog.Warn("RA auto-fetch: failed to enqueue", "game", game.Title, "error", err)
 			}

--- a/server/internal/scraper/queue.go
+++ b/server/internal/scraper/queue.go
@@ -139,6 +139,21 @@ func (q *ScrapeQueue) IsGameQueuedForType(gameID uint, itemType string) (bool, e
 	return count > 0, err
 }
 
+// WasGameRecentlyAttemptedForType reports whether a finished (completed or
+// failed) queue item of the given type exists for this game within `since`.
+// Use as a backoff so a polling client can't drive an infinite re-enqueue
+// loop when fetches keep failing — once a recent attempt is on record, the
+// caller should stop re-enqueuing and let the cooldown expire.
+func (q *ScrapeQueue) WasGameRecentlyAttemptedForType(gameID uint, itemType string, since time.Duration) (bool, error) {
+	cutoff := time.Now().Add(-since)
+	var count int64
+	err := q.db.Model(&db.ScrapeQueueItem{}).
+		Where("game_id = ? AND type = ? AND status IN ? AND completed_at >= ?",
+			gameID, itemType, []string{"completed", "failed"}, cutoff).
+		Count(&count).Error
+	return count > 0, err
+}
+
 // Dequeue returns the next pending item (highest priority first, then oldest)
 // and marks it as in_progress. Returns nil if queue is empty.
 func (q *ScrapeQueue) Dequeue() (*db.ScrapeQueueItem, error) {

--- a/server/internal/scraper/queue_test.go
+++ b/server/internal/scraper/queue_test.go
@@ -2,6 +2,7 @@ package scraper
 
 import (
 	"testing"
+	"time"
 
 	"github.com/spela/server/internal/db"
 	"github.com/stretchr/testify/assert"
@@ -336,6 +337,53 @@ func TestIsGameQueuedForType_IgnoresCompletedItems(t *testing.T) {
 	queued, err := q.IsGameQueuedForType(42, "ra_fetch")
 	require.NoError(t, err)
 	assert.False(t, queued)
+}
+
+func TestWasGameRecentlyAttemptedForType(t *testing.T) {
+	database := setupQueueTestDB(t)
+	q := NewScrapeQueue(database)
+
+	// Brand new — nothing attempted.
+	recent, err := q.WasGameRecentlyAttemptedForType(42, "ra_fetch", 5*time.Minute)
+	require.NoError(t, err)
+	assert.False(t, recent, "no queue item — should not be recently attempted")
+
+	// Pending/in-progress doesn't count as "attempted" (still ongoing).
+	require.NoError(t, q.EnqueueGameWithType(42, nil, 100, "ra_fetch"))
+	recent, _ = q.WasGameRecentlyAttemptedForType(42, "ra_fetch", 5*time.Minute)
+	assert.False(t, recent, "pending item — not yet attempted")
+
+	// Failed item within window → counts.
+	item, _ := q.Dequeue()
+	require.NotNil(t, item)
+	_, err = q.MarkFailed(item, "transient error")
+	require.NoError(t, err)
+	recent, _ = q.WasGameRecentlyAttemptedForType(42, "ra_fetch", 5*time.Minute)
+	assert.True(t, recent, "failed item within window — should count")
+
+	// Different type — not counted.
+	recent, _ = q.WasGameRecentlyAttemptedForType(42, "scrape", 5*time.Minute)
+	assert.False(t, recent, "different item type — should not count")
+
+	// Different game — not counted.
+	recent, _ = q.WasGameRecentlyAttemptedForType(99, "ra_fetch", 5*time.Minute)
+	assert.False(t, recent, "different game — should not count")
+
+	// Beyond window — not counted. Backdate the completion timestamp.
+	old := time.Now().Add(-10 * time.Minute)
+	require.NoError(t, database.Model(&db.ScrapeQueueItem{}).
+		Where("id = ?", item.ID).Update("completed_at", old).Error)
+	recent, _ = q.WasGameRecentlyAttemptedForType(42, "ra_fetch", 5*time.Minute)
+	assert.False(t, recent, "completed_at older than window — should not count")
+
+	// Completed (not just failed) within window also counts — same backoff applies.
+	require.NoError(t, q.EnqueueGameWithType(43, nil, 100, "ra_fetch"))
+	item2, _ := q.Dequeue()
+	require.NotNil(t, item2)
+	_, err = q.MarkCompleted(item2)
+	require.NoError(t, err)
+	recent, _ = q.WasGameRecentlyAttemptedForType(43, "ra_fetch", 5*time.Minute)
+	assert.True(t, recent, "completed item within window — should count")
 }
 
 func TestResetInProgressItems(t *testing.T) {


### PR DESCRIPTION
## Summary
- New `ScrapeQueue.WasGameRecentlyAttemptedForType(gameID, itemType, since)` reports whether a `completed` or `failed` queue item of the given type exists for a game within the lookback window.
- `huma_achievements.go` consults it before enqueuing a `ra_fetch`: if a fetch attempt completed or failed for this game within the last 5 minutes, return empty (status unset) so polling stops.

## Why
This is the follow-up to #775 / #774. That PR silenced the misleading WebSocket events; the underlying loop kept running. `useGameAchievements` polls `/api/games/{id}/achievements` every 2 s while the response is `status: "pending"`, and the endpoint re-enqueues a `ra_fetch` item when none is pending/in-progress. Once the worker fails the queue item (transient RA failure, marshalling error — anything that doesn't set the `RAHashChecked` sentinel), the next poll re-enqueues. Cycle.

A 5-minute completion-or-failure cooldown breaks the cycle without sacrificing recovery: after the window expires, the user can refresh the page to retry.

Fixes #782

## Test plan
- [ ] `TestWasGameRecentlyAttemptedForType` covers: pending isn't "attempted", failed within window counts, completed within window counts, different game/type doesn't count, beyond-window doesn't count.
- [ ] Manually: open a game whose RA fetch fails, watch the Network panel — `/api/games/{id}/achievements` should stop polling within ~5 s instead of looping every 2 s indefinitely.