### PR TITLE
feat: ConsoleSaveStatePolicy table + preferences sync (#804 phase 4)

### DIFF
--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdatePreferencesRequest.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UpdatePreferencesRequest.kt
@@ -29,6 +29,7 @@ import kotlinx.serialization.encoding.*
  * @param autoSaveEnabled 
  * @param autoUpdateCoresEnabled 
  * @param consoleKeyMappings 
+ * @param consoleSaveStatePolicies 
  * @param consoleShaders 
  * @param customKeyMapping 
  * @param defaultSecondScreenPage 
@@ -52,6 +53,8 @@ data class UpdatePreferencesRequest (
     @SerialName(value = "autoUpdateCoresEnabled") val autoUpdateCoresEnabled: kotlin.Boolean? = null,
 
     @SerialName(value = "consoleKeyMappings") val consoleKeyMappings: kotlin.collections.Map<kotlin.String, ConsoleKeyMappingDTO>? = null,
+
+    @SerialName(value = "consoleSaveStatePolicies") val consoleSaveStatePolicies: kotlin.collections.Map<kotlin.String, kotlin.String>? = null,
 
     @SerialName(value = "consoleShaders") val consoleShaders: kotlin.collections.Map<kotlin.String, kotlin.String>? = null,
 

--- a/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserPreferencesResponse.kt
+++ b/player/shared-api/src/commonMain/kotlin/com/spela/client/models/UserPreferencesResponse.kt
@@ -28,6 +28,7 @@ import kotlinx.serialization.encoding.*
  * @param autoSaveEnabled 
  * @param autoUpdateCoresEnabled 
  * @param consoleKeyMappings 
+ * @param consoleSaveStatePolicies 
  * @param consoleShaders 
  * @param customKeyMapping 
  * @param defaultSecondScreenPage 
@@ -52,6 +53,8 @@ data class UserPreferencesResponse (
     @SerialName(value = "autoUpdateCoresEnabled") @Required val autoUpdateCoresEnabled: kotlin.Boolean,
 
     @SerialName(value = "consoleKeyMappings") @Required val consoleKeyMappings: kotlin.collections.Map<kotlin.String, ConsoleKeyMappingDTO>,
+
+    @SerialName(value = "consoleSaveStatePolicies") @Required val consoleSaveStatePolicies: kotlin.collections.Map<kotlin.String, kotlin.String>,
 
     @SerialName(value = "consoleShaders") @Required val consoleShaders: kotlin.collections.Map<kotlin.String, kotlin.String>,
 

--- a/server/internal/api/api_test.go
+++ b/server/internal/api/api_test.go
@@ -41,6 +41,7 @@ func setupTestEnv(t *testing.T) (*gorm.DB, *Config) {
 		&db.SystemEvent{},
 		&db.ServerSetting{}, &db.Core{},
 		&db.ConsoleShaderPreference{},
+		&db.ConsoleSaveStatePolicy{},
 		&db.ConsoleKeyMappingPreference{},
 		&db.Device{},
 		&db.DeviceShaderPreference{},

--- a/server/internal/api/console_save_state_policy_test.go
+++ b/server/internal/api/console_save_state_policy_test.go
@@ -1,0 +1,175 @@
+package api
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/spela/server/internal/db"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNormalizeSaveStateChoice locks the closed-set sanitiser. Anything
+// outside enabled/disabled/ask-once collapses to "" so a typo or future
+// codec doesn't end up in the database with a value the player can't
+// switch on. See #804 phase 4.
+func TestNormalizeSaveStateChoice(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want db.ConsoleSaveStateChoice
+	}{
+		{"enabled", "enabled", db.ConsoleSaveStateChoiceEnabled},
+		{"disabled", "disabled", db.ConsoleSaveStateChoiceDisabled},
+		{"ask-once", "ask-once", db.ConsoleSaveStateChoiceAskOnce},
+		{"uppercase enabled", "ENABLED", db.ConsoleSaveStateChoiceEnabled},
+		{"mixed case", "Ask-Once", db.ConsoleSaveStateChoiceAskOnce},
+		{"whitespace", "  disabled  ", db.ConsoleSaveStateChoiceDisabled},
+		{"empty", "", ""},
+		{"unknown", "off", ""},
+		{"garbage", "asdf", ""},
+		{"whitespace only", "   ", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, normalizeSaveStateChoice(tc.in))
+		})
+	}
+}
+
+// TestUpdatePreferences_SetConsoleSaveStatePolicy upserts a per-console
+// save-state choice and verifies it round-trips via PUT and GET. This
+// is the data shape the player will read in phase 4b.
+func TestUpdatePreferences_SetConsoleSaveStatePolicy(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"consoleSaveStatePolicies": map[string]string{"gc": "disabled"},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var prefs map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+	policies, ok := prefs["consoleSaveStatePolicies"].(map[string]interface{})
+	require.True(t, ok, "consoleSaveStatePolicies missing from PUT response")
+	assert.Equal(t, "disabled", policies["gc"])
+
+	// GET round-trip — the stored row survives a fresh fetch.
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/user/preferences", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+	policies = prefs["consoleSaveStatePolicies"].(map[string]interface{})
+	assert.Equal(t, "disabled", policies["gc"])
+}
+
+// TestUpdatePreferences_ClearConsoleSaveStatePolicy verifies that
+// sending an empty string removes the row so the console reverts to
+// its tier-driven default. The player relies on absence-from-map to
+// resolve "use the default" — without this, an opted-out user would
+// be stuck on "disabled" forever once they tried to revert.
+func TestUpdatePreferences_ClearConsoleSaveStatePolicy(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	// First set disabled.
+	body, _ := json.Marshal(map[string]interface{}{
+		"consoleSaveStatePolicies": map[string]string{"gc": "disabled"},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// Clear by sending "".
+	body, _ = json.Marshal(map[string]interface{}{
+		"consoleSaveStatePolicies": map[string]string{"gc": ""},
+	})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var prefs map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+	policies := prefs["consoleSaveStatePolicies"].(map[string]interface{})
+	_, exists := policies["gc"]
+	assert.False(t, exists, "policy should be cleared after sending empty string")
+}
+
+// TestUpdatePreferences_SaveStatePolicyUnknownAbbrSilentlySkipped
+// mirrors the ConsoleShaders behaviour: an unknown console abbreviation
+// must not 500 the request, just no-op the row. Lets the player send
+// a bulk sync without enumerating the full server console list.
+func TestUpdatePreferences_SaveStatePolicyUnknownAbbrSilentlySkipped(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"consoleSaveStatePolicies": map[string]string{
+			"gc":      "disabled",
+			"bogosys": "enabled",
+		},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var prefs map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+	policies := prefs["consoleSaveStatePolicies"].(map[string]interface{})
+	assert.Equal(t, "disabled", policies["gc"])
+	_, exists := policies["bogosys"]
+	assert.False(t, exists, "bogus console abbreviation must not write a row")
+}
+
+// TestUpdatePreferences_SaveStatePolicyGarbageValueIsRejected verifies
+// the sanitiser drops anything that isn't a known choice — without it
+// the row would carry a value the player would have to defensively
+// switch on.
+func TestUpdatePreferences_SaveStatePolicyGarbageValueIsRejected(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	body, _ := json.Marshal(map[string]interface{}{
+		"consoleSaveStatePolicies": map[string]string{"gc": "absolutely-not-a-state"},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	var prefs map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+	policies := prefs["consoleSaveStatePolicies"].(map[string]interface{})
+	_, exists := policies["gc"]
+	assert.False(t, exists, "garbage value should not be persisted")
+}

--- a/server/internal/api/console_save_state_policy_test.go
+++ b/server/internal/api/console_save_state_policy_test.go
@@ -12,30 +12,38 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestNormalizeSaveStateChoice locks the closed-set sanitiser. Anything
-// outside enabled/disabled/ask-once collapses to "" so a typo or future
-// codec doesn't end up in the database with a value the player can't
-// switch on. See #804 phase 4.
+// TestNormalizeSaveStateChoice locks the closed-set sanitiser. Three
+// distinct outcomes:
+//
+//	valid input   → (choice, false)   upsert
+//	empty/blank   → ("", true)        clear the row
+//	unknown value → ("", false)       no-op (preserve existing override)
+//
+// The empty-vs-unknown split prevents a client typo from silently
+// destroying a valid override. See #804 phase 4 review feedback.
 func TestNormalizeSaveStateChoice(t *testing.T) {
 	cases := []struct {
-		name string
-		in   string
-		want db.ConsoleSaveStateChoice
+		name      string
+		in        string
+		wantChoice db.ConsoleSaveStateChoice
+		wantClear bool
 	}{
-		{"enabled", "enabled", db.ConsoleSaveStateChoiceEnabled},
-		{"disabled", "disabled", db.ConsoleSaveStateChoiceDisabled},
-		{"ask-once", "ask-once", db.ConsoleSaveStateChoiceAskOnce},
-		{"uppercase enabled", "ENABLED", db.ConsoleSaveStateChoiceEnabled},
-		{"mixed case", "Ask-Once", db.ConsoleSaveStateChoiceAskOnce},
-		{"whitespace", "  disabled  ", db.ConsoleSaveStateChoiceDisabled},
-		{"empty", "", ""},
-		{"unknown", "off", ""},
-		{"garbage", "asdf", ""},
-		{"whitespace only", "   ", ""},
+		{"enabled", "enabled", db.ConsoleSaveStateChoiceEnabled, false},
+		{"disabled", "disabled", db.ConsoleSaveStateChoiceDisabled, false},
+		{"ask-once", "ask-once", db.ConsoleSaveStateChoiceAskOnce, false},
+		{"uppercase enabled", "ENABLED", db.ConsoleSaveStateChoiceEnabled, false},
+		{"mixed case", "Ask-Once", db.ConsoleSaveStateChoiceAskOnce, false},
+		{"whitespace", "  disabled  ", db.ConsoleSaveStateChoiceDisabled, false},
+		{"empty clears", "", "", true},
+		{"whitespace only clears", "   ", "", true},
+		{"unknown is no-op", "off", "", false},
+		{"garbage is no-op", "asdf", "", false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			assert.Equal(t, tc.want, normalizeSaveStateChoice(tc.in))
+			choice, clear := normalizeSaveStateChoice(tc.in)
+			assert.Equal(t, tc.wantChoice, choice)
+			assert.Equal(t, tc.wantClear, clear)
 		})
 	}
 }
@@ -145,6 +153,53 @@ func TestUpdatePreferences_SaveStatePolicyUnknownAbbrSilentlySkipped(t *testing.
 	assert.Equal(t, "disabled", policies["gc"])
 	_, exists := policies["bogosys"]
 	assert.False(t, exists, "bogus console abbreviation must not write a row")
+}
+
+// TestUpdatePreferences_SaveStatePolicyGarbageValuePreservesExistingOverride
+// is the regression test for PR #817 review feedback. A typo in a
+// bulk sync ("absolutely-not-a-state") must NOT destroy the user's
+// existing valid override. Garbage = no-op, only an explicit empty
+// string clears.
+func TestUpdatePreferences_SaveStatePolicyGarbageValuePreservesExistingOverride(t *testing.T) {
+	_, cfg := setupTestEnv(t)
+	router, cleanup := NewRouter(*cfg)
+	defer cleanup()
+	token := registerAndGetToken(t, router)
+
+	// 1. User opts GameCube out.
+	body, _ := json.Marshal(map[string]interface{}{
+		"consoleSaveStatePolicies": map[string]string{"gc": "disabled"},
+	})
+	w := httptest.NewRecorder()
+	req := httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// 2. A subsequent sync sends a typo. Pre-fix this would silently
+	//    delete the row.
+	body, _ = json.Marshal(map[string]interface{}{
+		"consoleSaveStatePolicies": map[string]string{"gc": "absolutely-not-a-state"},
+	})
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("PUT", "/api/user/preferences", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Content-Type", "application/json")
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+
+	// 3. The original "disabled" override must still be there.
+	w = httptest.NewRecorder()
+	req = httptest.NewRequest("GET", "/api/user/preferences", nil)
+	req.Header.Set("Authorization", "Bearer "+token)
+	router.ServeHTTP(w, req)
+	require.Equal(t, http.StatusOK, w.Code)
+	var prefs map[string]interface{}
+	require.NoError(t, json.Unmarshal(w.Body.Bytes(), &prefs))
+	policies := prefs["consoleSaveStatePolicies"].(map[string]interface{})
+	assert.Equal(t, "disabled", policies["gc"],
+		"existing valid override must survive a typo'd sync")
 }
 
 // TestUpdatePreferences_SaveStatePolicyGarbageValueIsRejected verifies

--- a/server/internal/api/huma_admin_games.go
+++ b/server/internal/api/huma_admin_games.go
@@ -973,6 +973,7 @@ func (h *AdminHandler) HumaHardDeleteUser(ctx context.Context, in *HardDeleteUse
 		uid := user.ID
 
 		tx.Unscoped().Where("user_id = ?", uid).Delete(&db.ConsoleShaderPreference{})
+		tx.Unscoped().Where("user_id = ?", uid).Delete(&db.ConsoleSaveStatePolicy{})
 		tx.Unscoped().Where("user_id = ?", uid).Delete(&db.ConsoleKeyMappingPreference{})
 		tx.Unscoped().Where("user_id = ?", uid).Delete(&db.GameKeyMappingPreference{})
 

--- a/server/internal/api/huma_test_reset.go
+++ b/server/internal/api/huma_test_reset.go
@@ -112,6 +112,7 @@ func (h *TestHandler) HumaReset(_ context.Context, _ *TestResetInput) (*TestRese
 
 		// 7. User preferences
 		tx.Unscoped().Where("1 = 1").Delete(&db.ConsoleShaderPreference{})
+		tx.Unscoped().Where("1 = 1").Delete(&db.ConsoleSaveStatePolicy{})
 		tx.Unscoped().Where("1 = 1").Delete(&db.ConsoleKeyMappingPreference{})
 		tx.Unscoped().Where("1 = 1").Delete(&db.DeviceShaderPreference{})
 		tx.Unscoped().Where("1 = 1").Delete(&db.Device{})

--- a/server/internal/api/huma_user.go
+++ b/server/internal/api/huma_user.go
@@ -77,6 +77,7 @@ func (h *UserHandler) HumaGetPreferences(ctx context.Context, _ *GetPreferencesI
 	}
 
 	consoleShaders := h.buildConsoleShaderMap(uid)
+	consoleSaveStatePolicies := h.buildConsoleSaveStatePolicyMap(uid)
 	consoleKeyMappings := h.buildConsoleKeyMappingMap(uid)
 	customKeyMapping := parseJSONMap(user.CustomKeyMapping)
 
@@ -109,8 +110,9 @@ func (h *UserHandler) HumaGetPreferences(ctx context.Context, _ *GetPreferencesI
 			SelectedShader:          user.SelectedShader,
 			SelectedTheme:           selectedTheme,
 			DefaultSecondScreenPage: defaultSecondScreenPage,
-			ConsoleShaders:          consoleShaders,
-			SelectedKeyMapping:      selectedKeyMapping,
+			ConsoleShaders:           consoleShaders,
+			ConsoleSaveStatePolicies: consoleSaveStatePolicies,
+			SelectedKeyMapping:       selectedKeyMapping,
 			CustomKeyMapping:        customKeyMapping,
 			ConsoleKeyMappings:      consoleKeyMappings,
 			PreferredRegions:        preferredRegions,

--- a/server/internal/api/huma_user_mutations.go
+++ b/server/internal/api/huma_user_mutations.go
@@ -240,6 +240,34 @@ func (h *UserHandler) HumaUpdatePreferences(ctx context.Context, in *UpdatePrefe
 		}
 	}
 
+	if req.ConsoleSaveStatePolicies != nil {
+		for consoleAbbr, raw := range req.ConsoleSaveStatePolicies {
+			var console db.Console
+			if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", consoleAbbr).First(&console).Error; err != nil {
+				continue
+			}
+			choice := normalizeSaveStateChoice(raw)
+			if choice == "" {
+				h.DB.Unscoped().Where("user_id = ? AND console_id = ?", uid, console.ID).
+					Delete(&db.ConsoleSaveStatePolicy{})
+				continue
+			}
+			var existing db.ConsoleSaveStatePolicy
+			result := h.DB.Unscoped().Where("user_id = ? AND console_id = ?", uid, console.ID).First(&existing)
+			if result.Error == nil {
+				existing.Choice = choice
+				existing.DeletedAt = gorm.DeletedAt{}
+				h.DB.Unscoped().Save(&existing)
+			} else {
+				h.DB.Create(&db.ConsoleSaveStatePolicy{
+					UserID:    uid,
+					ConsoleID: console.ID,
+					Choice:    choice,
+				})
+			}
+		}
+	}
+
 	if req.ConsoleKeyMappings != nil {
 		for consoleAbbr, km := range req.ConsoleKeyMappings {
 			var console db.Console
@@ -275,6 +303,7 @@ func (h *UserHandler) HumaUpdatePreferences(ctx context.Context, in *UpdatePrefe
 	}
 
 	consoleShaders := h.buildConsoleShaderMap(uid)
+	consoleSaveStatePolicies := h.buildConsoleSaveStatePolicyMap(uid)
 	consoleKeyMappings := h.buildConsoleKeyMappingMap(uid)
 	customKeyMapping := parseJSONMap(user.CustomKeyMapping)
 
@@ -307,8 +336,9 @@ func (h *UserHandler) HumaUpdatePreferences(ctx context.Context, in *UpdatePrefe
 			SelectedShader:          user.SelectedShader,
 			SelectedTheme:           selectedTheme,
 			DefaultSecondScreenPage: defaultSecondScreenPage,
-			ConsoleShaders:          consoleShaders,
-			SelectedKeyMapping:      selectedKeyMapping,
+			ConsoleShaders:           consoleShaders,
+			ConsoleSaveStatePolicies: consoleSaveStatePolicies,
+			SelectedKeyMapping:       selectedKeyMapping,
 			CustomKeyMapping:        customKeyMapping,
 			ConsoleKeyMappings:      consoleKeyMappings,
 			PreferredRegions:        preferredRegions,

--- a/server/internal/api/huma_user_mutations.go
+++ b/server/internal/api/huma_user_mutations.go
@@ -246,12 +246,23 @@ func (h *UserHandler) HumaUpdatePreferences(ctx context.Context, in *UpdatePrefe
 			if err := h.DB.Where("LOWER(abbreviation) = LOWER(?)", consoleAbbr).First(&console).Error; err != nil {
 				continue
 			}
-			choice := normalizeSaveStateChoice(raw)
-			if choice == "" {
+			choice, clear := normalizeSaveStateChoice(raw)
+			if clear {
 				h.DB.Unscoped().Where("user_id = ? AND console_id = ?", uid, console.ID).
 					Delete(&db.ConsoleSaveStatePolicy{})
 				continue
 			}
+			if choice == "" {
+				// Garbage value — drop the entry rather than destroy
+				// the user's existing override. Only an explicit empty
+				// string is allowed to clear a row.
+				continue
+			}
+			// Unscoped lookup so a previously soft-deleted row gets
+			// revived in place rather than re-created with a new ID.
+			// This intentionally diverges from the ConsoleShaders
+			// pattern (which uses scoped writes) — we want stable
+			// row IDs for the future audit trail in #804 phase 4b.
 			var existing db.ConsoleSaveStatePolicy
 			result := h.DB.Unscoped().Where("user_id = ? AND console_id = ?", uid, console.ID).First(&existing)
 			if result.Error == nil {

--- a/server/internal/api/requests.go
+++ b/server/internal/api/requests.go
@@ -34,6 +34,13 @@ type UpdatePreferencesRequest struct {
 	SelectedTheme           *string                         `json:"selectedTheme,omitempty"`
 	DefaultSecondScreenPage *string                         `json:"defaultSecondScreenPage,omitempty"`
 	ConsoleShaders          map[string]string               `json:"consoleShaders,omitempty"`
+	// Per-console save-state opt-out upserts. Keys are console
+	// abbreviations (case-insensitive on the server). Allowed values
+	// are "enabled", "disabled", "ask-once". Sending "" clears the
+	// row so the console reverts to its tier-driven default. Unknown
+	// abbreviations are silently skipped, matching ConsoleShaders.
+	// See #804 phase 4.
+	ConsoleSaveStatePolicies map[string]string              `json:"consoleSaveStatePolicies,omitempty"`
 	SelectedKeyMapping      *string                         `json:"selectedKeyMapping,omitempty"`
 	CustomKeyMapping        map[string]string               `json:"customKeyMapping,omitempty"`
 	ConsoleKeyMappings      map[string]ConsoleKeyMappingDTO `json:"consoleKeyMappings,omitempty"`

--- a/server/internal/api/responses.go
+++ b/server/internal/api/responses.go
@@ -1098,6 +1098,13 @@ type UserPreferencesResponse struct {
 	SelectedTheme           string                          `json:"selectedTheme"`
 	DefaultSecondScreenPage string                          `json:"defaultSecondScreenPage"`
 	ConsoleShaders          map[string]string               `json:"consoleShaders"`
+	// Per-console save-state opt-out choices, keyed by console
+	// abbreviation (lowercase). Values are one of "enabled",
+	// "disabled", "ask-once". The map only contains consoles where
+	// the user has made a deliberate choice; the absence of a key
+	// means "use the tier-driven default" (small/medium → enabled,
+	// large → ask-once). See #804 phase 4.
+	ConsoleSaveStatePolicies map[string]string              `json:"consoleSaveStatePolicies"`
 	SelectedKeyMapping      string                          `json:"selectedKeyMapping"`
 	CustomKeyMapping        map[string]string               `json:"customKeyMapping"`
 	ConsoleKeyMappings      map[string]ConsoleKeyMappingDTO `json:"consoleKeyMappings"`

--- a/server/internal/api/user_handler.go
+++ b/server/internal/api/user_handler.go
@@ -85,20 +85,31 @@ func (h *UserHandler) buildConsoleSaveStatePolicyMap(userID uint) map[string]str
 }
 
 // normalizeSaveStateChoice clamps the client-supplied opt-out value to
-// the closed set the server stores. Empty / unknown collapses to "" so
-// callers can distinguish "clear the row" (empty) from "valid choice"
-// without trusting arbitrary input. Mirrors sanitizeCompression. See
-// #804 phase 4.
-func normalizeSaveStateChoice(raw string) db.ConsoleSaveStateChoice {
-	switch strings.ToLower(strings.TrimSpace(raw)) {
+// the closed set the server stores. Three outcomes:
+//
+//	non-empty choice, clear=false → upsert this value
+//	"", clear=true                → user wants the row deleted
+//	"", clear=false               → unknown / garbage value, no-op
+//
+// Distinguishing the two empty-string outcomes matters: a misbehaving
+// client sending a typo like "DISABLED " (note: that lowercases fine,
+// but other typos don't) must not silently destroy an existing
+// override. Only an explicit empty string means "clear me." See
+// #804 phase 4 review feedback on PR #817.
+func normalizeSaveStateChoice(raw string) (choice db.ConsoleSaveStateChoice, clear bool) {
+	trimmed := strings.TrimSpace(raw)
+	if trimmed == "" {
+		return "", true
+	}
+	switch strings.ToLower(trimmed) {
 	case string(db.ConsoleSaveStateChoiceEnabled):
-		return db.ConsoleSaveStateChoiceEnabled
+		return db.ConsoleSaveStateChoiceEnabled, false
 	case string(db.ConsoleSaveStateChoiceDisabled):
-		return db.ConsoleSaveStateChoiceDisabled
+		return db.ConsoleSaveStateChoiceDisabled, false
 	case string(db.ConsoleSaveStateChoiceAskOnce):
-		return db.ConsoleSaveStateChoiceAskOnce
+		return db.ConsoleSaveStateChoiceAskOnce, false
 	default:
-		return ""
+		return "", false
 	}
 }
 

--- a/server/internal/api/user_handler.go
+++ b/server/internal/api/user_handler.go
@@ -60,6 +60,48 @@ func (h *UserHandler) buildConsoleShaderMap(userID uint) map[string]string {
 	return m
 }
 
+// buildConsoleSaveStatePolicyMap queries all ConsoleSaveStatePolicy rows
+// for the user and returns a map keyed by console abbreviation
+// (lowercase). The map only contains consoles where the user has made
+// a deliberate choice; the absence of a key means the player should
+// fall back to the tier-driven default. See #804 phase 4.
+func (h *UserHandler) buildConsoleSaveStatePolicyMap(userID uint) map[string]string {
+	var prefs []db.ConsoleSaveStatePolicy
+	h.DB.Where("user_id = ?", userID).Find(&prefs)
+
+	consoleIDs := make([]uint, 0, len(prefs))
+	for _, p := range prefs {
+		consoleIDs = append(consoleIDs, p.ConsoleID)
+	}
+	abbrMap := resolveConsoleAbbrs(h.DB, consoleIDs)
+
+	m := make(map[string]string, len(prefs))
+	for _, p := range prefs {
+		if abbr, ok := abbrMap[p.ConsoleID]; ok {
+			m[abbr] = string(p.Choice)
+		}
+	}
+	return m
+}
+
+// normalizeSaveStateChoice clamps the client-supplied opt-out value to
+// the closed set the server stores. Empty / unknown collapses to "" so
+// callers can distinguish "clear the row" (empty) from "valid choice"
+// without trusting arbitrary input. Mirrors sanitizeCompression. See
+// #804 phase 4.
+func normalizeSaveStateChoice(raw string) db.ConsoleSaveStateChoice {
+	switch strings.ToLower(strings.TrimSpace(raw)) {
+	case string(db.ConsoleSaveStateChoiceEnabled):
+		return db.ConsoleSaveStateChoiceEnabled
+	case string(db.ConsoleSaveStateChoiceDisabled):
+		return db.ConsoleSaveStateChoiceDisabled
+	case string(db.ConsoleSaveStateChoiceAskOnce):
+		return db.ConsoleSaveStateChoiceAskOnce
+	default:
+		return ""
+	}
+}
+
 // buildConsoleKeyMappingMap queries all ConsoleKeyMappingPreference rows for the user
 // and returns a map keyed by console abbreviation (lowercase).
 func (h *UserHandler) buildConsoleKeyMappingMap(userID uint) map[string]ConsoleKeyMappingDTO {

--- a/server/internal/db/database.go
+++ b/server/internal/db/database.go
@@ -147,6 +147,7 @@ func Initialize(dbPath string) (*gorm.DB, error) {
 		&Core{},
 		&ConsoleShaderPreference{},
 		&ConsoleKeyMappingPreference{},
+		&ConsoleSaveStatePolicy{},
 		&Device{},
 		&DeviceShaderPreference{},
 		&RetroAchievementCredential{},

--- a/server/internal/db/models.go
+++ b/server/internal/db/models.go
@@ -447,6 +447,39 @@ type ServerSetting struct {
 	Value string `gorm:"type:text" json:"value"`
 }
 
+// ConsoleSaveStateChoice is the user's per-console save-state opt-out
+// state. Drives whether the in-game overlay shows the save/load
+// buttons or grays them out, and whether the first-launch prompt
+// fires for a large-tier console. See #804 phase 4.
+//
+//	"enabled"  — save states allowed for this console.
+//	"disabled" — save states hidden in the overlay; a tooltip points
+//	             back to Settings.
+//	"ask-once" — fire the first-launch prompt again on the next start.
+//	             The default for large-tier consoles when no row exists.
+type ConsoleSaveStateChoice string
+
+const (
+	ConsoleSaveStateChoiceEnabled  ConsoleSaveStateChoice = "enabled"
+	ConsoleSaveStateChoiceDisabled ConsoleSaveStateChoice = "disabled"
+	ConsoleSaveStateChoiceAskOnce  ConsoleSaveStateChoice = "ask-once"
+)
+
+// ConsoleSaveStatePolicy stores a user's per-console save-state opt-out
+// override. Mirrors the shape of [ConsoleShaderPreference]: a row only
+// exists once the user has made a deliberate choice. The absence of a
+// row resolves to a tier-driven default on the client (small/medium =
+// enabled, large = ask-once). See #804 phase 4.
+type ConsoleSaveStatePolicy struct {
+	ID        uint                   `gorm:"primarykey" json:"id"`
+	CreatedAt time.Time              `json:"createdAt"`
+	UpdatedAt time.Time              `json:"updatedAt"`
+	DeletedAt gorm.DeletedAt         `gorm:"index" json:"-"`
+	UserID    uint                   `gorm:"uniqueIndex:idx_user_console_savestate;not null" json:"userId"`
+	ConsoleID uint                   `gorm:"uniqueIndex:idx_user_console_savestate;not null" json:"consoleId"`
+	Choice    ConsoleSaveStateChoice `gorm:"type:varchar(16);not null" json:"choice"`
+}
+
 // ConsoleShaderPreference stores a user's per-console shader override.
 type ConsoleShaderPreference struct {
 	ID        uint           `gorm:"primarykey" json:"id"`

--- a/web/src/features/play/hooks/__tests__/use-resolved-game-preferences.test.ts
+++ b/web/src/features/play/hooks/__tests__/use-resolved-game-preferences.test.ts
@@ -9,6 +9,7 @@ function prefs(overrides: Partial<UserPreferences> = {}): UserPreferences {
     autoSaveEnabled: true,
     autoUpdateCoresEnabled: false,
     consoleKeyMappings: {},
+    consoleSaveStatePolicies: {},
     consoleShaders: {},
     customKeyMapping: {},
     defaultSecondScreenPage: "controls",

--- a/web/src/generated/api.d.ts
+++ b/web/src/generated/api.d.ts
@@ -8534,6 +8534,9 @@ export interface components {
             consoleKeyMappings?: {
                 [key: string]: components["schemas"]["ConsoleKeyMappingDTO"];
             };
+            consoleSaveStatePolicies?: {
+                [key: string]: string;
+            };
             consoleShaders?: {
                 [key: string]: string;
             };
@@ -8651,6 +8654,9 @@ export interface components {
             autoUpdateCoresEnabled: boolean;
             consoleKeyMappings: {
                 [key: string]: components["schemas"]["ConsoleKeyMappingDTO"];
+            };
+            consoleSaveStatePolicies: {
+                [key: string]: string;
             };
             consoleShaders: {
                 [key: string]: string;

--- a/web/src/generated/openapi.json
+++ b/web/src/generated/openapi.json
@@ -9860,6 +9860,12 @@
             },
             "type": "object"
           },
+          "consoleSaveStatePolicies": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "consoleShaders": {
             "additionalProperties": {
               "type": "string"
@@ -10133,6 +10139,12 @@
             },
             "type": "object"
           },
+          "consoleSaveStatePolicies": {
+            "additionalProperties": {
+              "type": "string"
+            },
+            "type": "object"
+          },
           "consoleShaders": {
             "additionalProperties": {
               "type": "string"
@@ -10185,6 +10197,7 @@
           "selectedTheme",
           "defaultSecondScreenPage",
           "consoleShaders",
+          "consoleSaveStatePolicies",
           "selectedKeyMapping",
           "customKeyMapping",
           "consoleKeyMappings",


### PR DESCRIPTION
Closes part of #804 (phase 4 — server-side data shape for the per-console save-state opt-out).

## Summary

Server-side half of phase 4. Adds the `ConsoleSaveStatePolicy` table that the player UI will read in the next slice (first-launch prompt, settings page, game-detail override, in-game overlay greying). No UX changes in this PR — just the column + endpoint contract so the player can hang the UI off it.

## Schema

`ConsoleSaveStatePolicy` mirrors `ConsoleShaderPreference`:

```go
type ConsoleSaveStatePolicy struct {
    UserID    uint
    ConsoleID uint
    Choice    ConsoleSaveStateChoice  // "enabled" | "disabled" | "ask-once"
}
// unique index (user_id, console_id)
```

A row only exists once the user makes a deliberate choice. **Absence of a row** is the signal to the player that "no override — fall back to the tier-driven default" using the `SaveStatePolicy` column shipped in #816 (small/medium → enabled, large → ask-once).

## API contract

`PUT /api/user/preferences` accepts a new `consoleSaveStatePolicies` map. Same upsert/clear semantics as `consoleShaders`:

| Sent value | Effect |
|------------|--------|
| `"enabled"` / `"disabled"` / `"ask-once"` | upsert row |
| `""` | clear row → revert to tier default |
| `"FOO"` (anything else) | silently dropped (sanitiser) |
| key for unknown abbreviation | no-op |

`GET /api/user/preferences` emits the same map. Lowercased abbreviations, matching the existing convention.

## Tests

- `TestNormalizeSaveStateChoice` — closed-set sanitiser handles case + whitespace + garbage.
- `TestUpdatePreferences_SetConsoleSaveStatePolicy` — round-trip via PUT + GET.
- `TestUpdatePreferences_ClearConsoleSaveStatePolicy` — empty value removes row.
- `TestUpdatePreferences_SaveStatePolicyUnknownAbbrSilentlySkipped` — bulk sync tolerates unknown abbreviations.
- `TestUpdatePreferences_SaveStatePolicyGarbageValueIsRejected` — "absolutely-not-a-state" never reaches the database.

Server: full Go suite green. Web: 1561 tests + tsc + vite build green. Player: 546 desktop + 9 e2e + Android compile green.

## Why server-only this time

Phase 4 has four touchpoints (settings UI, first-launch prompt, game-detail override, overlay read-only state). Bundling them all with the data column would make the PR enormous and hard to review. This PR ships the column + endpoint; the player UI lands in 4b.

## Phase order

- ~~Phase 1 — lift 64 MB cap (#806, merged)~~
- ~~Phase 2 — client-side compression (#814 + #815, merged)~~
- ~~Phase 3 — `SaveStatePolicy` field + tier seeding (#816, merged)~~
- **Phase 4a — this PR (server data shape)**
- Phase 4b — player UI (settings page, first-launch prompt, game-detail override, overlay greying)
- Phase 5 — slot-primary UX for medium/large
- Phase 6 — deferred / opportunistic sync
