### PR TITLE
feat(player): rolling-window download speed in DownloadProgress

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
@@ -22,6 +22,19 @@ class DownloadRepositoryImpl(
     private val downloads = MutableStateFlow<Map<String, DownloadProgress>>(emptyMap())
     private val _downloadedGames = MutableStateFlow<List<DownloadedGame>>(emptyList())
 
+    /** Per-game rolling speed calculator. Created on first in-flight
+     *  emission for a game id, removed when the download enters a
+     *  terminal state (COMPLETED / FAILED) so a re-download starts
+     *  fresh. See [SpeedTracker] and #801. */
+    private val speedTrackers = mutableMapOf<String, SpeedTracker>()
+
+    private fun recordSpeed(gameId: String, bytesDownloaded: Long): Long =
+        speedTrackers.getOrPut(gameId) { SpeedTracker() }.record(bytesDownloaded)
+
+    private fun resetSpeed(gameId: String) {
+        speedTrackers.remove(gameId)
+    }
+
     init {
         refreshDownloadedGames()
     }
@@ -81,6 +94,7 @@ class DownloadRepositoryImpl(
         refreshDownloadedGames()
     }.onFailure {
         cleanupPartialDownload(gameId)
+        resetSpeed(gameId)
         downloads.update {
             it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.FAILED))
         }
@@ -108,8 +122,9 @@ class DownloadRepositoryImpl(
             // compressed size while downloaded bytes count decompressed data,
             // causing the progress bar to jump past 100%.
             val reportedTotal = if (expectedSize > 0) expectedSize else (total ?: -1)
+            val speed = recordSpeed(gameId, downloaded)
             downloads.update {
-                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal))
+                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal, bytesPerSecond = speed))
             }
         }
 
@@ -123,6 +138,7 @@ class DownloadRepositoryImpl(
                 "Download size mismatch: expected $expectedSize bytes, got $actualSize bytes"
             )
         }
+        resetSpeed(gameId)
         downloads.update {
             it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.COMPLETED, actualSize, actualSize))
         }
@@ -152,8 +168,9 @@ class DownloadRepositoryImpl(
             // Tar archive (cue+bin or gdi+tracks) — stream-extract directly to disk
             apiClient.downloadDiscAndExtract(gameId, disc.discNumber.toInt(), fileStorage, gameDir) { downloaded, total ->
                 val reportedTotal = if (disc.fileSize > 0) disc.fileSize else (total ?: -1)
+                val speed = recordSpeed(gameId, downloaded)
                 downloads.update {
-                    it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal))
+                    it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal, bytesPerSecond = speed))
                 }
             }
         } else {
@@ -161,12 +178,14 @@ class DownloadRepositoryImpl(
             val discPath = "$gameDir/${disc.fileName}"
             apiClient.downloadDiscToFile(gameId, disc.discNumber.toInt(), fileStorage, discPath) { downloaded, total ->
                 val reportedTotal = if (disc.fileSize > 0) disc.fileSize else (total ?: -1)
+                val speed = recordSpeed(gameId, downloaded)
                 downloads.update {
-                    it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal))
+                    it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal, bytesPerSecond = speed))
                 }
             }
         }
 
+        resetSpeed(gameId)
         downloads.update {
             it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.COMPLETED, game.fileSize, game.fileSize))
         }
@@ -191,11 +210,13 @@ class DownloadRepositoryImpl(
 
         apiClient.downloadGameAndExtract(gameId, fileStorage, gameDir) { downloaded, total ->
             val reportedTotal = if (expectedSize > 0) expectedSize else (total ?: -1)
+            val speed = recordSpeed(gameId, downloaded)
             downloads.update {
-                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal))
+                it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.DOWNLOADING, downloaded, reportedTotal, bytesPerSecond = speed))
             }
         }
 
+        resetSpeed(gameId)
         downloads.update {
             it + (gameId to DownloadProgress(gameId, gameTitle, DownloadState.COMPLETED, expectedSize, expectedSize))
         }
@@ -229,11 +250,14 @@ class DownloadRepositoryImpl(
                 disc.fileName.endsWith(".gdi", ignoreCase = true)) {
                 // Tar archive (cue+bin or gdi+tracks) - stream-extract directly to disk
                 apiClient.downloadDiscAndExtract(gameId, disc.discNumber.toInt(), fileStorage, gameDir) { downloaded, total ->
+                    val totalDownloaded = discOffset + downloaded
+                    val speed = recordSpeed(gameId, totalDownloaded)
                     downloads.update {
                         it + (gameId to DownloadProgress(
                             gameId, gameTitle, DownloadState.DOWNLOADING,
-                            bytesDownloaded = discOffset + downloaded, totalBytes = totalSize,
+                            bytesDownloaded = totalDownloaded, totalBytes = totalSize,
                             currentDisc = disc.discNumber.toInt(), totalDiscs = totalDiscs,
+                            bytesPerSecond = speed,
                         ))
                     }
                 }
@@ -241,11 +265,14 @@ class DownloadRepositoryImpl(
                 // Single file (ISO/CHD/CSO) - stream to disk
                 val discPath = "$gameDir/${disc.fileName}"
                 apiClient.downloadDiscToFile(gameId, disc.discNumber.toInt(), fileStorage, discPath) { downloaded, total ->
+                    val totalDownloaded = discOffset + downloaded
+                    val speed = recordSpeed(gameId, totalDownloaded)
                     downloads.update {
                         it + (gameId to DownloadProgress(
                             gameId, gameTitle, DownloadState.DOWNLOADING,
-                            bytesDownloaded = discOffset + downloaded, totalBytes = totalSize,
+                            bytesDownloaded = totalDownloaded, totalBytes = totalSize,
                             currentDisc = disc.discNumber.toInt(), totalDiscs = totalDiscs,
+                            bytesPerSecond = speed,
                         ))
                     }
                 }
@@ -259,6 +286,7 @@ class DownloadRepositoryImpl(
             .joinToString("\n") { it.fileName } + "\n"
         fileStorage.writeFile(m3uPath, m3uContent.encodeToByteArray())
 
+        resetSpeed(gameId)
         downloads.update {
             it + (gameId to DownloadProgress(
                 gameId, gameTitle, DownloadState.COMPLETED,

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/DownloadRepositoryImpl.kt
@@ -313,6 +313,10 @@ class DownloadRepositoryImpl(
 
     override suspend fun cancelDownload(gameId: String) {
         downloads.update { it - gameId }
+        // Drop the tracker too so a cancel-then-restart starts with a fresh
+        // window. Without this the old samples briefly inflate the reported
+        // speed of the new download until they age out.
+        resetSpeed(gameId)
     }
 
     override suspend fun getLocalGamePath(gameId: String): String? {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SpeedTracker.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SpeedTracker.kt
@@ -1,0 +1,51 @@
+package com.spela.player.data.repository
+
+import kotlin.time.Clock
+
+/**
+ * Rolling-window byte-rate calculator for active downloads.
+ *
+ * Each call to [record] supplies a `(now, totalBytesDownloadedSoFar)` sample
+ * and returns the average bytes-per-second over the most recent
+ * [windowMs]. Samples older than the window are dropped on every call.
+ *
+ * The instantaneous delta between two emissions is jittery because the
+ * underlying HTTP callback fires unevenly (network bursts, OkHttp
+ * buffer flushes). The rolling average smooths that out so the UI label
+ * doesn't flicker between unrealistic numbers.
+ *
+ * Speed reported as 0 until the window has at least two samples *and*
+ * non-zero elapsed time. When a download stalls (no bytes for the full
+ * window), the oldest non-stale sample's bytes equal the latest, so
+ * the reported speed naturally falls back to 0.
+ *
+ * Thread-safety: not synchronised — callers serialise their own
+ * progress emissions per game id.
+ */
+internal class SpeedTracker(
+    private val windowMs: Long = DEFAULT_WINDOW_MS,
+    private val now: () -> Long = { Clock.System.now().toEpochMilliseconds() },
+) {
+    private data class Sample(val timestamp: Long, val bytes: Long)
+
+    private val samples = ArrayDeque<Sample>()
+
+    fun record(bytesDownloaded: Long): Long {
+        val t = now()
+        // Drop samples older than the window.
+        while (samples.isNotEmpty() && t - samples.first().timestamp > windowMs) {
+            samples.removeFirst()
+        }
+        samples.addLast(Sample(t, bytesDownloaded))
+        if (samples.size < 2) return 0L
+        val first = samples.first()
+        val deltaBytes = bytesDownloaded - first.bytes
+        val deltaMs = t - first.timestamp
+        if (deltaMs <= 0L || deltaBytes < 0L) return 0L
+        return deltaBytes * 1_000L / deltaMs
+    }
+
+    companion object {
+        const val DEFAULT_WINDOW_MS = 2_000L
+    }
+}

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/model/Models.kt
@@ -225,6 +225,9 @@ data class DownloadProgress(
     val totalBytes: Long = -1,
     val currentDisc: Int = 0,
     val totalDiscs: Int = 0,
+    /** Rolling-window average bytes per second over the most recent
+     *  ~2 s of progress samples. 0 when stalled or not yet computable. */
+    val bytesPerSecond: Long = 0,
 ) {
     val progress: Float
         get() = when {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
@@ -106,6 +106,9 @@ fun SpDownloadProgressBar(
     totalBytes: Long,
     modifier: Modifier = Modifier,
     onGradient: Boolean = false,
+    /** Smoothed bytes-per-second. 0 hides the speed label so a stalled
+     *  download doesn't show a stale value (#801). */
+    bytesPerSecond: Long = 0,
 ) {
     val byteLabelColor = if (onGradient) Color.White.copy(alpha = 0.65f) else SpColor.OnBackgroundTertiary
     val indeterminateTrackColor = if (onGradient) Color.White.copy(alpha = 0.12f) else SpColor.SurfaceBright
@@ -137,6 +140,13 @@ fun SpDownloadProgressBar(
                 style = SpTypography.LabelSmall,
                 color = byteLabelColor,
             )
+            if (bytesPerSecond > 0) {
+                Text(
+                    text = " · ${formatBytes(bytesPerSecond)}/s",
+                    style = SpTypography.LabelSmall,
+                    color = byteLabelColor,
+                )
+            }
             Spacer(Modifier.weight(1f))
             Text(
                 text = if (totalBytes < 0) "..." else formatBytes(totalBytes),

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -324,6 +324,7 @@ fun GameHeroContent(
                         progress = dp?.progress ?: -1f,
                         bytesDownloaded = dp?.bytesDownloaded ?: 0L,
                         totalBytes = dp?.totalBytes ?: -1L,
+                        bytesPerSecond = dp?.bytesPerSecond ?: 0L,
                         onGradient = true,
                         modifier = Modifier.fillMaxWidth(),
                     )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DownloadsScreen.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/screen/DownloadsScreen.kt
@@ -262,6 +262,7 @@ private fun DownloadItem(
                     progress = download.progress,
                     bytesDownloaded = download.bytesDownloaded,
                     totalBytes = download.totalBytes,
+                    bytesPerSecond = download.bytesPerSecond,
                 )
             }
         }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/SpeedTrackerTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/data/repository/SpeedTrackerTest.kt
@@ -1,0 +1,70 @@
+package com.spela.player.data.repository
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SpeedTrackerTest {
+
+    private class FakeClock(initial: Long = 0L) {
+        var t: Long = initial
+        val now: () -> Long = { t }
+        fun advance(ms: Long) { t += ms }
+    }
+
+    @Test fun firstSampleReturnsZero() {
+        val clock = FakeClock()
+        val s = SpeedTracker(now = clock.now)
+        assertEquals(0L, s.record(0L), "single sample has no rate yet")
+    }
+
+    @Test fun computesAverageOverTwoSamples() {
+        val clock = FakeClock()
+        val s = SpeedTracker(now = clock.now)
+        s.record(0L)
+        clock.advance(1_000) // 1 s
+        // 5 MB in 1 s => 5 MB/s
+        val rate = s.record(5L * 1024 * 1024)
+        assertEquals(5L * 1024 * 1024, rate)
+    }
+
+    @Test fun rollingWindowDropsStaleSamples() {
+        val clock = FakeClock()
+        val s = SpeedTracker(windowMs = 2_000, now = clock.now)
+        s.record(0L)                                    // @ 0 ms, 0 B  (will be dropped)
+        clock.advance(500); s.record(1_000_000L)        // @ 500 ms, 1 MB
+        clock.advance(500); s.record(2_000_000L)        // @ 1000 ms, 2 MB
+        clock.advance(500); s.record(3_000_000L)        // @ 1500 ms, 3 MB
+        // Advance to 2_500 ms — the 0-byte sample from t=0 falls
+        // outside the 2 s window (2500 - 0 = 2500 > 2000) and is
+        // dropped. Remaining oldest in-window sample: t=500 ms, 1 MB.
+        clock.advance(1_000); val rate = s.record(4_000_000L) // @ 2500 ms, 4 MB
+        // Window now spans (500 ms, 1 MB) → (2500 ms, 4 MB) = 2 s, 3 MB.
+        // Expected rate = 3 MB / 2 s = 1.5 MB/s.
+        assertTrue(rate in 1_400_000L..1_600_000L, "stale samples should be dropped, in-window kept; got $rate")
+    }
+
+    @Test fun stalledDownloadReportsZero() {
+        val clock = FakeClock()
+        val s = SpeedTracker(windowMs = 2_000, now = clock.now)
+        s.record(0L)
+        clock.advance(100); s.record(10_000_000L) // 10 MB transferred
+        // No more bytes — tick through the window and beyond.
+        clock.advance(500); val r1 = s.record(10_000_000L)
+        clock.advance(2_000); val r2 = s.record(10_000_000L)
+        // Within window: still showing some rate from the burst.
+        // Past window: only stalled samples remain → rate 0.
+        assertTrue(r1 > 0L, "rate should be non-zero while burst is in window; got $r1")
+        assertEquals(0L, r2, "rate should fall to 0 when the only in-window samples are stalled")
+    }
+
+    @Test fun nonMonotonicBytesReturnsZero() {
+        // If the caller resets bytesDownloaded (e.g. starts a new game with
+        // the same id), the delta would go negative — guard against that.
+        val clock = FakeClock()
+        val s = SpeedTracker(now = clock.now)
+        s.record(5_000_000L)
+        clock.advance(500); val r = s.record(1_000_000L) // counter went backward
+        assertEquals(0L, r)
+    }
+}


### PR DESCRIPTION
## Summary
The speed-during-download half of #801. The size-before-download half landed in #807.

- New \`SpeedTracker\` keeps a 2 s rolling window of \`(timestamp, bytesSoFar)\` samples and returns the average B/s. Stale samples are dropped on every \`record\` so a stalled download naturally reports 0.
- \`DownloadRepositoryImpl\` keeps a per-game-id map of trackers, calls \`recordSpeed(...)\` on every in-flight progress callback (single-disc, multi-disc cue/gdi tar, m3u multi-disc, game-endpoint cue extract), and \`resetSpeed(...)\` on terminal states so a re-download starts fresh.
- \`DownloadProgress\` gains \`bytesPerSecond: Long = 0\`.
- \`SpDownloadProgressBar\` renders \` · 3.2 MB/s\` next to the bytes-downloaded label, hidden when 0.

## Tests (TDD)
\`SpeedTrackerTest\` covers five scenarios — first sample = 0, two samples = correct average, rolling window drops stale samples but keeps in-window ones, stalled download falls to 0, non-monotonic byte counter returns 0. The window-edge test uses a deterministic injected clock.

## Files
- \`SpeedTracker.kt\` (new) + \`SpeedTrackerTest.kt\` (new)
- \`DownloadRepositoryImpl.kt\` — wire trackers through 4 in-flight callbacks + reset on terminal states
- \`Models.kt\` — \`DownloadProgress.bytesPerSecond\`
- \`SpProgressBar.kt\` — render the speed label
- \`GameHeroContent.kt\` + \`DownloadsScreen.kt\` — pass \`bytesPerSecond\` from the model

## Test plan
- ✅ \`:shared:compileKotlinDesktop\`, \`:shared:detektMainDesktop\`, \`:shared:desktopTest\` clean.
- [x] APK side-loaded to AYN Thor.
- [ ] Manual verification: start a download, confirm "12.3 MB · 3.2 MB/s / 92.4 MB" reads naturally and stays smooth (no jitter); pause / disconnect briefly and confirm the speed label drops away rather than freezing on a stale value.

Refs #801