### PR TITLE
feat(server): add compression metadata for session save uploads/downloads

### DIFF
--- a/server/internal/api/huma_downloads.go
+++ b/server/internal/api/huma_downloads.go
@@ -45,6 +45,24 @@ func streamFileFromDisk(absPath, downloadName, contentType string) *huma.StreamR
 	}
 }
 
+// streamSaveFromDisk wraps [streamFileFromDisk] with an X-Compression
+// response header so the downloading player knows whether to gunzip
+// before passing the bytes to retro_unserialize. Empty compression
+// means uncompressed (the only case before #804 phase 2). Players
+// that don't recognise a value should refuse to load the save rather
+// than feed garbage to the core.
+func streamSaveFromDisk(absPath, downloadName, compression string) *huma.StreamResponse {
+	inner := streamFileFromDisk(absPath, downloadName, "application/octet-stream")
+	return &huma.StreamResponse{
+		Body: func(hctx huma.Context) {
+			if compression != "" {
+				hctx.SetHeader("X-Compression", compression)
+			}
+			inner.Body(hctx)
+		},
+	}
+}
+
 // streamBytesInline returns a huma.StreamResponse that writes the given bytes
 // inline (no Content-Disposition — the browser renders them directly,
 // typical for console icons / logos). Used by endpoints that serve embedded
@@ -504,7 +522,7 @@ func (h *SessionHandler) HumaDownloadSessionSave(ctx context.Context, in *Sessio
 	if !storage.ValidateROMPath(save.FilePath, []string{h.Storage.SaveDir}) {
 		return nil, huma.Error403Forbidden("file access denied")
 	}
-	return streamFileFromDisk(save.FilePath, filepath.Base(save.FilePath), "application/octet-stream"), nil
+	return streamSaveFromDisk(save.FilePath, filepath.Base(save.FilePath), save.Compression), nil
 }
 
 // HumaDownloadAutoSave is the huma implementation of GET
@@ -526,7 +544,7 @@ func (h *SessionHandler) HumaDownloadAutoSave(ctx context.Context, in *SessionAu
 	if !storage.ValidateROMPath(save.FilePath, []string{h.Storage.SaveDir}) {
 		return nil, huma.Error403Forbidden("file access denied")
 	}
-	return streamFileFromDisk(save.FilePath, filepath.Base(save.FilePath), "application/octet-stream"), nil
+	return streamSaveFromDisk(save.FilePath, filepath.Base(save.FilePath), save.Compression), nil
 }
 
 // HumaDownloadSlotSave is the huma implementation of GET
@@ -550,7 +568,7 @@ func (h *SessionHandler) HumaDownloadSlotSave(ctx context.Context, in *SessionSl
 	if !storage.ValidateROMPath(save.FilePath, []string{h.Storage.SaveDir}) {
 		return nil, huma.Error403Forbidden("file access denied")
 	}
-	return streamFileFromDisk(save.FilePath, filepath.Base(save.FilePath), "application/octet-stream"), nil
+	return streamSaveFromDisk(save.FilePath, filepath.Base(save.FilePath), save.Compression), nil
 }
 
 // HumaDownloadSRAM is the huma implementation of GET /api/sessions/{id}/sram.

--- a/server/internal/api/huma_session_uploads.go
+++ b/server/internal/api/huma_session_uploads.go
@@ -26,6 +26,11 @@ type SessionSaveUploadBody struct {
 	Name       string        `form:"name" required:"false" doc:"Display name for the save (defaults to the uploaded filename)."`
 	CoreName   string        `form:"coreName" required:"false" doc:"Identifier of the libretro core that produced the save."`
 	CoreSha256 string        `form:"coreSha256" required:"false" doc:"Hex sha256 of the core binary that produced this save state. Optional — the server records it alongside the save for diagnostics and future rollback UX. Invalid values (not 64 hex chars) are silently dropped. See #555 Phase 3."`
+	// Compression algorithm applied to the save bytes before upload.
+	// Empty / omitted = uncompressed (pre-#804 default). Known values:
+	// \"\" | \"gzip\". Stored opaquely; the server doesn't decompress —
+	// players echo the value on download to decide whether to gunzip.
+	Compression string `form:"compression" required:"false" doc:"Compression algorithm applied to the save bytes (empty or 'gzip'). Stored opaquely; players use it on download to decide whether to decompress. See #804."`
 }
 
 // SessionSaveUploadInput wraps the path parameter and multipart body for
@@ -213,6 +218,7 @@ func (h *SessionHandler) HumaUploadSessionSave(ctx context.Context, in *SessionS
 		ScreenshotURL: screenshotURL,
 		CoreName:      body.CoreName,
 		CoreSha256:    sanitizeCoreSha256(body.CoreSha256),
+		Compression:   sanitizeCompression(body.Compression),
 		IsAuto:        false,
 	}
 	if err := h.DB.Create(&rec).Error; err != nil {
@@ -268,6 +274,7 @@ func (h *SessionHandler) HumaUploadAutoSave(ctx context.Context, in *SessionAuto
 		ScreenshotURL: screenshotURL,
 		CoreName:      body.CoreName,
 		CoreSha256:    sanitizeCoreSha256(body.CoreSha256),
+		Compression:   sanitizeCompression(body.Compression),
 		IsAuto:        true,
 		IsCurrent:     true,
 	}
@@ -342,6 +349,7 @@ func (h *SessionHandler) HumaUpsertSlotSave(ctx context.Context, in *SessionSlot
 			ScreenshotURL: screenshotURL,
 			CoreName:      body.CoreName,
 			CoreSha256:    sanitizeCoreSha256(body.CoreSha256),
+			Compression:   sanitizeCompression(body.Compression),
 			IsAuto:        false,
 			Slot:          &slotNum,
 		}
@@ -352,6 +360,7 @@ func (h *SessionHandler) HumaUpsertSlotSave(ctx context.Context, in *SessionSlot
 		rec.ScreenshotURL = screenshotURL
 		rec.CoreName = body.CoreName
 		rec.CoreSha256 = sanitizeCoreSha256(body.CoreSha256)
+		rec.Compression = sanitizeCompression(body.Compression)
 		h.DB.Save(&rec)
 	}
 
@@ -470,6 +479,20 @@ func sanitizeCoreSha256(raw string) string {
 		return ""
 	}
 	return strings.ToLower(raw)
+}
+
+// sanitizeCompression normalises the client-supplied compression value
+// to the closed set the server stores. Anything else collapses to ""
+// (uncompressed) — being conservative protects players that don't yet
+// recognise newer codecs from receiving a save tagged with one. See
+// #804 phase 2.
+func sanitizeCompression(raw string) string {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case "gzip":
+		return "gzip"
+	default:
+		return ""
+	}
 }
 
 // pinSessionCoreSha256 returns the sha256 to persist into

--- a/server/internal/api/huma_session_uploads_test.go
+++ b/server/internal/api/huma_session_uploads_test.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// sanitizeCompression normalises the client-supplied save-compression
+// value to the closed set the server stores. Anything outside that
+// set collapses to "" so a typo or future codec doesn't tag a save
+// with a value players can't decompress (#804 phase 2).
+func TestSanitizeCompression(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"gzip", "gzip", "gzip"},
+		{"gzip uppercase", "GZIP", "gzip"},
+		{"gzip mixed case", "GzIp", "gzip"},
+		{"gzip with whitespace", "  gzip  ", "gzip"},
+		{"unknown codec collapses to empty", "zstd", ""},
+		{"garbage collapses to empty", "asdf", ""},
+		{"whitespace-only collapses to empty", "   ", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, sanitizeCompression(tt.in))
+		})
+	}
+}

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -1029,6 +1029,11 @@ type SessionSaveResponse struct {
 	CurrentCore   string    `json:"currentCore"`
 	Notes         string    `json:"notes"`
 	Slot          *int      `json:"slot"`
+	// Compression algorithm applied to the saved bytes. Empty string =
+	// uncompressed (all pre-#804 saves). Known values: "" | "gzip".
+	// Players use this on download to decide whether to gunzip the
+	// stream before passing it to the libretro core. See #804 phase 2.
+	Compression   string    `json:"compression"`
 	CreatedAt     time.Time `json:"createdAt"`
 	UpdatedAt     time.Time `json:"updatedAt"`
 }

--- a/server/internal/api/session_handler.go
+++ b/server/internal/api/session_handler.go
@@ -143,6 +143,7 @@ func (h *SessionHandler) toSaveResponse(s db.SessionSaveState, currentCore strin
 		CoreSha256:    s.CoreSha256,
 		Notes:         s.Notes,
 		Slot:          s.Slot,
+		Compression:   s.Compression,
 		CreatedAt:     s.CreatedAt,
 		UpdatedAt:     s.UpdatedAt,
 	}

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -897,6 +897,12 @@ type SessionSaveState struct {
 	CoreSha256    string         `gorm:"size:64" json:"coreSha256"`
 	Notes         string         `gorm:"type:text" json:"notes"`
 	Slot          *int           `json:"slot"`
+	// Compression algorithm applied to the bytes at FilePath. Empty
+	// string = uncompressed (the only case for pre-#804 saves). Known
+	// values: "" | "gzip". Players that don't recognise a value should
+	// reject the save with a "newer client required" error rather than
+	// load garbage. See #804 phase 2.
+	Compression   string         `gorm:"size:16" json:"compression"`
 }
 
 // SessionSaveData represents SRAM/battery save data within a game session.


### PR DESCRIPTION
## Summary
First half of #804 phase 2 (client-side compression). The server stores the bytes opaquely and tags the record with which codec the player used; players gunzip on download as needed. This PR is the server foundation. **Player gzip-on-upload + gunzip-on-download lands in a follow-up.**

## What landed
- **Schema**: \`SessionSaveState.Compression\` (string, 16). GORM auto-migrates on next startup; existing rows default to \`""\` = uncompressed. Mirrored in \`SessionSaveResponse.Compression\` and \`toSaveResponse\`.
- **Upload**: \`SessionSaveUploadBody.Compression\` form field, parsed via \`sanitizeCompression\` which closes the value set to \`{"" | "gzip"}\`. Anything else collapses to \`""\` so a typo or future codec doesn't tag a save with something players can't decompress. Wired into the three save-write handlers (manual, auto, slot upsert).
- **Download**: new \`streamSaveFromDisk\` wrapper sets \`X-Compression\` response header when the record carries a non-empty compression. Players read the header and decide whether to gunzip the stream before passing it to \`retro_unserialize\`.

## Test
\`TestSanitizeCompression\` pins the closed value set: empty, "gzip" (case-insensitive, whitespace tolerated), and anything else collapses to "". \`go build ./...\` clean. Targeted Go tests pass.

## What's left from #804 phase 2
- **Player gzip-on-upload**: after native \`serializeToFile\` produces the temp file, gzip the file in place before passing to \`uploadSessionSaveFromFile\`. Send \`compression="gzip"\` form field. ~30 MB savings on Dolphin states.
- **Player gunzip-on-download**: read \`X-Compression\` from the streaming response, pipe through GZIP if present before \`unserializeFromFile\`.

Refs #804