### PR TITLE
feat(player): inline Save-button feedback in in-game overlay

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -81,6 +81,15 @@ data class EmulationState(
     val showExitConfirm: Boolean = false,
     val requestExit: Boolean = false,
     val statusMessage: String? = null,
+    /** True from the moment the user taps the in-game overlay's Save
+     *  button until the upload completes (success or failure). Drives
+     *  the inline button feedback in the overlay so the user sees
+     *  "Saving…" without having to wait for a toast. See #803. */
+    val isSaveInProgress: Boolean = false,
+    /** Sticky error message from the most recent failed manual save.
+     *  Cleared at the start of the next save attempt so the button
+     *  doesn't show stale failure text indefinitely. See #803. */
+    val saveStateError: String? = null,
     /**
      * Non-blocking warning shown when the session's pinned core
      * version (see `GameSession.pinnedCoreSha256`) is no longer

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.FastForward
 import androidx.compose.material.icons.filled.FastRewind
 import androidx.compose.material.icons.filled.Flag
@@ -25,6 +26,7 @@ import androidx.compose.material.icons.filled.FolderOpen
 import androidx.compose.material.icons.filled.PlayArrow
 import androidx.compose.material.icons.filled.Replay
 import androidx.compose.material.icons.filled.Save
+import androidx.compose.material.icons.filled.Sync
 import androidx.compose.material.icons.filled.Code
 import androidx.compose.material.icons.filled.SportsEsports
 import androidx.compose.material.icons.filled.Stop
@@ -270,6 +272,8 @@ internal fun InGameOverlayPanel(
                             supportsSaveStates = state.supportsSaveStates,
                             rewindEnabled = state.rewindEnabled,
                             hasCheats = state.hasCheats,
+                            isSaveInProgress = state.isSaveInProgress,
+                            saveStateError = state.saveStateError,
                             onSave = { viewModel.onIntent(EmulationIntent.SaveState) },
                             onLoad = { viewModel.onIntent(EmulationIntent.LoadState) },
                             onScreenshot = { viewModel.onIntent(EmulationIntent.TakeScreenshot) },
@@ -363,6 +367,8 @@ internal fun RowScope.OverlayActionButtons(
     supportsSaveStates: Boolean,
     rewindEnabled: Boolean = false,
     hasCheats: Boolean = false,
+    isSaveInProgress: Boolean = false,
+    saveStateError: String? = null,
     onSave: () -> Unit,
     onLoad: () -> Unit,
     onScreenshot: () -> Unit,
@@ -373,7 +379,26 @@ internal fun RowScope.OverlayActionButtons(
     onControls: () -> Unit,
 ) {
     if (supportsSaveStates) {
-        OverlayAction(label = "Save", icon = Icons.Filled.Save, onClick = onSave)
+        // State-aware Save action: idle / in-progress / failed (#803).
+        // Success uses the existing "State saved" toast — adding an
+        // auto-clearing checkmark to the button is a follow-up.
+        val saveLabel: String
+        val saveIcon: ImageVector
+        when {
+            isSaveInProgress -> {
+                saveLabel = "Saving…"
+                saveIcon = Icons.Filled.Sync
+            }
+            saveStateError != null -> {
+                saveLabel = "Save failed"
+                saveIcon = Icons.Filled.ErrorOutline
+            }
+            else -> {
+                saveLabel = "Save"
+                saveIcon = Icons.Filled.Save
+            }
+        }
+        OverlayAction(label = saveLabel, icon = saveIcon, onClick = onSave)
         OverlayAction(label = "Load", icon = Icons.Filled.FolderOpen, onClick = onLoad)
     }
     if (rewindEnabled) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -466,8 +466,24 @@ class SaveManager(
         // in flight (#803).
         _state.update { it.copy(isSaveInProgress = true, saveStateError = null) }
         scope.launch(dispatchers.io) {
-            val staged = stageSaveToTempFile() ?: run {
-                _state.update { it.copy(isSaveInProgress = false) }
+            // Wrap staging in try/catch so a thrown exception still
+            // clears isSaveInProgress — otherwise the button is stuck
+            // on "Saving…" for the rest of the session. The inner
+            // runCatching in stageSaveToTempFile only covers the
+            // file write, not the controller / FileStorage calls
+            // around it.
+            val staged = try {
+                stageSaveToTempFile() ?: run {
+                    _state.update { it.copy(isSaveInProgress = false) }
+                    return@launch
+                }
+            } catch (e: Exception) {
+                _state.update {
+                    it.copy(
+                        isSaveInProgress = false,
+                        saveStateError = "Failed to save: ${e.message}",
+                    )
+                }
                 return@launch
             }
             try {
@@ -494,9 +510,12 @@ class SaveManager(
                         },
                         onFailure = { error ->
                             withContext(dispatchers.main) {
+                                // saveStateError is the canonical surface for
+                                // manual-save failures (sticky inline label on
+                                // the Save button). Don't *also* fire the
+                                // top-of-screen error toast — duplicate UX.
                                 _state.update {
                                     it.copy(
-                                        error = "Failed to save: ${error.message}",
                                         isSaveInProgress = false,
                                         saveStateError = "Failed to save: ${error.message}",
                                     )

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -459,8 +459,17 @@ class SaveManager(
             emitRehearsalBlocked(RehearsalSaveKind.Manual)
             return
         }
+        // Inline button feedback: tap → "Saving…" immediately, even
+        // if the user dismisses the overlay before the toast renders.
+        // Clears any stale error from a prior failed attempt so the
+        // button doesn't read "Save failed" while a fresh save is
+        // in flight (#803).
+        _state.update { it.copy(isSaveInProgress = true, saveStateError = null) }
         scope.launch(dispatchers.io) {
-            val staged = stageSaveToTempFile() ?: return@launch
+            val staged = stageSaveToTempFile() ?: run {
+                _state.update { it.copy(isSaveInProgress = false) }
+                return@launch
+            }
             try {
                 val sessionId = currentSessionId
                 if (sessionId != null) {
@@ -473,6 +482,7 @@ class SaveManager(
                                 _state.update {
                                     it.copy(
                                         statusMessage = "State saved",
+                                        isSaveInProgress = false,
                                         secondaryToast = SecondaryToastData(
                                             message = "Saved to Slot ${it.activeSlot}",
                                             type = SecondaryToastType.SAVE,
@@ -484,14 +494,20 @@ class SaveManager(
                         },
                         onFailure = { error ->
                             withContext(dispatchers.main) {
-                                _state.update { it.copy(error = "Failed to save: ${error.message}") }
+                                _state.update {
+                                    it.copy(
+                                        error = "Failed to save: ${error.message}",
+                                        isSaveInProgress = false,
+                                        saveStateError = "Failed to save: ${error.message}",
+                                    )
+                                }
                             }
                         },
                     )
                 } else {
                     // No session — save state was serialized by the controller
                     withContext(dispatchers.main) {
-                        _state.update { it.copy(statusMessage = "State saved") }
+                        _state.update { it.copy(statusMessage = "State saved", isSaveInProgress = false) }
                     }
                 }
             } finally {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
@@ -304,6 +304,31 @@ class SaveManagerRehearsalTest {
         )
     }
 
+    /** Regression: if staging the save state throws (rather than
+     *  returns null), the in-progress flag must still reach false —
+     *  otherwise the Save button is stuck on "Saving…" for the rest
+     *  of the session. The inner runCatching in stageSaveToTempFile
+     *  only covers the file write, not the controller / FileStorage
+     *  calls around it, so this is a real path. */
+    @Test
+    fun saveStateClearsInProgressWhenStagingThrows() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeManagerFixture(scope, dispatcher)
+
+        fx.libretro.serializeThrows = true
+        fx.manager.rehearsalMode = false
+        fx.manager.saveState()
+        advanceUntilIdle()
+
+        assertEquals(false, fx.state.value.isSaveInProgress,
+            "isSaveInProgress must reach false even when staging throws")
+        assertTrue(
+            fx.state.value.saveStateError?.contains("native serialize threw") == true,
+            "saveStateError should carry the staging exception; got '${fx.state.value.saveStateError}'",
+        )
+    }
+
     /** A new save attempt clears any prior failure so the button isn't
      *  stuck in "Save failed" state forever. */
     @Test

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -44,6 +45,42 @@ class SaveManagerRehearsalTest {
             override val io: CoroutineDispatcher = dispatcher
             override val default: CoroutineDispatcher = dispatcher
         }
+
+    /** Bag of test fixtures returned by [makeManager]. Adds [state] so
+     *  tests can assert transitions on EmulationState fields the
+     *  manager mutates (e.g. isSaveInProgress, saveStateError). */
+    private data class ManagerFixture(
+        val manager: SaveManager,
+        val sessionRepo: StubSessionRepository,
+        val libretro: StubLibretroController,
+        val state: MutableStateFlow<EmulationState>,
+    )
+
+    private fun makeManagerFixture(
+        scope: CoroutineScope,
+        dispatcher: CoroutineDispatcher,
+    ): ManagerFixture {
+        val dispatchers = testDispatchers(dispatcher)
+        val apiClient = SpelaApiClient(StubMockEngineFactory, TokenManager())
+        val connectivity = ConnectivityMonitor(apiClient, dispatchers, scope)
+        val sessionRepo = StubSessionRepository()
+        val libretro = StubLibretroController()
+        val state = MutableStateFlow(EmulationState())
+        val manager = SaveManager(
+            saveDataRepository = StubSaveDataRepository(),
+            connectivityMonitor = connectivity,
+            libretroController = libretro,
+            screenshotCapture = null,
+            _state = state,
+            dispatchers = dispatchers,
+            scope = scope,
+            sessionRepository = sessionRepo,
+            fileStorage = TestFileStorage(),
+        )
+        manager.currentSessionId = "s1"
+        manager.currentCoreName = "nestopia"
+        return ManagerFixture(manager, sessionRepo, libretro, state)
+    }
 
     private fun makeManager(
         scope: CoroutineScope,
@@ -222,6 +259,68 @@ class SaveManagerRehearsalTest {
         advanceUntilIdle()
         assertEquals(1, sessionRepo.uploadSessionSaveCallCount,
             "upload must resume after rehearsal mode is cleared")
+    }
+
+    /** #803 — the in-game overlay's Save button needs feedback even
+     *  if the user dismisses the overlay before the success toast
+     *  renders. SaveManager must publish an in-progress flag while
+     *  the upload is in flight, and clear it before the success path
+     *  runs. */
+    @Test
+    fun saveStateClearsInProgressOnSuccess() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeManagerFixture(scope, dispatcher)
+
+        fx.manager.rehearsalMode = false
+        fx.manager.saveState()
+        advanceUntilIdle()
+
+        assertEquals(false, fx.state.value.isSaveInProgress,
+            "isSaveInProgress should be false after a successful save")
+        assertEquals(null, fx.state.value.saveStateError,
+            "saveStateError should be null after success")
+    }
+
+    /** Failure path: error sticks until cleared, in-progress drops. */
+    @Test
+    fun saveStateRecordsErrorOnFailure() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeManagerFixture(scope, dispatcher)
+
+        // Configure the stub to fail the upload.
+        fx.sessionRepo.uploadSessionSaveResult = Result.failure(RuntimeException("test: 413 too large"))
+
+        fx.manager.rehearsalMode = false
+        fx.manager.saveState()
+        advanceUntilIdle()
+
+        assertEquals(false, fx.state.value.isSaveInProgress,
+            "isSaveInProgress should be false after the upload finishes (success or failure)")
+        assertTrue(
+            fx.state.value.saveStateError?.contains("test: 413 too large") == true,
+            "saveStateError should carry the failure message; got '${fx.state.value.saveStateError}'",
+        )
+    }
+
+    /** A new save attempt clears any prior failure so the button isn't
+     *  stuck in "Save failed" state forever. */
+    @Test
+    fun newSaveAttemptClearsPriorError() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeManagerFixture(scope, dispatcher)
+
+        // Seed the state with a failure from a prior attempt.
+        fx.state.update { it.copy(saveStateError = "stale failure") }
+
+        fx.manager.rehearsalMode = false
+        fx.manager.saveState()
+        advanceUntilIdle()
+
+        assertEquals(null, fx.state.value.saveStateError,
+            "starting a new save attempt must clear any prior error")
     }
 
     @Test

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -116,6 +116,10 @@ open class StubLibretroController : LibretroController {
 
     var supportsSaveStatesResult = true
     var serializeResult: ByteArray? = byteArrayOf()
+    /** Drives [serialize] to throw, simulating a native serialize-to-file
+     *  exception. Used by tests that verify SaveManager clears its
+     *  in-progress flag when staging blows up (#803). */
+    var serializeThrows: Boolean = false
     var unserializeResult = true
     var isHwRenderEnabledResult = false
     var getSRAMResult: ByteArray? = byteArrayOf(1, 2, 3)
@@ -138,7 +142,11 @@ open class StubLibretroController : LibretroController {
     override fun resume() { resumeCallCount++ }
     override fun stop() { stopCallCount++ }
     override fun supportsSaveStates(): Boolean = supportsSaveStatesResult
-    override fun serialize(): ByteArray? { serializeCallCount++; return serializeResult }
+    override fun serialize(): ByteArray? {
+        serializeCallCount++
+        if (serializeThrows) throw RuntimeException("test: native serialize threw")
+        return serializeResult
+    }
     override fun unserialize(data: ByteArray): Boolean { unserializeCallCount++; lastUnserializeData = data; return unserializeResult }
     override fun setFastForward(enabled: Boolean) { setFastForwardCallCount++; lastFastForwardEnabled = enabled }
     override fun performanceStats(): Flow<Pair<Float, Float>> = emptyFlow()

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -357,6 +357,10 @@ class StubSessionRepository : SessionRepository {
 
     var downloadSessionAutoSaveResult: Result<ByteArray> = Result.failure(Exception("no auto-save"))
     var downloadSessionSramResult: Result<ByteArray> = Result.failure(Exception("no sram"))
+    /** Drives the manual-save-upload outcome. Default = success so existing
+     *  tests don't need to set it. Tests covering #803's failure feedback
+     *  set this to [Result.failure] before calling [SaveManager.saveState]. */
+    var uploadSessionSaveResult: Result<SaveState> = Result.success(SaveState(id = "1", name = "Manual Save"))
     var existingSessions: List<GameSession> = emptyList()
 
     override suspend fun getSessionsForGame(gameId: String) = Result.success(existingSessions)
@@ -413,11 +417,11 @@ class StubSessionRepository : SessionRepository {
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
     override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<SaveState> {
         uploadSessionSaveCallCount++
-        return Result.success(SaveState(id = "1", name = name))
+        return uploadSessionSaveResult
     }
     override suspend fun uploadSessionSaveFromFile(sessionId: String, name: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String): Result<SaveState> {
         uploadSessionSaveCallCount++
-        return Result.success(SaveState(id = "1", name = name))
+        return uploadSessionSaveResult
     }
     override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
     override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String): Result<Unit> {


### PR DESCRIPTION
## Summary
After tapping **Save state** in the in-game overlay, users had no feedback if they dismissed the overlay before the 2 s success toast rendered. The existing flow only emitted "State saved" through \`statusMessage\` *after* the upload succeeded, with **no in-progress signal at all**.

This PR pins the in-progress and failure states inline on the Save button itself — first slice of #803.

## What landed

- **EmulationState** gains \`isSaveInProgress: Boolean\` and \`saveStateError: String?\`.
- **SaveManager.saveState()** flips \`isSaveInProgress\` on entry, clears any prior \`saveStateError\`, and clears \`isSaveInProgress\` + sets / clears \`saveStateError\` on each terminal branch (success, failure, no-session, serialize-failed).
- **OverlayActionButtons** rewrites the Save action's label + icon based on state:
  - **Idle** → "Save" + \`Icons.Filled.Save\`
  - **In-progress** → "Saving…" + \`Icons.Filled.Sync\`
  - **Failed** → "Save failed" + \`Icons.Filled.ErrorOutline\` (sticks until the next save attempt)

## Tests (TDD)
Three new SaveManager tests — clears in-progress on success, records error on failure, clears stale error on next attempt. The existing 7 tests still pass. \`StubSessionRepository\` gains \`uploadSessionSaveResult: Result<SaveState>\` so failures can be simulated.

## What's left from #803
- **Success-state checkmark + auto-clear**: brief "Saved" check icon for ~1.5 s before falling back to idle. Needs UI-side LaunchedEffect timer; intentionally deferred.
- **Sync semantics labelling** ("Saved & synced" or cloud-checkmark icon).
- **Pause-while-saving**: keep the game paused during the upload so the user doesn't see un-saved frames after re-resuming.

Refs #803