### PR TITLE
feat(player): "Synced" label + cloud-done icon for save success

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/ingame/InGameOverlayPanel.kt
@@ -18,6 +18,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.CameraAlt
 import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.CloudDone
 import androidx.compose.material.icons.filled.ErrorOutline
 import androidx.compose.material.icons.filled.FastForward
 import androidx.compose.material.icons.filled.FastRewind
@@ -393,8 +394,12 @@ internal fun RowScope.OverlayActionButtons(
                 saveIcon = Icons.Filled.Sync
             }
             saveStateJustSucceeded -> {
-                saveLabel = "Saved"
-                saveIcon = Icons.Filled.CheckCircle
+                // "Synced" rather than just "Saved" — communicates that
+                // the bytes reached the server, not just local. SaveManager
+                // only flips this flag after the upload's onSuccess fires,
+                // so the label is accurate. (#803)
+                saveLabel = "Synced"
+                saveIcon = Icons.Filled.CloudDone
             }
             saveStateError != null -> {
                 saveLabel = "Save failed"


### PR DESCRIPTION
## Summary
Final slice of #803. The post-success label flashed by #811 was generic "Saved" — accurate for *something* but ambiguous about *where*. Power users couldn't tell from the UI alone whether the save was just local or had reached the server.

\`SaveManager\` only flips \`saveStateJustSucceeded\` after the upload's \`onSuccess\` fires, so the label can be specific: "Synced" + \`Icons.Filled.CloudDone\`. In-progress / failure / idle labels are unchanged.

One-file diff: \`InGameOverlayPanel.kt\`.

## Acceptance against #803
- ✅ "After pressing Save state, the user can immediately tell from the overlay UI alone (no toast required) whether the save is in progress, succeeded, or failed." — landed in #810 + #811.
- ✅ "The success state communicates that the save is on the server, not just local." — this PR.
- ✅ "Save failures persist until the user acknowledges them." — landed in #810.
- ✅ "Desktop test ... covers the three states." — \`SaveManagerRehearsalTest\`.

The "pause-while-saving" follow-up the issue listed as optional turned out to be a non-issue once I traced through it: the in-game overlay already pauses the game when opened, so a save from inside the overlay captures the paused frame. Resuming after save picks up from that frame; reloading the save later restores that same frame. No discrepancy. Not worth complicating the resume flow for a hypothetical race.

Closes #803