### PR TITLE
fix(server): raise save-upload cap to 256MB; make env-overridable

### DIFF
--- a/server/internal/api/huma_session_uploads.go
+++ b/server/internal/api/huma_session_uploads.go
@@ -108,7 +108,7 @@ func RegisterSessionSaveUploadRoutes(
 		Tags:          []string{"sessions"},
 		Middlewares:   uploadMW,
 		Security:      sec,
-		MaxBodyBytes:  maxSaveUploadSize,
+		MaxBodyBytes:  maxSaveUploadBytes(),
 	}, h.HumaUploadSessionSave)
 
 	huma.Register(api, huma.Operation{
@@ -121,7 +121,7 @@ func RegisterSessionSaveUploadRoutes(
 		Tags:          []string{"sessions"},
 		Middlewares:   uploadMW,
 		Security:      sec,
-		MaxBodyBytes:  maxSaveUploadSize,
+		MaxBodyBytes:  maxSaveUploadBytes(),
 	}, h.HumaUploadAutoSave)
 
 	huma.Register(api, huma.Operation{
@@ -133,7 +133,7 @@ func RegisterSessionSaveUploadRoutes(
 		Tags:         []string{"sessions"},
 		Middlewares:  uploadMW,
 		Security:     sec,
-		MaxBodyBytes: maxSaveUploadSize,
+		MaxBodyBytes: maxSaveUploadBytes(),
 	}, h.HumaUpsertSlotSave)
 
 	huma.Register(api, huma.Operation{
@@ -145,7 +145,7 @@ func RegisterSessionSaveUploadRoutes(
 		Tags:         []string{"sessions"},
 		Middlewares:  uploadMW,
 		Security:     sec,
-		MaxBodyBytes: maxSaveUploadSize,
+		MaxBodyBytes: maxSaveUploadBytes(),
 	}, h.HumaUploadSRAM)
 }
 

--- a/server/internal/api/huma_shared_uploads.go
+++ b/server/internal/api/huma_shared_uploads.go
@@ -97,7 +97,7 @@ func RegisterSharedUploadRoutes(
 		Tags:          []string{"shared-saves"},
 		Middlewares:   uploadMW,
 		Security:      sec,
-		MaxBodyBytes:  maxSaveUploadSize,
+		MaxBodyBytes:  maxSaveUploadBytes(),
 	}, sharedSaveH.HumaShareSave)
 
 	huma.Register(api, huma.Operation{
@@ -110,7 +110,7 @@ func RegisterSharedUploadRoutes(
 		Tags:          []string{"shared-sessions"},
 		Middlewares:   uploadMW,
 		Security:      sec,
-		MaxBodyBytes:  maxSaveUploadSize,
+		MaxBodyBytes:  maxSaveUploadBytes(),
 	}, sharedSessionH.HumaUploadSharedSessionSave)
 
 	huma.Register(api, huma.Operation{
@@ -122,7 +122,7 @@ func RegisterSharedUploadRoutes(
 		Tags:         []string{"shared-sessions"},
 		Middlewares:  uploadMW,
 		Security:     sec,
-		MaxBodyBytes: maxSaveUploadSize,
+		MaxBodyBytes: maxSaveUploadBytes(),
 	}, sharedSessionH.HumaUploadSharedSessionAutoSave)
 }
 

--- a/server/internal/api/middleware.go
+++ b/server/internal/api/middleware.go
@@ -16,8 +16,26 @@ import (
 	"gorm.io/gorm"
 )
 
-// maxSaveUploadSize is the maximum allowed save state upload size (64 MB).
-const maxSaveUploadSize = 64 << 20
+// defaultMaxSaveUploadMB is the default per-upload save-state cap. Sized
+// for uncompressed Dolphin GameCube states which typically run 80–100 MB
+// (#805). Smaller systems pay nothing extra — they just don't reach the
+// ceiling.
+const defaultMaxSaveUploadMB = 256
+
+// maxSaveUploadBytes returns the configured per-upload save-state cap in
+// bytes. Defaults to [defaultMaxSaveUploadMB]; override via the
+// SPELA_MAX_SAVE_UPLOAD_MB environment variable. Non-positive or
+// unparseable values fall back to the default so a typo can't accidentally
+// disable all uploads.
+func maxSaveUploadBytes() int64 {
+	mb := int64(defaultMaxSaveUploadMB)
+	if envVal := os.Getenv("SPELA_MAX_SAVE_UPLOAD_MB"); envVal != "" {
+		if parsed, err := strconv.ParseInt(envVal, 10, 64); err == nil && parsed > 0 {
+			mb = parsed
+		}
+	}
+	return mb << 20
+}
 
 const defaultMaxSaveStorageMB = 1024
 

--- a/server/internal/api/middleware_test.go
+++ b/server/internal/api/middleware_test.go
@@ -1,0 +1,46 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// Defaults to 256 MB so realistic uncompressed Dolphin GameCube saves fit
+// (typical ~80–100 MB). Below that, the server returned 413 to every
+// large-state save (#805).
+func TestMaxSaveUploadBytes_Default(t *testing.T) {
+	t.Setenv("SPELA_MAX_SAVE_UPLOAD_MB", "")
+	got := maxSaveUploadBytes()
+	const expected = int64(256) << 20
+	assert.Equal(t, expected, got, "default cap should be 256 MB")
+}
+
+func TestMaxSaveUploadBytes_EnvOverride(t *testing.T) {
+	t.Setenv("SPELA_MAX_SAVE_UPLOAD_MB", "512")
+	got := maxSaveUploadBytes()
+	const expected = int64(512) << 20
+	assert.Equal(t, expected, got, "env override should set cap to 512 MB")
+}
+
+// Garbage values fall back to the default rather than crashing the server
+// or accidentally setting a tiny cap.
+func TestMaxSaveUploadBytes_InvalidEnvFallsBackToDefault(t *testing.T) {
+	t.Setenv("SPELA_MAX_SAVE_UPLOAD_MB", "not-a-number")
+	got := maxSaveUploadBytes()
+	const expected = int64(256) << 20
+	assert.Equal(t, expected, got, "invalid env value should fall back to default")
+}
+
+// Zero / negative values fall back to the default — protects against an
+// operator setting "0" and silently disabling all uploads.
+func TestMaxSaveUploadBytes_NonPositiveEnvFallsBackToDefault(t *testing.T) {
+	for _, v := range []string{"0", "-1"} {
+		t.Run("env="+v, func(t *testing.T) {
+			t.Setenv("SPELA_MAX_SAVE_UPLOAD_MB", v)
+			got := maxSaveUploadBytes()
+			const expected = int64(256) << 20
+			assert.Equal(t, expected, got, "non-positive env value should fall back to default")
+		})
+	}
+}


### PR DESCRIPTION
## Summary
The server caps every save-state upload at 64 MB. With #802 the player no longer OOMs while uploading, but the next thing the user hits is a 413 from the server because Dolphin GameCube states typically run 80–100 MB uncompressed.

Bump the default to 256 MB and expose \`SPELA_MAX_SAVE_UPLOAD_MB\` for operators. Non-positive or unparseable values fall back to the default — same protective pattern as the sibling \`SPELA_MAX_SAVE_STORAGE_MB\`.

## Files
- \`server/internal/api/middleware.go\` — replace the \`maxSaveUploadSize\` const with a \`maxSaveUploadBytes()\` function reading the env override.
- \`server/internal/api/huma_session_uploads.go\`, \`server/internal/api/huma_shared_uploads.go\` — call the function at huma operation registration. 7 sites in total.
- \`server/internal/api/middleware_test.go\` — new test covering default, env override, invalid env (falls back), non-positive env (falls back).

## Behaviour notes
The cap is read at huma operation registration (server startup), not per-request. Matches the previous behaviour (the const couldn't change at all). Promoting it to per-request would need a custom body-size middleware — separate concern.

## Test plan
- ✅ \`go test ./internal/api/ -run TestMaxSaveUploadBytes -count=1\` green (TDD: tests written first, watched fail with \"undefined: maxSaveUploadBytes\", then implementation made them pass).
- ✅ \`go build ./...\` clean.
- [ ] Full \`go test ./...\` — running locally; CI will validate.

Refs #804 (phase 1)
Fixes #805