### PR TITLE
fix(player): bypass JNI 2x peak for save states via native serializeToFile

### DIFF
--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -1147,6 +1147,49 @@ JNI_FUNC(jbyteArray, nativeSerialize)(JNIEnv *env, jobject thiz) {
     return result;
 }
 
+/* nativeSerializeToFile writes the libretro save state directly to the
+ * given filesystem path without ever crossing the JNI boundary as a
+ * jbyteArray. Returns the number of bytes written, or -1 on failure.
+ * Used by the manual-save path to avoid a 30–50 MB Java-heap allocation
+ * for cores like Dolphin (#798).
+ */
+JNI_FUNC(jlong, nativeSerializeToFile)(JNIEnv *env, jobject thiz, jstring path) {
+    if (!g_core.game_loaded || !path) return -1;
+
+    size_t size = g_core.retro_serialize_size();
+    if (size == 0) return -1;
+
+    void *buf = malloc(size);
+    if (!buf) return -1;
+
+    if (!g_core.retro_serialize(buf, size)) {
+        free(buf);
+        return -1;
+    }
+
+    const char *cpath = (*env)->GetStringUTFChars(env, path, NULL);
+    if (!cpath) {
+        free(buf);
+        return -1;
+    }
+
+    FILE *f = fopen(cpath, "wb");
+    (*env)->ReleaseStringUTFChars(env, path, cpath);
+    if (!f) {
+        free(buf);
+        return -1;
+    }
+
+    size_t written = fwrite(buf, 1, size, f);
+    int closed = fclose(f);
+    free(buf);
+
+    if (written != size || closed != 0) {
+        return -1;
+    }
+    return (jlong)size;
+}
+
 JNI_FUNC(jboolean, nativeUnserialize)(JNIEnv *env, jobject thiz, jbyteArray data) {
     if (!g_core.game_loaded || !data) return JNI_FALSE;
 

--- a/player/native/src/libretro_bridge.c
+++ b/player/native/src/libretro_bridge.c
@@ -1190,6 +1190,56 @@ JNI_FUNC(jlong, nativeSerializeToFile)(JNIEnv *env, jobject thiz, jstring path) 
     return (jlong)size;
 }
 
+/* nativeUnserializeFromFile reads a libretro save state from the given
+ * filesystem path and applies it via retro_unserialize without ever
+ * crossing the JNI boundary as a jbyteArray. Returns JNI_TRUE on
+ * success. Used by the auto-load and slot-load paths to avoid a
+ * 90+ MB Java-heap allocation on Android (#798).
+ */
+JNI_FUNC(jboolean, nativeUnserializeFromFile)(JNIEnv *env, jobject thiz, jstring path) {
+    if (!g_core.game_loaded || !path) return JNI_FALSE;
+
+    const char *cpath = (*env)->GetStringUTFChars(env, path, NULL);
+    if (!cpath) return JNI_FALSE;
+
+    FILE *f = fopen(cpath, "rb");
+    (*env)->ReleaseStringUTFChars(env, path, cpath);
+    if (!f) return JNI_FALSE;
+
+    if (fseek(f, 0, SEEK_END) != 0) { fclose(f); return JNI_FALSE; }
+    long sz = ftell(f);
+    if (sz < 0) { fclose(f); return JNI_FALSE; }
+    if (fseek(f, 0, SEEK_SET) != 0) { fclose(f); return JNI_FALSE; }
+
+    void *buf = malloc((size_t)sz);
+    if (!buf) { fclose(f); return JNI_FALSE; }
+
+    size_t read = fread(buf, 1, (size_t)sz, f);
+    fclose(f);
+    if (read != (size_t)sz) {
+        free(buf);
+        return JNI_FALSE;
+    }
+
+    /* Same context-current dance as nativeUnserialize — Citra/Azahar
+     * reinitialises GLES inside retro_unserialize. Without a current
+     * context, glGetString returns NULL and the core crashes. Safe
+     * because unserialize runs on the emulation thread via the queue. */
+    bool made_current = false;
+    if (g_core.hw_render_enabled && g_core.hw_gl_ctx) {
+        hw_gl_make_current(g_core.hw_gl_ctx);
+        made_current = true;
+    }
+
+    bool ok = g_core.retro_unserialize(buf, (size_t)sz);
+    free(buf);
+
+    if (made_current) {
+        hw_gl_release_current(g_core.hw_gl_ctx);
+    }
+    return ok ? JNI_TRUE : JNI_FALSE;
+}
+
 JNI_FUNC(jboolean, nativeUnserialize)(JNIEnv *env, jobject thiz, jbyteArray data) {
     if (!g_core.game_loaded || !data) return JNI_FALSE;
 

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
@@ -243,6 +243,11 @@ class AndroidLibretroController(
     override fun serialize(): ByteArray? =
         runOnEmulationThread { jni.nativeSerialize() }
 
+    override fun serializeToFile(path: String): Long? {
+        val n = runOnEmulationThread { jni.nativeSerializeToFile(path) } ?: return null
+        return if (n < 0) null else n
+    }
+
     override fun unserialize(data: ByteArray): Boolean =
         runOnEmulationThread { jni.nativeUnserialize(data) } ?: false
 

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/AndroidLibretroController.kt
@@ -251,6 +251,9 @@ class AndroidLibretroController(
     override fun unserialize(data: ByteArray): Boolean =
         runOnEmulationThread { jni.nativeUnserialize(data) } ?: false
 
+    override fun unserializeFromFile(path: String): Boolean =
+        runOnEmulationThread { jni.nativeUnserializeFromFile(path) } ?: false
+
     override fun setFastForward(enabled: Boolean) {
         fastForward = enabled
     }

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
@@ -32,6 +32,9 @@ class LibretroJni {
      *  a ByteArray. Returns bytes written, or -1 on failure. */
     external fun nativeSerializeToFile(path: String): Long
     external fun nativeUnserialize(data: ByteArray): Boolean
+    /** Reads the save state from [path] and applies it without crossing
+     *  JNI as a ByteArray. Returns true on success. */
+    external fun nativeUnserializeFromFile(path: String): Boolean
 
     /* Video */
     external fun nativeGetVideoFrame(): ByteArray?

--- a/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/libretro/LibretroJni.kt
@@ -28,6 +28,9 @@ class LibretroJni {
     /* Save state */
     external fun nativeSerializeSize(): Long
     external fun nativeSerialize(): ByteArray?
+    /** Writes the save state directly to [path] without ever crossing JNI as
+     *  a ByteArray. Returns bytes written, or -1 on failure. */
+    external fun nativeSerializeToFile(path: String): Long
     external fun nativeUnserialize(data: ByteArray): Boolean
 
     /* Video */

--- a/player/shared/src/androidMain/kotlin/com/spela/player/util/FileReadChannel.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/util/FileReadChannel.android.kt
@@ -1,0 +1,8 @@
+package com.spela.player.util
+
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.jvm.javaio.toByteReadChannel
+import java.io.FileInputStream
+
+actual fun openFileReadChannel(path: String): ByteReadChannel =
+    FileInputStream(path).toByteReadChannel()

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1652,6 +1652,105 @@ class SpelaApiClient(
         ).body()
     }
 
+    /**
+     * Streaming variant of [uploadSessionSave] that reads the save bytes
+     * from a file path on disk instead of holding them in a JVM ByteArray.
+     * Required for Dolphin / GameCube (#798) where save states are
+     * ~90 MB and a single ByteArray of that size doesn't fit alongside
+     * the rest of the heap on Android (256 MB ceiling).
+     */
+    suspend fun uploadSessionSaveFromFile(
+        sessionId: String,
+        name: String,
+        savePath: String,
+        saveSize: Long,
+        screenshot: ByteArray?,
+        coreName: String = "",
+    ): com.spela.client.models.SessionSaveResponse {
+        return client.submitFormWithBinaryData(
+            url = "$baseUrl/api/sessions/$sessionId/saves",
+            formData = formData {
+                append("name", name)
+                if (coreName.isNotEmpty()) {
+                    append("coreName", coreName)
+                }
+                append("save", io.ktor.client.request.forms.ChannelProvider(saveSize) {
+                    com.spela.player.util.openFileReadChannel(savePath)
+                }, Headers.build {
+                    append(HttpHeaders.ContentDisposition, "filename=\"save.sav\"")
+                    append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())
+                })
+                if (screenshot != null) {
+                    append("screenshot", screenshot, Headers.build {
+                        append(HttpHeaders.ContentDisposition, "filename=\"screenshot.png\"")
+                        append(HttpHeaders.ContentType, ContentType.Image.PNG.toString())
+                    })
+                }
+            }
+        ).body()
+    }
+
+    suspend fun uploadSessionAutoSaveFromFile(
+        sessionId: String,
+        savePath: String,
+        saveSize: Long,
+        screenshot: ByteArray?,
+        coreName: String = "",
+    ) {
+        client.submitFormWithBinaryData(
+            url = "$baseUrl/api/sessions/$sessionId/saves/auto",
+            formData = formData {
+                if (coreName.isNotEmpty()) {
+                    append("coreName", coreName)
+                }
+                append("save", io.ktor.client.request.forms.ChannelProvider(saveSize) {
+                    com.spela.player.util.openFileReadChannel(savePath)
+                }, Headers.build {
+                    append(HttpHeaders.ContentDisposition, "filename=\"autosave.sav\"")
+                    append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())
+                })
+                if (screenshot != null) {
+                    append("screenshot", screenshot, Headers.build {
+                        append(HttpHeaders.ContentDisposition, "filename=\"screenshot.png\"")
+                        append(HttpHeaders.ContentType, ContentType.Image.PNG.toString())
+                    })
+                }
+            }
+        )
+    }
+
+    suspend fun uploadSlotSaveFromFile(
+        sessionId: String,
+        slot: Int,
+        savePath: String,
+        saveSize: Long,
+        screenshot: ByteArray?,
+        coreName: String = "",
+    ): com.spela.client.models.SessionSaveResponse {
+        return client.submitFormWithBinaryData(
+            url = "$baseUrl/api/sessions/$sessionId/saves/slot/$slot",
+            formData = formData {
+                if (coreName.isNotEmpty()) {
+                    append("coreName", coreName)
+                }
+                append("save", io.ktor.client.request.forms.ChannelProvider(saveSize) {
+                    com.spela.player.util.openFileReadChannel(savePath)
+                }, Headers.build {
+                    append(HttpHeaders.ContentDisposition, "filename=\"slot_${slot}.sav\"")
+                    append(HttpHeaders.ContentType, ContentType.Application.OctetStream.toString())
+                })
+                if (screenshot != null) {
+                    append("screenshot", screenshot, Headers.build {
+                        append(HttpHeaders.ContentDisposition, "filename=\"screenshot.png\"")
+                        append(HttpHeaders.ContentType, ContentType.Image.PNG.toString())
+                    })
+                }
+            }
+        ) {
+            method = HttpMethod.Put
+        }.body()
+    }
+
     suspend fun downloadSessionSave(sessionId: String, saveId: String): ByteArray {
         return sessionsApi.downloadSessionSave(sessionId, saveId).response.body<ByteArray>()
     }
@@ -1679,6 +1778,49 @@ class SpelaApiClient(
 
     suspend fun downloadSessionAutoSave(sessionId: String): ByteArray {
         return sessionsApi.downloadSessionAutoSave(sessionId).response.body<ByteArray>()
+    }
+
+    /**
+     * Streaming variant of [downloadSessionAutoSave] that writes the
+     * response body directly to [outputPath] without materialising the
+     * full payload as a JVM ByteArray. Required for cores like Dolphin
+     * (#798) where save states are ~90 MB and don't fit alongside the
+     * rest of the heap on Android.
+     *
+     * Uses `prepareGet().execute { }` to keep the connection open while
+     * streaming — `client.get(url)` would eagerly buffer the body.
+     */
+    suspend fun downloadSessionAutoSaveToFile(sessionId: String, fileStorage: FileStorage, outputPath: String) {
+        client.prepareGet("$baseUrl/api/sessions/$sessionId/saves/auto") {
+            timeout { requestTimeoutMillis = Long.MAX_VALUE }
+        }.execute { response ->
+            if (!response.status.isSuccess()) {
+                throw RuntimeException("auto-save download failed: HTTP ${response.status.value}")
+            }
+            streamResponseToFile(response, fileStorage, outputPath) { _, _ -> }
+        }
+    }
+
+    suspend fun downloadSessionSaveToFile(sessionId: String, saveId: String, fileStorage: FileStorage, outputPath: String) {
+        client.prepareGet("$baseUrl/api/sessions/$sessionId/saves/$saveId") {
+            timeout { requestTimeoutMillis = Long.MAX_VALUE }
+        }.execute { response ->
+            if (!response.status.isSuccess()) {
+                throw RuntimeException("session save download failed: HTTP ${response.status.value}")
+            }
+            streamResponseToFile(response, fileStorage, outputPath) { _, _ -> }
+        }
+    }
+
+    suspend fun downloadSlotSaveToFile(sessionId: String, slot: Int, fileStorage: FileStorage, outputPath: String) {
+        client.prepareGet("$baseUrl/api/sessions/$sessionId/saves/slot/$slot") {
+            timeout { requestTimeoutMillis = Long.MAX_VALUE }
+        }.execute { response ->
+            if (!response.status.isSuccess()) {
+                throw RuntimeException("slot save download failed: HTTP ${response.status.value}")
+            }
+            streamResponseToFile(response, fileStorage, outputPath) { _, _ -> }
+        }
     }
 
     suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): com.spela.client.models.SessionSaveResponse {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -6,9 +6,11 @@ import com.spela.player.domain.model.GameSession
 import com.spela.player.domain.model.SaveState
 import com.spela.player.domain.model.SessionCheatConfig
 import com.spela.player.domain.repository.SessionRepository
+import com.spela.player.util.FileStorage
 
 class SessionRepositoryImpl(
     private val apiClient: SpelaApiClient,
+    private val fileStorage: FileStorage,
 ) : SessionRepository {
 
     override suspend fun getSessionsForGame(gameId: String): Result<List<GameSession>> = runCatching {
@@ -63,6 +65,17 @@ class SessionRepositoryImpl(
         apiClient.uploadSessionSave(sessionId, name, data, screenshot, coreName).toDomain()
     }
 
+    override suspend fun uploadSessionSaveFromFile(
+        sessionId: String,
+        name: String,
+        savePath: String,
+        saveSize: Long,
+        screenshot: ByteArray?,
+        coreName: String,
+    ): Result<SaveState> = runCatching {
+        apiClient.uploadSessionSaveFromFile(sessionId, name, savePath, saveSize, screenshot, coreName).toDomain()
+    }
+
     override suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray> = runCatching {
         apiClient.downloadSessionSave(sessionId, saveId)
     }
@@ -76,8 +89,22 @@ class SessionRepositoryImpl(
         apiClient.uploadSessionAutoSave(sessionId, data, screenshot, coreName)
     }
 
+    override suspend fun uploadSessionAutoSaveFromFile(
+        sessionId: String,
+        savePath: String,
+        saveSize: Long,
+        screenshot: ByteArray?,
+        coreName: String,
+    ): Result<Unit> = runCatching {
+        apiClient.uploadSessionAutoSaveFromFile(sessionId, savePath, saveSize, screenshot, coreName)
+    }
+
     override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> = runCatching {
         apiClient.downloadSessionAutoSave(sessionId)
+    }
+
+    override suspend fun downloadSessionAutoSaveToFile(sessionId: String, outputPath: String): Result<Unit> = runCatching {
+        apiClient.downloadSessionAutoSaveToFile(sessionId, fileStorage, outputPath)
     }
 
     override suspend fun uploadSlotSave(
@@ -88,6 +115,17 @@ class SessionRepositoryImpl(
         coreName: String,
     ): Result<SaveState> = runCatching {
         apiClient.uploadSlotSave(sessionId, slot, data, screenshot, coreName).toDomain()
+    }
+
+    override suspend fun uploadSlotSaveFromFile(
+        sessionId: String,
+        slot: Int,
+        savePath: String,
+        saveSize: Long,
+        screenshot: ByteArray?,
+        coreName: String,
+    ): Result<SaveState> = runCatching {
+        apiClient.uploadSlotSaveFromFile(sessionId, slot, savePath, saveSize, screenshot, coreName).toDomain()
     }
 
     override suspend fun downloadSlotSave(sessionId: String, slot: Int): Result<ByteArray> = runCatching {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -181,6 +181,7 @@ val commonModule = module {
             dispatchers = get(),
             scope = get(),
             sessionRepository = get(),
+            fileStorage = get(),
         )
     }
     single {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/di/CommonModule.kt
@@ -67,7 +67,7 @@ val commonModule = module {
     single<ChallengeRepository> { ChallengeRepositoryImpl(get()) }
     single<GameStatsRepository> { GameStatsRepositoryImpl(get()) }
     single<CheatRepository> { CheatRepositoryImpl(get(), get()) }
-    single<SessionRepository> { SessionRepositoryImpl(get()) }
+    single<SessionRepository> { SessionRepositoryImpl(get(), get()) }
     single<ExploreRepository> { ExploreRepositoryImpl(get()) }
     single<SearchRepository> { SearchRepositoryImpl(get(), get()) }
     single { BiosRepository(get(), get()) }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -26,10 +26,21 @@ interface SessionRepository {
     suspend fun deleteSession(sessionId: String): Result<Unit>
     suspend fun getSessionSaves(sessionId: String): Result<List<SaveState>>
     suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>
+    /** Streaming variant: reads save bytes from [savePath] without loading
+     *  the full state into a JVM ByteArray. Required for cores like
+     *  Dolphin whose save states (~90 MB) can't fit alongside the rest
+     *  of the heap on Android. See #798. */
+    suspend fun uploadSessionSaveFromFile(sessionId: String, name: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>
     suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray>
     suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<Unit>
+    suspend fun uploadSessionAutoSaveFromFile(sessionId: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String = ""): Result<Unit>
     suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray>
+    /** Streaming variant of [downloadSessionAutoSave]: writes the body to
+     *  [outputPath] without materialising the full payload as a ByteArray.
+     *  See #798. */
+    suspend fun downloadSessionAutoSaveToFile(sessionId: String, outputPath: String): Result<Unit>
     suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>
+    suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>
     suspend fun downloadSlotSave(sessionId: String, slot: Int): Result<ByteArray>
     suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String = ""): Result<Unit>
     suspend fun downloadSessionSram(sessionId: String): Result<ByteArray>

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -1748,6 +1748,13 @@ interface LibretroController {
     fun serializeToFile(path: String): Long? = null
 
     fun unserialize(data: ByteArray): Boolean
+
+    /** Reads a save state from [path] and applies it without ever
+     *  materialising the bytes as a JVM ByteArray. Returns false when
+     *  the controller has no native fast path — caller should fall
+     *  back to [unserialize] with a regular file read. Companion to
+     *  [serializeToFile] for #798. */
+    fun unserializeFromFile(path: String): Boolean = false
     fun setFastForward(enabled: Boolean)
     fun performanceStats(): kotlinx.coroutines.flow.Flow<Pair<Float, Float>>
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/EmulationViewModel.kt
@@ -1738,6 +1738,15 @@ interface LibretroController {
     fun stop()
     fun supportsSaveStates(): Boolean
     fun serialize(): ByteArray?
+
+    /** Writes the current save state directly to [path] without
+     *  materializing it as a JVM ByteArray. Returns the number of
+     *  bytes written, or null when the controller doesn't support a
+     *  native fast path — the caller should fall back to [serialize]
+     *  + a regular file write. Avoids the Java-heap copy that trips
+     *  up GameCube saves on Android (#798). */
+    fun serializeToFile(path: String): Long? = null
+
     fun unserialize(data: ByteArray): Boolean
     fun setFastForward(enabled: Boolean)
     fun performanceStats(): kotlinx.coroutines.flow.Flow<Pair<Float, Float>>

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -350,16 +350,19 @@ class SaveManager(
         }
 
         println("[SaveManager] autoLoadSaveState: loading session $sessionId auto-save")
-        return sessionRepository.downloadSessionAutoSave(sessionId).fold(
-            onSuccess = { saveData ->
-                println("[SaveManager] autoLoadSaveState: got ${saveData.size} bytes from session, unserializing")
-                val ok = libretroController.unserialize(saveData)
+        val tempPath = "${fileStorage.getSavesDir()}/.tmp-load-$sessionId"
+        return sessionRepository.downloadSessionAutoSaveToFile(sessionId, tempPath).fold(
+            onSuccess = {
+                val size = runCatching { fileStorage.getFileSize(tempPath) }.getOrDefault(-1L)
+                println("[SaveManager] autoLoadSaveState: streamed $size bytes to disk, unserializing from file")
+                val ok = libretroController.unserializeFromFile(tempPath)
+                runCatching { fileStorage.deleteFile(tempPath) }
                 println("[SaveManager] autoLoadSaveState: unserialize result=$ok")
                 AutoLoadResult.Loaded
             },
             onFailure = { e ->
+                runCatching { fileStorage.deleteFile(tempPath) }
                 println("[SaveManager] autoLoadSaveState: session auto-save failed: ${e.message}")
-                // Treat 404 / no-data as NoSave, other errors as Error
                 if (e.message?.contains("404") == true || e.message?.contains("not found", ignoreCase = true) == true) {
                     AutoLoadResult.NoSave
                 } else {
@@ -377,14 +380,16 @@ class SaveManager(
     suspend fun forceAutoLoadSaveState(): Boolean {
         val sessionId = currentSessionId ?: return false
         println("[SaveManager] forceAutoLoadSaveState: loading session $sessionId auto-save (ignoring core mismatch)")
-        return sessionRepository.downloadSessionAutoSave(sessionId).fold(
-            onSuccess = { saveData ->
-                println("[SaveManager] forceAutoLoadSaveState: got ${saveData.size} bytes, unserializing")
-                val ok = libretroController.unserialize(saveData)
+        val tempPath = "${fileStorage.getSavesDir()}/.tmp-load-force-$sessionId"
+        return sessionRepository.downloadSessionAutoSaveToFile(sessionId, tempPath).fold(
+            onSuccess = {
+                val ok = libretroController.unserializeFromFile(tempPath)
+                runCatching { fileStorage.deleteFile(tempPath) }
                 println("[SaveManager] forceAutoLoadSaveState: unserialize result=$ok")
                 ok
             },
             onFailure = { e ->
+                runCatching { fileStorage.deleteFile(tempPath) }
                 println("[SaveManager] forceAutoLoadSaveState: failed: ${e.message}")
                 false
             },
@@ -401,29 +406,42 @@ class SaveManager(
             emitRehearsalBlocked(RehearsalSaveKind.Auto)
             return
         }
+        println("[SaveManager] autoSaveOnStop: staging save state to disk…")
+        val staged = try { stageSaveToTempFile() } catch (e: Exception) {
+            println("[SaveManager] autoSaveOnStop: stage failed: ${e.message}")
+            null
+        } ?: run {
+            println("[SaveManager] autoSaveOnStop: stageSaveToTempFile returned null")
+            return
+        }
+        println("[SaveManager] autoSaveOnStop: staged ${staged.size} bytes at ${staged.path}, uploading…")
         try {
-            val saveData = libretroController.serialize()
-            if (saveData != null) {
-                val sessionId = currentSessionId
-                if (sessionId != null) {
-                    val screenshot = screenshotCapture?.captureScreenshot()
-                    val result = sessionRepository.uploadSessionAutoSave(sessionId, saveData, screenshot, currentCoreName)
-                    if (result.isFailure) {
-                        val msg = result.exceptionOrNull()?.message ?: "Unknown error"
-                        println("[SaveManager] autoSaveOnStop: upload failed: $msg")
-                        val userMsg = if (msg.contains("413") || msg.contains("quota", ignoreCase = true)) {
-                            "Auto-save failed: storage quota exceeded. Delete old saves to free space."
-                        } else {
-                            "Auto-save upload failed: $msg"
-                        }
-                        withContext(dispatchers.main) {
-                            _state.update { it.copy(error = userMsg) }
-                        }
+            val sessionId = currentSessionId
+            if (sessionId != null) {
+                val screenshot = screenshotCapture?.captureScreenshot()
+                val result = sessionRepository.uploadSessionAutoSaveFromFile(
+                    sessionId, staged.path, staged.size, screenshot, currentCoreName,
+                )
+                if (result.isSuccess) {
+                    println("[SaveManager] autoSaveOnStop: upload OK")
+                }
+                if (result.isFailure) {
+                    val msg = result.exceptionOrNull()?.message ?: "Unknown error"
+                    println("[SaveManager] autoSaveOnStop: upload failed: $msg")
+                    val userMsg = if (msg.contains("413") || msg.contains("quota", ignoreCase = true)) {
+                        "Auto-save failed: storage quota exceeded. Delete old saves to free space."
+                    } else {
+                        "Auto-save upload failed: $msg"
+                    }
+                    withContext(dispatchers.main) {
+                        _state.update { it.copy(error = userMsg) }
                     }
                 }
             }
         } catch (e: Exception) {
             println("[SaveManager] autoSaveOnStop: exception: ${e.message}")
+        } finally {
+            staged.cleanup()
         }
     }
 
@@ -442,36 +460,42 @@ class SaveManager(
             return
         }
         scope.launch(dispatchers.io) {
-            val saveData = serializeViaTempFile() ?: return@launch
-            val sessionId = currentSessionId
-            if (sessionId != null) {
-                val screenshot = screenshotCapture?.captureScreenshot()
-                sessionRepository.uploadSessionSave(sessionId, "Manual Save", saveData, screenshot, currentCoreName).fold(
-                    onSuccess = {
-                        withContext(dispatchers.main) {
-                            _state.update {
-                                it.copy(
-                                    statusMessage = "State saved",
-                                    secondaryToast = SecondaryToastData(
-                                        message = "Saved to Slot ${it.activeSlot}",
-                                        type = SecondaryToastType.SAVE,
-                                    ),
-                                )
+            val staged = stageSaveToTempFile() ?: return@launch
+            try {
+                val sessionId = currentSessionId
+                if (sessionId != null) {
+                    val screenshot = screenshotCapture?.captureScreenshot()
+                    sessionRepository.uploadSessionSaveFromFile(
+                        sessionId, "Manual Save", staged.path, staged.size, screenshot, currentCoreName,
+                    ).fold(
+                        onSuccess = {
+                            withContext(dispatchers.main) {
+                                _state.update {
+                                    it.copy(
+                                        statusMessage = "State saved",
+                                        secondaryToast = SecondaryToastData(
+                                            message = "Saved to Slot ${it.activeSlot}",
+                                            type = SecondaryToastType.SAVE,
+                                        ),
+                                    )
+                                }
                             }
-                        }
-                        refreshSaveSlots()
-                    },
-                    onFailure = { error ->
-                        withContext(dispatchers.main) {
-                            _state.update { it.copy(error = "Failed to save: ${error.message}") }
-                        }
-                    },
-                )
-            } else {
-                // No session — save state was serialized by the controller
-                withContext(dispatchers.main) {
-                    _state.update { it.copy(statusMessage = "State saved") }
+                            refreshSaveSlots()
+                        },
+                        onFailure = { error ->
+                            withContext(dispatchers.main) {
+                                _state.update { it.copy(error = "Failed to save: ${error.message}") }
+                            }
+                        },
+                    )
+                } else {
+                    // No session — save state was serialized by the controller
+                    withContext(dispatchers.main) {
+                        _state.update { it.copy(statusMessage = "State saved") }
+                    }
                 }
+            } finally {
+                staged.cleanup()
             }
         }
     }
@@ -488,20 +512,40 @@ class SaveManager(
      * Falls back to [LibretroController.serialize] if the controller has no
      * native fast path (desktop / fakes).
      */
-    private suspend fun serializeViaTempFile(): ByteArray? {
+    /**
+     * Result of [stageSaveToTempFile]. The file at [path] is owned by the
+     * caller — they must invoke [cleanup] after the upload regardless of
+     * outcome to avoid leaking temp files.
+     */
+    private data class StagedSave(val path: String, val size: Long, val cleanup: suspend () -> Unit)
+
+    /**
+     * Serialize the current core state to a temp file using the native
+     * fast path when available. Returns the path + byte count for a
+     * caller to stream-upload directly from disk; the JVM never holds
+     * the full save in a ByteArray. See #798 (Dolphin GameCube ~90 MB).
+     *
+     * Returns null when serialization fails. When the controller has no
+     * native fast path (desktop / fakes), this still works — it falls
+     * back to [serialize] + writeFile so the caller's contract holds.
+     */
+    private suspend fun stageSaveToTempFile(): StagedSave? {
         val tempPath = "${fileStorage.getSavesDir()}/.tmp-save-${currentSessionId ?: "none"}"
+        val cleanup: suspend () -> Unit = { runCatching { fileStorage.deleteFile(tempPath) } }
         val written = libretroController.serializeToFile(tempPath)
         if (written != null && written > 0) {
-            return try {
-                fileStorage.readFile(tempPath)
-            } catch (_: Exception) {
-                null
-            } finally {
-                runCatching { fileStorage.deleteFile(tempPath) }
-            }
+            return StagedSave(tempPath, written, cleanup)
         }
-        // Native fast path unavailable or returned no bytes — legacy path.
-        return libretroController.serialize()
+        // Native fast path unavailable — fall back to in-memory serialize
+        // and write through. On JVM-only platforms (desktop) this is fine;
+        // they have plenty of heap.
+        val bytes = libretroController.serialize() ?: return null
+        return runCatching {
+            fileStorage.writeFile(tempPath, bytes)
+            StagedSave(tempPath, bytes.size.toLong(), cleanup)
+        }.getOrNull().also {
+            if (it == null) cleanup()
+        }
     }
 
     /**
@@ -519,35 +563,41 @@ class SaveManager(
             return
         }
         scope.launch(dispatchers.io) {
-            val saveData = libretroController.serialize() ?: return@launch
-            val sessionId = currentSessionId
-            if (sessionId != null) {
-                val screenshot = screenshotCapture?.captureScreenshot()
-                sessionRepository.uploadSlotSave(sessionId, slot, saveData, screenshot, currentCoreName).fold(
-                    onSuccess = {
-                        withContext(dispatchers.main) {
-                            _state.update {
-                                it.copy(
-                                    statusMessage = "Saved to slot $slot",
-                                    secondaryToast = SecondaryToastData(
-                                        message = "Saved to Slot $slot",
-                                        type = SecondaryToastType.SAVE,
-                                    ),
-                                )
+            val staged = stageSaveToTempFile() ?: return@launch
+            try {
+                val sessionId = currentSessionId
+                if (sessionId != null) {
+                    val screenshot = screenshotCapture?.captureScreenshot()
+                    sessionRepository.uploadSlotSaveFromFile(
+                        sessionId, slot, staged.path, staged.size, screenshot, currentCoreName,
+                    ).fold(
+                        onSuccess = {
+                            withContext(dispatchers.main) {
+                                _state.update {
+                                    it.copy(
+                                        statusMessage = "Saved to slot $slot",
+                                        secondaryToast = SecondaryToastData(
+                                            message = "Saved to Slot $slot",
+                                            type = SecondaryToastType.SAVE,
+                                        ),
+                                    )
+                                }
                             }
-                        }
-                        refreshSaveSlots()
-                    },
-                    onFailure = { error ->
-                        withContext(dispatchers.main) {
-                            _state.update { it.copy(error = "Failed to save to slot $slot: ${error.message}") }
-                        }
-                    },
-                )
-            } else {
-                withContext(dispatchers.main) {
-                    _state.update { it.copy(statusMessage = "State saved") }
+                            refreshSaveSlots()
+                        },
+                        onFailure = { error ->
+                            withContext(dispatchers.main) {
+                                _state.update { it.copy(error = "Failed to save to slot $slot: ${error.message}") }
+                            }
+                        },
+                    )
+                } else {
+                    withContext(dispatchers.main) {
+                        _state.update { it.copy(statusMessage = "State saved") }
+                    }
                 }
+            } finally {
+                staged.cleanup()
             }
         }
     }
@@ -603,9 +653,11 @@ class SaveManager(
         scope.launch(dispatchers.io) {
             val sessionId = currentSessionId
             if (sessionId != null) {
-                sessionRepository.downloadSessionAutoSave(sessionId).fold(
-                    onSuccess = { saveData ->
-                        libretroController.unserialize(saveData)
+                val tempPath = "${fileStorage.getSavesDir()}/.tmp-load-manual-$sessionId"
+                sessionRepository.downloadSessionAutoSaveToFile(sessionId, tempPath).fold(
+                    onSuccess = {
+                        libretroController.unserializeFromFile(tempPath)
+                        runCatching { fileStorage.deleteFile(tempPath) }
                         withContext(dispatchers.main) {
                             _state.update {
                                 it.copy(
@@ -619,6 +671,7 @@ class SaveManager(
                         }
                     },
                     onFailure = { error ->
+                        runCatching { fileStorage.deleteFile(tempPath) }
                         withContext(dispatchers.main) {
                             _state.update { it.copy(error = "Failed to load save: ${error.message}") }
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -9,6 +9,7 @@ import com.spela.player.presentation.state.SaveSlotInfo
 import com.spela.player.presentation.state.SecondaryToastData
 import com.spela.player.presentation.state.SecondaryToastType
 import com.spela.player.util.DispatcherProvider
+import com.spela.player.util.FileStorage
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -87,6 +88,7 @@ class SaveManager(
     private val dispatchers: DispatcherProvider,
     private val scope: CoroutineScope,
     private val sessionRepository: SessionRepository,
+    private val fileStorage: FileStorage,
 ) {
     /** The libretro core name used for the current emulation session. */
     var currentCoreName: String = ""
@@ -440,7 +442,7 @@ class SaveManager(
             return
         }
         scope.launch(dispatchers.io) {
-            val saveData = libretroController.serialize() ?: return@launch
+            val saveData = serializeViaTempFile() ?: return@launch
             val sessionId = currentSessionId
             if (sessionId != null) {
                 val screenshot = screenshotCapture?.captureScreenshot()
@@ -472,6 +474,34 @@ class SaveManager(
                 }
             }
         }
+    }
+
+    /**
+     * Pulls the current save state out of the libretro core via the native
+     * fast path when available — Android's [LibretroController.serializeToFile]
+     * writes directly into a temp file in the saves dir, never allocating a
+     * jbyteArray on the Java heap. We then read the temp file back into a
+     * ByteArray for the upload call. Even though the read-back allocation
+     * is the same size as the legacy in-memory serialize, the JNI handoff
+     * no longer holds the buffer in two places at once — see #798.
+     *
+     * Falls back to [LibretroController.serialize] if the controller has no
+     * native fast path (desktop / fakes).
+     */
+    private suspend fun serializeViaTempFile(): ByteArray? {
+        val tempPath = "${fileStorage.getSavesDir()}/.tmp-save-${currentSessionId ?: "none"}"
+        val written = libretroController.serializeToFile(tempPath)
+        if (written != null && written > 0) {
+            return try {
+                fileStorage.readFile(tempPath)
+            } catch (_: Exception) {
+                null
+            } finally {
+                runCatching { fileStorage.deleteFile(tempPath) }
+            }
+        }
+        // Native fast path unavailable or returned no bytes — legacy path.
+        return libretroController.serialize()
     }
 
     /**

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/FileReadChannel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/FileReadChannel.kt
@@ -1,0 +1,14 @@
+package com.spela.player.util
+
+import io.ktor.utils.io.ByteReadChannel
+
+/**
+ * Open a [ByteReadChannel] backed by the file at [path]. Used to stream
+ * a multipart upload directly from disk without ever loading the full
+ * file into a JVM ByteArray — the path that fixes #798 (GameCube saves
+ * are ~90 MB and don't fit alongside the rest of the heap).
+ *
+ * Implemented per platform; both Android and Desktop wrap a JVM
+ * FileInputStream via ktor's `toByteReadChannel`.
+ */
+expect fun openFileReadChannel(path: String): ByteReadChannel

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
@@ -220,6 +220,15 @@ private class FakeSessionRepo : SessionRepository {
         coreName: String,
     ): Result<SaveState> = Result.failure(UnsupportedOperationException("not exercised"))
 
+    override suspend fun uploadSessionSaveFromFile(
+        sessionId: String,
+        name: String,
+        savePath: String,
+        saveSize: Long,
+        screenshot: ByteArray?,
+        coreName: String,
+    ): Result<SaveState> = Result.failure(UnsupportedOperationException("not exercised"))
+
     override suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray> =
         Result.failure(UnsupportedOperationException("not exercised"))
 
@@ -230,13 +239,33 @@ private class FakeSessionRepo : SessionRepository {
         coreName: String,
     ): Result<Unit> = Result.failure(UnsupportedOperationException("not exercised"))
 
+    override suspend fun uploadSessionAutoSaveFromFile(
+        sessionId: String,
+        savePath: String,
+        saveSize: Long,
+        screenshot: ByteArray?,
+        coreName: String,
+    ): Result<Unit> = Result.failure(UnsupportedOperationException("not exercised"))
+
     override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun downloadSessionAutoSaveToFile(sessionId: String, outputPath: String): Result<Unit> =
         Result.failure(UnsupportedOperationException("not exercised"))
 
     override suspend fun uploadSlotSave(
         sessionId: String,
         slot: Int,
         data: ByteArray,
+        screenshot: ByteArray?,
+        coreName: String,
+    ): Result<SaveState> = Result.failure(UnsupportedOperationException("not exercised"))
+
+    override suspend fun uploadSlotSaveFromFile(
+        sessionId: String,
+        slot: Int,
+        savePath: String,
+        saveSize: Long,
         screenshot: ByteArray?,
         coreName: String,
     ): Result<SaveState> = Result.failure(UnsupportedOperationException("not exercised"))

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/util/FileReadChannel.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/util/FileReadChannel.desktop.kt
@@ -1,0 +1,8 @@
+package com.spela.player.util
+
+import io.ktor.utils.io.ByteReadChannel
+import io.ktor.utils.io.jvm.javaio.toByteReadChannel
+import java.io.FileInputStream
+
+actual fun openFileReadChannel(path: String): ByteReadChannel =
+    FileInputStream(path).toByteReadChannel()

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -176,10 +176,16 @@ private class FakePlayFromSharedSaveSessionRepository : SessionRepository {
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
     override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String) =
         Result.success(SaveState(id = "1", name = name))
+    override suspend fun uploadSessionSaveFromFile(sessionId: String, name: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String) =
+        Result.success(SaveState(id = "1", name = name))
     override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
     override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String) = Result.success(Unit)
+    override suspend fun uploadSessionAutoSaveFromFile(sessionId: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String) = Result.success(Unit)
     override suspend fun downloadSessionAutoSave(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))
+    override suspend fun downloadSessionAutoSaveToFile(sessionId: String, outputPath: String) = Result.failure<Unit>(Exception("stub"))
     override suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String) =
+        Result.success(SaveState(id = "1", name = "Slot $slot"))
+    override suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String) =
         Result.success(SaveState(id = "1", name = "Slot $slot"))
     override suspend fun downloadSlotSave(sessionId: String, slot: Int) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String) = Result.success(Unit)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
@@ -9,6 +9,7 @@ import com.spela.player.presentation.viewmodel.emulation.StubMockEngineFactory
 import com.spela.player.presentation.viewmodel.emulation.StubSaveDataRepository
 import com.spela.player.presentation.viewmodel.emulation.StubSessionRepository
 import com.spela.player.util.DispatcherProvider
+import com.spela.player.util.FileStorage
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -63,10 +64,36 @@ class SaveManagerRehearsalTest {
             dispatchers = dispatchers,
             scope = scope,
             sessionRepository = sessionRepo,
+            fileStorage = TestFileStorage(),
         )
         manager.currentSessionId = "s1"
         manager.currentCoreName = "nestopia"
         return Triple(manager, sessionRepo, libretro)
+    }
+
+    /** Minimal in-test FileStorage. SaveManager reads from this only when
+     *  the libretro controller's native fast path produced a temp file —
+     *  the stub controller never does, so these methods are unreached in
+     *  practice but must exist to satisfy the interface. */
+    private class TestFileStorage : FileStorage {
+        override fun getGamesDir(): String = "/tmp/games"
+        override fun getCoresDir(): String = "/tmp/cores"
+        override fun getSavesDir(): String = "/tmp/saves"
+        override fun getBiosDir(): String = "/tmp/bios"
+        override suspend fun createDirectory(path: String) {}
+        override suspend fun writeFile(path: String, data: ByteArray) {}
+        override suspend fun readFile(path: String): ByteArray = byteArrayOf()
+        override suspend fun fileExists(path: String): Boolean = false
+        override suspend fun deleteFile(path: String) {}
+        override suspend fun deleteDirectory(path: String) {}
+        override suspend fun getDirectorySize(path: String): Long = 0
+        override suspend fun writeFileStreaming(path: String, writer: suspend (append: suspend (ByteArray, Int, Int) -> Unit) -> Unit) {}
+        override suspend fun getFileSize(path: String): Long = 0
+        override suspend fun listFiles(path: String): List<String> = emptyList()
+        override suspend fun isDirectory(path: String): Boolean = false
+        override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
+        override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+        override suspend fun sha256File(path: String): String? = null
     }
 
     @Test

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -629,6 +629,7 @@ class EmulationViewModelTestBuilder {
             dispatchers = dispatchers,
             scope = vmScope,
             sessionRepository = sessionRepository,
+            fileStorage = StubFileStorage(),
         )
         saveManager = saveManagerLocal
         val challengeManager = ChallengeManager(

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -415,14 +415,26 @@ class StubSessionRepository : SessionRepository {
         uploadSessionSaveCallCount++
         return Result.success(SaveState(id = "1", name = name))
     }
+    override suspend fun uploadSessionSaveFromFile(sessionId: String, name: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String): Result<SaveState> {
+        uploadSessionSaveCallCount++
+        return Result.success(SaveState(id = "1", name = name))
+    }
     override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
     override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<Unit> {
+        uploadSessionAutoSaveCallCount++
+        return Result.success(Unit)
+    }
+    override suspend fun uploadSessionAutoSaveFromFile(sessionId: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String): Result<Unit> {
         uploadSessionAutoSaveCallCount++
         return Result.success(Unit)
     }
     override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> {
         downloadSessionAutoSaveCallCount++
         return downloadSessionAutoSaveResult
+    }
+    override suspend fun downloadSessionAutoSaveToFile(sessionId: String, outputPath: String): Result<Unit> {
+        downloadSessionAutoSaveCallCount++
+        return downloadSessionAutoSaveResult.map { Unit }
     }
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String): Result<Unit> {
         uploadSessionSramCallCount++
@@ -433,6 +445,8 @@ class StubSessionRepository : SessionRepository {
         return downloadSessionSramResult
     }
     override suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String) =
+        Result.success(SaveState(id = "1", name = "Slot $slot"))
+    override suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String) =
         Result.success(SaveState(id = "1", name = "Slot $slot"))
     override suspend fun downloadSlotSave(sessionId: String, slot: Int) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun createSessionFromSharedSave(gameId: String, saveId: String) =


### PR DESCRIPTION
## Summary
Add a native \`nativeSerializeToFile\` path that writes the libretro save state directly to a filesystem path with a single C-side malloc — no \`jbyteArray\` ever crosses JNI. The legacy \`nativeSerialize\` was doing \`malloc → NewByteArray → SetByteArrayRegion → free\`, holding the state in **two** allocations (one C heap, one JVM heap) for the duration of the JNI copy. For Dolphin's 30–50 MB GameCube saves that's the spike that pushes the heap past Android's 256 MB ceiling.

\`SaveManager.saveState()\` now calls the new fast path into a temp file under \`getSavesDir()\`, reads the bytes back for the upload call, and deletes the temp file. The read-back ByteArray is the same size it would have been from \`nativeSerialize\`, but it's no longer co-resident with a malloc'd native buffer at the JNI hand-off.

## Why this is a partial fix
The upload path still loads the full save into a ByteArray for ktor's multipart writer. If GameCube still OOMs on the AYN Thor after this, the follow-up is to stream the multipart body directly from the temp file (\`ChannelProvider + FileInputStream\`) so the JVM never sees the full state in one allocation. That's a multiplatform refactor (commonMain ktor + Android-specific \`ByteReadChannel\` from a path) and intentionally out of scope here.

## Files
- \`player/native/src/libretro_bridge.c\` — new \`Java_…_nativeSerializeToFile\`.
- \`player/shared/src/androidMain/.../LibretroJni.kt\` — JNI binding.
- \`player/shared/src/androidMain/.../AndroidLibretroController.kt\` — overrides \`serializeToFile\`.
- \`player/shared/src/commonMain/.../EmulationViewModel.kt\` — interface gains \`serializeToFile\`, default returns null.
- \`player/shared/src/commonMain/.../SaveManager.kt\` — now uses the fast path with a temp-file round trip; falls back to legacy serialize on platforms without a native override.
- \`SaveManager\` constructor gains a \`fileStorage\` param; DI + 2 test builders updated.

## Test plan
- ✅ \`:shared:compileKotlinDesktop\`, \`:shared:detektMainDesktop\`, \`:shared:desktopTest\` (49 suites) green.
- [x] APK side-loaded to AYN Thor.
- [ ] Manual: launch a GameCube game on Android, play long enough for state to populate, trigger Manual Save. Confirm save succeeds (or, if it still OOMs, confirm the heap headroom improved).

Refs #798