### PR TITLE
feat: surface "Scrape queued" state on game-detail screens

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/ScrapeService.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/ScrapeService.kt
@@ -34,6 +34,10 @@ class ScrapeService(
     private val _scrapingGameIds = MutableStateFlow<Set<String>>(emptySet())
     val scrapingGameIds: StateFlow<Set<String>> = _scrapingGameIds.asStateFlow()
 
+    /** Games queued for scraping but not yet picked up by the worker. */
+    private val _queuedGameIds = MutableStateFlow<Set<String>>(emptySet())
+    val queuedGameIds: StateFlow<Set<String>> = _queuedGameIds.asStateFlow()
+
     /** Emitted when a game finishes scraping (status: idle). Observers should refetch game data. */
     private val _gameScrapeDone = MutableSharedFlow<String>(extraBufferCapacity = 16)
     val gameScrapeDone: SharedFlow<String> = _gameScrapeDone.asSharedFlow()
@@ -74,8 +78,13 @@ class ScrapeService(
      */
     fun onScrapeStatusChanged(gameId: String, status: String) {
         when (status) {
-            "scraping" -> _scrapingGameIds.update { it + gameId }
+            "queued" -> _queuedGameIds.update { it + gameId }
+            "scraping" -> {
+                _queuedGameIds.update { it - gameId }
+                _scrapingGameIds.update { it + gameId }
+            }
             "idle" -> {
+                _queuedGameIds.update { it - gameId }
                 _scrapingGameIds.update { it - gameId }
                 _gameScrapeDone.tryEmit(gameId)
                 // Fetch updated game to get the new cover URL for card updates

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/GameDetailState.kt
@@ -32,6 +32,7 @@ data class GameDetailState(
     val isLoading: Boolean = false,
     val isDownloading: Boolean = false,
     val isScraping: Boolean = false,
+    val isScrapeQueued: Boolean = false,
     val isSharing: Boolean = false,
     val myRating: Int? = null,
     val ratingSummary: RatingSummary? = null,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -220,6 +220,7 @@ fun GameHeroContent(
             // Status indicators (scraping, syncing, downloading)
             val statusText = when {
                 state.isScraping -> "Scraping\u2026"
+                state.isScrapeQueued -> "Scrape queued"
                 syncState != null && !syncState.isTimedOut -> syncState.message
                 state.isDownloading -> {
                     val p = state.downloadProgress

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/GameDetailViewModel.kt
@@ -256,6 +256,13 @@ class GameDetailViewModel(
                 _state.update { it.copy(isScraping = gameId in scrapingIds) }
             }
         }
+        // Track queued state — game has a pending ScrapeQueueItem the
+        // worker hasn't picked up yet. Drives the "Scrape queued" hint.
+        scope.launch(dispatchers.io) {
+            scrapeService.queuedGameIds.collect { queuedIds ->
+                _state.update { it.copy(isScrapeQueued = gameId in queuedIds) }
+            }
+        }
 
         // Reload game data when scraping finishes
         scope.launch(dispatchers.io) {

--- a/server/cmd/server/main.go
+++ b/server/cmd/server/main.go
@@ -255,6 +255,10 @@ func main() {
 	hub := websocket.NewHub(effectiveWSOrigins)
 	go hub.Run()
 
+	// Wire the hub into the scrape queue so enqueue paths can broadcast
+	// "queued" scrape-status events. Done after the hub is constructed.
+	metaScraper.Queue.SetHub(hub)
+
 	// Initialize Netplay WebSocket hub
 	netplayHub := websocket.NewNetplayHub(effectiveWSOrigins)
 	netplayHub.StartCleanup(database)

--- a/server/internal/scraper/queue.go
+++ b/server/internal/scraper/queue.go
@@ -5,17 +5,44 @@ import (
 	"time"
 
 	"github.com/spela/server/internal/db"
+	ws "github.com/spela/server/internal/websocket"
 	"gorm.io/gorm"
 )
 
 // ScrapeQueue manages the persistent scrape queue backed by SQLite.
 type ScrapeQueue struct {
-	db *gorm.DB
+	db  *gorm.DB
+	hub *ws.Hub
 }
 
 // NewScrapeQueue creates a new ScrapeQueue.
 func NewScrapeQueue(database *gorm.DB) *ScrapeQueue {
 	return &ScrapeQueue{db: database}
+}
+
+// SetHub wires the WebSocket hub so the queue can broadcast scrape
+// status changes (queued / scraping / idle). Safe to leave unset —
+// the broadcast helpers are nil-safe — but production wiring should
+// call this once at startup.
+func (q *ScrapeQueue) SetHub(hub *ws.Hub) {
+	q.hub = hub
+}
+
+// broadcastQueued emits a "queued" scrape-status event for a single
+// game. Skipped when no hub is wired or when itemType isn't "scrape" —
+// only user-visible scrape activity belongs in the scrape-status feed
+// (mirrors the broadcastStatus gate in worker.go::processItem).
+func (q *ScrapeQueue) broadcastQueued(gameID uint, itemType string) {
+	if q.hub == nil || itemType != "scrape" {
+		return
+	}
+	q.hub.Broadcast(ws.Event{
+		Type: ws.EventGameScrapeStatus,
+		Payload: ws.GameScrapeStatusPayload{
+			GameID: gameID,
+			Status: "queued",
+		},
+	})
 }
 
 // CreateJob creates a new scrape job in "running" state.
@@ -50,6 +77,9 @@ func (q *ScrapeQueue) GetActiveJob() (*db.ScrapeJob, error) {
 }
 
 // EnqueueGames bulk-inserts queue items for the given game IDs.
+// Items default to Type="scrape", so each enqueued game also broadcasts a
+// "queued" scrape-status event so the UI can show "Scrape queued" before
+// the worker actually picks the item up.
 func (q *ScrapeQueue) EnqueueGames(jobID uint, gameIDs []uint, priority int) error {
 	if len(gameIDs) == 0 {
 		return nil
@@ -65,6 +95,9 @@ func (q *ScrapeQueue) EnqueueGames(jobID uint, gameIDs []uint, priority int) err
 	}
 	if err := q.db.CreateInBatches(items, 500).Error; err != nil {
 		return fmt.Errorf("enqueuing %d games: %w", len(gameIDs), err)
+	}
+	for _, gid := range gameIDs {
+		q.broadcastQueued(gid, "scrape")
 	}
 	return nil
 }
@@ -87,6 +120,9 @@ func (q *ScrapeQueue) EnqueueGamesWithType(jobID uint, gameIDs []uint, priority 
 	if err := q.db.CreateInBatches(items, 500).Error; err != nil {
 		return fmt.Errorf("enqueuing %d games (type=%s): %w", len(gameIDs), itemType, err)
 	}
+	for _, gid := range gameIDs {
+		q.broadcastQueued(gid, itemType)
+	}
 	return nil
 }
 
@@ -101,6 +137,7 @@ func (q *ScrapeQueue) EnqueueGame(gameID uint, jobID *uint, priority int) error 
 	if err := q.db.Create(item).Error; err != nil {
 		return fmt.Errorf("enqueuing game %d: %w", gameID, err)
 	}
+	q.broadcastQueued(gameID, "scrape")
 	return nil
 }
 
@@ -126,6 +163,7 @@ func (q *ScrapeQueue) EnqueueGameWithType(gameID uint, jobID *uint, priority int
 	if err := q.db.Create(item).Error; err != nil {
 		return fmt.Errorf("enqueuing game %d (type=%s): %w", gameID, itemType, err)
 	}
+	q.broadcastQueued(gameID, itemType)
 	return nil
 }
 

--- a/server/internal/websocket/events.go
+++ b/server/internal/websocket/events.go
@@ -111,7 +111,10 @@ type ScrapeCancelledPayload struct {
 }
 
 // GameScrapeStatusPayload is the payload for EventGameScrapeStatus.
-// Status is typically "scraping" or "idle".
+// Status is one of "queued" (item enqueued, worker hasn't started),
+// "scraping" (worker actively processing), or "idle" (no scrape activity
+// — completed, failed, cancelled, or never started). Only "scrape"-typed
+// queue items broadcast these events; "ra_fetch" items are silent.
 type GameScrapeStatusPayload struct {
 	GameID uint   `json:"gameId"`
 	Status string `json:"status"`

--- a/web/src/features/game-detail/components/__tests__/game-hero.test.tsx
+++ b/web/src/features/game-detail/components/__tests__/game-hero.test.tsx
@@ -14,7 +14,7 @@ const defaultProps = {
   isAdmin: false,
   isFavorite: false,
   isInPlayLater: false,
-  isScraping: false,
+  scrapeStatus: "idle" as const,
   onPlay: vi.fn(),
   onScrape: vi.fn(),
   onToggleFavorite: vi.fn(),

--- a/web/src/features/game-detail/components/game-hero.tsx
+++ b/web/src/features/game-detail/components/game-hero.tsx
@@ -28,6 +28,8 @@ import {
 import { cn } from "@/lib/cn";
 import type { Game } from "@/types/api";
 
+import type { GameScrapeStatus } from "@/hooks/use-game-scrape-status";
+
 interface GameHeroProps {
   game: Game;
   canPlayInBrowser: boolean;
@@ -35,7 +37,7 @@ interface GameHeroProps {
   isFavorite: boolean;
   isInPlayLater: boolean;
   isPlayLaterPending?: boolean;
-  isScraping: boolean;
+  scrapeStatus: GameScrapeStatus;
   isRefreshingAchievements?: boolean;
   hasAchievements?: boolean;
   achievementCount?: number;
@@ -59,7 +61,7 @@ export function GameHero({
   isFavorite,
   isInPlayLater,
   isPlayLaterPending,
-  isScraping,
+  scrapeStatus,
   isRefreshingAchievements,
   hasAchievements,
   achievementCount,
@@ -78,6 +80,8 @@ export function GameHero({
   const [showCoverModal, setShowCoverModal] = useState(false);
   const [showHeroModal, setShowHeroModal] = useState(false);
   const consoleName = game.consoleName;
+  const isScraping = scrapeStatus === "scraping";
+  const isQueued = scrapeStatus === "queued";
 
   // Prefer hero art (from SteamGridDB), fall back to first screenshot
   const heroImage = game.heroUrl || game.screenshotUrls?.[0] || null;
@@ -308,6 +312,12 @@ export function GameHero({
                 <span className="flex items-center gap-1.5 text-sm text-brand-400">
                   <RefreshCw className="h-4 w-4 animate-spin" />
                   Scraping…
+                </span>
+              )}
+              {isQueued && (
+                <span className="flex items-center gap-1.5 text-sm text-white/60">
+                  <Clock className="h-4 w-4" />
+                  Scrape queued
                 </span>
               )}
               <div className="flex items-center gap-3 text-sm text-white/60">

--- a/web/src/hooks/use-game-scrape-status.ts
+++ b/web/src/hooks/use-game-scrape-status.ts
@@ -1,23 +1,29 @@
 import { useState } from "react";
 import { useWebSocketEvent } from "@/hooks/use-websocket";
 
+export type GameScrapeStatus = "idle" | "queued" | "scraping";
+
 interface GameScrapeStatusEvent {
   gameId: number;
-  status: "scraping" | "idle";
+  status: GameScrapeStatus;
 }
 
 /**
  * Listens for game_scrape_status WebSocket events for a specific game.
- * Returns whether the game is currently being scraped.
+ * Returns the current scrape state — "idle", "queued" (item in the
+ * scrape queue but worker hasn't started), or "scraping" (worker
+ * actively processing). The boolean `isScraping` is kept for
+ * backward compatibility with callers that only care about the
+ * actively-running case.
  */
 export function useGameScrapeStatus(gameId: string) {
-  const [isScraping, setIsScraping] = useState(false);
+  const [scrapeStatus, setScrapeStatus] = useState<GameScrapeStatus>("idle");
 
   useWebSocketEvent("game_scrape_status", (payload: GameScrapeStatusEvent) => {
     if (String(payload.gameId) === gameId) {
-      setIsScraping(payload.status === "scraping");
+      setScrapeStatus(payload.status);
     }
   });
 
-  return { isScraping };
+  return { scrapeStatus, isScraping: scrapeStatus === "scraping" };
 }

--- a/web/src/pages/game-detail-page.tsx
+++ b/web/src/pages/game-detail-page.tsx
@@ -130,7 +130,7 @@ export function GameDetailPage() {
   const togglePlayLater = useTogglePlayLater();
   const { user: currentUser } = useAuth();
   const scrapeGame = useScrapeGame();
-  const { isScraping } = useGameScrapeStatus(id!);
+  const { scrapeStatus } = useGameScrapeStatus(id!);
   const refreshAchievements = useRefreshAchievements();
   const scrapeIfNeeded = useScrapeIfNeeded();
   const { data: consoles } = useConsoles();
@@ -218,7 +218,7 @@ export function GameDetailPage() {
         isFavorite={isFavorite}
         isInPlayLater={isInPlayLater}
         isPlayLaterPending={togglePlayLater.isPending}
-        isScraping={isScraping}
+        scrapeStatus={scrapeStatus}
         hasAchievements={hasAchievements}
         achievementCount={achievementCount}
         achievementUnlocked={achievementUnlocked}


### PR DESCRIPTION
## Summary
Cross-cutting change so a game enqueued for scraping shows "Scrape queued" before the worker actually starts on it. Same status-indicator slot as the existing "Scraping…" line.

- **Server** — scrape-typed enqueue paths (`EnqueueGame`, `EnqueueGames`, `EnqueueGameWithType`, `EnqueueGamesWithType`) now broadcast a `GameScrapeStatusPayload` with `status: "queued"` via the existing `EventGameScrapeStatus` channel. The worker's "scraping" / "idle" broadcasts are unchanged. `ra_fetch` items remain silent (mirrors the `broadcastStatus` gate in `worker.go::processItem`). `ScrapeQueue` exposes a `SetHub()` setter so `main.go` can wire the hub after both are constructed.
- **Web** — `useGameScrapeStatus` exposes a tristate `scrapeStatus: "idle" | "queued" | "scraping"` alongside the existing `isScraping` bool (kept for back-compat). `GameHero` takes `scrapeStatus` and renders "Scraping…" / "Scrape queued" / nothing accordingly. Game-detail page passes the new prop.
- **Player** — `ScrapeService` tracks `queuedGameIds` alongside the existing `scrapingGameIds`. `GameDetailViewModel` observes both and exposes `isScrapeQueued` on `GameDetailState`. `GameHeroContent`'s status text now includes "Scrape queued".

## Why
Before: clicking "Scrape this game" on a busy queue surfaced nothing — the user couldn't tell whether the action was acknowledged or dropped. With a 50-game scrape job already running, only the active game showed activity; the rest were invisible.

After: each enqueued game flips queued → scraping → idle in real time, so a 50-game job's progress is visible per-game even before the worker reaches it.

## Test plan
- ✅ Server: `go test ./internal/scraper/...` green; `go build ./...` clean.
- ✅ Web: 1561 unit tests pass; tsc clean; `useGameScrapeStatus` keeps the back-compat `isScraping` boolean so non-detail surfaces (e.g. `useGameScrapedListener`) keep working.
- ✅ Player: `:shared:desktopTest` (49 suites) green; detekt clean.
- [ ] Manual: trigger a multi-game scrape job, watch a not-yet-scraped game's detail page show "Scrape queued" → "Scraping…" → idle in sequence.

Fixes #789