### PR TITLE
feat(player): flash "Saved" checkmark on Save button after success

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/state/EmulationState.kt
@@ -90,6 +90,10 @@ data class EmulationState(
      *  Cleared at the start of the next save attempt so the button
      *  doesn't show stale failure text indefinitely. See #803. */
     val saveStateError: String? = null,
+    /** True briefly after a manual save succeeds so the in-game
+     *  overlay can flash a "Saved" checkmark on the Save button.
+     *  Auto-cleared by SaveManager ~1.5 s after the upload settles. */
+    val saveStateJustSucceeded: Boolean = false,
     /**
      * Non-blocking warning shown when the session's pinned core
      * version (see `GameSession.pinnedCoreSha256`) is no longer

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
@@ -274,6 +274,7 @@ internal fun InGameOverlayPanel(
                             hasCheats = state.hasCheats,
                             isSaveInProgress = state.isSaveInProgress,
                             saveStateError = state.saveStateError,
+                            saveStateJustSucceeded = state.saveStateJustSucceeded,
                             onSave = { viewModel.onIntent(EmulationIntent.SaveState) },
                             onLoad = { viewModel.onIntent(EmulationIntent.LoadState) },
                             onScreenshot = { viewModel.onIntent(EmulationIntent.TakeScreenshot) },
@@ -369,6 +370,7 @@ internal fun RowScope.OverlayActionButtons(
     hasCheats: Boolean = false,
     isSaveInProgress: Boolean = false,
     saveStateError: String? = null,
+    saveStateJustSucceeded: Boolean = false,
     onSave: () -> Unit,
     onLoad: () -> Unit,
     onScreenshot: () -> Unit,
@@ -379,15 +381,20 @@ internal fun RowScope.OverlayActionButtons(
     onControls: () -> Unit,
 ) {
     if (supportsSaveStates) {
-        // State-aware Save action: idle / in-progress / failed (#803).
-        // Success uses the existing "State saved" toast — adding an
-        // auto-clearing checkmark to the button is a follow-up.
+        // State-aware Save action: idle / in-progress / just-succeeded /
+        // failed (#803). Success briefly flashes a checkmark before
+        // returning to idle, so the user catches the confirmation even
+        // if they dismiss the overlay before the toast renders.
         val saveLabel: String
         val saveIcon: ImageVector
         when {
             isSaveInProgress -> {
                 saveLabel = "Saving…"
                 saveIcon = Icons.Filled.Sync
+            }
+            saveStateJustSucceeded -> {
+                saveLabel = "Saved"
+                saveIcon = Icons.Filled.CheckCircle
             }
             saveStateError != null -> {
                 saveLabel = "Save failed"

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -449,6 +449,12 @@ class SaveManager(
      * Manual save state. Blocks in challenge mode and hardcore mode.
      * When no session is active, delegates to the libretro controller directly.
      */
+    private companion object {
+        /** How long the "Saved" checkmark stays on the in-game overlay's
+         *  Save button after a successful upload (#803). */
+        const val SAVE_SUCCESS_FLASH_MS = 1_500L
+    }
+
     fun saveState() {
         if (_state.value.isChallengeMode) return
         if (_state.value.isHardcoreMode) {
@@ -464,7 +470,13 @@ class SaveManager(
         // Clears any stale error from a prior failed attempt so the
         // button doesn't read "Save failed" while a fresh save is
         // in flight (#803).
-        _state.update { it.copy(isSaveInProgress = true, saveStateError = null) }
+        _state.update {
+            it.copy(
+                isSaveInProgress = true,
+                saveStateError = null,
+                saveStateJustSucceeded = false,
+            )
+        }
         scope.launch(dispatchers.io) {
             // Wrap staging in try/catch so a thrown exception still
             // clears isSaveInProgress — otherwise the button is stuck
@@ -499,6 +511,7 @@ class SaveManager(
                                     it.copy(
                                         statusMessage = "State saved",
                                         isSaveInProgress = false,
+                                        saveStateJustSucceeded = true,
                                         secondaryToast = SecondaryToastData(
                                             message = "Saved to Slot ${it.activeSlot}",
                                             type = SecondaryToastType.SAVE,
@@ -507,6 +520,16 @@ class SaveManager(
                                 }
                             }
                             refreshSaveSlots()
+                            // Hold the "Saved" checkmark briefly so the
+                            // user catches it even if the toast is
+                            // dismissed first, then drop the flag so
+                            // the button returns to idle. (#803)
+                            scope.launch(dispatchers.io) {
+                                kotlinx.coroutines.delay(SAVE_SUCCESS_FLASH_MS)
+                                withContext(dispatchers.main) {
+                                    _state.update { it.copy(saveStateJustSucceeded = false) }
+                                }
+                            }
                         },
                         onFailure = { error ->
                             withContext(dispatchers.main) {

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerRehearsalTest.kt
@@ -282,6 +282,34 @@ class SaveManagerRehearsalTest {
             "saveStateError should be null after success")
     }
 
+    /** After a successful save the "Saved" flag flashes true and then
+     *  auto-clears so the in-game overlay's checkmark disappears
+     *  cleanly (#803). */
+    @Test
+    fun saveStateFlashesSuccessAndAutoClears() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val scope = CoroutineScope(dispatcher + Job())
+        val fx = makeManagerFixture(scope, dispatcher)
+
+        fx.manager.rehearsalMode = false
+        fx.manager.saveState()
+        // Settle the upload but don't yet pass the auto-clear delay.
+        // (UnconfinedTestDispatcher runs everything inline; here we
+        // verify the flag is true between settle and auto-clear by
+        // checking right after advanceUntilIdle which blocks on the
+        // launched timer too — so we instead advance time slightly
+        // less than the flash window.)
+        testScheduler.advanceTimeBy(1_400)
+        testScheduler.runCurrent()
+        assertEquals(true, fx.state.value.saveStateJustSucceeded,
+            "saveStateJustSucceeded should still be true within the flash window")
+
+        testScheduler.advanceTimeBy(200)
+        testScheduler.runCurrent()
+        assertEquals(false, fx.state.value.saveStateJustSucceeded,
+            "saveStateJustSucceeded should auto-clear after the flash window")
+    }
+
     /** Failure path: error sticks until cleared, in-progress drops. */
     @Test
     fun saveStateRecordsErrorOnFailure() = runTest {


### PR DESCRIPTION
## Summary
Completes the success state of #803's three-state inline feedback. PR #810 landed in-progress + failure; this adds the "just-succeeded" flash so the user catches save confirmation right where they tapped, even if they dismiss the overlay before the toast renders.

## What landed
- \`EmulationState\` gains \`saveStateJustSucceeded: Boolean\`.
- \`SaveManager.saveState()\` sets it true on success, schedules an auto-clear after 1.5 s, and drops it on entry to a new save attempt so a quick re-tap doesn't leave the checkmark visible while the next upload is in flight.
- \`OverlayActionButtons\` renders \`Icons.Filled.CheckCircle\` + "Saved" between in-progress and idle states.

## Tests (TDD)
One new test pins the auto-clear contract: advances the virtual clock to 1.4 s and asserts \`saveStateJustSucceeded == true\`, advances past 1.5 s total and asserts it's been cleared. The 11 previous tests still pass.

## What's left from #803
- **Sync semantics labelling** — "Saved & synced" or cloud-checkmark icon. The existing copy says "Saved" which is unambiguous in the immediate surface but doesn't communicate that the save reached the server.
- **Pause-while-saving** — keep the game paused during the upload so the user doesn't see un-saved frames after re-resuming.

Refs #803