### PR TITLE
fix(player): show download progress on game-detail hero

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
@@ -105,7 +105,12 @@ fun SpDownloadProgressBar(
     bytesDownloaded: Long,
     totalBytes: Long,
     modifier: Modifier = Modifier,
+    onGradient: Boolean = false,
 ) {
+    val byteLabelColor = if (onGradient) Color.White.copy(alpha = 0.65f) else SpColor.OnBackgroundTertiary
+    val indeterminateTrackColor = if (onGradient) Color.White.copy(alpha = 0.12f) else SpColor.SurfaceBright
+    val indeterminateColor = if (onGradient) Color.White.copy(alpha = 0.90f) else SpColor.Accent
+
     Column(modifier = modifier) {
         if (progress < 0f) {
             if (com.spela.player.presentation.ui.components.LocalAnimationsEnabled.current) {
@@ -114,14 +119,15 @@ fun SpDownloadProgressBar(
                         .fillMaxWidth()
                         .height(6.dp)
                         .clip(RoundedCornerShape(3.dp)),
-                    color = SpColor.Accent,
-                    trackColor = SpColor.SurfaceBright,
+                    color = indeterminateColor,
+                    trackColor = indeterminateTrackColor,
                 )
             }
         } else {
             SpProgressBar(
                 progress = progress,
                 progressColors = listOf(SpColor.Accent, SpColor.AccentLight),
+                onGradient = onGradient,
             )
         }
         Spacer(Modifier.height(SpSpacing.XSmall))
@@ -129,13 +135,13 @@ fun SpDownloadProgressBar(
             Text(
                 text = formatBytes(bytesDownloaded),
                 style = SpTypography.LabelSmall,
-                color = SpColor.OnBackgroundTertiary,
+                color = byteLabelColor,
             )
             Spacer(Modifier.weight(1f))
             Text(
                 text = if (totalBytes < 0) "..." else formatBytes(totalBytes),
                 style = SpTypography.LabelSmall,
-                color = SpColor.OnBackgroundTertiary,
+                color = byteLabelColor,
             )
         }
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -5,7 +5,11 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.EmojiEvents
@@ -34,6 +38,7 @@ import com.spela.player.presentation.ui.components.SpButton
 import com.spela.player.presentation.ui.components.SpButtonStyle
 import com.spela.player.presentation.ui.components.SpChip
 import com.spela.player.presentation.ui.components.SpConsoleChip
+import com.spela.player.presentation.ui.components.SpDownloadProgressBar
 import com.spela.player.presentation.ui.components.SpRegionChip
 import com.spela.player.presentation.ui.components.SpSplitButton
 import com.spela.player.presentation.ui.components.SpSplitButtonMenuItem
@@ -226,24 +231,42 @@ fun GameHeroContent(
                 else -> null
             }
             if (statusText != null) {
-                Row(
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                Column(
+                    modifier = Modifier.widthIn(max = 320.dp).fillMaxWidth(),
+                    verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
                 ) {
-                    // Show spinner for non-download statuses (scraping, sync).
-                    // Downloads already have a spinner in the button.
-                    if (!state.isDownloading) {
-                        CircularProgressIndicator(
-                            modifier = Modifier.size(14.dp),
-                            strokeWidth = 2.dp,
+                    Row(
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(SpSpacing.XSmall),
+                    ) {
+                        // Show spinner for non-download statuses (scraping, sync).
+                        // Downloads already have a spinner in the button.
+                        if (!state.isDownloading) {
+                            CircularProgressIndicator(
+                                modifier = Modifier.size(14.dp),
+                                strokeWidth = 2.dp,
+                                color = Color.White.copy(alpha = 0.65f),
+                            )
+                        }
+                        Text(
+                            text = statusText,
+                            style = SpTypography.LabelSmall,
                             color = Color.White.copy(alpha = 0.65f),
                         )
                     }
-                    Text(
-                        text = statusText,
-                        style = SpTypography.LabelSmall,
-                        color = Color.White.copy(alpha = 0.65f),
-                    )
+
+                    // Download progress: bytes + bar / indeterminate stripe.
+                    // Only when an active download is reporting progress.
+                    val dp = state.downloadProgress
+                    if (state.isDownloading && dp != null && dp.state == DownloadState.DOWNLOADING) {
+                        SpDownloadProgressBar(
+                            progress = dp.progress,
+                            bytesDownloaded = dp.bytesDownloaded,
+                            totalBytes = dp.totalBytes,
+                            onGradient = true,
+                            modifier = Modifier.fillMaxWidth(),
+                        )
+                    }
                 }
             }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -5,9 +5,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material.icons.Icons


### PR DESCRIPTION
## Summary
Surface `SpDownloadProgressBar` (already used on the dedicated DownloadsScreen) on the game-detail hero whenever a download is active. Adds an `onGradient` parameter to the bar so its byte labels read correctly against the hero's brand-gradient backdrop.

## Why
Tapping Download on the game-detail screen flipped the button into a "Downloading…" spinner with a faint status line below — but no actual progress, no percentage, no bytes counter. Users couldn't tell whether a slow download was 1% in or 99% in.

The data plumbing has been there all along — `GameDetailViewModel` already collects `DownloadRepository.observeDownload(gameId)` into `state.downloadProgress`, and `DownloadProgress` already exposes `progress: Float`, `bytesDownloaded`, `totalBytes`, and `isIndeterminate`. Only the UI was missing.

The hero status block now wraps its existing status text in a Column and renders the progress bar below it when `state.isDownloading && downloadProgress.state == DOWNLOADING`. Indeterminate downloads (`totalBytes < 0`) get the striped `LinearProgressIndicator` branch the bar already supports.

Width is capped at 320 dp so the bar doesn't stretch across very wide hero layouts.

Fixes #784

## Test plan
- [ ] Tap Download on a game's detail screen. Confirm a progress bar appears below the "Downloading…" status text and grows from 0% to 100%, with `bytesDownloaded / totalBytes` shown beneath.
- [ ] For a download where `totalBytes < 0` (server doesn't report content-length), confirm the indeterminate striped bar shows instead.
- [ ] Confirm the bar disappears once the download completes and the button flips to Resume / Play.
- [ ] Confirm Scraping… and Sync… status text is unaffected (no progress bar shown).