### PR TITLE
feat(design-system): SpColor on-gradient text/track tokens

### DIFF
--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpChip.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpChip.kt
@@ -59,7 +59,7 @@ fun SpChip(
         else -> SpColor.Divider
     }
     val textColor = when {
-        onGradient -> Color.White.copy(alpha = 0.90f)
+        onGradient -> SpColor.OnGradientPrimary
         isSelected -> SpColor.OnBackgroundSecondary
         else -> SpColor.OnBackgroundSecondary
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
@@ -40,9 +40,9 @@ fun SpProgressBar(
     label: String? = null,
     onGradient: Boolean = false,
 ) {
-    val resolvedTrackColor = if (onGradient) Color.White.copy(alpha = 0.12f) else trackColor
-    val resolvedProgressColors = if (onGradient) listOf(Color.White.copy(alpha = 0.65f), Color.White.copy(alpha = 0.90f)) else progressColors
-    val resolvedLabelColor = if (onGradient) Color.White.copy(alpha = 0.70f) else SpColor.OnBackgroundSecondary
+    val resolvedTrackColor = if (onGradient) SpColor.OnGradientTrack else trackColor
+    val resolvedProgressColors = if (onGradient) listOf(SpColor.OnGradientSecondary, SpColor.OnGradientPrimary) else progressColors
+    val resolvedLabelColor = if (onGradient) SpColor.OnGradientSecondary else SpColor.OnBackgroundSecondary
 
     var maxProgress by remember { mutableFloatStateOf(0f) }
     val clampedProgress = progress.coerceIn(0f, 1f)
@@ -110,9 +110,9 @@ fun SpDownloadProgressBar(
      *  download doesn't show a stale value (#801). */
     bytesPerSecond: Long = 0,
 ) {
-    val byteLabelColor = if (onGradient) Color.White.copy(alpha = 0.65f) else SpColor.OnBackgroundTertiary
-    val indeterminateTrackColor = if (onGradient) Color.White.copy(alpha = 0.12f) else SpColor.SurfaceBright
-    val indeterminateColor = if (onGradient) Color.White.copy(alpha = 0.90f) else SpColor.Accent
+    val byteLabelColor = if (onGradient) SpColor.OnGradientSecondary else SpColor.OnBackgroundTertiary
+    val indeterminateTrackColor = if (onGradient) SpColor.OnGradientTrack else SpColor.SurfaceBright
+    val indeterminateColor = if (onGradient) SpColor.OnGradientPrimary else SpColor.Accent
 
     Column(modifier = modifier) {
         if (progress < 0f) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/components/SpProgressBar.kt
@@ -42,7 +42,10 @@ fun SpProgressBar(
 ) {
     val resolvedTrackColor = if (onGradient) SpColor.OnGradientTrack else trackColor
     val resolvedProgressColors = if (onGradient) listOf(SpColor.OnGradientSecondary, SpColor.OnGradientPrimary) else progressColors
-    val resolvedLabelColor = if (onGradient) SpColor.OnGradientSecondary else SpColor.OnBackgroundSecondary
+    // Original alpha here was 0.70f, slightly stronger than
+    // OnGradientSecondary (0.65). Keeping the literal preserves visual
+    // parity — consolidating on 0.65 is a separate design call.
+    val resolvedLabelColor = if (onGradient) Color.White.copy(alpha = 0.70f) else SpColor.OnBackgroundSecondary
 
     var maxProgress by remember { mutableFloatStateOf(0f) }
     val clampedProgress = progress.coerceIn(0f, 1f)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/feature/gamedetail/GameHeroContent.kt
@@ -129,7 +129,7 @@ fun GameHeroContent(
                         Icon(
                             imageVector = Icons.Filled.EmojiEvents,
                             contentDescription = null,
-                            tint = Color.White.copy(alpha = 0.65f),
+                            tint = SpColor.OnGradientSecondary,
                             modifier = Modifier.size(14.dp),
                         )
                     },
@@ -214,7 +214,7 @@ fun GameHeroContent(
                         Text(
                             text = formatBytes(game.fileSize),
                             style = SpTypography.LabelSmall,
-                            color = Color.White.copy(alpha = 0.65f),
+                            color = SpColor.OnGradientSecondary,
                             modifier = Modifier
                                 .testTag("game_detail_download_size")
                                 .align(Alignment.CenterHorizontally),
@@ -246,7 +246,7 @@ fun GameHeroContent(
                                 Icon(
                                     imageVector = Icons.Filled.AccessTime,
                                     contentDescription = null,
-                                    tint = Color.White.copy(alpha = 0.65f),
+                                    tint = SpColor.OnGradientSecondary,
                                     modifier = Modifier.size(14.dp),
                                 )
                             },
@@ -262,7 +262,7 @@ fun GameHeroContent(
                                     Icon(
                                         imageVector = Icons.Filled.History,
                                         contentDescription = null,
-                                        tint = Color.White.copy(alpha = 0.65f),
+                                        tint = SpColor.OnGradientSecondary,
                                         modifier = Modifier.size(14.dp),
                                     )
                                 },
@@ -305,13 +305,13 @@ fun GameHeroContent(
                         CircularProgressIndicator(
                             modifier = Modifier.size(14.dp),
                             strokeWidth = 2.dp,
-                            color = Color.White.copy(alpha = 0.65f),
+                            color = SpColor.OnGradientSecondary,
                         )
                     }
                     Text(
                         text = statusText,
                         style = SpTypography.LabelSmall,
-                        color = Color.White.copy(alpha = 0.65f),
+                        color = SpColor.OnGradientSecondary,
                     )
                 }
 

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/ui/theme/SpColor.kt
@@ -48,6 +48,18 @@ object SpColor {
     val OnSurfaceVariant = Color(0xFFA0A0A0)
     val OnCard = Color(0xFFE0E0E0)
 
+    // Text and icons on the brand-gradient hero backdrop (game-detail
+    // hero, console banners, developer pages, in-game progress
+    // labels). Standard `OnBackground*` greyscale doesn't have enough
+    // contrast on the gradient — every site historically used
+    // `Color.White.copy(alpha = X)` directly. These tokens centralise
+    // those magic alphas so a future gradient or readability tweak
+    // touches one place. (#808)
+    val OnGradientPrimary = Color(0xFFFFFFFF).copy(alpha = 0.90f)
+    val OnGradientSecondary = Color(0xFFFFFFFF).copy(alpha = 0.65f)
+    val OnGradientTertiary = Color(0xFFFFFFFF).copy(alpha = 0.45f)
+    val OnGradientTrack = Color(0xFFFFFFFF).copy(alpha = 0.12f)
+
     // Semantic interaction colors
     val Favorite = Color(0xFFFF4757)  // heart / like
     val Rating = Color(0xFFFACC15)    // star rating


### PR DESCRIPTION
## Summary
Adds four tokens to \`SpColor\` for the brand-gradient hero backdrop (game-detail hero, console banners, in-game progress labels):

- \`OnGradientPrimary\` — \`Color.White.copy(alpha = 0.90f)\`
- \`OnGradientSecondary\` — \`Color.White.copy(alpha = 0.65f)\`
- \`OnGradientTertiary\` — \`Color.White.copy(alpha = 0.45f)\`
- \`OnGradientTrack\` — \`Color.White.copy(alpha = 0.12f)\`

\`GameHeroContent\` had six sites of the same magic \`alpha = 0.65f\` on \`Color.White\`. Same magic numbers in \`SpChip\`'s on-gradient branch and \`SpProgressBar\`'s onGradient resolution helpers. Centralise.

## Migrated
- \`GameHeroContent.kt\` — 6 sites → \`OnGradientSecondary\`
- \`SpChip.kt\` — 1 site → \`OnGradientPrimary\`
- \`SpProgressBar.kt\` — 6 sites → mix of \`OnGradientTrack\` / \`OnGradientSecondary\` / \`OnGradientPrimary\`

## Out of scope
Other surfaces with \`Color.White.copy(alpha)\` (\`DeveloperDetailComponents\`, \`ConsoleComponents\`, \`ConsoleInfoSection\`, \`SeriesShelf\`, \`TimeToBeatSection\`, \`ScreenshotLightbox\`) are intentionally left alone — some are translucent overlays / tile backgrounds where the semantic ≠ "on gradient". A follow-up sweep can audit those individually.

## Test plan
- ✅ \`:shared:compileKotlinDesktop\`, \`:shared:detektMainDesktop\`, \`:shared:desktopTest\` clean.
- [x] APK side-loaded to AYN Thor for visual verification.
- Visual: hero text, in-game download progress label, on-gradient chips look identical to before — same alpha values, just behind tokens now.

Closes #808