### PR TITLE
fix(player): drop neon-glow on disabled SpButton

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpButton.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpButton.kt
@@ -77,7 +77,7 @@ fun SpButton(
                 onClick = { if (!isLoading) onClick() },
                 modifier = modifier
                     .heightIn(min = 48.dp)
-                    .then(if (!skipBackground) Modifier.neonGlow(shape = shape, intense = true) else Modifier)
+                    .then(if (!skipBackground && enabled) Modifier.neonGlow(shape = shape, intense = true) else Modifier)
                     .then(if (!skipBackground) Modifier.background(
                         brush = if (enabled) brush else Brush.linearGradient(
                             listOf(SpColor.SurfaceBright, SpColor.SurfaceBright)
@@ -107,7 +107,7 @@ fun SpButton(
                 onClick = { if (!isLoading) onClick() },
                 modifier = modifier
                     .heightIn(min = 48.dp)
-                    .neonGlow(shape = shape, intense = false)
+                    .then(if (enabled) Modifier.neonGlow(shape = shape, intense = false) else Modifier)
                     .border(1.5.dp, if (enabled) brush else Brush.linearGradient(listOf(SpColor.Divider, SpColor.Divider)), shape)
                     .then(focusMods),
                 enabled = enabled,
@@ -132,7 +132,7 @@ fun SpButton(
                 onClick = { if (!isLoading) onClick() },
                 modifier = modifier
                     .heightIn(min = 48.dp)
-                    .neonGlow(shape = shape, intense = false)
+                    .then(if (enabled) Modifier.neonGlow(shape = shape, intense = false) else Modifier)
                     .then(focusMods),
                 enabled = enabled,
                 shape = shape,


### PR DESCRIPTION
## Summary
Gate `neonGlow` on `enabled` for all three glow-bearing SpButton variants (Primary, Secondary, Outlined). Disabled buttons no longer render the bright purple/pink stroke around their dim fill.

## Why
The Resume button on the game-detail screen has no glow when **enabled** (correct), but **gets** a glow when **disabled** — making the disabled state look more prominent than the enabled one. Inverted.

The cause: each style's `neonGlow` modifier was applied unconditionally (or only gated against the SpSplitButton shared-gradient path), never against `enabled`. When the surrounding SpSplitButton drops its shared gradient because `enabled = false`, the inner SpButton falls into the `!skipBackground` branch, which draws both the disabled-grey fill **and** the neon glow stroke. A disabled-but-still-glowing button is the result.

The fix is small: each style now drops neonGlow when `enabled = false`. Enabled visuals are unchanged.

## Test plan
- [ ] On the game-detail screen, find a game whose Resume button is disabled (e.g. required BIOS missing, or save state is syncing). Confirm no purple/pink glow.
- [ ] Confirm enabled Resume / Play / Download buttons still have their glow as before.
- [ ] Spot-check a Secondary / Outlined button in disabled state — also no glow now.

Fixes #785