### PR TITLE
feat(web): Input supports leftIcon / rightIcon, vertically centred

### DIFF
--- a/web/src/components/ui/input.test.tsx
+++ b/web/src/components/ui/input.test.tsx
@@ -31,4 +31,35 @@ describe("Input", () => {
     const input = container.querySelector("input");
     expect(input?.className).toContain("border-danger-500");
   });
+
+  it("renders a left icon and pads the input to make room", () => {
+    const { container } = render(
+      <Input
+        leftIcon={<svg data-testid="left-icon" />}
+        placeholder="Search"
+      />,
+    );
+    expect(screen.getByTestId("left-icon")).toBeInTheDocument();
+    expect(container.querySelector("input")?.className).toContain("pl-10");
+  });
+
+  it("renders a right icon and pads the input to make room", () => {
+    const { container } = render(
+      <Input rightIcon={<svg data-testid="right-icon" />} />,
+    );
+    expect(screen.getByTestId("right-icon")).toBeInTheDocument();
+    expect(container.querySelector("input")?.className).toContain("pr-10");
+  });
+
+  it("vertically centers icons via flex (no -translate hack)", () => {
+    // The wrapper span should fill the input height (`inset-y-0`) and
+    // center the icon via flex — adapts to any input height without
+    // hard-coded translate math.
+    render(<Input leftIcon={<svg data-testid="left-icon" />} />);
+    const wrapper = screen.getByTestId("left-icon").parentElement;
+    expect(wrapper?.className).toContain("inset-y-0");
+    expect(wrapper?.className).toContain("flex");
+    expect(wrapper?.className).toContain("items-center");
+    expect(wrapper?.className).not.toContain("-translate-y-1/2");
+  });
 });

--- a/web/src/components/ui/input.tsx
+++ b/web/src/components/ui/input.tsx
@@ -1,13 +1,18 @@
-import { type InputHTMLAttributes, forwardRef } from "react";
+import { type InputHTMLAttributes, type ReactNode, forwardRef } from "react";
 import { cn } from "@/lib/cn";
 
 interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
   label?: string;
   error?: string;
+  leftIcon?: ReactNode;
+  rightIcon?: ReactNode;
 }
 
 export const Input = forwardRef<HTMLInputElement, InputProps>(
-  ({ className, label, error, id, ...props }, ref) => {
+  (
+    { className, label, error, id, leftIcon, rightIcon, ...props },
+    ref,
+  ) => {
     return (
       <div data-comp="Input" className="space-y-1.5">
         {label && (
@@ -18,20 +23,40 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
             {label}
           </label>
         )}
-        <input
-          ref={ref}
-          id={id}
-          className={cn(
-            "w-full rounded-lg bg-surface-900 border px-3.5 py-2.5 text-sm text-surface-100 placeholder:text-surface-500",
-            "transition-all duration-200",
-            "focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500",
-            error
-              ? "border-danger-500/50 focus:ring-danger-500/40 focus:border-danger-500"
-              : "border-surface-700 hover:border-surface-600",
-            className,
+        <div className="relative">
+          {leftIcon && (
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-y-0 left-3 flex items-center text-surface-500"
+            >
+              {leftIcon}
+            </span>
           )}
-          {...props}
-        />
+          <input
+            ref={ref}
+            id={id}
+            className={cn(
+              "w-full rounded-lg bg-surface-900 border px-3.5 py-2.5 text-sm text-surface-100 placeholder:text-surface-500",
+              "transition-all duration-200",
+              "focus:outline-none focus:ring-2 focus:ring-brand-500/40 focus:border-brand-500",
+              error
+                ? "border-danger-500/50 focus:ring-danger-500/40 focus:border-danger-500"
+                : "border-surface-700 hover:border-surface-600",
+              leftIcon && "pl-10",
+              rightIcon && "pr-10",
+              className,
+            )}
+            {...props}
+          />
+          {rightIcon && (
+            <span
+              aria-hidden="true"
+              className="pointer-events-none absolute inset-y-0 right-3 flex items-center text-surface-500"
+            >
+              {rightIcon}
+            </span>
+          )}
+        </div>
         {error && <p className="text-sm text-danger-500">{error}</p>}
       </div>
     );

--- a/web/src/features/admin/components/system-events-filters.tsx
+++ b/web/src/features/admin/components/system-events-filters.tsx
@@ -139,34 +139,22 @@ export function SystemEventsFilters({
 
       {/* Username + IP search row */}
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <div className="relative">
-          <Search
-            aria-hidden="true"
-            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-500"
-          />
-          <Input
-            type="text"
-            placeholder="Username contains..."
-            value={username}
-            onChange={(e) => onUsernameChange(e.target.value)}
-            className="pl-9"
-            aria-label="Filter by username"
-          />
-        </div>
-        <div className="relative">
-          <Search
-            aria-hidden="true"
-            className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-surface-500"
-          />
-          <Input
-            type="text"
-            placeholder="IP starts with..."
-            value={ip}
-            onChange={(e) => onIpChange(e.target.value)}
-            className="pl-9"
-            aria-label="Filter by IP"
-          />
-        </div>
+        <Input
+          type="text"
+          placeholder="Username contains..."
+          value={username}
+          onChange={(e) => onUsernameChange(e.target.value)}
+          leftIcon={<Search aria-hidden="true" className="h-4 w-4" />}
+          aria-label="Filter by username"
+        />
+        <Input
+          type="text"
+          placeholder="IP starts with..."
+          value={ip}
+          onChange={(e) => onIpChange(e.target.value)}
+          leftIcon={<Search aria-hidden="true" className="h-4 w-4" />}
+          aria-label="Filter by IP"
+        />
       </div>
 
       {/* Event type chips — filtered by selected category */}

--- a/web/src/features/sessions/components/session-cheat-selector.tsx
+++ b/web/src/features/sessions/components/session-cheat-selector.tsx
@@ -55,13 +55,12 @@ export function SessionCheatSelector({
   return (
     <div data-comp="SessionCheatSelector" className="mt-4 space-y-3">
       <div className="flex items-center gap-2">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-surface-500" />
+        <div className="flex-1">
           <Input
             value={filter}
             onChange={(e) => setFilter(e.target.value)}
             placeholder="Filter cheats..."
-            className="pl-9"
+            leftIcon={<Search className="h-4 w-4" />}
             data-testid="cheat-filter-input"
           />
         </div>


### PR DESCRIPTION
## Summary
Bake icon affordance into the shared `Input` component so call sites stop reinventing the same absolute-positioned, hand-translate-y-1/2 trick.

```tsx
<Input leftIcon={<Search className="h-4 w-4" />} placeholder="Filter…" />
<Input rightIcon={<X className="h-4 w-4" />} value={…} />
```

The icon sits in a span with `inset-y-0 flex items-center` — fills the input's actual rendered height and centres via flex, no hard-coded translate math. Input auto-pads (`pl-10` / `pr-10`) when an icon is supplied. Symmetric `rightIcon` is included for free.

## Migrated
- `web/src/features/admin/components/system-events-filters.tsx` — username + IP filter inputs.
- `web/src/features/sessions/components/session-cheat-selector.tsx` — cheat filter.

These two were the call sites that already used `Input` + an ad-hoc absolute Search icon and `pl-9`. Each loses its `relative` wrapper and explicit `-translate-y-1/2` math.

## Out of scope
- `invite-modal.tsx` and `showcase-editor.tsx` use a raw `<input>` with one-off styling (different background, padding) — switching to `Input` would change visuals. Left untouched.
- `SearchInput` wrapper has its own distinct shape (`rounded-xl`, `pr-4`, `type="search"`). Left untouched.

A follow-up could harmonise these. This PR sticks to the maintenance bug.

## Test plan
- ✅ 1558 web unit tests pass; new `Input` tests cover left/right icon rendering, `pl-10`/`pr-10` auto-padding, and the flex-centring contract (asserts `inset-y-0 flex items-center` is present and `-translate-y-1/2` is absent).
- ✅ TypeScript strict, web build clean.

Fixes #792