### PR TITLE
feat(player): show download size under Download button on game-detail

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -46,6 +46,7 @@ import com.spela.player.presentation.ui.gamepad.autoFocus
 import com.spela.player.presentation.ui.theme.SpColor
 import com.spela.player.presentation.ui.theme.SpSpacing
 import com.spela.player.presentation.ui.theme.SpTypography
+import com.spela.player.util.formatBytes
 import com.spela.player.util.formatPlayTime
 
 /**
@@ -194,15 +195,32 @@ fun GameHeroContent(
                         add(SpSplitButtonMenuItem("Netplay") { onCreateNetplay(gameId) })
                     }
                 }
-                SpSplitButton(
-                    text = if (isBusy) "Downloading..." else "Download",
-                    onClick = onDownloadGame,
-                    modifier = Modifier.testTag("game_detail_download_button"),
-                    isLoading = isBusy,
-                    enabled = !isBusy,
-                    menuItems = menuItems,
-                    onGradient = true,
-                )
+                Column(verticalArrangement = Arrangement.spacedBy(SpSpacing.XSmall)) {
+                    SpSplitButton(
+                        text = if (isBusy) "Downloading..." else "Download",
+                        onClick = onDownloadGame,
+                        modifier = Modifier.testTag("game_detail_download_button"),
+                        isLoading = isBusy,
+                        enabled = !isBusy,
+                        menuItems = menuItems,
+                        onGradient = true,
+                    )
+                    // Size hint under the button — answers "is this 5 MB or
+                    // 5 GB?" before the user commits, without scrolling
+                    // down to the metadata table. Hidden during the active
+                    // download because SpDownloadProgressBar already shows
+                    // the downloaded / total byte counter (#801).
+                    if (!isBusy && game.fileSize > 0) {
+                        Text(
+                            text = formatBytes(game.fileSize),
+                            style = SpTypography.LabelSmall,
+                            color = Color.White.copy(alpha = 0.65f),
+                            modifier = Modifier
+                                .testTag("game_detail_download_size")
+                                .align(Alignment.CenterHorizontally),
+                        )
+                    }
+                }
             }
 
             GameActionsMenu(


### PR DESCRIPTION
## Summary
On the game-detail hero, render the file size right under the **Download** button so users can answer "is this 5 MB or 5 GB?" without scrolling down to the metadata table.

The size text:
- Hides during the active download (SpDownloadProgressBar already shows \`downloaded / total\`).
- Hides when \`game.fileSize == 0\` (legacy entries without a recorded size — no "?" / "0 B" placeholder).
- Multi-disc games render the **total** size; \`Game.fileSize\` is already populated as the sum across discs by the scanner.

Single-file change: wrap the existing \`SpSplitButton\` in a \`Column\` with the label below.

## Files
- \`player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt\`

## Test plan
- ✅ \`:shared:compileKotlinDesktop\`, \`:shared:detektMainDesktop\` clean.
- ✅ \`:shared:desktopTest\` (49 suites) green.
- [x] APK side-loaded to AYN Thor for manual verification.

## What's left from #801
The speed-during-download half — adds \`bytesPerSecond\` to \`DownloadProgress\` with a rolling-window-smoothed average, renders inside the progress bar, falls to 0 when stalled. That's a deeper change (data model + repository + UI) and intentionally a follow-up PR. This PR is the smaller, lower-risk half.

Refs #801