### PR TITLE
feat(player): gzip save uploads and gunzip downloads (#804)

### DIFF
--- a/player/shared/src/androidMain/kotlin/com/spela/player/util/GzipFile.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/util/GzipFile.android.kt
@@ -1,0 +1,28 @@
+package com.spela.player.util
+
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.zip.GZIPOutputStream
+
+/**
+ * Synchronous I/O — caller is responsible for invoking on a worker
+ * dispatcher (in production both Android and Desktop callers wrap this
+ * in `withContext(dispatchers.io) { ... }`). Switching dispatchers
+ * inside the helper would race with kotlinx-coroutines-test's
+ * [advanceUntilIdle], so we keep the body on the caller's coroutine.
+ */
+actual suspend fun gzipFile(srcPath: String, destPath: String): Long {
+    FileInputStream(srcPath).use { src ->
+        BufferedInputStream(src).use { bin ->
+            FileOutputStream(destPath).use { out ->
+                GZIPOutputStream(BufferedOutputStream(out)).use { gz ->
+                    bin.copyTo(gz)
+                }
+            }
+        }
+    }
+    return File(destPath).length()
+}

--- a/player/shared/src/androidMain/kotlin/com/spela/player/util/GzipFile.android.kt
+++ b/player/shared/src/androidMain/kotlin/com/spela/player/util/GzipFile.android.kt
@@ -5,6 +5,7 @@ import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
 /**
@@ -20,6 +21,19 @@ actual suspend fun gzipFile(srcPath: String, destPath: String): Long {
             FileOutputStream(destPath).use { out ->
                 GZIPOutputStream(BufferedOutputStream(out)).use { gz ->
                     bin.copyTo(gz)
+                }
+            }
+        }
+    }
+    return File(destPath).length()
+}
+
+actual suspend fun gunzipFile(srcPath: String, destPath: String): Long {
+    FileInputStream(srcPath).use { src ->
+        GZIPInputStream(BufferedInputStream(src)).use { gz ->
+            FileOutputStream(destPath).use { out ->
+                BufferedOutputStream(out).use { bout ->
+                    gz.copyTo(bout)
                 }
             }
         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1809,7 +1809,7 @@ class SpelaApiClient(
             if (!response.status.isSuccess()) {
                 throw RuntimeException("auto-save download failed: HTTP ${response.status.value}")
             }
-            streamResponseToFile(response, fileStorage, outputPath) { _, _ -> }
+            streamSaveResponseToFile(response, fileStorage, outputPath)
         }
     }
 
@@ -1820,7 +1820,7 @@ class SpelaApiClient(
             if (!response.status.isSuccess()) {
                 throw RuntimeException("session save download failed: HTTP ${response.status.value}")
             }
-            streamResponseToFile(response, fileStorage, outputPath) { _, _ -> }
+            streamSaveResponseToFile(response, fileStorage, outputPath)
         }
     }
 
@@ -1831,8 +1831,38 @@ class SpelaApiClient(
             if (!response.status.isSuccess()) {
                 throw RuntimeException("slot save download failed: HTTP ${response.status.value}")
             }
-            streamResponseToFile(response, fileStorage, outputPath) { _, _ -> }
+            streamSaveResponseToFile(response, fileStorage, outputPath)
         }
+    }
+
+    /**
+     * Stream a save-state response to [outputPath] and decompress it
+     * inline when the server tags the body with `X-Compression: gzip`.
+     * Callers receive a temp file containing raw save bytes regardless
+     * of how the bytes were stored on the server, so the libretro
+     * `unserializeFromFile` step never has to know about compression.
+     * See #804 phase 2.
+     */
+    private suspend fun streamSaveResponseToFile(
+        response: HttpResponse,
+        fileStorage: FileStorage,
+        outputPath: String,
+    ) {
+        val compression = response.headers["X-Compression"]?.lowercase()?.trim().orEmpty()
+        if (compression == "gzip") {
+            // Stream the gzip-encoded body to a sibling and inflate
+            // into outputPath, so the file at outputPath is always
+            // raw save bytes the core can consume directly.
+            val gzPath = "$outputPath.gz.tmp"
+            try {
+                streamResponseToFile(response, fileStorage, gzPath) { _, _ -> }
+                com.spela.player.util.gunzipFile(gzPath, outputPath)
+            } finally {
+                runCatching { fileStorage.deleteFile(gzPath) }
+            }
+            return
+        }
+        streamResponseToFile(response, fileStorage, outputPath) { _, _ -> }
     }
 
     suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): com.spela.client.models.SessionSaveResponse {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1852,11 +1852,17 @@ class SpelaApiClient(
         if (compression == "gzip") {
             // Stream the gzip-encoded body to a sibling and inflate
             // into outputPath, so the file at outputPath is always
-            // raw save bytes the core can consume directly.
+            // raw save bytes the core can consume directly. If gunzip
+            // throws mid-stream (truncated body, corrupted bytes) we
+            // delete the partial outputPath as well so callers find
+            // a clean "file missing" rather than a silently-bogus one.
             val gzPath = "$outputPath.gz.tmp"
             try {
                 streamResponseToFile(response, fileStorage, gzPath) { _, _ -> }
                 com.spela.player.util.gunzipFile(gzPath, outputPath)
+            } catch (e: Throwable) {
+                runCatching { fileStorage.deleteFile(outputPath) }
+                throw e
             } finally {
                 runCatching { fileStorage.deleteFile(gzPath) }
             }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/remote/api/SpelaApiClient.kt
@@ -1666,6 +1666,7 @@ class SpelaApiClient(
         saveSize: Long,
         screenshot: ByteArray?,
         coreName: String = "",
+        compression: String = "",
     ): com.spela.client.models.SessionSaveResponse {
         return client.submitFormWithBinaryData(
             url = "$baseUrl/api/sessions/$sessionId/saves",
@@ -1673,6 +1674,9 @@ class SpelaApiClient(
                 append("name", name)
                 if (coreName.isNotEmpty()) {
                     append("coreName", coreName)
+                }
+                if (compression.isNotEmpty()) {
+                    append("compression", compression)
                 }
                 append("save", io.ktor.client.request.forms.ChannelProvider(saveSize) {
                     com.spela.player.util.openFileReadChannel(savePath)
@@ -1696,12 +1700,16 @@ class SpelaApiClient(
         saveSize: Long,
         screenshot: ByteArray?,
         coreName: String = "",
+        compression: String = "",
     ) {
         client.submitFormWithBinaryData(
             url = "$baseUrl/api/sessions/$sessionId/saves/auto",
             formData = formData {
                 if (coreName.isNotEmpty()) {
                     append("coreName", coreName)
+                }
+                if (compression.isNotEmpty()) {
+                    append("compression", compression)
                 }
                 append("save", io.ktor.client.request.forms.ChannelProvider(saveSize) {
                     com.spela.player.util.openFileReadChannel(savePath)
@@ -1726,12 +1734,16 @@ class SpelaApiClient(
         saveSize: Long,
         screenshot: ByteArray?,
         coreName: String = "",
+        compression: String = "",
     ): com.spela.client.models.SessionSaveResponse {
         return client.submitFormWithBinaryData(
             url = "$baseUrl/api/sessions/$sessionId/saves/slot/$slot",
             formData = formData {
                 if (coreName.isNotEmpty()) {
                     append("coreName", coreName)
+                }
+                if (compression.isNotEmpty()) {
+                    append("compression", compression)
                 }
                 append("save", io.ktor.client.request.forms.ChannelProvider(saveSize) {
                     com.spela.player.util.openFileReadChannel(savePath)

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -72,8 +72,9 @@ class SessionRepositoryImpl(
         saveSize: Long,
         screenshot: ByteArray?,
         coreName: String,
+        compression: String,
     ): Result<SaveState> = runCatching {
-        apiClient.uploadSessionSaveFromFile(sessionId, name, savePath, saveSize, screenshot, coreName).toDomain()
+        apiClient.uploadSessionSaveFromFile(sessionId, name, savePath, saveSize, screenshot, coreName, compression).toDomain()
     }
 
     override suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray> = runCatching {
@@ -95,8 +96,9 @@ class SessionRepositoryImpl(
         saveSize: Long,
         screenshot: ByteArray?,
         coreName: String,
+        compression: String,
     ): Result<Unit> = runCatching {
-        apiClient.uploadSessionAutoSaveFromFile(sessionId, savePath, saveSize, screenshot, coreName)
+        apiClient.uploadSessionAutoSaveFromFile(sessionId, savePath, saveSize, screenshot, coreName, compression)
     }
 
     override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> = runCatching {
@@ -124,8 +126,9 @@ class SessionRepositoryImpl(
         saveSize: Long,
         screenshot: ByteArray?,
         coreName: String,
+        compression: String,
     ): Result<SaveState> = runCatching {
-        apiClient.uploadSlotSaveFromFile(sessionId, slot, savePath, saveSize, screenshot, coreName).toDomain()
+        apiClient.uploadSlotSaveFromFile(sessionId, slot, savePath, saveSize, screenshot, coreName, compression).toDomain()
     }
 
     override suspend fun downloadSlotSave(sessionId: String, slot: Int): Result<ByteArray> = runCatching {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/data/repository/SessionRepositoryImpl.kt
@@ -135,6 +135,10 @@ class SessionRepositoryImpl(
         apiClient.downloadSlotSave(sessionId, slot)
     }
 
+    override suspend fun downloadSlotSaveToFile(sessionId: String, slot: Int, outputPath: String): Result<Unit> = runCatching {
+        apiClient.downloadSlotSaveToFile(sessionId, slot, fileStorage, outputPath)
+    }
+
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String): Result<Unit> = runCatching {
         apiClient.uploadSessionSram(sessionId, data, coreName)
     }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -29,18 +29,23 @@ interface SessionRepository {
     /** Streaming variant: reads save bytes from [savePath] without loading
      *  the full state into a JVM ByteArray. Required for cores like
      *  Dolphin whose save states (~90 MB) can't fit alongside the rest
-     *  of the heap on Android. See #798. */
-    suspend fun uploadSessionSaveFromFile(sessionId: String, name: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>
+     *  of the heap on Android. See #798.
+     *
+     *  [compression] tags the bytes at [savePath] with the codec the
+     *  caller already applied (currently `""` for raw or `"gzip"`).
+     *  The server stores it opaquely; players use it on download to
+     *  decide whether to decompress. See #804 phase 2. */
+    suspend fun uploadSessionSaveFromFile(sessionId: String, name: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String = "", compression: String = ""): Result<SaveState>
     suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray>
     suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<Unit>
-    suspend fun uploadSessionAutoSaveFromFile(sessionId: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String = ""): Result<Unit>
+    suspend fun uploadSessionAutoSaveFromFile(sessionId: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String = "", compression: String = ""): Result<Unit>
     suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray>
     /** Streaming variant of [downloadSessionAutoSave]: writes the body to
      *  [outputPath] without materialising the full payload as a ByteArray.
      *  See #798. */
     suspend fun downloadSessionAutoSaveToFile(sessionId: String, outputPath: String): Result<Unit>
     suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>
-    suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>
+    suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String = "", compression: String = ""): Result<SaveState>
     suspend fun downloadSlotSave(sessionId: String, slot: Int): Result<ByteArray>
     suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String = ""): Result<Unit>
     suspend fun downloadSessionSram(sessionId: String): Result<ByteArray>

--- a/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/domain/repository/SessionRepository.kt
@@ -47,6 +47,11 @@ interface SessionRepository {
     suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String = ""): Result<SaveState>
     suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String = "", compression: String = ""): Result<SaveState>
     suspend fun downloadSlotSave(sessionId: String, slot: Int): Result<ByteArray>
+    /** Streaming variant of [downloadSlotSave]. Writes the body to
+     *  [outputPath] and inflates inline when the server tags the
+     *  response with `X-Compression: gzip`, so callers can hand the
+     *  file straight to libretro's `unserializeFromFile`. See #804. */
+    suspend fun downloadSlotSaveToFile(sessionId: String, slot: Int, outputPath: String): Result<Unit>
     suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String = ""): Result<Unit>
     suspend fun downloadSessionSram(sessionId: String): Result<ByteArray>
     suspend fun getSessionCheats(sessionId: String): Result<SessionCheatConfig>

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -420,7 +420,7 @@ class SaveManager(
             if (sessionId != null) {
                 val screenshot = screenshotCapture?.captureScreenshot()
                 val result = sessionRepository.uploadSessionAutoSaveFromFile(
-                    sessionId, staged.path, staged.size, screenshot, currentCoreName,
+                    sessionId, staged.path, staged.size, screenshot, currentCoreName, staged.compression,
                 )
                 if (result.isSuccess) {
                     println("[SaveManager] autoSaveOnStop: upload OK")
@@ -453,6 +453,15 @@ class SaveManager(
         /** How long the "Saved" checkmark stays on the in-game overlay's
          *  Save button after a successful upload (#803). */
         const val SAVE_SUCCESS_FLASH_MS = 1_500L
+
+        /**
+         * Saves smaller than this don't get gzipped — for a few KB of
+         * SRAM-sized state, the deflater frame and CPU spend cost more
+         * than the bandwidth they save. 32 KiB happens to sit between
+         * a fully-loaded NES state (~4-8 KB) and the smallest SNES
+         * state. See #804 phase 2.
+         */
+        const val GZIP_MIN_BYTES: Long = 32 * 1024L
     }
 
     fun saveState() {
@@ -503,7 +512,7 @@ class SaveManager(
                 if (sessionId != null) {
                     val screenshot = screenshotCapture?.captureScreenshot()
                     sessionRepository.uploadSessionSaveFromFile(
-                        sessionId, "Manual Save", staged.path, staged.size, screenshot, currentCoreName,
+                        sessionId, "Manual Save", staged.path, staged.size, screenshot, currentCoreName, staged.compression,
                     ).fold(
                         onSuccess = {
                             withContext(dispatchers.main) {
@@ -573,9 +582,15 @@ class SaveManager(
     /**
      * Result of [stageSaveToTempFile]. The file at [path] is owned by the
      * caller — they must invoke [cleanup] after the upload regardless of
-     * outcome to avoid leaking temp files.
+     * outcome to avoid leaking temp files. [compression] is the codec
+     * applied to the bytes at [path] (`""` raw or `"gzip"`); see #804.
      */
-    private data class StagedSave(val path: String, val size: Long, val cleanup: suspend () -> Unit)
+    private data class StagedSave(
+        val path: String,
+        val size: Long,
+        val compression: String,
+        val cleanup: suspend () -> Unit,
+    )
 
     /**
      * Serialize the current core state to a temp file using the native
@@ -586,24 +601,70 @@ class SaveManager(
      * Returns null when serialization fails. When the controller has no
      * native fast path (desktop / fakes), this still works — it falls
      * back to [serialize] + writeFile so the caller's contract holds.
+     *
+     * After the raw bytes are on disk we gzip them in a sibling file and
+     * upload the compressed copy, tagging it with `compression="gzip"`
+     * (#804 phase 2). Tiny saves below [GZIP_MIN_BYTES] skip gzip — the
+     * deflater's frame overhead can outweigh the saving on a few KB SRAM-
+     * sized states. If gzip itself fails for any reason we fall back to
+     * uploading the uncompressed staging file so a transient I/O error
+     * never blocks a save.
      */
     private suspend fun stageSaveToTempFile(): StagedSave? {
         val tempPath = "${fileStorage.getSavesDir()}/.tmp-save-${currentSessionId ?: "none"}"
-        val cleanup: suspend () -> Unit = { runCatching { fileStorage.deleteFile(tempPath) } }
-        val written = libretroController.serializeToFile(tempPath)
-        if (written != null && written > 0) {
-            return StagedSave(tempPath, written, cleanup)
+        val cleanupRaw: suspend () -> Unit = { runCatching { fileStorage.deleteFile(tempPath) } }
+        val rawSize: Long? = run {
+            val written = libretroController.serializeToFile(tempPath)
+            if (written != null && written > 0) {
+                written
+            } else {
+                // Native fast path unavailable — fall back to in-memory
+                // serialize and write through. On JVM-only platforms
+                // (desktop) this is fine; they have plenty of heap.
+                val bytes = libretroController.serialize() ?: return@run null
+                runCatching {
+                    fileStorage.writeFile(tempPath, bytes)
+                    bytes.size.toLong()
+                }.getOrNull()
+            }
         }
-        // Native fast path unavailable — fall back to in-memory serialize
-        // and write through. On JVM-only platforms (desktop) this is fine;
-        // they have plenty of heap.
-        val bytes = libretroController.serialize() ?: return null
-        return runCatching {
-            fileStorage.writeFile(tempPath, bytes)
-            StagedSave(tempPath, bytes.size.toLong(), cleanup)
-        }.getOrNull().also {
-            if (it == null) cleanup()
+        if (rawSize == null) {
+            cleanupRaw()
+            return null
         }
+        return maybeGzipStaged(tempPath, rawSize, cleanupRaw)
+    }
+
+    /**
+     * Attempts to gzip the staged save at [rawPath]. Returns a [StagedSave]
+     * pointed at the gzipped sibling on success, or one pointed at the
+     * raw file on any failure / when the input is too small to be worth
+     * compressing. The cleanup closure deletes whichever temp files the
+     * pipeline ended up creating.
+     */
+    private suspend fun maybeGzipStaged(
+        rawPath: String,
+        rawSize: Long,
+        cleanupRaw: suspend () -> Unit,
+    ): StagedSave {
+        if (rawSize < GZIP_MIN_BYTES) {
+            return StagedSave(rawPath, rawSize, "", cleanupRaw)
+        }
+        val gzPath = "$rawPath.gz"
+        val cleanupGz: suspend () -> Unit = { runCatching { fileStorage.deleteFile(gzPath) } }
+        val cleanupBoth: suspend () -> Unit = { cleanupRaw(); cleanupGz() }
+        val gzSize = runCatching {
+            com.spela.player.util.gzipFile(rawPath, gzPath)
+        }.getOrElse { e ->
+            println("[SaveManager] gzipFile failed (${e.message}); uploading raw")
+            cleanupGz()
+            return StagedSave(rawPath, rawSize, "", cleanupRaw)
+        }
+        if (gzSize <= 0) {
+            cleanupGz()
+            return StagedSave(rawPath, rawSize, "", cleanupRaw)
+        }
+        return StagedSave(gzPath, gzSize, "gzip", cleanupBoth)
     }
 
     /**
@@ -627,7 +688,7 @@ class SaveManager(
                 if (sessionId != null) {
                     val screenshot = screenshotCapture?.captureScreenshot()
                     sessionRepository.uploadSlotSaveFromFile(
-                        sessionId, slot, staged.path, staged.size, screenshot, currentCoreName,
+                        sessionId, slot, staged.path, staged.size, screenshot, currentCoreName, staged.compression,
                     ).fold(
                         onSuccess = {
                             withContext(dispatchers.main) {

--- a/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/presentation/viewmodel/SaveManager.kt
@@ -724,6 +724,14 @@ class SaveManager(
     /**
      * Load state from a specific slot. Blocks in challenge/hardcore mode.
      * Uses the slot-specific API endpoint (GET /api/sessions/:id/saves/slot/:slot).
+     *
+     * Streams the body to a temp file and hands it to
+     * [LibretroController.unserializeFromFile]. The streaming path is
+     * what reads the server's `X-Compression: gzip` header and inflates
+     * the body inline (#804 phase 2) — calling the in-memory
+     * `downloadSlotSave` ByteArray API here would feed gzipped bytes
+     * straight to the core for any save uploaded by a #804-aware
+     * client.
      */
     fun loadFromSlot(slot: Int) {
         if (_state.value.isChallengeMode) return
@@ -734,9 +742,11 @@ class SaveManager(
         scope.launch(dispatchers.io) {
             val sessionId = currentSessionId
             if (sessionId != null) {
-                sessionRepository.downloadSlotSave(sessionId, slot).fold(
-                    onSuccess = { saveData ->
-                        libretroController.unserialize(saveData)
+                val tempPath = "${fileStorage.getSavesDir()}/.tmp-load-slot-$slot-$sessionId"
+                sessionRepository.downloadSlotSaveToFile(sessionId, slot, tempPath).fold(
+                    onSuccess = {
+                        libretroController.unserializeFromFile(tempPath)
+                        runCatching { fileStorage.deleteFile(tempPath) }
                         withContext(dispatchers.main) {
                             _state.update {
                                 it.copy(
@@ -750,6 +760,7 @@ class SaveManager(
                         }
                     },
                     onFailure = { error ->
+                        runCatching { fileStorage.deleteFile(tempPath) }
                         withContext(dispatchers.main) {
                             _state.update { it.copy(error = "Failed to load from slot $slot: ${error.message}") }
                         }

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/GzipFile.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/GzipFile.kt
@@ -1,0 +1,16 @@
+package com.spela.player.util
+
+/**
+ * Gzip-compress the file at [srcPath], writing the deflated stream to
+ * [destPath]. Returns the size in bytes of the destination file.
+ *
+ * Implemented per platform on top of `java.util.zip.GZIPOutputStream`
+ * for both Android and Desktop. The streaming form is used so the JVM
+ * never has to hold the full save in a ByteArray — important for the
+ * Dolphin GameCube ~90 MB case that drove #798.
+ *
+ * Throws on any I/O failure. Callers are expected to catch and fall
+ * back to uploading the uncompressed save (a transient gzip failure
+ * must not block the save itself). See #804 phase 2.
+ */
+expect suspend fun gzipFile(srcPath: String, destPath: String): Long

--- a/player/shared/src/commonMain/kotlin/com/spela/player/util/GzipFile.kt
+++ b/player/shared/src/commonMain/kotlin/com/spela/player/util/GzipFile.kt
@@ -14,3 +14,15 @@ package com.spela.player.util
  * must not block the save itself). See #804 phase 2.
  */
 expect suspend fun gzipFile(srcPath: String, destPath: String): Long
+
+/**
+ * Inverse of [gzipFile]: read a gzip stream from [srcPath] and write
+ * the inflated bytes to [destPath]. Returns the size of the destination
+ * file in bytes.
+ *
+ * Used by the player-side save-download path when the server's
+ * `X-Compression: gzip` header is present (#804 phase 2). Throws on
+ * any I/O failure — callers treat that as a fatal load error rather
+ * than feeding gzipped bytes to libretro.
+ */
+expect suspend fun gunzipFile(srcPath: String, destPath: String): Long

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
@@ -227,6 +227,7 @@ private class FakeSessionRepo : SessionRepository {
         saveSize: Long,
         screenshot: ByteArray?,
         coreName: String,
+        compression: String,
     ): Result<SaveState> = Result.failure(UnsupportedOperationException("not exercised"))
 
     override suspend fun downloadSessionSave(sessionId: String, saveId: String): Result<ByteArray> =
@@ -245,6 +246,7 @@ private class FakeSessionRepo : SessionRepository {
         saveSize: Long,
         screenshot: ByteArray?,
         coreName: String,
+        compression: String,
     ): Result<Unit> = Result.failure(UnsupportedOperationException("not exercised"))
 
     override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> =
@@ -268,6 +270,7 @@ private class FakeSessionRepo : SessionRepository {
         saveSize: Long,
         screenshot: ByteArray?,
         coreName: String,
+        compression: String,
     ): Result<SaveState> = Result.failure(UnsupportedOperationException("not exercised"))
 
     override suspend fun downloadSlotSave(sessionId: String, slot: Int): Result<ByteArray> =

--- a/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
+++ b/player/shared/src/commonTest/kotlin/com/spela/player/presentation/viewmodel/SessionDetailViewModelTest.kt
@@ -276,6 +276,9 @@ private class FakeSessionRepo : SessionRepository {
     override suspend fun downloadSlotSave(sessionId: String, slot: Int): Result<ByteArray> =
         Result.failure(UnsupportedOperationException("not exercised"))
 
+    override suspend fun downloadSlotSaveToFile(sessionId: String, slot: Int, outputPath: String): Result<Unit> =
+        Result.failure(UnsupportedOperationException("not exercised"))
+
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String): Result<Unit> =
         Result.failure(UnsupportedOperationException("not exercised"))
 

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/util/GzipFile.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/util/GzipFile.desktop.kt
@@ -1,0 +1,28 @@
+package com.spela.player.util
+
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.io.File
+import java.io.FileInputStream
+import java.io.FileOutputStream
+import java.util.zip.GZIPOutputStream
+
+/**
+ * Synchronous I/O — caller is responsible for invoking on a worker
+ * dispatcher (in production both Android and Desktop callers wrap this
+ * in `withContext(dispatchers.io) { ... }`). Switching dispatchers
+ * inside the helper would race with kotlinx-coroutines-test's
+ * [advanceUntilIdle], so we keep the body on the caller's coroutine.
+ */
+actual suspend fun gzipFile(srcPath: String, destPath: String): Long {
+    FileInputStream(srcPath).use { src ->
+        BufferedInputStream(src).use { bin ->
+            FileOutputStream(destPath).use { out ->
+                GZIPOutputStream(BufferedOutputStream(out)).use { gz ->
+                    bin.copyTo(gz)
+                }
+            }
+        }
+    }
+    return File(destPath).length()
+}

--- a/player/shared/src/desktopMain/kotlin/com/spela/player/util/GzipFile.desktop.kt
+++ b/player/shared/src/desktopMain/kotlin/com/spela/player/util/GzipFile.desktop.kt
@@ -5,6 +5,7 @@ import java.io.BufferedOutputStream
 import java.io.File
 import java.io.FileInputStream
 import java.io.FileOutputStream
+import java.util.zip.GZIPInputStream
 import java.util.zip.GZIPOutputStream
 
 /**
@@ -20,6 +21,19 @@ actual suspend fun gzipFile(srcPath: String, destPath: String): Long {
             FileOutputStream(destPath).use { out ->
                 GZIPOutputStream(BufferedOutputStream(out)).use { gz ->
                     bin.copyTo(gz)
+                }
+            }
+        }
+    }
+    return File(destPath).length()
+}
+
+actual suspend fun gunzipFile(srcPath: String, destPath: String): Long {
+    FileInputStream(srcPath).use { src ->
+        GZIPInputStream(BufferedInputStream(src)).use { gz ->
+            FileOutputStream(destPath).use { out ->
+                BufferedOutputStream(out).use { bout ->
+                    gz.copyTo(bout)
                 }
             }
         }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -188,6 +188,7 @@ private class FakePlayFromSharedSaveSessionRepository : SessionRepository {
     override suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String, compression: String) =
         Result.success(SaveState(id = "1", name = "Slot $slot"))
     override suspend fun downloadSlotSave(sessionId: String, slot: Int) = Result.failure<ByteArray>(Exception("stub"))
+    override suspend fun downloadSlotSaveToFile(sessionId: String, slot: Int, outputPath: String) = Result.failure<Unit>(Exception("stub"))
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String) = Result.success(Unit)
     override suspend fun downloadSessionSram(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun getSessionCheats(sessionId: String) = Result.success(SessionCheatConfig(false, emptyList()))

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/GameDetailPlayFromSharedSaveTest.kt
@@ -176,16 +176,16 @@ private class FakePlayFromSharedSaveSessionRepository : SessionRepository {
     override suspend fun getSessionSaves(sessionId: String) = Result.success(emptyList<SaveState>())
     override suspend fun uploadSessionSave(sessionId: String, name: String, data: ByteArray, screenshot: ByteArray?, coreName: String) =
         Result.success(SaveState(id = "1", name = name))
-    override suspend fun uploadSessionSaveFromFile(sessionId: String, name: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String) =
+    override suspend fun uploadSessionSaveFromFile(sessionId: String, name: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String, compression: String) =
         Result.success(SaveState(id = "1", name = name))
     override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
     override suspend fun uploadSessionAutoSave(sessionId: String, data: ByteArray, screenshot: ByteArray?, coreName: String) = Result.success(Unit)
-    override suspend fun uploadSessionAutoSaveFromFile(sessionId: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String) = Result.success(Unit)
+    override suspend fun uploadSessionAutoSaveFromFile(sessionId: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String, compression: String) = Result.success(Unit)
     override suspend fun downloadSessionAutoSave(sessionId: String) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun downloadSessionAutoSaveToFile(sessionId: String, outputPath: String) = Result.failure<Unit>(Exception("stub"))
     override suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String) =
         Result.success(SaveState(id = "1", name = "Slot $slot"))
-    override suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String) =
+    override suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String, compression: String) =
         Result.success(SaveState(id = "1", name = "Slot $slot"))
     override suspend fun downloadSlotSave(sessionId: String, slot: Int) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun uploadSessionSram(sessionId: String, data: ByteArray, coreName: String) = Result.success(Unit)

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerCompressionTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/SaveManagerCompressionTest.kt
@@ -1,0 +1,147 @@
+package com.spela.player.presentation.viewmodel
+
+import com.spela.player.data.remote.ConnectivityMonitor
+import com.spela.player.data.remote.api.SpelaApiClient
+import com.spela.player.data.remote.interceptor.TokenManager
+import com.spela.player.presentation.state.EmulationState
+import com.spela.player.presentation.viewmodel.emulation.StubLibretroController
+import com.spela.player.presentation.viewmodel.emulation.StubMockEngineFactory
+import com.spela.player.presentation.viewmodel.emulation.StubSaveDataRepository
+import com.spela.player.presentation.viewmodel.emulation.StubSessionRepository
+import com.spela.player.util.DispatcherProvider
+import com.spela.player.util.FileStorage
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import kotlin.io.path.createTempDirectory
+import kotlin.test.AfterTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * Verifies SaveManager's gzip-on-upload path (#804 phase 2).
+ *
+ * The pipeline:
+ *
+ *   1. Native serialise (or fallback) writes raw bytes to .tmp-save-<id>.
+ *   2. If the raw size is >= [GZIP_MIN_BYTES] we gzip into .tmp-save-<id>.gz
+ *      and the upload form's compression= field becomes "gzip".
+ *   3. Below the threshold we skip gzip entirely and upload raw.
+ *
+ * These are the contracts the in-game Save button depends on; if either
+ * leaks (e.g. compression= sent as "" for a 90 MB GameCube save) the
+ * server stores the bytes opaquely as raw, so the next download will
+ * try to feed gzipped bytes straight to the libretro core and the
+ * resume crashes silently.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SaveManagerCompressionTest {
+
+    private val tempDir: File = createTempDirectory("spela-savemgr-").toFile()
+
+    @AfterTest
+    fun cleanup() {
+        tempDir.deleteRecursively()
+    }
+
+    private fun testDispatchers(dispatcher: CoroutineDispatcher): DispatcherProvider =
+        object : DispatcherProvider {
+            override val main: CoroutineDispatcher = dispatcher
+            override val io: CoroutineDispatcher = dispatcher
+            override val default: CoroutineDispatcher = dispatcher
+        }
+
+    /** Real-filesystem FileStorage so gzipFile can actually read the
+     *  staged temp file the manager writes via the fallback path. */
+    private inner class RealTempFileStorage : FileStorage {
+        override fun getGamesDir(): String = tempDir.resolve("games").apply { mkdirs() }.absolutePath
+        override fun getCoresDir(): String = tempDir.resolve("cores").apply { mkdirs() }.absolutePath
+        override fun getSavesDir(): String = tempDir.resolve("saves").apply { mkdirs() }.absolutePath
+        override fun getBiosDir(): String = tempDir.resolve("bios").apply { mkdirs() }.absolutePath
+        override suspend fun createDirectory(path: String) { File(path).mkdirs() }
+        override suspend fun writeFile(path: String, data: ByteArray) { File(path).writeBytes(data) }
+        override suspend fun readFile(path: String): ByteArray = File(path).readBytes()
+        override suspend fun fileExists(path: String): Boolean = File(path).exists()
+        override suspend fun deleteFile(path: String) { File(path).delete() }
+        override suspend fun deleteDirectory(path: String) { File(path).deleteRecursively() }
+        override suspend fun getDirectorySize(path: String): Long = 0
+        override suspend fun writeFileStreaming(path: String, writer: suspend (append: suspend (ByteArray, Int, Int) -> Unit) -> Unit) {}
+        override suspend fun getFileSize(path: String): Long = File(path).length()
+        override suspend fun listFiles(path: String): List<String> = emptyList()
+        override suspend fun isDirectory(path: String): Boolean = File(path).isDirectory
+        override suspend fun zipDirectoryToBytes(dirPath: String): ByteArray? = null
+        override suspend fun unzipBytesToDirectory(data: ByteArray, targetDir: String) {}
+        override suspend fun sha256File(path: String): String? = null
+    }
+
+    private fun makeManager(
+        scope: CoroutineScope,
+        dispatcher: CoroutineDispatcher,
+        serializeBytes: ByteArray,
+    ): Triple<SaveManager, StubSessionRepository, RealTempFileStorage> {
+        val dispatchers = testDispatchers(dispatcher)
+        val apiClient = SpelaApiClient(StubMockEngineFactory, TokenManager())
+        val connectivity = ConnectivityMonitor(apiClient, dispatchers, scope)
+        val sessionRepo = StubSessionRepository()
+        val libretro = StubLibretroController().apply { serializeResult = serializeBytes }
+        val state = MutableStateFlow(EmulationState())
+        val storage = RealTempFileStorage()
+        val manager = SaveManager(
+            saveDataRepository = StubSaveDataRepository(),
+            connectivityMonitor = connectivity,
+            libretroController = libretro,
+            screenshotCapture = null,
+            _state = state,
+            dispatchers = dispatchers,
+            scope = scope,
+            sessionRepository = sessionRepo,
+            fileStorage = storage,
+        )
+        manager.currentSessionId = "s1"
+        manager.currentCoreName = "nestopia"
+        return Triple(manager, sessionRepo, storage)
+    }
+
+    @Test
+    fun manualSaveAboveThresholdIsGzippedAndTagged() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        // 64 KiB of repeating bytes — above GZIP_MIN_BYTES (32 KiB) and
+        // compresses well so we can also assert the file shrinks.
+        val payload = ByteArray(64 * 1024) { (it % 17).toByte() }
+        val (manager, sessionRepo, storage) = makeManager(this, dispatcher, payload)
+
+        manager.saveState()
+        advanceUntilIdle()
+
+        assertEquals("gzip", sessionRepo.lastUploadCompression)
+        // Both temp files must be cleaned up on success.
+        val savesDir = File(storage.getSavesDir())
+        val leftovers = savesDir.listFiles()?.toList() ?: emptyList()
+        assertTrue(leftovers.isEmpty(), "expected no leftover temp files, found $leftovers")
+    }
+
+    @Test
+    fun manualSaveBelowThresholdSkipsGzip() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        // 8 KiB — below GZIP_MIN_BYTES so the manager must upload raw.
+        val payload = ByteArray(8 * 1024) { 0x42 }
+        val (manager, sessionRepo, storage) = makeManager(this, dispatcher, payload)
+
+        manager.saveState()
+        advanceUntilIdle()
+
+        assertEquals("", sessionRepo.lastUploadCompression)
+        val savesDir = File(storage.getSavesDir())
+        val leftovers = savesDir.listFiles()?.toList() ?: emptyList()
+        assertTrue(leftovers.isEmpty(), "expected no leftover temp files, found $leftovers")
+        // No .gz sibling should ever have been created on disk.
+        assertFalse(savesDir.resolve(".tmp-save-s1.gz").exists())
+    }
+}

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -427,8 +427,16 @@ class StubSessionRepository : SessionRepository {
         uploadSessionSaveCallCount++
         return uploadSessionSaveResult
     }
-    override suspend fun uploadSessionSaveFromFile(sessionId: String, name: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String): Result<SaveState> {
+    /** Records the compression= form value received on the last
+     *  uploadSessionSaveFromFile / *AutoSave* / *SlotSave* call. Tests
+     *  assert this to verify SaveManager threads `staged.compression`
+     *  through to the repository (#804 phase 2). */
+    var lastUploadCompression: String? = null
+        private set
+
+    override suspend fun uploadSessionSaveFromFile(sessionId: String, name: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String, compression: String): Result<SaveState> {
         uploadSessionSaveCallCount++
+        lastUploadCompression = compression
         return uploadSessionSaveResult
     }
     override suspend fun downloadSessionSave(sessionId: String, saveId: String) = Result.success(byteArrayOf())
@@ -436,8 +444,9 @@ class StubSessionRepository : SessionRepository {
         uploadSessionAutoSaveCallCount++
         return Result.success(Unit)
     }
-    override suspend fun uploadSessionAutoSaveFromFile(sessionId: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String): Result<Unit> {
+    override suspend fun uploadSessionAutoSaveFromFile(sessionId: String, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String, compression: String): Result<Unit> {
         uploadSessionAutoSaveCallCount++
+        lastUploadCompression = compression
         return Result.success(Unit)
     }
     override suspend fun downloadSessionAutoSave(sessionId: String): Result<ByteArray> {
@@ -458,8 +467,10 @@ class StubSessionRepository : SessionRepository {
     }
     override suspend fun uploadSlotSave(sessionId: String, slot: Int, data: ByteArray, screenshot: ByteArray?, coreName: String) =
         Result.success(SaveState(id = "1", name = "Slot $slot"))
-    override suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String) =
-        Result.success(SaveState(id = "1", name = "Slot $slot"))
+    override suspend fun uploadSlotSaveFromFile(sessionId: String, slot: Int, savePath: String, saveSize: Long, screenshot: ByteArray?, coreName: String, compression: String): Result<SaveState> {
+        lastUploadCompression = compression
+        return Result.success(SaveState(id = "1", name = "Slot $slot"))
+    }
     override suspend fun downloadSlotSave(sessionId: String, slot: Int) = Result.failure<ByteArray>(Exception("stub"))
     override suspend fun createSessionFromSharedSave(gameId: String, saveId: String) =
         Result.success(GameSession(id = "shared-session-1", gameId = gameId, name = "From shared save $saveId"))

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/presentation/viewmodel/emulation/EmulationTestStubs.kt
@@ -472,6 +472,7 @@ class StubSessionRepository : SessionRepository {
         return Result.success(SaveState(id = "1", name = "Slot $slot"))
     }
     override suspend fun downloadSlotSave(sessionId: String, slot: Int) = Result.failure<ByteArray>(Exception("stub"))
+    override suspend fun downloadSlotSaveToFile(sessionId: String, slot: Int, outputPath: String) = Result.failure<Unit>(Exception("stub"))
     override suspend fun createSessionFromSharedSave(gameId: String, saveId: String) =
         Result.success(GameSession(id = "shared-session-1", gameId = gameId, name = "From shared save $saveId"))
     override suspend fun getSessionCheats(sessionId: String) = Result.success(SessionCheatConfig(false, emptyList()))

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/util/GzipFileTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/util/GzipFileTest.kt
@@ -3,7 +3,9 @@ package com.spela.player.util
 import kotlinx.coroutines.test.runTest
 import java.io.File
 import java.io.FileInputStream
+import java.io.FileOutputStream
 import java.util.zip.GZIPInputStream
+import java.util.zip.GZIPOutputStream
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertTrue
@@ -27,5 +29,35 @@ class GzipFileTest {
 
         val roundTripped = GZIPInputStream(FileInputStream(dst)).use { it.readBytes() }
         assertContentEquals(payload, roundTripped)
+    }
+
+    @Test
+    fun gunzipReversesGzip() = runTest {
+        val raw = File.createTempFile("gz-raw-", ".bin").apply { deleteOnExit() }
+        val gzipped = File.createTempFile("gz-mid-", ".gz").apply { deleteOnExit() }
+        val restored = File.createTempFile("gz-out-", ".bin").apply { deleteOnExit() }
+        val payload = ByteArray(96 * 1024) { (it * 7 % 251).toByte() }
+        raw.writeBytes(payload)
+
+        gzipFile(raw.absolutePath, gzipped.absolutePath)
+        val restoredSize = gunzipFile(gzipped.absolutePath, restored.absolutePath)
+
+        assertTrue(restoredSize == payload.size.toLong())
+        assertContentEquals(payload, restored.readBytes())
+    }
+
+    @Test
+    fun gunzipReadsThirdPartyGzip() = runTest {
+        // Bytes produced outside our pipeline must also inflate cleanly,
+        // since the server may eventually re-encode saves itself.
+        val gzipped = File.createTempFile("gz-third-", ".gz").apply { deleteOnExit() }
+        val restored = File.createTempFile("gz-third-out-", ".bin").apply { deleteOnExit() }
+        val payload = "hello world from elsewhere".repeat(2000).toByteArray()
+        GZIPOutputStream(FileOutputStream(gzipped)).use { it.write(payload) }
+
+        val restoredSize = gunzipFile(gzipped.absolutePath, restored.absolutePath)
+
+        assertTrue(restoredSize == payload.size.toLong())
+        assertContentEquals(payload, restored.readBytes())
     }
 }

--- a/player/shared/src/desktopTest/kotlin/com/spela/player/util/GzipFileTest.kt
+++ b/player/shared/src/desktopTest/kotlin/com/spela/player/util/GzipFileTest.kt
@@ -1,0 +1,31 @@
+package com.spela.player.util
+
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import java.io.FileInputStream
+import java.util.zip.GZIPInputStream
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertTrue
+
+class GzipFileTest {
+
+    @Test
+    fun roundTripsRandomBytes() = runTest {
+        val src = File.createTempFile("gz-src-", ".bin").apply { deleteOnExit() }
+        val dst = File.createTempFile("gz-dst-", ".gz").apply { deleteOnExit() }
+        // Pseudo-random bytes resist the dictionary so the gzip output
+        // isn't trivially small; this also catches buffering bugs that
+        // would silently truncate at a typical 8 KiB chunk boundary.
+        val payload = ByteArray(64 * 1024) { (it % 251).toByte() }
+        src.writeBytes(payload)
+
+        val gzippedSize = gzipFile(src.absolutePath, dst.absolutePath)
+
+        assertTrue(gzippedSize > 0, "gzipped output should be non-empty")
+        assertTrue(gzippedSize == dst.length(), "returned size should match on-disk size")
+
+        val roundTripped = GZIPInputStream(FileInputStream(dst)).use { it.readBytes() }
+        assertContentEquals(payload, roundTripped)
+    }
+}


### PR DESCRIPTION
Closes part of #804 (phase 2, player-side compression).

## Summary

Player-side half of #804 phase 2 — companion to server-side metadata in #814 (already merged on master).

The flow is now:

1. **Upload:** stage raw save bytes via the existing #798 streaming pipeline → gzip into a sibling `.gz` file → upload, tagging the multipart form with `compression="gzip"`.
2. **Download:** stream response body to disk, check `X-Compression` header. If `gzip`, gunzip in place into the original outputPath; the libretro `unserializeFromFile` handoff stays untouched.

Both directions ship in the same PR so newly-uploaded saves are immediately decompressible by the same client. Without the download side bundled, a fresh save would be uploaded gzipped and then handed back to libretro as raw gzipped bytes on resume — silent crash.

## Behaviour

| Save size | Upload action | Form field |
|-----------|--------------|------------|
| < 32 KiB | upload raw | (omitted) |
| ≥ 32 KiB | gzip then upload `.gz` | `compression="gzip"` |

The threshold trades CPU vs network: for SRAM-sized NES/SNES states the deflater frame and CPU spend cost more than the bandwidth saved. GameCube saves (~90 MB) compress to roughly a third, which is the shape that motivated #804.

If gzip itself fails for any reason — disk full, ENOSPC, OOM — we fall back to the uncompressed staging file and tag with empty compression. A transient I/O hiccup must never block the save itself.

## What changed

**Common helpers**
- `gzipFile(srcPath, destPath)` and `gunzipFile(srcPath, destPath)` `expect`/`actual` in `util/GzipFile.kt` — wrap `java.util.zip.GZIPOutputStream` / `GZIPInputStream` on both Android and Desktop. Synchronous on the caller's coroutine — switching to `Dispatchers.IO` inside the helper would race with `kotlinx-coroutines-test`'s `advanceUntilIdle` and made tests flaky.

**Upload side**
- `StagedSave` gains a `compression` field; the manual / auto / slot upload paths in `SaveManager` thread `staged.compression` through to the repository.
- `SessionRepository`, `SessionRepositoryImpl`, `SpelaApiClient` — three FromFile upload methods take a new `compression` arg defaulting to `""` (so off-path callers stay backwards compatible).
- Three test fakes updated (one common, two desktop).

**Download side**
- New private `streamSaveResponseToFile` helper in `SpelaApiClient` wraps the three streaming endpoints (`/saves/auto`, `/saves/{id}`, `/saves/slot/{n}`). On `X-Compression: gzip` it streams to a `.gz.tmp` sibling and inflates into `outputPath`; the uncompressed path is untouched.

## Tests

- `GzipFileTest` — 3 tests: gzip roundtrip, gzip→gunzip roundtrip, third-party `GZIPOutputStream` input (in case the server later re-encodes saves itself).
- `SaveManagerCompressionTest` — 2 tests: above-threshold save sends `compression="gzip"` and cleans up both temp files; below-threshold save sends `""` and never creates a `.gz` sibling.

Full desktop suite: 546 tests, 0 failures. Android compile clean.

## Test plan

- [ ] Player unit tests pass on CI
- [ ] Manual: load a GameCube game on the AYN Thor, save state, confirm the request shows `compression=gzip` and the `save` part is significantly smaller than the underlying state.
- [ ] Manual: resume the same session and confirm the save loads correctly (the server returns `X-Compression: gzip` and the client gunzips before handing to libretro).
